### PR TITLE
Symbol pollution for pr8132

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -335,7 +335,7 @@ int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *dataty
     }
 
     return ompi_coll_adapt_ibcast_generic(buff, count, datatype, root, comm, request, module,
-                                          adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ibcast_algorithm),
+                                          ompi_adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ibcast_algorithm),
                                           mca_coll_adapt_component.adapt_ibcast_segment_size);
 }
 

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -504,7 +504,7 @@ int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi
 
 
     return ompi_coll_adapt_ireduce_generic(sbuf, rbuf, count, dtype, op, root, comm, request, module,
-                                           adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ireduce_algorithm),
+                                           ompi_adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ireduce_algorithm),
                                            mca_coll_adapt_component.adapt_ireduce_segment_size);
 
 }

--- a/ompi/mca/coll/adapt/coll_adapt_module.c
+++ b/ompi/mca/coll/adapt/coll_adapt_module.c
@@ -63,8 +63,8 @@ static void adapt_module_construct(mca_coll_adapt_module_t * module)
 static void adapt_module_destruct(mca_coll_adapt_module_t * module)
 {
     if (NULL != module->topo_cache) {
-        adapt_topology_cache_item_t *item;
-        while (NULL != (item = (adapt_topology_cache_item_t*)opal_list_remove_first(module->topo_cache))) {
+        ompi_adapt_topology_cache_item_t *item;
+        while (NULL != (item = (ompi_adapt_topology_cache_item_t*)opal_list_remove_first(module->topo_cache))) {
             OBJ_RELEASE(item);
         }
         OBJ_RELEASE(module->topo_cache);

--- a/ompi/mca/coll/adapt/coll_adapt_topocache.c
+++ b/ompi/mca/coll/adapt/coll_adapt_topocache.c
@@ -14,14 +14,14 @@
 
 #include "ompi/communicator/communicator.h"
 
-static void destruct_topology_cache(adapt_topology_cache_item_t *item)
+static void destruct_topology_cache(ompi_adapt_topology_cache_item_t *item)
 {
     if (NULL != item->tree) {
         ompi_coll_base_topo_destroy_tree(&item->tree);
     }
 }
 
-OBJ_CLASS_INSTANCE(adapt_topology_cache_item_t, opal_list_item_t,
+OBJ_CLASS_INSTANCE(ompi_adapt_topology_cache_item_t, opal_list_item_t,
                    NULL, &destruct_topology_cache);
 
 static ompi_coll_tree_t *create_topology(
@@ -73,17 +73,17 @@ static ompi_coll_tree_t *create_topology(
     }
 }
 
-ompi_coll_tree_t* adapt_module_cached_topology(
+ompi_coll_tree_t* ompi_adapt_module_cached_topology(
     mca_coll_base_module_t *module,
     struct ompi_communicator_t *comm,
     int root,
     ompi_coll_adapt_algorithm_t algorithm)
 {
     mca_coll_adapt_module_t *adapt_module = (mca_coll_adapt_module_t*)module;
-    adapt_topology_cache_item_t *item;
+    ompi_adapt_topology_cache_item_t *item;
     ompi_coll_tree_t * tree;
     if (NULL != adapt_module->topo_cache) {
-        OPAL_LIST_FOREACH(item, adapt_module->topo_cache, adapt_topology_cache_item_t) {
+        OPAL_LIST_FOREACH(item, adapt_module->topo_cache, ompi_adapt_topology_cache_item_t) {
             if (item->root == root && item->algorithm == algorithm) {
                 return item->tree;
             }
@@ -95,7 +95,7 @@ ompi_coll_tree_t* adapt_module_cached_topology(
     /* topology not found, create one */
     tree = create_topology(algorithm, root, comm);
 
-    item = OBJ_NEW(adapt_topology_cache_item_t);
+    item = OBJ_NEW(ompi_adapt_topology_cache_item_t);
     item->tree = tree;
     item->root = root;
     item->algorithm = algorithm;

--- a/ompi/mca/coll/adapt/coll_adapt_topocache.h
+++ b/ompi/mca/coll/adapt/coll_adapt_topocache.h
@@ -17,17 +17,17 @@
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/coll_base_topo.h"
 
-typedef struct adapt_topology_cache_item_t {
+typedef struct ompi_adapt_topology_cache_item_t {
     opal_list_item_t super;
     ompi_coll_tree_t *tree;
     int root;
     ompi_coll_adapt_algorithm_t algorithm;
-} adapt_topology_cache_item_t;
+} ompi_adapt_topology_cache_item_t;
 
-OBJ_CLASS_DECLARATION(adapt_topology_cache_item_t);
+OBJ_CLASS_DECLARATION(ompi_adapt_topology_cache_item_t);
 
 
-OMPI_DECLSPEC ompi_coll_tree_t* adapt_module_cached_topology(
+OMPI_DECLSPEC ompi_coll_tree_t* ompi_adapt_module_cached_topology(
     mca_coll_base_module_t *module,
     struct ompi_communicator_t *comm,
     int root,

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -356,7 +356,7 @@ int mca_coll_han_init_query(bool enable_progress_threads, bool enable_mpi_thread
 
 mca_coll_base_module_t *mca_coll_han_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int han_request_free(ompi_request_t ** request);
+int ompi_han_request_free(ompi_request_t ** request);
 
 /* Subcommunicator creation */
 int mca_coll_han_comm_create(struct ompi_communicator_t *comm, mca_coll_han_module_t * han_module);

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -96,7 +96,7 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
     temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -525,7 +525,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
                 opal_output_verbose(30, mca_coll_han_component.han_output,
                                     "coll:han:allreduce_reproducible: "
                                     "fallback on %s\n",
-                                    available_components[fallback].component_name);
+                                    ompi_han_available_components[fallback].component_name);
             }
             han_module->reproducible_allreduce_module = fallback_module;
             han_module->reproducible_allreduce = fallback_module->coll_allreduce;

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -33,7 +33,7 @@
 const char *mca_coll_han_component_version_string =
     "Open MPI HAN collective MCA component version " OMPI_VERSION;
 
-ompi_coll_han_components available_components[COMPONENTS_COUNT] = {
+ompi_coll_han_components ompi_han_available_components[COMPONENTS_COUNT] = {
     { SELF, "self",  NULL },
     { BASIC, "basic", NULL },
     { LIBNBC, "libnbc", NULL },
@@ -328,7 +328,7 @@ static int han_register(void)
                 param_desc_size += snprintf(param_desc+param_desc_size, sizeof(param_desc) - param_desc_size,
                                             "%d = %s; ",
                                             component,
-                                            available_components[component].component_name);
+                                            ompi_han_available_components[component].component_name);
             }
 
             mca_base_component_var_register(c, param_name, param_desc,

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -44,7 +44,7 @@ mca_coll_han_component_name_to_id(const char* name)
     }
 
     for( int i = SELF; i < COMPONENTS_COUNT ; i++ ) {
-        if (0 == strcmp(name, available_components[i].component_name)) {
+        if (0 == strcmp(name, ompi_han_available_components[i].component_name)) {
             return i;
         }
     }
@@ -237,7 +237,7 @@ get_dynamic_rule(COLLTYPE_T collective,
                         msg_size_rule->topologic_level,
                         mca_coll_han_topo_lvl_to_str(msg_size_rule->topologic_level),
                         msg_size_rule->configuration_size,
-                        msg_size_rule->msg_size, component, available_components[component].component_name);
+                        msg_size_rule->msg_size, component, ompi_han_available_components[component].component_name);
 
     return msg_size_rule;
 }

--- a/ompi/mca/coll/han/coll_han_dynamic.h
+++ b/ompi/mca/coll/han/coll_han_dynamic.h
@@ -113,7 +113,7 @@ typedef struct {
     mca_coll_base_component_t* component;
 } ompi_coll_han_components;
 
-extern ompi_coll_han_components available_components[COMPONENTS_COUNT];
+extern ompi_coll_han_components ompi_han_available_components[COMPONENTS_COUNT];
 
 /* Topologic levels */
 typedef enum TOPO_LVL {

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -600,7 +600,7 @@ void mca_coll_han_dump_dynamic_rules(void)
                                 "mesage size %d -> collective component %d (%s)\n",
                                 nb_entries, coll_id, mca_coll_base_colltype_to_str(coll_id),
                                 topo_lvl, mca_coll_han_topo_lvl_to_str(topo_lvl), conf_size,
-                                msg_size, component, available_components[component].component_name);
+                                msg_size, component, ompi_han_available_components[component].component_name);
 
                     nb_entries++;
                 }

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -108,7 +108,7 @@ mca_coll_han_gather_intra(const void *sbuf, int scount,
     temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -330,7 +330,7 @@ mca_coll_han_module_disable(mca_coll_base_module_t * module,
 /*
  * Free the han request
  */
-int han_request_free(ompi_request_t ** request)
+int ompi_han_request_free(ompi_request_t ** request)
 {
     (*request)->req_state = OMPI_REQUEST_INVALID;
     OBJ_RELEASE(*request);

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -405,7 +405,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
                 opal_output_verbose(30, mca_coll_han_component.han_output,
                                     "coll:han:reduce_reproducible: "
                                     "fallback on %s\n",
-                                    available_components[fallback].component_name);
+                                    ompi_han_available_components[fallback].component_name);
             }
             han_module->reproducible_reduce_module = fallback_module;
             han_module->reproducible_reduce = fallback_module->coll_reduce;

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -107,7 +107,7 @@ mca_coll_han_scatter_intra(const void *sbuf, int scount,
     ompi_request_t *temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/libnbc/libdict/dict.c
+++ b/ompi/mca/coll/libnbc/libdict/dict.c
@@ -12,22 +12,22 @@
 #include "dict.h"
 #include "dict_private.h"
 
-dict_malloc_func _dict_malloc = malloc;
-dict_free_func _dict_free = free;
+dict_malloc_func ompi_nbc_dict_malloc = malloc;
+dict_free_func ompi_nbc_dict_free = free;
 
 dict_malloc_func
-dict_set_malloc(dict_malloc_func func)
+ompi_nbc_dict_set_malloc(dict_malloc_func func)
 {
-	dict_malloc_func old = _dict_malloc;
-	_dict_malloc = func ? func : malloc;
+	dict_malloc_func old = ompi_nbc_dict_malloc;
+	ompi_nbc_dict_malloc = func ? func : malloc;
 	return old;
 }
 
 dict_free_func
-dict_set_free(dict_free_func func)
+ompi_nbc_dict_set_free(dict_free_func func)
 {
-	dict_free_func old = _dict_free;
-	_dict_free = func ? func : free;
+	dict_free_func old = ompi_nbc_dict_free;
+	ompi_nbc_dict_free = func ? func : free;
 	return old;
 }
 
@@ -36,7 +36,7 @@ dict_set_free(dict_free_func func)
  * overflow.
  */
 int
-dict_int_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_int_cmp(const void *k1, const void *k2)
 {
 	const int *a = (int*)k1, *b = (int*)k2;
 
@@ -44,7 +44,7 @@ dict_int_cmp(const void *k1, const void *k2)
 }
 
 int
-dict_uint_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_uint_cmp(const void *k1, const void *k2)
 {
 	const unsigned int *a = (unsigned int*)k1, *b = (unsigned int*)k2;
 
@@ -52,7 +52,7 @@ dict_uint_cmp(const void *k1, const void *k2)
 }
 
 int
-dict_long_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_long_cmp(const void *k1, const void *k2)
 {
 	const long *a = (long*)k1, *b = (long*)k2;
 
@@ -60,7 +60,7 @@ dict_long_cmp(const void *k1, const void *k2)
 }
 
 int
-dict_ulong_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_ulong_cmp(const void *k1, const void *k2)
 {
 	const unsigned long *a = (unsigned long*)k1, *b = (unsigned long*)k2;
 
@@ -68,13 +68,13 @@ dict_ulong_cmp(const void *k1, const void *k2)
 }
 
 int
-dict_ptr_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_ptr_cmp(const void *k1, const void *k2)
 {
 	return (k1 > k2) - (k1 < k2);
 }
 
 int
-dict_str_cmp(const void *k1, const void *k2)
+ompi_nbc_dict_str_cmp(const void *k1, const void *k2)
 {
 	const char *a = (char*)k1, *b = (char*)k2;
 	char p, q;
@@ -88,7 +88,7 @@ dict_str_cmp(const void *k1, const void *k2)
 }
 
 void
-dict_destroy(dict *dct, int del)
+ompi_nbc_dict_destroy(dict *dct, int del)
 {
 	ASSERT(dct != NULL);
 
@@ -97,7 +97,7 @@ dict_destroy(dict *dct, int del)
 }
 
 void
-dict_itor_destroy(dict_itor *itor)
+ompi_nbc_dict_itor_destroy(dict_itor *itor)
 {
 	ASSERT(itor != NULL);
 

--- a/ompi/mca/coll/libnbc/libdict/dict.h
+++ b/ompi/mca/coll/libnbc/libdict/dict.h
@@ -46,8 +46,8 @@ BEGIN_DECL
 typedef void *(*dict_malloc_func)(size_t);
 typedef void  (*dict_free_func)(void *);
 
-dict_malloc_func	dict_set_malloc		__P((dict_malloc_func func));
-dict_free_func		dict_set_free		__P((dict_free_func func));
+dict_malloc_func	ompi_nbc_dict_set_malloc		__P((dict_malloc_func func));
+dict_free_func		ompi_nbc_dict_set_free		__P((dict_free_func func));
 
 typedef int			(*dict_cmp_func)	__P((const void *, const void *));
 typedef void		(*dict_del_func)	__P((void *));
@@ -78,7 +78,7 @@ struct dict {
 #define dict_walk(dct,f)		(dct)->_walk((dct)->_object, (f))
 #define dict_count(dct)			(dct)->_count((dct)->_object)
 #define dict_empty(dct,d)		(dct)->_empty((dct)->_object, (d))
-void dict_destroy __P((dict *dct, int del));
+void ompi_nbc_dict_destroy __P((dict *dct, int del));
 #define dict_itor_new(dct)		(dct)->_inew((dct)->_object)
 
 struct dict_itor {
@@ -116,14 +116,14 @@ struct dict_itor {
 #define dict_itor_cdata(i)			(i)->_cdata((i)->_itor)
 #define dict_itor_set_data(i,dat,d)	(i)->_setdata((i)->_itor, (dat), (d))
 #define dict_itor_remove(i)			(i)->_remove((i)->_itor)
-void dict_itor_destroy __P((dict_itor *itor));
+void ompi_nbc_dict_itor_destroy __P((dict_itor *itor));
 
-int		dict_int_cmp __P((const void *k1, const void *k2));
-int		dict_uint_cmp __P((const void *k1, const void *k2));
-int		dict_long_cmp __P((const void *k1, const void *k2));
-int		dict_ulong_cmp __P((const void *k1, const void *k2));
-int		dict_ptr_cmp __P((const void *k1, const void *k2));
-int		dict_str_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_int_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_uint_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_long_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_ulong_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_ptr_cmp __P((const void *k1, const void *k2));
+int		ompi_nbc_dict_str_cmp __P((const void *k1, const void *k2));
 
 END_DECL
 

--- a/ompi/mca/coll/libnbc/libdict/dict_private.h
+++ b/ompi/mca/coll/libnbc/libdict/dict_private.h
@@ -59,10 +59,10 @@ typedef int			 (*icompare_func)	__P((void *, void *itor2));
 # define ASSERT(expr)
 #endif
 
-extern dict_malloc_func _dict_malloc;
-extern dict_free_func _dict_free;
-#define MALLOC(n)	(*_dict_malloc)(n)
-#define FREE(p)		(*_dict_free)(p)
+extern dict_malloc_func ompi_nbc_dict_malloc;
+extern dict_free_func ompi_nbc_dict_free;
+#define MALLOC(n)	(*ompi_nbc_dict_malloc)(n)
+#define FREE(p)		(*ompi_nbc_dict_free)(p)
 
 #define ABS(a)		((a) < 0 ? -(a) : +(a))
 #define MIN(a,b)	((a) < (b) ? (a) : (b))

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.c
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.c
@@ -52,7 +52,7 @@ static hb_node *node_next __P((hb_node *node));
 static hb_node *node_prev __P((hb_node *node));
 
 hb_tree *
-hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
+ompi_nbc_hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 			dict_del_func dat_del)
 {
 	hb_tree *tree;
@@ -62,7 +62,7 @@ hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 
 	tree->root = NULL;
 	tree->count = 0;
-	tree->key_cmp = key_cmp ? key_cmp : dict_ptr_cmp;
+	tree->key_cmp = key_cmp ? key_cmp : ompi_nbc_dict_ptr_cmp;
 	tree->key_del = key_del;
 	tree->dat_del = dat_del;
 
@@ -70,7 +70,7 @@ hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 }
 
 dict *
-hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
+ompi_nbc_hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
 			dict_del_func dat_del)
 {
 	dict *dct;
@@ -79,38 +79,38 @@ hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
 	if ((dct = (dict*)MALLOC(sizeof(*dct))) == NULL)
 		return NULL;
 
-	if ((tree = hb_tree_new(key_cmp, key_del, dat_del)) == NULL) {
+	if ((tree = ompi_nbc_hb_tree_new(key_cmp, key_del, dat_del)) == NULL) {
 		FREE(dct);
 		return NULL;
 	}
 
 	dct->_object = tree;
-	dct->_inew = (inew_func)hb_dict_itor_new;
-	dct->_destroy = (destroy_func)hb_tree_destroy;
-	dct->_insert = (insert_func)hb_tree_insert;
-	dct->_probe = (probe_func)hb_tree_probe;
-	dct->_search = (search_func)hb_tree_search;
-	dct->_remove = (remove_func)hb_tree_remove;
-	dct->_empty = (empty_func)hb_tree_empty;
-	dct->_walk = (walk_func)hb_tree_walk;
-	dct->_count = (count_func)hb_tree_count;
+	dct->_inew = (inew_func)ompi_nbc_hb_dict_itor_new;
+	dct->_destroy = (destroy_func)ompi_nbc_hb_tree_destroy;
+	dct->_insert = (insert_func)ompi_nbc_hb_tree_insert;
+	dct->_probe = (probe_func)ompi_nbc_hb_tree_probe;
+	dct->_search = (search_func)ompi_nbc_hb_tree_search;
+	dct->_remove = (remove_func)ompi_nbc_hb_tree_remove;
+	dct->_empty = (empty_func)ompi_nbc_hb_tree_empty;
+	dct->_walk = (walk_func)ompi_nbc_hb_tree_walk;
+	dct->_count = (count_func)ompi_nbc_hb_tree_count;
 
 	return dct;
 }
 
 void
-hb_tree_destroy(hb_tree *tree, int del)
+ompi_nbc_hb_tree_destroy(hb_tree *tree, int del)
 {
 	ASSERT(tree != NULL);
 
 	if (tree->root)
-		hb_tree_empty(tree, del);
+		ompi_nbc_hb_tree_empty(tree, del);
 
 	FREE(tree);
 }
 
 void
-hb_tree_empty(hb_tree *tree, int del)
+ompi_nbc_hb_tree_empty(hb_tree *tree, int del)
 {
 	hb_node *node, *parent;
 
@@ -148,7 +148,7 @@ hb_tree_empty(hb_tree *tree, int del)
 }
 
 void *
-hb_tree_search(hb_tree *tree, const void *key)
+ompi_nbc_hb_tree_search(hb_tree *tree, const void *key)
 {
 	int rv;
 	hb_node *node;
@@ -170,7 +170,7 @@ hb_tree_search(hb_tree *tree, const void *key)
 }
 
 int
-hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
+ompi_nbc_hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
 {
 	int rv = 0;
 	hb_node *node, *parent = NULL, *q = NULL;
@@ -237,7 +237,7 @@ hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
 }
 
 int
-hb_tree_probe(hb_tree *tree, void *key, void **dat)
+ompi_nbc_hb_tree_probe(hb_tree *tree, void *key, void **dat)
 {
 	int rv = 0;
 	hb_node *node, *parent = NULL, *q = NULL;
@@ -306,7 +306,7 @@ hb_tree_probe(hb_tree *tree, void *key, void **dat)
 	FREE(n)
 
 int
-hb_tree_remove(hb_tree *tree, const void *key, int del)
+ompi_nbc_hb_tree_remove(hb_tree *tree, const void *key, int del)
 {
 	int rv, left;
 	hb_node *node, *out, *parent = NULL;
@@ -403,7 +403,7 @@ higher:
 }
 
 const void *
-hb_tree_min(const hb_tree *tree)
+ompi_nbc_hb_tree_min(const hb_tree *tree)
 {
 	const hb_node *node;
 
@@ -418,7 +418,7 @@ hb_tree_min(const hb_tree *tree)
 }
 
 const void *
-hb_tree_max(const hb_tree *tree)
+ompi_nbc_hb_tree_max(const hb_tree *tree)
 {
 	const hb_node *node;
 
@@ -433,7 +433,7 @@ hb_tree_max(const hb_tree *tree)
 }
 
 void
-hb_tree_walk(hb_tree *tree, dict_vis_func visit)
+ompi_nbc_hb_tree_walk(hb_tree *tree, dict_vis_func visit)
 {
 	hb_node *node;
 
@@ -447,7 +447,7 @@ hb_tree_walk(hb_tree *tree, dict_vis_func visit)
 }
 
 unsigned
-hb_tree_count(const hb_tree *tree)
+ompi_nbc_hb_tree_count(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
@@ -455,7 +455,7 @@ hb_tree_count(const hb_tree *tree)
 }
 
 unsigned
-hb_tree_height(const hb_tree *tree)
+ompi_nbc_hb_tree_height(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
@@ -463,7 +463,7 @@ hb_tree_height(const hb_tree *tree)
 }
 
 unsigned
-hb_tree_mheight(const hb_tree *tree)
+ompi_nbc_hb_tree_mheight(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
@@ -471,7 +471,7 @@ hb_tree_mheight(const hb_tree *tree)
 }
 
 unsigned
-hb_tree_pathlen(const hb_tree *tree)
+ompi_nbc_hb_tree_pathlen(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
@@ -683,7 +683,7 @@ rot_right(hb_tree *tree, hb_node *node)
 }
 
 hb_itor *
-hb_itor_new(hb_tree *tree)
+ompi_nbc_hb_itor_new(hb_tree *tree)
 {
 	hb_itor *itor;
 
@@ -693,12 +693,12 @@ hb_itor_new(hb_tree *tree)
 		return NULL;
 
 	itor->tree = tree;
-	hb_itor_first(itor);
+	ompi_nbc_hb_itor_first(itor);
 	return itor;
 }
 
 dict_itor *
-hb_dict_itor_new(hb_tree *tree)
+ompi_nbc_hb_dict_itor_new(hb_tree *tree)
 {
 	dict_itor *itor;
 
@@ -707,31 +707,31 @@ hb_dict_itor_new(hb_tree *tree)
 	if ((itor = (dict_itor*)MALLOC(sizeof(*itor))) == NULL)
 		return NULL;
 
-	if ((itor->_itor = hb_itor_new(tree)) == NULL) {
+	if ((itor->_itor = ompi_nbc_hb_itor_new(tree)) == NULL) {
 		FREE(itor);
 		return NULL;
 	}
 
-	itor->_destroy = (idestroy_func)hb_itor_destroy;
-	itor->_valid = (valid_func)hb_itor_valid;
-	itor->_invalid = (invalidate_func)hb_itor_invalidate;
-	itor->_next = (next_func)hb_itor_next;
-	itor->_prev = (prev_func)hb_itor_prev;
-	itor->_nextn = (nextn_func)hb_itor_nextn;
-	itor->_prevn = (prevn_func)hb_itor_prevn;
-	itor->_first = (first_func)hb_itor_first;
-	itor->_last = (last_func)hb_itor_last;
-	itor->_search = (isearch_func)hb_itor_search;
-	itor->_key = (key_func)hb_itor_key;
-	itor->_data = (data_func)hb_itor_data;
-	itor->_cdata = (cdata_func)hb_itor_cdata;
-	itor->_setdata = (dataset_func)hb_itor_set_data;
+	itor->_destroy = (idestroy_func)ompi_nbc_hb_itor_destroy;
+	itor->_valid = (valid_func)ompi_nbc_hb_itor_valid;
+	itor->_invalid = (invalidate_func)ompi_nbc_hb_itor_invalidate;
+	itor->_next = (next_func)ompi_nbc_hb_itor_next;
+	itor->_prev = (prev_func)ompi_nbc_hb_itor_prev;
+	itor->_nextn = (nextn_func)ompi_nbc_hb_itor_nextn;
+	itor->_prevn = (prevn_func)ompi_nbc_hb_itor_prevn;
+	itor->_first = (first_func)ompi_nbc_hb_itor_first;
+	itor->_last = (last_func)ompi_nbc_hb_itor_last;
+	itor->_search = (isearch_func)ompi_nbc_hb_itor_search;
+	itor->_key = (key_func)ompi_nbc_hb_itor_key;
+	itor->_data = (data_func)ompi_nbc_hb_itor_data;
+	itor->_cdata = (cdata_func)ompi_nbc_hb_itor_cdata;
+	itor->_setdata = (dataset_func)ompi_nbc_hb_itor_set_data;
 
 	return itor;
 }
 
 void
-hb_itor_destroy(hb_itor *itor)
+ompi_nbc_hb_itor_destroy(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -741,7 +741,7 @@ hb_itor_destroy(hb_itor *itor)
 #define RETVALID(itor)		return itor->node != NULL
 
 int
-hb_itor_valid(const hb_itor *itor)
+ompi_nbc_hb_itor_valid(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -749,7 +749,7 @@ hb_itor_valid(const hb_itor *itor)
 }
 
 void
-hb_itor_invalidate(hb_itor *itor)
+ompi_nbc_hb_itor_invalidate(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -757,37 +757,37 @@ hb_itor_invalidate(hb_itor *itor)
 }
 
 int
-hb_itor_next(hb_itor *itor)
+ompi_nbc_hb_itor_next(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	if (itor->node == NULL)
-		hb_itor_first(itor);
+		ompi_nbc_hb_itor_first(itor);
 	else
 		itor->node = node_next(itor->node);
 	RETVALID(itor);
 }
 
 int
-hb_itor_prev(hb_itor *itor)
+ompi_nbc_hb_itor_prev(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	if (itor->node == NULL)
-		hb_itor_last(itor);
+		ompi_nbc_hb_itor_last(itor);
 	else
 		itor->node = node_prev(itor->node);
 	RETVALID(itor);
 }
 
 int
-hb_itor_nextn(hb_itor *itor, unsigned count)
+ompi_nbc_hb_itor_nextn(hb_itor *itor, unsigned count)
 {
 	ASSERT(itor != NULL);
 
 	if (count) {
 		if (itor->node == NULL) {
-			hb_itor_first(itor);
+			ompi_nbc_hb_itor_first(itor);
 			count--;
 		}
 
@@ -799,13 +799,13 @@ hb_itor_nextn(hb_itor *itor, unsigned count)
 }
 
 int
-hb_itor_prevn(hb_itor *itor, unsigned count)
+ompi_nbc_hb_itor_prevn(hb_itor *itor, unsigned count)
 {
 	ASSERT(itor != NULL);
 
 	if (count) {
 		if (itor->node == NULL) {
-			hb_itor_last(itor);
+			ompi_nbc_hb_itor_last(itor);
 			count--;
 		}
 
@@ -817,7 +817,7 @@ hb_itor_prevn(hb_itor *itor, unsigned count)
 }
 
 int
-hb_itor_first(hb_itor *itor)
+ompi_nbc_hb_itor_first(hb_itor *itor)
 {
 	hb_tree *t;
 
@@ -829,7 +829,7 @@ hb_itor_first(hb_itor *itor)
 }
 
 int
-hb_itor_last(hb_itor *itor)
+ompi_nbc_hb_itor_last(hb_itor *itor)
 {
 	hb_tree *t;
 
@@ -841,7 +841,7 @@ hb_itor_last(hb_itor *itor)
 }
 
 int
-hb_itor_search(hb_itor *itor, const void *key)
+ompi_nbc_hb_itor_search(hb_itor *itor, const void *key)
 {
 	int rv;
 	hb_node *node;
@@ -861,7 +861,7 @@ hb_itor_search(hb_itor *itor, const void *key)
 }
 
 const void *
-hb_itor_key(const hb_itor *itor)
+ompi_nbc_hb_itor_key(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -869,7 +869,7 @@ hb_itor_key(const hb_itor *itor)
 }
 
 void *
-hb_itor_data(hb_itor *itor)
+ompi_nbc_hb_itor_data(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -877,7 +877,7 @@ hb_itor_data(hb_itor *itor)
 }
 
 const void *
-hb_itor_cdata(const hb_itor *itor)
+ompi_nbc_hb_itor_cdata(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -885,7 +885,7 @@ hb_itor_cdata(const hb_itor *itor)
 }
 
 int
-hb_itor_set_data(hb_itor *itor, void *dat, int del)
+ompi_nbc_hb_itor_set_data(hb_itor *itor, void *dat, int del)
 {
 	ASSERT(itor != NULL);
 

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.h
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.h
@@ -17,45 +17,45 @@ BEGIN_DECL
 struct hb_tree;
 typedef struct hb_tree hb_tree;
 
-hb_tree *hb_tree_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
+hb_tree *ompi_nbc_hb_tree_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
 						  dict_del_func dat_del));
-dict	*hb_dict_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
+dict	*ompi_nbc_hb_dict_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
 						  dict_del_func dat_del));
-void	 hb_tree_destroy __P((hb_tree *tree, int del));
+void	 ompi_nbc_hb_tree_destroy __P((hb_tree *tree, int del));
 
-int hb_tree_insert __P((hb_tree *tree, void *key, void *dat, int overwrite));
-int hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
-void *hb_tree_search __P((hb_tree *tree, const void *key));
-int hb_tree_remove __P((hb_tree *tree, const void *key, int del));
-void hb_tree_empty __P((hb_tree *tree, int del));
-void hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
-unsigned hb_tree_count __P((const hb_tree *tree));
-unsigned hb_tree_height __P((const hb_tree *tree));
-unsigned hb_tree_mheight __P((const hb_tree *tree));
-unsigned hb_tree_pathlen __P((const hb_tree *tree));
-const void *hb_tree_min __P((const hb_tree *tree));
-const void *hb_tree_max __P((const hb_tree *tree));
+int ompi_nbc_hb_tree_insert __P((hb_tree *tree, void *key, void *dat, int overwrite));
+int ompi_nbc_hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
+void *ompi_nbc_hb_tree_search __P((hb_tree *tree, const void *key));
+int ompi_nbc_hb_tree_remove __P((hb_tree *tree, const void *key, int del));
+void ompi_nbc_hb_tree_empty __P((hb_tree *tree, int del));
+void ompi_nbc_hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
+unsigned ompi_nbc_hb_tree_count __P((const hb_tree *tree));
+unsigned ompi_nbc_hb_tree_height __P((const hb_tree *tree));
+unsigned ompi_nbc_hb_tree_mheight __P((const hb_tree *tree));
+unsigned ompi_nbc_hb_tree_pathlen __P((const hb_tree *tree));
+const void *ompi_nbc_hb_tree_min __P((const hb_tree *tree));
+const void *ompi_nbc_hb_tree_max __P((const hb_tree *tree));
 
 struct hb_itor;
 typedef struct hb_itor hb_itor;
 
-hb_itor *hb_itor_new __P((hb_tree *tree));
-dict_itor *hb_dict_itor_new __P((hb_tree *tree));
-void hb_itor_destroy __P((hb_itor *tree));
+hb_itor *ompi_nbc_hb_itor_new __P((hb_tree *tree));
+dict_itor *ompi_nbc_hb_dict_itor_new __P((hb_tree *tree));
+void ompi_nbc_hb_itor_destroy __P((hb_itor *tree));
 
-int hb_itor_valid __P((const hb_itor *itor));
-void hb_itor_invalidate __P((hb_itor *itor));
-int hb_itor_next __P((hb_itor *itor));
-int hb_itor_prev __P((hb_itor *itor));
-int hb_itor_nextn __P((hb_itor *itor, unsigned count));
-int hb_itor_prevn __P((hb_itor *itor, unsigned count));
-int hb_itor_first __P((hb_itor *itor));
-int hb_itor_last __P((hb_itor *itor));
-int hb_itor_search __P((hb_itor *itor, const void *key));
-const void *hb_itor_key __P((const hb_itor *itor));
-void *hb_itor_data __P((hb_itor *itor));
-const void *hb_itor_cdata __P((const hb_itor *itor));
-int hb_itor_set_data __P((hb_itor *itor, void *dat, int del));
+int ompi_nbc_hb_itor_valid __P((const hb_itor *itor));
+void ompi_nbc_hb_itor_invalidate __P((hb_itor *itor));
+int ompi_nbc_hb_itor_next __P((hb_itor *itor));
+int ompi_nbc_hb_itor_prev __P((hb_itor *itor));
+int ompi_nbc_hb_itor_nextn __P((hb_itor *itor, unsigned count));
+int ompi_nbc_hb_itor_prevn __P((hb_itor *itor, unsigned count));
+int ompi_nbc_hb_itor_first __P((hb_itor *itor));
+int ompi_nbc_hb_itor_last __P((hb_itor *itor));
+int ompi_nbc_hb_itor_search __P((hb_itor *itor, const void *key));
+const void *ompi_nbc_hb_itor_key __P((const hb_itor *itor));
+void *ompi_nbc_hb_itor_data __P((hb_itor *itor));
+const void *ompi_nbc_hb_itor_cdata __P((const hb_itor *itor));
+int ompi_nbc_hb_itor_set_data __P((hb_itor *itor, void *dat, int del));
 int hb_itor_remove __P((hb_itor *itor, int del));
 
 END_DECL

--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -598,46 +598,46 @@ int  NBC_Init_comm(MPI_Comm comm, NBC_Comminfo *comminfo) {
 
 #ifdef NBC_CACHE_SCHEDULE
   /* initialize the NBC_ALLTOALL SchedCache tree */
-  comminfo->NBC_Dict[NBC_ALLTOALL] = hb_tree_new((dict_cmp_func)NBC_Alltoall_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_ALLTOALL] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_ALLTOALL] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Alltoall_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_ALLTOALL] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_ALLTOALL]);
   comminfo->NBC_Dict_size[NBC_ALLTOALL] = 0;
   /* initialize the NBC_ALLGATHER SchedCache tree */
-  comminfo->NBC_Dict[NBC_ALLGATHER] = hb_tree_new((dict_cmp_func)NBC_Allgather_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_ALLGATHER] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_ALLGATHER] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Allgather_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_ALLGATHER] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_ALLGATHER]);
   comminfo->NBC_Dict_size[NBC_ALLGATHER] = 0;
   /* initialize the NBC_ALLREDUCE SchedCache tree */
-  comminfo->NBC_Dict[NBC_ALLREDUCE] = hb_tree_new((dict_cmp_func)NBC_Allreduce_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_ALLREDUCE] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_ALLREDUCE] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Allreduce_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_ALLREDUCE] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_ALLREDUCE]);
   comminfo->NBC_Dict_size[NBC_ALLREDUCE] = 0;
   /* initialize the NBC_BARRIER SchedCache tree - is not needed -
    * schedule is hung off directly */
   comminfo->NBC_Dict_size[NBC_BARRIER] = 0;
   /* initialize the NBC_BCAST SchedCache tree */
-  comminfo->NBC_Dict[NBC_BCAST] = hb_tree_new((dict_cmp_func)NBC_Bcast_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_BCAST] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_BCAST] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Bcast_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_BCAST] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_BCAST]);
   comminfo->NBC_Dict_size[NBC_BCAST] = 0;
   /* initialize the NBC_GATHER SchedCache tree */
