### PR TITLE
common/ofi: fixing error message to be a debug output

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -340,7 +340,10 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
                                        &pname, &locality_string, PMIX_STRING);
         if (PMIX_SUCCESS != rc || NULL == locality_string) {
             // If we don't have information about locality, fall back to procid
-            opal_show_help("help-common-ofi.txt", "package_rank failed", true);
+            opal_output_verbose(1, opal_common_ofi.output,
+                                "%s:%d:Unable to get locality string from local peers.\n"
+                                "This may negatively impact performance.\n",
+                                __FILE__, __LINE__);
             return (uint32_t)process_info->myprocid.rank;
         }
 


### PR DESCRIPTION
A path that was being used in oversubscribed cases caused a help message to
output for each process. This replaces the help message with a debug output to
prevent excessive output unless the user enables debug output.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>