### PR TITLE
coll/base: do not drop const qualifier

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -7,8 +7,8 @@
  * Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015-2018 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -405,6 +405,16 @@ OMPI_DECLSPEC int ompi_datatype_pack_external_size( const char datarep[], int in
                                 (void*)(ddt), (ddt)->name, (ddt)->super.super.obj_reference_count, \
                                 __func__, __LINE__));                   \
             OBJ_RELEASE((ddt));                                         \
+        }                                                               \
+    }
+
+#define OMPI_DATATYPE_RELEASE_NO_NULLIFY(ddt)                           \
+    {                                                                   \
+        if( !ompi_datatype_is_predefined((ddt)) ) {                     \
+            OPAL_OUTPUT_VERBOSE((0, 100, "Datatype %p [%s] refcount %d in file %s:%d\n",     \
+                                (void*)(ddt), (ddt)->name, (ddt)->super.super.obj_reference_count, \
+                                __func__, __LINE__));                   \
+            OBJ_RELEASE_NO_NULLIFY((ddt));                              \
         }                                                               \
     }
 

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -220,7 +220,7 @@ static void release_vecs_callback(ompi_coll_base_nbc_request_t *request) {
     if (NULL != request->data.vecs.stypes) {
         for (int i=0; i<scount; i++) {
             if (NULL != request->data.vecs.stypes[i]) {
-                OMPI_DATATYPE_RELEASE(request->data.vecs.stypes[i]);
+                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.vecs.stypes[i]);
             }
         }
         request->data.vecs.stypes = NULL;
@@ -228,7 +228,7 @@ static void release_vecs_callback(ompi_coll_base_nbc_request_t *request) {
     if (NULL != request->data.vecs.rtypes) {
         for (int i=0; i<rcount; i++) {
             if (NULL != request->data.vecs.rtypes[i]) {
-                OMPI_DATATYPE_RELEASE(request->data.vecs.rtypes[i]);
+                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.vecs.rtypes[i]);
             }
         }
         request->data.vecs.rtypes = NULL;

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -58,8 +58,8 @@ struct ompi_coll_base_nbc_request_t {
             opal_object_t *objs[2];
         } objs;
         struct {
-            ompi_datatype_t **stypes;
-            ompi_datatype_t **rtypes;
+            ompi_datatype_t * const *stypes;
+            ompi_datatype_t * const *rtypes;
         } vecs;
     } data;
 };

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -11,8 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -345,6 +345,27 @@ static inline opal_object_t *opal_obj_new_debug(opal_class_t* type, const char* 
     } while (0)
 #endif
 
+#if OPAL_ENABLE_DEBUG
+#define OBJ_RELEASE_NO_NULLIFY(object)                                  \
+    do {                                                                \
+        assert(OPAL_OBJ_MAGIC_ID == ((opal_object_t *) (object))->obj_magic_id); \
+        assert(NULL != ((opal_object_t *) (object))->obj_class);        \
+        if (0 == opal_obj_update((opal_object_t *) (object), -1)) {     \
+            OBJ_SET_MAGIC_ID((object), 0);                              \
+            opal_obj_run_destructors((opal_object_t *) (object));       \
+            OBJ_REMEMBER_FILE_AND_LINENO( object, __FILE__, __LINE__ ); \
+            free((void *) object);                                      \
+        }                                                               \
+    } while (0)
+#else
+#define OBJ_RELEASE_NO_NULLIFY(object)                                   \
+    do {                                                                \
+        if (0 == opal_obj_update((opal_object_t *) (object), -1)) {     \
+            opal_obj_run_destructors((opal_object_t *) (object));       \
+            free((void *) object);                                      \
+        }                                                               \
+    } while (0)
+#endif
 
 /**
  * Construct (initialize) objects that are not dynamically allocated.


### PR DESCRIPTION
MPI_Ialltoallw() and friends take a const MPI_Datatype types[] argument.
In order to be able to call OBJ_RELEASE(types[0]), we used to simply
drop the const modifier. This change make it right by introducing the
OBJ_RELEASE_NO_NULLIFY(object) macro that no more set object = NULL
if the object is freed.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>