### PR TITLE
v4.1.x: Correctly skip the "mpirun" node when launching orted on it

### DIFF
--- a/orte/mca/ras/base/ras_base_node.c
+++ b/orte/mca/ras/base/ras_base_node.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -98,6 +98,7 @@ int orte_ras_base_node_insert(opal_list_t* nodes, orte_job_t *jdata)
                 hnp_node->name = strdup("mpirun");
                 skiphnp = true;
                 ORTE_SET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping, ORTE_MAPPING_NO_USE_LOCAL);
+                ORTE_FLAG_SET(hnp_node, ORTE_NODE_NON_USABLE);  // leave this node out of mapping operations
             }
         }
     }

--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -314,8 +314,12 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
         /* the list is empty - if the HNP is allocated, then add it */
         if (orte_hnp_is_allocated) {
             nd = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0);
-            OBJ_RETAIN(nd);
-            opal_list_append(allocated_nodes, &nd->super);
+            if (!ORTE_FLAG_TEST(nd, ORTE_NODE_NON_USABLE)) {
+                OBJ_RETAIN(nd);
+                opal_list_append(allocated_nodes, &nd->super);
+            } else {
+                nd = NULL;
+            }
         } else {
             nd = NULL;
         }


### PR DESCRIPTION
Mark the node as "unusable" so it does not get included when computing
number of procs for the case where the user does not specify -np.

Signed-off-by: Ralph Castain <rhc@pmix.org>