### PR TITLE
Using package_rank to select between NIC of equal distance from the process.

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -133,6 +133,11 @@ AC_DEFUN([_OPAL_CHECK_OFI],[
                        [$opal_check_fi_info_pci],
                        [check if pci data is available in ofi])
 
+    AC_CHECK_DECLS([PMIX_PACKAGE_RANK],
+                   [],
+                   [],
+                   [#include <pmix.h>])
+
     CPPFLAGS=$opal_check_ofi_save_CPPFLAGS
     LDFLAGS=$opal_check_ofi_save_LDFLAGS
     LIBS=$opal_check_ofi_save_LIBS

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -15,6 +15,7 @@
  * $HEADER$
  */
 
+#include "opal_config.h"
 #include "mtl_ofi.h"
 #include "opal/util/argv.h"
 #include "opal/util/printf.h"
@@ -337,7 +338,7 @@ select_ofi_provider(struct fi_info *providers,
                         __FILE__, __LINE__,
                         (prov ? prov->fabric_attr->prov_name : "none"));
 
-     /* The initial fi_getinfo() call will return a list of providers
+    /** The initial provider selection will return a list of providers
       * available for this process. once a provider is selected from the
       * list, we will cycle through the remaining list to identify NICs
       * serviced by this provider, and try to pick one on the same NUMA
@@ -350,9 +351,13 @@ select_ofi_provider(struct fi_info *providers,
       * attributes for the same NIC. The initial provider attributes
       * are used to ensure that all NICs we return provide the same
       * capabilities as the inital one.
+      *
+      * We use package rank to select between NICs of equal distance
+      * if we cannot calculate a package_rank, we fall back to using the
+      * process id.
       */
     if (NULL != prov) {
-        prov = opal_mca_common_ofi_select_provider(prov, ompi_process_info.my_local_rank);
+        prov = opal_mca_common_ofi_select_provider(prov, ompi_process_info);
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                             "%s:%d: mtl:ofi:provider: %s\n",
                             __FILE__, __LINE__,
@@ -1170,6 +1175,3 @@ finalize_err:
 
     return OMPI_ERROR;
 }
-
-
-

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -391,7 +391,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
              * are used to ensure that all NICs we return provide the same
              * capabilities as the inital one.
              */
-            selected_info = opal_mca_common_ofi_select_provider(info, opal_process_info.my_local_rank);
+            selected_info = opal_mca_common_ofi_select_provider(info, opal_process_info);
             rc = mca_btl_ofi_init_device(selected_info);
             if (OPAL_SUCCESS == rc) {
                 info = selected_info;

--- a/opal/mca/common/ofi/Makefile.am
+++ b/opal/mca/common/ofi/Makefile.am
@@ -31,6 +31,8 @@
 
 AM_CPPFLAGS = $(opal_ofi_CPPFLAGS)
 
+dist_opaldata_DATA = help-common-ofi.txt
+
 # Header files
 
 headers = \

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -19,6 +19,7 @@
 #include "opal_config.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/base/mca_base_framework.h"
+#include "opal/util/proc.h"
 #include <rdma/fabric.h>
 
 BEGIN_C_DECLS
@@ -36,8 +37,7 @@ extern opal_common_ofi_module_t opal_common_ofi;
 OPAL_DECLSPEC int opal_common_ofi_register_mca_variables(const mca_base_component_t *component);
 OPAL_DECLSPEC void opal_common_ofi_mca_register(void);
 OPAL_DECLSPEC void opal_common_ofi_mca_deregister(void);
-OPAL_DECLSPEC struct fi_info* opal_common_ofi_select_ofi_provider(struct fi_info *providers, 
-                                                                  char *framework_name);
+
 /*
  * @param list (IN)    List of strings corresponding to lower providers.
  * @param item (IN)    Single string corresponding to a provider.
@@ -56,6 +56,6 @@ OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item);
 
 END_C_DECLS
 
-struct fi_info* opal_mca_common_ofi_select_provider(struct fi_info *provider_list, int rank);
+struct fi_info* opal_mca_common_ofi_select_provider(struct fi_info *provider_list, opal_process_info_t process_info);
 
 #endif /* OPAL_MCA_COMMON_OFI_H */

--- a/opal/mca/common/ofi/help-common-ofi.txt
+++ b/opal/mca/common/ofi/help-common-ofi.txt
@@ -1,0 +1,14 @@
+# -*- text -*-
+#
+# Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[package_rank failed]
+Open MPI's OFI driver detected multiple equidistant NICs from the current process,
+but had insufficient information to ensure MPI processes fairly pick a NIC for use.
+This may negatively impact performance. A more modern PMIx server is necessary to
+resolve this issue.


### PR DESCRIPTION
If PMIX_PACKAGE_RANK is available, uses this value to select between multiple
NIC of equal distance between the current process. If this value is not
available, try to calculate it by getting the locality string from each local
process and assign a package_rank. If everything fails, fall back to using
process_id.rank to select the NIC. This last case is not ideal, but has a small
chance of occuring, and causes an output to be displayed to notify that this is
occuring.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>