### PR TITLE
Fix 3rd-party package CPPFLAGS (and others) handlinge

### DIFF
--- a/config/aclocal_subcfg.m4
+++ b/config/aclocal_subcfg.m4
@@ -73,31 +73,45 @@ AC_DEFUN([PAC_CONFIG_SUBDIR_ARGS],[
           --disable-option-checking)
             ;;
           *)
-            # MPICH note: this is a more robust version of the "precious
-            # variable" propagation code that was present in the previous
-            # incarnation of this macro
+            # strip out precious variables from ac_configure_args,
+            # which will include precious variables that are currently
+            # set and were set on the command line or in the
+            # environment at the time configure was invoked.  Instead,
+            # we add all precious variables which have been tagged as
+            # set, so that we can more closely control the environment
+            # of sub-configures.
+            is_precious=0
             for pac_pvar in $ac_precious_vars ; do
                 # check if configure argument token contains the
                 # precious variable, i.e. "name_of_prec_var=".
                 if ( echo $pac_arg | grep "^$pac_pvar=" >/dev/null 2>&1 ) ; then
-                    # check if current precious variable is set in env
-                    eval pvar_set=\${$pac_pvar+set}
-                    if test "$pvar_set" = "set" ; then
-                        # Append 'name_of_prec_var=value_of_prec_var'
-                        # to the subconfigure arguments list, where
-                        # value_of_prec_var is fetched from the env.
-                        # this also overrides any value set on the command line
-                        eval pac_pval=\${$pac_pvar}
-                        pac_arg="$pac_pvar=$pac_pval"
-                        break
-                    fi
+                    is_precious=1
+                    break
                 fi
             done
-            case $pac_arg in
-            *\'*) pac_arg=`AS_ECHO(["$pac_arg"]) | sed "s/'/'\\\\\\\\''/g"` ;;
-            esac
-            AS_VAR_APPEND([pac_sub_configure_args], [" '$pac_arg'"]) ;;
+            if test $is_precious -eq 0; then
+              case $pac_arg in
+              *\'*) pac_arg=`AS_ECHO(["$pac_arg"]) | sed "s/'/'\\\\\\\\''/g"` ;;
+              esac
+              AS_VAR_APPEND([pac_sub_configure_args], [" '$pac_arg'"]) 
+            fi ;;
           esac
