### PR TITLE
v4.1.x: Adding ofi include to CPPFLAGS so that configure can check fabric.h

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -121,11 +121,13 @@ AC_DEFUN([_OPAL_CHECK_OFI],[
                               [],
                               [opal_ofi_happy=no])])
 
+    CPPFLAGS="$CPPFLAGS $opal_ofi_CPPFLAGS"
+
     AS_IF([test $opal_ofi_happy = yes],
           [AC_CHECK_MEMBER([struct fi_info.nic],
                            [opal_check_fi_info_pci=1],
                            [opal_check_fi_info_pci=0],
-                           [[#include "$with_ofi/include/rdma/fabric.h"]])])
+                           [[#include <rdma/fabric.h>]])])
 
     AC_DEFINE_UNQUOTED([OPAL_OFI_PCI_DATA_AVAILABLE],
                        [$opal_check_fi_info_pci],


### PR DESCRIPTION
configure was previously failing to check for the fi_info.nic struct because
fabric.h relied on other header files in the ofi/include dir. This adds that
include to CPPFLAGS before running that check so that configure can check for
the struct.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>
(cherry picked from commit 08e8205fb73ea3c1a6f2822dacaea8c98949b62c)