### PR TITLE
coll: do not retain datatypes of MPI_I*alltoallw* non blocking collec…

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -203,96 +203,6 @@ int ompi_coll_base_retain_datatypes( ompi_request_t *req, ompi_datatype_t *stype
             request->cb.req_complete_cb = req->req_complete_cb;
             request->req_complete_cb_data = req->req_complete_cb_data;
             req->req_complete_cb = complete_objs_callback;
-            req->req_complete_cb_data = request;
-        }
-    }
-    return OMPI_SUCCESS;
-}
-
-static void release_vecs_callback(ompi_coll_base_nbc_request_t *request) {
-    ompi_communicator_t *comm = request->super.req_mpi_object.comm;
-    int scount, rcount;
-    if (OMPI_COMM_IS_TOPO(comm)) {
-        (void)mca_topo_base_neighbor_count (comm, &rcount, &scount);
-    } else {
-        scount = rcount = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
-    }
-    if (NULL != request->data.vecs.stypes) {
-        for (int i=0; i<scount; i++) {
-            if (NULL != request->data.vecs.stypes[i]) {
-                OMPI_DATATYPE_RELEASE(request->data.vecs.stypes[i]);
-            }
-        }
-        request->data.vecs.stypes = NULL;
-    }
-    if (NULL != request->data.vecs.rtypes) {
-        for (int i=0; i<rcount; i++) {
-            if (NULL != request->data.vecs.rtypes[i]) {
-                OMPI_DATATYPE_RELEASE(request->data.vecs.rtypes[i]);
-            }
-        }
-        request->data.vecs.rtypes = NULL;
-    }
-}
-
-static int complete_vecs_callback(struct ompi_request_t *req) {
-    ompi_coll_base_nbc_request_t *request = (ompi_coll_base_nbc_request_t *)req;
-    int rc = OMPI_SUCCESS;
-    assert (NULL != request);
-    if (NULL != request->cb.req_complete_cb) {
-        rc = request->cb.req_complete_cb(request->req_complete_cb_data);
-    }
-    release_vecs_callback(request);
-    return rc;
-}
-
-static int free_vecs_callback(struct ompi_request_t **rptr) {
-    struct ompi_coll_base_nbc_request_t *request = *(ompi_coll_base_nbc_request_t **)rptr;
-    int rc = OMPI_SUCCESS;
-    if (NULL != request->cb.req_free) {
-        rc = request->cb.req_free(rptr);
-    }
-    release_vecs_callback(request);
-    return rc;
-}
-
-int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
-                                       ompi_datatype_t * const stypes[], ompi_datatype_t * const rtypes[]) {
-    ompi_coll_base_nbc_request_t *request = (ompi_coll_base_nbc_request_t *)req;
-    bool retain = false;
-    ompi_communicator_t *comm = request->super.req_mpi_object.comm;
-    int scount, rcount;
-    if (REQUEST_COMPLETE(req)) {
-        return OMPI_SUCCESS;
-    }
-    if (OMPI_COMM_IS_TOPO(comm)) {
-        (void)mca_topo_base_neighbor_count (comm, &rcount, &scount);
-    } else {
-        scount = rcount = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
-    }
-
-    for (int i=0; i<scount; i++) {
-        if (NULL != stypes && NULL != stypes[i] && !ompi_datatype_is_predefined(stypes[i])) {
-            OBJ_RETAIN(stypes[i]);
-            retain = true;
-        }
-    }
-    for (int i=0; i<rcount; i++) {
-        if (NULL != rtypes && NULL != rtypes[i] && !ompi_datatype_is_predefined(rtypes[i])) {
-            OBJ_RETAIN(rtypes[i]);
-            retain = true;
-        }
-    }
-    if (OPAL_UNLIKELY(retain)) {
-        request->data.vecs.stypes = (ompi_datatype_t **) stypes;
-        request->data.vecs.rtypes = (ompi_datatype_t **) rtypes;
-        if (req->req_persistent) {
-            request->cb.req_free = req->req_free;
-            req->req_free = free_vecs_callback;
-        } else {
-            request->cb.req_complete_cb = req->req_complete_cb;
-            request->req_complete_cb_data = req->req_complete_cb_data;
-            req->req_complete_cb = complete_vecs_callback;
             req->req_complete_cb_data = request;
         }
     }

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -57,10 +57,6 @@ struct ompi_coll_base_nbc_request_t {
         struct {
             opal_object_t *objs[2];
         } objs;
-        struct {
-            ompi_datatype_t **stypes;
-            ompi_datatype_t **rtypes;
-        } vecs;
     } data;
 };
 
@@ -167,15 +163,6 @@ int ompi_coll_base_retain_op( ompi_request_t *request,
 int ompi_coll_base_retain_datatypes( ompi_request_t *request,
                                       ompi_datatype_t *stype,
                                      ompi_datatype_t *rtype);
-
-/**
- * If necessary, retain the datatypes and store them in the
- * request object, which should be of type ompi_coll_base_nbc_request_t
- * (will be cast internally).
- */
-int ompi_coll_base_retain_datatypes_w( ompi_request_t *request,
-                                       ompi_datatype_t * const stypes[],
-                                       ompi_datatype_t * const rtypes[]);
 
 /* File reading function */
 int ompi_coll_base_file_getnext_long(FILE *fptr, int *fileline, long* val);

--- a/ompi/mpi/c/ialltoallw.c
+++ b/ompi/mpi/c/ialltoallw.c
@@ -122,9 +122,6 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
                                        sendtypes, recvbuf, recvcounts,
                                        rdispls, recvtypes, comm, request,
                                        comm->c_coll->coll_ialltoallw_module);
-    if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes);
-    }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -147,9 +147,6 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
     err = comm->c_coll->coll_ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
                                                 recvbuf, recvcounts, rdispls, recvtypes, comm, request,
                                                 comm->c_coll->coll_ineighbor_alltoallw_module);
-    if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes);
-    }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpiext/pcollreq/c/alltoallw_init.c
+++ b/ompi/mpiext/pcollreq/c/alltoallw_init.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -129,9 +129,6 @@ int MPIX_Alltoallw_init(const void *sendbuf, const int sendcounts[], const int s
                                             sendtypes, recvbuf, recvcounts,
                                             rdispls, recvtypes, comm, info, request,
                                             comm->c_coll->coll_alltoallw_init_module);
-    if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes);
-    }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpiext/pcollreq/c/neighbor_alltoallw_init.c
+++ b/ompi/mpiext/pcollreq/c/neighbor_alltoallw_init.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Research Organization for Information Science
+ * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -150,9 +150,6 @@ int MPIX_Neighbor_alltoallw_init(const void *sendbuf, const int sendcounts[], co
                                                      recvbuf, recvcounts, rdispls, recvtypes, comm,
                                                      info, request,
                                                      comm->c_coll->coll_neighbor_alltoallw_init_module);
-    if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes);
-    }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 


### PR DESCRIPTION
…tive

Section 5.12 of the 3.1 standard says:

"Once initiated, all associated send buffers and buffers associated with input arguments (such
as arrays of counts, displacements, or datatypes in the vector versions of the collectives)
should not be modified, and all associated receive buffers should not be accessed, until the
collective operation completes."

So the right thing to do is *not* retain the datatypes (and fix the const qualifier
being dropped)

Thanks Joseph Schuchart for pointing me to the correct interpretation of the MPI standard.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>