### PR TITLE
oshmem/tools/oshmem_info: fix fortran keyword issue when compiling param.c

### DIFF
--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -61,7 +61,7 @@ const char *opal_info_deprecated_value = "deprecated-ompi-info-value";
  */
 void oshmem_info_do_config(bool want_all)
 {
-    char *fortran;
+    char *fortran_binding;
     char *heterogeneous;
     char *memprofile;
     char *memdebug;
@@ -117,13 +117,13 @@ void oshmem_info_do_config(bool want_all)
 
     /* setup strings that require allocation */
     if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) {
-        (void)opal_asprintf(&fortran, "yes (%s)",
+        (void)opal_asprintf(&fortran_binding, "yes (%s)",
                        (OPAL_HAVE_WEAK_SYMBOLS ? "all" :
                         (OMPI_FORTRAN_CAPS ? "caps" :
                          (OMPI_FORTRAN_PLAIN ? "lower case" :
                           (OMPI_FORTRAN_SINGLE_UNDERSCORE ? "single underscore" : "double underscore")))));
     } else {
-        fortran = strdup("no");
+        fortran_binding = strdup("no");
     }
 
     (void)opal_asprintf(&threads, "%s (MPI_THREAD_MULTIPLE: yes, OPAL support: yes, OMPI progress: %s, Event lib: yes)",
@@ -146,8 +146,8 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Built host", "build:host", OMPI_BUILD_HOST);
 
     opal_info_out("C bindings", "bindings:c", "yes");
-    opal_info_out("Fort shmem.fh", "bindings:fortran", fortran);
-    free(fortran);
+    opal_info_out("Fort shmem.fh", "bindings:fortran", fortran_binding);
+    free(fortran_binding);
 
     opal_info_out("Wrapper compiler rpath", "compiler:all:rpath",
                   WRAPPER_RPATH_SUPPORT);


### PR DESCRIPTION
fix the issue when compiling oshmem_info/param.c #8221

Signed-off-by: Pak Lui <pak.lui@amd.com>