### PR TITLE
ompi/man5: include nroff-ified pages in tarball

### DIFF
--- a/ompi/mpi/man/man5/Makefile.am
+++ b/ompi/mpi/man/man5/Makefile.am
@@ -23,6 +23,8 @@ native_nroff_files = \
         MPI.5 \
         OpenMPI.5
 
+man_pages_from_md = $(MD_FILES:.5.md=.5)
+
 if OPAL_ENABLE_MAN_PAGES
 man_MANS = $(man_pages_from_md) $(native_nroff_files)
 MAINTAINERCLEANFILES = $(man_pages_from_md)


### PR DESCRIPTION
Add a line that was accidentally left out that includes the generated
nroff pages (from the Markdown pages) in the dist tarball.

The lack of these files in the dist tarball was causing configure to
fail a test and therefore conclude that we need to have pandoc
installed.  Put differently: it's a specific goal that we do not want
end users to have to have Pandoc installed -- all Markdown files must
generate their nroff equivalents and have those nroff files included
in the distribution tarball.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>