+        done
+
+        # add all precious values with a set token to the configure
+        # args.  If the caller hasn't artificially manipulated the
+        # environment, this will simply be any precious variables as
+        # they were originally specified on the top-level configure
+        # line (or in the environment at start of configure).
+        # However, callers may manipulate that environment, preferably
+        # with the OPAL_SUBDIR_ENV macros.
+        for temp_var in $ac_precious_vars; do
+            eval temp_var_set=\$ac_env_${temp_var}_set
+            if test "$temp_var_set" = "set" ; then
+                eval temp_val=\$$temp_var
+                temp_arg="$temp_var=$temp_val"
+                AS_VAR_APPEND([pac_sub_configure_args], [" '$temp_arg'"])
+            fi
         done
 
         # Always prepend --prefix to ensure using the same prefix

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -148,7 +148,7 @@ dnl        [internal_prrte_args="$internal_prrte_args --with-platform=$with_prrt
             [[--with-libevent=internal], [--with-hwloc=internal],
              [--with-libevent=external], [--with-hwloc=external],
              [--with-pmix=internal], [--with-pmix=external],
-             [--with-platform=.*]],
+             [--with-platform=[[^ 	]]*]],
             [], [internal_prrte_happy="no"])
     OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS prrte"
 

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -100,7 +100,7 @@ AC_DEFUN([OMPI_SETUP_PRRTE_INTERNAL], [
     # user did not specify an option.  PRTE defaults to not enabling
     # prefix-by-default, but open mpi wants that behavior.
     AS_IF([test -n "$deprecated_prefix_by_default"],
-              [internal_prrte_args="internal_prrte_args --enable-prte-prefix-by-default=$deprecated_prefix_by_default"],
+              [internal_prrte_args="$internal_prrte_args --enable-prte-prefix-by-default=$deprecated_prefix_by_default"],
           [test -z "$enable_prte_prefix_by_default"],
               [internal_prrte_args="$internal_prrte_args --enable-prte-prefix-by-default"])
 
@@ -136,9 +136,6 @@ AC_DEFUN([OMPI_SETUP_PRRTE_INTERNAL], [
                         AC_MSG_WARN([Slurm's srun to launch the job - by configuring with the])
                         AC_MSG_WARN([--disable-internal-rte option.])
                         AC_MSG_ERROR([Cannot continue])])])
-
-dnl    AS_IF([test ! -z $with_prrte_platform && test "$with_prrte_platform" != "yes"],
-dnl        [internal_prrte_args="$internal_prrte_args --with-platform=$with_prrte_platform"])
 
     # add the extra libs
     internal_prrte_args="$internal_prrte_args --with-prte-extra-lib=\"$internal_prrte_libs\" --with-prte-extra-ltlib=\"$internal_prrte_libs\""

--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -162,7 +162,8 @@ AC_DEFUN([_OPAL_CONFIG_HWLOC_INTERNAL], [
          # note: because we only ship/commit a tarball (and not the source
          # directory), the source is always expanded in the builddir, so we
          # only need to add a -I to the builddir.
-         CPPFLAGS="$CPPFLAGS -I$OMPI_TOP_BUILDDIR/$internal_hwloc_location/include -I$OMPI_TOP_SRCDIR/$internal_hwloc_location/include"
+         opal_hwloc_CPPFLAGS="-I$OMPI_TOP_BUILDDIR/$internal_hwloc_location/include -I$OMPI_TOP_SRCDIR/$internal_hwloc_location/include"
+         CPPFLAGS="$CPPFLAGS $opal_hwloc_CPPFLAGS"
          # No need to update LDFLAGS, because they will install into
          # our tree and in the mean time are referenced by their .la
          # files.

--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -154,8 +154,10 @@ AC_DEFUN([_OPAL_CONFIG_HWLOC_INTERNAL], [
     # Note: To update the version of hwloc shipped, update the
     # constant in autogen.pl.
     OPAL_EXPAND_TARBALL([3rd-party/hwloc_tarball], [3rd-party/hwloc_directory], [configure])
+    OPAL_SUBDIR_ENV_CLEAN([opal_hwloc_configure])
     PAC_CONFIG_SUBDIR_ARGS([3rd-party/hwloc_directory], [], [],
         [subconfig_happy=1], [subconfig_happy=0])
+    OPAL_SUBDIR_ENV_RESTORE([opal_hwloc_configure])
 
     AS_IF([test "$subconfig_happy" = "1"],
         [internal_hwloc_location="3rd-party/hwloc_directory"

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -183,9 +183,11 @@ AC_DEFUN([_OPAL_CONFIG_LIBEVENT_INTERNAL], [
     # Libevent, so we will never actually fix said warnnings and 2)
     # some of the warning options cause failures with compilers that
     # fake being GCC (I'm looking at you, PGI).
+    OPAL_SUBDIR_ENV_CLEAN([opal_libevent_configure])
     PAC_CONFIG_SUBDIR_ARGS([3rd-party/libevent_directory],
        [--disable-dns --disable-http --disable-rpc --disable-openssl --enable-thread-support --disable-evport --disable-gcc-warnings],
        [], [subconfig_happy=1], [subconfig_happy=0])
+    OPAL_SUBDIR_ENV_RESTORE([opal_libevent_configure])
 
     AS_IF([test "$subconfig_happy" = "1"],
         [internal_libevent_location="3rd-party/libevent_directory"

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -192,7 +192,8 @@ AC_DEFUN([_OPAL_CONFIG_LIBEVENT_INTERNAL], [
          # note: because we only ship/commit a tarball (and not the source
          # directory), the source is always expanded in the builddir, so we
          # only need to add a -I to the builddir.
-         CPPFLAGS="$CPPFLAGS -I$OMPI_TOP_BUILDDIR/$internal_libevent_location -I$OMPI_TOP_BUILDDIR/$internal_libevent_location/include"
+         opal_libevent_CPPFLAGS="-I$OMPI_TOP_BUILDDIR/$internal_libevent_location -I$OMPI_TOP_BUILDDIR/$internal_libevent_location/include"
+         CPPFLAGS="$CPPFLAGS $opal_libevent_CPPFLAGS"
          # No need to update LDFLAGS, because they will install into
          # our tree and in the mean time are referenced by their .la
          # files.

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -57,7 +57,7 @@ dnl         LD_LIBRARY_PATH.
 dnl   * CPPFLAGS, LDFLAGS - Updated opal_pmix_CPPFLAGS and
 dnl         opal_pmix_LDFLAGS.
 AC_DEFUN([OPAL_CONFIG_PMIX], [
-    OPAL_VAR_SCOPE_PUSH([external_pmix_happy internal_pmix_happy internal_pmix_args internal_pmix_libs])
+    OPAL_VAR_SCOPE_PUSH([external_pmix_happy internal_pmix_happy internal_pmix_args internal_pmix_libs internal_pmix_CPPFLAGS])
 
     opal_show_subtitle "Configuring PMIx"
 
@@ -71,13 +71,16 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
          # make dist always works.
 	 internal_pmix_args="--without-tests-examples --disable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
          internal_pmix_libs=
+         internal_pmix_CPPFLAGS=
 
          AS_IF([test "$opal_libevent_mode" = "internal"],
                [internal_pmix_args="$internal_pmix_args --with-libevent=cobuild"
+                internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_libevent_CPPFLAGS"
                 internal_pmix_libs="$internal_pmix_libs $opal_libevent_LIBS"])
 
          AS_IF([test "$opal_hwloc_mode" = "internal"],
                [internal_pmix_args="$internal_pmix_args --with-hwloc=cobuild"
+                internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_hwloc_CPPFLAGS"
                 internal_pmix_libs="$internal_pmix_libs $opal_hwloc_LIBS"])
 
          AS_IF([test ! -z "$internal_pmix_libs"],
@@ -87,12 +90,15 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
          # picks up how to build an internal HWLOC and libevent, plus
          # picks up any user-specified compiler flags from the master
          # configure run.
-         export CFLAGS CPPFLAGS LDFLAGS
+         OPAL_SUBDIR_ENV_CLEAN([opal_pmix_configure])
+         AS_IF([test -n "$internal_pmix_CPPFLAGS"],
+               [OPAL_SUBDIR_ENV_APPEND([CPPFLAGS], [$internal_pmix_CPPFLAGS])])
          PAC_CONFIG_SUBDIR_ARGS([3rd-party/openpmix], [$internal_pmix_args],
                            [[--with-libevent=internal], [--with-hwloc=internal],
                             [--with-libevent=external], [--with-hwloc=external],
                             [--with-pmix=[[^ 	]]*], [--with-platform=[[^ 	]]*]],
                            [internal_pmix_happy=1])
+         OPAL_SUBDIR_ENV_RESTORE([opal_pmix_configure])
          OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])
 
     # unless internal specifically requested by the user, try to find

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -91,7 +91,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
          PAC_CONFIG_SUBDIR_ARGS([3rd-party/openpmix], [$internal_pmix_args],
                            [[--with-libevent=internal], [--with-hwloc=internal],
                             [--with-libevent=external], [--with-hwloc=external],
-                            [--with-pmix=.*], [--with-platform=.*]],
+                            [--with-pmix=[[^ 	]]*], [--with-platform=[[^ 	]]*]],
                            [internal_pmix_happy=1])
          OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])
 

--- a/config/opal_subdir_env.m4
+++ b/config/opal_subdir_env.m4
@@ -1,0 +1,89 @@
+dnl -*- autoconf -*-
+dnl
+dnl Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+dnl                         reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl OPAL_SUBDIR_ENV_CLEAN([prefix])
+dnl
+dnl Save all precious variables with the specified prefix and reset
+dnl all precious variables to their state at the start of configure.
+dnl That is, if a precious variable (say CPPFLAGS) was set on the
+dnl configure command line or in the environment at the start of
+dnl configure, it will be reset to that stored value.  Otherwise, it
+dnl will be unset.  The current state is recorded so that it can be
+dnl restored with OPAL_SUBDIR_ENV_RESTORE.  Useful for wrapping calles
+dnl to subconfigure scripts.
+AC_DEFUN([OPAL_SUBDIR_ENV_CLEAN], [
+    for temp_var in $ac_precious_vars; do
+        # save all set variables, with a <prefix>_<name>_set and
+        # <prefix>_<name>_value format.  _set will always be saved,
+        # _value if _set evaluates to "set".
+        #
+        # Because we may modify the environment with
+        # OPAL_SUBDIR_ENV_APPEND, also store the original values of
+        # ac_env_<name>_set in <prefix>_ac_env_<name>_set
+        eval temp_var_set=\${${temp_var}+set}
+        eval $1_${temp_var}_set=$temp_var_set
+        eval $1_ac_env_${temp_var}_set=\$ac_env_${temp_var}_set
+        if test "$temp_var_set" = "set" ; then
+            eval $1_${temp_var}_value=\$${temp_var}
+        fi
+        unset tmp_var_set
+
+	# restore the variables that were set at the start of
+	# configure and unset the ones that were not.
+        eval temp_var_orig_set=\$ac_env_${temp_var}_set
+        if test "$temp_var_set" = "set" ; then
+             eval ${temp_var}=\$ac_env_${temp_var}_value
+        else
+             unset $temp_var
+        fi
+    done
+])
+
+dnl OPAL_SUBDIR_ENV_RESTORE([prefix])
+dnl
+dnl Match with call to OPAL_SUBDIR_ENV_CLEAN.  Restore will return all
+dnl precious variables to their state at the time that
+dnl OPAL_SUBDIR_ENV_CLEAN was called.  If a variable was set at that
+dnl time, it will be set to that value.  Otherwise, it will be unset.
+dnl
+dnl The state of the ac_env_<var>_set value is also restored to its
+dnl value from when OPAL_SUBDIR_ENV_CLEAN is called.  The
+dnl ac_env_<var>_set variables may be manipulated by
+dnl OPAL_SUBDIR_ENV_APPEND.
+AC_DEFUN([OPAL_SUBDIR_ENV_RESTORE], [
+    for temp_var in $ac_precious_vars; do
+        # always restore the value of ac_env_<name>_set
+        eval ac_env_${temp_var}_set=\$$1_ac_env_${temp_var}_set
+
+        # conditionally restore any variable values that were set at
+        # CLEAN time
+        eval temp_var_set=\$$1_${temp_var}_set
+        if test "$temp_var_set" = "set" ; then
+            eval ${temp_var}=\$$1_${temp_var}_value
+        fi
+
+        unset $1_${temp_var}_value
+        unset $1_${temp_var}_set
+        unset $1_ac_env_${temp_var}_set
+    done
+])
+
+dnl OPAL_SUBDIR_ENV_APPEND([precious variable], [append value])
+dnl
+dnl Append the contents of [append value] to precious variable
+dnl [precious variable] and set the ac_env_<param>_set variable so
+dnl that PAC_CONFIG_SUBDIR_ARGS can pick up the variables for
+dnl subconfigure runs.  Most useful between a call to
+dnl OPAL_SUBDIR_ENV_CLEAN and OPAL_SUBDIR_ENV_RESTORE
+AC_DEFUN([OPAL_SUBDIR_ENV_APPEND], [
+    ac_env_$1_set="set"
+    AS_IF([test -z "$$1"], [$1=$2], [$1="$$1 $2"])
+])


### PR DESCRIPTION
This patch series started as a fix for George's report that we broke support for `--enable-visibility`, but expanded to a significant cleanup of the Autoconf precious flags (`CC`, `CXX`, `CPPFLAGS`, etc.; the ones listed at the bottom of `./configure --help`).  The core issue with `--enable-visibility` was that the top-level configure adds `-Wmissing-prototypes` to `CFLAGS`.  The visibility tests use `-Werror` in `CFLAGS` to make the compiler puke if it does not support visibility features.  However, the test for visibility features uses the standard Autoconf C program template, which does not fully specify the `main()` prototype.  That test, plus `-Wmissing-prototypes`, plus `-Werror` resulted in a compiler error.

With this patch series, the sub-configure for the 3rd party packages will not use the current environment to determine which precious variables are passed down (nor their values).  Instead, precious variables will be passed down if either they were in the environment at the start of configure, they were on the configure command line, or the caller to the subconfigure explicitly sets a new value for the precious variable and asks that it is passed to the subconfigure.  In this way, the subconfigure scripts will have the exact same precious variable values as the top level, modulo any explicitly requested changes (like adding the -Is for co-built packages).  This fixes the `--enable-visibility` issue and should lead to fewer subpackage surprises in the future.