### PR TITLE
Added an initial implementation of partitioned communication.

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
- * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2011-2013 INRIA.  All rights reserved.
@@ -1618,6 +1618,17 @@ OMPI_DECLSPEC  int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, 
                              int tag, MPI_Comm comm, MPI_Request *request);
 OMPI_DECLSPEC  int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest,
                               int tag, MPI_Comm comm, MPI_Request *request);
+OMPI_DECLSPEC  int MPI_Precv_init(const void* buf, int partitions, MPI_Count count,
+                                  MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
+                                  MPI_Request *request);
+OMPI_DECLSPEC  int MPI_Psend_init(const void* buf, int partitions, MPI_Count count,
+                                  MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
+                                  MPI_Request *request);
+OMPI_DECLSPEC  int MPI_Pready(int partitions, MPI_Request request);
+OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
+                                    MPI_Request request);
+OMPI_DECLSPEC  int MPI_Pready_list(int length, int partition_list[], MPI_Request request);
+OMPI_DECLSPEC  int MPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
 OMPI_DECLSPEC  int MPI_Is_thread_main(int *flag);
 OMPI_DECLSPEC  int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
 OMPI_DECLSPEC  MPI_Fint MPI_Message_c2f(MPI_Message message);
@@ -2279,6 +2290,17 @@ OMPI_DECLSPEC  int PMPI_Isend(const void *buf, int count, MPI_Datatype datatype,
                               int tag, MPI_Comm comm, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request);
+OMPI_DECLSPEC  int PMPI_Precv_init(const void* buf, int partitions, MPI_Count count,
+                                  MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
+                                  MPI_Request *request);
+OMPI_DECLSPEC  int PMPI_Psend_init(const void* buf, int partitions, MPI_Count count,
+                                  MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
+                                  MPI_Request *request);
+OMPI_DECLSPEC  int PMPI_Pready(int partitions, MPI_Request request);
+OMPI_DECLSPEC  int PMPI_Pready_range(int partition_low, int partition_high,
+                                    MPI_Request request);
+OMPI_DECLSPEC  int PMPI_Pready_list(int length, int partition_list[], MPI_Request request);
+OMPI_DECLSPEC  int PMPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
 OMPI_DECLSPEC  int PMPI_Is_thread_main(int *flag);
 OMPI_DECLSPEC  int PMPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
 OMPI_DECLSPEC  MPI_Fint PMPI_Message_c2f(MPI_Message message);

--- a/ompi/mca/part/Makefile.am
+++ b/ompi/mca/part/Makefile.am
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# main library setup
+noinst_LTLIBRARIES = libmca_part.la
+libmca_part_la_SOURCES =
+
+# local files
+headers = part.h 
+libmca_part_la_SOURCES += $(headers) $(nodist_headers)
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+ompidir = $(ompiincludedir)/$(subdir)
+nobase_ompi_HEADERS = $(headers)
+nobase_nodist_ompi_HEADERS = $(nodist_headers)
+endif
+
+include base/Makefile.am
+
+distclean-local:
+	rm -f base/static-components.h

--- a/ompi/mca/part/base/Makefile.am
+++ b/ompi/mca/part/base/Makefile.am
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers += \
+        base/base.h \
+        base/part_base_prequest.h \
+        base/part_base_precvreq.h \
+        base/part_base_psendreq.h 
+
+libmca_part_la_SOURCES += \
+        base/part_base_frame.c \
+        base/part_base_precvreq.c \
+        base/part_base_prequest.c \
+        base/part_base_select.c \
+        base/part_base_psendreq.c 

--- a/ompi/mca/part/base/base.h
+++ b/ompi/mca/part/base/base.h
@@ -1,0 +1,71 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_PART_BASE_H
+#define MCA_PART_BASE_H
+
+#include "ompi_config.h"
+
+#include "ompi/mca/mca.h"
+#include "opal/mca/base/mca_base_framework.h"
+#include "opal/class/opal_list.h"
+#include "opal/class/opal_pointer_array.h"
+
+#include "ompi/mca/part/part.h"
+
+/*
+ * Global functions for PART
+ */
+
+BEGIN_C_DECLS
+
+/*
+ * This is the base priority for a PART wrapper component
+ * If there exists more than one then it is undefined
+ * which one is picked.
+ */
+#define PART_SELECT_WRAPPER_PRIORITY -128
+
+/*
+ * MCA framework
+ */
+OMPI_DECLSPEC extern mca_base_framework_t ompi_part_base_framework;
+
+/*
+ * Select an available component.
+ */
+OMPI_DECLSPEC  int mca_part_base_select(bool enable_progress_threads,
+                                        bool enable_mpi_threads);
+
+OMPI_DECLSPEC  int mca_part_base_progress(void);
+
+OMPI_DECLSPEC int mca_part_base_finalize(void);
+
+/*
+ * Globals
+ */
+OMPI_DECLSPEC extern mca_part_base_component_t mca_part_base_selected_component;
+OMPI_DECLSPEC extern mca_part_base_module_t mca_part;
+OMPI_DECLSPEC extern opal_pointer_array_t mca_part_base_part;
+
+END_C_DECLS
+
+#endif /* MCA_PART_BASE_H */

--- a/ompi/mca/part/base/part_base_frame.c
+++ b/ompi/mca/part/base/part_base_frame.c
@@ -1,0 +1,153 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif  /* HAVE_UNIST_H */
+#include "ompi/mca/mca.h"
+#include "opal/util/output.h"
+#include "opal/mca/base/base.h"
+
+
+#include "ompi/constants.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/base.h"
+#include "ompi/mca/part/base/part_base_prequest.h"
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "ompi/mca/part/base/static-components.h"
+
+/*
+ * This function allows modules to not declare a progress function,
+ * by defaulting to doing nothing.
+ */
+int mca_part_base_progress(void)
+{
+    return OMPI_SUCCESS;
+}
+
+#define xstringify(part) #part
+#define stringify(part) xstringify(part)
+
+/*
+ * Global variables
+ */
+mca_part_base_module_t mca_part = {
+    mca_part_base_progress,   /* part_progress */
+    NULL,                     /* part_precv_init */
+    NULL,                     /* part_psend_init */
+    NULL,                     /* part_start */
+    NULL,                     /* part_pready */
+    NULL                      /* part_parrived */
+};
+
+mca_part_base_component_t mca_part_base_selected_component = {{0}};
+opal_pointer_array_t mca_part_base_part = {{0}};
+
+static int mca_part_base_register(mca_base_register_flag_t flags)
+{
+    return OMPI_SUCCESS;
+}
+
+int mca_part_base_finalize(void) {
+  if (NULL != mca_part_base_selected_component.partm_finalize) {
+    return mca_part_base_selected_component.partm_finalize();
+  }
+  return OMPI_SUCCESS;
+}
+
+
+static int mca_part_base_close(void)
+{
+    int i, j;
+
+    /* unregister the progress function */
+    if( NULL != mca_part.part_progress ) {
+        opal_progress_unregister(mca_part.part_progress);
+    }
+
+    /* reset the progress function to do nothing */
+    mca_part.part_progress = mca_part_base_progress;
+
+    /* Free all the strings in the array of components */
+    j = opal_pointer_array_get_size(&mca_part_base_part);
+    for (i = 0; i < j; ++i) {
+        char *str;
+        str = (char*) opal_pointer_array_get_item(&mca_part_base_part, i);
+        free(str);
+    }
+    OBJ_DESTRUCT(&mca_part_base_part);
+
+    OBJ_DESTRUCT(&mca_part_base_psend_requests);
+    OBJ_DESTRUCT(&mca_part_base_precv_requests);
+
+    /* Close all remaining available components */
+    return mca_base_framework_components_close(&ompi_part_base_framework, NULL);
+}
+
+/**
+ * Function for finding and opening either all MCA components, or the one
+ * that was specifically requested via a MCA parameter.
+ */
+static int mca_part_base_open(mca_base_open_flag_t flags)
+{
+    OBJ_CONSTRUCT(&mca_part_base_part, opal_pointer_array_t);
+
+    
+    OBJ_CONSTRUCT(&mca_part_base_psend_requests, opal_free_list_t);
+    OBJ_CONSTRUCT(&mca_part_base_precv_requests, opal_free_list_t);
+    /* Open up all available components */
+
+    if (OPAL_SUCCESS !=
+        mca_base_framework_components_open(&ompi_part_base_framework, flags)) {
+        return OMPI_ERROR;
+    }
+
+    /* Set a sentinel in case we don't select any components (e.g.,
+       ompi_info) */
+
+    mca_part_base_selected_component.partm_finalize = NULL;
+
+    /* Currently this uses a default with no selection criteria as there is only 1 module. */
+    opal_pointer_array_add(&mca_part_base_part, strdup("rma"));
+
+    return OMPI_SUCCESS;
+}
+
+MCA_BASE_FRAMEWORK_DECLARE(ompi, part, "OMPI PART", mca_part_base_register,
+                           mca_part_base_open, mca_part_base_close,
+                           mca_part_base_static_components, 0);

--- a/ompi/mca/part/base/part_base_precvreq.c
+++ b/ompi/mca/part/base/part_base_precvreq.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+#include "ompi_config.h"
+#include "ompi/types.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/part_base_precvreq.h"
+
+
+static void mca_part_base_precv_request_construct(mca_part_base_precv_request_t*);
+static void mca_part_base_precv_request_destruct(mca_part_base_precv_request_t*);
+
+
+OBJ_CLASS_INSTANCE(
+    mca_part_base_precv_request_t,
+    mca_part_base_prequest_t,
+    mca_part_base_precv_request_construct,
+    mca_part_base_precv_request_destruct
+);
+
+
+static void mca_part_base_precv_request_construct(mca_part_base_precv_request_t* request)
+{
+    OBJ_CONSTRUCT(&request->req_base.req_convertor, opal_convertor_t);
+}
+
+
+static void mca_part_base_precv_request_destruct(mca_part_base_precv_request_t* request)
+{
+    /* For each request the convertor get cleaned after each message
+     * (in the base _FINI macro). Therefore, as the convertor is a static object
+     * we don't have to call OBJ_DESTRUCT here.
+     */
+}
+

--- a/ompi/mca/part/base/part_base_precvreq.h
+++ b/ompi/mca/part/base/part_base_precvreq.h
@@ -1,0 +1,50 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ */
+#ifndef MCA_PART_BASE_PRECV_REQUEST_H
+#define MCA_PART_BASE_PRECV_REQUEST_H
+
+#include "ompi_config.h"
+#include "ompi/mca/part/base/part_base_prequest.h"
+#include "opal/datatype/opal_convertor.h"
+#include "ompi/peruse/peruse-internal.h"
+
+BEGIN_C_DECLS
+
+/**
+ * Base type for receive requests.
+ */
+struct mca_part_base_precv_request_t {
+   mca_part_base_prequest_t req_base;  /**< base request */
+   size_t parts;                       /**< number of partitions */
+};
+typedef struct mca_part_base_precv_request_t mca_part_base_precv_request_t;
+
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_part_base_precv_request_t);
+
+END_C_DECLS
+
+#endif
+

--- a/ompi/mca/part/base/part_base_prequest.c
+++ b/ompi/mca/part/base/part_base_prequest.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/part_base_prequest.h"
+
+/**
+ * If you wonder why these 2 freelists are declared here read the comment
+ * in the part_base_request.h file.
+ */
+opal_free_list_t mca_part_base_psend_requests = {{{0}}};
+opal_free_list_t mca_part_base_precv_requests = {{{0}}};
+
+static void mca_part_base_prequest_construct(mca_part_base_prequest_t* req)
+{
+    req->req_ompi.req_type = OMPI_REQUEST_PART;
+}
+
+OBJ_CLASS_INSTANCE(
+    mca_part_base_prequest_t,
+    ompi_request_t,
+    mca_part_base_prequest_construct,
+    NULL
+);
+

--- a/ompi/mca/part/base/part_base_prequest.h
+++ b/ompi/mca/part/base/part_base_prequest.h
@@ -1,0 +1,72 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ */
+#ifndef MCA_PART_BASE_REQUEST_H
+#define MCA_PART_BASE_REQUEST_H
+
+#include "ompi_config.h"
+#include "opal/class/opal_free_list.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/request/request.h"
+#include "opal/datatype/opal_convertor.h"
+#include "part_base_request_dbg.h"
+BEGIN_C_DECLS
+
+/**
+ * External list for the partitioned requests. 
+ */
+OMPI_DECLSPEC extern opal_free_list_t mca_part_base_psend_requests;
+OMPI_DECLSPEC extern opal_free_list_t mca_part_base_precv_requests;
+
+/**
+ *  Base type for Partitoned P2P requests
+ */
+struct mca_part_base_prequest_t {
+
+    ompi_request_t req_ompi;              /**< base request */
+    volatile int32_t req_part_complete;   /**< flag indicating if the pt-2-pt layer is done with this request */
+    volatile int32_t req_free_called;     /**< flag indicating if the user has freed this request */
+    mca_part_base_request_type_t req_type; /**< MPI request type - used for test */
+    struct ompi_communicator_t *req_comm; /**< communicator pointer */
+    struct ompi_datatype_t *req_datatype; /**< pointer to data type */
+    opal_convertor_t req_convertor;       /**< always need the convertor */
+
+    void *req_addr;                       /**< pointer to application buffer */
+    size_t req_parts;                     /**< number of partitions */
+    size_t req_count;                     /**< count of user datatype elements */
+    int32_t req_peer;                     /**< peer process - rank w/in this communicator */
+    int32_t req_tag;                      /**< user defined tag */
+    struct ompi_proc_t* req_proc;         /**< peer process */
+};
+typedef struct mca_part_base_prequest_t mca_part_base_prequest_t;
+
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_part_base_prequest_t);
+
+END_C_DECLS
+
+#endif
+

