### PR TITLE
Check for spaces in prefix, srcdir, and builddir

### DIFF
--- a/config/opal_get_version.m4
+++ b/config/opal_get_version.m4
@@ -83,9 +83,9 @@ m4_define([OPAL_GET_VERSION],[
             if test -d "$srcdir/.git" && test $git_happy -eq 1; then
                 if test "$srcdir" != "`pwd`"; then
                     git_save_dir=`pwd`
-                    cd $srcdir
+                    cd "$srcdir"
                     $2_REPO_REV=`git describe --tags --always`
-                    cd $git_save_dir
+                    cd "$git_save_dir"
                     unset git_save_dir
                 else
                     $2_REPO_REV=`git describe --tags --always`

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,26 @@ AM_SILENT_RULES([yes])
 # Make configure depend on the VERSION file, since it's used in AC_INIT
 AC_SUBST([CONFIGURE_DEPENDENCIES], ['$(top_srcdir)/VERSION'])
 
+# Sanity checks
+AC_DEFUN([OMPI_CHECK_DIR_FOR_SPACES],[
+    dir="$1"
+    article="$2"
+    label="$3"
+
+    AC_MSG_CHECKING([directory of $label])
+    AC_MSG_RESULT([$dir])
+    AS_IF([test -n "`echo $dir | grep ' '`"],
+          [AC_MSG_WARN([This version of Open MPI does not support $article $label])
+           AC_MSG_WARN([with a path that contains spaces])
+           AC_MSG_ERROR([Cannot continue.])])
+])
+
+OMPI_CHECK_DIR_FOR_SPACES([$srcdir], [a], [source tree])
+OMPI_CHECK_DIR_FOR_SPACES([`readlink -f $srcdir`], [an], [absolute source tree])
+OMPI_CHECK_DIR_FOR_SPACES([`readlink -f .`], [a], [build tree])
+OMPI_CHECK_DIR_FOR_SPACES([$prefix], [a], [prefix])
+OMPI_CHECK_DIR_FOR_SPACES([`readlink -f $prefix`], [an], [absolute prefix])
+
 opal_show_subtitle "Checking versions"
 
 # Get the version of OMPI that we are installing


### PR DESCRIPTION
See individual commit messages for details.

The short version is: Open MPI doesn't properly handle prefixes, source dirs, or build dirs with spaces.  We have made attempts at cleaning this up in the past, but more stuff keeps slipping through.  Rather than try to fix this, just put in checks right up at the top of configure to abort early with a helpful message if we detect spaces in any of the relevant directories.

If we do decide to properly, formally support spaces in directories someday, these checks are easy enough to remove.