### PR TITLE
Coverity fixes for recent OFI changes

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -357,7 +357,7 @@ select_ofi_provider(struct fi_info *providers,
       * process id.
       */
     if (NULL != prov) {
-        prov = opal_mca_common_ofi_select_provider(prov, ompi_process_info);
+        prov = opal_mca_common_ofi_select_provider(prov, &ompi_process_info);
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                             "%s:%d: mtl:ofi:provider: %s\n",
                             __FILE__, __LINE__,

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -391,7 +391,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
              * are used to ensure that all NICs we return provide the same
              * capabilities as the inital one.
              */
-            selected_info = opal_mca_common_ofi_select_provider(info, opal_process_info);
+            selected_info = opal_mca_common_ofi_select_provider(info, &opal_process_info);
             rc = mca_btl_ofi_init_device(selected_info);
             if (OPAL_SUCCESS == rc) {
                 info = selected_info;

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -297,12 +297,12 @@ count_providers(struct fi_info* provider_list)
  * otherwise falls back to using opal_process_info.myprocid.rank
  * this can affect performance, but is unlikely to happen.
  */
-static uint32_t get_package_rank(opal_process_info_t process_info)
+static uint32_t get_package_rank(opal_process_info_t *process_info)
 {
     int i;
     uint16_t relative_locality, *package_rank_ptr;
     uint16_t current_package_rank = 0;
-    uint16_t package_ranks[process_info.num_local_peers];
+    uint16_t package_ranks[process_info->num_local_peers];
     opal_process_name_t pname;
     opal_status_t rc;
     char **peers = NULL;
@@ -327,7 +327,7 @@ static uint32_t get_package_rank(opal_process_info_t process_info)
     if (PMIX_SUCCESS != rc || NULL == local_peers) {
         // We can't find package_rank, fall back to procid
         opal_show_help("help-common-ofi.txt", "package_rank failed", true);
-        return (uint32_t)process_info.myprocid.rank;
+        return (uint32_t)process_info->myprocid.rank;
     }
     peers = opal_argv_split(local_peers, ',');
     free(local_peers);
@@ -341,11 +341,11 @@ static uint32_t get_package_rank(opal_process_info_t process_info)
         if (PMIX_SUCCESS != rc || NULL == locality_string) {
             // If we don't have information about locality, fall back to procid
             opal_show_help("help-common-ofi.txt", "package_rank failed", true);
-            return (uint32_t)process_info.myprocid.rank;
+            return (uint32_t)process_info->myprocid.rank;
         }
 
         // compute relative locality
-        relative_locality = opal_hwloc_compute_relative_locality(process_info.cpuset, locality_string);
+        relative_locality = opal_hwloc_compute_relative_locality(process_info->cpuset, locality_string);
         free(locality_string);
 
         if (relative_locality & OPAL_PROC_ON_SOCKET) {
@@ -354,7 +354,7 @@ static uint32_t get_package_rank(opal_process_info_t process_info)
         }
     }
 
-    return (uint32_t)package_ranks[process_info.my_local_rank];
+    return (uint32_t)package_ranks[process_info->my_local_rank];
 }
 
 /* Selects a NIC based on hardware locality between process cpuset and device BDF.
@@ -413,7 +413,7 @@ static uint32_t get_package_rank(opal_process_info_t process_info)
  * balance across available NICs.
  */
 struct fi_info*
-opal_mca_common_ofi_select_provider(struct fi_info *provider_list, opal_process_info_t process_info)
+opal_mca_common_ofi_select_provider(struct fi_info *provider_list, opal_process_info_t *process_info)
 {
     struct fi_info *provider = provider_list, *current_provider = provider_list;
     struct fi_info **provider_table;

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -56,6 +56,6 @@ OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item);
 
 END_C_DECLS
 
-struct fi_info* opal_mca_common_ofi_select_provider(struct fi_info *provider_list, opal_process_info_t process_info);
+struct fi_info* opal_mca_common_ofi_select_provider(struct fi_info *provider_list, opal_process_info_t *process_info);
 
 #endif /* OPAL_MCA_COMMON_OFI_H */


### PR DESCRIPTION
8017f12 introduced a new function to get the package rank of a process,
which had a pass-by-value signature (opal_process_info_t); and coverity
was not happy about it. This commit changes the signature to take a
reference to opal_process_info_t instead.

Signed-off-by: Raghu Raja <craghun@amazon.com>