--- a/ompi/mca/part/base/part_base_psendreq.c
+++ b/ompi/mca/part/base/part_base_psendreq.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <string.h>
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/part_base_psendreq.h"
+
+static void mca_part_base_psend_request_construct(mca_part_base_psend_request_t* req);
+static void mca_part_base_psend_request_destruct(mca_part_base_psend_request_t* req);
+
+
+OBJ_CLASS_INSTANCE(
+    mca_part_base_psend_request_t,
+    mca_part_base_prequest_t,
+    mca_part_base_psend_request_construct,
+    mca_part_base_psend_request_destruct
+);
+
+
+static void mca_part_base_psend_request_construct(mca_part_base_psend_request_t* request)
+{
+    /* no need to reinit for every send -- never changes */
+    OBJ_CONSTRUCT(&request->req_base.req_convertor, opal_convertor_t);
+}
+
+static void mca_part_base_psend_request_destruct(mca_part_base_psend_request_t* req)
+{
+    /* For each request the convertor get cleaned after each message
+     * (in the base _FINI macro). Therefore, as the convertor is a static object
+     * we don't have to call OBJ_DESTRUCT here.
+     */
+}
+

--- a/ompi/mca/part/base/part_base_psendreq.h
+++ b/ompi/mca/part/base/part_base_psendreq.h
@@ -1,0 +1,54 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ */
+#ifndef MCA_PART_BASE_PSEND_REQUEST_H
+#define MCA_PART_BASE_PSEND_REQUEST_H
+
+#include "ompi_config.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/part_base_prequest.h"
+#include "opal/datatype/opal_convertor.h"
+#include "ompi/peruse/peruse-internal.h"
+
+BEGIN_C_DECLS
+
+/**
+ * Base type for send requests
+ */
+struct mca_part_base_psend_request_t {
+    mca_part_base_prequest_t req_base;       /**< base request type - common data structure for use by wait/test */
+    const void *req_addr;                    /**< pointer to send buffer - may not be application buffer */
+    size_t req_bytes_packed;                 /**< packed size of a message given the datatype and count */
+};
+typedef struct mca_part_base_psend_request_t mca_part_base_psend_request_t;
+
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_part_base_psend_request_t );
+
+END_C_DECLS
+
+#endif

--- a/ompi/mca/part/base/part_base_request_dbg.h
+++ b/ompi/mca/part/base/part_base_request_dbg.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#ifndef MCA_PART_BASE_REQUEST_DBG_H
+#define MCA_PART_BASE_REQUEST_DBG_H
+
+/*
+ * This file contains definitions used by both OMPI and debugger plugins.
+ * For more information on why we do this see the Notice to developers
+ * comment at the top of the ompi_msgq_dll.c file.
+ */
+
+/**
+ * Type of request.
+ */
+typedef enum {
+    MCA_PART_REQUEST_NULL,
+    MCA_PART_REQUEST_PSEND,
+    MCA_PART_REQUEST_PRECV
+} mca_part_base_request_type_t;
+
+#endif /* MCA_PART_BASE_REQUEST_DBG_H */

--- a/ompi/mca/part/base/part_base_select.c
+++ b/ompi/mca/part/base/part_base_select.c
@@ -1,0 +1,233 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include <string.h>
+
+#include "opal/class/opal_list.h"
+#include "opal/util/output.h"
+#include "opal/util/show_help.h"
+#include "opal/runtime/opal_progress.h"
+#include "ompi/mca/mca.h"
+#include "opal/mca/base/base.h"
+#include "opal/runtime/opal.h"
+#include "opal/mca/pmix/pmix-internal.h"
+
+#include "ompi/constants.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/base.h"
+#include "ompi/proc/proc.h"
+
+typedef struct opened_component_t {
+  opal_list_item_t super;
+  mca_part_base_component_t *om_component;
+} opened_component_t;
+
+static bool modex_reqd=false;
+
+/**
+ * Function for selecting one component from all those that are
+ * available.
+ *
+ * Call the init function on all available components and get their
+ * priorities.  Select the component with the highest priority.  All
+ * other components will be closed and unloaded.  The selected component
+ * will have all of its function pointers saved and returned to the
+ * caller.
+ */
+int mca_part_base_select(bool enable_progress_threads,
+                        bool enable_mpi_threads)
+{
+    int i, priority = 0, best_priority = 0, num_part = 0;
+    opal_list_item_t *item = NULL;
+    mca_base_component_list_item_t *cli = NULL;
+    mca_part_base_component_t *component = NULL, *best_component = NULL;
+    mca_part_base_module_t *module = NULL, *best_module = NULL;
+    opal_list_t opened;
+    opened_component_t *om = NULL;
+    bool found_part;
+
+    /* Traverse the list of available components; call their init
+       functions. */
+
+    best_priority = -1;
+    best_component = NULL;
+    module = NULL;
+    OBJ_CONSTRUCT(&opened, opal_list_t);
+    OPAL_LIST_FOREACH(cli, &ompi_part_base_framework.framework_components, mca_base_component_list_item_t) {
+        component = (mca_part_base_component_t *) cli->cli_component;
+
+        /* if there is an include list - item must be in the list to be included */
+        found_part = false;
+        for( i = 0; i < opal_pointer_array_get_size(&mca_part_base_part); i++) {
+            char * tmp_val = NULL;
+            tmp_val = (char *) opal_pointer_array_get_item(&mca_part_base_part, i);
+            if( NULL == tmp_val) {
+                continue;
+            }
+
+            if(0 == strncmp(component->partm_version.mca_component_name,
+                            tmp_val, strlen(component->partm_version.mca_component_name)) ) {
+                found_part = true;
+                break;
+            }
+        }
+
+        if(!found_part && opal_pointer_array_get_size(&mca_part_base_part)) {
+            opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                                     "select: component %s not in the include list",
+                                     component->partm_version.mca_component_name );
+
+            continue;
+        }
+
+        /* if there is no init function - ignore it */
+        if (NULL == component->partm_init) {
+            opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                                 "select: no init function; ignoring component %s",
+                                 component->partm_version.mca_component_name );
+            continue;
+        }
+
+        /* this is a part that could be considered */
+        num_part++;
+
+        /* Init component to get its priority */
+        opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                             "select: initializing %s component %s",
+                             component->partm_version.mca_type_name,
+                             component->partm_version.mca_component_name );
+        priority = best_priority;
+        module = component->partm_init(&priority, enable_progress_threads,
+                                      enable_mpi_threads);
+        if (NULL == module) {
+            opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                                 "select: init returned failure for component %s",
+                                 component->partm_version.mca_component_name );
+            continue;
+        }
+
+        opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                             "select: init returned priority %d", priority );
+        if (priority > best_priority) {
+            best_priority = priority;
+            best_component = component;
+            best_module = module;
+        }
+
+        om = (opened_component_t*)malloc(sizeof(opened_component_t));
+        if (NULL == om) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        OBJ_CONSTRUCT(om, opal_list_item_t);
+        om->om_component = component;
+        opal_list_append(&opened, (opal_list_item_t*) om);
+    }
+
+    /* Finished querying all components.  Check for the bozo case. */
+
+    if( NULL == best_component ) {
+        opal_show_help("help-mca-base.txt", "find-available:none found",
+                       true, "part",
+                       opal_process_info.nodename,
+                       "part");
+        for( i = 0; i < opal_pointer_array_get_size(&mca_part_base_part); i++) {
+            char * tmp_val = NULL;
+            tmp_val = (char *) opal_pointer_array_get_item(&mca_part_base_part, i);
+            if( NULL == tmp_val) {
+                continue;
+            }
+            ompi_rte_abort(1, "PART %s cannot be selected", tmp_val);
+        }
+        if(0 == i) {
+            ompi_rte_abort(2, "No part component available.  This shouldn't happen.");
+        }
+    }
+
+    opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                         "selected %s best priority %d\n",
+                         best_component->partm_version.mca_component_name, best_priority);
+
+    /* if more than one PART could be considered, then we still need the
+     * modex since we cannot know which one will be selected on all procs
+     */
+    if (1 < num_part) {
+        modex_reqd = true;
+    }
+
+    /* Finalize all non-selected components */
+
+    for (item = opal_list_remove_first(&opened);
+         NULL != item;
+         item = opal_list_remove_first(&opened)) {
+        om = (opened_component_t *) item;
+
+        if (om->om_component != best_component
+            ) {
+            /* Finalize */
+
+            if (NULL != om->om_component->partm_finalize) {
+
+                /* Blatently ignore the return code (what would we do to
+                   recover, anyway?  This component is going away, so errors
+                   don't matter anymore) */
+
+                om->om_component->partm_finalize();
+                opal_output_verbose(10, ompi_part_base_framework.framework_output,
+                                    "select: component %s not selected / finalized",
+                                    om->om_component->partm_version.mca_component_name);
+            }
+        }
+        OBJ_DESTRUCT( om );
+        free(om);
+    }
+    OBJ_DESTRUCT( &opened );
+
+    /* Save the winner */
+
+    mca_part_base_selected_component = *best_component;
+    mca_part = *best_module;
+    opal_output_verbose( 10, ompi_part_base_framework.framework_output,
+                         "select: component %s selected",
+                         mca_part_base_selected_component.partm_version.mca_component_name );
+
+    /* This base function closes, unloads, and removes from the
+       available list all unselected components.  The available list will
+       contain only the selected component. */
+
+    mca_base_components_close(ompi_part_base_framework.framework_output,
+                              &ompi_part_base_framework.framework_components,
+                              (mca_base_component_t *) best_component);
+
+    /* register the winner's callback */
+    if( NULL != mca_part.part_progress ) {
+        opal_progress_register(mca_part.part_progress);
+    }
+
+    /* All done */
+
+    return OMPI_SUCCESS;
+}
+

--- a/ompi/mca/part/configure.m4
+++ b/ompi/mca/part/configure.m4
@@ -1,0 +1,18 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2013-2020 Sandia National Laboratories.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AC_DEFUN([MCA_ompi_part_CONFIG],[
+    # configure all the components
+    MCA_CONFIGURE_FRAMEWORK($1, $2, 1)
+
+    # this is a direct callable component, so set that up.
+    MCA_SETUP_DIRECT_CALL($1, $2)
+])

