### PR TITLE
OSC RDMA: put memory for each process into separate pages [4.1.x]

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -650,7 +650,12 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
         }
 
         if (size && MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
-            *base = (void *)((intptr_t) module->segment_base + my_base_offset);
+            char *baseptr = (char *)((intptr_t) module->segment_base + my_base_offset);
+            *base = (void *)baseptr;
+            // touch each page to force allocation on local NUMA node
+            for (size_t i = 0; i < size; i += page_size) {
+                baseptr[i] = 0;
+            }
         }
 
         module->rank_array = (ompi_osc_rdma_rank_data_t *) module->segment_base;


### PR DESCRIPTION
This is to prevent processes from sharing pages, esp. across NUMA domains.

Also: only touch pages, no need to fill them.

Backport of https://github.com/open-mpi/ompi/pull/8070 to 4.1.x

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>