### PR TITLE
MPI_T Events

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -831,12 +831,12 @@ typedef enum {
 /*
  * MPIT source ordering
  */
-enum ompi_mpi_t_order_t {
+enum ompi_mpi_t_source_order_t {
   MPI_T_ORDERED,
   MPI_T_UNORDERED,
 };
 
-typedef enum ompi_mpi_t_order_t MPI_T_order;
+typedef enum ompi_mpi_t_source_order_t MPI_T_source_order;
 
 /*
  * MPI Tool event functions
@@ -2719,7 +2719,7 @@ OMPI_DECLSPEC  int PMPI_T_event_get_timestamp (MPI_T_event_instance event, MPI_C
 OMPI_DECLSPEC  int PMPI_T_event_get_source (MPI_T_event_instance event, int *source_index);
 OMPI_DECLSPEC  int PMPI_T_source_get_num (int *num_source);
 OMPI_DECLSPEC  int PMPI_T_source_get_info (int source_id, char *name, int *name_len,
-                                           char *desc, int *desc_len, MPI_T_order *ordering,
+                                           char *desc, int *desc_len, MPI_T_source_order *ordering,
                                            MPI_Count *ticks_per_second, MPI_Count *max_timestamp,
                                            MPI_Info *info);
 OMPI_DECLSPEC  int PMPI_T_source_get_timestamp (int source_id, MPI_Count *timestamp);
@@ -2820,7 +2820,7 @@ OMPI_DECLSPEC  int MPI_T_event_get_source (MPI_T_event_instance event, int *sour
 
 OMPI_DECLSPEC  int MPI_T_source_get_num (int *num_source);
 OMPI_DECLSPEC  int MPI_T_source_get_info (int source_id, char *name, int *name_len,
-                                          char *desc, int *desc_len, MPI_T_order *ordering,
+                                          char *desc, int *desc_len, MPI_T_source_order *ordering,
                                           MPI_Count *ticks_per_second, MPI_Count *max_timestamp,
                                           MPI_Info *info);
 OMPI_DECLSPEC  int MPI_T_source_get_timestamp (int source_id, MPI_Count *timestamp);

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -21,6 +21,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -417,6 +419,8 @@ typedef struct mca_base_var_enum_t *MPI_T_enum;
 typedef struct ompi_mpit_cvar_handle_t *MPI_T_cvar_handle;
 typedef struct mca_base_pvar_handle_t *MPI_T_pvar_handle;
 typedef struct mca_base_pvar_session_t *MPI_T_pvar_session;
+typedef struct mca_base_raised_event_t *MPI_T_event_instance;
+typedef struct mca_base_event_registration_t *MPI_T_event_registration;
 
 /*
  * MPI_Status
@@ -815,6 +819,41 @@ enum {
 };
 
 /*
+ * MPIT callback safety levels
+ */
+typedef enum {
+  MPI_T_CB_REQUIRE_NONE,
+  MPI_T_CB_REQUIRE_MPI_RESTRICTED,
+  MPI_T_CB_REQUIRE_THREAD_SAFE,
+  MPI_T_CB_REQUIRE_ASYNC_SIGNAL_SAFE
+} MPI_T_cb_safety;
+
+/*
+ * MPIT source ordering
+ */
+enum ompi_mpi_t_order_t {
+  MPI_T_ORDERED,
+  MPI_T_UNORDERED,
+};
+
+typedef enum ompi_mpi_t_order_t MPI_T_order;
+
+/*
+ * MPI Tool event functions
+ */
+typedef void (*MPI_T_event_free_cb_function) (MPI_T_event_registration handle,
+                                              MPI_T_cb_safety cb_safety,
+                                              void *user_data);
+typedef void (*MPI_T_event_dropped_cb_function) (int count,
+                                                 MPI_T_event_registration handle,
+                                                 MPI_T_cb_safety cb_safety,
+                                                 void *user_data);
+typedef void (*MPI_T_event_cb_function) (MPI_T_event_instance event,
+                                         MPI_T_event_registration handle,
+                                         MPI_T_cb_safety cb_safety,
+                                         void *user_data);
+
+/*
  * NULL handles
  */
 #define MPI_GROUP_NULL OMPI_PREDEFINED_GLOBAL(MPI_Group, ompi_mpi_group_null)
@@ -848,6 +887,7 @@ enum {
 #define MPI_T_PVAR_HANDLE_NULL ((MPI_T_pvar_handle) 0)
 #define MPI_T_PVAR_SESSION_NULL ((MPI_T_pvar_session) 0)
 #define MPI_T_CVAR_HANDLE_NULL ((MPI_T_cvar_handle) 0)
+#define MPI_T_EVENT_REGISTRATION_NULL ((MPI_T_event_registration) 0)
 
 /* MPI-2 specifies that the name "MPI_TYPE_NULL_DELETE_FN" (and all
    related friends) must be accessible in C, C++, and Fortran. This is
@@ -2650,6 +2690,40 @@ OMPI_DECLSPEC  int PMPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *nam
 OMPI_DECLSPEC  int PMPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
                                         int *name_len);
 
+OMPI_DECLSPEC  int PMPI_T_event_get_num (int *num_events);
+OMPI_DECLSPEC  int PMPI_T_event_get_info (int event_index, char *name, int *name_len,
+                                          int *verbosity, MPI_Datatype *array_of_datatypes,
+                                          MPI_Aint *array_of_displacements, int *num_elements,
+                                          MPI_Aint *extent, MPI_T_enum *enumtype, MPI_Info *info,
+                                          char *desc, int *desc_len, int *bind);
+OMPI_DECLSPEC  int PMPI_T_event_get_index (const char *name, int *event_index);
+OMPI_DECLSPEC  int PMPI_T_event_handle_alloc (int event_index, void *obj_handle,
+                                              MPI_Info info, MPI_T_event_registration *event_registration);
+OMPI_DECLSPEC  int PMPI_T_event_handle_set_info (MPI_T_event_registration event_registration, MPI_Info info);
+OMPI_DECLSPEC  int PMPI_T_event_handle_get_info (MPI_T_event_registration event_registration,
+                                                    MPI_Info *info_used);
+OMPI_DECLSPEC  int PMPI_T_event_register_callback (MPI_T_event_registration event_registration,
+                                                   MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data,
+                                                   MPI_T_event_cb_function event_cb_function);
+OMPI_DECLSPEC  int PMPI_T_event_callback_set_info (MPI_T_event_registration event_registration,
+                                                    MPI_T_cb_safety cb_safety, MPI_Info info);
+OMPI_DECLSPEC  int PMPI_T_event_callback_get_info (MPI_T_event_registration event_registration,
+                                                   MPI_T_cb_safety cb_safety, MPI_Info *info_used);
+OMPI_DECLSPEC  int PMPI_T_event_handle_free (MPI_T_event_registration event_registration,
+                                             MPI_T_event_free_cb_function free_cb_function);
+OMPI_DECLSPEC  int PMPI_T_event_set_dropped_handler (MPI_T_event_registration handle,
+                                                     MPI_T_event_dropped_cb_function dropped_cb_function);
+OMPI_DECLSPEC  int PMPI_T_event_read (MPI_T_event_instance event, int element_index, void *buffer);
+OMPI_DECLSPEC  int PMPI_T_event_copy (MPI_T_event_instance event, void *buffer);
+OMPI_DECLSPEC  int PMPI_T_event_get_timestamp (MPI_T_event_instance event, MPI_Count *event_time);
+OMPI_DECLSPEC  int PMPI_T_event_get_source (MPI_T_event_instance event, int *source_index);
+OMPI_DECLSPEC  int PMPI_T_source_get_num (int *num_source);
+OMPI_DECLSPEC  int PMPI_T_source_get_info (int source_id, char *name, int *name_len,
+                                           char *desc, int *desc_len, MPI_T_order *ordering,
+                                           MPI_Count *ticks_per_second, MPI_Count *max_timestamp,
+                                           MPI_Info *info);
+OMPI_DECLSPEC  int PMPI_T_source_get_timestamp (int source_id, MPI_Count *timestamp);
+
   /*
    * Tool MPI API
    */
@@ -2715,6 +2789,41 @@ OMPI_DECLSPEC  int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
             __mpi_interface_deprecated__("MPI_Attr_put was deprecated in MPI-2.0; use MPI_Comm_set_attr instead");
 OMPI_DECLSPEC  int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
             __mpi_interface_deprecated__("PMPI_Attr_put was deprecated in MPI-2.0; use PMPI_Comm_set_attr instead");
+
+OMPI_DECLSPEC  int MPI_T_event_get_num (int *num_events);
+OMPI_DECLSPEC  int MPI_T_event_get_info (int event_index, char *name, int *name_len,
+                                         int *verbosity, MPI_Datatype *array_of_datatypes,
+                                         MPI_Aint *array_of_displacements, int *num_elements,
+                                         MPI_Aint *extent, MPI_T_enum *enumtype, MPI_Info *info,
+                                         char *desc, int *desc_len, int *bind);
+OMPI_DECLSPEC  int MPI_T_event_get_index (const char *name, int *event_index);
+OMPI_DECLSPEC  int MPI_T_event_handle_alloc (int event_index, void *obj_handle,
+                                             MPI_Info info, MPI_T_event_registration *event_registration);
+OMPI_DECLSPEC  int MPI_T_event_handle_set_info (MPI_T_event_registration event_registration, MPI_Info info);
+OMPI_DECLSPEC  int MPI_T_event_handle_get_info (MPI_T_event_registration event_registration,
+                                                MPI_Info *info_used);
+OMPI_DECLSPEC  int MPI_T_event_handle_free (MPI_T_event_registration event_registration,
+                                            MPI_T_event_free_cb_function free_cb_function);
+OMPI_DECLSPEC  int MPI_T_event_register_callback (MPI_T_event_registration event_registration,
+                                                  MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data,
+                                                  MPI_T_event_cb_function event_cb_function);
+OMPI_DECLSPEC  int MPI_T_event_callback_set_info (MPI_T_event_registration event_registration,
+                                                  MPI_T_cb_safety cb_safety, MPI_Info info);
+OMPI_DECLSPEC  int MPI_T_event_callback_get_info (MPI_T_event_registration event_registration,
+                                                  MPI_T_cb_safety cb_safety, MPI_Info *info_used);
+OMPI_DECLSPEC  int MPI_T_event_set_dropped_handler (MPI_T_event_registration handle,
+                                                    MPI_T_event_dropped_cb_function dropped_cb_function);
+OMPI_DECLSPEC  int MPI_T_event_read (MPI_T_event_instance event, int element_index, void *buffer);
+OMPI_DECLSPEC  int MPI_T_event_copy (MPI_T_event_instance event, void *buffer);
+OMPI_DECLSPEC  int MPI_T_event_get_timestamp (MPI_T_event_instance event, MPI_Count *event_time);
+OMPI_DECLSPEC  int MPI_T_event_get_source (MPI_T_event_instance event, int *source_index);
+
+OMPI_DECLSPEC  int MPI_T_source_get_num (int *num_source);
+OMPI_DECLSPEC  int MPI_T_source_get_info (int source_id, char *name, int *name_len,
+                                          char *desc, int *desc_len, MPI_T_order *ordering,
+                                          MPI_Count *ticks_per_second, MPI_Count *max_timestamp,
+                                          MPI_Info *info);
+OMPI_DECLSPEC  int MPI_T_source_get_timestamp (int source_id, MPI_Count *timestamp);
 
 /*
  * Even though MPI_Copy_function and MPI_Delete_function are

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -50,6 +50,34 @@
 #include "osc_rdma_peer.h"
 
 #include "opal_stdint.h"
+#include "opal/mca/base/mca_base_event.h"
+
+enum {
+    OMPI_OSC_RDMA_EVENT_LOCK_ACQUIRED,
+    OMPI_OSC_RDMA_EVENT_LOCK_RELEASED,
+    OMPI_OSC_RDMA_EVENT_PUT_STARTED,
+    OMPI_OSC_RDMA_EVENT_PUT_COMPLETE,
+    OMPI_OSC_RDMA_EVENT_GET_STARTED,
+    OMPI_OSC_RDMA_EVENT_GET_COMPLETE,
+    OMPI_OSC_RDMA_EVENT_FLUSH_STARTED,
+    OMPI_OSC_RDMA_EVENT_FLUSH_COMPLETE,
+    OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_START,
+    OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_COMPLETE,
+    OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_START,
+    OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_COMPLETE,
+    OMPI_OSC_RDMA_EVENT_FENCE,
+    OMPI_OSC_RDMA_EVENT_MAX,
+};
+
+struct mca_osc_rdma_rdma_event_t {
+    int target;
+    uint64_t address;
+    uint64_t size;
+};
+
+typedef struct mca_osc_rdma_rdma_event_t mca_osc_rdma_rdma_event_t;
+
+extern mca_base_event_list_item_t mca_osc_rdma_events[];
 
 #define RANK_ARRAY_COUNT(module) ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count)
 

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -208,6 +208,8 @@ static void ompi_osc_rdma_handle_post (ompi_osc_rdma_module_t *module, int rank,
                              rank, (int) (npeers - state->num_post_msgs - 1));
             /* an atomic is not really necessary as this function is currently used but it doesn't hurt */
             ompi_osc_rdma_counter_add (&state->num_post_msgs, 1);
+            mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_START].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                 module->win, NULL, &rank);
             return;
         }
     }
@@ -333,6 +335,9 @@ int ompi_osc_rdma_post_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
         return OMPI_SUCCESS;
     }
 
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_START].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, NULL);
+
     /* translate group ranks into the communicator */
     peers = ompi_osc_rdma_get_peers (module, module->pw_group);
     if (OPAL_UNLIKELY(NULL == peers)) {
@@ -419,6 +424,8 @@ int ompi_osc_rdma_start_atomic (ompi_group_t *group, int assert, ompi_win_t *win
                                      "from %d processes", peer->rank, (int) (group_size - state->num_post_msgs - 1));
                     opal_list_remove_item (&module->pending_posts, &pending_post->super);
                     OBJ_RELEASE(pending_post);
+                    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_START].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                         module->win, NULL, &peer->rank);
                     ompi_osc_rdma_counter_add (&state->num_post_msgs, 1);
                     break;
                 }
@@ -487,6 +494,9 @@ int ompi_osc_rdma_complete_atomic (ompi_win_t *win)
         ompi_osc_rdma_peer_t *peer = peers[i];
         intptr_t target = (intptr_t) peer->state + offsetof (ompi_osc_rdma_state_t, num_complete_msgs);
 
+        mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_COMPLETE].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                             module->win, NULL, &peer->rank);
+
         if (!ompi_osc_rdma_peer_local_state (peer)) {
             ret = ompi_osc_rdma_lock_btl_op (module, peer, target, MCA_BTL_ATOMIC_ADD, 1, true);
             assert (OMPI_SUCCESS == ret);
@@ -529,6 +539,9 @@ int ompi_osc_rdma_wait_atomic (ompi_win_t *win)
         ompi_osc_rdma_progress (module);
         opal_atomic_mb ();
     }
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_COMPLETE].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, NULL);
 
     OPAL_THREAD_LOCK(&module->lock);
     group = module->pw_group;
@@ -578,6 +591,9 @@ int ompi_osc_rdma_test_atomic (ompi_win_t *win, int *flag)
     group = module->pw_group;
     module->pw_group = NULL;
     OPAL_THREAD_UNLOCK(&(module->lock));
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_COMPLETE].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, NULL);
 
     OBJ_RELEASE(group);
 

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -13,6 +13,7 @@
  * $HEADER$
  */
 
+#include "osc_rdma.h"
 #include "osc_rdma_comm.h"
 #include "osc_rdma_sync.h"
 #include "osc_rdma_request.h"
