### PR TITLE
PML OB1: Fix potential overcounting of SPC sent/received message sizes and account for fin messages

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -47,6 +47,7 @@
 #include "ompi/mca/bml/base/base.h"
 #include "opal/mca/pmix/pmix-internal.h"
 #include "ompi/runtime/ompi_cr.h"
+#include "ompi/runtime/ompi_spc.h"
 
 #include "pml_ob1.h"
 #include "pml_ob1_component.h"
@@ -708,6 +709,7 @@ int mca_pml_ob1_send_fin( ompi_proc_t* proc,
         if( OPAL_LIKELY( 1 == rc ) ) {
             MCA_PML_OB1_PROGRESS_PENDING(bml_btl);
         }
+        SPC_RECORD(OMPI_SPC_BYTES_SENT_MPI, (ompi_spc_value_t)sizeof(mca_pml_ob1_fin_hdr_t));
         return OMPI_SUCCESS;
     }
     mca_bml_base_free(bml_btl, fin);

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -252,7 +252,7 @@ int mca_pml_ob1_recv_request_ack_send_btl(
     des->des_cbfunc = mca_pml_ob1_recv_ctl_completion;
 
     rc = mca_bml_base_send(bml_btl, des, MCA_PML_OB1_HDR_TYPE_ACK);
-    SPC_RECORD(OMPI_SPC_BYTES_RECEIVED_MPI, (ompi_spc_value_t)size);
+    SPC_RECORD(OMPI_SPC_BYTES_SENT_MPI, (ompi_spc_value_t)sizeof(mca_pml_ob1_ack_hdr_t));
     if( OPAL_LIKELY( rc >= 0 ) ) {
         return OMPI_SUCCESS;
     }
@@ -456,8 +456,8 @@ static int mca_pml_ob1_recv_request_put_frag (mca_pml_ob1_rdma_frag_t *frag)
 
     /* send rdma request to peer */
     rc = mca_bml_base_send (bml_btl, ctl, MCA_PML_OB1_HDR_TYPE_PUT);
-    /* Increment counter for bytes_put even though they probably haven't all been received yet */
-    SPC_RECORD(OMPI_SPC_BYTES_PUT, (ompi_spc_value_t)frag->rdma_length);
+    /* Increment counter for bytes sent by MPI */
+    SPC_RECORD(OMPI_SPC_BYTES_SENT_MPI, (ompi_spc_value_t)(sizeof (mca_pml_ob1_rdma_hdr_t) + reg_size));
     if (OPAL_UNLIKELY(rc < 0)) {
         mca_bml_base_free (bml_btl, ctl);
         return rc;


### PR DESCRIPTION
This PR fixes a potential over-counting of sent/received messages sizes in `pml/ob1`: the two functions `mca_pml_ob1_recv_request_ack_send_btl` and `mca_pml_ob1_recv_request_put_frag` do not transfer payload but manage the underlying protocol, so count the transferred data accordingly. Also add instrumentation for sending `fin` messages in `mca_pml_ob1_send_fin`.