--- a/ompi/mca/part/part.h
+++ b/ompi/mca/part/part.h
@@ -1,0 +1,246 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ *
+ * Partitioned Communication (PART)
+ *
+ * An MCA component type that provides the partitioned interface functionality
+ * required by the MPI-4 specification. Part is designed to act as intermediary 
+ * between the MPI layer and another transfer layer. This differs from other 
+ * components, such as PML, by allowing the component to leverage the underlying 
+ * transfer mechanism to be another MPI layer, such as the osc component/the 
+ * RMA interface.
+ *
+ *   ------------------------------------
+ *   |                MPI               |
+ *   ------------------------------------
+ *   |               PART               |
+ *   ------------------------------------
+ *   |             OSC (RDMA)           |
+ *   ------------------------------------
+ * 
+ * The initial implementation is currently leveraging the RMA interface, 
+ * with the intent to remove the MPI layer and directly call the osc component.
+ * Other transport mechanisms could be used in future implementation (such as 
+ * the MTL and BTL components). 
+ *
+ * This component and it's initial module are under development and have 
+ * extra restrictions on use than described in the MPI-4 specification. 
+ * Currently, MPI_Psend_init and MPI_Precv_init are both blocking in the RMA 
+ * component which requires careful use to avoid deadlocks. This will 
+ * be addressed in future updates. 
+ */
+
+#ifndef MCA_PART_H
+#define MCA_PART_H
+
+#include "ompi_config.h"
+#include "ompi/mca/mca.h"
+#include "mpi.h" /* needed for MPI_ANY_TAG */
+#include "ompi/request/request.h"
+
+BEGIN_C_DECLS
+
+struct ompi_proc_t;
+
+/**
+ * MCA->PART Called by MCA framework to initialize the component.
+ *
+ * @param priority (OUT) Relative priority or ranking used by MCA to
+ * selected a component.
+ *
+ * @param enable_progress_threads (IN) Whether this component is
+ * allowed to run a hidden/progress thread or not.
+ *
+ * @param enable_mpi_threads (IN) Whether support for multiple MPI
+ * threads is enabled or not (i.e., MPI_THREAD_MULTIPLE), which
+ * indicates whether multiple threads may invoke this component
+ * simultaneously or not.
+ */
+typedef struct mca_part_base_module_1_0_1_t * (*mca_part_base_component_init_fn_t)(
+    int *priority,
+    bool enable_progress_threads,
+    bool enable_mpi_threads);
+
+typedef int (*mca_part_base_component_finalize_fn_t)(void);
+
+/**
+ * PART component version and interface functions.
+ */
+
+struct mca_part_base_component_4_0_0_t {
+   mca_base_component_t partm_version;
+   mca_base_component_data_t partm_data;
+   mca_part_base_component_init_fn_t partm_init;
+   mca_part_base_component_finalize_fn_t partm_finalize;
+};
+typedef struct mca_part_base_component_4_0_0_t mca_part_base_component_4_0_0_t;
+typedef mca_part_base_component_4_0_0_t mca_part_base_component_t;
+
+
+/**
+ * MCA management functions.
+ */
+
+
+/**
+ * For non-threaded case, provides MCA the opportunity to
+ * progress outstanding requests on all btls.
+ *
+ *  * @return        Count of "completions", a metric of
+ *                   how many items where completed in the call
+ *                   to progress.
+*/
+typedef int (*mca_part_base_module_progress_fn_t)(void);
+
+/**
+ * MPI Interface Functions
+ */
+
+/**
+ *  Initialize a partitioned receive request.
+ *
+ *  @param buf (IN)         User buffer.
+ *  @param parts (IN)       Number of partitions.
+ *  @param count (IN)       Number of elements of the specified datatype.
+ *  @param datatype (IN)    User defined datatype.
+ *  @param src (IN)         Source rank w/in communicator.
+ *  @param tag (IN)         User defined tag.
+ *  @param comm (IN)        Communicator.
+ *  @param request (OUT)    Request handle.
+ *  @return                 OMPI_SUCCESS or failure status.
+ */
+
+typedef int (*mca_part_base_module_precv_init_fn_t)(
+    void *buf,
+    size_t parts,
+    size_t count,
+    struct ompi_datatype_t *datatype,
+    int src,
+    int tag,
+    struct ompi_communicator_t* comm,
+    struct ompi_request_t **request
+);
+
+/**
+ *  Initialize a partitioned send request.
+ *
+ *  @param buf (IN)         User buffer.
+ *  @param parts (IN)       Number of partitions.
+ *  @param count (IN)       Number of elements of the specified datatype.
+ *  @param datatype (IN)    User defined datatype.
+ *  @param dst (IN)         Peer rank w/in communicator.
+ *  @param tag (IN)         User defined tag.
+ *  @param mode (IN)        Send mode (STANDARD,BUFFERED,SYNCHRONOUS,READY)
+ *  @param comm (IN)        Communicator.
+ *  @param request (OUT)    Request handle.
+ *  @return                 OMPI_SUCCESS or failure status.
+ */
+typedef int (*mca_part_base_module_psend_init_fn_t)(
+    const void *buf,
+    size_t parts, 
+    size_t count,
+    struct ompi_datatype_t *datatype,
+    int dst,
+    int tag,
+    struct ompi_communicator_t* comm,
+    struct ompi_request_t **request
+);
+
+/**
+ * Initiate one or more partitioned requests.
+ *
+ * @param count (IN)        Number of requests
+ * @param requests (IN/OUT) Array of persistent requests
+ * @return                  OMPI_SUCCESS or failure status.
+ */
+typedef ompi_request_start_fn_t mca_part_base_module_start_fn_t;
+
+/**
+ * Mark a range of partitions ready in a partitioned send request.
+ *
+ * @param min_part         Minimum partition to mark ready for transfer. 
+ * @param max_part         Maximum partition to mark ready for transfer.
+ * @param request (IN/OUT) Request
+ * @return                 OMPI_SUCCESS or failure status.
+ *
+ */
+typedef int (*mca_part_base_module_pready_fn_t)(
+    size_t min_part,
+    size_t max_part,
+    struct ompi_request_t* request
+);
+
+/**
+ * Check a range of partitions in a partitioned receive request.
+ *
+ * @param min_part         Minimum partition to check. 
+ * @param max_part         Maximum partition to check.
+ * @param flag             Flag for completion of entire range. 
+ * @param request (IN/OUT) Request
+ * @return                 OMPI_SUCCESS or failure status.
+ *
+ */
+typedef int (*mca_part_base_module_parrived_fn_t)(
+    size_t min_part,
+    size_t max_part,
+    int* flag,
+    struct ompi_request_t* request
+);
+
+/**
+ *  PART instance.
+ */
+
+struct mca_part_base_module_1_0_1_t {
+
+    /* downcalls from MCA to PART */
+    mca_part_base_module_progress_fn_t    part_progress;
+
+    /* downcalls from MPI to PART */
+    mca_part_base_module_precv_init_fn_t  part_precv_init;
+    mca_part_base_module_psend_init_fn_t  part_psend_init;
+    mca_part_base_module_start_fn_t       part_start; 
+    mca_part_base_module_pready_fn_t      part_pready;
+    mca_part_base_module_parrived_fn_t    part_parrived;
+    /* diagnostics */
+
+    /* FT Event */
+
+    /* maximum constant sizes */
+};
+typedef struct mca_part_base_module_1_0_1_t mca_part_base_module_1_0_1_t;
+typedef mca_part_base_module_1_0_1_t mca_part_base_module_t;
+
+/*
+ * Macro for use in components that are of type part
+ */
+#define MCA_PART_BASE_VERSION_2_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("part", 4, 0, 0)
+
+OMPI_DECLSPEC extern mca_part_base_module_t mca_part;
+
+END_C_DECLS
+#endif /* MCA_PART_H */