@@ -448,6 +449,9 @@ static int ompi_osc_rdma_put_real (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_pee
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "initiating btl put of %lu bytes to remote address %" PRIx64 ", sync "
                      "object %p...", (unsigned long) size, target_address, (void *) sync);
 
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_PUT_STARTED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &((mca_osc_rdma_rdma_event_t){.target = peer->rank, .address = target_address, .size = size}));
+
     /* flag outstanding rma requests */
     ompi_osc_rdma_sync_rdma_inc (sync);
 
@@ -697,6 +701,9 @@ static int ompi_osc_rdma_get_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_p
          * as well. this path also covers the case where the get operation is not buffered. */
         ompi_osc_rdma_sync_rdma_inc (sync);
     }
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_GET_STARTED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &((mca_osc_rdma_rdma_event_t){.target = peer->rank, .address = source_address, .size = size}));
 
     do {
         ret = module->selected_btl->btl_get (module->selected_btl, peer->data_endpoint, ptr,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -84,6 +84,87 @@ static char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, char *ke
 static char *ompi_osc_rdma_btl_names;
 static char *ompi_osc_rdma_mtl_names;
 
+static char *mca_osc_rdma_target_element[] = {
+    "target", NULL,
+};
+
+static opal_datatype_t *mca_osc_rdma_rdma_event_types[] = {
+    &ompi_mpi_int.dt.super, &ompi_mpi_int64_t.dt.super, &ompi_mpi_int64_t.dt.super,
+};
+
+static char *mca_osc_rdma_rdma_event_elements[] = {
+    "target", "address", "size_bytes", NULL,
+};
+
+static unsigned long mca_osc_rdma_rdma_event_offsets[] = {
+    offsetof (mca_osc_rdma_rdma_event_t, target), offsetof (mca_osc_rdma_rdma_event_t, address),
+    offsetof (mca_osc_rdma_rdma_event_t, size),
+};
+
+mca_base_event_list_item_t mca_osc_rdma_events[] = {
+    [OMPI_OSC_RDMA_EVENT_LOCK_ACQUIRED] = {.name = "lock_acquired", .desc = "Passive-target lock aquired",
+                                           .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                           .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                           .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_LOCK_RELEASED] = {.name = "lock_released", .desc = "Passive-target lock required",
+                                           .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                           .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                           .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PUT_STARTED] = {.name = "put_started", .desc = "Put started to target. Complete event may not exist.",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = mca_osc_rdma_rdma_event_types,
+                                         .offsets = mca_osc_rdma_rdma_event_offsets, .num_datatypes = 3,
+                                         .elements = mca_osc_rdma_rdma_event_elements, .extent = 24, .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PUT_COMPLETE] = {.name = "put_complete", .desc = "Put completed on target",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = mca_osc_rdma_rdma_event_types,
+                                         .offsets = mca_osc_rdma_rdma_event_offsets, .num_datatypes = 3,
+                                         .elements = mca_osc_rdma_rdma_event_elements, .extent = 24, .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_GET_STARTED] = {.name = "get_started", .desc = "Put started to target. Complete event may not exist.",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = mca_osc_rdma_rdma_event_types,
+                                         .offsets = mca_osc_rdma_rdma_event_offsets, .num_datatypes = 3,
+                                         .elements = mca_osc_rdma_rdma_event_elements, .extent = 24, .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_GET_COMPLETE] = {.name = "get_complete", .desc = "Put completed on target",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = mca_osc_rdma_rdma_event_types,
+                                         .offsets = mca_osc_rdma_rdma_event_offsets, .num_datatypes = 3,
+                                         .elements = mca_osc_rdma_rdma_event_elements, .extent = 24, .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_FLUSH_STARTED] = {.name = "flush_started", .desc = "Flush started on target",
+                                           .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                           .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                           .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_FLUSH_COMPLETE] = {.name = "flush_complete", .desc = "Flush complete on target",
+                                            .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                            .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                            .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_START] = {.name = "pscw_expose_start", .desc = "PSWW exposure started",
+                                          .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                          .offsets = &(unsigned long) {0}, .num_datatypes = 0, .elements = mca_osc_rdma_target_element,
+                                          .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PSCW_EXPOSE_COMPLETE] = {.name = "pscw_expose_complete", .desc = "PSWW exposure complete",
+                                             .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                             .offsets = &(unsigned long) {0}, .num_datatypes = 0, .elements = mca_osc_rdma_target_element,
+                                             .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_START] = {.name = "pscw_access_start", .desc = "PSWW access epoch started",
+                                          .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                          .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                          .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_PSCW_ACCESS_COMPLETE] = {.name = "pscw_access_complete", .desc = "PSWW access epoch complete",
+                                             .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_int.dt.super},
+                                             .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_osc_rdma_target_element,
+                                             .extent = sizeof (int), .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+
+    [OMPI_OSC_RDMA_EVENT_FENCE] = {.name = "fence", .desc = "Fence called", .verbosity = OPAL_INFO_LVL_5, .bind = MCA_BASE_VAR_BIND_MPI_WIN},
+};
+
 static const mca_base_var_enum_value_t ompi_osc_rdma_locking_modes[] = {
     {.value = OMPI_OSC_RDMA_LOCKING_TWO_LEVEL, .string = "two_level"},
     {.value = OMPI_OSC_RDMA_LOCKING_ON_DEMAND, .string = "on_demand"},
@@ -291,6 +372,8 @@ static int ompi_osc_rdma_component_register (void)
                                              NULL, MCA_BASE_VAR_BIND_MPI_WIN, MCA_BASE_PVAR_FLAG_CONTINUOUS,
                                              ompi_osc_rdma_pvar_read, NULL, NULL,
                                              (void *) (intptr_t) offsetof (ompi_osc_rdma_module_t, get_retry_count));
+
+    mca_base_component_event_register_list (&mca_osc_rdma_component.super.osc_version, mca_osc_rdma_events, OMPI_OSC_RDMA_EVENT_MAX);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/osc/rdma/osc_rdma_passive_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_passive_target.c
@@ -55,8 +55,14 @@ int ompi_osc_rdma_flush (int target, struct ompi_win_t *win)
     }
     OPAL_THREAD_UNLOCK(&module->lock);
 
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_FLUSH_STARTED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &target);
+
     /* finish all outstanding fragments */
     ompi_osc_rdma_sync_rdma_complete (lock);
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_FLUSH_COMPLETE].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &target);
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "flush on target %d complete", target);
 
@@ -84,6 +90,9 @@ int ompi_osc_rdma_flush_all (struct ompi_win_t *win)
         ompi_osc_rdma_sync_rdma_complete (&module->all_sync);
     }
 
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_FLUSH_STARTED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &(int) {-1});
+
     /* flush all locks */
     ret = opal_hash_table_get_first_key_uint32 (&module->outstanding_locks, &key, (void **) &lock, &node);
     while (OPAL_SUCCESS == ret) {
@@ -92,6 +101,9 @@ int ompi_osc_rdma_flush_all (struct ompi_win_t *win)
         ret = opal_hash_table_get_next_key_uint32 (&module->outstanding_locks, &key, (void **) &lock,
                                                    node, &node);
     }
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_FLUSH_COMPLETE].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &(int) {-1});
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "flush_all complete");
 
@@ -158,6 +170,9 @@ static inline int ompi_osc_rdma_lock_atomic_internal (ompi_osc_rdma_module_t *mo
         } while (1);
     }
 
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_LOCK_ACQUIRED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &peer->rank);
+
     return OMPI_SUCCESS;
 }
 
@@ -181,6 +196,10 @@ static inline int ompi_osc_rdma_unlock_atomic_internal (ompi_osc_rdma_module_t *
         ompi_osc_rdma_lock_release_shared (module, peer, -1, offsetof (ompi_osc_rdma_state_t, local_lock));
         peer->flags &= ~OMPI_OSC_RDMA_PEER_DEMAND_LOCKED;
     }
+
+    mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_LOCK_RELEASED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                         module->win, NULL, &peer->rank);
+
 
     return OMPI_SUCCESS;
 }
@@ -354,6 +373,9 @@ int ompi_osc_rdma_lock_all_atomic (int assert, struct ompi_win_t *win)
             ret = ompi_osc_rdma_lock_acquire_shared (module, module->leader, 0x0000000100000000UL,
                                                      offsetof(ompi_osc_rdma_state_t, global_lock),
                                                      0x00000000ffffffffUL);
+
+            mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_LOCK_ACQUIRED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                 module->win, NULL, &(int) {-1});
         } else {
             /* always lock myself */
             ret = ompi_osc_rdma_demand_lock_peer (module, module->my_peer);
@@ -409,6 +431,9 @@ int ompi_osc_rdma_unlock_all_atomic (struct ompi_win_t *win)
             /* decrement the master lock shared count */
             (void) ompi_osc_rdma_lock_release_shared (module, module->leader, -0x0000000100000000UL,
                                                       offsetof (ompi_osc_rdma_state_t, global_lock));
+
+            mca_base_event_raise(mca_osc_rdma_events[OMPI_OSC_RDMA_EVENT_LOCK_RELEASED].event, MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                 module->win, NULL, &(int) {-1});
         }
     }
 

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2006-2008 University of Houston.  All rights reserved.
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
@@ -237,8 +237,8 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
          * figure out if the messages are not received in the correct
          * order (if multiple network interfaces).
          */
-        PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_ARRIVED, comm,
-                               hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_MESSAGE_ARRIVED].event,
+                              MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, hdr);
 
         /* There is no matching to be done, and no lock to be held on the communicator as
          * we know at this point that the communicator has not yet been returned to the user.
@@ -254,8 +254,8 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
 #else
             custom_match_umq_append(pml_comm->umq, hdr->hdr_tag, hdr->hdr_src, frag);
 #endif
-            PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_INSERT_IN_UNEX_Q, comm,
-                                   hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_UNEX_INSERT].event,
+                                  MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, hdr);
             continue;
         }
 
@@ -269,8 +269,9 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
 #else
             custom_match_umq_append(pml_comm->umq, hdr->hdr_tag, hdr->hdr_src, frag);
 #endif
-            PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_INSERT_IN_UNEX_Q, comm,
-                                   hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_UNEX_INSERT].event,
+                                  MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, hdr);
+
             /* And now the ugly part. As some fragments can be inserted in the cant_match list,
              * every time we succesfully add a fragment in the unexpected list we have to make
              * sure the next one is not in the cant_match. Otherwise, we will endup in a deadlock

--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -41,6 +41,7 @@
 #include "ompi/mca/bml/base/base.h"
 #include "ompi/proc/proc.h"
 #include "opal/mca/allocator/base/base.h"
+#include "opal/mca/base/mca_base_event.h"
 
 BEGIN_C_DECLS
 
@@ -85,6 +86,34 @@ struct mca_pml_ob1_t {
     unsigned int unexpected_limit;
 };
 typedef struct mca_pml_ob1_t mca_pml_ob1_t;
+
+enum {
+    MCA_PML_OB1_EVENT_MESSAGE_ARRIVED,
+    MCA_PML_OB1_EVENT_SEARCH_POSTED_BEGIN,
+    MCA_PML_OB1_EVENT_SEARCH_POSTED_END,
+    MCA_PML_OB1_EVENT_SEARCH_UNEX_BEGIN,
+    MCA_PML_OB1_EVENT_SEARCH_UNEX_END,
+    MCA_PML_OB1_EVENT_POSTED_INSERT,
+    MCA_PML_OB1_EVENT_POSTED_REMOVE,
+    MCA_PML_OB1_EVENT_UNEX_INSERT,
+    MCA_PML_OB1_EVENT_UNEX_REMOVE,
+    MCA_PML_OB1_EVENT_TRANSFER_BEGIN,
+    MCA_PML_OB1_EVENT_TRANSFER,
+    MCA_PML_OB1_EVENT_TRANSFER_END,
+    MCA_PML_OB1_EVENT_RECEIVE_CANCELED,
+    MCA_PML_OB1_EVENT_REQUEST_FREE,
+    MCA_PML_OB1_EVENT_REQUEST_ACTIVATE,
+    MCA_PML_OB1_EVENT_REQUEST_COMPLETE,
+    MCA_PML_OB1_EVENT_MAX,
+};
+
+extern mca_base_event_list_item_t mca_pml_ob1_events[];
+
+struct mca_pml_ob1_transfer_event_t {
+    void *request;
+    int64_t length;
+};
+typedef struct mca_pml_ob1_transfer_event_t mca_pml_ob1_transfer_event_t;
 
 extern mca_pml_ob1_t mca_pml_ob1;
 extern int mca_pml_ob1_output;

--- a/ompi/mca/pml/ob1/pml_ob1_component.c
+++ b/ompi/mca/pml/ob1/pml_ob1_component.c
@@ -99,12 +99,12 @@ mca_base_event_list_item_t mca_pml_ob1_events[] = {
 
     [MCA_PML_OB1_EVENT_SEARCH_POSTED_BEGIN] = {.name = "search_posted_begin", .desc = "Begin searching posted message queue",
                                                .verbosity = OPAL_INFO_LVL_5, .datatypes = &mca_pml_ob1_match_hdr_types[1],
-                                               .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 2,
+                                               .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 3,
                                                .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
 
     [MCA_PML_OB1_EVENT_SEARCH_POSTED_END] = {.name = "search_posted_end", .desc = "Finished searching posted message queue",
                                              .verbosity = OPAL_INFO_LVL_5, .datatypes = &mca_pml_ob1_match_hdr_types[1],
-                                             .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 2,
+                                             .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 3,
                                              .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
 
     [MCA_PML_OB1_EVENT_SEARCH_UNEX_BEGIN] = {.name = "search_unexpected_begin", .desc = "Begin searching unexpected message queue",

--- a/ompi/mca/pml/ob1/pml_ob1_component.c
+++ b/ompi/mca/pml/ob1/pml_ob1_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved
- * Copyright (c) 2013-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Sandia National Laboratories
  *                         All rights reserved.
@@ -59,6 +59,111 @@ static int mca_pml_ob1_component_fini(void);
 int mca_pml_ob1_output = 0;
 static int mca_pml_ob1_verbose = 0;
 bool mca_pml_ob1_matching_protection = false;
+
+static opal_datatype_t *mca_pml_ob1_match_hdr_types[] = {
+    &ompi_mpi_int16_t.dt.super, &ompi_mpi_int32_t.dt.super,
+    &ompi_mpi_int32_t.dt.super, &ompi_mpi_int16_t.dt.super,
+};
+
+static opal_datatype_t *mca_pml_ob1_request_size_types[] = {
+    &ompi_mpi_aint.dt.super, &ompi_mpi_int64_t.dt.super,
+};
+
+static unsigned long mca_pml_ob1_match_hdr_offsets[] = {
+    offsetof (mca_pml_ob1_match_hdr_t, hdr_ctx), offsetof (mca_pml_ob1_match_hdr_t, hdr_src),
+    offsetof (mca_pml_ob1_match_hdr_t, hdr_tag), offsetof (mca_pml_ob1_match_hdr_t, hdr_seq),
+};
+
+static unsigned long mca_pml_ob1_request_size_offsets[] = {
+    offsetof (mca_pml_ob1_transfer_event_t, request), offsetof (mca_pml_ob1_transfer_event_t, length),
+};
+
+static char *mca_pml_ob1_match_hdr_names[] = {
+    "context id", "source", "tag", "sequence number", NULL,
+};
+
+static char *mca_pml_ob1_request_element[] = {
+    "request", NULL,
+};
+
+static char *mca_pml_ob1_request_size_elements[] = {
+    "request", "length", NULL,
+};
+
+
+mca_base_event_list_item_t mca_pml_ob1_events[] = {
+    [MCA_PML_OB1_EVENT_MESSAGE_ARRIVED] = {.name = "message_arrived", .desc = "Message arrived for match",
+                                           .verbosity = OPAL_INFO_LVL_5, .datatypes = mca_pml_ob1_match_hdr_types,
+                                           .offsets = mca_pml_ob1_match_hdr_offsets, .num_datatypes = 4,
+                                           .elements = mca_pml_ob1_match_hdr_names, .extent = 12, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_SEARCH_POSTED_BEGIN] = {.name = "search_posted_begin", .desc = "Begin searching posted message queue",
+                                               .verbosity = OPAL_INFO_LVL_5, .datatypes = &mca_pml_ob1_match_hdr_types[1],
+                                               .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 2,
+                                               .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_SEARCH_POSTED_END] = {.name = "search_posted_end", .desc = "Finished searching posted message queue",
+                                             .verbosity = OPAL_INFO_LVL_5, .datatypes = &mca_pml_ob1_match_hdr_types[1],
+                                             .offsets = &mca_pml_ob1_match_hdr_offsets[1], .num_datatypes = 2,
+                                             .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_SEARCH_UNEX_BEGIN] = {.name = "search_unexpected_begin", .desc = "Begin searching unexpected message queue",
+                                             .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super},
+                                             .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_pml_ob1_request_element,
+                                             .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_SEARCH_UNEX_END] = {.name = "search_unexpected_end", .desc = "Finished searching unexpected message queue",
+                                           .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super},
+                                           .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_pml_ob1_request_element,
+                                           .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_POSTED_INSERT] = {.name = "posted_insert", .desc = "Added request to the posted message queue",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super},
+                                         .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_pml_ob1_request_element,
+                                         .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_POSTED_REMOVE] = {.name = "posted_remove", .desc = "Remove request from the posted message queue",
+                                         .verbosity = OPAL_INFO_LVL_5, .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super},
+                                         .offsets = &(unsigned long) {0}, .num_datatypes = 1, .elements = mca_pml_ob1_request_element,
+                                         .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_UNEX_INSERT] = {.name = "unex_insert", .desc = "Unexpected message inserted in queue", .verbosity = OPAL_INFO_LVL_5,
+                                       .datatypes = &mca_pml_ob1_match_hdr_types[1], .offsets = &mca_pml_ob1_match_hdr_offsets[1],
+                                       .num_datatypes = 2, .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_UNEX_REMOVE] = {.name = "unex_remove", .desc = "Unexpected message removed from queue", .verbosity = OPAL_INFO_LVL_5,
+                                       .datatypes = &mca_pml_ob1_match_hdr_types[1], .offsets = &mca_pml_ob1_match_hdr_offsets[1],
+                                       .num_datatypes = 2, .elements = &mca_pml_ob1_match_hdr_names[1], .extent = 8, .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_TRANSFER_BEGIN] = {.name = "transfer_begin", .desc = "Transfer has begun", .verbosity = OPAL_INFO_LVL_5,
+                                          .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                          .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_TRANSFER] = {.name = "transfer", .desc = "Transfer event", .verbosity = OPAL_INFO_LVL_5,
+                                    .datatypes = mca_pml_ob1_request_size_types, .offsets = mca_pml_ob1_request_size_offsets, .num_datatypes = 2,
+                                    .elements = mca_pml_ob1_request_size_elements, .extent = sizeof (mca_pml_ob1_transfer_event_t),
+                                    .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_TRANSFER_END] = {.name = "transfer_end", .desc = "Transfer has completed", .verbosity = OPAL_INFO_LVL_5,
+                                        .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                        .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_RECEIVE_CANCELED] = {.name = "cancel", .desc = "Receive request canceled", .verbosity = OPAL_INFO_LVL_5,
+                                            .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                            .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_REQUEST_FREE] = {.name = "free", .desc = "Request object freed", .verbosity = OPAL_INFO_LVL_5,
+                                        .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                        .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_REQUEST_ACTIVATE] = {.name = "request_activate", .desc = "Request activated", .verbosity = OPAL_INFO_LVL_5,
+                                            .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                            .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+
+    [MCA_PML_OB1_EVENT_REQUEST_COMPLETE] = {.name = "request_complete", .desc = "Request completed", .verbosity = OPAL_INFO_LVL_5,
+                                            .datatypes = &(opal_datatype_t *) {&ompi_mpi_aint.dt.super}, .offsets = &(unsigned long) {0}, .num_datatypes = 1,
+                                            .elements = mca_pml_ob1_request_element, .extent = sizeof (MPI_Aint), .bind = MCA_BASE_VAR_BIND_MPI_COMM},
+};
 
 mca_pml_base_component_2_0_0_t mca_pml_ob1_component = {
     /* First, the mca_base_component_t struct containing meta
@@ -238,6 +343,8 @@ static int mca_pml_ob1_component_register(void)
                                            MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, MPI_T_BIND_MPI_COMM,
                                            MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
                                            mca_pml_ob1_get_posted_recvq_size, NULL, mca_pml_ob1_comm_size_notify, NULL);
+
+    mca_base_component_event_register_list (&mca_pml_ob1_component.pmlm_version, mca_pml_ob1_events, MCA_PML_OB1_EVENT_MAX);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
@@ -59,9 +59,8 @@ int mca_pml_ob1_irecv_init(void *addr,
                                    addr,
                                    count, datatype, src, tag, comm, true);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &((recvreq)->req_recv.req_base),
-                             PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &recvreq);
 
     /* Work around a leak in start by marking this request as complete. The
      * problem occured because we do not have a way to differentiate an
@@ -91,9 +90,8 @@ int mca_pml_ob1_irecv(void *addr,
                                    addr,
                                    count, datatype, src, tag, comm, false);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &((recvreq)->req_recv.req_base),
-                             PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &recvreq);
 
     MCA_PML_OB1_RECV_REQUEST_START(recvreq);
     *request = (ompi_request_t *) recvreq;
@@ -127,9 +125,8 @@ int mca_pml_ob1_recv(void *addr,
     MCA_PML_OB1_RECV_REQUEST_INIT(recvreq, addr, count, datatype,
                                   src, tag, comm, false);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &(recvreq->req_recv.req_base),
-                             PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &recvreq);
 
     MCA_PML_OB1_RECV_REQUEST_START(recvreq);
     ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
@@ -213,9 +210,8 @@ mca_pml_ob1_imrecv( void *buf,
                                   src, tag, comm, false);
     OBJ_RELEASE(comm);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &((recvreq)->req_recv.req_base),
-                             PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &recvreq);
 
     /* init/re-init the request */
     recvreq->req_lock = 0;
