### PR TITLE
[v4.1.x] ompi : add memory barrier in PMIx registration callback

### DIFF
--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -229,6 +229,7 @@ void ompi_errhandler_registration_callback(int status,
 
     default_errhandler_id = errhandler_ref;
     errtrk->status = status;
+    opal_atomic_wmb();
     errtrk->active = false;
 }
 

--- a/ompi/interlib/interlib.c
+++ b/ompi/interlib/interlib.c
@@ -52,6 +52,7 @@ static void model_registration_callback(int status,
 
     trk->status = status;
     interlibhandler_id = errhandler_ref;
+    opal_atomic_wmb();
     trk->active = false;
 }
 static void model_callback(int status,


### PR DESCRIPTION
PMIx reigstration callback functions are used when regitering PMIx
event handler.

This patch adjusts two such callback functions:

```c
    model_registration_callback()
         in ompi/interlib/interlib.c and

    ompi_errhandler_registration_callback()
         in ompi/errhandler/errhandler.c
```

Both of them employes the following code structure:

```c
static void xxx_callback(int status,
			 size_t errhandler_ref,
			 void *cbdata)
{
    myreg_t *trk = (myreg_t*)cbdata;

    trk->status = status;
    interlibhandler_id = errhandler_ref;
    trk->active = false;
}
```

The workflow is:

1. caller will call opal_pmix.register_evhandler() with
   callback function as an argument.
2. caller will call OMPI_LAZY_WAIT_FOR_COMPLETION(trk.active)
   to wait for trk->active to became false,
3. PMIx do the registration on anther thread, then call the
   registration callback function, which will set trk->active
   to false.
4. caller check trk->status to determine whether registration
   succeeded.

The expected behavior of the registration callback functions therefore
is that trk->status be updated first, then trk->active be set to false.

However, on ARM based systems, the expected behavior is not guaranteed
because ARM uses a relaxed memory model.

To address this issue, this patch added a call to opal_atomic_wmb()
(write memory barrier) after trk->status being set, to achieve the
expected behavior.

Signed-off-by: Wei Zhang <wzam@amazon.com>

Refs #8274 