### PR TITLE
Fix some issues with dynamic algorithm selection in coll/tuned

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
@@ -77,7 +77,8 @@ ompi_coll_tuned_allgather_intra_check_forced_init(coll_tuned_force_algorithm_mca
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "allgather_algorithm",
-                                        "Which allallgather algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 bruck, 3 recursive doubling, 4 ring, 5 neighbor exchange, 6: two proc only.",
+                                        "Which allallgather algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 bruck, 3 recursive doubling, 4 ring, 5 neighbor exchange, 6: two proc only. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -31,7 +31,7 @@ static int coll_tuned_allgather_tree_fanout;
 static int coll_tuned_allgather_chain_fanout;
 
 /* valid values for coll_tuned_allgather_forced_algorithm */
-static mca_base_var_enum_value_t allgather_algorithms[] = {
+static const mca_base_var_enum_value_t allgather_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "bruck"},

--- a/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -31,7 +31,7 @@ static int coll_tuned_allgatherv_tree_fanout;
 static int coll_tuned_allgatherv_chain_fanout;
 
 /* valid values for coll_tuned_allgatherv_forced_algorithm */
-static mca_base_var_enum_value_t allgatherv_algorithms[] = {
+static const mca_base_var_enum_value_t allgatherv_algorithms[] = {
     {0, "ignore"},
     {1, "default"},
     {2, "bruck"},

--- a/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
@@ -76,7 +76,8 @@ ompi_coll_tuned_allgatherv_intra_check_forced_init(coll_tuned_force_algorithm_mc
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "allgatherv_algorithm",
-                                        "Which allallgatherv algorithm is used. Can be locked down to choice of: 0 ignore, 1 default (allgathervv + bcast), 2 bruck, 3 ring, 4 neighbor exchange, 5: two proc only.",
+                                        "Which allallgatherv algorithm is used. Can be locked down to choice of: 0 ignore, 1 default (allgathervv + bcast), 2 bruck, 3 ring, 4 neighbor exchange, 5: two proc only. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_CONSTANT,

--- a/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
@@ -34,7 +34,7 @@ static int coll_tuned_allreduce_tree_fanout;
 static int coll_tuned_allreduce_chain_fanout;
 
 /* valid values for coll_tuned_allreduce_forced_algorithm */
-static mca_base_var_enum_value_t allreduce_algorithms[] = {
+static const mca_base_var_enum_value_t allreduce_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "nonoverlapping"},

--- a/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
@@ -77,7 +77,8 @@ int ompi_coll_tuned_allreduce_intra_check_forced_init (coll_tuned_force_algorith
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "allreduce_algorithm",
-                                        "Which allreduce algorithm is used. Can be locked down to any of: 0 ignore, 1 basic linear, 2 nonoverlapping (tuned reduce + tuned bcast), 3 recursive doubling, 4 ring, 5 segmented ring",
+                                        "Which allreduce algorithm is used. Can be locked down to any of: 0 ignore, 1 basic linear, 2 nonoverlapping (tuned reduce + tuned bcast), 3 recursive doubling, 4 ring, 5 segmented ring. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
@@ -74,7 +74,8 @@ int ompi_coll_tuned_alltoall_intra_check_forced_init (coll_tuned_force_algorithm
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "alltoall_algorithm",
-                                        "Which alltoall algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 pairwise, 3: modified bruck, 4: linear with sync, 5:two proc only.",
+                                        "Which alltoall algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 pairwise, 3: modified bruck, 4: linear with sync, 5:two proc only. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -32,7 +32,7 @@ static int coll_tuned_alltoall_tree_fanout;
 static int coll_tuned_alltoall_chain_fanout;
 
 /* valid values for coll_tuned_alltoall_forced_algorithm */
-static mca_base_var_enum_value_t alltoall_algorithms[] = {
+static const mca_base_var_enum_value_t alltoall_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "pairwise"},

--- a/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
@@ -71,7 +71,8 @@ int ompi_coll_tuned_alltoallv_intra_check_forced_init(coll_tuned_force_algorithm
                                         "alltoallv_algorithm",
                                         "Which alltoallv algorithm is used. "
                                         "Can be locked down to choice of: 0 ignore, "
-                                        "1 basic linear, 2 pairwise.",
+                                        "1 basic linear, 2 pairwise. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -29,7 +29,7 @@
 static int coll_tuned_alltoallv_forced_algorithm = 0;
 
 /* valid values for coll_tuned_alltoallv_forced_algorithm */
-static mca_base_var_enum_value_t alltoallv_algorithms[] = {
+static const mca_base_var_enum_value_t alltoallv_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "pairwise"},

--- a/ompi/mca/coll/tuned/coll_tuned_barrier_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_barrier_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -27,7 +27,7 @@
 static int coll_tuned_barrier_forced_algorithm = 0;
 
 /* valid values for coll_tuned_barrier_forced_algorithm */
-static mca_base_var_enum_value_t barrier_algorithms[] = {
+static const mca_base_var_enum_value_t barrier_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "double_ring"},

--- a/ompi/mca/coll/tuned/coll_tuned_barrier_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_barrier_decision.c
@@ -72,7 +72,8 @@ int ompi_coll_tuned_barrier_intra_check_forced_init (coll_tuned_force_algorithm_
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "barrier_algorithm",
-                                        "Which barrier algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 double ring, 3: recursive doubling 4: bruck, 5: two proc only, 6: tree",
+                                        "Which barrier algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 double ring, 3: recursive doubling 4: bruck, 5: two proc only, 6: tree. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
@@ -80,7 +80,8 @@ int ompi_coll_tuned_bcast_intra_check_forced_init (coll_tuned_force_algorithm_mc
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "bcast_algorithm",
-                                        "Which bcast algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 chain, 3: pipeline, 4: split binary tree, 5: binary tree, 6: binomial tree, 7: knomial tree, 8: scatter_allgather, 9: scatter_allgather_ring.",
+                                        "Which bcast algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 chain, 3: pipeline, 4: split binary tree, 5: binary tree, 6: binomial tree, 7: knomial tree, 8: scatter_allgather, 9: scatter_allgather_ring. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -34,7 +34,7 @@ static int coll_tuned_bcast_chain_fanout;
 static int coll_tuned_bcast_knomial_radix = 4;
 
 /* valid values for coll_tuned_bcast_forced_algorithm */
-static mca_base_var_enum_value_t bcast_algorithms[] = {
+static const mca_base_var_enum_value_t bcast_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "chain"},

--- a/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -97,7 +97,7 @@ ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int c
  *
  *    Function:    - seletects alltoall algorithm to use
  *    Accepts:    - same arguments as MPI_Alltoall()
- *    Returns:    - MPI_SUCCESS or error code (passed from the bcast implementation)
+ *    Returns:    - MPI_SUCCESS or error code (passed from the alltoall implementation)
  */
 
 int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
@@ -238,7 +238,7 @@ int ompi_coll_tuned_barrier_intra_dec_dynamic(struct ompi_communicator_t *comm,
 /*
  *   bcast_intra_dec
  *
- *   Function:   - seletects broadcast algorithm to use
+ *   Function:   - selects broadcast algorithm to use
  *   Accepts:   - same arguments as MPI_Bcast()
  *   Returns:   - MPI_SUCCESS or error code (passed from the bcast implementation)
  */

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -92,30 +92,10 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int coun
             } else {
                 alg = 2;
             }
-        } else if (communicator_size < 32) {
-            alg = 3;
-        } else if (communicator_size < 64) {
-            if (total_dsize < 131072) {
-                alg = 1;
-            } else {
-                alg = 3;
-            }
         } else if (communicator_size < 128) {
-            if (total_dsize < 128) {
-                alg = 1;
-            } else if (total_dsize < 512) {
-                alg = 3;
-            } else if (total_dsize < 8192) {
-                alg = 1;
-            } else {
-                alg = 3;
-            }
+            alg = 3;
         } else if (communicator_size < 256) {
-            if (total_dsize < 2048) {
-                alg = 2;
-            } else if (total_dsize < 16384) {
-                alg = 1;
-            } else if (total_dsize < 131072) {
+            if (total_dsize < 131072) {
                 alg = 2;
             } else if (total_dsize < 524288) {
                 alg = 3;
@@ -183,23 +163,13 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int coun
                 alg = 6;
             }
         } else if (communicator_size < 128) {
-            if (total_dsize < 128) {
-                alg = 1;
-            } else if (total_dsize < 512) {
-                alg = 3;
-            } else if (total_dsize < 8192) {
-                alg = 1;
-            } else if (total_dsize < 262144) {
+            if (total_dsize < 262144) {
                 alg = 3;
             } else {
                 alg = 6;
             }
         } else if (communicator_size < 256) {
-            if (total_dsize < 2048) {
-                alg = 2;
-            } else if (total_dsize < 16384) {
-                alg = 1;
-            } else if (total_dsize < 131072) {
+            if (total_dsize < 131072) {
                 alg = 2;
             } else if (total_dsize < 262144) {
                 alg = 3;
@@ -1158,9 +1128,7 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
             alg = 4;
         }
     } else if (communicator_size < 128) {
-        if (total_dsize < 64) {
-            alg = 1;
-        } else if (total_dsize < 512) {
+        if (total_dsize < 512) {
             alg = 3;
         } else if (total_dsize < 65536) {
             alg = 5;
@@ -1168,9 +1136,7 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
             alg = 4;
         }
     } else if (communicator_size < 256) {
-        if (total_dsize < 32) {
-            alg = 1;
-        } else if (total_dsize < 512) {
+        if (total_dsize < 512) {
             alg = 3;
         } else if (total_dsize < 131072) {
             alg = 5;
@@ -1182,9 +1148,7 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
             alg = 4;
         }
     } else if (communicator_size < 512) {
-        if (total_dsize < 16) {
-            alg = 1;
-        } else if (total_dsize < 32) {
+        if (total_dsize < 32) {
             alg = 3;
         } else if (total_dsize < 128) {
             alg = 2;
@@ -1200,9 +1164,7 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
             alg = 4;
         }
     } else if (communicator_size < 1024) {
-        if (total_dsize < 4) {
-            alg = 1;
-        } else if (total_dsize < 64) {
+        if (total_dsize < 64) {
             alg = 3;
         } else if (total_dsize < 256) {
             alg = 2;
@@ -1212,9 +1174,7 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
             alg = 5;
         }
     } else if (communicator_size < 2048) {
-        if (total_dsize < 2) {
-            alg = 1;
-        } else if (total_dsize < 4) {
+        if (total_dsize < 4) {
             alg = 3;
         } else if (total_dsize < 8) {
             alg = 2;

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -567,9 +567,7 @@ int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
      *  {9, "scatter_allgather_ring"},
      */
     if (communicator_size < 4) {
-        if (total_dsize < 2) {
-            alg = 9;
-        } else if (total_dsize < 32) {
+        if (total_dsize < 32) {
             alg = 3;
         } else if (total_dsize < 256) {
             alg = 5;
@@ -591,9 +589,7 @@ int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
             alg = 5;
         }
     } else if (communicator_size < 8) {
-        if (total_dsize < 2) {
-            alg = 8;
-        } else if (total_dsize < 64) {
+        if (total_dsize < 64) {
             alg = 5;
         } else if (total_dsize < 128) {
             alg = 6;
@@ -639,8 +635,6 @@ int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
     } else if (communicator_size < 256) {
         if (total_dsize < 2) {
             alg = 6;
-        } else if (total_dsize < 128) {
-            alg = 8;
         } else if (total_dsize < 16384) {
             alg = 5;
         } else if (total_dsize < 32768) {

--- a/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
@@ -2,6 +2,9 @@
 /*
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +29,7 @@
 static int coll_tuned_exscan_forced_algorithm = 0;
 
 /* valid values for coll_tuned_exscan_forced_algorithm */
-static mca_base_var_enum_value_t exscan_algorithms[] = {
+static const mca_base_var_enum_value_t exscan_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "recursive_doubling"},

--- a/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
@@ -68,7 +68,8 @@ int ompi_coll_tuned_exscan_intra_check_forced_init (coll_tuned_force_algorithm_m
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "exscan_algorithm",
-                                        "Which exscan algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 recursive_doubling",
+                                        "Which exscan algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 recursive_doubling. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -32,7 +32,7 @@ static int coll_tuned_gather_tree_fanout;
 static int coll_tuned_gather_chain_fanout;
 
 /* valid values for coll_tuned_gather_forced_algorithm */
-static mca_base_var_enum_value_t gather_algorithms[] = {
+static const mca_base_var_enum_value_t gather_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "binomial"},

--- a/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
@@ -75,7 +75,8 @@ ompi_coll_tuned_gather_intra_check_forced_init(coll_tuned_force_algorithm_mca_pa
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "gather_algorithm",
-                                        "Which gather algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 binomial, 3 linear with synchronization.",
+                                        "Which gather algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 binomial, 3 linear with synchronization. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
@@ -33,7 +33,7 @@ static int coll_tuned_reduce_tree_fanout;
 static int coll_tuned_reduce_chain_fanout;
 
 /* valid values for coll_tuned_reduce_forced_algorithm */
-static mca_base_var_enum_value_t reduce_algorithms[] = {
+static const mca_base_var_enum_value_t reduce_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "chain"},

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
@@ -80,7 +80,8 @@ int ompi_coll_tuned_reduce_intra_check_forced_init (coll_tuned_force_algorithm_m
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "reduce_algorithm",
-                                        "Which reduce algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 chain, 3 pipeline, 4 binary, 5 binomial, 6 in-order binary, 7 rabenseifner",
+                                        "Which reduce algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 chain, 3 pipeline, 4 binary, 5 binomial, 6 in-order binary, 7 rabenseifner. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
@@ -4,6 +4,9 @@
  *                         and Information Sciences. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +34,7 @@ static int coll_tuned_reduce_scatter_block_segment_size = 0;
 static int coll_tuned_reduce_scatter_block_tree_fanout;
 
 /* valid values for coll_tuned_reduce_scatter_blokc_forced_algorithm */
-static mca_base_var_enum_value_t reduce_scatter_block_algorithms[] = {
+static const mca_base_var_enum_value_t reduce_scatter_block_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "recursive_doubling"},
@@ -131,7 +134,7 @@ int ompi_coll_tuned_reduce_scatter_block_intra_do_this(const void *sbuf, void *r
                                                                                  dtype, op, comm, module);
     case (3): return ompi_coll_base_reduce_scatter_block_intra_recursivehalving(sbuf, rbuf, rcount,
                                                                                 dtype, op, comm, module);
-    case (4): return ompi_coll_base_reduce_scatter_block_intra_butterfly(sbuf, rbuf, rcount, dtype, op, comm, 
+    case (4): return ompi_coll_base_reduce_scatter_block_intra_butterfly(sbuf, rbuf, rcount, dtype, op, comm,
                                                                          module);
     } /* switch */
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:reduce_scatter_block_intra_do_this attempt to select algorithm %d when only 0-%d is valid?",

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
@@ -77,7 +77,8 @@ int ompi_coll_tuned_reduce_scatter_block_intra_check_forced_init (coll_tuned_for
                                         "reduce_scatter_block_algorithm",
                                         "Which reduce reduce_scatter_block algorithm is used. "
                                         "Can be locked down to choice of: 0 ignore, 1 basic_linear, 2 recursive_doubling, "
-                                        "3 recursive_halving, 4 butterfly",
+                                        "3 recursive_halving, 4 butterfly. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
@@ -77,7 +77,8 @@ int ompi_coll_tuned_reduce_scatter_intra_check_forced_init (coll_tuned_force_alg
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "reduce_scatter_algorithm",
-                                        "Which reduce reduce_scatter algorithm is used. Can be locked down to choice of: 0 ignore, 1 non-overlapping (Reduce + Scatterv), 2 recursive halving, 3 ring, 4 butterfly",
+                                        "Which reduce reduce_scatter algorithm is used. Can be locked down to choice of: 0 ignore, 1 non-overlapping (Reduce + Scatterv), 2 recursive halving, 3 ring, 4 butterfly. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -33,7 +33,7 @@ static int coll_tuned_reduce_scatter_tree_fanout;
 static int coll_tuned_reduce_scatter_chain_fanout;
 
 /* valid values for coll_tuned_reduce_scatter_forced_algorithm */
-static mca_base_var_enum_value_t reduce_scatter_algorithms[] = {
+static const mca_base_var_enum_value_t reduce_scatter_algorithms[] = {
     {0, "ignore"},
     {1, "non-overlapping"},
     {2, "recursive_halving"},

--- a/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
@@ -2,6 +2,9 @@
 /*
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +29,7 @@
 static int coll_tuned_scan_forced_algorithm = 0;
 
 /* valid values for coll_tuned_scan_forced_algorithm */
-static mca_base_var_enum_value_t scan_algorithms[] = {
+static const mca_base_var_enum_value_t scan_algorithms[] = {
     {0, "ignore"},
     {1, "linear"},
     {2, "recursive_doubling"},

--- a/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
@@ -68,7 +68,8 @@ int ompi_coll_tuned_scan_intra_check_forced_init (coll_tuned_force_algorithm_mca
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "scan_algorithm",
-                                        "Which scan algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 recursive_doubling",
+                                        "Which scan algorithm is used. Can be locked down to choice of: 0 ignore, 1 linear, 2 recursive_doubling. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
@@ -76,7 +76,8 @@ ompi_coll_tuned_scatter_intra_check_forced_init(coll_tuned_force_algorithm_mca_p
     mca_param_indices->algorithm_param_index =
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "scatter_algorithm",
-                                        "Which scatter algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 binomial, 3 non-blocking linear.",
+                                        "Which scatter algorithm is used. Can be locked down to choice of: 0 ignore, 1 basic linear, 2 binomial, 3 non-blocking linear. "
+                                        "Only relevant if coll_tuned_use_dynamic_rules is true.",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -33,7 +33,7 @@ static int coll_tuned_scatter_tree_fanout;
 static int coll_tuned_scatter_chain_fanout;
 
 /* valid values for coll_tuned_scatter_forced_algorithm */
-static mca_base_var_enum_value_t scatter_algorithms[] = {
+static const mca_base_var_enum_value_t scatter_algorithms[] = {
     {0, "ignore"},
     {1, "basic_linear"},
     {2, "binomial"},


### PR DESCRIPTION
This PR addresses a potential performance issue with the algorithm selection in `coll/tuned` and some minor issues found while digging into it:

1) Performance: some bcast and allreduce algorithms require the number of elements to be larger than the number of ranks and will fall back to a linear implementation if that is not the case. This hit me bitterly with 4B bcast on 128 ranks on a single node where latency increased 10x compared to 127 ranks.
2) The documentation for the `coll_tuned_*_algorithm` MCA variables should mention that they only take effect if the `coll_tuned_use_dynamic_rules` variable is set to true.
3) Mark global static array used for the MCA parameters as `const`.
4) Fix some glitches in comments.