### PR TITLE
Add UCX crash note from v4.0.x to master

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,8 @@ Copyright (c) 2017-2018 Los Alamos National Security, LLC.  All rights
 Copyright (c) 2017      Research Organization for Information Science
                         and Technology (RIST). All rights reserved.
 Copyright (c) 2020      Google, LLC. All rights reserved.
+Copyright (c) 2019-2020 Triad National Security, LLC. All rights
+                        reserved.
 
 $COPYRIGHT$
 
@@ -724,6 +726,11 @@ Network Support
       shell$ mpirun --mca pml cm --mca mtl [MTL] ...
       or
       shell$ mpirun --mca pml ucx ...
+
+  There is a known issue when using UCX with very old Mellanox Infiniband
+  HCAs, in particular HCAs preceding the introduction of the ConnectX
+  product line, which can result in Open MPI crashing in MPI_Finalize.
+  This issue will be addressed by UCX release 1.9.0 and newer.
 
 - The main OpenSHMEM network model is "ucx"; it interfaces directly
   with UCX.


### PR DESCRIPTION
related to #7968

The README update was not added to master, for some reason.  Copying there to eventually copy to v4.1.x.