### PR TITLE
OPAL: fix string buffer allocation for large env variables [v4.1.x]

### DIFF
--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -274,21 +274,37 @@ static int save_param_name (void)
 
 static int add_to_env_str(char *var, char *val)
 {
-    int sz, varsz, valsz;
+    int sz, varsz, valsz, new_envsize;
     void *tmp;
 
     if (NULL == var) {
         return OPAL_ERR_BAD_PARAM;
     }
 
+    varsz = strlen(var);
+    if (NULL != val) {
+        valsz = strlen(val);
+        /* account for '=' */
+        valsz += 1;
+    }
+    sz = 0;
     if (NULL != env_str) {
-        varsz = strlen(var);
-        valsz = (NULL != val) ? strlen(val) : 0;
-        sz = strlen(env_str)+varsz+valsz+2;
-        if (envsize <= sz) {
-            envsize *=2;
+        sz = strlen(env_str);
+        /* account for ';' */
+        sz += 1;
+    }
+    /* add required new size incl NUL byte */
+    sz += varsz+valsz+1;
 
-            tmp = realloc(env_str, envsize);
+    /* make sure we have sufficient space */
+    new_envsize = envsize;
+    while (new_envsize <= sz) {
+        new_envsize *=2;
+    }
+
+    if (NULL != env_str) {
+        if (new_envsize > envsize) {
+            tmp = realloc(env_str, new_envsize);
             if (NULL == tmp) {
                 return OPAL_ERR_OUT_OF_RESOURCE;
             }
@@ -296,11 +312,12 @@ static int add_to_env_str(char *var, char *val)
         }
         strcat(env_str, ";");
     } else {
-        env_str = calloc(1, envsize);
+        env_str = calloc(1, new_envsize);
         if (NULL == env_str) {
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
     }
+    envsize = new_envsize;
 
     strcat(env_str, var);
     if (NULL != val) {


### PR DESCRIPTION
In OPAL's keyval parser in `add_to_env_str`, for the first variable a buffer of size 1024 was allocated, regardless of the space needed. For any additional variables, the size might have been doubled at best, even if more space was required. This PR makes sure the allocated buffer is sufficiently large to store the value.

Cherry-pick of https://github.com/open-mpi/ompi/pull/8144 to v4.1.x release branch.

See #8117

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>