### PR TITLE
symbol pollution

### DIFF
--- a/ompi/runtime/ompi_spc.c
+++ b/ompi/runtime/ompi_spc.c
@@ -8,6 +8,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +18,7 @@
 
 #include "ompi_spc.h"
 
-opal_timer_t sys_clock_freq_mhz = 0;
+static opal_timer_t sys_clock_freq_mhz = 0;
 
 static void ompi_spc_dump(void);
 


### PR DESCRIPTION
Made a couple vars static if they didn't look like they were used
more than one place, and added prefixes to a few.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit 34b42b1b0996049aea60c72f2a1505c5d1e55b8c)