-  comminfo->NBC_Dict[NBC_GATHER] = hb_tree_new((dict_cmp_func)NBC_Gather_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_GATHER] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_GATHER] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Gather_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_GATHER] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_GATHER]);
   comminfo->NBC_Dict_size[NBC_GATHER] = 0;
   /* initialize the NBC_REDUCE SchedCache tree */
-  comminfo->NBC_Dict[NBC_REDUCE] = hb_tree_new((dict_cmp_func)NBC_Reduce_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_REDUCE] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_REDUCE] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Reduce_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_REDUCE] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_REDUCE]);
   comminfo->NBC_Dict_size[NBC_REDUCE] = 0;
   /* initialize the NBC_SCAN SchedCache tree */
-  comminfo->NBC_Dict[NBC_SCAN] = hb_tree_new((dict_cmp_func)NBC_Scan_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_SCAN] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_SCAN] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Scan_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_SCAN] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_SCAN]);
   comminfo->NBC_Dict_size[NBC_SCAN] = 0;
   /* initialize the NBC_SCATTER SchedCache tree */
-  comminfo->NBC_Dict[NBC_SCATTER] = hb_tree_new((dict_cmp_func)NBC_Scatter_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
-  if(comminfo->NBC_Dict[NBC_SCATTER] == NULL) { printf("Error in hb_tree_new()\n"); return OMPI_ERROR;; }
+  comminfo->NBC_Dict[NBC_SCATTER] = ompi_nbc_hb_tree_new((dict_cmp_func)NBC_Scatter_args_compare, NBC_SchedCache_args_delete_key_dummy, NBC_SchedCache_args_delete);
+  if(comminfo->NBC_Dict[NBC_SCATTER] == NULL) { printf("Error in ompi_nbc_hb_tree_new()\n"); return OMPI_ERROR;; }
   NBC_DEBUG(1, "added tree at address %lu\n", (unsigned long)comminfo->NBC_Dict[NBC_SCATTER]);
   comminfo->NBC_Dict_size[NBC_SCATTER] = 0;
 #endif

--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -110,7 +110,7 @@ static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype s
   search.recvbuf = recvbuf;
   search.recvcount = recvcount;
   search.recvtype = recvtype;
-  found = (NBC_Allgather_args *) hb_tree_search ((hb_tree*)libnbc_module->NBC_Dict[NBC_ALLGATHER], &search);
+  found = (NBC_Allgather_args *) ompi_nbc_hb_tree_search ((hb_tree*)libnbc_module->NBC_Dict[NBC_ALLGATHER], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -163,7 +163,7 @@ static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype s
     args->recvtype = recvtype;
     args->schedule = schedule;
 
-    res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLGATHER], args, args, 0);
+    res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLGATHER], args, args, 0);
     if (res != 0) {
       free (args);
     } else {

--- a/ompi/mca/coll/libnbc/nbc_iallreduce.c
+++ b/ompi/mca/coll/libnbc/nbc_iallreduce.c
@@ -141,7 +141,7 @@ static int nbc_allreduce_init(const void* sendbuf, void* recvbuf, int count, MPI
   search.count = count;
   search.datatype = datatype;
   search.op = op;
-  found = (NBC_Allreduce_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLREDUCE], &search);
+  found = (NBC_Allreduce_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLREDUCE], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -193,7 +193,7 @@ static int nbc_allreduce_init(const void* sendbuf, void* recvbuf, int count, MPI
       args->datatype = datatype;
       args->op = op;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLREDUCE], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLREDUCE], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ialltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoall.c
