### PR TITLE
do not include automatically generated file into the dist tarball

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -62,8 +62,9 @@ libforce_usempif08_internal_modules_to_be_built_la_SOURCES = \
         pmpi-f08-interfaces.F90 \
         mpi-f08-interfaces-callbacks.F90
 
-noinst_HEADERS = mpi-f08-interfaces.h mpi-f08-rename.h
+nodist_noinst_HEADERS = mpi-f08-interfaces.h
 
+noinst_HEADERS = mpi-f08-rename.h
 
 libforce_usempi_internal_modules_to_be_built.la: libusempif08_internal_modules.la
 

--- a/ompi/mpiext/shortfloat/c/Makefile.am
+++ b/ompi/mpiext/shortfloat/c/Makefile.am
@@ -14,4 +14,4 @@
 ompidir = $(ompiincludedir)/mpiext
 
 # This is the header file that is installed.
-ompi_HEADERS = mpiext_shortfloat_c.h
+nodist_ompi_HEADERS = mpiext_shortfloat_c.h

--- a/ompi/mpiext/shortfloat/mpif-h/Makefile.am
+++ b/ompi/mpiext/shortfloat/mpif-h/Makefile.am
@@ -13,13 +13,13 @@ ompidir = $(ompiincludedir)/mpiext
 
 # Just like noinst_LTLIBRARIES, set this macro to empty and
 # conditionally add to it later.
-ompi_HEADERS =
+nodist_ompi_HEADERS =
 
 # Use the Automake conditional to know if we're building the mpif.h
 # bindings.
 if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
 
 # This is the header file that is installed.
-ompi_HEADERS += mpiext_shortfloat_mpifh.h
+nodist_ompi_HEADERS += mpiext_shortfloat_mpifh.h
 
 endif

--- a/ompi/mpiext/shortfloat/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/shortfloat/use-mpi-f08/Makefile.am
@@ -20,6 +20,6 @@ if OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS
 # mpiext_shortfloat_usempif08.h is automatically slurped up into the
 # mpi_f08_ext module.  It must be listed so that it is included in
 # dist tarballs.
-noinst_HEADERS = mpiext_shortfloat_usempif08.h
+nodist_noinst_HEADERS = mpiext_shortfloat_usempif08.h
 
 endif


### PR DESCRIPTION
 - ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h
 - ompi/mpiext/shortfloat/c/mpiext_shortfloat_c.h
 - ompi/mpiext/shortfloat/mpif-h/mpiext_shortfloat_mpifh.h
 - ompi/mpiext/shortfloat/use-mpi-f08/mpiext_shortfloat_usempif08.h

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>