### PR TITLE
Don't allow some rank to don't count the collective if they have no data to exchange.

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -67,7 +67,13 @@ static int nbc_alltoallw_init(const void* sendbuf, const int *sendcounts, const 
         span = lspan;
       }
     }
+    /**
+     * If this process has no data to send or receive it can bail out early,
+     * but it needs to increase the nonblocking tag to stay in sycn with the
+     * rest of the processses.
+     */
     if (OPAL_UNLIKELY(0 == span)) {
+      ompi_coll_base_nbc_reserve_tags(comm, 1);
       return nbc_get_noop_request(persistent, request);
     }
     tmpbuf = malloc(span);


### PR DESCRIPTION
This is the same logic as in 77eaa5c applied to ialltoallw.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>