@@ -188,7 +188,7 @@ static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype se
   search.recvbuf = recvbuf;
   search.recvcount = recvcount;
   search.recvtype = recvtype;
-  found = (NBC_Alltoall_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLTOALL], &search);
+  found = (NBC_Alltoall_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLTOALL], &search);
   if (NULL == found) {
 #endif
     /* not found - generate new schedule */
@@ -250,7 +250,7 @@ static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype se
       args->recvcount = recvcount;
       args->recvtype = recvtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLTOALL], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_ALLTOALL], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -118,7 +118,7 @@ static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int ro
   search.count = count;
   search.datatype = datatype;
   search.root = root;
-  found = (NBC_Bcast_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_BCAST], &search);
+  found = (NBC_Bcast_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_BCAST], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -161,7 +161,7 @@ static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int ro
       args->datatype = datatype;
       args->root = root;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_BCAST], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_BCAST], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN (schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_iexscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iexscan.c
@@ -95,7 +95,7 @@ static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
     search.count = count;
     search.datatype = datatype;
     search.op = op;
-    found = (NBC_Scan_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_EXSCAN], &search);
+    found = (NBC_Scan_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_EXSCAN], &search);
     if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -134,7 +134,7 @@ static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
             args->datatype = datatype;
             args->op = op;
             args->schedule = schedule;