@@ -306,9 +302,8 @@ mca_pml_ob1_mrecv( void *buf,
                                   src, tag, comm, false);
     OBJ_RELEASE(comm);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &((recvreq)->req_recv.req_base),
-                             PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &recvreq);
 
     /* init/re-init the request */
     recvreq->req_lock = 0;

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -60,9 +60,8 @@ int mca_pml_ob1_isend_init(const void *buf,
                                   dst, tag,
                                   comm, sendmode, true);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &(sendreq)->req_send.req_base,
-                             PERUSE_SEND);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &sendreq);
 
     /* Work around a leak in start by marking this request as complete. The
      * problem occured because we do not have a way to differentiate an
@@ -191,9 +190,8 @@ int mca_pml_ob1_isend(const void *buf,
                                   dst, tag,
                                   comm, sendmode, false);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &(sendreq)->req_send.req_base,
-                             PERUSE_SEND);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &sendreq);
 
     MCA_PML_OB1_SEND_REQUEST_START_W_SEQ(sendreq, endpoint, seqn, rc);
     *request = (ompi_request_t *) sendreq;
@@ -271,9 +269,8 @@ int mca_pml_ob1_send(const void *buf,
                                   dst, tag,
                                   comm, sendmode, false);
 
-    PERUSE_TRACE_COMM_EVENT (PERUSE_COMM_REQ_ACTIVATE,
-                             &sendreq->req_send.req_base,
-                             PERUSE_SEND);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_ACTIVATE].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, comm, NULL, &sendreq);
 
     MCA_PML_OB1_SEND_REQUEST_START_W_SEQ(sendreq, endpoint, seqn, rc);
     if (OPAL_LIKELY(rc == OMPI_SUCCESS)) {

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2006-2008 University of Houston.  All rights reserved.
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -381,8 +381,8 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
      * figure out if the messages are not received in the correct
      * order (if multiple network interfaces).
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_ARRIVED, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_MESSAGE_ARRIVED].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     /* get next expected message sequence number - if threaded
      * run, lock to make sure that if another thread is processing
@@ -416,8 +416,8 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
      * received in the correct sequence. Otherwise, we delay the event
      * generation until we reach the correct sequence number.
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_BEGIN, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_POSTED_BEGIN].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     match = match_one(btl, hdr, segments, num_segments, comm_ptr, proc, NULL);
 
@@ -425,8 +425,8 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
      * before going into check_cantmatch_for_match so we can make
      * a difference for the searching time for all messages.
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_END, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_POSTED_END].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     /* release matching lock before processing fragment */
     OB1_MATCHING_UNLOCK(&comm->matching_lock);
@@ -730,8 +730,9 @@ static mca_pml_ob1_recv_request_t *match_incomming(const mca_pml_ob1_match_hdr_t
         req_tag = (*match)->req_recv.req_base.req_tag;
         if(req_tag == tag || (req_tag == OMPI_ANY_TAG && tag >= 0)) {
             opal_list_remove_item(queue, (opal_list_item_t*)(*match));
-            PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_REQ_REMOVE_FROM_POSTED_Q,
-                    &((*match)->req_recv.req_base), PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_POSTED_REMOVE].event,
+                                  MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                                  (*match)->req_recv.req_base.req_comm, NULL, match);
             return *match;
         }
 
@@ -758,8 +759,9 @@ static mca_pml_ob1_recv_request_t *match_incomming_no_any_source (const mca_pml_
 
         if (req_tag == tag || (req_tag == OMPI_ANY_TAG && tag >= 0)) {
             opal_list_remove_item (&proc->specific_receives, (opal_list_item_t *) recv_req);
-            PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_REQ_REMOVE_FROM_POSTED_Q,
-                    &(recv_req->req_recv.req_base), PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_POSTED_REMOVE].event,
+                                  MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                                  recv_req->req_recv.req_base.req_comm, NULL, &recv_req);
             return recv_req;
         }
     }
@@ -825,8 +827,9 @@ static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
                 return NULL;
             }
 
-            PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_MSG_MATCH_POSTED_REQ,
-                                    &(match->req_recv.req_base), PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_POSTED_REMOVE].event,
+                                  MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                  match->req_recv.req_base.req_comm, NULL, &match);
             SPC_TIMER_STOP(OMPI_SPC_MATCH_TIME, &timer);
             return match;
         }
@@ -842,9 +845,10 @@ static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
         SPC_RECORD(OMPI_SPC_UNEXPECTED, 1);
         SPC_RECORD(OMPI_SPC_UNEXPECTED_IN_QUEUE, 1);
         SPC_UPDATE_WATERMARK(OMPI_SPC_MAX_UNEXPECTED_IN_QUEUE, OMPI_SPC_UNEXPECTED_IN_QUEUE);
-        PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_INSERT_IN_UNEX_Q, comm_ptr,
-                               hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
-        SPC_TIMER_STOP(OMPI_SPC_MATCH_TIME, &timer);
+
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_UNEX_INSERT].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, hdr);
+	SPC_TIMER_STOP(OMPI_SPC_MATCH_TIME, &timer);
         return NULL;
     } while(true);
 }
@@ -917,8 +921,8 @@ static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
      * figure out if the messages are not received in the correct
      * order (if multiple network interfaces).
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_ARRIVED, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_MESSAGE_ARRIVED].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     /* get next expected message sequence number - if threaded
      * run, lock to make sure that if another thread is processing
@@ -992,8 +996,8 @@ mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
      * received in the correct sequence. Otherwise, we delay the event
      * generation until we reach the correct sequence number.
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_BEGIN, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_POSTED_BEGIN].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     match = match_one(btl, hdr, segments, num_segments, comm_ptr, proc, frag);
 
@@ -1001,8 +1005,8 @@ mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
      * before going into check_cantmatch_for_match we can make a
      * difference for the searching time for all messages.
      */
-    PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_END, comm_ptr,
-                           hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_POSTED_END].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm_ptr, NULL, hdr);
 
     /* release matching lock before processing fragment */
     OB1_MATCHING_UNLOCK(&comm->matching_lock);

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2011-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2012      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
@@ -77,8 +77,9 @@ static int mca_pml_ob1_recv_request_free(struct ompi_request_t** request)
     assert (false == recvreq->req_recv.req_base.req_free_called);
 
     recvreq->req_recv.req_base.req_free_called = true;
-    PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_NOTIFY,
-                             &(recvreq->req_recv.req_base), PERUSE_RECV );
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_FREE].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                          recvreq->req_recv.req_base.req_comm, NULL, &recvreq);
 
     if( true == recvreq->req_recv.req_base.req_pml_complete ) {
         /* make buffer defined when the request is compeleted,
@@ -121,8 +122,10 @@ static int mca_pml_ob1_recv_request_cancel(struct ompi_request_t* ompi_request, 
         opal_list_remove_item(&proc->specific_receives, (opal_list_item_t*)request);
     }
 #endif
-    PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_REMOVE_FROM_POSTED_Q,
-                             &(request->req_recv.req_base), PERUSE_RECV );
+
+    void *req = &(request->req_recv.req_base);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_RECEIVE_CANCELED].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &req);
     /**
      * As now the PML is done with this request we have to force the pml_complete
      * to true. Otherwise, the request will never be freed.
@@ -411,6 +414,7 @@ static void mca_pml_ob1_rget_completion (mca_btl_base_module_t* btl, struct mca_
 static int mca_pml_ob1_recv_request_put_frag (mca_pml_ob1_rdma_frag_t *frag)
 {
     mca_pml_ob1_recv_request_t *recvreq = (mca_pml_ob1_recv_request_t *) frag->rdma_req;
+    ompi_communicator_t *comm = recvreq->req_recv.req_base.req_comm;
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
     ompi_proc_t* proc = (ompi_proc_t*)recvreq->req_recv.req_base.req_proc;
 #endif
@@ -450,9 +454,10 @@ static int mca_pml_ob1_recv_request_put_frag (mca_pml_ob1_rdma_frag_t *frag)
 
     recvreq->req_ack_sent = true;
 
-    PERUSE_TRACE_COMM_OMPI_EVENT( PERUSE_COMM_REQ_XFER_CONTINUE,
-                                  &(recvreq->req_recv.req_base), frag->rdma_length,
-                                  PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL,
+                          &((mca_pml_ob1_transfer_event_t) {.request = recvreq, .length = frag->rdma_length}));
+
 
     /* send rdma request to peer */
     rc = mca_bml_base_send (bml_btl, ctl, MCA_PML_OB1_HDR_TYPE_PUT);
@@ -491,9 +496,9 @@ int mca_pml_ob1_recv_request_get_frag (mca_pml_ob1_rdma_frag_t *frag)
         local_handle = recvreq->local_handle;
     }
 
-    PERUSE_TRACE_COMM_OMPI_EVENT(PERUSE_COMM_REQ_XFER_CONTINUE,
-                                 &(((mca_pml_ob1_recv_request_t *) frag->rdma_req)->req_recv.req_base),
-                                 frag->rdma_length, PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER].event,
+                          MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE, recvreq->req_recv.req_base.req_comm, NULL,
+                          &((mca_pml_ob1_transfer_event_t){.request = frag->rdma_req, .length = frag->rdma_length}));
 
     /* queue up get request */
     rc = mca_bml_base_get (bml_btl, frag->local_address, frag->remote_address, local_handle,
@@ -507,9 +512,6 @@ int mca_pml_ob1_recv_request_get_frag (mca_pml_ob1_rdma_frag_t *frag)
 
     return OMPI_SUCCESS;
 }
