### PR TITLE
Typo in ob1 comments, and uniform conditions

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -135,7 +135,7 @@ int mca_pml_ob1_recv(void *addr,
     ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
 
     if( true == recvreq->req_recv.req_base.req_pml_complete ) {
-        /* make buffer defined when the request is compeleted */
+        /* make buffer defined when the request is completed */
         MEMCHECKER(
             memchecker_call(&opal_memchecker_base_mem_defined,
                             recvreq->req_recv.req_base.req_addr,
@@ -151,7 +151,7 @@ int mca_pml_ob1_recv(void *addr,
     rc = recvreq->req_recv.req_base.req_ompi.req_status.MPI_ERROR;
 
     if (recvreq->req_recv.req_base.req_pml_complete) {
-        /* make buffer defined when the request is compeleted,
+        /* make buffer defined when the request is completed,
            and before releasing the objects. */
         MEMCHECKER(
             memchecker_call(&opal_memchecker_base_mem_defined,

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -134,7 +134,7 @@ int mca_pml_ob1_recv(void *addr,
     MCA_PML_OB1_RECV_REQUEST_START(recvreq);
     ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
 
-    if( true == recvreq->req_recv.req_base.req_pml_complete ) {
+    if (recvreq->req_recv.req_base.req_pml_complete) {
         /* make buffer defined when the request is completed */
         MEMCHECKER(
             memchecker_call(&opal_memchecker_base_mem_defined,

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -81,7 +81,7 @@ static int mca_pml_ob1_recv_request_free(struct ompi_request_t** request)
                              &(recvreq->req_recv.req_base), PERUSE_RECV );
 
     if( true == recvreq->req_recv.req_base.req_pml_complete ) {
-        /* make buffer defined when the request is compeleted,
+        /* make buffer defined when the request is completed,
            and before releasing the objects. */
         MEMCHECKER(
                    memchecker_call(&opal_memchecker_base_mem_defined,

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -80,7 +80,7 @@ static int mca_pml_ob1_recv_request_free(struct ompi_request_t** request)
     PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_NOTIFY,
                              &(recvreq->req_recv.req_base), PERUSE_RECV );
 
-    if( true == recvreq->req_recv.req_base.req_pml_complete ) {
+    if (recvreq->req_recv.req_base.req_pml_complete) {
         /* make buffer defined when the request is completed,
            and before releasing the objects. */
         MEMCHECKER(
@@ -105,7 +105,7 @@ static int mca_pml_ob1_recv_request_cancel(struct ompi_request_t* ompi_request, 
 
     /* The rest should be protected behind the match logic lock */
     OB1_MATCHING_LOCK(&ob1_comm->matching_lock);
-    if( true == request->req_match_received ) { /* way to late to cancel this one */
+    if (request->req_match_received) { /* way to late to cancel this one */
         OB1_MATCHING_UNLOCK(&ob1_comm->matching_lock);
         assert( OMPI_ANY_TAG != ompi_request->req_status.MPI_TAG ); /* not matched isn't it */
         return OMPI_SUCCESS;

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -106,7 +106,7 @@ static int mca_pml_ob1_send_request_free(struct ompi_request_t** request)
         PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_NOTIFY,
                              &(sendreq->req_send.req_base), PERUSE_SEND );
 
-        if( true == sendreq->req_send.req_base.req_pml_complete ) {
+        if (sendreq->req_send.req_base.req_pml_complete) {
             /* make buffer defined when the request is completed,
                and before releasing the objects. */
             MEMCHECKER(

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -107,7 +107,7 @@ static int mca_pml_ob1_send_request_free(struct ompi_request_t** request)
                              &(sendreq->req_send.req_base), PERUSE_SEND );
 
         if( true == sendreq->req_send.req_base.req_pml_complete ) {
-            /* make buffer defined when the request is compeleted,
+            /* make buffer defined when the request is completed,
                and before releasing the objects. */
             MEMCHECKER(
                 memchecker_call(&opal_memchecker_base_mem_defined,


### PR DESCRIPTION
I think I found another typo, in ob1 comments

Also I thought it was weird that before the comment we have `if( true == recvreq->req_recv.req_base.req_pml_complete )` three times but in one place we simply have `if (recvreq->req_recv.req_base.req_pml_complete)`, but this seems that it can't be a copy/paste error so maybe it was intended ? I don't fully understand everything this code does so I'm not 100% sure