### PR TITLE
build: Ignore use-mpi's types file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,8 @@ ompi/mpi/fortran/mpif-h/sizeof_f.f90
 ompi/mpi/fortran/mpif-h/profile/p*.c
 ompi/mpi/fortran/mpif-h/profile/psizeof_f.f90
 
+ompi/mpi/fortran/use-mpi/mpi-types.F90
+
 ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-constants.h
 ompi/mpi/fortran/use-mpi-f08/sizeof_f08.f90
 ompi/mpi/fortran/use-mpi-f08/sizeof_f08.h


### PR DESCRIPTION
This file is autogenerated, so git should not try to track it.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>