### PR TITLE
Fix confusion between cpuset and locality

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2020      Triad National Security, LLC. All rights
@@ -345,7 +345,7 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
         }
 
         // compute relative locality
-        relative_locality = opal_hwloc_compute_relative_locality(process_info->cpuset, locality_string);
+        relative_locality = opal_hwloc_compute_relative_locality(process_info->locality, locality_string);
         free(locality_string);
 
         if (relative_locality & OPAL_PROC_ON_SOCKET) {

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -41,6 +41,7 @@ opal_process_info_t opal_process_info = {
     .my_local_rank = 0,    /* I'm the only process around here */
     .my_node_rank = 0,
     .cpuset = NULL,
+    .locality = NULL,
     .pid = 0,
     .num_procs = 0,
     .app_num = 0,

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -115,6 +115,7 @@ typedef struct opal_process_info_t {
     uint16_t my_local_rank;             /**< local rank on this node within my job */
     uint16_t my_node_rank;
     char *cpuset;                       /**< String-representation of bitmap where we are bound */
+    char *locality;                     /**< String-representation of process locality */
     pid_t pid;
     uint32_t num_procs;
     uint32_t app_num;


### PR DESCRIPTION
Ensure we correctly collect and save the cpuset of the process
separately from its locality string. Ensure we use the correct one when
computing things like relative locality between processes.

Signed-off-by: Ralph Castain <rhc@pmix.org>