-
-
-
 
 /*
  * Update the recv request status to reflect the number of bytes
@@ -1086,16 +1088,15 @@ static inline void append_recv_req_to_queue(opal_list_t *queue,
 {
     opal_list_append(queue, (opal_list_item_t*)req);
 
-#if OMPI_WANT_PERUSE
     /**
      * We don't want to generate this kind of event for MPI_Probe.
      */
     if (req->req_recv.req_base.req_type != MCA_PML_REQUEST_PROBE &&
         req->req_recv.req_base.req_type != MCA_PML_REQUEST_MPROBE) {
-        PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_REQ_INSERT_IN_POSTED_Q,
-                                &(req->req_recv.req_base), PERUSE_RECV);
+        ompi_communicator_t *comm = req->req_recv.req_base.req_comm;
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_POSTED_INSERT].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &req);
     }
-#endif
 }
 
 /*
@@ -1258,8 +1259,8 @@ void mca_pml_ob1_recv_req_start(mca_pml_ob1_recv_request_t *req)
      * The laps of time between the ACTIVATE event and the SEARCH_UNEX one include
      * the cost of the request lock.
      */
-    PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_SEARCH_UNEX_Q_BEGIN,
-                            &(req->req_recv.req_base), PERUSE_RECV);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_UNEX_BEGIN].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &req);
 
     /* assign sequence number */
     req->req_recv.req_base.req_sequence = ob1_comm->recv_sequence++;
@@ -1297,8 +1298,8 @@ void mca_pml_ob1_recv_req_start(mca_pml_ob1_recv_request_t *req)
     }
 
     if(OPAL_UNLIKELY(NULL == frag)) {
-        PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_SEARCH_UNEX_Q_END,
-                                &(req->req_recv.req_base), PERUSE_RECV);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_UNEX_END].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &req);
         /* We didn't find any matches.  Record this irecv so we can match
            it when the message comes in. */
         if(OPAL_LIKELY(req->req_recv.req_base.req_type != MCA_PML_REQUEST_IPROBE &&
@@ -1314,18 +1315,13 @@ void mca_pml_ob1_recv_req_start(mca_pml_ob1_recv_request_t *req)
         OB1_MATCHING_UNLOCK(&ob1_comm->matching_lock);
     } else {
         if(OPAL_LIKELY(!IS_PROB_REQ(req))) {
-            PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_REQ_MATCH_UNEX,
-                                    &(req->req_recv.req_base), PERUSE_RECV);
-
             hdr = (mca_pml_ob1_hdr_t*)frag->segments->seg_addr.pval;
-            PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_REMOVE_FROM_UNEX_Q,
-                                   req->req_recv.req_base.req_comm,
-                                   hdr->hdr_match.hdr_src,
-                                   hdr->hdr_match.hdr_tag,
-                                   PERUSE_RECV);
 
-            PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_SEARCH_UNEX_Q_END,
-                                    &(req->req_recv.req_base), PERUSE_RECV);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_UNEX_REMOVE].event,
+                                  MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &hdr->hdr_match);
+
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_SEARCH_UNEX_END].event,
+                                  MCA_BASE_CB_REQUIRE_MPI_RESTRICTED, comm, NULL, &req);
 
 #if MCA_PML_OB1_CUSTOM_MATCH
             custom_match_umq_remove_hold(req->req_recv.req_base.req_comm->c_pml_comm->umq, hold_prev, hold_elem, hold_index);

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -124,8 +124,9 @@ do {                                                                \
  */
 #define MCA_PML_OB1_RECV_REQUEST_MPI_COMPLETE( recvreq )                              \
     do {                                                                              \
-        PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_COMPLETE,                            \
-                                 &(recvreq->req_recv.req_base), PERUSE_RECV );        \
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_COMPLETE].event, \
+                              MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,             \
+                              (recvreq)->req_recv.req_base.req_comm, NULL, &(recvreq)); \
         ompi_request_complete( &(recvreq->req_recv.req_base.req_ompi), true );        \
     } while (0)
 
@@ -162,8 +163,9 @@ recv_request_pml_complete(mca_pml_ob1_recv_request_t *recvreq)
     if(false == recvreq->req_recv.req_base.req_pml_complete){
 
         if(recvreq->req_recv.req_bytes_packed > 0) {
-            PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_XFER_END,
-                    &recvreq->req_recv.req_base, PERUSE_RECV );
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_END].event,
+                                  MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                  recvreq->req_recv.req_base.req_comm, NULL, &recvreq);
         }
 
         for(i = 0; i < recvreq->req_rdma_cnt; i++) {
@@ -258,8 +260,9 @@ static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
             prepare_recv_req_converter(req);
         }
 #endif  /* OPAL_ENABLE_HETEROGENEOUS_SUPPORT */
-        PERUSE_TRACE_COMM_EVENT(PERUSE_COMM_REQ_XFER_BEGIN,
-                                &req->req_recv.req_base, PERUSE_RECV);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_BEGIN].event,
+                              MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                              req->req_recv.req_base.req_comm, NULL, &req);
     }
 }
 
@@ -268,7 +271,7 @@ static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
  *
  */
 
-#define MCA_PML_OB1_RECV_REQUEST_UNPACK( request,                                 \
+#define MCA_PML_OB1_RECV_REQUEST_UNPACK( req,                                     \
                                          segments,                                \
                                          num_segments,                            \
                                          seg_offset,                              \
@@ -277,7 +280,7 @@ static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
                                          bytes_delivered)                         \
 do {                                                                              \
     bytes_delivered = 0;                                                          \
-    if(request->req_recv.req_bytes_packed > 0) {                                  \
+    if((req)->req_recv.req_bytes_packed > 0) {                                    \
         struct iovec iov[MCA_BTL_DES_MAX_SEGMENTS];                               \
         uint32_t iov_count = 0;                                                   \
         size_t max_data = bytes_received;                                         \
@@ -295,18 +298,21 @@ do {                                                                            
                 offset = 0;                                                       \
             }                                                                     \
         }                                                                         \
-        OPAL_THREAD_LOCK(&request->lock);                                         \
-        PERUSE_TRACE_COMM_OMPI_EVENT (PERUSE_COMM_REQ_XFER_CONTINUE,              \
-                                      &(request->req_recv.req_base), max_data,    \
-                                      PERUSE_RECV);                               \
-        opal_convertor_set_position( &(request->req_recv.req_base.req_convertor), \
+        OPAL_THREAD_LOCK(&(req)->lock);                                           \
+                                                                                  \
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER].event, \
+                              MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,              \
+                              (req)->req_recv.req_base.req_comm, NULL,            \
+            &((mca_pml_ob1_transfer_event_t){.request = req, .length = max_data})); \
+                                                                                  \
+        opal_convertor_set_position( &((req)->req_recv.req_base.req_convertor),   \
                                      &data_offset );                              \
-        opal_convertor_unpack( &(request)->req_recv.req_base.req_convertor,       \
+        opal_convertor_unpack( &(req)->req_recv.req_base.req_convertor,           \
                                iov,                                               \
                                &iov_count,                                        \
                                &max_data );                                       \
         bytes_delivered = max_data;                                               \
-        OPAL_THREAD_UNLOCK(&request->lock);                                       \
+        OPAL_THREAD_UNLOCK(&(req)->lock);                                         \
     }                                                                             \
 } while (0)
 

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2012-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
@@ -103,8 +103,9 @@ static int mca_pml_ob1_send_request_free(struct ompi_request_t** request)
     if(false == sendreq->req_send.req_base.req_free_called) {
 
         sendreq->req_send.req_base.req_free_called = true;
-        PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_NOTIFY,
-                             &(sendreq->req_send.req_base), PERUSE_SEND );
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_FREE].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                              sendreq->req_send.req_base.req_comm, NULL, &sendreq);
 
         if( true == sendreq->req_send.req_base.req_pml_complete ) {
             /* make buffer defined when the request is compeleted,
@@ -163,8 +164,10 @@ mca_pml_ob1_match_completion_free_request( mca_bml_base_btl_t* bml_btl,
                                            mca_pml_ob1_send_request_t* sendreq )
 {
     if( sendreq->req_send.req_bytes_packed > 0 ) {
-        PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_XFER_BEGIN,
-                                 &(sendreq->req_send.req_base), PERUSE_SEND );
+        void *req = &(sendreq->req_send.req_base);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_BEGIN].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                              sendreq->req_send.req_base.req_comm, NULL, &req);
     }
 
     /* signal request completion */
@@ -198,8 +201,10 @@ mca_pml_ob1_rndv_completion_request( mca_bml_base_btl_t* bml_btl,
                                      size_t req_bytes_delivered )
 {
     if( sendreq->req_send.req_bytes_packed > 0 ) {
-        PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_XFER_BEGIN,
-                                 &(sendreq->req_send.req_base), PERUSE_SEND );
+        void *req = &(sendreq->req_send.req_base);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_BEGIN].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                              sendreq->req_send.req_base.req_comm, NULL, &req);
     }
 
     OPAL_THREAD_ADD_FETCH_SIZE_T(&sendreq->req_bytes_delivered, req_bytes_delivered);
@@ -745,8 +750,10 @@ int mca_pml_ob1_send_request_start_rdma( mca_pml_ob1_send_request_t* sendreq,
      * sent the GET message ...
      */
     if( sendreq->req_send.req_bytes_packed > 0 ) {
-        PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_XFER_BEGIN,
-                                 &(sendreq->req_send.req_base), PERUSE_SEND );
+        void *req = &(sendreq->req_send.req_base);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_BEGIN].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                              sendreq->req_send.req_base.req_comm, NULL, &req);
     }
 
     /* send */
@@ -1042,10 +1049,10 @@ cannot_pack:
         ob1_hdr_hton(hdr, MCA_PML_OB1_HDR_TYPE_FRAG,
                 sendreq->req_send.req_base.req_proc);
 
-#if OMPI_WANT_PERUSE
-         PERUSE_TRACE_COMM_OMPI_EVENT(PERUSE_COMM_REQ_XFER_CONTINUE,
-                 &(sendreq->req_send.req_base), size, PERUSE_SEND);
-#endif  /* OMPI_WANT_PERUSE */
+        void *req = &(sendreq->req_send.req_base);
+        mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER].event,
+                              MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                              sendreq->req_send.req_base.req_comm, NULL, &req);
 
 #if OPAL_CUDA_SUPPORT /* CUDA_ASYNC_SEND */
          /* At this point, check to see if the BTL is doing an asynchronous
@@ -1193,8 +1200,10 @@ int mca_pml_ob1_send_request_put_frag( mca_pml_ob1_rdma_frag_t *frag )
         }
     }
 
-    PERUSE_TRACE_COMM_OMPI_EVENT( PERUSE_COMM_REQ_XFER_CONTINUE,
-                                  &(((mca_pml_ob1_send_request_t*)frag->rdma_req)->req_send.req_base), frag->rdma_length, PERUSE_SEND );
+    void *req = &(((mca_pml_ob1_send_request_t*)frag->rdma_req)->req_send.req_base);
+    mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER].event,
+                          MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+                          sendreq->req_send.req_base.req_comm, NULL, &req);
 
     rc = mca_bml_base_put (bml_btl, frag->local_address, frag->remote_address, local_handle,
                            (mca_btl_base_registration_handle_t *) frag->remote_handle, frag->rdma_length,

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -207,8 +207,9 @@ do {                                                                            
    (sendreq)->req_send.req_base.req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;        \
    (sendreq)->req_send.req_base.req_ompi.req_status._ucount =                        \
         (sendreq)->req_send.req_bytes_packed;                                        \
-   PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_COMPLETE,                                \
-                            &(sendreq->req_send.req_base), PERUSE_SEND);             \
+   mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_REQUEST_COMPLETE].event, \
+                         MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,                 \
+                         (sendreq)->req_send.req_base.req_comm, NULL, &(sendreq));   \
                                                                                      \
    ompi_request_complete( &((sendreq)->req_send.req_base.req_ompi), (with_signal) ); \
 } while(0)
@@ -256,8 +257,9 @@ send_request_pml_complete(mca_pml_ob1_send_request_t *sendreq)
 {
     if(false == sendreq->req_send.req_base.req_pml_complete) {
         if(sendreq->req_send.req_bytes_packed > 0) {
-            PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_XFER_END,
-                                     &(sendreq->req_send.req_base), PERUSE_SEND);
+            mca_base_event_raise (mca_pml_ob1_events[MCA_PML_OB1_EVENT_TRANSFER_END].event,
+                                  MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+                                  sendreq->req_send.req_base.req_comm, NULL, &sendreq);
         }
 
         /* return mpool resources */

--- a/ompi/mpi/tool/Makefile.am
+++ b/ompi/mpi/tool/Makefile.am
@@ -4,7 +4,9 @@
 #                         reserved.
 # Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
-# Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2018-2019 Triad National Security, LLC. All rightsa
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -38,7 +40,13 @@ libmpi_mpit_la_SOURCES = init_thread.c finalize.c cvar_get_num.c \
                      pvar_reset.c pvar_session_create.c pvar_session_free.c \
                      pvar_start.c pvar_stop.c pvar_write.c \
                      enum_get_info.c enum_get_item.c cvar_get_index.c \
-                     pvar_get_index.c category_get_index.c
+                     pvar_get_index.c category_get_index.c \
+                     event_get_index.c event_copy.c event_callback_get_info.c \
+                     event_callback_set_info.c event_handle_get_info.c \
+                     event_handle_set_info.c event_get_info.c event_get_num.c event_get_source.c \
+                     event_get_timestamp.c event_handle_alloc.c event_handle_free.c \
+                     event_read.c event_register_callback.c event_set_dropped_handler.c \
+                     source_get_num.c source_get_info.c source_get_timestamp.c
 
 # Conditionally install the header files
 

