### PR TITLE
Fix man-page for MPI_File_set_view

### DIFF
--- a/ompi/mpi/man/man3/MPI_File_set_view.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_view.3in
@@ -112,7 +112,7 @@ The
 displacement argument specifies the position (absolute offset in
 bytes from the beginning of the file) where the view begins.
 .sp
-The MPI_File_set_view interface allows the user to pass a data-representation string to MPI I/O via the \fIdatarep\fP argument. To obtain the default value (or "native"), pass NULL. The user can also pass information via the \fIinfo\fP argument. See the HINTS section for a list of hints that can be set. For more information, see the MPI-2 standard.
+The MPI_File_set_view interface allows the user to pass a data-representation string to MPI I/O via the \fIdatarep\fP argument. To obtain the default value pass the value "native". The user can also pass information via the \fIinfo\fP argument. See the HINTS section for a list of hints that can be set. For more information, see the MPI-2 standard.
 
 .SH HINTS
 .ft R


### PR DESCRIPTION
The datarep may not be NULL, as check was added in ba955883329.

Signed-off-by: Rainer Keller <rainer.keller@hs-esslingen.de>