-            res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_EXSCAN], args, args, 0);
+            res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_EXSCAN], args, args, 0);
             if (0 == res) {
                 OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_igather.c
+++ b/ompi/mca/coll/libnbc/nbc_igather.c
@@ -84,7 +84,7 @@ static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype send
   search.recvcount = recvcount;
   search.recvtype = recvtype;
   search.root = root;
-  found = (NBC_Gather_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_GATHER],
+  found = (NBC_Gather_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_GATHER],
                                               &search);
   if (NULL == found) {
 #endif
@@ -143,7 +143,7 @@ static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype send
       args->recvtype = recvtype;
       args->root = root;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_GATHER], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_GATHER], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
@@ -69,7 +69,7 @@ static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatyp
   search.rbuf = rbuf;
   search.rcount = rcount;
   search.rtype = rtype;
-  found = (NBC_Ineighbor_allgather_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHER],
+  found = (NBC_Ineighbor_allgather_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHER],
                                                            &search);
   if (NULL == found) {
 #endif
@@ -134,7 +134,7 @@ static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatyp
       args->rcount = rcount;
       args->rtype = rtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHER], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHER], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
@@ -69,7 +69,7 @@ static int nbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Dataty
   search.rbuf = rbuf;
   search.rcount = rcount;
   search.rtype = rtype;
