### PR TITLE
coll/hcoll: svatterv inplace fix

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -413,6 +413,10 @@ int mca_coll_hcoll_scatterv(const void* sbuf, const int *scounts, const int *dis
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_hcoll_dtype(sdtype, NO_DERIVED);
     rtype = ompi_dtype_2_hcoll_dtype(rdtype, NO_DERIVED);
+    if (rbuf == MPI_IN_PLACE) {
+        assert(root == comm->c_my_rank);
+        rtype = stype;
+    }
     if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype))) {
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */


### PR DESCRIPTION
recv type is undefined if MPI_IN_PLACE is used. this may lead to incorrect fallback on the root rank.