### PR TITLE
Change MCA component build style default to static

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,7 +20,7 @@ Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
 Copyright (c) 2012      University of Houston. All rights reserved.
 Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
-Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.  All Rights
                         reserved.
 $COPYRIGHT$
 
@@ -80,6 +80,8 @@ Master (not on release branches yet)
   Currently, this means the Open SHMEM layer will only build if
   a MXM or UCX library is found.
 - Remove all vestiges of the C/R support
+- Change the default component build behavior to prefer building
+  components as part of libmpi.so instead of individual DSOs.
 
 4.0.5 -- August, 2020
 ---------------------

--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -275,8 +275,6 @@ AC_ARG_ENABLE([dlopen],
                      Disabling dlopen implies --disable-mca-dso.
                      (default: enabled)])])
 if test "$enable_dlopen" = "no" ; then
-    enable_mca_dso=no
-    enable_mca_static=yes
     OPAL_ENABLE_DLOPEN_SUPPORT=0
     AC_MSG_RESULT([no])
 else

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -166,7 +166,7 @@ AC_DEFUN([OPAL_MCA],[
     # resolution (prefer static) is done in the big loop below
     #
     AC_MSG_CHECKING([which components should be run-time loadable])
-    if test "$enable_static" != "no"; then
+    if test "$enable_static" != "no" || test "$OPAL_ENABLE_DLOPEN_SUPPORT" = 0; then
         DSO_all=0
         msg=none
     elif test -z "$enable_mca_dso" || test "$enable_mca_dso" = "yes"; then
@@ -175,7 +175,6 @@ AC_DEFUN([OPAL_MCA],[
     elif test "$enable_mca_dso" = "no"; then
         DSO_all=0
         msg=none
-        enable_dlopen=no
     else
         DSO_all=0
         ifs_save="$IFS"

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -705,15 +705,12 @@ AC_DEFUN([MCA_COMPONENT_COMPILE_MODE],[
         [str="STATIC_COMPONENT=\$STATIC_$2_$3"
          eval $str])
 
-    shared_mode_override=static
-
     # Setup for either shared or static
     if test "$STATIC_FRAMEWORK" = "1" || \
        test "$STATIC_COMPONENT" = "1" || \
        test "$STATIC_all" = "1" ; then
         $4="static"
-    elif test "$shared_mode_override" = "dso" || \
-         test "$SHARED_FRAMEWORK" = "1" || \
+    elif test "$SHARED_FRAMEWORK" = "1" || \
          test "$SHARED_COMPONENT" = "1" || \
          test "$DSO_all" = "1"; then
         $4="dso"

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
-dnl Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
+dnl Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -68,8 +68,7 @@ AC_DEFUN([OPAL_MCA],[
                         type-component pairs that will be built as
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
-                        platform.  The default is to build all components
-                        as DSOs.])])
+                        platform.])])
     AC_ARG_ENABLE([mca-static],
         [AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or
@@ -77,7 +76,8 @@ AC_DEFUN([OPAL_MCA],[
                         linked into the library.  The default (if DSOs are
                         supported) is to build all components as DSOs.
                         Enabling a component as static disables it
-                        building as a DSO.])])
+                        building as a DSO.  The default is to build all
+                        components staticly.])])
     AC_ARG_ENABLE([mca-direct],
         [AS_HELP_STRING([--enable-mca-direct=LIST],
                        [Comma-separated list of type-component pairs that
@@ -166,15 +166,21 @@ AC_DEFUN([OPAL_MCA],[
     # resolution (prefer static) is done in the big loop below
     #
     AC_MSG_CHECKING([which components should be run-time loadable])
-    if test "$enable_static" != "no" || test "$OPAL_ENABLE_DLOPEN_SUPPORT" = 0; then
+    if test "$enable_static" != "no"; then
         DSO_all=0
-        msg=none
-    elif test -z "$enable_mca_dso" || test "$enable_mca_dso" = "yes"; then
-        DSO_all=1
-        msg=all
+        msg="none (static libraries built)"
+    elif test "$OPAL_ENABLE_DLOPEN_SUPPORT" = 0; then
+        DSO_all=0
+        msg="none (dlopen disabled)"
+    elif test -z "$enable_mca_dso"; then
+        DSO_all=0
+        msg=default
     elif test "$enable_mca_dso" = "no"; then
         DSO_all=0
         msg=none
+    elif test "$enable_mca_dso" = "yes"; then
+        DSO_all=1
+        msg=all
     else
         DSO_all=0
         ifs_save="$IFS"
@@ -195,12 +201,15 @@ AC_DEFUN([OPAL_MCA],[
     fi
 
     AC_MSG_CHECKING([which components should be static])
-    if test "$enable_mca_static" = "yes"; then
-        STATIC_all=1
-        msg=all
-    elif test -z "$enable_mca_static" || test "$enable_mca_static" = "no"; then
+    if test -z "$enable_mca_static" ; then
+        STATIC_all=0
+        msg=default
+    elif test "$enable_mca_static" = "no"; then
         STATIC_all=0
         msg=none
+    elif test "$enable_mca_static" = "yes"; then
+        STATIC_all=1
+        msg=all
     else
         STATIC_all=0
         ifs_save="$IFS"
@@ -705,17 +714,23 @@ AC_DEFUN([MCA_COMPONENT_COMPILE_MODE],[
         [str="STATIC_COMPONENT=\$STATIC_$2_$3"
          eval $str])
 
-    # Setup for either shared or static
-    if test "$STATIC_FRAMEWORK" = "1" || \
-       test "$STATIC_COMPONENT" = "1" || \
-       test "$STATIC_all" = "1" ; then
-        $4="static"
-    elif test "$SHARED_FRAMEWORK" = "1" || \
-         test "$SHARED_COMPONENT" = "1" || \
-         test "$DSO_all" = "1"; then
-        $4="dso"
+    # Look for the most specific specifier between static/dso.  If
+    # there is a tie (either neither or both specified), prefer
+    # static.
+    if test "$STATIC_COMPONENT" = "1"; then
+        $4=static
+    elif test "SHARED_COMPONENT" = "1"; then
+        $4=dso
+    elif test "$STATIC_FRAMEWORK" = "1"; then
+        $4=static
+    elif test "$SHARED_FRAMEWORK" = "1"; then
+        $4=dso
+    elif test "$STATIC_all" = "1"; then
+        $4=static
+    elif test "$DSO_all" = "1"; then
+        $4=dso
     else
-        $4="static"
+        $4=static
     fi
 
     AC_MSG_CHECKING([for MCA component $2:$3 compile mode])


### PR DESCRIPTION
This patch series primarily changes the default component build style from dso to static.  At the same time, it cleans up some minor nits and clarifies the selection logic when there are conflicting --enable-mca-dso and --enable-mca-static arguments.