--- a/ompi/mca/part/rma/Makefile.am
+++ b/ompi/mca/part/rma/Makefile.am
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009      High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+EXTRA_DIST = post_configure.sh
+
+if MCA_BUILD_ompi_part_rma_DSO
+component_noinst =
+component_install = mca_part_rma.la
+else
+component_noinst = libmca_part_rma.la
+component_install =
+endif
+
+local_sources = \
+	part_rma.c \
+	part_rma.h \
+	part_rma_component.c \
+	part_rma_component.h \
+	part_rma_recvreq.h \
+	part_rma_recvreq.c \
+	part_rma_request.h \
+	part_rma_request.c \
+	part_rma_sendreq.h \
+	part_rma_sendreq.c 
+
+mcacomponentdir = $(ompilibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_part_rma_la_SOURCES = $(local_sources)
+mca_part_rma_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(part_rma_LIBS)
+mca_part_rma_la_LDFLAGS = -module -avoid-version $(part_rma_LDFLAGS)
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_part_rma_la_SOURCES = $(local_sources)
+libmca_part_rma_la_LIBADD = $(part_rma_LIBS)
+libmca_part_rma_la_LDFLAGS = -module -avoid-version $(part_rma_LDFLAGS)
+

--- a/ompi/mca/part/rma/part_rma.c
+++ b/ompi/mca/part/rma/part_rma.c
@@ -1,0 +1,68 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2006-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/part/base/part_base_prequest.h"
+#include "ompi/mca/part/base/base.h"
+
+#include "part_rma.h"
+#include "part_rma_sendreq.h"
+#include "part_rma_recvreq.h"
+
+ompi_part_rma_t ompi_part_rma = {
+    {
+        mca_part_rma_progress,
+        mca_part_rma_precv_init,
+        mca_part_rma_psend_init,
+        mca_part_rma_start,
+        mca_part_rma_pready,
+        mca_part_rma_parrived, 
+    }
+};
+
+
+int mca_part_rma_create_pcomm(ompi_communicator_t* comm,
+                               int rank_count,
+                               const int ranks[],
+                               int tag,
+                               ompi_communicator_t** new_comm)
+{
+    int err = OMPI_SUCCESS;
+    MPI_Group group_super, group_sub;
+
+    err = MPI_Comm_group(comm, &group_super);
+    if(OMPI_SUCCESS != err) return err;
+
+    err = MPI_Group_incl(group_super, rank_count, ranks, &group_sub);
+    if(OMPI_SUCCESS != err) return err;
+
+    err = MPI_Comm_create_group(comm, group_sub, tag, new_comm);
+    return err;
+}
+
+
+OBJ_CLASS_INSTANCE(mca_part_rma_list_t,
+                   opal_list_item_t,
+                   NULL,
+                   NULL);
+

--- a/ompi/mca/part/rma/part_rma.h
+++ b/ompi/mca/part/rma/part_rma.h
@@ -1,0 +1,498 @@
+/*
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * Copyright (c) 2019-2020 The University of Tennessee at Chattanooga and The University
+ *                         of Tennessee Research Foundation. All rights 
+ *                         reserved.
+ * Copyright (c) 2019-2020 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PART_RMA_H
+#define PART_RMA_H
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/mca/part/base/base.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/request/request.h"
+#include "opal/sys/atomic.h"
+
+#include "part_rma_request.h"
+#include "ompi/mca/part/base/part_base_precvreq.h"
+#include "part_rma_recvreq.h"
+#include "part_rma_sendreq.h"
+#include "ompi/message/message.h"
+
+BEGIN_C_DECLS
+
+typedef struct mca_part_rma_list_t {
+    opal_list_item_t        super;
+    mca_part_rma_request_t *item;
+} mca_part_rma_list_t;
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_part_rma_list_t);
+
+
+struct ompi_part_rma_t {
+    mca_part_base_module_t super;
+    int                    free_list_num;
+    int                    free_list_max;
+    int                    free_list_inc;
+    opal_list_t           *progress_list;
+
+    /* This is used to protect the progress engine, in cases were progress threads and thread multiple are active. */
+    opal_mutex_t lock; 
+};
+typedef struct ompi_part_rma_t ompi_part_rma_t;
+extern ompi_part_rma_t ompi_part_rma;
+
+/**
+ * This is a helper function that frees a request. This requires ompi_part_rma.lock be held before calling.
+ */
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_free_req(struct mca_part_rma_request_t* req)
+{
+    int err = OMPI_SUCCESS;
+
+    opal_list_remove_item(ompi_part_rma.progress_list, (opal_list_item_t*)req->progress_elem);
+    OBJ_RELEASE(req->progress_elem);
+    err = MPI_Win_flush_all(req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    err = MPI_Win_flush_all(req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    err = MPI_Win_unlock_all(req->req_data_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    err = MPI_Win_unlock_all(req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Comm_free(&(req->req_window_comm));
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    free((void*)req->req_counters);
+    free((void*)req->req_flags);
+
+    if( MCA_PART_RMA_REQUEST_PRECV == req->req_type ) {
+        MCA_PART_RMA_PRECV_REQUEST_RETURN(req);
+    } else {
+        MCA_PART_RMA_PSEND_REQUEST_RETURN(req);
+    }
+    return err;
+}
+
+
+/**
+ * This is a helper function for the progress engine, it checks a single request for completion
+ * and sets the complete flag based on that. 
+ */
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_test(struct mca_part_rma_request_t* request)
+{
+    int finished = 1;
+    int i;
+    for(i = 0; i < request->req_flags_size; i++) {
+        finished = request->req_flags[i] && finished;
+    }
+    if(1 == finished) {
+        if(MCA_PART_RMA_REQUEST_PRECV == request->req_type) {
+            request->req_ompi.req_status.MPI_SOURCE = request->req_peer; 
+        } else {
+            request->req_ompi.req_status.MPI_SOURCE = request->req_comm->c_my_rank;
+        }
+        request->req_ompi.req_complete_cb = NULL;
+        request->req_ompi.req_status.MPI_TAG = request->req_tag;  
+        request->req_ompi.req_status._ucount = request->req_bytes;
+        request->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
+        request->req_part_complete = true;
+        ompi_request_complete(&(request->req_ompi), true );
+    }
+    return finished;
+}
+
+__opal_attribute_always_inline__ static inline void mca_part_rma_init_lists(void)
+{
+    opal_free_list_init (&mca_part_base_precv_requests,
+                         sizeof(mca_part_rma_precv_request_t),
+                         opal_cache_line_size,
+                         OBJ_CLASS(mca_part_rma_precv_request_t),
+                         0,opal_cache_line_size,
+                         ompi_part_rma.free_list_num,
+                         ompi_part_rma.free_list_max,
+                         ompi_part_rma.free_list_inc,
+                         NULL, 0, NULL, NULL, NULL);
+    opal_free_list_init (&mca_part_base_psend_requests,
+                         sizeof(mca_part_rma_psend_request_t),
+                         opal_cache_line_size,
+                         OBJ_CLASS(mca_part_rma_psend_request_t),
+                         0,opal_cache_line_size,
+                         ompi_part_rma.free_list_num,
+                         ompi_part_rma.free_list_max,
+                         ompi_part_rma.free_list_inc,
+                         NULL, 0, NULL, NULL, NULL);
+     ompi_part_rma.progress_list = OBJ_NEW(opal_list_t);
+}
+
+/**
+ * mca_part_rma_progress is the progress function that will be registered. It handles 
+ * both send and recv request testing and completion. It also handles freeing requests,
+ * after MPI_Free is called and the requests have become inactive.
+ */
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_progress(void)
+{
+    mca_part_rma_list_t *current;
+
+    OPAL_THREAD_LOCK(&ompi_part_rma.lock);
+ 
+    mca_part_rma_request_t* to_delete = NULL;
+
+    OPAL_LIST_FOREACH(current, ompi_part_rma.progress_list, mca_part_rma_list_t) {
+        mca_part_rma_request_t *req = (mca_part_rma_request_t *) current->item;
+
+        if(false == req->req_part_complete && REQUEST_COMPLETED != req->req_ompi.req_complete && OMPI_REQUEST_ACTIVE == req->req_ompi.req_state) {
+            mca_part_rma_test(req);
+        }
+
+        if(true == req->req_free_called && true == req->req_part_complete && REQUEST_COMPLETED == req->req_ompi.req_complete &&  OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
+            to_delete = req;
+        }
+
+    }
+    if(to_delete) {
+        int err = mca_part_rma_free_req(to_delete);
+        if(MPI_SUCCESS != err) return OMPI_ERROR;
+    }
+    OPAL_THREAD_UNLOCK(&ompi_part_rma.lock);
+
+    return OMPI_SUCCESS;
+}
+
+/*
+ * This is a helper function for creating a communicater in psend_init and precv_init
+ */
+OMPI_DECLSPEC extern int mca_part_rma_create_pcomm(ompi_communicator_t* comm,
+                                                   int rank_count,
+                                                   const int ranks[],
+                                                   int tag,
+                                                   ompi_communicator_t** new_comm);
+
+/*
+ * This is a helper function for the init calls
+ */
+__opal_attribute_always_inline__ static inline int 
+mca_part_rma_gcd(int a, int b)
+{
+    if (0 == a || 0 == b) return 0;
+    else if (a == b)      return a;
+    else if (a > b)       return mca_part_rma_gcd(a-b, b);
+    else                  return mca_part_rma_gcd(a, b-a);
+}
+
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_precv_init(void *buf,
+                        size_t parts, 
+                        size_t count,
+                        ompi_datatype_t * datatype,
+                        int src,
+                        int tag,
+                        struct ompi_communicator_t *comm,
+                        struct ompi_request_t **request)
+{
+    int err = MPI_SUCCESS;
+    int rank_super;
+    int ranks[2];
+    int remote_part = 0;
+    int dt_size;
+    mca_part_rma_list_t* new_progress_elem = NULL;
+    mca_part_rma_precv_request_t *recvreq;
+
+    /* Allocate a new request */
+    MCA_PART_RMA_PRECV_REQUEST_ALLOC(recvreq);
+    if (OPAL_UNLIKELY(NULL == recvreq)) return OMPI_ERR_OUT_OF_RESOURCE;
+
+    MCA_PART_RMA_PRECV_REQUEST_INIT(recvreq, ompi_proc, comm, tag, src,
+                                     datatype, buf, parts, count, flags);
+
+    mca_part_rma_request_t *req = (mca_part_rma_request_t *) recvreq;
+
+    /* Initialize the new request */
+    err = MPI_Comm_rank(comm, &rank_super);
+    if(MPI_SUCCESS != err) return OMPI_ERROR; 
+
+    ranks[0] = src; ranks[1] = rank_super;
+    mca_part_rma_create_pcomm(comm, 2, ranks, tag, &req->req_window_comm);
+
+    err = MPI_Recv(&remote_part, 1, MPI_INT, 0, 0, req->req_window_comm, MPI_STATUS_IGNORE);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    err = MPI_Send(&parts, 1, MPI_INT, 0, 0, req->req_window_comm);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    req->req_flags_size = mca_part_rma_gcd(parts,remote_part);
+    req->req_counter_thresh = parts / req->req_flags_size;
+
+    req->req_counters = (int*) malloc(sizeof(int)* req->req_flags_size);
+    req->req_flags  = (int*) malloc(sizeof(int)* req->req_flags_size);
+
+    err = MPI_Type_size(req->req_datatype, &dt_size);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    req->req_bytes = parts * count * dt_size;
+    err = MPI_Win_create((void*)(req->req_addr),
+                         parts * count * dt_size,
+                         dt_size,
+                         MPI_INFO_NULL,
+                         req->req_window_comm,
+                         &req->req_data_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+ 
+    err = MPI_Win_lock_all(0, req->req_data_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Win_create(req->req_flags,
+                         req->req_flags_size * sizeof(int),
+                         sizeof(int),
+                         MPI_INFO_NULL,
+                         req->req_window_comm,
+                         &req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Win_lock_all(0, req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    new_progress_elem = OBJ_NEW(mca_part_rma_list_t);
+    new_progress_elem->item = req;
+    req->progress_elem = new_progress_elem; 
+
+    req->req_ompi.req_persistent = true;
+    req->req_part_complete = true;
+    req->req_ompi.req_complete = REQUEST_COMPLETED;
+    req->req_ompi.req_state = OMPI_REQUEST_INACTIVE;
+
+    *request = (ompi_request_t*) recvreq;
+
+    OPAL_THREAD_LOCK(&ompi_part_rma.lock);
+    opal_list_append(ompi_part_rma.progress_list, (opal_list_item_t*)new_progress_elem);
+    OPAL_THREAD_UNLOCK(&ompi_part_rma.lock);
+
+    return err;
+}
+
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_psend_init(const void* buf,
+                        size_t parts,
+                        size_t count,
+                        ompi_datatype_t* datatype,
+                        int dst,
+                        int tag,
+                        ompi_communicator_t* comm,
+                        ompi_request_t** request)
+{
+    int err = MPI_SUCCESS;
+    int rank_super;
+    int ranks[2];
+    int remote_part = 0;
+    int dt_size;
+    mca_part_rma_list_t* new_progress_elem = NULL;
+    mca_part_rma_psend_request_t *sendreq;
+
+
+
+    MCA_PART_RMA_PSEND_REQUEST_ALLOC(sendreq, comm, dst, ompi_proc);
+    if (OPAL_UNLIKELY(NULL == sendreq)) return OMPI_ERR_OUT_OF_RESOURCE;
+
+    MCA_PART_RMA_PSEND_REQUEST_INIT(sendreq, ompi_proc, comm, tag, dst,
+                                    datatype, buf, parts, count, flags);
+
+    mca_part_rma_request_t *req = (mca_part_rma_request_t *) sendreq;
+
+    err = MPI_Comm_rank(comm, &rank_super);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    ranks[0] = rank_super; ranks[1] = dst;
+    mca_part_rma_create_pcomm(comm, 2, ranks, tag, &req->req_window_comm); 
+
+    err = MPI_Send(&parts, 1, MPI_INT, 1, 0, req->req_window_comm);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Recv(&remote_part, 1, MPI_INT, 1, 0, req->req_window_comm, MPI_STATUS_IGNORE);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    req->req_flags_size = mca_part_rma_gcd(parts,remote_part);
+    req->req_counter_thresh = parts / req->req_flags_size;
+
+    req->req_counters = (int*) malloc(sizeof(int)* req->req_flags_size);
+    req->req_flags    = (int*) malloc(sizeof(int)* req->req_flags_size);
+
+    err = MPI_Type_size(req->req_datatype, &dt_size);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+    req->req_bytes = parts * count * dt_size;
+
+    err = MPI_Win_create(0,
+                         0,
+                         dt_size,
+                         MPI_INFO_NULL,
+                         req->req_window_comm,
+                         &req->req_data_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Win_lock_all(0, req->req_data_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Win_create(0,
+                         0,
+                         sizeof(int),
+                         MPI_INFO_NULL,
+                         req->req_window_comm,
+                         &req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    err = MPI_Win_lock_all(0, req->req_flags_window);
+    if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+    new_progress_elem = OBJ_NEW(mca_part_rma_list_t);
+    new_progress_elem->item = req;
+    req->progress_elem = new_progress_elem; 
+
+    sendreq->req_base.req_ompi.req_persistent = true;
+
+
+    req->req_part_complete = true;
+    req->req_ompi.req_complete = REQUEST_COMPLETED;
+    req->req_ompi.req_state = OMPI_REQUEST_INACTIVE;
+
+    *request = (ompi_request_t*) sendreq;
+
+    OPAL_THREAD_LOCK(&ompi_part_rma.lock);
+    opal_list_append(ompi_part_rma.progress_list, (opal_list_item_t*)new_progress_elem);
+    OPAL_THREAD_UNLOCK(&ompi_part_rma.lock);
+
+    return err;
+}
+
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_start(size_t count, ompi_request_t** requests)
+{
+    int err = MPI_SUCCESS;
+    size_t i;
+    int32_t j;
+
+    for(i = 0; i < count; i++) {
+        mca_part_rma_request_t *req = (mca_part_rma_request_t*) requests[i];
+        if(true == req->req_free_called) return OMPI_ERROR;
+
+        for(j = 0; j < req->req_flags_size; ++j) {
+            req->req_counters[j] = req->req_flags[j] = 0;
+        }
+
+        /* init/re-init the request */                                      
+        req->req_ompi.req_state = OMPI_REQUEST_ACTIVE;         
+        req->req_ompi.req_status.MPI_TAG = MPI_ANY_TAG;       
+        req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;     
+        req->req_ompi.req_status._cancelled = 0;               
+        req->req_part_complete = false;
+        req->req_ompi.req_complete = false;
+        OPAL_ATOMIC_SWAP_PTR(&req->req_ompi.req_complete, REQUEST_PENDING);
+    }
+    return err;
+}
+
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_pready(size_t min_part,
+                    size_t max_part,
+                    ompi_request_t* request)
+{
+    int err = MPI_SUCCESS;
+    size_t i;
+    for(i = min_part; i <= max_part; i++) {
+        int datatype_size;
+        int receiver = 1;
+        MPI_Aint displacement;
+        void* head;
+        int bin;
+        int32_t current_bin_size;
+
+        mca_part_rma_request_t *req = (mca_part_rma_request_t *)request;
+
+        err = MPI_Type_size(req->req_datatype, &datatype_size);
+        if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+        displacement = i * req->req_count;
+        head = ((char*)req->req_addr)+(displacement * datatype_size);
+        err = MPI_Put(head, req->req_count, req->req_datatype, receiver,
+                     displacement, req->req_count, req->req_datatype, req->req_data_window);
+        if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+        bin = i / req->req_counter_thresh;
+        current_bin_size = opal_atomic_add_fetch_32(&(req->req_flags[bin]), 1);
+
+        if(current_bin_size == req->req_counter_thresh) {
+            req->req_flags[bin] = 1;
+
+            err = MPI_Win_flush_all(req->req_data_window);
+            if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+            err = MPI_Put(&(req->req_flags[bin]), 1, MPI_INT, receiver, bin, 1, MPI_INT, req->req_flags_window);
+            if(MPI_SUCCESS != err) return OMPI_ERROR;
+
+            err = MPI_Win_flush_all(req->req_flags_window);
+            if(MPI_SUCCESS != err) return OMPI_ERROR;
+        }
+
+    }
+    return err;
+}
+
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_parrived(size_t min_part,
+                      size_t max_part,
+                      int* flag, 
+                      ompi_request_t* request)
+{
+    int err = MPI_SUCCESS;
+    size_t i, index;
+    int _flag = 1;
+    for(i = min_part; i <= max_part; i++) {
+        mca_part_rma_request_t *req = (mca_part_rma_request_t *)request;
+        index = i / req->req_counter_thresh;
+
+        _flag = req->req_flags[index] && _flag;
+    }
+    *flag = _flag;
+    return err;
+}
+
+
+/**
+ * mca_part_rma_free marks an entry as free called and sets the request to 
+ * MPI_REQUEST_NULL. Note: requests get freed in the progress engine. 
+ */
+__opal_attribute_always_inline__ static inline int
+mca_part_rma_free(ompi_request_t** request)
+{
+    mca_part_rma_request_t* req = *(mca_part_rma_request_t**)request;
+
+    if(true == req->req_free_called) return OMPI_ERROR;
+    req->req_free_called = true;
+
+    *request = MPI_REQUEST_NULL;
+    return OMPI_SUCCESS;
+}
+
+END_C_DECLS
+
+#endif  /* PART_RMA_H_HAS_BEEN_INCLUDED */

--- a/ompi/mca/part/rma/part_rma_component.c
+++ b/ompi/mca/part/rma/part_rma_component.c
@@ -1,0 +1,129 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2006-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "part_rma.h"
+#include "opal/mca/event/event.h"
+
+#include "part_rma_sendreq.h"
+#include "part_rma_recvreq.h"
+#include "part_rma_component.h"
+
+static int mca_part_rma_component_register(void);
+static int mca_part_rma_component_open(void);
+static int mca_part_rma_component_close(void);
+static mca_part_base_module_t* mca_part_rma_component_init( int* priority,
+                            bool enable_progress_threads, bool enable_mpi_threads);
+static int mca_part_rma_component_fini(void);
+
+mca_part_base_component_4_0_0_t mca_part_rma_component = {
+    /* First, the mca_base_component_t struct containing meta
+     * information about the component itself */
+
+    .partm_version = {
+        MCA_PART_BASE_VERSION_2_0_0,
+
+        .mca_component_name = "rma",
+        MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
+                              OMPI_RELEASE_VERSION),
+        .mca_open_component = mca_part_rma_component_open,
+        .mca_close_component = mca_part_rma_component_close,
+        .mca_register_component_params = mca_part_rma_component_register,
+    },
+    .partm_data = {
+        /* This component is not checkpoint ready */
+        MCA_BASE_METADATA_PARAM_NONE
+    },
+
+    .partm_init = mca_part_rma_component_init,
+    .partm_finalize = mca_part_rma_component_fini,
+};
+
+static int
+mca_part_rma_component_register(void)
+{
+    ompi_part_rma.free_list_num = 4;
+    (void) mca_base_component_var_register(&mca_part_rma_component.partm_version, "free_list_num",
+                                           "Initial size of request free lists",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_part_rma.free_list_num);
+
+    ompi_part_rma.free_list_max = -1;
+    (void) mca_base_component_var_register(&mca_part_rma_component.partm_version, "free_list_max",
+                                           "Maximum size of request free lists",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_part_rma.free_list_max);
+
+    ompi_part_rma.free_list_inc = 64;
+    (void) mca_base_component_var_register(&mca_part_rma_component.partm_version, "free_list_inc",
+                                           "Number of elements to add when growing request free lists",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_part_rma.free_list_inc);
+
+
+    return OPAL_SUCCESS;
+}
+
+static int
+mca_part_rma_component_open(void)
+{
+    OBJ_CONSTRUCT(&ompi_part_rma.lock, opal_mutex_t);
+ 
+    mca_part_rma_init_lists();
+
+    return OMPI_SUCCESS;
+}
+
+
+static int
+mca_part_rma_component_close(void)
+{
+    OBJ_DESTRUCT(&ompi_part_rma.lock);
+    return OMPI_SUCCESS; 
+}
+
+
+static mca_part_base_module_t*
+mca_part_rma_component_init(int* priority,
+                            bool enable_progress_threads,
+                            bool enable_mpi_threads)
+{
+    *priority = 1;
+
+    opal_output_verbose( 10, 0,
+                         "in rma part priority is %d\n", *priority);
+    return &ompi_part_rma.super;
+}
+
+
+static int
+mca_part_rma_component_fini(void)
+{
+    return OMPI_SUCCESS;
+}
+

--- a/ompi/mca/part/rma/part_rma_component.h
+++ b/ompi/mca/part/rma/part_rma_component.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ *  @file
+ */
+
+#ifndef MCA_PART_RMA_COMPONENT_H
+#define MCA_PART_RMA_COMPONENT_H
+
+BEGIN_C_DECLS
+
+/*
+ * PART module functions.
+ */
+OMPI_MODULE_DECLSPEC extern mca_part_base_component_4_0_0_t mca_part_rma_component;
+
+END_C_DECLS
+
+#endif

--- a/ompi/mca/part/rma/part_rma_recvreq.c
+++ b/ompi/mca/part/rma/part_rma_recvreq.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "part_rma.h"
+#include "part_rma_recvreq.h"
+
+
+static void
+mca_part_rma_precv_request_construct(mca_part_rma_precv_request_t* recvreq)
+{
+    recvreq->req_base.req_ompi.req_start = mca_part_rma_start;
+    recvreq->req_base.req_ompi.req_free = mca_part_rma_free;
+    recvreq->req_base.req_ompi.req_cancel = NULL; 
+    recvreq->req_base.req_ompi.req_persistent = true; // All Partitioned requests are persistant (for now?)
+    OBJ_CONSTRUCT( &(recvreq->req_base.req_convertor), opal_convertor_t );
+}
+
+
+OBJ_CLASS_INSTANCE(mca_part_rma_precv_request_t,
+                   mca_part_rma_request_t,
+                   mca_part_rma_precv_request_construct,
+                   NULL);
+

--- a/ompi/mca/part/rma/part_rma_recvreq.h
+++ b/ompi/mca/part/rma/part_rma_recvreq.h
@@ -1,0 +1,103 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2020 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PART_RMA_RECVREQ_H
+#define PART_RMA_RECVREQ_H
+
+#include "part_rma_request.h"
+#include "ompi/mca/part/base/part_base_precvreq.h"
+
+struct mca_part_rma_precv_request_t {
+    mca_part_rma_request_t req_base;
+};
+typedef struct mca_part_rma_precv_request_t mca_part_rma_precv_request_t;
+OBJ_CLASS_DECLARATION(mca_part_rma_precv_request_t);
+
+/**
+ *  Allocate a recv request from the modules free list.
+ *
+ *  @param rc (OUT)  OMPI_SUCCESS or error status on failure.
+ *  @return          Receive request.
+ */
+#define MCA_PART_RMA_PRECV_REQUEST_ALLOC(precvreq)                           \
+do {                                                                         \
+    precvreq = (mca_part_rma_precv_request_t*)                               \
+      opal_free_list_get (&mca_part_base_precv_requests);                    \
+    precvreq->req_base.req_type = MCA_PART_RMA_REQUEST_PRECV;            \
+ } while (0)
+
+/**
+ * Initialize a receive request with call parameters.
+ *
+ * @param request (IN)       Receive request.
+ * @param addr (IN)          User buffer.
+ * @param count (IN)         Number of elements of indicated datatype.
+ * @param datatype (IN)      User defined datatype.
+ * @param src (IN)           Source rank w/in the communicator.
+ * @param comm (IN)          Communicator.
+ * @param persistent (IN)    Is this a ersistent request.
+ */
+#define MCA_PART_RMA_PRECV_REQUEST_INIT( request,                     \
+                                         ompi_proc,                   \
+                                         comm,                        \
+                                         tag,                         \
+                                         src,                         \
+                                         datatype,                    \
+                                         addr,                        \
+                                         parts,                       \
+                                         count,                       \
+                                         flags )                      \
+do {                                                                  \
+        OBJ_RETAIN(comm);                                             \
+        OMPI_DATATYPE_RETAIN(datatype);                               \
+        (request)->req_base.req_comm = comm;                         \
+        (request)->req_base.req_datatype = datatype;                 \
+        (request)->req_base.req_ompi.req_mpi_object.comm = comm;     \
+        (request)->req_base.req_ompi.req_status.MPI_SOURCE = src;    \
+        (request)->req_base.req_ompi.req_status.MPI_TAG = tag;       \
+        (request)->req_base.req_part_complete = true;                \
+        (request)->req_base.req_ompi.req_status._ucount = count;     \
+        (request)->req_base.req_free_called = false;                 \
+        (request)->req_base.req_addr = addr;                       /**< pointer to application buffer */\
+        (request)->req_base.req_parts = parts;                /**< number of partitions */\
+        (request)->req_base.req_count = count;                     /**< count of user datatype elements */\
+        (request)->req_base.req_peer = src;                     /**< peer process - rank w/in this communicator */\
+        (request)->req_base.req_tag = tag;                           \
+} while(0)
+
+/**
+ *  Free the PART receive request
+ */
+#define MCA_PART_RMA_PRECV_REQUEST_RETURN(recvreq)                      \
+{                                                                       \
+    OBJ_RELEASE((recvreq)->req_comm);                          \
+    OMPI_DATATYPE_RELEASE((recvreq)->req_datatype);            \
+    OMPI_REQUEST_FINI(&(recvreq)->req_ompi);                   \
+    opal_convertor_cleanup( &((recvreq)->req_convertor) );     \
+    opal_free_list_return ( &mca_part_base_precv_requests,               \
+                           (opal_free_list_item_t*)(recvreq));          \
+}
+
+#endif
+
+

--- a/ompi/mca/part/rma/part_rma_request.c
+++ b/ompi/mca/part/rma/part_rma_request.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "part_rma.h"
+#include "part_rma_request.h"
+
+
+static void mca_part_rma_request_construct( mca_part_rma_request_t* req) {
+    OBJ_CONSTRUCT(&req->req_convertor, opal_convertor_t);
+    req->req_ompi.req_type = OMPI_REQUEST_PART;
+}
+
+static void mca_part_rma_request_destruct( mca_part_rma_request_t* req) {
+    OBJ_DESTRUCT(&req->req_convertor);
+}
+
+OBJ_CLASS_INSTANCE(mca_part_rma_request_t,
+                   ompi_request_t,
+                   mca_part_rma_request_construct,
+                   mca_part_rma_request_destruct);

--- a/ompi/mca/part/rma/part_rma_request.h
+++ b/ompi/mca/part/rma/part_rma_request.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PART_RMA_REQUEST_H
+#define PART_RMA_REQUEST_H
+
+#include "ompi/mca/part/base/part_base_psendreq.h"
+#include "ompi/mca/part/part.h"
+#include "opal/sys/atomic.h"
+/**
+ * Type of request.
+ */
+typedef enum {
+    MCA_PART_RMA_REQUEST_PSEND,
+    MCA_PART_RMA_REQUEST_PRECV,
+    MCA_PART_RMA_REQUEST_NULL
+} mca_part_rma_request_type_t;
+
+struct mca_part_rma_list_t;
+
+/**
+ *  Base type for PART RMA requests
+ */
+struct mca_part_rma_request_t {
+
+/* START: These fields have to match the definition of the mca_part_rma_request_t */
+    ompi_request_t req_ompi;              /**< base request */
+    volatile int32_t req_part_complete;   /**< flag indicating if the pt-2-pt layer is done with this request */
+    volatile int32_t req_free_called;     /**< flag indicating if the user has freed this request */
+    mca_part_rma_request_type_t req_type; /**< MPI request type - used for test */
+    struct ompi_communicator_t *req_comm; /**< communicator pointer */
+    struct ompi_datatype_t *req_datatype; /**< pointer to data type */
+    opal_convertor_t req_convertor;       /**< always need the convertor */
+
+    const void *req_addr;                       /**< pointer to application buffer */
+    size_t req_parts;                     /**< number of partitions */
+    size_t req_count;                     /**< count of user datatype elements */
+    int32_t req_peer;                     /**< peer process - rank w/in this communicator */
+    int32_t req_tag;                      /**< user defined tag */
+    struct ompi_proc_t* req_proc;         /**< peer process */
+
+/* END: These fields have to match the definition of the mca_part_rma_request_t */
+
+    size_t  req_bytes;                    /**< bytes for completion status */
+
+    MPI_Comm req_window_comm;             /**< New communicator for the window */
+    MPI_Win req_data_window;              /**< RMA window for data transfer */
+    MPI_Win req_flags_window;             /**< RMA window for completion */
+
+    int32_t req_partitions_send;          /**< Send side number of partitions */
+    int32_t req_sent;                     /**< TODO - Does this do anything? */
+    int32_t req_partitions_recv;          /**< Recv side number of partitions */
+
+    int32_t req_flags_size;
+    int32_t req_counter_thresh;           /**< threshold for counters*/ 
+    volatile int32_t *req_counters; /**< counters for local partitions (should be size of 'req_flags_size') */
+    int32_t *req_flags; /**< completion flags to transfer (should be size of 'req_flags_size') */
+
+    struct mca_part_rma_list_t* progress_elem; /**< pointer to progress list element for removal durring free. */ 
+
+};
+typedef struct mca_part_rma_request_t mca_part_rma_request_t;
+OBJ_CLASS_DECLARATION(mca_part_rma_request_t);
+
+#endif

--- a/ompi/mca/part/rma/part_rma_sendreq.c
+++ b/ompi/mca/part/rma/part_rma_sendreq.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "part_rma.h"
+#include "part_rma_sendreq.h"
+
+
+static void mca_part_rma_psend_request_construct(mca_part_rma_psend_request_t* sendreq)
+{
+    /* no need to reinit for every send -- never changes */
+    sendreq->req_base.req_ompi.req_start = mca_part_rma_start;
+    sendreq->req_base.req_ompi.req_free = mca_part_rma_free;
+    sendreq->req_base.req_ompi.req_persistent = true;
+    sendreq->req_base.req_ompi.req_cancel = NULL;
+}
+
+OBJ_CLASS_INSTANCE(mca_part_rma_psend_request_t,
+                   mca_part_rma_request_t,
+                   mca_part_rma_psend_request_construct,
+                   NULL);
+

--- a/ompi/mca/part/rma/part_rma_sendreq.h
+++ b/ompi/mca/part/rma/part_rma_sendreq.h
@@ -1,0 +1,94 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2006 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PART_RMA_PSENDREQ_H
+#define PART_RMA_PSENDREQ_H
+
+#include "part_rma_request.h"
+#include "ompi/mca/part/base/part_base_psendreq.h"
+#include "ompi/mca/part/part.h"
+#include "opal/prefetch.h"
+
+struct mca_part_rma_psend_request_t {
+    mca_part_rma_request_t req_base;
+};
+typedef struct mca_part_rma_psend_request_t mca_part_rma_psend_request_t;
+OBJ_CLASS_DECLARATION(mca_part_rma_psend_request_t);
+
+
+#define MCA_PART_RMA_PSEND_REQUEST_ALLOC(sendreq, comm, dst,          \
+                                           ompi_proc)                 \
+do {                                                                  \
+    sendreq = (mca_part_rma_psend_request_t*)                         \
+        opal_free_list_wait (&mca_part_base_psend_requests);          \
+    sendreq->req_base.req_type = MCA_PART_RMA_REQUEST_PSEND;          \
+} while(0)
+
+#define MCA_PART_RMA_PSEND_REQUEST_INIT( req_send,                    \
+                                         ompi_proc,                   \
+                                         comm,                        \
+                                         tag,                         \
+                                         dst,                         \
+                                         datatype,                    \
+                                         buf,                         \
+                                         parts,                       \
+                                         count,                       \
+                                         flags )                      \
+    do {                                                              \
+        OMPI_REQUEST_INIT(&(sendreq->req_base.req_ompi),     \
+                          false);                                     \
+        OBJ_RETAIN(comm);                                             \
+        OMPI_DATATYPE_RETAIN(datatype);                               \
+        (req_send)->req_base.req_comm = comm;                         \
+        (req_send)->req_base.req_datatype = datatype;                 \
+        (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;     \
+        (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =         \
+        comm->c_my_rank;                                              \
+        (req_send)->req_base.req_ompi.req_status.MPI_TAG = tag;       \
+        (req_send)->req_base.req_part_complete = true;                  \
+        (req_send)->req_base.req_ompi.req_status._ucount = count;     \
+        (req_send)->req_base.req_free_called = false;                 \
+        (req_send)->req_base.req_addr = buf;                       /**< pointer to application buffer */\
+        (req_send)->req_base.req_parts = parts;                /**< number of partitions */\
+        (req_send)->req_base.req_count = count;                     /**< count of user datatype elements */\
+        (req_send)->req_base.req_peer = dst;                     /**< peer process - rank w/in this communicator */\
+        (req_send)->req_base.req_tag = tag;                      /**< user defined tag */\
+    } while(0)
+
+/*
+ * Release resources associated with a request
+ */
+#define MCA_PART_RMA_PSEND_REQUEST_RETURN(sendreq)                      \
+    {                                                                   \
+        /*  Let the base handle the reference counts */                 \
+        OMPI_DATATYPE_RETAIN(sendreq->req_datatype);  \
+        OBJ_RELEASE(sendreq->req_comm);               \
+        OMPI_REQUEST_FINI(&sendreq->req_ompi);        \
+        opal_convertor_cleanup( &(sendreq->req_convertor) ); \
+        opal_free_list_return ( &mca_part_base_psend_requests,            \
+                               (opal_free_list_item_t*)sendreq);        \
+    }
+
+#endif

--- a/ompi/mca/part/rma/post_configure.sh
+++ b/ompi/mca/part/rma/post_configure.sh
@@ -1,0 +1,1 @@
+DIRECT_CALL_HEADER="ompi/mca/part/rma/part_rma.h"

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -273,6 +273,12 @@ libmpi_c_mpi_la_SOURCES = \
         is_thread_main.c \
         isend.c \
         issend.c \
+        pready.c \
+        pready_range.c \
+        pready_list.c \
+        parrived.c \
+        psend_init.c \
+        precv_init.c \
         lookup_name.c \
         message_f2c.c \
         message_c2f.c \

--- a/ompi/mpi/c/parrived.c
+++ b/ompi/mpi/c/parrived.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Parrived = PMPI_Parrived
+#endif
+#define MPI_Parrived PMPI_Parrived
+#endif
+
+static const char FUNC_NAME[] = "MPI_Parrived";
+
+
+int MPI_Parrived(MPI_Request request, MPI_Count partition,  int *flag)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+
+    rc = mca_part.part_parrived(partition, partition, flag, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready.c
+++ b/ompi/mpi/c/pready.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Pready = PMPI_Pready
+#endif
+#define MPI_Pready PMPI_Pready
+#endif
+
+static const char FUNC_NAME[] = "MPI_Pready";
+
+
+int MPI_Pready(int partition, MPI_Request request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+
+    rc = mca_part.part_pready(partition, partition, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready_list.c
+++ b/ompi/mpi/c/pready_list.c
@@ -1,0 +1,68 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Pready_list = PMPI_Pready_list
+#endif
+#define MPI_Pready_list PMPI_Pready_list
+#endif
+
+static const char FUNC_NAME[] = "MPI_Pready_list";
+
+
+int MPI_Pready_list(int length, int* partitions, MPI_Request request)
+{
+    int rc = OMPI_SUCCESS;
+    int i; 
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+    
+    for(i = 0; i < length && OMPI_SUCCESS == rc; i++) {
+        rc = mca_part.part_pready(partitions[i], partitions[i], request);
+    }
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready_range.c
+++ b/ompi/mpi/c/pready_range.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Pready_range = PMPI_Pready_range
+#endif
+#define MPI_Pready_range PMPI_Pready_range
+#endif
+
+static const char FUNC_NAME[] = "MPI_Pready_range";
+
+
+int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+
+    rc = mca_part.part_pready(partition_low, partition_high, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Precv_init = PMPI_Precv_init
+#endif
+#define MPI_Precv_init PMPI_Precv_init
+#endif
+
+static const char FUNC_NAME[] = "MPI_Precv_init";
+
+
+int MPI_Precv_init(const void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+
+    rc = mca_part.part_precv_init(buf, partitions, count, datatype, source, tag, comm, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -253,6 +253,12 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pis_thread_main.c \
         pisend.c \
         pissend.c \
+        ppready.c \
+        ppready_range.c \
+        ppready_list.c \
+        pparrived.c \
+        ppsend_init.c \
+        pprecv_init.c \
         plookup_name.c \
         pmessage_f2c.c \
         pmessage_c2f.c \

--- a/ompi/mpi/c/psend_init.c
+++ b/ompi/mpi/c/psend_init.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Psend_init = PMPI_Psend_init
+#endif
+#define MPI_Psend_init PMPI_Psend_init
+#endif
+
+static const char FUNC_NAME[] = "MPI_Psend_init";
+
+
+int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
+
+    rc = mca_part.part_psend_init(buf, partitions, count, datatype, dest, tag, comm, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,6 +69,7 @@ int MPI_Start(MPI_Request *request)
     switch((*request)->req_type) {
     case OMPI_REQUEST_PML:
     case OMPI_REQUEST_COLL:
+    case OMPI_REQUEST_PART:
         if ( MPI_PARAM_CHECK && !(*request)->req_persistent) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_REQUEST, FUNC_NAME);
         }

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -340,6 +340,12 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         iscatter_f.c \
         iscatterv_f.c \
         issend_f.c \
+	parrived_f.c \
+	pready_f.c \
+	pready_list_f.c \
+	pready_range_f.c \
+	precv_init_f.c \
+	psend_init_f.c \
         is_thread_main_f.c \
         keyval_create_f.c \
         keyval_free_f.c \

--- a/ompi/mpi/fortran/mpif-h/parrived_f.c
+++ b/ompi/mpi/fortran/mpif-h/parrived_f.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PARRIVED = ompi_parrived_f
+#pragma weak pmpi_parrived = ompi_parrived_f
+#pragma weak pmpi_parrived_ = ompi_parrived_f
+#pragma weak pmpi_parrived__ = ompi_parrived_f
+
+#pragma weak PMPI_Parrived_f = ompi_parrived_f
+#pragma weak PMPI_Parrived_f08 = ompi_parrived_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PARRIVED,
+                           pmpi_parrived,
+                           pmpi_parrived_,
+                           pmpi_parrived__,
+                           pompi_parrived_f,
+                           (MPI_Fint *request, MPI_Fint *partition, MPI_Fint *flag, MPI_Fint *ierr),
+                           (request, partition, flag, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PARRIVED = ompi_parrived_f
+#pragma weak mpi_parrived = ompi_parrived_f
+#pragma weak mpi_parrived_ = ompi_parrived_f
+#pragma weak mpi_parrived__ = ompi_parrived_f
+
+#pragma weak MPI_Parrived_f = ompi_parrived_f
+#pragma weak MPI_Parrived_f08 = ompi_parrived_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PARRIVED,
+                           mpi_parrived,
+                           mpi_parrived_,
+                           mpi_parrived__,
+                           ompi_parrived_f,
+                           (MPI_Fint *request, MPI_Fint *partition, MPI_Fint *flag, MPI_Fint *ierr),
+                           (request, partition, flag, ierr) )
+#else
+#define ompi_parrived_f pompi_parrived_f
+#endif
+#endif
+
+
+void ompi_parrived_f(MPI_Fint *request, MPI_Fint *partition, ompi_fortran_logical_t *flag, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Request c_req = PMPI_Request_f2c(*request);
+    OMPI_LOGICAL_NAME_DECL(flag);
+
+    c_ierr = PMPI_Parrived(c_req, OMPI_FINT_2_INT(*partition), OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+
+    OMPI_SINGLE_INT_2_LOGICAL(flag);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr && *flag) {
+        *request = OMPI_INT_2_FINT(c_req->req_f_to_c_index);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/pready_f.c
+++ b/ompi/mpi/fortran/mpif-h/pready_f.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PREADY = ompi_pready_f
+#pragma weak pmpi_pready = ompi_pready_f
+#pragma weak pmpi_pready_ = ompi_pready_f
+#pragma weak pmpi_pready__ = ompi_pready_f
+
+#pragma weak PMPI_Pready_f = ompi_pready_f
+#pragma weak PMPI_Pready_f08 = ompi_pready_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PREADY,
+                           pmpi_pready,
+                           pmpi_pready_,
+                           pmpi_pready__,
+                           pompi_pready_f,
+                           (MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr),
+                           (partition, request, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PREADY = ompi_pready_f
+#pragma weak mpi_pready = ompi_pready_f
+#pragma weak mpi_pready_ = ompi_pready_f
+#pragma weak mpi_pready__ = ompi_pready_f
+
+#pragma weak MPI_Pready_f = ompi_pready_f
+#pragma weak MPI_Pready_f08 = ompi_pready_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PREADY,
+                           mpi_pready,
+                           mpi_pready_,
+                           mpi_pready__,
+                           ompi_pready_f,
+                           (MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr),
+                           (partition, request, ierr) )
+#else
+#define ompi_pready_f pompi_pready_f
+#endif
+#endif
+
+
+void ompi_pready_f(MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr)
+{
+   int c_ierr;
+   MPI_Request c_req = PMPI_Request_f2c(*request);
+
+   c_ierr = PMPI_Pready(OMPI_FINT_2_INT(*partition), c_req);
+   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+
+   if (MPI_SUCCESS == c_ierr) 
+   {
+       *request = PMPI_Request_c2f(c_req);
+   }
+}

--- a/ompi/mpi/fortran/mpif-h/pready_list_f.c
+++ b/ompi/mpi/fortran/mpif-h/pready_list_f.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PREADY_LIST = ompi_pready_list_f
+#pragma weak pmpi_pready_list = ompi_pready_list_f
+#pragma weak pmpi_pready_list_ = ompi_pready_list_f
+#pragma weak pmpi_pready_list__ = ompi_pready_list_f
+
+#pragma weak PMPI_Pready_list_f = ompi_pready_list_f
+#pragma weak PMPI_Pready_list_f08 = ompi_pready_list_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PREADY_LIST,
+                           pmpi_pready_list,
+                           pmpi_pready_list_,
+                           pmpi_pready_list__,
+                           pompi_pready_list_f,
+                           (MPI_Fint *length, MPI_Fint *partitions, MPI_Fint *request, MPI_Fint *ierr),
+                           (length, partitions, request, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PREADY_LIST = ompi_pready_list_f
+#pragma weak mpi_pready_list = ompi_pready_list_f
+#pragma weak mpi_pready_list_ = ompi_pready_list_f
+#pragma weak mpi_pready_list__ = ompi_pready_list_f
+
+#pragma weak MPI_Pready_list_f = ompi_pready_list_f
+#pragma weak MPI_Pready_list_f08 = ompi_pready_list_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PREADY_LIST,
+                           mpi_pready_list,
+                           mpi_pready_list_,
+                           mpi_pready_list__,
+                           ompi_pready_list_f,
+                           (MPI_Fint *length, MPI_Fint *partitions, MPI_Fint *request, MPI_Fint *ierr),
+                           (length, partitions, request, ierr) )
+#else
+#define ompi_pready_list_f pompi_pready_list_f
+#endif
+#endif
+
+
+void ompi_pready_list_f(MPI_Fint *length, MPI_Fint *partitions, MPI_Fint *request, MPI_Fint *ierr)
+{
+   int c_ierr, i;
+   MPI_Request c_req = PMPI_Request_f2c(*request);
+   int *c_partitions = (int*)malloc(sizeof(int)*OMPI_FINT_2_INT(*length));
+   for(i = 0; i < OMPI_FINT_2_INT(*length); i++)
+   {
+       c_partitions[i] = OMPI_FINT_2_INT(partitions[i]);
+   }
+
+   c_ierr = PMPI_Pready_list(OMPI_FINT_2_INT(*length), c_partitions, c_req);
+  
+   free(c_partitions);
+
+   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+   if (MPI_SUCCESS == c_ierr) {
+      *request = PMPI_Request_c2f(c_req);
+   }
+}

--- a/ompi/mpi/fortran/mpif-h/pready_range_f.c
+++ b/ompi/mpi/fortran/mpif-h/pready_range_f.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PREADY_RANGE = ompi_pready_range_f
+#pragma weak pmpi_pready_range = ompi_pready_range_f
+#pragma weak pmpi_pready_range_ = ompi_pready_range_f
+#pragma weak pmpi_pready_range__ = ompi_pready_range_f
+
+#pragma weak PMPI_Pready_range_f = ompi_pready_range_f
+#pragma weak PMPI_Pready_range_f08 = ompi_pready_range_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PREADY_RANGE,
+                           pmpi_pready_range,
+                           pmpi_pready_range_,
+                           pmpi_pready_range__,
+                           pompi_pready_range_f,
+                           (MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr),
+                           (partition_low, partition_high, request, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PREADY_RANGE = ompi_pready_range_f
+#pragma weak mpi_pready_range = ompi_pready_range_f
+#pragma weak mpi_pready_range_ = ompi_pready_range_f
+#pragma weak mpi_pready_range__ = ompi_pready_range_f
+
+#pragma weak MPI_Pready_range_f = ompi_pready_range_f
+#pragma weak MPI_Pready_range_f08 = ompi_pready_range_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PREADY_RANGE,
+                           mpi_pready_range,
+                           mpi_pready_range_,
+                           mpi_pready_range__,
+                           ompi_pready_range_f,
+                           (MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr),
+                           (partition_low, partition_high, request, ierr) )
+#else
+#define ompi_pready_range_f pompi_pready_range_f
+#endif
+#endif
+
+
+void ompi_pready_range_f(MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr)
+{
+   int c_ierr;
+   MPI_Request c_req = PMPI_Request_f2c(*request);
+
+   c_ierr = PMPI_Pready_range(OMPI_FINT_2_INT(*partition_low), OMPI_FINT_2_INT(*partition_high), c_req);
+   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+   if (MPI_SUCCESS == c_ierr) {
+      *request = PMPI_Request_c2f(c_req);
+   }
+}

--- a/ompi/mpi/fortran/mpif-h/precv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/precv_init_f.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PRECV_INIT = ompi_precv_init_f
+#pragma weak pmpi_precv_init = ompi_precv_init_f
+#pragma weak pmpi_precv_init_ = ompi_precv_init_f
+#pragma weak pmpi_precv_init__ = ompi_precv_init_f
+
+#pragma weak PMPI_Precv_init_f = ompi_precv_init_f
+#pragma weak PMPI_Precv_init_f08 = ompi_precv_init_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PRECV_INIT,
+                           pmpi_precv_init,
+                           pmpi_precv_init_,
+                           pmpi_precv_init__,
+                           pompi_precv_init_f,
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PRECV_INIT = ompi_precv_init_f
+#pragma weak mpi_precv_init = ompi_precv_init_f
+#pragma weak mpi_precv_init_ = ompi_precv_init_f
+#pragma weak mpi_precv_init__ = ompi_precv_init_f
+
+#pragma weak MPI_Precv_init_f = ompi_precv_init_f
+#pragma weak MPI_Precv_init_f08 = ompi_precv_init_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PRECV_INIT,
+                           mpi_precv_init,
+                           mpi_precv_init_,
+                           mpi_precv_init__,
+                           ompi_precv_init_f,
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+#else
+#define ompi_precv_init_f pompi_precv_init_f
+#endif
+#endif
+
+
+void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr)
+{
+   int c_ierr;
+   MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
+   MPI_Request c_req;
+   MPI_Comm c_comm;
+
+   c_comm = PMPI_Comm_f2c (*comm);
+
+   c_ierr = PMPI_Precv_init(OMPI_F2C_BOTTOM(buf), 
+                      OMPI_FINT_2_INT(*partitions),
+                      OMPI_FINT_2_INT(*count),
+                      c_type, OMPI_FINT_2_INT(*dest),
+                      OMPI_FINT_2_INT(*tag),
+                      c_comm, &c_req);
+   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+   if (MPI_SUCCESS == c_ierr) {
+      *request = PMPI_Request_c2f(c_req);
+   }
+}

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -254,6 +254,12 @@ linked_files = \
         piscatterv_f.c \
         pisend_f.c \
         pissend_f.c \
+        pparrived_f.c \
+        ppready_f.c \
+        ppready_list_f.c \
+        ppready_range_f.c \
+        pprecv_init_f.c \
+        ppsend_init_f.c \
         pis_thread_main_f.c \
         pkeyval_create_f.c \
         pkeyval_free_f.c \

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -304,6 +304,12 @@ PN2(void, MPI_Irecv, mpi_irecv, MPI_IRECV, (char *buf, MPI_Fint *count, MPI_Fint
 PN2(void, MPI_Irsend, mpi_irsend, MPI_IRSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Isend, mpi_isend, MPI_ISEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Issend, mpi_issend, MPI_ISSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Parrived, mpi_parrived, MPI_PARRIVED, (MPI_Fint *request, MPI_Fint *partition, ompi_fortran_logical_t *flag, MPI_Fint *ierr));
+PN2(void, MPI_Pready, mpi_pready, MPI_PREADY, (MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Pready_list, mpi_pready_list, MPI_PREADY_LIST, (MPI_Fint *length, MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Pready_range, mpi_pready_range, MPI_PREADY_RANGE, (MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Psend_init, mpi_psend_init, MPI_PSEND_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Precv_init, mpi_precv_init, MPI_PRECV_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *src, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Is_thread_main, mpi_is_thread_main, MPI_IS_THREAD_MAIN, (ompi_fortran_logical_t *flag, MPI_Fint *ierr));
 PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Keyval_free, mpi_keyval_free, MPI_KEYVAL_FREE, (MPI_Fint *keyval, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/psend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/psend_init_f.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_PSEND_INIT = ompi_psend_init_f
+#pragma weak pmpi_psend_init = ompi_psend_init_f
+#pragma weak pmpi_psend_init_ = ompi_psend_init_f
+#pragma weak pmpi_psend_init__ = ompi_psend_init_f
+
+#pragma weak PMPI_Psend_init_f = ompi_psend_init_f
+#pragma weak PMPI_Psend_init_f08 = ompi_psend_init_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_PSEND_INIT,
+                           pmpi_psend_init,
+                           pmpi_psend_init_,
+                           pmpi_psend_init__,
+                           pompi_psend_init_f,
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_PSEND_INIT = ompi_psend_init_f
+#pragma weak mpi_psend_init = ompi_psend_init_f
+#pragma weak mpi_psend_init_ = ompi_psend_init_f
+#pragma weak mpi_psend_init__ = ompi_psend_init_f
+
+#pragma weak MPI_Psend_init_f = ompi_psend_init_f
+#pragma weak MPI_Psend_init_f08 = ompi_psend_init_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_PSEND_INIT,
+                           mpi_psend_init,
+                           mpi_psend_init_,
+                           mpi_psend_init__,
+                           ompi_psend_init_f,
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+#else
+#define ompi_psend_init_f pompi_psend_init_f
+#endif
+#endif
+
+
+void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr)
+{
+   int c_ierr;
+   MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
+   MPI_Request c_req;
+   MPI_Comm c_comm;
+
+   c_comm = PMPI_Comm_f2c (*comm);
+
+   c_ierr = PMPI_Psend_init(OMPI_F2C_BOTTOM(buf), 
+                      OMPI_FINT_2_INT(*partitions),
+                      OMPI_FINT_2_INT(*count),
+                      c_type, OMPI_FINT_2_INT(*dest),
+                      OMPI_FINT_2_INT(*tag),
+                      c_comm, &c_req);
+   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+   if (MPI_SUCCESS == c_ierr) {
+      *request = PMPI_Request_c2f(c_req);
+   }
+}

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
 # Copyright (c) 2019      Triad National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -315,6 +316,12 @@ mpi_api_files = \
         iscatterv_f08.F90 \
         isend_f08.F90 \
         issend_f08.F90 \
+        psend_init_f08.F90 \
+        precv_init_f08.F90 \
+        pready_f08.F90 \
+        pready_range_f08.F90 \
+        pready_list_f08.F90 \
+        parrived_f08.F90 \
         is_thread_main_f08.F90 \
         lookup_name_f08.F90 \
         mprobe_f08.F90 \
@@ -670,6 +677,12 @@ pmpi_api_files = \
         profile/piscatterv_f08.F90 \
         profile/pisend_f08.F90 \
         profile/pissend_f08.F90 \
+        profile/ppsend_init_f08.F90 \
+        profile/pprecv_init_f08.F90 \
+        profile/ppready_f08.F90 \
+        profile/ppready_range_f08.F90 \
+        profile/ppready_list_f08.F90 \
+        profile/pparrived_f08.F90 \
         profile/pis_thread_main_f08.F90 \
         profile/plookup_name_f08.F90 \
         profile/pmprobe_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -276,6 +276,53 @@ subroutine ompi_issend_f(buf,count,datatype,dest,tag,comm,request,ierror) &
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_issend_f
 
+subroutine ompi_psend_init_f(buf,partitions,count,datatype,dest,tag,comm,request,ierror) &
+   BIND(C, name="ompi_psend_init_f")
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: datatype
+   INTEGER, INTENT(IN) :: comm
+   INTEGER, INTENT(OUT) :: request
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine ompi_psend_init_f
+
+subroutine ompi_precv_init_f(buf,partitions,count,datatype,dest,tag,comm,request,ierror) &
+   BIND(C, name="ompi_precv_init_f")
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: datatype
+   INTEGER, INTENT(IN) :: comm
+   INTEGER, INTENT(OUT) :: request
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine ompi_precv_init_f
+
+subroutine ompi_pready_f(partition,request,ierror) &
+   BIND(C, name="ompi_pready_f")
+   implicit none
+   INTEGER, INTENT(IN) :: partition
+   INTEGER, INTENT(IN) :: request
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine ompi_pready_f
+
+subroutine ompi_pready_list_f(length,partitions,request,ierror) &
+   BIND(C, name="ompi_pready_list_f")
+   implicit none
+   INTEGER, INTENT(IN) :: length
+   INTEGER, INTENT(IN) :: partitions(*)
+   INTEGER, INTENT(IN) :: request
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine ompi_pready_list_f
+
+subroutine ompi_pready_range_f(partition_low,partition_high,request,ierror) &
+   BIND(C, name="ompi_pready_range_f")
+   implicit none
+   INTEGER, INTENT(IN) :: partition_low, partition_high
+   INTEGER, INTENT(IN) :: request
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine ompi_pready_range_f
+
 subroutine ompi_probe_f(source,tag,comm,status,ierror) &
    BIND(C, name="ompi_probe_f")
    use :: mpi_f08_types, only : MPI_Status

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -202,6 +202,85 @@ subroutine PMPI_Issend_f08(buf,count,datatype,dest,tag,comm,request,ierror)
 end subroutine PMPI_Issend_f08
 end interface  PMPI_Issend
 
+
+interface  PMPI_Precv_init
+subroutine PMPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   implicit none
+   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
+   !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
+   !$PRAGMA IGNORE_TKR buf
+   !DIR$ IGNORE_TKR buf
+   !IBM* IGNORE_TKR buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Precv_init_f08
+end interface  PMPI_Precv_init
+
+interface  PMPI_Psend_init
+subroutine PMPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   implicit none
+   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
+   !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
+   !$PRAGMA IGNORE_TKR buf
+   !DIR$ IGNORE_TKR buf
+   !IBM* IGNORE_TKR buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Psend_init_f08
+end interface  PMPI_Psend_init
+
+interface  PMPI_Pready
+subroutine PMPI_Pready_f08(partition,request,ierror)
+   use :: mpi_f08_types, only : MPI_Request
+   implicit none
+   INTEGER, INTENT(IN) :: partition
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Pready_f08
+end interface  PMPI_Pready
+
+interface  PMPI_Pready_list
+subroutine PMPI_Pready_list_f08(length,partitions,request,ierror)
+   use :: mpi_f08_types, only : MPI_Request
+   implicit none
+   INTEGER, INTENT(IN) :: length
+   INTEGER, DIMENSION(*), INTENT(IN) :: partitions
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Pready_list_f08
+end interface  PMPI_Pready_list
+
+interface  PMPI_Pready_range
+subroutine PMPI_Pready_range_f08(partition_low,partition_high,request,ierror)
+   use :: mpi_f08_types, only : MPI_Request
+   implicit none
+   INTEGER, INTENT(IN) :: partition_low, partition_high
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Pready_range_f08
+end interface  PMPI_Pready_range
+
+interface  PMPI_Parrived
+subroutine PMPI_Parrived_f08(request,partition,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Request
+   implicit none
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, INTENT(IN) :: partition
+   LOGICAL, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Parrived_f08
+end interface  PMPI_Parrived
+
 interface  PMPI_Probe
 subroutine PMPI_Probe_f08(source,tag,comm,status,ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Status

--- a/ompi/mpi/fortran/use-mpi-f08/parrived_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/parrived_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Parrived_f08(request,partition,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: mpi, only : PMPI_Parrived
+   implicit none
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, INTENT(IN) :: partition
+   LOGICAL, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call PMPI_Parrived(request%MPI_VAL,partition,flag,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Parrived_f08

--- a/ompi/mpi/fortran/use-mpi-f08/pready_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pready_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Pready_f08(partition,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_f
+   implicit none
+   INTEGER, INTENT(IN) :: partition
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_f(partition,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Pready_f08

--- a/ompi/mpi/fortran/use-mpi-f08/pready_list_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pready_list_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Pready_list_f08(length,partitions,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_list_f
+   implicit none
+   INTEGER, INTENT(IN) :: length
+   INTEGER, dimension(*), INTENT(IN) :: partitions
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_list_f(length,partitions,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Pready_list_f08

--- a/ompi/mpi/fortran/use-mpi-f08/pready_range_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pready_range_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Pready_range_f08(partition_low,partition_high,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_range_f
+   implicit none
+   INTEGER, INTENT(IN) :: partition_low,partition_high
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_range_f(partition_low,partition_high,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Pready_range_f08

--- a/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_precv_init_f
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_precv_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Precv_init_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pparrived_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pparrived_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Parrived_f08(request,partition,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: mpi, only : PMPI_Parrived
+   implicit none
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, INTENT(IN) :: partition
+   LOGICAL, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call PMPI_Parrived(request%MPI_VAL,partition,flag,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Parrived_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppready_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppready_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Pready_f08(partition,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_f
+   implicit none
+   INTEGER, INTENT(IN) :: partition
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_f(partition,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Pready_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppready_list_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppready_list_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Pready_list_f08(length,partitions,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_list_f
+   implicit none
+   INTEGER, INTENT(IN) :: length
+   INTEGER, dimension(*), INTENT(IN) :: partitions
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_list_f(length,partitions,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Pready_list_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppready_range_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppready_range_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Pready_range_f08(partition_low,partition_high,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_pready_range_f
+   implicit none
+   INTEGER, INTENT(IN) :: partition_low,partition_high
+   TYPE(MPI_Request), INTENT(IN) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_pready_range_f(partition_low,partition_high,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Pready_range_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pprecv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pprecv_init_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_precv_init_f
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_precv_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Precv_init_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppsend_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppsend_init_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_psend_init_f
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_psend_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Psend_init_f08

--- a/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: ompi_mpifh_bindings, only : ompi_psend_init_f
+   implicit none
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_psend_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Psend_init_f08

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -4362,6 +4362,168 @@ end subroutine PMPI_Issend
 end interface
 
 
+interface MPI_Psend_init
+
+subroutine MPI_Psend_init(buf, partitions, count, datatype, dest, tag, &
+        comm, request, ierror)
+  @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+  @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
+  integer, intent(in) :: partitions 
+  integer, intent(in) :: count
+  integer, intent(in) :: datatype
+  integer, intent(in) :: dest
+  integer, intent(in) :: tag
+  integer, intent(in) :: comm
+  integer, intent(out) :: request
+  integer, intent(out) :: ierror
+end subroutine MPI_Psend_init
+
+end interface
+
+interface PMPI_Psend_init
+
+subroutine PMPI_Psend_init(buf, partitions, count, datatype, dest, tag, &
+        comm, request, ierror)
+  @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+  @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
+  integer, intent(in) :: partitions
+  integer, intent(in) :: count
+  integer, intent(in) :: datatype
+  integer, intent(in) :: dest
+  integer, intent(in) :: tag
+  integer, intent(in) :: comm
+  integer, intent(out) :: request
+  integer, intent(out) :: ierror
+end subroutine PMPI_Psend_init
+
+end interface
+
+
+interface MPI_Precv_init
+
+subroutine MPI_Precv_init(buf, partitions, count, datatype, dest, tag, &
+        comm, request, ierror)
+  @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+  @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
+  integer, intent(in) :: partitions
+  integer, intent(in) :: count 
+  integer, intent(in) :: datatype
+  integer, intent(in) :: dest
+  integer, intent(in) :: tag
+  integer, intent(in) :: comm
+  integer, intent(out) :: request
+  integer, intent(out) :: ierror
+end subroutine MPI_Precv_init
+
+end interface
+
+interface PMPI_Precv_init
+
+subroutine PMPI_Precv_init(buf, partitions, count, datatype, dest, tag, &
+        comm, request, ierror)
+  @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+  @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
+  integer, intent(in) :: partitions
+  integer, intent(in) :: count
+  integer, intent(in) :: datatype
+  integer, intent(in) :: dest
+  integer, intent(in) :: tag
+  integer, intent(in) :: comm
+  integer, intent(out) :: request
+  integer, intent(out) :: ierror
+end subroutine PMPI_Precv_init
+
+end interface
+
+
+interface MPI_Pready
+
+subroutine MPI_Pready(partition, request, ierror)
+  integer, intent(in) :: partition
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine MPI_Pready
+
+end interface
+
+interface PMPI_Pready
+
+subroutine PMPI_Pready(partition, request, ierror)
+  integer, intent(in) :: partition
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine PMPI_Pready
+
+end interface
+
+
+interface MPI_Pready_list
+
+subroutine MPI_Pready_list(length, partitions, request, ierror)
+  integer, intent(in) :: length
+  integer, dimension(*), intent(in) :: partitions
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine MPI_Pready_list
+
+end interface
+
+interface PMPI_Pready_list
+
+subroutine PMPI_Pready_list(length, partitions, request, ierror)
+  integer, intent(in) :: length
+  integer, dimension(*), intent(in) :: partitions
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine PMPI_Pready_list
+
+end interface
+
+
+interface MPI_Pready_range
+
+subroutine MPI_Pready_range(partition_low, partition_high, request, ierror)
+  integer, intent(in) :: partition_low
+  integer, intent(in) :: partition_high
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine MPI_Pready_range
+
+end interface
+
+interface PMPI_Pready_range
+
+subroutine PMPI_Pready_range(partition_low, partition_high, request, ierror)
+  integer, intent(in) :: partition_low
+  integer, intent(in) :: partition_high
+  integer, intent(in) :: request
+  integer, intent(out) :: ierror
+end subroutine PMPI_Pready_range
+
+end interface
+
+interface MPI_Parrived
+
+subroutine MPI_Parrived(request, partition, flag, ierror)
+  integer, intent(in) :: request
+  integer, intent(in) :: partition
+  logical, intent(in) :: flag
+  integer, intent(out) :: ierror
+end subroutine MPI_Parrived
+
+end interface
+
+interface PMPI_Parrived
+
+subroutine PMPI_Parrived(request, partition, flag, ierror)
+  integer, intent(in) :: request
+  integer, intent(in) :: partition
+  logical, intent(in) :: flag
+  integer, intent(out) :: ierror
+end subroutine PMPI_Parrived
+
+end interface
+
 interface MPI_Lookup_name
 
 subroutine MPI_Lookup_name(service_name, info, port_name, ierror)

--- a/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
@@ -621,6 +621,18 @@ end subroutine PMPI_Finalized
 end interface
 
 
+interface PMPI_Parrived
+
+subroutine PMPI_Parrived(request, partition, flag, ierror)
+  integer, intent(in) :: request
+  integer, intent(in) :: partition
+  logical, intent(out) :: flag
+  integer, intent(out) :: ierror
+end subroutine PMPI_Parrived
+
+end interface
+
+
 interface PMPI_Get_count
 
 subroutine PMPI_Get_count(status, datatype, count, ierror)

--- a/ompi/mpi/man/man3/MPI_Parrived.3in
+++ b/ompi/mpi/man/man3/MPI_Parrived.3in
@@ -1,0 +1,66 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Parrived 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Parrived\fP \- Tests for completion of a specified receive-side partition.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Parrived(MPI_Request\fI *request\fP, int\fI partition\fP, int\fI *flag\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PARRIVED(REQUEST, PARTITION, FLAG IERROR\fP)
+	INTEGER	\fIREQUEST, PARTITION, FLAG(*), IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Parrived(\fIrequest\fP, \fIpartition\fP, \fIflag\fP, \fIierror\fP)
+	TYPE(MPI_Request), INTENT(in) :: \fIrequest\fP
+        INTEGER, INTENT(IN) :: \fIpartition\fP
+        INTEGER, INTENT(out) :: \fIflag\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+request
+Communication request (handle).
+.TP 1i
+partition
+The number of the partition to test for completion (integer).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+flag
+True if partition is completed. 
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+MPI_Pready_list, MPI_Pready_range, MPI_Parrived
+.br

--- a/ompi/mpi/man/man3/MPI_Pready.3in
+++ b/ompi/mpi/man/man3/MPI_Pready.3in
@@ -1,0 +1,61 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Pready 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Pready\fP \- Indicates that a given send-side partition is ready to be transferred.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Pready(int\fI partition\fP, MPI_Request\fI *request\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PREADY(PARTITION, REQUEST, IERROR\fP)
+	INTEGER	\fIPARTITION, REQUEST, IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Pready(\fIpartition\fP, \fIrequest\fP, \fIierror\fP)
+	INTEGER, INTENT(IN) :: \fIpartition\fP
+	TYPE(MPI_Request), INTENT(IN) :: \fIrequest\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+partition
+The number of the partition to mark ready for transfer (integer).
+.TP 1i
+request
+Communication request (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+MPI_Pready_list, MPI_Pready_range, MPI_Parrived
+.br

--- a/ompi/mpi/man/man3/MPI_Pready_list.3in
+++ b/ompi/mpi/man/man3/MPI_Pready_list.3in
@@ -1,0 +1,65 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Pready_list 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Pready_list\fP \- Indicates that a list given send-side partitions are ready to be transferred.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Pready_list(int\fI length\fP, int\fI *partitions\fP, MPI_Request\fI *request\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PREADY_LIST(LENGTH, PARTITIONS, REQUEST, IERROR\fP)
+	INTEGER	\fILENGTH, PARTITIONS(*), REQUEST, IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Pready_list(\fIlength\fP, \fIpartitions\fP, \fIrequest\fP, \fIierror\fP)
+        INTEGER, INTENT(IN) :: \fIlength\fP
+	INTEGER, INTENT(IN) :: \fIpartitions\fP
+	TYPE(MPI_Request), INTENT(IN) :: \fIrequest\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+length
+The length of the given partition array (integer).
+.TP 1i
+partitions
+An array of numbers of partitions to mark ready for transfer (integer).
+.TP 1i
+request
+Communication request (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+MPI_Pready, MPI_Pready_range, MPI_Parrived
+.br

--- a/ompi/mpi/man/man3/MPI_Pready_range.3in
+++ b/ompi/mpi/man/man3/MPI_Pready_range.3in
@@ -1,0 +1,64 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Pready_range 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Pready_range\fP \- Indicates that a given range os send-side partitions are ready to be transferred.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Pready_range(int\fI partition_low\fP, int\fI partition_high\fP, MPI_Request\fI *request\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PREADY(PARTITION_LOW, PARTITION_HIGH, REQUEST, IERROR\fP)
+	INTEGER	\fIPARTITION_LOW, PARTITION_HIGH, REQUEST, IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Pready(\fIpartition_low\fP, \fIpartition_high\fP, \fIrequest\fP, \fIierror\fP)
+	INTEGER, INTENT(IN) :: \fIpartition_low\fP, \fIpartition_high\fP
+	TYPE(MPI_Request), INTENT(IN) :: \fIrequest\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+partition_low
+The lowest of the range of partitions to mark ready for transfer (integer).
+.TP 1i
+partition_high
+The highest of the range of partitions to mark ready for transfer (integer).
+.TP 1i
+request
+Communication request (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+MPI_Pready, MPI_Pready_list, MPI_Parrived
+.br

--- a/ompi/mpi/man/man3/MPI_Precv_init.3in
+++ b/ompi/mpi/man/man3/MPI_Precv_init.3in
@@ -1,0 +1,89 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Precv_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Precv_init\fP \- Initializes a partitioned receive.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Precv_init(const void *\fIbuf\fP, int\fI partitions\fP, int\fI count\fP, MPI_Datatype\fI datatype\fP, int\fI dest\fP,
+	int\fI tag\fP, MPI_Comm\fI comm\fP, MPI_Request\fI *request\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PRECV_INIT(\fIBUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIPARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Precv_init(\fIbuf\fP, \fIpartitions\fP, \fIcount\fP, \fIdatatype\fP, \fIdest\fP, \fItag\fP, \fIcomm\fP, \fIrequest\fP, \fIierror\fP)
+	TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: \fIbuf\fP
+	INTEGER, INTENT(IN) :: \fIpartitions\fP, \fIcount\fP, \fIdest\fP, \fItag\fP
+	TYPE(MPI_Datatype), INTENT(IN) :: \fIdatatype\fP
+	TYPE(MPI_Comm), INTENT(IN) :: \fIcomm\fP
+	TYPE(MPI_Request), INTENT(OUT) :: \fIrequest\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+buf
+Initial address of receive buffer (choice).
+.TP 1i
+partitions
+Number of partitions (integer).
+.TP 1i
+count
+Number of elements to be received per partition  (integer).
+.TP 1i
+datatype
+Datatype of each element (handle).
+.TP 1i
+dest
+Rank of source (integer).
+.TP 1i
+tag
+Message tag (integer).
+.TP 1i
+comm
+Communicator (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+request
+Communication request (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH NOTE
+.ft R
+The current implementation is an early prototype and is not fully compliant with the MPI-4.0 specification. Specifically this function and it's counterpart (MPI_Psend_init) will block until the partitioned communication request is initialized on both ends. This behavior will be corrected in future versions.
+
+.SH SEE ALSO
+MPI_Psend_init
+.br

--- a/ompi/mpi/man/man3/MPI_Psend_init.3in
+++ b/ompi/mpi/man/man3/MPI_Psend_init.3in
@@ -1,0 +1,89 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Psend_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Psend_init\fP \- Initializes a partitioned send.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Psend_init(const void *\fIbuf\fP, int\fI partitions\fP, int\fI count\fP, MPI_Datatype\fI datatype\fP, int\fI dest\fP,
+	int\fI tag\fP, MPI_Comm\fI comm\fP, MPI_Request\fI *request\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_PSEND_INIT(\fIBUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIPARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Psend_init(\fIbuf\fP, \fIpartitions\fP, \fIcount\fP, \fIdatatype\fP, \fIdest\fP, \fItag\fP, \fIcomm\fP, \fIrequest\fP, \fIierror\fP)
+	TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: \fIbuf\fP
+	INTEGER, INTENT(IN) :: \fIpartitions\fP, \fIcount\fP, \fIdest\fP, \fItag\fP
+	TYPE(MPI_Datatype), INTENT(IN) :: \fIdatatype\fP
+	TYPE(MPI_Comm), INTENT(IN) :: \fIcomm\fP
+	TYPE(MPI_Request), INTENT(OUT) :: \fIrequest\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+buf
+Initial address of send buffer (choice).
+.TP 1i
+partitions
+Number of partitions (integer).
+.TP 1i
+count
+Number of elements to be sent per partition  (integer).
+.TP 1i
+datatype
+Datatype of each element (handle).
+.TP 1i
+dest
+Rank of source (integer).
+.TP 1i
+tag
+Message tag (integer).
+.TP 1i
+comm
+Communicator (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+request
+Communication request (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH NOTE
+.ft R
+The current implementation is an early prototype and is not fully compliant with the MPI-4.0 specification. Specifically this function and it's counterpart (MPI_Precv_init) will block until the partitioned communication request is initialized on both ends. This behavior will be corrected in future versions.
+
+.SH SEE ALSO
+MPI_Precv_init
+.br

--- a/ompi/mpi/man/man3/Makefile.am
+++ b/ompi/mpi/man/man3/Makefile.am
@@ -275,6 +275,12 @@ TEMPLATE_FILES = \
         MPI_Probe.3in \
         MPI_Publish_name.3in \
         MPI_Put.3in \
+	MPI_Parrived.3in \
+	MPI_Pready.3in \
+	MPI_Pready_list.3in \
+	MPI_Pready_range.3in \
+	MPI_Precv_init.3in \
+	MPI_Psend_init.3in \
         MPI_Query_thread.3in \
         MPI_Raccumulate.3in \
         MPI_Recv.3in \

--- a/ompi/request/request_dbg.h
+++ b/ompi/request/request_dbg.h
@@ -25,6 +25,7 @@ typedef enum {
     OMPI_REQUEST_GEN,      /**< MPI-2 generalized request */
     OMPI_REQUEST_WIN,      /**< MPI-2 one-sided request */
     OMPI_REQUEST_COLL,     /**< MPI-3 non-blocking collectives request */
+    OMPI_REQUEST_PART,     /**< MPI-4 partitioned communication request */
     OMPI_REQUEST_NULL,     /**< NULL request */
     OMPI_REQUEST_NOOP,     /**< A request that does nothing (e.g., to PROC_NULL) */
     OMPI_REQUEST_COMM,     /**< MPI-3 non-blocking communicator duplication */

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -75,6 +75,7 @@
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/bml/base/base.h"
 #include "ompi/mca/osc/base/base.h"
+#include "ompi/mca/part/base/base.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/runtime/ompi_rte.h"
 #include "ompi/mca/topo/base/base.h"
@@ -312,6 +313,10 @@ int ompi_mpi_finalize(void)
         goto done;
     }
 
+    if (OMPI_SUCCESS != (ret = mca_part_base_finalize())) {
+        goto done;
+    }
+
     /* free communicator resources. this MUST come before finalizing the PML
      * as this will call into the pml */
     if (OMPI_SUCCESS != (ret = ompi_comm_finalize())) {
@@ -429,6 +434,9 @@ int ompi_mpi_finalize(void)
     }
     (void) mca_base_framework_close(&ompi_topo_base_framework);
     if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_osc_base_framework))) {
+        goto done;
+    }
+    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_part_base_framework))) {
         goto done;
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_coll_base_framework))) {

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2006-2009 University of Houston. All rights reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
@@ -85,6 +85,7 @@
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/bml/base/base.h"
 #include "ompi/mca/osc/base/base.h"
+#include "ompi/mca/part/base/base.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/mca/io/io.h"
 #include "ompi/mca/io/base/base.h"
@@ -610,6 +611,12 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
         goto error;
     }
 
+    
+    if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_part_base_framework, 0))) {
+        error = "ompi_part_base_open() failed";
+        goto error;
+    }
+
 #if OPAL_ENABLE_FT_CR == 1
     if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_crcp_base_framework, 0))) {
         error = "ompi_crcp_base_open() failed";
@@ -726,6 +733,13 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
         (ret = ompi_osc_base_find_available(OPAL_ENABLE_PROGRESS_THREADS,
                                             ompi_mpi_thread_multiple))) {
         error = "ompi_osc_base_find_available() failed";
+        goto error;
+    }
+
+    if (OMPI_SUCCESS !=
+        (ret = mca_part_base_select(OPAL_ENABLE_PROGRESS_THREADS,
+                                   ompi_mpi_thread_multiple))) {
+        error = "mca_part_base_select() failed";
         goto error;
     }
 


### PR DESCRIPTION
This is an initial implementation of partitioned communication, adding the part mca component and 'rma module' for the initial back end implementation (this initial implementation uses the MPI RMA interface). 

There is one notable caveat to this implementation; that both MPI_Psend_init and MPI_Precv_init are blocking, which is not compliant with the upcoming MPI-4 specification.  
.