### PR TITLE
coll/base/coll_base_scatter.c: fix binomial tree algorithm

### DIFF
--- a/ompi/mca/coll/base/coll_base_scatter.c
+++ b/ompi/mca/coll/base/coll_base_scatter.c
@@ -129,8 +129,8 @@ ompi_coll_base_scatter_intra_binomial(
         /* non-root, non-leaf nodes, allocate temp buffer for recv
          * the most we need is rcount*size/2 */
         ompi_datatype_type_extent(rdtype, &rextent);
-        rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * size, &rgap);
-        tempbuf = (char *)malloc(rsize / 2);
+        rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * size / 2, &rgap);
+        tempbuf = (char *)malloc(rsize);
         if (NULL == tempbuf) {
             err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto err_hndl;
         }


### PR DESCRIPTION
Binomial tree algorithm allocates too small temporary buffer tempbuf for the non-contiguous derived datatype rdtype. Reproducer:

```c
#include <stdio.h>
#include <stdlib.h>
#include <mpi.h>
#include <string.h>

#define MCW MPI_COMM_WORLD

int main(int argc, char *argv[])
{
    int rank, commsize;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MCW, &commsize);
    MPI_Comm_rank(MCW, &rank);

    int m = 4;
    int n = commsize * 2;
    int count = 2;
    
    double *sbuf = malloc(m * n * sizeof(*sbuf));
    double *rbuf = malloc(m * n * sizeof(*rbuf));

    MPI_Datatype rvec_, rvec;
    MPI_Type_vector(m, 1, n, MPI_DOUBLE, &rvec_);
    MPI_Type_commit(&rvec_);
    MPI_Type_create_resized(rvec_, 0, sizeof(*rbuf), &rvec);
    MPI_Type_commit(&rvec);

    MPI_Scatter(sbuf, m * count, MPI_DOUBLE, rbuf, count, rvec, 0, MCW);
    
    MPI_Type_free(&rvec_);
    MPI_Type_free(&rvec);
    
    if (sbuf != NULL)
        free(sbuf);
    if (rbuf != NULL)
        free(rbuf);
    MPI_Finalize();
    return 0;
}
```

Signed-off-by: sadcat11 <destructivecoyote@gmail.com>

Refs #8285