-  found = (NBC_Ineighbor_allgatherv_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHERV],
+  found = (NBC_Ineighbor_allgatherv_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHERV],
                                                             &search);
   if (NULL == found) {
 #endif
@@ -134,7 +134,7 @@ static int nbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Dataty
       args->rcount = rcount;
       args->rtype = rtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHERV], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLGATHERV], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
@@ -72,7 +72,7 @@ static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype
   search.rbuf = rbuf;
   search.rcount = rcount;
   search.rtype = rtype;
-  found = (NBC_Ineighbor_alltoall_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALL],
+  found = (NBC_Ineighbor_alltoall_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALL],
                                                           &search);
   if (NULL == found) {
 #endif
@@ -137,7 +137,7 @@ static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype
       args->rcount = rcount;
       args->rtype = rtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALL], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALL], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
@@ -75,7 +75,7 @@ static int nbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, con
   search.rbuf = rbuf;
   search.rcount = rcount;
   search.rtype = rtype;
-  found = (NBC_Ineighbor_alltoallv_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLV],
+  found = (NBC_Ineighbor_alltoallv_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLV],
                                                            &search);
   if (NULL == found) {
 #endif
@@ -141,7 +141,7 @@ static int nbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, con
       args->rcount = rcount;
       args->rtype = rtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLV], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLV], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
@@ -61,7 +61,7 @@ static int nbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, con
   search.rbuf = rbuf;
   search.rcount = rcount;
   search.rtype = rtype;
-  found = (NBC_Ineighbor_alltoallw_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLW],
+  found = (NBC_Ineighbor_alltoallw_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLW],
                                                            &search);
   if(found == NULL) {
 #endif
@@ -127,7 +127,7 @@ static int nbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, con
       args->rcount = rcount;
       args->rtype = rtype;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLW], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_NEIGHBOR_ALLTOALLW], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -553,12 +553,12 @@ static inline int NBC_Unpack(void *src, int srccount, MPI_Datatype srctype, void
 static inline void NBC_SchedCache_dictwipe(hb_tree *dict, int *size) {
   hb_itor *itor;
 
-  itor = hb_itor_new(dict);
-  for (; hb_itor_valid(itor) && (*size>NBC_SCHED_DICT_LOWER); hb_itor_next(itor)) {
-    hb_tree_remove(dict, hb_itor_key(itor), 0);
+  itor = ompi_nbc_hb_itor_new(dict);
+  for (; ompi_nbc_hb_itor_valid(itor) && (*size>NBC_SCHED_DICT_LOWER); ompi_nbc_hb_itor_next(itor)) {
+    ompi_nbc_hb_tree_remove(dict, ompi_nbc_hb_itor_key(itor), 0);
     *size = *size-1;
   }
-  hb_itor_destroy(itor);
+  ompi_nbc_hb_itor_destroy(itor);
 }
 
 #define NBC_IN_PLACE(sendbuf, recvbuf, inplace) \

--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -157,7 +157,7 @@ static int nbc_reduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
   search.datatype = datatype;
   search.op = op;
   search.root = root;
-  found = (NBC_Reduce_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_REDUCE], &search);
+  found = (NBC_Reduce_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_REDUCE], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -206,7 +206,7 @@ static int nbc_reduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
       args->op = op;
       args->root = root;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_REDUCE], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_REDUCE], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_iscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iscan.c
