### PR TITLE
brew: hack for building under brew

### DIFF
--- a/ompi/mca/op/avx/Makefile.am
+++ b/ompi/mca/op/avx/Makefile.am
@@ -20,6 +20,8 @@
 # First, list all .h and .c sources.  It is necessary to list all .h
 # files so that they will be picked up in the distribution tarball.
 
+SUBDIRS = sub
+
 sources = op_avx_component.c op_avx.h
 sources_extended = op_avx_functions.c
 

--- a/ompi/mca/op/avx/configure.m4
+++ b/ompi/mca/op/avx/configure.m4
@@ -19,7 +19,7 @@
 # ------------------------------------------------
 # We can always build, unless we were explicitly disabled.
 AC_DEFUN([MCA_ompi_op_avx_CONFIG],[
-    AC_CONFIG_FILES([ompi/mca/op/avx/Makefile])
+    AC_CONFIG_FILES([ompi/mca/op/avx/Makefile ompi/mca/op/avx/sub/Makefile])
 
     MCA_BUILD_OP_AVX_FLAGS=""
     MCA_BUILD_OP_AVX2_FLAGS=""

--- a/ompi/mca/op/avx/sub/Makefile.am
+++ b/ompi/mca/op/avx/sub/Makefile.am
@@ -1,0 +1,20 @@
+noinst_LTLIBRARIES =
+
+if MCA_BUILD_ompi_op_has_avx2_support
+noinst_LTLIBRARIES += libfoo.la
+nodist_libfoo_la_SOURCES = foo.c
+foo.c:
+	cd .. && env HOMEBREW_ARCHFLAGS=@MCA_BUILD_OP_AVX2_FLAGS@ make liblocal_ops_avx2.la
+	touch foo.c
+endif
+
+if MCA_BUILD_ompi_op_has_avx512_support
+noinst_LTLIBRARIES += libbar.la
+nodist_libbar_la_SOURCES = bar.c
+bar.c:
+	cd .. && env HOMEBREW_ARCHFLAGS=@MCA_BUILD_OP_AVX512_FLAGS@ make liblocal_ops_avx512.la
+	touch bar.c
+endif
+
+clean-local:
+	rm -f foo.c bar.c


### PR DESCRIPTION
-march=... currently works at configure time, but is replaced
with -march=nehalem at build time under brew's superenv.

This causes Open MPI build to fail under brew.

This commit does pass the -march=... option that worked at configure time
via the HOMEBREW_ARCHFLAGS environment variable.

This is a bit hacky, but less suboptimal than simply not building
the op/avx component (e.g. configure --enable-mca-no-build=op-avx)

The suspicious superenv behavior has been reported at Homebrew/brew#10078.

Refs. open-mpi/ompi#8306

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>