--- a/ompi/mpi/tool/event_callback_get_info.c
+++ b/ompi/mpi/tool/event_callback_get_info.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2019      Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_callback_get_info = PMPI_T_event_callback_get_info
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_callback_get_info (MPI_T_event_registration event_registration,
+                                   MPI_T_cb_safety cb_safety, MPI_Info *info_used)
+{
+    ompi_info_t *info;
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    info = OBJ_NEW(ompi_info_t);
+    if (NULL == info) {
+        return ompit_opal_to_mpit_error(OMPI_ERR_OUT_OF_RESOURCE);
+    }
+
+    /* mca_base_cb_safety_t and MPI_T_cb_safety must be kept in sync for this to work */
+    ret = mca_base_event_callback_get_info (event_registration, (mca_base_cb_safety_t) cb_safety, &info->super);
+    if (OPAL_SUCCESS != ret) {
+        OBJ_RELEASE(info);
+    } else {
+        *info_used = info;
+    }
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_callback_set_info.c
+++ b/ompi/mpi/tool/event_callback_set_info.c
@@ -1,0 +1,41 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2019      Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_callback_set_info = PMPI_T_event_callback_set_info
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_callback_set_info (MPI_T_event_registration event_registration,
+                                   MPI_T_cb_safety cb_safety, MPI_Info info)
+{
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    /* mca_base_cb_safety_t and MPI_T_cb_safety must be kept in sync for this to work */
+    ret = mca_base_event_callback_set_info (event_registration, (mca_base_cb_safety_t) cb_safety, &info->super);
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_copy.c
+++ b/ompi/mpi/tool/event_copy.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_copy = PMPI_T_event_copy
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_copy (MPI_T_event_instance event, void *buffer)
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    mca_base_event_copy (event, buffer);
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/event_get_index.c
+++ b/ompi/mpi/tool/event_get_index.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_get_index = PMPI_T_event_get_index
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_get_index (const char *name, int *event_index)
+{
+    mca_base_event_t *event = NULL;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    if (MPI_PARAM_CHECK && (NULL == event_index || NULL == name)) {
+        return MPI_ERR_ARG;
+    }
+
+    ompi_mpit_lock ();
+    (void) mca_base_event_get_by_fullname (name, &event);
+    ompi_mpit_unlock ();
+
+    if (NULL == event) {
+        return MPI_T_ERR_INVALID_NAME;
+    }
+
+    *event_index = event->event_index;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/event_get_info.c
+++ b/ompi/mpi/tool/event_get_info.c
@@ -61,7 +61,30 @@ int MPI_T_event_get_info (int event_index, char *name, int *name_len,
         mpit_copy_string (name, name_len, event->event_name);
         mpit_copy_string (desc, desc_len, event->event_description);
 
-        max_datatypes = num_elements ? (*num_elements < (int) (event->event_datatype_count + 1) ? *num_elements - 1 : event->event_datatype_count) : 0;
+        // num_elements is INOUT
+        //
+        // Can query number of datatypes, returned in num_elements
+        //   if array_of_datatypes or displacements are NULL, just return data_type_count.
+        // Otherwise, if array_of_datatypes or displacements are not NULL, use num_elements
+        //   as maximum datatypes or displacements returned.
+        //
+        // Unless the user passes the NULL pointer for num_elements, 
+        //   the function returns the number of elements required for this event type.
+        //
+        // If the number of elements used by the event type is larger than the value of num_elements 
+        //   provided by the user, the number of datatype handles and displacements returned in the 
+        //   corresponding arrays is truncated to the value of num_elements passed in by the user.
+
+        max_datatypes = 0;
+        if (num_elements) {
+            if (NULL != array_of_datatypes || NULL != array_of_displacements) {
+                if (*num_elements < (int) (event->event_datatype_count))
+                    max_datatypes = *num_elements;
+                else
+                    max_datatypes = event->event_datatype_count;
+            }
+            *num_elements = event->event_datatype_count;
+        }
 
         if (max_datatypes) {
             if (array_of_datatypes) {

--- a/ompi/mpi/tool/event_get_info.c
+++ b/ompi/mpi/tool/event_get_info.c
@@ -1,0 +1,117 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+/* needed to convert between opal and ompi datatypes until a function is provided */
+#include "ompi/datatype/ompi_datatype_internal.h"
+
+#if OMPI_PROFILING_DEFINES
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_T_event_get_info = PMPI_T_event_get_info
+#endif
+
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+int MPI_T_event_get_info (int event_index, char *name, int *name_len,
+                          int *verbosity, MPI_Datatype *array_of_datatypes,
+                          MPI_Aint *array_of_displacements, int *num_elements,
+                          MPI_Aint *extent, MPI_T_enum *enumtype, MPI_Info *info,
+                          char *desc, int *desc_len, int *bind)
+{
+    mca_base_event_t * const event;
+    int ret, max_datatypes = 0;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ompi_mpit_lock ();
+
+    do {
+        /* Find the performance variable. mca_base_event_get() handles the
+           bounds checking. */
+        ret = mca_base_event_get_by_index (event_index, (mca_base_event_t **) &event);
+        if (OMPI_SUCCESS != ret) {
+            break;
+        }
+
+        /* Check the variable binding is something sane */
+        if (event->event_bind > MPI_T_BIND_MPI_INFO || event->event_bind < MPI_T_BIND_NO_OBJECT) {
+            /* This variable specified an invalid binding (not an MPI object). */
+            ret = MPI_T_ERR_INVALID_INDEX;
+            break;
+        }
+
+        /* Copy name and description */
+        mpit_copy_string (name, name_len, event->event_name);
+        mpit_copy_string (desc, desc_len, event->event_description);
+
+        max_datatypes = num_elements ? (*num_elements < (int) (event->event_datatype_count + 1) ? *num_elements - 1 : event->event_datatype_count) : 0;
+
+        if (max_datatypes) {
+            if (array_of_datatypes) {
+                for (int i = 0 ; i < max_datatypes ; i++) {
+                    ompi_datatype_t *ompi_datatype = NULL;
+
+                    for (int j = 0 ; j < OMPI_DATATYPE_MPI_MAX_PREDEFINED ; ++j) {
+                        if (ompi_datatype_basicDatatypes[j]->super.id == event->event_datatypes[i]->id) {
+                            ompi_datatype = (ompi_datatype_t *) ompi_datatype_basicDatatypes[j];
+                            break;
+                        }
+                    }
+
+                    assert (NULL != ompi_datatype);
+
+                    array_of_datatypes[i] = ompi_datatype;
+                }
+            }
+
+            if (array_of_displacements) {
+                for (int i = 0 ; i < max_datatypes ; i++) {
+                    array_of_displacements[i] = (MPI_Aint) event->event_offsets[i];
+                }
+            }
+
+            *num_elements = max_datatypes;
+        }
+
+        if (verbosity) {
+            *verbosity = event->event_verbosity;
+        }
+
+        if (NULL != enumtype) {
+            *enumtype = event->event_enumerator ? (MPI_T_enum) event->event_enumerator : MPI_T_ENUM_NULL;
+        }
+
+        if (NULL != bind) {
+            *bind = event->event_bind;
+        }
+
+        if (NULL != extent) {
+            *extent = event->event_extent;
+        }
+
+        if (NULL != info) {
+            *info = OBJ_NEW(ompi_info_t);
+        }
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return ret;
+}

--- a/ompi/mpi/tool/event_get_num.c
+++ b/ompi/mpi/tool/event_get_num.c
@@ -1,0 +1,35 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_get_num = PMPI_T_event_get_num
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_get_num (int *num_event)
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    if (MPI_PARAM_CHECK && NULL == num_event) {
+        return MPI_ERR_ARG;
+    }
+
+    return mca_base_event_get_count (num_event);
+}

--- a/ompi/mpi/tool/event_get_source.c
+++ b/ompi/mpi/tool/event_get_source.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_get_source = PMPI_T_event_get_source
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_get_source (MPI_T_event_instance event, int *source_index)
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    mca_base_event_get_source (event, source_index);
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/event_get_timestamp.c
+++ b/ompi/mpi/tool/event_get_timestamp.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OMPI_PROFILING_DEFINES
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_T_event_get_timestamp = PMPI_T_event_get_timestamp
+#endif
+
+#include "ompi/mpi/tool/profile/defines.h"
+
+#endif
+
+
+int MPI_T_event_get_timestamp (MPI_T_event_instance event, MPI_Count *event_time)
+{
+    uint64_t mca_time;
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ret = mca_base_event_get_time (event, &mca_time);
+    *event_time = (MPI_Count) mca_time;
+
+    return ompit_opal_to_mpit_error (ret);
+}

--- a/ompi/mpi/tool/event_handle_alloc.c
+++ b/ompi/mpi/tool/event_handle_alloc.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_handle_alloc = PMPI_T_event_handle_alloc
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_handle_alloc (int event_index, void *obj_handle, MPI_Info info,
+                              MPI_T_event_registration *event_registration)
+{
+    mca_base_event_t * const event;
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ompi_mpit_lock ();
+
+    do {
+        /* Find the performance variable. mca_base_event_get() handles the
+           bounds checking. */
+        ret = mca_base_event_get_by_index (event_index, (mca_base_event_t **) &event);
+        if (OMPI_SUCCESS != ret) {
+            break;
+        }
+
+        /* Check the variable binding is something sane */
+        if (event->event_bind > MPI_T_BIND_MPI_INFO || event->event_bind < MPI_T_BIND_NO_OBJECT) {
+            /* This variable specified an invalid binding (not an MPI object). */
+            ret = MPI_T_ERR_INVALID_INDEX;
+            break;
+        }
+
+        ret = mca_base_event_registration_alloc (event, obj_handle, &info->super, event_registration);
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_handle_free.c
+++ b/ompi/mpi/tool/event_handle_free.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_handle_free = PMPI_T_event_handle_free
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_handle_free (MPI_T_event_registration event_registration,
+                             MPI_T_event_free_cb_function free_cb_function)
+{
+    int ret = MPI_SUCCESS;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ompi_mpit_lock ();
+
+    do {
+        /* Check that this is a valid handle */
+        if (MPI_T_EVENT_REGISTRATION_NULL == event_registration) {
+            ret = MPI_T_ERR_INVALID_HANDLE;
+            break;
+        }
+
+        mca_base_event_registration_free (event_registration, (mca_base_event_registration_free_cb_fn_t) free_cb_function);
+        /* *event_registration = MPI_T_EVENT_REGISTRATION_NULL; */
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return ret;
+}

--- a/ompi/mpi/tool/event_handle_get_info.c
+++ b/ompi/mpi/tool/event_handle_get_info.c
@@ -1,0 +1,51 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2019      Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_handle_get_info = PMPI_T_event_handle_get_info
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_handle_get_info (MPI_T_event_registration event_registration,
+                                 MPI_Info *info_used)
+{
+    ompi_info_t *info;
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    info = OBJ_NEW(ompi_info_t);
+    if (NULL == info) {
+        return ompit_opal_to_mpit_error(OMPI_ERR_OUT_OF_RESOURCE);
+    }
+
+    ret = mca_base_event_handle_get_info (event_registration, &info->super);
+    if (OPAL_SUCCESS != ret) {
+        OBJ_RELEASE(info);
+    } else {
+        *info_used = info;
+    }
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_handle_set_info.c
+++ b/ompi/mpi/tool/event_handle_set_info.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2019      Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_handle_set_info = PMPI_T_event_handle_set_info
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_handle_set_info (MPI_T_event_registration event_registration,
+                                 MPI_Info info)
+{
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ret = mca_base_event_handle_set_info (event_registration, &info->super);
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_read.c
+++ b/ompi/mpi/tool/event_read.c
@@ -1,0 +1,36 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_read = PMPI_T_event_read
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_read (MPI_T_event_instance event, int element_index, void *buffer)
+{
+    int ret;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ret = mca_base_event_read (event, element_index, buffer);
+
+    return ompit_opal_to_mpit_error (ret);
+}

--- a/ompi/mpi/tool/event_register_callback.c
+++ b/ompi/mpi/tool/event_register_callback.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_register_callback = PMPI_T_event_register_callback
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_event_register_callback (MPI_T_event_registration event_registration,
+                                   MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data,
+                                   MPI_T_event_cb_function event_cb_function)
+{
+    mca_base_event_t * const event;
+    int ret;
+    
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ompi_mpit_lock ();
+
+    ret = mca_base_event_register_callback (event_registration, (mca_base_cb_safety_t) cb_safety,
+                                            &info->super, user_data, (mca_base_event_cb_fn_t) event_cb_function);
+
+    ompi_mpit_unlock ();
+
+    return ompit_opal_to_mpit_error(ret);
+}

--- a/ompi/mpi/tool/event_set_dropped_handler.c
+++ b/ompi/mpi/tool/event_set_dropped_handler.c
@@ -1,0 +1,39 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_event_set_dropped_handler = PMPI_T_event_set_dropped_handler
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+int MPI_T_event_set_dropped_handler (MPI_T_event_registration handle, MPI_T_event_dropped_cb_function dropped_cb_function)
+
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    /* Check that this is a valid handle */
+    if (MPI_T_EVENT_REGISTRATION_NULL == handle) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    mca_base_event_registration_set_dropped_handler (handle, (mca_base_event_dropped_cb_fn_t) dropped_cb_function);
+
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2011      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
@@ -15,11 +15,10 @@
 #if !defined(MPIT_INTERNAL_H)
 #define MPIT_INTERNAL_H
 
+#include "ompi/include/ompi_config.h"
 #include "opal/util/string_copy.h"
 #include "opal/mca/base/mca_base_var.h"
-#include "opal/mca/base/mca_base_pvar.h"
-
-#include "ompi/include/ompi_config.h"
+#include "opal/mca/base/mca_base_event.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/constants.h"

--- a/ompi/mpi/tool/profile/Makefile.am
+++ b/ompi/mpi/tool/profile/Makefile.am
@@ -1,3 +1,4 @@
+
 # -*- makefile -*-
 #
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
@@ -16,6 +17,8 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+#                         reserved.
+# Copyright (c) 2018-2019 Triad National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -75,7 +78,21 @@ nodist_libmpi_pmpit_la_SOURCES = \
 	ppvar_session_free.c \
 	ppvar_start.c \
 	ppvar_stop.c \
-	ppvar_write.c
+	ppvar_write.c \
+	pevent_get_index.c \
+	pevent_get_info.c \
+	pevent_get_num.c \
+	pevent_get_source.c \
+	pevent_get_timestamp.c \
+	pevent_register_callback.c \
+	pevent_handle_alloc.c \
+	pevent_handle_free.c \
+	pevent_read.c \
+	pevent_copy.c \
+	pevent_set_dropped_handler.c \
+	psource_get_num.c \
+	psource_get_info.c \
+	psource_get_timestamp.c
 
 #
 # Sym link in the sources from the real MPI directory

--- a/ompi/mpi/tool/profile/defines.h
+++ b/ompi/mpi/tool/profile/defines.h
@@ -60,4 +60,18 @@
 #define MPI_T_pvar_start PMPI_T_pvar_start
 #define MPI_T_pvar_stop PMPI_T_pvar_stop
 #define MPI_T_pvar_write PMPI_T_pvar_write
+#define MPI_T_event_get_num PMPI_T_event_get_num
+#define MPI_T_event_get_info PMPI_T_event_get_info
+#define MPI_T_event_get_index PMPI_T_event_get_index
+#define MPI_T_event_register_callback PMPI_T_event_register_callback
+#define MPI_T_event_handle_alloc PMPI_T_event_handle_alloc
+#define MPI_T_event_handle_free PMPI_T_event_handle_free
+#define MPI_T_event_set_dropped_handler PMPI_T_event_set_dropped_handler
+#define MPI_T_event_read PMPI_T_event_read
+#define MPI_T_event_copy PMPI_T_event_copy
+#define MPI_T_event_get_timestamp PMPI_T_event_get_timestamp
+#define MPI_T_event_get_source PMPI_T_event_get_source
+#define MPI_T_source_get_num PMPI_T_source_get_num
+#define MPI_T_source_get_info PMPI_T_source_get_info
+#define MPI_T_source_get_timestamp PMPI_T_source_get_timestamp
 #endif /* OMPIT_C_PROFILE_DEFINES_H */

--- a/ompi/mpi/tool/source_get_info.c
+++ b/ompi/mpi/tool/source_get_info.c
@@ -20,7 +20,7 @@
 #include "ompi/mpi/tool/profile/defines.h"
 #endif
 
-int MPI_T_source_get_info (int source_id, char *name, int *name_len, char *desc, int *desc_len, MPI_T_order *ordering,
+int MPI_T_source_get_info (int source_id, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering,
                            MPI_Count *ticks_per_second, MPI_Count *max_timestamp, MPI_Info *info)
 {
     mca_base_source_t *source;
@@ -35,10 +35,16 @@ int MPI_T_source_get_info (int source_id, char *name, int *name_len, char *desc,
         return MPI_T_ERR_INVALID_INDEX;
     }
 
+    if (NULL == name && name_len)
+      *name_len = strlen(source->source_name);
+
     if (name && name_len) {
         strncpy (name, source->source_name, *name_len);
         *name_len = strlen (name);
     }
+
+    if (NULL == desc && desc_len)
+      *desc_len = strlen(source->source_description);
 
     if (desc && desc_len) {
         strncpy (desc, source->source_description, *desc_len);
@@ -54,10 +60,10 @@ int MPI_T_source_get_info (int source_id, char *name, int *name_len, char *desc,
     }
 
     if (max_timestamp) {
-        *max_timestamp = SIZE_T_MAX;
+        *max_timestamp = SIZE_MAX;
     }
 
-    if (*info) {
+    if (NULL != info && *info) {
         *info = OBJ_NEW(ompi_info_t);
     }
 

--- a/ompi/mpi/tool/source_get_info.c
+++ b/ompi/mpi/tool/source_get_info.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_source_get_info = PMPI_T_source_get_info
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+int MPI_T_source_get_info (int source_id, char *name, int *name_len, char *desc, int *desc_len, MPI_T_order *ordering,
+                           MPI_Count *ticks_per_second, MPI_Count *max_timestamp, MPI_Info *info)
+{
+    mca_base_source_t *source;
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    ompi_mpit_lock ();
+    source = mca_base_source_get (source_id);
+    ompi_mpit_unlock ();
+    if (OPAL_UNLIKELY(NULL == source)) {
+        return MPI_T_ERR_INVALID_INDEX;
+    }
+
+    if (name && name_len) {
+        strncpy (name, source->source_name, *name_len);
+        *name_len = strlen (name);
+    }
+
+    if (desc && desc_len) {
+        strncpy (desc, source->source_description, *desc_len);
+        *desc_len = strlen (desc);
+    }
+
+    if (ordering) {
+        *ordering = source->source_ordered;
+    }
+
+    if (ticks_per_second) {
+        *ticks_per_second = source->source_ticks;
+    }
+
+    if (max_timestamp) {
+        *max_timestamp = SIZE_T_MAX;
+    }
+
+    if (*info) {
+        *info = OBJ_NEW(ompi_info_t);
+    }
+
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/source_get_num.c
+++ b/ompi/mpi/tool/source_get_num.c
@@ -1,0 +1,35 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_source_get_num = PMPI_T_source_get_num
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+
+int MPI_T_source_get_num (int *num_source)
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    if (MPI_PARAM_CHECK && NULL == num_source) {
+        return MPI_ERR_ARG;
+    }
+
+    return mca_base_source_get_count (num_source);
+}

--- a/ompi/mpi/tool/source_get_timestamp.c
+++ b/ompi/mpi/tool/source_get_timestamp.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILING_DEFINES
+#pragma weak MPI_T_source_get_timestamp = PMPI_T_source_get_timestamp
+#endif
+
+#if OMPI_PROFILING_DEFINES
+#include "ompi/mpi/tool/profile/defines.h"
+#endif
+
+int MPI_T_source_get_timestamp (int source_id, MPI_Count *timestamp)
+{
+    mca_base_source_t *source;
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    if (MPI_PARAM_CHECK && !timestamp) {
+        return MPI_ERR_ARG;
+    }
+
+    ompi_mpit_lock ();
+    source = mca_base_source_get (source_id);
+    ompi_mpit_unlock ();
+    if (OPAL_UNLIKELY(NULL == source)) {
+        return MPI_T_ERR_INVALID_INDEX;
+    }
+
+    *timestamp = source->source_time ();
+
+    return MPI_SUCCESS;
+}

--- a/opal/mca/base/Makefile.am
+++ b/opal/mca/base/Makefile.am
@@ -10,6 +10,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
+#                         reserved.
 # Copyright (c) 2020      Google LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -39,7 +41,10 @@ headers = \
 	mca_base_var_enum.h \
         mca_base_var_group.h \
         mca_base_vari.h \
-	mca_base_framework.h
+	mca_base_framework.h \
+        mca_base_event.h \
+        mca_base_source.h
+
 
 # Library
 
@@ -62,7 +67,9 @@ libmca_base_la_SOURCES = \
         mca_base_var_group.c \
         mca_base_parse_paramfile.c \
 	mca_base_components_register.c \
-	mca_base_framework.c
+	mca_base_framework.c \
+        mca_base_event.c \
+        mca_base_source.c
 
 # Conditionally install the header files
 

--- a/opal/mca/base/mca_base_event.c
+++ b/opal/mca/base/mca_base_event.c
@@ -26,7 +26,7 @@
 
 #include "opal/class/opal_pointer_array.h"
 #include "opal/class/opal_hash_table.h"
-#include "opal/threads/thread_usage.h"
+#include "opal/mca/threads/thread_usage.h"
 
 static opal_hash_table_t mca_base_event_index_hash;
 static opal_pointer_array_t registered_events;

--- a/opal/mca/base/mca_base_event.c
+++ b/opal/mca/base/mca_base_event.c
@@ -1,0 +1,648 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Bull SAS.  All rights reserved.
+ * Copyright (c) 2015      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "mca_base_event.h"
+#include "mca_base_vari.h"
+
+#include <stddef.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include "opal/class/opal_pointer_array.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/threads/thread_usage.h"
+
+static opal_hash_table_t mca_base_event_index_hash;
+static opal_pointer_array_t registered_events;
+static bool mca_base_event_initialized = false;
+static int event_count = 0;
+
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#define max(a,b) ((a) > (b) ? (a) : (b))
+
+static int mca_base_event_get_by_index_internal (int index, mca_base_event_t **event, bool invalidok);
+static int mca_base_event_get_by_fullname_internal (const char *full_name, mca_base_event_t **event, bool invalidok);
+static int mca_base_event_get_by_name_internal (const char *project, const char *framework, const char *component, const char *name,
+                                                mca_base_event_t **event, bool invalidok);
+
+/***************************************************************************************************/
+
+int mca_base_event_init (void)
+{
+    int ret = OPAL_SUCCESS;
+
+    if (!mca_base_event_initialized) {
+        mca_base_event_initialized = true;
+
+        OBJ_CONSTRUCT(&registered_events, opal_pointer_array_t);
+        opal_pointer_array_init(&registered_events, 128, 2048, 128);
+
+        OBJ_CONSTRUCT(&mca_base_event_index_hash, opal_hash_table_t);
+        ret = opal_hash_table_init (&mca_base_event_index_hash, 1024);
+        if (OPAL_SUCCESS != ret) {
+            mca_base_event_initialized = false;
+            OBJ_DESTRUCT(&registered_events);
+            OBJ_DESTRUCT(&mca_base_event_index_hash);
+        }
+    }
+
+    return ret;
+}
+
+int mca_base_event_finalize (void)
+{
+    int i;
+
+    if (mca_base_event_initialized)  {
+        mca_base_event_initialized = false;
+
+        for (i = 0 ; i < event_count ; ++i) {
+            mca_base_event_t *event = opal_pointer_array_get_item (&registered_events, i);
+            if (event) {
+                OBJ_RELEASE(event);
+            }
+        }
+
+        event_count = 0;
+
+        OBJ_DESTRUCT(&registered_events);
+        OBJ_DESTRUCT(&mca_base_event_index_hash);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/***************************************************************************************************/
+
+
+/** lookup functions */
+
+static int mca_base_event_get_by_fullname_internal (const char *full_name, mca_base_event_t **event, bool invalidok)
+{
+    void *tmp;
+    int rc;
+
+    rc = opal_hash_table_get_value_ptr (&mca_base_event_index_hash, full_name, strlen (full_name),
+                                        &tmp);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    return mca_base_event_get_by_index_internal ((int)(uintptr_t) tmp, event, invalidok);
+}
+
+int mca_base_event_get_by_fullname (const char *full_name, mca_base_event_t **event)
+{
+    return mca_base_event_get_by_fullname_internal (full_name, event, false);
+}
+
+static int mca_base_event_get_by_name_internal (const char *project, const char *framework, const char *component, const char *name,
+                                                mca_base_event_t **event, bool invalidok)
+{
+    char *full_name;
+    int ret;
+
+    ret = mca_base_var_generate_full_name4 (project, framework, component, name, &full_name);
+    if (OPAL_SUCCESS != ret) {
+        return OPAL_ERROR;
+    }
+
+    ret = mca_base_event_get_by_fullname_internal (full_name, event, invalidok);
+    free (full_name);
+
+    return ret;
+}
+
+int mca_base_event_get_by_name (const char *project, const char *framework, const char *component, const char *name,
+                                mca_base_event_t **event)
+{
+    return mca_base_event_get_by_name_internal (project, framework, component, name, event, false);
+}
+
+int mca_base_registration_get_event (mca_base_event_registration_t *registration, mca_base_event_t **event)
+{
+    if (OPAL_UNLIKELY(NULL == registration)) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    *event = registration->event;
+
+    return OPAL_SUCCESS;
+}
+
+static int mca_base_event_get_by_index_internal (int index, mca_base_event_t **event, bool invalidok)
+{
+    if (index >= event_count) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    *event = opal_pointer_array_get_item (&registered_events, index);
+
+    /* variables should never be removed per MPI 3.0 § 14.3.7 */
+    assert (*event);
+
+    if (((*event)->event_flags & MCA_BASE_EVENT_FLAG_INVALID) && !invalidok) {
+        *event = NULL;
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_get_by_index (int index, mca_base_event_t **event)
+{
+    return mca_base_event_get_by_index_internal (index, (mca_base_event_t **) event, false);
+}
+
+/***************************************************************************************************/
+
+int mca_base_event_get_count (int *count)
+{
+    *count = event_count;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_register (const char *project, const char *framework, const char *component, const char *name,
+                             const char *description, mca_base_var_info_lvl_t verbosity, opal_datatype_t **datatypes,
+                             unsigned long *offsets, size_t num_datatypes, mca_base_var_enum_t *enumerator, int extent, int bind,
+                             int source, uint32_t flags, mca_base_notify_fn_t notify, void *ctx, mca_base_event_t **event_out)
+{
+    int ret, group_index;
+    mca_base_event_t *event;
+
+    /* ensure the caller did not set an invalid flag */
+    assert (!(flags & 0x3f));
+
+    /* update this assert if more MPIT verbosity levels are added */
+    assert (verbosity >= OPAL_INFO_LVL_1 && verbosity <= OPAL_INFO_LVL_9);
+
+
+    flags &= ~MCA_BASE_EVENT_FLAG_INVALID;
+
+    /* check if this variable is already registered */
+    ret = mca_base_event_get_by_name (project, framework, component, name, &event);
+    if (OPAL_SUCCESS > ret) {
+        /* find/register an MCA parameter group for this performance variable */
+        group_index = mca_base_var_group_register (project, framework, component, NULL);
+        if (-1 > group_index) {
+            return group_index;
+        }
+
+        /* create a new parameter entry */
+        event = OBJ_NEW(mca_base_event_t);
+        if (NULL == event) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        do {
+            /* generate the variable's full name */
+            ret = mca_base_var_generate_full_name4 (project, framework, component, name, &event->event_name);
+            if (OPAL_SUCCESS != ret) {
+                ret = OPAL_ERR_OUT_OF_RESOURCE;
+                break;
+            }
+
+            if (NULL != description) {
+                event->event_description = strdup(description);
+                if (NULL == event->event_description) {
+                    ret = OPAL_ERR_OUT_OF_RESOURCE;
+                    break;
+                }
+            }
+
+            event->event_index = opal_pointer_array_add (&registered_events, event);
+            if (0 > event->event_index) {
+                ret = OPAL_ERR_OUT_OF_RESOURCE;
+                break;
+            }
+
+            /* add this performance variable to the MCA variable group */
+            if (0 <= group_index) {
+                ret = mca_base_var_group_add_event (group_index, event->event_index);
+                if (0 > ret) {
+                    break;
+                }
+            }
+
+            opal_hash_table_set_value_ptr (&mca_base_event_index_hash, event->event_name, strlen (event->event_name),
+                                           (void *)(uintptr_t) event->event_index);
+
+            event_count++;
+            ret = OPAL_SUCCESS;
+        } while (0);
+
+        if (OPAL_SUCCESS != ret) {
+            OBJ_RELEASE(event);
+            return ret;
+        }
+
+        event->event_group_index = group_index;
+    }
+
+    event->event_verbosity = verbosity;
+    event->event_source = mca_base_source_get (source);
+    event->event_extent = extent;
+
+    if (event->event_enumerator) {
+        OBJ_RELEASE(event->event_enumerator);
+    }
+
+    event->event_enumerator = enumerator;
+    if (enumerator) {
+        OBJ_RETAIN(enumerator);
+    }
+
+    event->event_bind = bind;
+    event->event_flags = flags;
+    event->event_ctx = ctx;
+
+    event->event_datatypes = calloc (num_datatypes, sizeof (event->event_datatypes[0]));
+    event->event_offsets = calloc (num_datatypes, sizeof (event->event_offsets[0]));
+    if (NULL == event->event_datatypes || NULL == event->event_offsets) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    memcpy (event->event_datatypes, datatypes, num_datatypes * sizeof (event->event_datatypes[0]));
+    memcpy (event->event_offsets, offsets, num_datatypes * sizeof (event->event_offsets[0]));
+
+    event->event_datatype_count = num_datatypes;
+
+    if (event_out) {
+        *event_out = event;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_component_event_register (const mca_base_component_t *component, const char *name,
+                                       const char *description, mca_base_var_info_lvl_t verbosity, opal_datatype_t **datatypes,
+                                       unsigned long *offsets, size_t num_datatypes, mca_base_var_enum_t *enumerator, int extent, int bind,
+                                       int source, uint32_t flags, mca_base_notify_fn_t notify, void *ctx, mca_base_event_t **event_out)
+{
+    /* invalidate this variable if the component's group is deregistered */
+    return mca_base_event_register (component->mca_project_name, component->mca_type_name, component->mca_component_name,
+                                    name, description, verbosity, datatypes, offsets, num_datatypes, enumerator, extent, bind,
+                                    source, flags | MCA_BASE_EVENT_FLAG_IWG, notify, ctx, event_out);
+}
+
+int mca_base_component_event_register_list (const mca_base_component_t *component, mca_base_event_list_item_t *list, int count)
+{
+    mca_base_var_enum_t *new_enum = NULL;
+    int ret;
+
+    for (int i = 0 ; i < count ; ++i) {
+        mca_base_event_list_item_t *item = list + i;
+        if (NULL != item->elements && NULL != item->elements[0]) {
+            char *full_name;
+            ret = mca_base_var_generate_full_name4 (component->mca_project_name, component->mca_type_name, component->mca_component_name,
+                                                    item->name, &full_name);
+            if (OPAL_SUCCESS != ret) {
+                return OPAL_ERROR;
+            }
+
+            mca_base_var_enum_create_simple (full_name, item->elements, &new_enum);
+        }
+
+        ret =  mca_base_event_register (component->mca_project_name, component->mca_type_name, component->mca_component_name,
+                                        item->name, item->desc, item->verbosity, item->datatypes, item->offsets, item->num_datatypes,
+                                        new_enum, item->extent, item->bind, item->source, item->flags | MCA_BASE_EVENT_FLAG_IWG,
+                                        item->notify, item->ctx, &item->event);
+
+        if (new_enum) {
+            OBJ_RELEASE(new_enum);
+        }
+
+        if (OPAL_SUCCESS != ret) {
+            return ret;
+        }
+
+        new_enum = NULL;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+
+int mca_base_event_mark_invalid (mca_base_event_t *event)
+{
+    event->event_flags |= MCA_BASE_PVAR_FLAG_INVALID;
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_registration_alloc (mca_base_event_t *event, void *obj_registration, opal_info_t *info,
+                                       mca_base_event_registration_t **registration)
+{
+    mca_base_event_registration_t *event_registration = NULL;
+
+    if (0 == event->event_bind) {
+        /* ignore binding object */
+        obj_registration = NULL;
+    } else if (0 != event->event_bind && NULL == obj_registration) {
+        /* this is an application error. what is the correct error code? */
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* allocate and initialize the registration */
+    event_registration = OBJ_NEW(mca_base_event_registration_t);
+    if (NULL == event_registration) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    event_registration->obj_registration = (NULL == obj_registration ? NULL : *(void**)obj_registration);
+    event_registration->event = event;
+    event_registration->obj_registration = obj_registration;
+
+    *registration = event_registration;
+    opal_list_append (&event->event_bound_registrations, &event_registration->super);
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_handle_set_info (mca_base_event_registration_t *registration, opal_info_t *info)
+{
+    /* nothing to do at this time */
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_handle_get_info (mca_base_event_registration_t *registration, opal_info_t *info_used)
+{
+    /* nothing to do at this time */
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_register_callback (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                      opal_info_t *info, void *user_data, mca_base_event_cb_fn_t event_cbfn)
+{
+    if (cb_safety >= MCA_BASE_CB_SAFETY_MAX || cb_safety < 0) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    registration->user_data[cb_safety] = user_data;
+    /* ensure the user data is commited before setting the callback function */
+    opal_atomic_wmb();
+    opal_atomic_swap_ptr ((opal_atomic_intptr_t *) (registration->event_cbs + cb_safety), (intptr_t) event_cbfn);
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_callback_set_info (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                      opal_info_t *info)
+{
+    /* nothing to do */
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_callback_get_info (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                      opal_info_t *info_used)
+{
+    /* nothing to do */
+    return OPAL_SUCCESS;
+}
+
+void mca_base_event_registration_free (mca_base_event_registration_t *registration, mca_base_event_registration_free_cb_fn_t cbfn)
+{
+    registration->free_cb = cbfn;
+    OBJ_RELEASE(registration);
+}
+
+int mca_base_event_dump(int index, char ***out, mca_base_var_dump_type_t output_type)
+{
+    const char *framework, *component, *full_name;
+    mca_base_var_group_t *group;
+    int line = 0, line_count;
+    mca_base_event_t *event;
+    int ret, enum_count = 0;
+    char *tmp;
+
+    ret = mca_base_event_get_by_index (index, &event);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = mca_base_var_group_get_internal (event->event_group_index, &group, true);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    framework = group->group_framework;
+    component = group->group_component ? group->group_component : "base";
+    full_name = event->event_name;
+
+    if (NULL != event->event_enumerator) {
+        (void) event->event_enumerator->get_count(event->event_enumerator, &enum_count);
+    }
+
+    if (MCA_BASE_VAR_DUMP_PARSABLE == output_type) {
+        line_count = 2 + !!(event->event_description) + enum_count + event->event_datatype_count;
+
+        *out = (char **) calloc (line_count + 1, sizeof (char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        /* build the message*/
+        (void)asprintf(&tmp, "mca:%s:%s:event:%s:", framework, component, full_name);
+
+        (void)asprintf(out[0] + line++, "%sextent:%lu", tmp, (unsigned long) event->event_extent);
+        (void)asprintf(out[0] + line++, "%snum_datatypes:%lu", tmp, (unsigned long) event->event_datatype_count);
+        for (size_t i = 0 ; i < event->event_datatype_count ; ++i) {
+            (void)asprintf(out[0] + line++, "%sdatatypes:%lu:%s", tmp, (unsigned long) i, event->event_datatypes[i]->name);
+        }
+
+        /* if it has a help message, output the help message */
+        if (event->event_description) {
+            (void)asprintf(out[0] + line++, "%shelp:%s", tmp, event->event_description);
+        }
+
+        if (NULL != event->event_enumerator) {
+            for (int i = 0 ; i < enum_count ; ++i) {
+                const char *enum_string = NULL;
+                int enum_value;
+
+                ret = event->event_enumerator->get_value (event->event_enumerator, i, &enum_value,
+                                                          &enum_string);
+                if (OPAL_SUCCESS != ret) {
+                    continue;
+                }
+
+                (void)asprintf(out[0] + line++, "%senumerator:element:%d:%s", tmp, enum_value, enum_string);
+            }
+        }
+
+        free(tmp);  // release tmp storage
+    } else {
+        /* there will be at most three lines in the pretty print case */
+        *out = (char **) calloc (4, sizeof (char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        (void)asprintf (out[0] + line++, "event \"%s\" (extent: %lu, datatype count: %ld)", full_name,
+                        (unsigned long) event->event_extent, (long) event->event_datatype_count);
+
+        if (event->event_description) {
+            (void)asprintf(out[0] + line++, "%s", event->event_description);
+        }
+
+        if (NULL != event->event_enumerator) {
+            char *values;
+
+            ret = event->event_enumerator->dump(event->event_enumerator, &values);
+            if (OPAL_SUCCESS == ret) {
+                (void)asprintf (out[0] + line++, "Elements: %s", values);
+                free (values);
+            }
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+void mca_base_event_raise_internal (mca_base_event_t *event, mca_base_cb_safety_t cb_safety, void *obj, mca_base_source_t *source, void *data)
+{
+    mca_base_raised_event_t revent = {.re_timestamp = source ? source->source_time () : event->event_source->source_time (),
+                                      .re_source = source ? source->source_index  : event->event_source->source_index,
+                                      .re_data = data, .re_event = event};
+    mca_base_event_registration_t *registration;
+
+    OPAL_LIST_FOREACH(registration, &event->event_bound_registrations, mca_base_event_registration_t) {
+        if (registration->obj_registration != obj) {
+            continue;
+        }
+
+        for (mca_base_cb_safety_t i = cb_safety ; i < MCA_BASE_CB_SAFETY_MAX ; ++i) {
+            mca_base_event_cb_fn_t cb = registration->event_cbs[i];
+
+            if (NULL == cb) {
+                continue;
+            }
+
+            /* call only the least restrictive callback allowed by the raise */
+            cb (&revent, registration, cb_safety, registration->user_data[i]);
+            break;
+        }
+    }
+}
+
+/* mca_base_event_t class */
+static void mca_base_event_contructor (mca_base_event_t *event)
+{
+    memset ((char *) event + sizeof (event->super), 0, sizeof (*event) - sizeof (event->super));
+    OBJ_CONSTRUCT(&event->event_bound_registrations, opal_list_t);
+}
+
+static void mca_base_event_destructor (mca_base_event_t *event)
+{
+    free (event->event_name);
+    free (event->event_description);
+
+    if (NULL != event->event_enumerator) {
+        OBJ_RELEASE(event->event_enumerator);
+    }
+
+    free (event->event_datatypes);
+
+    OBJ_DESTRUCT(&event->event_bound_registrations);
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_t, opal_object_t, mca_base_event_contructor, mca_base_event_destructor);
+
+/* mca_base_event_registration_t class */
+static void mca_base_event_registration_constructor (mca_base_event_registration_t *registration)
+{
+    memset ((char *) registration + sizeof (registration->super), 0, sizeof (*registration) - sizeof (registration->super));
+}
+
+static void mca_base_event_registration_destructor (mca_base_event_registration_t *registration)
+{
+    /* remove this registration from the event's list */
+    if (registration->event) {
+        opal_list_remove_item (&registration->event->event_bound_registrations, &registration->super);
+    }
+
+    if (registration->free_cb) {
+        registration->free_cb (registration, MCA_BASE_CB_REQUIRE_NONE, registration->user_data);
+    }
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_registration_t, opal_list_item_t, mca_base_event_registration_constructor,
+                   mca_base_event_registration_destructor);
+
+
+/* query functions */
+int mca_base_event_get_time (mca_base_raised_event_t *revent, uint64_t *event_time)
+{
+    *event_time = revent->re_timestamp;
+    return OPAL_SUCCESS;
+}
+
+void mca_base_event_get_source (mca_base_raised_event_t *revent, int *source_index)
+{
+    *source_index = revent->re_source;
+}
+
+int mca_base_event_read (mca_base_raised_event_t *revent, unsigned int element_index, void *buffer)
+{
+    mca_base_event_t *event = revent->re_event;
+
+    if (element_index > event->event_datatype_count) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    memcpy (buffer, revent->re_data + event->event_offsets[element_index], event->event_datatypes[element_index]->size);
+
+    return OPAL_SUCCESS;
+}
+
+void mca_base_event_copy (mca_base_raised_event_t *revent, void *buffer)
+{
+    mca_base_event_t *event = revent->re_event;
+
+    memcpy (buffer, revent->re_data, event->event_extent);
+}
+
+int mca_base_event_read_some (mca_base_raised_event_t *revent, void *array_of_buffers[])
+{
+    mca_base_event_t *event = revent->re_event;
+
+    for (size_t i = 0 ; i < event->event_datatype_count ; ++i) {
+        if (array_of_buffers[i]) {
+            memcpy (array_of_buffers[i], revent->re_data + event->event_offsets[i], event->event_datatypes[i]->size);
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_read_all (mca_base_raised_event_t *revent, void *array_of_buffers[])
+{
+    mca_base_event_t *event = revent->re_event;
+
+    for (size_t i = 0 ; i < event->event_datatype_count ; ++i) {
+        memcpy (array_of_buffers[i], revent->re_data + event->event_offsets[i], event->event_datatypes[i]->size);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+void mca_base_event_registration_set_dropped_handler (mca_base_event_registration_t *registration, mca_base_event_dropped_cb_fn_t cbfn)
+{
+    registration->dropped_cb = cbfn;
+}

--- a/opal/mca/base/mca_base_event.h
+++ b/opal/mca/base/mca_base_event.h
@@ -1,0 +1,230 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(MCA_BASE_EVENT_H)
+#define MCA_BASE_EVENT_H
+
+#include "opal/datatype/opal_datatype.h"
+#include "opal/util/info.h"
+#include "mca_base_pvar.h"
+#include "mca_base_source.h"
+
+struct mca_base_event_t;
+struct mca_base_event_registration_t;
+struct mca_base_raised_event_t;
+
+/*
+ * These flags are used when registering a new event.
+ */
+typedef enum {
+    /** This variable should be marked as invalid when the containing
+        group is deregistered (IWG = "invalidate with group").  This
+        flag is set automatically when you register a variable with
+        mca_base_component_pvvar_register(), but can also be set
+        manually when you register a variable with
+        mca_base_pvar_register().  Analogous to the
+        MCA_BASE_VAR_FLAG_DWG flag. */
+    MCA_BASE_EVENT_FLAG_IWG        = 0x040,
+    /** This variable has been marked as invalid. This flag is ignored
+        by mca_base_pvar_register(). */
+    MCA_BASE_EVENT_FLAG_INVALID    = 0x400,
+} mca_base_event_flag_t;
+
+/**
+ * @basic Callback safety levels
+ *
+ * If these are modified then similar modifications will be needed in mpi.h.in.
+ */
+typedef enum {
+    MCA_BASE_CB_REQUIRE_NONE,
+    MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+    MCA_BASE_CB_REQUIRE_THREAD_SAFE,
+    MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+    MCA_BASE_CB_SAFETY_MAX,
+} mca_base_cb_safety_t;
+
+typedef void (*mca_base_event_cb_fn_t) (struct mca_base_raised_event_t *event, struct mca_base_event_registration_t *registration,
+                                        mca_base_cb_safety_t cb_safety, void *user_data);
+
+typedef void (*mca_base_event_registration_free_cb_fn_t) (struct mca_base_event_registration_t *registration,
+                                                    mca_base_cb_safety_t cb_safety, void *user_data);
+
+typedef void (*mca_base_event_dropped_cb_fn_t) (int count, struct mca_base_event_registration_t *registration,
+                                                mca_base_cb_safety_t cb_safety, void *user_data);
+
+typedef struct mca_base_raised_event_t {
+    struct mca_base_event_t *re_event;
+    int      re_source;
+    uint64_t re_timestamp;
+    int8_t  *re_data;
+} mca_base_raised_event_t;
+
+typedef struct mca_base_event_t {
+    /** Make this an opal object */
+    opal_object_t super;
+
+    /** Variable index */
+    int event_index;
+
+    /** Full name of the variable: form is framework_component_name */
+    char *event_name;
+
+    /** Description of this performance variable */
+    char *event_description;
+
+    /** MCA variable group this variable is associated with */
+    int event_group_index;
+
+    /** Verbosity level of this variable */
+    mca_base_var_info_lvl_t event_verbosity;
+
+    /** Event datatypes */
+    opal_datatype_t **event_datatypes;
+
+    /** Event offsets */
+    unsigned long *event_offsets;
+
+    /** Size of the event_datatypes array */
+    size_t event_datatype_count;
+
+    /** size of the event data */
+    size_t event_extent;
+
+
+    /** Enumerator for integer values */
+    mca_base_var_enum_t *event_enumerator;
+
+    /** Type of object to which this variable must be bound or MCA_BASE_VAR_BIND_NULL */
+    int event_bind;
+
+    /** event source (may be NULL) */
+    mca_base_source_t *event_source;
+
+    /** Flags for this variable */
+    uint32_t event_flags;
+
+    /** Notify the creator of this variable of a new/deleted handle. This callback can
+     * be used to turn on/off code that is needed for the event but may reduce performance
+     * in the case where there are no active event listeners. */
+    mca_base_notify_fn_t event_notify;
+
+    /** Context of this variable */
+    void *event_ctx;
+
+    /** List of bound event registrations. NOTE: The items in this list are
+        offsetof(mca_base_pvar_registration_t, list2) into a pvar registration. */
+    opal_list_t event_bound_registrations;
+} mca_base_event_t;
+
+OBJ_CLASS_DECLARATION(mca_base_event_t);
+
+typedef struct mca_base_event_list_item_t {
+    const char *name;
+    const char *desc;
+    mca_base_var_info_lvl_t verbosity;
+    opal_datatype_t **datatypes;
+    unsigned long *offsets;
+    size_t num_datatypes;
+    char **elements;
+    int extent;
+    int bind;
+    int source;
+    uint32_t flags;
+    mca_base_notify_fn_t notify;
+    void *ctx;
+    mca_base_event_t *event;
+}  mca_base_event_list_item_t;
+
+typedef struct mca_base_event_registration_t {
+    opal_list_item_t super;
+
+    /** associated event */
+    mca_base_event_t *event;
+
+    /** user callback to trigger on event */
+    mca_base_event_cb_fn_t event_cbs[MCA_BASE_CB_SAFETY_MAX];
+
+    /** user callback to trigger when an event was dropped */
+    mca_base_event_dropped_cb_fn_t dropped_cb;
+
+    /** free callback */
+    mca_base_event_registration_free_cb_fn_t free_cb;
+
+    /** user data specified when this registration was created */
+    void *user_data[MCA_BASE_CB_SAFETY_MAX];
+
+    /** bound object registration */
+    void *obj_registration;
+} mca_base_event_registration_t;
+
+OBJ_CLASS_DECLARATION(mca_base_event_registration_t);
+
+OPAL_DECLSPEC int mca_base_event_init (void);
+OPAL_DECLSPEC int mca_base_event_finalize (void);
+
+OPAL_DECLSPEC int mca_base_event_get_count (int *count);
+OPAL_DECLSPEC int mca_base_event_mark_invalid (mca_base_event_t *event);
+OPAL_DECLSPEC int mca_base_event_dump(int index, char ***out, mca_base_var_dump_type_t output_type);
+
+OPAL_DECLSPEC int mca_base_event_register (const char *project, const char *framework, const char *component, const char *name,
+                                           const char *description, mca_base_var_info_lvl_t verbosity, opal_datatype_t **datatypes,
+                                           unsigned long *offsets, size_t num_datatypes, mca_base_var_enum_t *enumerator, int extent, int bind,
+                                           int source, uint32_t flags, mca_base_notify_fn_t notify, void *ctx, mca_base_event_t **event_out);
+
+OPAL_DECLSPEC int mca_base_component_event_register (const mca_base_component_t *component, const char *name,
+                                                     const char *description, mca_base_var_info_lvl_t verbosity, opal_datatype_t **datatypes,
+                                                     unsigned long *offsets, size_t num_datatypes, mca_base_var_enum_t *enumerator, int extent, int bind,
+                                                     int source, uint32_t flags, mca_base_notify_fn_t notify, void *ctx, mca_base_event_t **event_out);
+
+OPAL_DECLSPEC int mca_base_component_event_register_list (const mca_base_component_t *component, mca_base_event_list_item_t *list, int count);
+
+OPAL_DECLSPEC void mca_base_event_raise_internal (mca_base_event_t *event, mca_base_cb_safety_t cb_safety, void *obj, mca_base_source_t *source,
+                                                  void *data);
+
+#define mca_base_event_raise(eventp, cb_safety, obj, source, data)             \
+    do {                                                                \
+        if (OPAL_UNLIKELY(0 != opal_list_get_size (&(eventp)->event_bound_registrations))) { \
+            /* at least one registration is bound to this event. raise the event with the user code */ \
+            mca_base_event_raise_internal (eventp, cb_safety, obj, source, data); \
+        }                                                               \
+    } while (0);
+
+OPAL_DECLSPEC int mca_base_event_registration_alloc (mca_base_event_t *event, void *obj_registration, opal_info_t *info,
+                                                     mca_base_event_registration_t **registration);
+OPAL_DECLSPEC int mca_base_event_register_callback (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                                    opal_info_t *info, void *user_data, mca_base_event_cb_fn_t event_cbfn);
+
+OPAL_DECLSPEC void mca_base_event_registration_free (mca_base_event_registration_t *registration, mca_base_event_registration_free_cb_fn_t cbfn);
+
+OPAL_DECLSPEC void mca_base_event_registration_set_dropped_handler (mca_base_event_registration_t *registration, mca_base_event_dropped_cb_fn_t cbfn);
+
+OPAL_DECLSPEC int mca_base_event_get_by_index (int index, mca_base_event_t **event);
+OPAL_DECLSPEC int mca_base_event_get_by_name (const char *project, const char *framework, const char *component, const char *name,
+                                              mca_base_event_t **event);
+OPAL_DECLSPEC int mca_base_registration_get_event (mca_base_event_registration_t *registration, mca_base_event_t **event);
+OPAL_DECLSPEC int mca_base_event_get_by_fullname (const char *full_name, mca_base_event_t **event);
+
+OPAL_DECLSPEC int mca_base_event_get_time (mca_base_raised_event_t *revent, uint64_t *event_time);
+OPAL_DECLSPEC void mca_base_event_get_source (mca_base_raised_event_t *revent, int *source_index);
+OPAL_DECLSPEC int mca_base_event_read (mca_base_raised_event_t *revent, unsigned int element_index, void *buffer);
+OPAL_DECLSPEC void mca_base_event_copy (mca_base_raised_event_t *revent, void *buffer);
+OPAL_DECLSPEC int mca_base_event_read_some (mca_base_raised_event_t *revent, void *array_of_buffers[]);
+OPAL_DECLSPEC int mca_base_event_read_all (mca_base_raised_event_t *revent, void *array_of_buffers[]);
+
+OPAL_DECLSPEC int mca_base_event_handle_set_info (mca_base_event_registration_t *registration, opal_info_t *info);
+OPAL_DECLSPEC int mca_base_event_handle_get_info (mca_base_event_registration_t *registration, opal_info_t *info_used);
+OPAL_DECLSPEC int mca_base_event_callback_set_info (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                                    opal_info_t *info);
+OPAL_DECLSPEC int mca_base_event_callback_get_info (mca_base_event_registration_t *registration, mca_base_cb_safety_t cb_safety,
+                                                    opal_info_t *info_used);
+
+#endif /* !defined(MCA_BASE_EVENT_H) */

--- a/opal/mca/base/mca_base_source.c
+++ b/opal/mca/base/mca_base_source.c
@@ -1,0 +1,238 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Bull SAS.  All rights reserved.
+ * Copyright (c) 2015      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "mca_base_source.h"
+#include "mca_base_vari.h"
+
+#include <stddef.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include "opal/class/opal_pointer_array.h"
+#include "opal/class/opal_hash_table.h"
+
+static opal_pointer_array_t registered_sources;
+static int mca_base_source_initialized;
+static int source_count;
+
+int mca_base_source_default_source = -1;
+
+static uint64_t mca_base_source_default_time_source (void)
+{
+    uint64_t time_value;
+
+#if OPAL_HAVE_CLOCK_GETTIME
+    struct timespec current;
+
+    clock_gettime (CLOCK_MONOTONIC, &current);
+    time_value = 1000000000ul * current.tv_sec + current.tv_nsec;
+#else
+    struct timeval current;
+
+    gettimeofday (&current, NULL);
+    time_value = 1000000ul * current.tv_sec + current.tv_usec;
+#endif
+
+    return time_value;
+}
+
+static uint64_t mca_base_source_default_time_source_ticks (void)
+{
+#if OPAL_HAVE_CLOCK_GETTIME
+    return 1000000000;
+#else
+    return 1000000;
+#endif
+}
+
+/***************************************************************************************************/
+
+int mca_base_source_init (void)
+{
+    int ret = OPAL_SUCCESS;
+
+    if (!mca_base_source_initialized++) {
+        mca_base_source_initialized = true;
+
+        OBJ_CONSTRUCT(&registered_sources, opal_pointer_array_t);
+        opal_pointer_array_init(&registered_sources, 16, 512, 16);
+
+        mca_base_source_default_source = mca_base_source_register ("opal", "mca", "base", "default_source",
+                                                                   "Default source for MCA events", true,
+                                                                   mca_base_source_default_time_source,
+                                                                   mca_base_source_default_time_source_ticks ());
+
+    }
+
+    return ret;
+}
+
+int mca_base_source_finalize (void)
+{
+    int i;
+
+    if (0 == --mca_base_source_initialized)  {
+        for (i = 0 ; i < source_count ; ++i) {
+            mca_base_source_t *source = opal_pointer_array_get_item (&registered_sources, i);
+            if (source) {
+                OBJ_RELEASE(source);
+            }
+        }
+
+        source_count = 0;
+
+        OBJ_DESTRUCT(&registered_sources);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/***************************************************************************************************/
+
+mca_base_source_t *mca_base_source_get (int source_index)
+{
+    return opal_pointer_array_get_item (&registered_sources, source_index);
+}
+
+int mca_base_source_set_time_source (int source_index, mca_base_source_time_fn_t time_source, uint64_t time_ticks)
+{
+    mca_base_source_t *source = mca_base_source_get (source_index);
+
+    if (NULL == source) {
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    if (!time_source) {
+        time_source = mca_base_source_default_time_source;
+        time_ticks = mca_base_source_default_time_source_ticks ();
+    }
+
+    source->source_time = time_source;
+    source->source_ticks = time_ticks;
+
+    return OPAL_SUCCESS;
+}
+
+/***************************************************************************************************/
+
+int mca_base_source_get_count (int *count)
+{
+    *count = source_count;
+    return OPAL_SUCCESS;
+}
+
+static inline int mca_base_source_get_by_name (const char *name, mca_base_source_t **source_out)
+{
+    /* there are expected to be a relatively small number of sources so a linear search should be fine */
+    for (int i = 0 ; i < source_count ; ++i) {
+        mca_base_source_t *source = opal_pointer_array_get_item (&registered_sources, i);
+        if (NULL != source && 0 == strcmp (name, source->source_name)) {
+            if (source) {
+                *source_out = source;
+            }
+
+            return OPAL_SUCCESS;
+        }
+    }
+
+    return OPAL_ERR_NOT_FOUND;
+}
+
+int mca_base_source_register (const char *project, const char *framework, const char *component, const char *name,
+                              const char *description, bool ordered, mca_base_source_time_fn_t source_time, uint64_t source_ticks)
+{
+    mca_base_source_t *source;
+    char *source_name;
+    int ret;
+
+    /* generate the variable's full name */
+    ret = mca_base_var_generate_full_name4 (NULL, framework, component, name, &source_name);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+
+    /* check if this variable is already registered */
+    ret = mca_base_source_get_by_name (source_name, &source);
+    if (OPAL_SUCCESS > ret) {
+        /* create a new parameter entry */
+        source = OBJ_NEW(mca_base_source_t);
+        if (NULL == source) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        do {
+            source->source_name = source_name;
+
+            if (NULL != description) {
+                source->source_description = strdup(description);
+                if (NULL == source->source_description) {
+                    ret = OPAL_ERR_OUT_OF_RESOURCE;
+                    break;
+                }
+            }
+
+            source->source_index = opal_pointer_array_add (&registered_sources, source);
+            if (0 > source->source_index) {
+                ret = OPAL_ERR_OUT_OF_RESOURCE;
+                break;
+            }
+
+            source_count++;
+            ret = OPAL_SUCCESS;
+        } while (0);
+
+        if (OPAL_SUCCESS != ret) {
+            OBJ_RELEASE(source);
+            return ret;
+        }
+    } else {
+        free (source_name);
+    }
+
+    source->source_ordered = ordered;
+    if (NULL == source_time) {
+        source_time = mca_base_source_default_time_source;
+        source_ticks = mca_base_source_default_time_source_ticks ();
+    }
+
+    source->source_time = source_time;
+    source->source_ticks = source_ticks;
+
+    return OPAL_SUCCESS;
+}
+int mca_base_component_source_register (const mca_base_component_t *component, const char *name, const char *description, bool ordered,
+                                        mca_base_source_time_fn_t source_time, uint64_t source_ticks)
+{
+    /* invalidate this variable if the component's group is deregistered */
+    return mca_base_source_register (component->mca_project_name, component->mca_type_name, component->mca_component_name,
+                                     name, description, ordered, source_time, source_ticks);
+}
+
+/* mca_base_source_t class */
+static void mca_base_source_contructor (mca_base_source_t *source)
+{
+    memset ((char *) source + sizeof (source->super), 0, sizeof (*source) - sizeof (source->super));
+}
+
+static void mca_base_source_destructor (mca_base_source_t *source)
+{
+    free (source->source_name);
+    free (source->source_description);
+}
+
+OBJ_CLASS_INSTANCE(mca_base_source_t, opal_object_t, mca_base_source_contructor, mca_base_source_destructor);

--- a/opal/mca/base/mca_base_source.h
+++ b/opal/mca/base/mca_base_source.h
@@ -1,0 +1,68 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(MCA_BASE_SOURCE_H)
+#define MCA_BASE_SOURCE_H
+
+#include "opal/datatype/opal_datatype.h"
+#include "mca_base_pvar.h"
+
+enum {
+    /* default source */
+    MCA_BASE_SOURCE_DEFAULT_SOURCE,
+};
+
+typedef uint64_t (*mca_base_source_time_fn_t) (void);
+
+typedef struct mca_base_source_t {
+    /** Make this an opal object */
+    opal_object_t super;
+
+    /** Source index */
+    int source_index;
+
+    /** Source ordering */
+    bool source_ordered;
+
+    /** Full name of the variable: form is framework_component_name */
+    char *source_name;
+
+    /** Description of this performance variable */
+    char *source_description;
+
+    /** Time source (never NULL) */
+    mca_base_source_time_fn_t source_time;
+
+    /** Time source ticks per second */
+    uint64_t source_ticks;
+} mca_base_source_t;
+
+OBJ_CLASS_DECLARATION(mca_base_source_t);
+
+extern int mca_base_source_default_source;
+
+OPAL_DECLSPEC int mca_base_source_init (void);
+OPAL_DECLSPEC int mca_base_source_finalize (void);
+
+OPAL_DECLSPEC int mca_base_source_get_count (int *count);
+
+OPAL_DECLSPEC int mca_base_source_dump(int index, char ***out, mca_base_var_dump_type_t output_type);
+
+OPAL_DECLSPEC int mca_base_source_register (const char *project, const char *framework, const char *component, const char *name,
+                                            const char *description, bool ordered, mca_base_source_time_fn_t source_time, uint64_t source_ticks);
+
+OPAL_DECLSPEC int mca_base_component_source_register (const mca_base_component_t *component, const char *name, const char *description,
+                                                      bool ordered, mca_base_source_time_fn_t source_time, uint64_t source_ticks);
+
+OPAL_DECLSPEC int mca_base_source_set_time_source (int source_index, mca_base_source_time_fn_t time_source, uint64_t time_ticks);
+
+OPAL_DECLSPEC mca_base_source_t *mca_base_source_get (int source_index);
+
+#endif /* !defined(MCA_BASE_SOURCE_H) */

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -302,6 +302,7 @@ int mca_base_var_init(void)
         if( NULL == (cwd = getcwd(NULL, 0) )) {
             opal_output(0, "Error: Unable to get the current working directory\n");
             cwd = strdup(".");
+        }
 
         ret = mca_base_source_init ();
         if (OPAL_SUCCESS != ret) {

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -302,6 +302,15 @@ int mca_base_var_init(void)
         if( NULL == (cwd = getcwd(NULL, 0) )) {
             opal_output(0, "Error: Unable to get the current working directory\n");
             cwd = strdup(".");
+
+        ret = mca_base_source_init ();
+        if (OPAL_SUCCESS != ret) {
+            return ret;
+        }
+
+        ret = mca_base_event_init ();
+        if (OPAL_SUCCESS != ret) {
+            return ret;
         }
 
         /* Set this before we register the parameter, below */

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -361,6 +361,43 @@ int mca_base_var_enum_create (const char *name, const mca_base_var_enum_value_t 
     return OPAL_SUCCESS;
 }
 
+int mca_base_var_enum_create_simple (const char *name, char * const strings[], mca_base_var_enum_t **enumerator)
+{
+    mca_base_var_enum_t *new_enum;
+    int i;
+
+    *enumerator = NULL;
+
+    new_enum = OBJ_NEW(mca_base_var_enum_t);
+    if (NULL == new_enum) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    new_enum->enum_name = strdup (name);
+    if (NULL == new_enum->enum_name) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0 ; strings[i] ; ++i);
+    new_enum->enum_value_count = i;
+
+    /* make a copy of the values */
+    new_enum->enum_values = calloc (new_enum->enum_value_count + 1, sizeof (*new_enum->enum_values));
+    if (NULL == new_enum->enum_values) {
+        OBJ_RELEASE(new_enum);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0 ; i < new_enum->enum_value_count ; ++i) {
+        new_enum->enum_values[i].value = i;
+        new_enum->enum_values[i].string = strdup (strings[i]);
+    }
+
+    *enumerator = new_enum;
+
+    return OPAL_SUCCESS;
+}
+
 int mca_base_var_enum_create_flag (const char *name, const mca_base_var_enum_value_flag_t *flags, mca_base_var_enum_flag_t **enumerator)
 {
     mca_base_var_enum_flag_t *new_enum;

--- a/opal/mca/base/mca_base_var_enum.h
+++ b/opal/mca/base/mca_base_var_enum.h
@@ -202,6 +202,9 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_base_var_enum_t);
 OPAL_DECLSPEC int mca_base_var_enum_create (const char *name, const mca_base_var_enum_value_t values[],
                                             mca_base_var_enum_t **enumerator);
 
+OPAL_DECLSPEC int mca_base_var_enum_create_simple (const char *name, char * const strings[],
+                                                   mca_base_var_enum_t **enumerator);
+
 /**
  * Create a new default flag enumerator
  *

--- a/opal/mca/base/mca_base_var_group.h
+++ b/opal/mca/base/mca_base_var_group.h
@@ -57,6 +57,9 @@ struct mca_base_var_group_t {
 
     /** Pointer array of group enums */
     opal_value_array_t group_enums;
+
+    /** Pointer array of group events */
+    opal_value_array_t group_events;
 };
 
 typedef struct mca_base_var_group_t mca_base_var_group_t;

--- a/opal/mca/base/mca_base_vari.h
+++ b/opal/mca/base/mca_base_vari.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -48,6 +48,8 @@
 #include "opal/class/opal_hash_table.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_source.h"
+#include "opal/mca/base/mca_base_event.h"
 
 BEGIN_C_DECLS
 
@@ -145,6 +147,13 @@ OPAL_DECLSPEC int mca_base_var_group_add_pvar (const int group_index, const int 
  * Add an enum to a group
  */
 OPAL_DECLSPEC int mca_base_var_group_add_enum (const int group_index, const void *storage);
+
+/**
+ * \internal
+ *
+ * Add an event to a group
+ */
+OPAL_DECLSPEC int mca_base_var_group_add_event (const int group_index, const int event_index);
 
 /**
  * \internal


### PR DESCRIPTION
This PR includes Nathan Hjelm's reworking of PERUSE functionality to implement the MPI_T Events API as specified in the MPI 4.0 proposal. Subsequent minor changes to the MPI_T Events API were made and included here. The API and an initial set of events were tested against Marc-André Hermann's MEL tracing tool and other test cases. History, a description of the API and experience with tools can be found in "Enabling callback-driven runtime introspection via MPI_T."