@@ -96,7 +96,7 @@ static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Data
   search.count = count;
   search.datatype = datatype;
   search.op = op;
-  found = (NBC_Scan_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCAN], &search);
+  found = (NBC_Scan_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCAN], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -135,7 +135,7 @@ static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Data
       args->datatype = datatype;
       args->op = op;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCAN], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCAN], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/coll/libnbc/nbc_iscatter.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatter.c
@@ -81,7 +81,7 @@ static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype se
   search.recvcount=recvcount;
   search.recvtype=recvtype;
   search.root=root;
-  found = (NBC_Scatter_args *) hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCATTER], &search);
+  found = (NBC_Scatter_args *) ompi_nbc_hb_tree_search ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCATTER], &search);
   if (NULL == found) {
 #endif
     schedule = OBJ_NEW(NBC_Schedule);
@@ -138,7 +138,7 @@ static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype se
       args->recvtype = recvtype;
       args->root = root;
       args->schedule = schedule;
-      res = hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCATTER], args, args, 0);
+      res = ompi_nbc_hb_tree_insert ((hb_tree *) libnbc_module->NBC_Dict[NBC_SCATTER], args, args, 0);
       if (0 == res) {
         OBJ_RETAIN(schedule);
 

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -83,7 +83,7 @@ static double log10_2 = 0.;
 static int rank_world = -1;
 static int nprocs_world = 0;
 
-opal_hash_table_t *common_monitoring_translation_ht = NULL;
+opal_hash_table_t *ompi_common_monitoring_translation_ht = NULL;
 
 /* Reset all the monitoring arrays */
 static void mca_common_monitoring_reset ( void );
@@ -225,8 +225,8 @@ int mca_common_monitoring_init( void )
     mca_common_monitoring_output_stream_id =
         opal_output_open(&mca_common_monitoring_output_stream_obj);
     /* Initialize proc translation hashtable */
-    common_monitoring_translation_ht = OBJ_NEW(opal_hash_table_t);
-    opal_hash_table_init(common_monitoring_translation_ht, 2048);
+    ompi_common_monitoring_translation_ht = OBJ_NEW(opal_hash_table_t);
+    opal_hash_table_init(ompi_common_monitoring_translation_ht, 2048);
     return OMPI_SUCCESS;
 }
 
@@ -246,8 +246,8 @@ void mca_common_monitoring_finalize( void )
     free(mca_common_monitoring_output_stream_obj.lds_prefix);
     /* Free internal data structure */
     free((void *) pml_data);  /* a single allocation */
