### PR TITLE
opal/util: Fix typo

### DIFF
--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -236,7 +237,7 @@ static void show_stackframe (int signo, siginfo_t * info, void * p)
             case BUS_ADRERR: si_code_str = "Non-existant physical address"; break;
 #endif
 #ifdef BUS_OBJERR
-            case BUS_OBJERR: si_code_str = "Objet-specific hardware error"; break;
+            case BUS_OBJERR: si_code_str = "Object-specific hardware error"; break;
 #endif
             }
             break;


### PR DESCRIPTION
Fix a typo in `opal/util/stacktrace.c`

Signed-off-by: NARIBAYASHI Akira <a.naribayashi@fujitsu.com>