### PR TITLE
Fix preference treatment in coll/base [v4.1.x]

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_module.c
+++ b/ompi/mca/coll/adapt/coll_adapt_module.c
@@ -3,9 +3,9 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 
@@ -146,7 +146,7 @@ mca_coll_base_module_t *ompi_coll_adapt_comm_query(struct ompi_communicator_t * 
     /* Get the priority level attached to this module.
        If priority is less than or equal to 0, then the module is unavailable. */
     *priority = mca_coll_adapt_component.adapt_priority;
-    if (mca_coll_adapt_component.adapt_priority <= 0) {
+    if (mca_coll_adapt_component.adapt_priority < 0) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:adapt:comm_query (%d/%s): priority too low; "
                             "disqualifying myself",

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -39,7 +39,6 @@ ompi_coll_han_components available_components[COMPONENTS_COUNT] = {
     { LIBNBC, "libnbc", NULL },
     { TUNED, "tuned", NULL },
     { SM, "sm", NULL },
-    { SHARED, "shared", NULL },
     { ADAPT, "adapt", NULL },
     { HAN, "han", NULL }
 };
@@ -179,7 +178,7 @@ static int han_register(void)
 
     cs->han_bcast_low_module = 0;
     (void) mca_base_component_var_register(c, "bcast_low_module",
-                                           "low level module for bcast, 0 sm, 1 solo",
+                                           "low level module for bcast, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_bcast_low_module);
@@ -200,7 +199,7 @@ static int han_register(void)
 
     cs->han_reduce_low_module = 0;
     (void) mca_base_component_var_register(c, "reduce_low_module",
-                                           "low level module for allreduce, 0 sm, 1 shared",
+                                           "low level module for allreduce, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_reduce_low_module);
@@ -220,7 +219,7 @@ static int han_register(void)
 
     cs->han_allreduce_low_module = 0;
     (void) mca_base_component_var_register(c, "allreduce_low_module",
-                                           "low level module for allreduce, 0 sm, 1 shared",
+                                           "low level module for allreduce, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_allreduce_low_module);
@@ -234,7 +233,7 @@ static int han_register(void)
 
     cs->han_allgather_low_module = 0;
     (void) mca_base_component_var_register(c, "allgather_low_module",
-                                           "low level module for allgather, 0 sm, 1 shared",
+                                           "low level module for allgather, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_allgather_low_module);
@@ -248,7 +247,7 @@ static int han_register(void)
 
     cs->han_gather_low_module = 0;
     (void) mca_base_component_var_register(c, "gather_low_module",
-                                           "low level module for gather, 0 sm, 1 shared",
+                                           "low level module for gather, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_gather_low_module);
@@ -262,7 +261,7 @@ static int han_register(void)
 
     cs->han_scatter_low_module = 0;
     (void) mca_base_component_var_register(c, "scatter_low_module",
-                                           "low level module for scatter, 0 sm, 1 shared",
+                                           "low level module for scatter, 0 tuned, 1 sm",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_scatter_low_module);

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -183,7 +183,7 @@ static int han_register(void)
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_bcast_low_module);
 
-    cs->han_reduce_segsize = 524288;
+    cs->han_reduce_segsize = 65536;
     (void) mca_base_component_var_register(c, "reduce_segsize",
                                            "segment size for reduce",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
@@ -203,7 +203,7 @@ static int han_register(void)
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_reduce_low_module);
-    cs->han_allreduce_segsize = 524288;
+    cs->han_allreduce_segsize = 65536;
     (void) mca_base_component_var_register(c, "allreduce_segsize",
                                            "segment size for allreduce",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,

--- a/ompi/mca/coll/han/coll_han_dynamic.h
+++ b/ompi/mca/coll/han/coll_han_dynamic.h
@@ -102,7 +102,6 @@ typedef enum COMPONENTS {
     LIBNBC,
     TUNED,
     SM,
-    SHARED,
     ADAPT,
     HAN,
     COMPONENTS_COUNT

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -188,7 +188,7 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
     /* Get the priority level attached to this module. If priority is less
      * than or equal to 0, then the module is unavailable. */
     *priority = mca_coll_han_component.han_priority;
-    if (mca_coll_han_component.han_priority <= 0) {
+    if (mca_coll_han_component.han_priority < 0) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:han:comm_query (%d/%s): priority too low; disqualifying myself",
                             comm->c_contextid, comm->c_name);

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -258,7 +258,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
      * Upgrade sm module priority to set up low_comms[0] with sm module
      * This sub-communicator contains the ranks that share my node.
      */
-    opal_info_set(&comm_info, "ompi_comm_coll_preference", "sm,^han");
+    opal_info_set(&comm_info, "ompi_comm_coll_preference", "tuned,^han");
     ompi_comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0,
                          &comm_info, &(low_comms[0]));
 
@@ -272,7 +272,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
      * Upgrade shared module priority to set up low_comms[1] with shared module
      * This sub-communicator contains the ranks that share my node.
      */
-    opal_info_set(&comm_info, "ompi_comm_coll_preference", "shared,^han");
+    opal_info_set(&comm_info, "ompi_comm_coll_preference", "sm,^han");
     ompi_comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0,
                          &comm_info, &(low_comms[1]));
 

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -180,10 +180,10 @@ mca_coll_sm_comm_query(struct ompi_communicator_t *comm, int *priority)
     /* Get the priority level attached to this module. If priority is less
      * than or equal to 0, then the module is unavailable. */
     *priority = mca_coll_sm_component.sm_priority;
-    if (mca_coll_sm_component.sm_priority <= 0) {
+    if (mca_coll_sm_component.sm_priority < 0) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:sm:comm_query (%d/%s): priority too low; disqualifying myself", comm->c_contextid, comm->c_name);
-	return NULL;
+        return NULL;
     }
 
     sm_module = OBJ_NEW(mca_coll_sm_module_t);


### PR DESCRIPTION
While testing HAN with ADAPT I noticed that ADAPT is not selected without jumping through some hoops:

1) The preference treatment in coll/base should append the coll modules to the `selectable` list (the list is order in ascending priority order) and it should preserve the priority provided by the user (decreasing priority order in the `ompi_comm_coll_preference` info key).
2) Fix priority handling in `coll/sm`, `coll/adapt`, and `coll/han` and removed references to experimental components `coll/solo` and `coll/shared`

Backport of https://github.com/open-mpi/ompi/pull/8220 to v4.1.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>