-    opal_hash_table_remove_all( common_monitoring_translation_ht );
-    OBJ_RELEASE(common_monitoring_translation_ht);
+    opal_hash_table_remove_all( ompi_common_monitoring_translation_ht );
+    OBJ_RELEASE(ompi_common_monitoring_translation_ht);
     mca_common_monitoring_coll_finalize();
     if( NULL != mca_common_monitoring_current_filename ) {
         free(mca_common_monitoring_current_filename);
@@ -484,7 +484,7 @@ int mca_common_monitoring_add_procs(struct ompi_proc_t **procs,
 
             key = *((uint64_t*)&tmp);
             /* save the rank of the process in MPI_COMM_WORLD in the hash using the proc_name as the key */
-            if( OPAL_SUCCESS != opal_hash_table_set_value_uint64(common_monitoring_translation_ht,
+            if( OPAL_SUCCESS != opal_hash_table_set_value_uint64(ompi_common_monitoring_translation_ht,
                                                                  key, (void*)(uintptr_t)peer_rank) ) {
                 return OMPI_ERR_OUT_OF_RESOURCE;  /* failed to allocate memory or growing the hash table */
             }

--- a/ompi/mca/common/monitoring/common_monitoring.h
+++ b/ompi/mca/common/monitoring/common_monitoring.h
@@ -45,7 +45,7 @@ BEGIN_C_DECLS
 extern int mca_common_monitoring_output_stream_id;
 extern int mca_common_monitoring_enabled;
 extern int mca_common_monitoring_current_state;
-extern opal_hash_table_t *common_monitoring_translation_ht;
+extern opal_hash_table_t *ompi_common_monitoring_translation_ht;
 
 OMPI_DECLSPEC int mca_common_monitoring_init( void );
 OMPI_DECLSPEC void mca_common_monitoring_finalize( void );
@@ -88,7 +88,7 @@ static inline int mca_common_monitoring_get_world_rank(int dest, ompi_group_t *g
      * If this fails the destination is not part of my MPI_COM_WORLD
      * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
      */
-    int ret = opal_hash_table_get_value_uint64(common_monitoring_translation_ht,
+    int ret = opal_hash_table_get_value_uint64(ompi_common_monitoring_translation_ht,
                                                key, (void *)&rank);
 
     /* Use intermediate variable to avoid overwriting while looking up in the hashtbale. */

--- a/ompi/mca/fbtl/posix/fbtl_posix.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix.c
@@ -35,7 +35,7 @@
 #include <aio.h>
 #endif
 
-int fbtl_posix_max_aio_active_reqs=2048;
+int ompi_fbtl_posix_max_aio_active_reqs=2048;
 
 #include "ompi/mca/fbtl/fbtl.h"
 #include "ompi/mca/fbtl/posix/fbtl_posix.h"
@@ -104,7 +104,7 @@ int mca_fbtl_posix_module_init (ompio_file_t *file) {
 #if defined (FBTL_POSIX_HAVE_AIO)
     long val = sysconf(_SC_AIO_MAX);
     if ( -1 != val ) {
-	fbtl_posix_max_aio_active_reqs = (int)val;
+	ompi_fbtl_posix_max_aio_active_reqs = (int)val;
     }
 #endif
     return OMPI_SUCCESS;

--- a/ompi/mca/fbtl/posix/fbtl_posix.h
+++ b/ompi/mca/fbtl/posix/fbtl_posix.h
@@ -41,7 +41,7 @@ int mca_fbtl_posix_component_file_unquery (ompio_file_t *file);
 int mca_fbtl_posix_module_init (ompio_file_t *file);
 int mca_fbtl_posix_module_finalize (ompio_file_t *file);
 
-extern int fbtl_posix_max_aio_active_reqs;
+extern int ompi_fbtl_posix_max_aio_active_reqs;
 
 OMPI_MODULE_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_posix_component;
 /*

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
@@ -51,7 +51,7 @@ ssize_t mca_fbtl_posix_ipreadv (ompio_file_t *fh,
     data->aio_req_count = fh->f_num_of_io_entries;
     data->aio_open_reqs = fh->f_num_of_io_entries;
     data->aio_req_type  = FBTL_POSIX_READ;
-    data->aio_req_chunks = fbtl_posix_max_aio_active_reqs;
+    data->aio_req_chunks = ompi_fbtl_posix_max_aio_active_reqs;
     data->aio_total_len = 0;
     data->aio_reqs = (struct aiocb *) malloc (sizeof(struct aiocb) *
                                               fh->f_num_of_io_entries);

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
@@ -50,7 +50,7 @@ ssize_t  mca_fbtl_posix_ipwritev (ompio_file_t *fh,
     data->aio_req_count = fh->f_num_of_io_entries;
     data->aio_open_reqs = fh->f_num_of_io_entries;
     data->aio_req_type  = FBTL_POSIX_WRITE;
-    data->aio_req_chunks = fbtl_posix_max_aio_active_reqs;
+    data->aio_req_chunks = ompi_fbtl_posix_max_aio_active_reqs;
     data->aio_total_len = 0;
     data->aio_reqs = (struct aiocb *) malloc (sizeof(struct aiocb) *
                                               fh->f_num_of_io_entries);

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -120,7 +120,7 @@ static int is_aggregator(int rank,
 			 int *aggregator_list);
 #endif
 
-void two_phase_heap_merge(mca_common_ompio_access_array_t *others_req,
+static void two_phase_heap_merge(mca_common_ompio_access_array_t *others_req,
 			  int *count,
 			  OMPI_MPI_OFFSET_TYPE *srt_off,
 			  int *srt_len,
@@ -1404,7 +1404,7 @@ static int two_phase_fill_send_buffer(ompio_file_t *fh,
 
 
 
-void two_phase_heap_merge( mca_common_ompio_access_array_t *others_req,
+static void two_phase_heap_merge( mca_common_ompio_access_array_t *others_req,
 			   int *count,
 			   OMPI_MPI_OFFSET_TYPE *srt_off,
 			   int *srt_len,

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -47,7 +47,7 @@ struct mca_mtl_request_t;
  * These are called internally by the library when the send
  * is completed from its perspective.
  */
-extern void (*send_completion_callbacks[])
+extern void (*ompi_cm_send_completion_callbacks[])
     (struct mca_mtl_request_t *mtl_request);
 
 struct ompi_pml_cm_t {

--- a/ompi/mca/pml/cm/pml_cm_component.c
+++ b/ompi/mca/pml/cm/pml_cm_component.c
@@ -67,7 +67,7 @@ mca_pml_base_component_2_0_0_t mca_pml_cm_component = {
  * These are called internally by the library when the send
  * is completed from its perspective.
  */
-void (*send_completion_callbacks[MCA_PML_BASE_SEND_SIZE])
+void (*ompi_cm_send_completion_callbacks[MCA_PML_BASE_SEND_SIZE])
     (struct mca_mtl_request_t *mtl_request) =
   { mca_pml_cm_send_request_completion,
     mca_pml_cm_send_request_completion,

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -279,14 +279,14 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
              * the network.
              */
             if( NULL != pml_proc->frags_cant_match ) {
-                frag = check_cantmatch_for_match(pml_proc);
+                frag = ompi_ob1_check_cantmatch_for_match(pml_proc);
                 if( NULL != frag ) {
                     hdr = &frag->hdr.hdr_match;
                     goto add_fragment_to_unexpected;
                 }
             }
         } else {
-            append_frag_to_ordered_list(&pml_proc->frags_cant_match, frag,
+            ompi_ob1_append_frag_to_ordered_list(&pml_proc->frags_cant_match, frag,
                                         pml_proc->expected_sequence);
         }
     }

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -114,7 +114,7 @@ append_frag_to_umq(custom_match_umq *queue, mca_btl_base_module_t *btl,
  * messages. On the vertical layer, messages with contiguous sequence
  * number organize themselves in a way to minimize the search space.
  */
-void append_frag_to_ordered_list (mca_pml_ob1_recv_frag_t **queue,
+void ompi_ob1_append_frag_to_ordered_list (mca_pml_ob1_recv_frag_t **queue,
                                   mca_pml_ob1_recv_frag_t *frag,
                                   uint16_t seq)
 {
@@ -327,7 +327,7 @@ static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
                                               mca_pml_ob1_comm_proc_t *proc,
                                               mca_pml_ob1_recv_frag_t *frag);
 
-mca_pml_ob1_recv_frag_t *check_cantmatch_for_match (mca_pml_ob1_comm_proc_t *proc)
+mca_pml_ob1_recv_frag_t *ompi_ob1_check_cantmatch_for_match (mca_pml_ob1_comm_proc_t *proc)
 {
     mca_pml_ob1_recv_frag_t *frag = proc->frags_cant_match;
 
@@ -402,7 +402,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
             mca_pml_ob1_recv_frag_t* frag;
             MCA_PML_OB1_RECV_FRAG_ALLOC(frag);
             MCA_PML_OB1_RECV_FRAG_INIT(frag, hdr, segments, num_segments, btl);
-            append_frag_to_ordered_list(&proc->frags_cant_match, frag, proc->expected_sequence);
+            ompi_ob1_append_frag_to_ordered_list(&proc->frags_cant_match, frag, proc->expected_sequence);
             SPC_RECORD(OMPI_SPC_OUT_OF_SEQUENCE, 1);
             OB1_MATCHING_UNLOCK(&comm->matching_lock);
             return;
@@ -422,7 +422,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
     match = match_one(btl, hdr, segments, num_segments, comm_ptr, proc, NULL);
 
     /* The match is over. We generate the SEARCH_POSTED_Q_END here,
-     * before going into check_cantmatch_for_match so we can make
+     * before going into ompi_ob1_check_cantmatch_for_match so we can make
      * a difference for the searching time for all messages.
      */
     PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_END, comm_ptr,
@@ -499,7 +499,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
         mca_pml_ob1_recv_frag_t* frag;
 
         OB1_MATCHING_LOCK(&comm->matching_lock);
-        if((frag = check_cantmatch_for_match(proc))) {
+        if((frag = ompi_ob1_check_cantmatch_for_match(proc))) {
             /* mca_pml_ob1_recv_frag_match_proc() will release the lock. */
             mca_pml_ob1_recv_frag_match_proc(frag->btl, comm_ptr, proc,
                                              &frag->hdr.hdr_match,
@@ -938,7 +938,7 @@ static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
             mca_pml_ob1_recv_frag_t* frag;
             MCA_PML_OB1_RECV_FRAG_ALLOC(frag);
             MCA_PML_OB1_RECV_FRAG_INIT(frag, hdr, segments, num_segments, btl);
-            append_frag_to_ordered_list(&proc->frags_cant_match, frag, next_msg_seq_expected);
+            ompi_ob1_append_frag_to_ordered_list(&proc->frags_cant_match, frag, next_msg_seq_expected);
 
             SPC_RECORD(OMPI_SPC_OUT_OF_SEQUENCE, 1);
             SPC_RECORD(OMPI_SPC_OOS_IN_QUEUE, 1);
@@ -998,7 +998,7 @@ mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
     match = match_one(btl, hdr, segments, num_segments, comm_ptr, proc, frag);
 
     /* The match is over. We generate the SEARCH_POSTED_Q_END here,
-     * before going into check_cantmatch_for_match we can make a
+     * before going into ompi_ob1_check_cantmatch_for_match we can make a
      * difference for the searching time for all messages.
      */
     PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_SEARCH_POSTED_Q_END, comm_ptr,
@@ -1031,7 +1031,7 @@ mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
      */
     if(OPAL_UNLIKELY(NULL != proc->frags_cant_match)) {
         OB1_MATCHING_LOCK(&comm->matching_lock);
-        if((frag = check_cantmatch_for_match(proc))) {
+        if((frag = ompi_ob1_check_cantmatch_for_match(proc))) {
             hdr = &frag->hdr.hdr_match;
             segments = frag->segments;
             num_segments = frag->num_segments;

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
@@ -163,9 +163,9 @@ extern void mca_pml_ob1_recv_frag_callback_fin (mca_btl_base_module_t *btl,
  * will be the next in sequence.
  */
 extern mca_pml_ob1_recv_frag_t*
-check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc);
+ompi_ob1_check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc);
 
-void append_frag_to_ordered_list(mca_pml_ob1_recv_frag_t** queue,
+void ompi_ob1_append_frag_to_ordered_list(mca_pml_ob1_recv_frag_t** queue,
                                  mca_pml_ob1_recv_frag_t* frag,
                                  uint16_t seq);
 

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_component.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_component.c
@@ -183,13 +183,13 @@ static int mca_vprotocol_pessimist_component_finalize(void)
 int mca_vprotocol_pessimist_enable(bool enable) {
     if(enable) {
         int ret;
-        if((ret = vprotocol_pessimist_sender_based_init(_mmap_file_name,
+        if((ret = ompi_vprotocol_pessimist_sender_based_init(_mmap_file_name,
                                                  _sender_based_size)) != OMPI_SUCCESS)
             return ret;
     }
     else {
-        vprotocol_pessimist_sender_based_finalize();
-        vprotocol_pessimist_event_logger_disconnect(mca_vprotocol_pessimist.el_comm);
+        ompi_vprotocol_pessimist_sender_based_finalize();
+        ompi_vprotocol_pessimist_event_logger_disconnect(mca_vprotocol_pessimist.el_comm);
     }
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
@@ -18,7 +18,7 @@
 #include "opal/util/printf.h"
 #include "ompi/dpm/dpm.h"
 
-int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm)
+int ompi_vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm)
 {
     int rc;
     pmix_status_t prc;
@@ -67,13 +67,13 @@ int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **
     return rc;
 }
 
-int vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm)
+int ompi_vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm)
 {
     ompi_dpm_disconnect(el_comm);
     return OMPI_SUCCESS;
 }
 
-void vprotocol_pessimist_matching_replay(int *src) {
+void ompi_vprotocol_pessimist_matching_replay(int *src) {
 #if OPAL_ENABLE_DEBUG
     vprotocol_pessimist_clock_t max = 0;
 #endif
@@ -109,7 +109,7 @@ void vprotocol_pessimist_matching_replay(int *src) {
 #endif
 }
 
-void vprotocol_pessimist_delivery_replay(size_t n, ompi_request_t **reqs,
+void ompi_vprotocol_pessimist_delivery_replay(size_t n, ompi_request_t **reqs,
                                          int *outcount, int *index,
                                          ompi_status_public_t *status) {
     mca_vprotocol_pessimist_event_t *event;

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.h
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.h
@@ -20,12 +20,12 @@ BEGIN_C_DECLS
 /** Initialize the MPI connexion with the event logger
  * @return OMPI_SUCCESS or error code
  */
-int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm);
+int ompi_vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm);
 
 /** Finalize the MPI connexion with the event logger
  * @return OMPI_SUCCESS or error code
  */
-int vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm);
+int ompi_vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm);
 
 /*******************************************************************************
   * ANY_SOURCE MATCHING
@@ -84,7 +84,7 @@ static inline void vprotocol_pessimist_matching_log_finish(ompi_request_t *req)
         vprotocol_pessimist_clock_t max_clock;                                \
         if(OPAL_UNLIKELY(ompi_comm_invalid(mca_vprotocol_pessimist.el_comm))) \
         {                                                                     \
-            rc = vprotocol_pessimist_event_logger_connect(0,                  \
+            rc = ompi_vprotocol_pessimist_event_logger_connect(0,                  \
                                         &mca_vprotocol_pessimist.el_comm);    \
             if(OMPI_SUCCESS != rc)                                            \
                 OMPI_ERRHANDLER_INVOKE(mca_vprotocol_pessimist.el_comm, rc,   \
@@ -170,9 +170,9 @@ static inline void vprotocol_pessimist_event_flush(void)
  */
 #define VPROTOCOL_PESSIMIST_MATCHING_REPLAY(src) do {                         \
   if(mca_vprotocol_pessimist.replay && ((src) == MPI_ANY_SOURCE))             \
-    vprotocol_pessimist_matching_replay(&(src));                              \
+    ompi_vprotocol_pessimist_matching_replay(&(src));                              \
 } while(0)
-void vprotocol_pessimist_matching_replay(int *src);
+void ompi_vprotocol_pessimist_matching_replay(int *src);
 
 /*******************************************************************************
   * WAIT/TEST-SOME/ANY & PROBES
@@ -233,9 +233,9 @@ static inline void vprotocol_pessimist_delivery_log(ompi_request_t *req)
   */
 #define VPROTOCOL_PESSIMIST_DELIVERY_REPLAY(n, reqs, outcount, i, status) do {\
   if(mca_vprotocol_pessimist.replay)                                          \
-    vprotocol_pessimist_delivery_replay(n, reqs, outcount, i, status);        \
+    ompi_vprotocol_pessimist_delivery_replay(n, reqs, outcount, i, status);        \
 } while(0)
-void vprotocol_pessimist_delivery_replay(size_t, ompi_request_t **,
+void ompi_vprotocol_pessimist_delivery_replay(size_t, ompi_request_t **,
                                          int *, int *, ompi_status_public_t *);
 
 END_C_DECLS

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
@@ -80,7 +80,7 @@ static void sb_mmap_free(void)
                      (void *) sb.sb_addr, strerror(errno));
 }
 
-int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
+int ompi_vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
 {
     char *path;
 #ifdef SB_USE_CONVERTOR_METHOD
@@ -107,7 +107,7 @@ int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
     return OMPI_SUCCESS;
 }
 
-void vprotocol_pessimist_sender_based_finalize(void)
+void ompi_vprotocol_pessimist_sender_based_finalize(void)
 {
     if(((uintptr_t) NULL) != sb.sb_addr)
         sb_mmap_free();
@@ -118,7 +118,7 @@ void vprotocol_pessimist_sender_based_finalize(void)
 /** Manage mmap floating window, allocating enough memory for the message to be
   * asynchronously copied to disk.
   */
-void vprotocol_pessimist_sender_based_alloc(size_t len)
+void ompi_vprotocol_pessimist_sender_based_alloc(size_t len)
 {
     if(((uintptr_t) NULL) != sb.sb_addr)
         sb_mmap_free();

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.h
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.h
@@ -22,16 +22,16 @@ BEGIN_C_DECLS
 
 /** Prepare for using the sender based storage
   */
-int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size);
+int ompi_vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size);
 
 /** Cleanup mmap etc
   */
-void vprotocol_pessimist_sender_based_finalize(void);
+void ompi_vprotocol_pessimist_sender_based_finalize(void);
 
 /** Manage mmap floating window, allocating enough memory for the message to be
   * asynchronously copied to disk.
   */
-void vprotocol_pessimist_sender_based_alloc(size_t len);
+void ompi_vprotocol_pessimist_sender_based_alloc(size_t len);
 
 
 /*******************************************************************************
@@ -177,7 +177,7 @@ static inline void vprotocol_pessimist_sender_based_copy_start(ompi_request_t *r
             pmlreq->req_bytes_packed +
             sizeof(vprotocol_pessimist_sender_based_header_t))
     {
-        vprotocol_pessimist_sender_based_alloc(pmlreq->req_bytes_packed);
+        ompi_vprotocol_pessimist_sender_based_alloc(pmlreq->req_bytes_packed);
     }
 
     /* Copy message header to the sender-based space */

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -341,7 +341,7 @@ smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl,
         return rc;
     }
     /* now that res is fully populated, create the thing */
-    mca_btl_smcuda_component.sm_mpools[0] = common_sm_mpool_create (res);
+    mca_btl_smcuda_component.sm_mpools[0] = ompi_sm_common_sm_mpool_create (res);
     /* Sanity check to ensure that we found it */
     if (NULL == mca_btl_smcuda_component.sm_mpools[0]) {
         free(res);

--- a/opal/mca/common/sm/common_sm_mpool.c
+++ b/opal/mca/common/sm/common_sm_mpool.c
@@ -87,7 +87,7 @@ static void mca_common_sm_mpool_module_init(mca_common_sm_mpool_module_t* mpool)
     mpool->mem_node = -1;
 }
 
-mca_mpool_base_module_t *common_sm_mpool_create (mca_common_sm_mpool_resources_t *resources)
+mca_mpool_base_module_t *ompi_sm_common_sm_mpool_create (mca_common_sm_mpool_resources_t *resources)
 {
     mca_common_sm_mpool_module_t *mpool_module;
     mca_allocator_base_component_t* allocator_component;

--- a/opal/mca/common/sm/common_sm_mpool.h
+++ b/opal/mca/common/sm/common_sm_mpool.h
@@ -57,7 +57,7 @@ typedef struct mca_common_sm_mpool_module_t {
     int32_t mem_node;
 } mca_common_sm_mpool_module_t;
 
-OPAL_DECLSPEC mca_mpool_base_module_t *common_sm_mpool_create (mca_common_sm_mpool_resources_t *);
+OPAL_DECLSPEC mca_mpool_base_module_t *ompi_sm_common_sm_mpool_create (mca_common_sm_mpool_resources_t *);
 
 END_C_DECLS
 

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.c
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.c
@@ -62,7 +62,7 @@
 
 /* ////////////////////////////////////////////////////////////////////////// */
 int
-shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
+ompi_shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
 {
     int attempt = 0, fd = -1;
 
@@ -92,7 +92,7 @@ shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
              */
             else {
                 opal_output_verbose(10, opal_shmem_base_framework.framework_output,
-                     "shmem_posix_shm_open: disqualifying posix because "
+                     "ompi_shmem_posix_shm_open: disqualifying posix because "
                      "shm_open(2) failed with error: %s (errno %d)\n",
                      strerror(err), err);
                 break;

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.h
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.h
@@ -42,7 +42,7 @@ BEGIN_C_DECLS
  * successful shm_open.  otherwise, -1 is returned and the contents of
  * posix_file_name_buff are undefined.
  */
-OPAL_DECLSPEC extern int shmem_posix_shm_open(char *posix_file_name_buff,
+OPAL_DECLSPEC extern int ompi_shmem_posix_shm_open(char *posix_file_name_buff,
                                               size_t size);
 
 END_C_DECLS

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -175,8 +175,8 @@ posix_runtime_query(mca_base_module_t **module,
          "shmem: posix: runtime_query: NO HINT PROVIDED:"
          "starting run-time test...\n")
     );
-    /* shmem_posix_shm_open successfully shm_opened - we can use posix sm! */
-    if (-1 != (fd = shmem_posix_shm_open(tmp_buff,
+    /* ompi_shmem_posix_shm_open successfully shm_opened - we can use posix sm! */
+    if (-1 != (fd = ompi_shmem_posix_shm_open(tmp_buff,
                                          OPAL_SHMEM_POSIX_FILE_LEN_MAX -1))) {
         /* free up allocated resources before we return */
         if (0 != shm_unlink(tmp_buff)) {
@@ -186,7 +186,7 @@ posix_runtime_query(mca_base_module_t **module,
             opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1,
                            hn, "shm_unlink(2)", "", strerror(err), err);
             /* something strange happened, so consider this a run-time test
-             * failure even though shmem_posix_shm_open was successful */
+             * failure even though ompi_shmem_posix_shm_open was successful */
         }
         /* all is well */
         else {

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -186,11 +186,11 @@ segment_create(opal_shmem_ds_t *ds_buf,
      * being located on a network file system... so no check is needed here.
      */
 
-    /* calling shmem_posix_shm_open searches for an available posix shared
+    /* calling ompi_shmem_posix_shm_open searches for an available posix shared
      * memory object name and upon successful completion populates the name
      * buffer
      */
-    if (-1 == (ds_buf->seg_id = shmem_posix_shm_open(
+    if (-1 == (ds_buf->seg_id = ompi_shmem_posix_shm_open(
                                     ds_buf->seg_name,
                                     OPAL_SHMEM_POSIX_FILE_LEN_MAX - 1))) {
         /* snaps!  something happened in posix_shm_open.  don't report anything


### PR DESCRIPTION
There's an incoming PR
https://github.com/open-mpi/ompi/pull/8132
that makes more MCAs get built into the main library, and that brings more potential symbol name pollution.

My testcase
https://github.com/open-mpi/ompi-tests-public/pull/3
identified a bunch of symbols without recognized prefixes when I built 8132, so this PR adds a bunch of prefixes and/or makes symbols static if they didn't look like they were used anywhere.

I think 2/3 of these changes are in treematch, but they span other files too.