### PR TITLE
Use reference-counted immutable strings with info objects

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -492,7 +492,7 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
 }
 
 #define OMPI_COMM_SET_INFO_FN(name, flag)       \
-    static char *ompi_comm_set_ ## name (opal_infosubscriber_t *obj, char *key, char *value) \
+    static const char *ompi_comm_set_ ## name (opal_infosubscriber_t *obj, const char *key, const char *value) \
     {                                                                   \
         ompi_communicator_t *comm = (ompi_communicator_t *) obj;        \
                                                                         \

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -714,7 +714,10 @@ static int dpm_convert(opal_list_t *infos,
                if (0 != strncasecmp(ck, directive, strlen(directive))) {
                     opal_asprintf(&help_str, "Conflicting directives \"%s %s\"", ck, directive);
 #if PMIX_NUMERIC_VERSION >= 0x00040000
-                    attr = PMIx_Get_attribute_string(option);
+                    /* TODO: remove strdup if PMIx_Get_attribute_string takes const char* */
+                    char *option_dup = strdup(option);
+                    attr = PMIx_Get_attribute_string(option_dup);
+                    free(option_dup);
 #else
                     attr = option;
 #endif
@@ -745,8 +748,10 @@ static int dpm_convert(opal_list_t *infos,
                         /* we have a conflict */
                         opal_asprintf(&ptr, "  Option %s\n  Conflicting modifiers \"%s %s\"", option, infokey, modifier);
 #if PMIX_NUMERIC_VERSION >= 0x00040000
-                        /* TODO: this triggers a const warning :/ */
-                        attr = PMIx_Get_attribute_string(option);
+                        /* TODO: remove strdup if PMIx_Get_attribute_string takes const char* */
+                        char *option_dup = strdup(option);
+                        attr = PMIx_Get_attribute_string(option_dup);
+                        free(option_dup);
 #else
                         attr = option;
 #endif

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -654,7 +654,7 @@ static dpm_conflicts_t bindto_modifiers[] = {
     {.name = ""}
 };
 
-static int check_modifiers(char *modifier, char **checks, dpm_conflicts_t *conflicts)
+static int check_modifiers(const char *modifier, char **checks, dpm_conflicts_t *conflicts)
 {
     int n, m, k;
 
@@ -674,10 +674,10 @@ static int check_modifiers(char *modifier, char **checks, dpm_conflicts_t *confl
 }
 
 static int dpm_convert(opal_list_t *infos,
-                       char *infokey,
-                       char *option,
-                       char *directive,
-                       char *modifier,
+                       const char *infokey,
+                       const char *option,
+                       const char *directive,
+                       const char *modifier,
                        bool deprecated)
 {
     opal_info_item_t *iptr;
@@ -745,6 +745,7 @@ static int dpm_convert(opal_list_t *infos,
                         /* we have a conflict */
                         opal_asprintf(&ptr, "  Option %s\n  Conflicting modifiers \"%s %s\"", option, infokey, modifier);
 #if PMIX_NUMERIC_VERSION >= 0x00040000
+                        /* TODO: this triggers a const warning :/ */
                         attr = PMIx_Get_attribute_string(option);
 #else
                         attr = option;
@@ -805,14 +806,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
     int rc, i, j;
     int have_wdir=0;
     int flag=0;
-    char cwd[OPAL_PATH_MAX];
-    char host[OPAL_MAX_INFO_VAL];  /*** should define OMPI_HOST_MAX ***/
-    char init_errh[OPAL_MAX_INFO_VAL];
-    char prefix[OPAL_MAX_INFO_VAL];
-    char stdin_target[OPAL_MAX_INFO_VAL];
-    char params[OPAL_MAX_INFO_VAL];
-    char mapper[OPAL_MAX_INFO_VAL];
-    char slot_list[OPAL_MAX_INFO_VAL];
+    opal_cstring_t *info_str;
     uint32_t ui32;
     bool personality = false;
     char *tmp;
@@ -908,33 +902,36 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
         if ( array_of_info != NULL && array_of_info[i] != MPI_INFO_NULL ) {
 
             /* check for personality - this is a job-level key */
-            ompi_info_get (array_of_info[i], "personality", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "personality", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_PERSONALITY */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "personality", "PMIX_PERSONALITY");
                 personality = true;
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_PERSONALITY", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_PERSONALITY", &info_str, &flag);
             if ( flag ) {
                 personality = true;
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_PERSONALITY");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 personality = true;
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PERSONALITY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
@@ -943,68 +940,75 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
              * MPI standard ch. 10.3.4 */
 
             /* check for 'host' */
-            ompi_info_get (array_of_info[i], "host", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "host", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&dash_host, host);
+                opal_argv_append_nosize(&dash_host, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_HOST", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_HOST", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&dash_host, host);
+                opal_argv_append_nosize(&dash_host, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_HOST");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&dash_host, host);
+                opal_argv_append_nosize(&dash_host, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'wdir' */
-            ompi_info_get (array_of_info[i], "wdir", sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], "wdir", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 have_wdir = 1;
             }
-            ompi_info_get (array_of_info[i], "PMIX_WDIR", sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_WDIR", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 have_wdir = 1;
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_WDIR");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_WDIR, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 have_wdir = 1;
                 continue;
             }
 #endif
 
             /* check for 'mpi_initial_errhandler' */
-            ompi_info_get (array_of_info[i], "mpi_initial_errhandler", sizeof(init_errh) - 1, init_errh, &flag);
+            ompi_info_get (array_of_info[i], "mpi_initial_errhandler", &info_str, &flag);
             if ( flag ) {
                 /* this is set as an environment because it must be available
                  * before pmix_init */
-                opal_setenv("OMPI_MCA_mpi_initial_errhandler", init_errh, true, &app->env);
+                opal_setenv("OMPI_MCA_mpi_initial_errhandler", info_str->string, true, &app->env);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 
@@ -1018,108 +1022,119 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
              * deprecated in the non-prefixed form */
 
             /* check for 'hostfile' */
-            ompi_info_get (array_of_info[i], "hostfile", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "hostfile", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&hostfiles, host);
+                opal_argv_append_nosize(&hostfiles, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_HOSTFILE", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_HOSTFILE", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&hostfiles, host);
+                opal_argv_append_nosize(&hostfiles, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_HOSTFILE");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
-                opal_argv_append_nosize(&hostfiles, host);
+                opal_argv_append_nosize(&hostfiles, info_str->string);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'add-hostfile' */
-            ompi_info_get (array_of_info[i], "add-hostfile", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "add-hostfile", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_ADD_HOSTFILE */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "add-hostfile", "PMIX_ADD_HOSTFILE");
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_ADD_HOSTFILE", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_ADD_HOSTFILE", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_ADD_HOSTFILE");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOSTFILE, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'add-host' */
-            ompi_info_get (array_of_info[i], "add-host", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "add-host", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_ADD_HOST */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "add-host", "PMIX_ADD_HOST");
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_ADD_HOST", sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_ADD_HOST", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_ADD_HOST");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(host) - 1, host, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, host, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_ADD_HOST, info_str->string, PMIX_STRING);
                 opal_list_append(&app_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for env */
-            ompi_info_get (array_of_info[i], "env", sizeof(host)-1, host, &flag);
+            ompi_info_get (array_of_info[i], "env", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_ENVAR */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "env", "PMIX_ENVAR");
-                envars = opal_argv_split(host, '\n');
+                envars = opal_argv_split(info_str->string, '\n');
+                OBJ_RELEASE(info_str);
                 for (j=0; NULL != envars[j]; j++) {
                     opal_argv_append_nosize(&app->env, envars[j]);
                 }
                 opal_argv_free(envars);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_ENVAR", sizeof(host)-1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_ENVAR", &info_str, &flag);
             if ( flag ) {
-                envars = opal_argv_split(host, '\n');
+                envars = opal_argv_split(info_str->string, '\n');
+                OBJ_RELEASE(info_str);
                 for (j=0; NULL != envars[j]; j++) {
                     opal_argv_append_nosize(&app->env, envars[j]);
                 }
@@ -1128,9 +1143,10 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_ENVAR");
-            ompi_info_get (array_of_info[i], "PMIX_ENVAR", sizeof(host)-1, host, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_ENVAR", &info_str, &flag);
             if ( flag ) {
-                envars = opal_argv_split(host, '\n');
+                envars = opal_argv_split(info_str->string, '\n');
+                OBJ_RELEASE(info_str);
                 for (j=0; NULL != envars[j]; j++) {
                     opal_argv_append_nosize(&app->env, envars[j]);
                 }
@@ -1144,59 +1160,65 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
              *
              * This is a job-level key
              */
-            ompi_info_get (array_of_info[i], "ompi_prefix", sizeof(prefix) - 1, prefix, &flag);
+            ompi_info_get (array_of_info[i], "ompi_prefix", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_PREFIX */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "ompi_prefix", "PMIX_PREFIX");
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, prefix, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_PREFIX", sizeof(prefix) - 1, prefix, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_PREFIX", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, prefix, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_PREFIX");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(prefix) - 1, prefix, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, prefix, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PREFIX, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'mapper' - a job-level key */
-            ompi_info_get(array_of_info[i], "mapper", sizeof(mapper) - 1, mapper, &flag);
+            ompi_info_get(array_of_info[i], "mapper", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_MAPPER */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "mapper", "PMIX_MAPPER");
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, mapper, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get(array_of_info[i], "PMIX_MAPPER", sizeof(mapper) - 1, mapper, &flag);
+            ompi_info_get(array_of_info[i], "PMIX_MAPPER", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, mapper, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_MAPPER");
-            ompi_info_get(array_of_info[i], checkkey, sizeof(mapper) - 1, mapper, &flag);
+            ompi_info_get(array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, mapper, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_MAPPER, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
@@ -1222,11 +1244,12 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'npernode' and 'ppr' - job-level key */
-            ompi_info_get (array_of_info[i], "npernode", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get (array_of_info[i], "npernode", &info_str, &flag);
             if ( flag ) {
-                opal_asprintf(&tmp, "PPR:%s:NODE", slot_list);
+                opal_asprintf(&tmp, "PPR:%s:NODE", info_str->string);
                 rc = dpm_convert(&job_info, "npernode", PMIX_MAPBY, tmp, NULL, true);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1242,10 +1265,11 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 }
                 continue;
             }
-            ompi_info_get (array_of_info[i], "pernode", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get (array_of_info[i], "pernode", &info_str, &flag);
             if ( flag ) {
                 rc = dpm_convert(&job_info, "pernode", PMIX_MAPBY, "PPR:1:NODE", NULL, true);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1261,11 +1285,11 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 }
                 continue;
             }
-            ompi_info_get (array_of_info[i], "ppr", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get (array_of_info[i], "ppr", &info_str, &flag);
             if ( flag ) {
                 /* must have correct syntax with two colons */
-                if (NULL == (tmp = strchr(slot_list, ':'))) {
-                    opal_show_help("help-dpm.txt", "bad-ppr", true, slot_list);
+                if (NULL == (tmp = strchr(info_str->string, ':'))) {
+                    opal_show_help("help-dpm.txt", "bad-ppr", true, info_str->string);
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
                     PMIX_APP_FREE(apps, scount);
@@ -1276,11 +1300,12 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                     if (NULL != dash_host) {
                         opal_argv_free(dash_host);
                     }
+                    OBJ_RELEASE(info_str);
                     return MPI_ERR_SPAWN;
                 }
                 ++tmp; // step over first colon
                 if (NULL == strchr(tmp, ':')) {
-                    opal_show_help("help-dpm.txt", "bad-ppr", true, slot_list);
+                    opal_show_help("help-dpm.txt", "bad-ppr", true, info_str->string);
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
                     PMIX_APP_FREE(apps, scount);
@@ -1291,10 +1316,12 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                     if (NULL != dash_host) {
                         opal_argv_free(dash_host);
                     }
+                    OBJ_RELEASE(info_str);
                     return MPI_ERR_SPAWN;
                 }
-                rc = dpm_convert(&job_info, "ppr", PMIX_MAPBY, slot_list, NULL, true);
+                rc = dpm_convert(&job_info, "ppr", PMIX_MAPBY, info_str->string, NULL, true);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1312,10 +1339,11 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'map_by' - job-level key */
-            ompi_info_get(array_of_info[i], "map_by", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "map_by", &info_str, &flag);
             if ( flag ) {
-                rc = dpm_convert(&job_info, "map_by", PMIX_MAPBY, slot_list, NULL, false);
+                rc = dpm_convert(&job_info, "map_by", PMIX_MAPBY, info_str->string, NULL, false);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1331,29 +1359,32 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 }
                 continue;
             }
-            ompi_info_get(array_of_info[i], "PMIX_MAPBY", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "PMIX_MAPBY", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_MAPBY, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_MAPBY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_MAPBY");
-            ompi_info_get(array_of_info[i], checkkey, sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_MAPBY, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_MAPBY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'rank_by' - job-level key */
-            ompi_info_get(array_of_info[i], "rank_by", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "rank_by", &info_str, &flag);
             if ( flag ) {
-                rc = dpm_convert(&job_info, "rank_by", PMIX_RANKBY, slot_list, NULL, false);
+                rc = dpm_convert(&job_info, "rank_by", PMIX_RANKBY, info_str->string, NULL, false);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1363,29 +1394,32 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 }
                 continue;
             }
-            ompi_info_get(array_of_info[i], "PMIX_RANKBY", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "PMIX_RANKBY", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_RANKBY, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_RANKBY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_RANKBY");
-            ompi_info_get(array_of_info[i], checkkey, sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_RANKBY, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_RANKBY, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
 
             /* check for 'bind_to' - job-level key */
-            ompi_info_get(array_of_info[i], "bind_to", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "bind_to", &info_str, &flag);
             if ( flag ) {
-                rc = dpm_convert(&job_info, "bind_to", PMIX_BINDTO, slot_list, NULL, false);
+                rc = dpm_convert(&job_info, "bind_to", PMIX_BINDTO, info_str->string, NULL, false);
                 free(tmp);
+                OBJ_RELEASE(info_str);
                 if (OMPI_SUCCESS != rc) {
                     OPAL_LIST_DESTRUCT(&job_info);
                     OPAL_LIST_DESTRUCT(&app_info);
@@ -1395,20 +1429,22 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 }
                 continue;
             }
-            ompi_info_get(array_of_info[i], "PMIX_BINDTO", sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], "PMIX_BINDTO", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_BINDTO, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_BINDTO, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_BINDTO");
-            ompi_info_get(array_of_info[i], checkkey, sizeof(slot_list) - 1, slot_list, &flag);
+            ompi_info_get(array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_BINDTO, slot_list, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_BINDTO, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
@@ -1443,30 +1479,33 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
 #endif
 
             /* check for 'preload_files' - job-level key */
-            ompi_info_get (array_of_info[i], "ompi_preload_files", sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], "ompi_preload_files", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_PRELOAD_FILES */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "ompi_preload_files", "PMIX_PRELOAD_FILES");
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_PRELOAD_FILES", sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_PRELOAD_FILES", &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_PRELOAD_FILES");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(cwd) - 1, cwd, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_info_item_t);
-                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, cwd, PMIX_STRING);
+                PMIX_INFO_LOAD(&info->info, PMIX_PRELOAD_FILES, info_str->string, PMIX_STRING);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
@@ -1482,61 +1521,65 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* see if this is an MCA param that the user wants applied to the child job */
-            ompi_info_get (array_of_info[i], "ompi_param", sizeof(params) - 1, params, &flag);
+            ompi_info_get (array_of_info[i], "ompi_param", &info_str, &flag);
             if ( flag ) {
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "ompi_param", "PMIX_ENVAR");
-                opal_argv_append_unique_nosize(&app->env, params, true);
+                opal_argv_append_unique_nosize(&app->env, info_str->string, true);
+                OBJ_RELEASE(info_str);
             }
 
             /* see if user specified what to do with stdin - defaults to
              * not forwarding stdin to child processes - job-level key
              */
-            ompi_info_get (array_of_info[i], "ompi_stdin_target", sizeof(stdin_target) - 1, stdin_target, &flag);
+            ompi_info_get (array_of_info[i], "ompi_stdin_target", &info_str, &flag);
             if ( flag ) {
                 /* deprecate --> PMIX_STDIN_TGT */
                 opal_show_help("help-dpm.txt", "deprecated-converted", true,
                                 "ompi_stdin_target", "PMIX_STDIN_TGT");
-                if (0 == strcmp(stdin_target, "all")) {
+                if (0 == strcmp(info_str->string, "all")) {
                     ui32 = OPAL_VPID_WILDCARD;
-                } else if (0 == strcmp(stdin_target, "none")) {
+                } else if (0 == strcmp(info_str->string, "none")) {
                     ui32 = OPAL_VPID_INVALID;
                 } else {
-                    ui32 = strtoul(stdin_target, NULL, 10);
+                    ui32 = strtoul(info_str->string, NULL, 10);
                 }
                 info = OBJ_NEW(opal_info_item_t);
                 PMIX_INFO_LOAD(&info->info, PMIX_STDIN_TGT, &ui32, PMIX_UINT32);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
-            ompi_info_get (array_of_info[i], "PMIX_STDIN_TGT", sizeof(stdin_target) - 1, stdin_target, &flag);
+            ompi_info_get (array_of_info[i], "PMIX_STDIN_TGT", &info_str, &flag);
             if ( flag ) {
-                if (0 == strcmp(stdin_target, "all")) {
+                if (0 == strcmp(info_str->string, "all")) {
                     ui32 = OPAL_VPID_WILDCARD;
-                } else if (0 == strcmp(stdin_target, "none")) {
+                } else if (0 == strcmp(info_str->string, "none")) {
                     ui32 = OPAL_VPID_INVALID;
                 } else {
-                    ui32 = strtoul(stdin_target, NULL, 10);
+                    ui32 = strtoul(info_str->string, NULL, 10);
                 }
                 info = OBJ_NEW(opal_info_item_t);
                 PMIX_INFO_LOAD(&info->info, PMIX_STDIN_TGT, &ui32, PMIX_UINT32);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #if PMIX_NUMERIC_VERSION >= 0x00040000
             checkkey = PMIx_Get_attribute_string("PMIX_STDIN_TGT");
-            ompi_info_get (array_of_info[i], checkkey, sizeof(stdin_target) - 1, stdin_target, &flag);
+            ompi_info_get (array_of_info[i], checkkey, &info_str, &flag);
             if ( flag ) {
-                if (0 == strcmp(stdin_target, "all")) {
+                if (0 == strcmp(info_str->string, "all")) {
                     ui32 = OPAL_VPID_WILDCARD;
-                } else if (0 == strcmp(stdin_target, "none")) {
+                } else if (0 == strcmp(info_str->string, "none")) {
                     ui32 = OPAL_VPID_INVALID;
                 } else {
-                    ui32 = strtoul(stdin_target, NULL, 10);
+                    ui32 = strtoul(info_str->string, NULL, 10);
                 }
                 info = OBJ_NEW(opal_info_item_t);
                 PMIX_INFO_LOAD(&info->info, PMIX_STDIN_TGT, &ui32, PMIX_UINT32);
                 opal_list_append(&job_info, &info->super);
+                OBJ_RELEASE(info_str);
                 continue;
             }
 #endif
@@ -1546,6 +1589,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
          * executable, we assume the current working directory
          */
         if ( !have_wdir ) {
+            char cwd[OPAL_PATH_MAX];
             if (OMPI_SUCCESS != (rc = opal_getcwd(cwd, OPAL_PATH_MAX))) {
                 OMPI_ERROR_LOG(rc);
                 PMIX_APP_FREE(apps, (size_t)count);

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -224,10 +224,10 @@ int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
 {
     return opal_info_set_value_enum (&(info->super), key, value, var_enum);
 }
-int ompi_info_get (ompi_info_t *info, const char *key, int valuelen,
-                   char *value, int *flag)
+int ompi_info_get (ompi_info_t *info, const char *key,
+                   opal_cstring_t **value, int *flag)
 {
-    return opal_info_get (&(info->super), key, valuelen, value, flag);
+    return opal_info_get (&(info->super), key, value, flag);
 }
 int ompi_info_get_value_enum (ompi_info_t *info, const char *key, int *value,
                               int default_value, mca_base_var_enum_t *var_enum,
@@ -247,7 +247,7 @@ int ompi_info_get_valuelen (ompi_info_t *info, const char *key, int *valuelen,
 {
     return opal_info_get_valuelen (&(info->super), key, valuelen, flag);
 }
-int ompi_info_get_nthkey (ompi_info_t *info, int n, char *key) {
+int ompi_info_get_nthkey (ompi_info_t *info, int n, opal_cstring_t **key) {
     return opal_info_get_nthkey (&(info->super), n, key);
 }
 int ompi_info_get_nkeys(ompi_info_t *info, int *nkeys)
@@ -304,8 +304,8 @@ int ompi_mpiinfo_finalize(void)
                          item = opal_list_get_next(item)) {
                         entry = (opal_info_entry_t *) item;
                         opal_output(0, "WARNING:   key=\"%s\", value=\"%s\"",
-                                    entry->ie_key,
-                                    NULL != entry->ie_value ? entry->ie_value : "(null)");
+                                    entry->ie_key->string,
+                                    NULL != entry->ie_value ? entry->ie_value->string : "(null)");
                         found = true;
                     }
                 }

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -130,8 +130,8 @@ OMPI_DECLSPEC int ompi_info_get_value_enum (ompi_info_t *info, const char *key,
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */
-OMPI_DECLSPEC int ompi_info_get (ompi_info_t *info, const char *key, int valuelen,
-                                 char *value, int *flag);
+OMPI_DECLSPEC int ompi_info_get (ompi_info_t *info, const char *key,
+                                 opal_cstring_t **value, int *flag);
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */
@@ -144,7 +144,7 @@ OMPI_DECLSPEC int ompi_info_get_valuelen (ompi_info_t *info, const char *key, in
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */
-OMPI_DECLSPEC int ompi_info_get_nthkey (ompi_info_t *info, int n, char *key);
+OMPI_DECLSPEC int ompi_info_get_nthkey (ompi_info_t *info, int n, opal_cstring_t **key);
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -348,7 +348,6 @@ static opal_list_t *check_components(opal_list_t * components,
     mca_coll_base_module_t *module;
     opal_list_t *selectable;
     mca_coll_base_avail_coll_t *avail;
-    char info_val[OPAL_MAX_INFO_VAL+1];
     char **coll_argv = NULL, **coll_exclude = NULL, **coll_include = NULL;
 
     /* Check if this communicator comes with restrictions on the collective modules
@@ -360,12 +359,14 @@ static opal_list_t *check_components(opal_list_t * components,
      * force a change in the component priority.
      */
     if( NULL != comm->super.s_info) {
+        opal_cstring_t *info_str;
         opal_info_get(comm->super.s_info, "ompi_comm_coll_preference",
-                      sizeof(info_val), info_val, &flag);
+                      &info_str, &flag);
         if( !flag ) {
             goto proceed_to_select;
         }
-        coll_argv = opal_argv_split(info_val, ',');
+        coll_argv = opal_argv_split(info_str->string, ',');
+        OBJ_RELEASE(info_str);
         if(NULL == coll_argv) {
             goto proceed_to_select;
         }

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -225,15 +225,17 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
         char info_val[OPAL_MAX_INFO_VAL+1];
 
         /* Get the info value disaqualifying coll components */
+        opal_cstring_t *info_str;
         opal_info_get(comm->super.s_info, "ompi_comm_coll_han_topo_level",
-                      sizeof(info_val), info_val, &flag);
+                      &info_str, &flag);
 
         if (flag) {
-            if (0 == strcmp(info_val, "INTER_NODE")) {
+            if (0 == strcmp(info_str->string, "INTER_NODE")) {
                 han_module->topologic_level = INTER_NODE;
             } else {
                 han_module->topologic_level = INTRA_NODE;
             }
+            OBJ_RELEASE(info_str);
         }
     }
 

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -415,7 +415,7 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
 {
 
    if (NULL != fh) {
-       char char_stripe[MPI_MAX_INFO_VAL];
+       opal_cstring_t *stripe_str;
        ompi_datatype_t *types[2];
        int blocklen[2] = {1, 1};
        ptrdiff_t d[2], base;
@@ -426,11 +426,12 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
        fh->f_flags = 0;
        
        fh->f_bytes_per_agg = OMPIO_MCA_GET(fh, bytes_per_agg);
-       opal_info_get (fh->f_info, "cb_buffer_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+       opal_info_get (fh->f_info, "cb_buffer_size", &stripe_str, &flag);
        if ( flag ) {
            /* Info object trumps mca parameter value */
-           sscanf ( char_stripe, "%d", &fh->f_bytes_per_agg  );
-           OMPIO_MCA_PRINT_INFO(fh, "cb_buffer_size", char_stripe, "");
+           sscanf ( stripe_str->string, "%d", &fh->f_bytes_per_agg  );
+           OMPIO_MCA_PRINT_INFO(fh, "cb_buffer_size", stripe_str->string, "");
+           OBJ_RELEASE(stripe_str);
        }
 
        fh->f_atomicity = 0;

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -220,19 +220,21 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
        }
     }
 
-    char char_stripe[MPI_MAX_INFO_VAL];
+    opal_cstring_t *stripe_str;
     /* Check the info object set during File_open */
-    opal_info_get (fh->f_info, "cb_nodes", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (fh->f_info, "cb_nodes", &stripe_str, &flag);
     if ( flag ) {
-        sscanf ( char_stripe, "%d", &num_cb_nodes );
-        OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", char_stripe, "");
+        sscanf ( stripe_str->string, "%d", &num_cb_nodes );
+        OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
+        OBJ_RELEASE(stripe_str);
     }
     else {
         /* Check the info object set during file_set_view */
-        opal_info_get (info, "cb_nodes", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        opal_info_get (info, "cb_nodes", &stripe_str, &flag);
         if ( flag ) {
-            sscanf ( char_stripe, "%d", &num_cb_nodes );
-            OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", char_stripe, "");
+            sscanf ( stripe_str->string, "%d", &num_cb_nodes );
+            OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
+            OBJ_RELEASE(stripe_str);
         }
     }
         
@@ -323,23 +325,25 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     }
 
     bool info_is_set=false;
-    opal_info_get (fh->f_info, "collective_buffering", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (fh->f_info, "collective_buffering", &stripe_str, &flag);
     if ( flag ) {
-        if ( strncmp ( char_stripe, "false", sizeof("true") )){
+        if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
             info_is_set = true;
-            OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", char_stripe, "enforcing using individual fcoll component");
+            OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "enforcing using individual fcoll component");
         } else {
-            OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", char_stripe, "");
+            OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
         }
+        OBJ_RELEASE(stripe_str);
     } else {
-        opal_info_get (info, "collective_buffering", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        opal_info_get (info, "collective_buffering", &stripe_str, &flag);
         if ( flag ) {
-            if ( strncmp ( char_stripe, "false", sizeof("true") )){
+            if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
                 info_is_set = true;
-                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", char_stripe, "enforcing using individual fcoll component");
+                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "enforcing using individual fcoll component");
             } else {
-                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", char_stripe, "");
+                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
             }
+            OBJ_RELEASE(stripe_str);
         }
     }
 

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -69,21 +69,23 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     int flag;
     int fs_lustre_stripe_size = -1;
     int fs_lustre_stripe_width = -1;
-    char char_stripe[MPI_MAX_INFO_KEY];
+    opal_cstring_t *stripe_str;
 
     struct lov_user_md *lump=NULL;
 
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", &stripe_str, &flag);
     if ( flag ) {
-        sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
+        sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
+        OBJ_RELEASE(stripe_str);
     }
 
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", &stripe_str, &flag);
     if ( flag ) {
-        sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
+        sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
+        OBJ_RELEASE(stripe_str);
     }
 
     if (fs_lustre_stripe_size < 0) {

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -74,7 +74,7 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
     struct ompi_datatype_t *types[2] = {&ompi_mpi_int.dt, &ompi_mpi_byte.dt};
     int lens[2] = {1, sizeof(PVFS_object_ref)};
     ptrdiff_t offsets[2];
-    char char_stripe[MPI_MAX_INFO_KEY];
+    opal_cstring_t *stripe_str;
     int flag;
     int fs_pvfs2_stripe_size = -1;
     int fs_pvfs2_stripe_width = -1;
@@ -109,14 +109,16 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
        update mca_fs_pvfs2_stripe_width and mca_fs_pvfs2_stripe_size
        before calling fake_an_open() */
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", &stripe_str, &flag);
     if ( flag ) {
-        sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_size );
+        sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_size );
+        OBJ_RELEASE(stripe_str);
     }
 
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", &stripe_str, &flag);
     if ( flag ) {
-        sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_width );
+        sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_width );
+        OBJ_RELEASE(stripe_str);
     }
 
     if (fs_pvfs2_stripe_size < 0) {

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -81,7 +81,7 @@ static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, ompi_osc_rdma_mo
 static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_osc_rdma_module_t *module);
 static int ompi_osc_rdma_query_mtls (void);
 
-static char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, char *key, char *value);
+static const char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, const char *key, const char *value);
 
 static char *ompi_osc_rdma_btl_names;
 static char *ompi_osc_rdma_mtl_names;
@@ -1509,7 +1509,8 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
 }
 
 
-static char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, char *key, char *value)
+static const char*
+ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, const char *key, const char *value)
 {
 
     struct ompi_win_t *win = (struct ompi_win_t*) obj;

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -43,8 +43,8 @@ static int component_register (void);
 static int component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
                             struct ompi_communicator_t *comm, struct opal_info_t *info,
                             int flavor, int *model);
-static char* component_set_blocking_fence_info(opal_infosubscriber_t *obj, char *key, char *val);
-static char* component_set_alloc_shared_noncontig_info(opal_infosubscriber_t *obj, char *key, char *val);
+static const char* component_set_blocking_fence_info(opal_infosubscriber_t *obj, const char *key, const char *val);
+static const char* component_set_alloc_shared_noncontig_info(opal_infosubscriber_t *obj, const char *key, const char *val);
 
 
 ompi_osc_sm_component_t mca_osc_sm_component = {
@@ -561,8 +561,8 @@ ompi_osc_sm_set_info(struct ompi_win_t *win, struct opal_info_t *info)
 }
 
 
-static char*
-component_set_blocking_fence_info(opal_infosubscriber_t *obj, char *key, char *val)
+static const char*
+component_set_blocking_fence_info(opal_infosubscriber_t *obj, const char *key, const char *val)
 {
     ompi_osc_sm_module_t *module = (ompi_osc_sm_module_t*) ((struct ompi_win_t*) obj)->w_osc_module;
 /*
@@ -572,8 +572,8 @@ component_set_blocking_fence_info(opal_infosubscriber_t *obj, char *key, char *v
 }
 
 
-static char*
-component_set_alloc_shared_noncontig_info(opal_infosubscriber_t *obj, char *key, char *val)
+static const char*
+component_set_alloc_shared_noncontig_info(opal_infosubscriber_t *obj, const char *key, const char *val)
 {
 
     ompi_osc_sm_module_t *module = (ompi_osc_sm_module_t*) ((struct ompi_win_t*) obj)->w_osc_module;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -264,7 +264,7 @@ static void ompi_osc_ucx_unregister_progress()
     _osc_ucx_init_unlock();
 }
 
-static char* ompi_osc_ucx_set_no_lock_info(opal_infosubscriber_t *obj, char *key, char *value)
+static const char* ompi_osc_ucx_set_no_lock_info(opal_infosubscriber_t *obj, const char *key, const char *value)
 {
 
     struct ompi_win_t *win = (struct ompi_win_t*) obj;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -77,8 +77,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
     bool relaxed_order_flag=false;
     opal_info_t *info;
     int flag;
-    int valuelen;
-    char value[MPI_MAX_INFO_VAL+1];
+    opal_cstring_t *info_str;
     *priority = 0;
 
     /*test, and update priority*/
@@ -105,16 +104,16 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
     /* 2. Did the user specify MPI_INFO relaxed ordering flag? */
     info = fh->f_info;
     if ( info != &(MPI_INFO_NULL->super) ){
-        valuelen = MPI_MAX_INFO_VAL;
-        opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", valuelen, value, &flag);
+        opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", &info_str, &flag);
         if ( flag ) {
            if ( mca_sharedfp_individual_verbose ) {
                 opal_output(ompi_sharedfp_base_framework.framework_output,
                         "mca_sharedfp_individual_component_file_query: "
-                        "OMPIO_SHAREDFP_RELAXED_ORDERING=%s\n",value);
+                        "OMPIO_SHAREDFP_RELAXED_ORDERING=%s\n", info_str->string);
 	    }
             /* flag - Returns true if key defined, false if not (boolean). */
             relaxed_order_flag=true;
+            OBJ_RELEASE(info_str);
         }
         else {
             if ( mca_sharedfp_individual_verbose ) {

--- a/ompi/mpi/c/alloc_mem.c
+++ b/ompi/mpi/c/alloc_mem.c
@@ -46,8 +46,8 @@ static const char FUNC_NAME[] = "MPI_Alloc_mem";
 
 int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
 {
-    char info_value[MPI_MAX_INFO_VAL + 1];
-    char *mpool_hints = NULL;
+    opal_cstring_t *info_str = NULL;
+    const char *mpool_hints = NULL;
 
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
@@ -74,14 +74,19 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
 
     if (MPI_INFO_NULL != info) {
         int flag;
-        (void) ompi_info_get (info, "mpool_hints", MPI_MAX_INFO_VAL, info_value, &flag);
+        (void) ompi_info_get (info, "mpool_hints", &info_str, &flag);
         if (flag) {
-            mpool_hints = info_value;
+            mpool_hints = info_str->string;
         }
     }
 
     *((void **) baseptr) = mca_mpool_base_alloc ((size_t) size, (struct opal_info_t*)info,
                                                  mpool_hints);
+
+    if (NULL != info_str) {
+        OBJ_RELEASE(info_str);
+    }
+
     if (NULL == *((void **) baseptr)) {
         return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM,
                                       FUNC_NAME);

--- a/ompi/mpi/c/info_get.c
+++ b/ompi/mpi/c/info_get.c
@@ -29,6 +29,7 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
+#include "opal/util/string_copy.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -65,6 +66,7 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen,
 {
     int err;
     int key_length;
+    opal_cstring_t *info_str;
 
     /*
      * Simple function. All we need to do is search for the value
@@ -99,6 +101,11 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen,
         }
     }
 
-    err = ompi_info_get(info, key, valuelen, value, flag);
+    err = ompi_info_get(info, key, &info_str, flag);
+    if (*flag) {
+        opal_string_copy(value, info_str->string, valuelen+1);
+        OBJ_RELEASE(info_str);
+    }
+
     OMPI_ERRHANDLER_NOHANDLE_RETURN(err, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_nthkey.c
+++ b/ompi/mpi/c/info_get_nthkey.c
@@ -25,6 +25,7 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
+#include "opal/util/string_copy.h"
 #include <string.h>
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -89,6 +90,11 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
 
     /* Everything seems alright. Call the back end key copy */
 
-    err = ompi_info_get_nthkey (info, n, key);
+    opal_cstring_t *key_str = NULL;
+    err = ompi_info_get_nthkey (info, n, &key_str);
+    if (NULL != key_str) {
+        opal_string_copy(key, key_str->string, MPI_MAX_INFO_KEY);
+        OBJ_RELEASE(key);
+    }
     OMPI_ERRHANDLER_NOHANDLE_RETURN(err, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -48,7 +48,6 @@ static const char FUNC_NAME[] = "MPI_Lookup_name";
 
 int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
 {
-    char range[OPAL_MAX_INFO_VAL];
     int flag=0, ret;
     pmix_status_t rc;
     pmix_pdata_t pdat;
@@ -75,17 +74,19 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
     /* OMPI supports info keys to pass the range to
      * be searched for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        opal_cstring_t *info_str;
+        ompi_info_get (info, "range", &info_str, &flag);
         if (flag) {
-            if (0 == strcmp(range, "nspace")) {
+            if (0 == strcmp(info_str->string, "nspace")) {
                 rng = PMIX_RANGE_NAMESPACE;  // share only with procs in same nspace
-            } else if (0 == strcmp(range, "session")) {
+            } else if (0 == strcmp(info_str->string, "session")) {
                 rng = PMIX_RANGE_SESSION; // share only with procs in same session
             } else {
                 /* unrecognized scope */
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
                                             FUNC_NAME);
             }
+            OBJ_RELEASE(info_str);
         }
     }
     PMIX_INFO_LOAD(&pinfo, PMIX_RANGE, &rng, PMIX_DATA_RANGE);

--- a/ompi/mpi/c/publish_name.c
+++ b/ompi/mpi/c/publish_name.c
@@ -49,7 +49,7 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
                      const char *port_name)
 {
     int ret;
-    char range[OPAL_MAX_INFO_VAL];
+    opal_cstring_t *info_str;
     int flag=0;
     pmix_status_t rc;
     pmix_info_t pinfo[3];
@@ -76,33 +76,35 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
     /* OMPI supports info keys to pass the range and persistence to
      * be used for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        ompi_info_get (info, "range", &info_str, &flag);
         if (flag) {
-            if (0 == strcmp(range, "nspace")) {
+            if (0 == strcmp(info_str->string, "nspace")) {
                 rng = PMIX_RANGE_NAMESPACE;  // share only with procs in same nspace
-            } else if (0 == strcmp(range, "session")) {
+            } else if (0 == strcmp(info_str->string, "session")) {
                 rng = PMIX_RANGE_SESSION; // share only with procs in same session
             } else {
                 /* unrecognized scope */
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
                                             FUNC_NAME);
             }
+            OBJ_RELEASE(info_str);
         }
-        ompi_info_get (info, "persistence", sizeof(range) - 1, range, &flag);
+        ompi_info_get (info, "persistence", &info_str, &flag);
         if (flag) {
-            if (0 == strcmp(range, "indef")) {
+            if (0 == strcmp(info_str->string, "indef")) {
                 pers = PMIX_PERSIST_INDEF;   // retain until specifically deleted
-            } else if (0 == strcmp(range, "proc")) {
+            } else if (0 == strcmp(info_str->string, "proc")) {
                 pers = PMIX_PERSIST_PROC;    // retain until publishing process terminates
-            } else if (0 == strcmp(range, "app")) {
+            } else if (0 == strcmp(info_str->string, "app")) {
                 pers = PMIX_PERSIST_APP;     // retain until application terminates
-            } else if (0 == strcmp(range, "session")) {
+            } else if (0 == strcmp(info_str->string, "session")) {
                 pers = PMIX_PERSIST_SESSION; // retain until session/allocation terminates
             } else {
                 /* unrecognized persistence */
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
                                             FUNC_NAME);
             }
+            OBJ_RELEASE(info_str);
         }
     }
 

--- a/ompi/mpi/c/unpublish_name.c
+++ b/ompi/mpi/c/unpublish_name.c
@@ -50,7 +50,7 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
                        const char *port_name)
 {
     int ret;
-    char range[OPAL_MAX_INFO_VAL];
+    opal_cstring_t *info_str;
     int flag=0;
     pmix_status_t rc;
     pmix_info_t pinfo;
@@ -77,17 +77,18 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
     /* OMPI supports info keys to pass the range to
      * be searched for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        ompi_info_get (info, "range", &info_str, &flag);
         if (flag) {
-            if (0 == strcmp(range, "nspace")) {
+            if (0 == strcmp(info_str->string, "nspace")) {
                 rng = PMIX_RANGE_NAMESPACE;  // share only with procs in same nspace
-            } else if (0 == strcmp(range, "session")) {
+            } else if (0 == strcmp(info_str->string, "session")) {
                 rng = PMIX_RANGE_SESSION; // share only with procs in same session
             } else {
                 /* unrecognized scope */
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
                                             FUNC_NAME);
             }
+            OBJ_RELEASE(info_str);
         }
     }
 

--- a/ompi/mpi/fortran/base/fortran_base_strings.h
+++ b/ompi/mpi/fortran/base/fortran_base_strings.h
@@ -55,7 +55,7 @@ BEGIN_C_DECLS
      * convert C strings to fortran strings.  It is assumed that the
      * fortran string is already allocated and has a length of len.
      */
-    OMPI_DECLSPEC int ompi_fortran_string_c2f(char *cstr, char *fstr, int len);
+    OMPI_DECLSPEC int ompi_fortran_string_c2f(const char* cstr, char* fstr, int len);
 
     /**
      * Convert an array of Fortran strings that are terminated with a

--- a/ompi/mpi/fortran/base/strings.c
+++ b/ompi/mpi/fortran/base/strings.c
@@ -90,7 +90,7 @@ int ompi_fortran_string_f2c(char *fstr, int len, char **cstr)
  * shorter string, or reading a shorter record, automatically pads the
  * rest of the string with blanks."
  */
-int ompi_fortran_string_c2f(char *cstr, char *fstr, int len)
+int ompi_fortran_string_c2f(const char *cstr, char *fstr, int len)
 {
     int i;
 

--- a/ompi/mpi/fortran/mpif-h/info_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_f.c
@@ -82,8 +82,9 @@ void ompi_info_get_f(MPI_Fint *info, char *key, MPI_Fint *valuelen,
 {
     int c_ierr, ret;
     MPI_Info c_info;
-    char *c_key = NULL, c_value[MPI_MAX_INFO_VAL + 1];
+    char *c_key = NULL;
     OMPI_LOGICAL_NAME_DECL(flag);
+    opal_cstring_t *info_str;
 
     if (OMPI_SUCCESS != (ret = ompi_fortran_string_f2c(key, key_len, &c_key))) {
         c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
@@ -92,10 +93,8 @@ void ompi_info_get_f(MPI_Fint *info, char *key, MPI_Fint *valuelen,
     }
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_get(c_info, c_key,
-                          OMPI_FINT_2_INT(*valuelen),
-                          c_value,
-                          OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_info_get(c_info, c_key, &info_str,
+                           OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
@@ -107,12 +106,13 @@ void ompi_info_get_f(MPI_Fint *info, char *key, MPI_Fint *valuelen,
            Fortran compilers have TRUE == 1).  Note: use the full
            length of the Fortran string, not *valuelen.  See comment
            in ompi/mpi/fortran/base/strings.c. */
-        if (*flag && OMPI_SUCCESS !=
-            (ret = ompi_fortran_string_c2f(c_value, value, value_len))) {
-            c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
-            if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-            free(c_key);
-            return;
+        if (*flag) {
+            if (OMPI_SUCCESS !=
+                (ret = ompi_fortran_string_c2f(info_str->string, value, value_len))) {
+                c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+                if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+            }
+            OBJ_RELEASE(info_str);
         }
     }
 

--- a/ompi/mpi/fortran/mpif-h/info_get_nthkey_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_nthkey_f.c
@@ -81,18 +81,19 @@ void ompi_info_get_nthkey_f(MPI_Fint *info, MPI_Fint *n, char *key,
 {
     int c_ierr, ret;
     MPI_Info c_info;
-    char c_key[MPI_MAX_INFO_KEY + 1];
+    opal_cstring_t *key_str;
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_get_nthkey(c_info,
-                                 OMPI_FINT_2_INT(*n),
-                                 c_key);
+    c_ierr = ompi_info_get_nthkey(c_info, OMPI_FINT_2_INT(*n), &key_str);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    if (OMPI_SUCCESS != (ret = ompi_fortran_string_c2f(c_key, key, key_len))) {
-        c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
-        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-        return;
+    if (NULL != key_str) {
+        if (OMPI_SUCCESS != (ret = ompi_fortran_string_c2f(key_str->string, key, key_len))) {
+            c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+            if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        }
+        OBJ_RELEASE(key_str);
     }
+
 }

--- a/opal/class/Makefile.am
+++ b/opal/class/Makefile.am
@@ -27,6 +27,7 @@
 # Source code files
 headers += \
         class/opal_bitmap.h \
+        class/opal_cstring.h \
         class/opal_free_list.h \
         class/opal_hash_table.h \
         class/opal_hotel.h \
@@ -43,6 +44,7 @@ headers += \
 
 lib@OPAL_LIB_PREFIX@open_pal_la_SOURCES += \
         class/opal_bitmap.c \
+        class/opal_cstring.c \
         class/opal_free_list.c \
         class/opal_hash_table.c \
         class/opal_hotel.c \

--- a/opal/class/opal_cstring.c
+++ b/opal/class/opal_cstring.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2020      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_cstring.h"
+
+#include <errno.h>
+#include <ctype.h>
+#include <stddef.h>
+#include "opal/constants.h"
+#include "opal/util/string_copy.h"
+
+static void opal_cstring_ctor(opal_cstring_t *obj);
+
+OBJ_CLASS_INSTANCE(
+    opal_cstring_t,
+    opal_object_t,
+    &opal_cstring_ctor,
+    NULL
+);
+
+/* make sure we have sufficient padding to always null-terminate the string */
+#if (__STDC_VERSION__ >= 201112L)
+_Static_assert(sizeof(opal_cstring_t) > offsetof(opal_cstring_t, string),
+               "Insufficient padding available in opal_cstring_t");
+#endif // (__STDC_VERSION__ >= 201112L)
+
+static void opal_cstring_ctor(opal_cstring_t *obj)
+{
+    *(size_t*)&(obj->length) = 0;
+    /* make sure the string is null-terminated */
+    ((char*)obj->string)[0] = '\n';
+}
+
+static inline size_t opal_cstring_alloc_size(size_t len)
+{
+    /* the size required for the object and the string, incl. the null-terminator */
+    size_t res = sizeof(opal_cstring_t) + len + 1;
+    /* adjust for the additional padding that is used for the string anyway */
+    res -= (sizeof(opal_cstring_t) - offsetof(opal_cstring_t, string));
+    /* make sure we allocate at least sizeof(opal_cstring_t) */
+    return (res > sizeof(opal_cstring_t)) ? res : sizeof(opal_cstring_t);
+}
+
+opal_cstring_t* opal_cstring_create_l(const char *string, size_t len)
+{
+    if (NULL == string || 0 == len) {
+        return OBJ_NEW(opal_cstring_t);
+    }
+
+    /* Allocate space for the object, the characters in \c string and the terminating null */
+    opal_cstring_t* res = (opal_cstring_t*)malloc(opal_cstring_alloc_size(len));
+    if (NULL == res) {
+        return NULL;
+    }
+    OBJ_CONSTRUCT(res, opal_cstring_t);
+
+    /* cast away const for setting the member values */
+    *(size_t*)&(res->length) = len;
+    opal_string_copy((char*)res->string, string, len+1);
+
+    return res;
+}
+
+opal_cstring_t* opal_cstring_create(const char *string)
+{
+    if (NULL == string) {
+        return OBJ_NEW(opal_cstring_t);
+    }
+    size_t len = strlen(string);
+    return opal_cstring_create_l(string, len);
+}
+
+
+int opal_cstring_to_int(opal_cstring_t *string, int *interp)
+{
+    long tmp;
+    char *endp;
+
+    if (NULL == string || '\0' == string->string[0]) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    errno = 0;
+    tmp = strtol(string->string, &endp, 10);
+    /* we found something not a number */
+    if (*endp != '\0') return OPAL_ERR_BAD_PARAM;
+    /* underflow */
+    if (tmp == 0 && errno == EINVAL) return OPAL_ERR_BAD_PARAM;
+
+    *interp = (int) tmp;
+
+    return OPAL_SUCCESS;
+}
+
+
+static int
+opal_str_to_bool_impl(const char *string, bool *interp)
+{
+    const char *ptr = string;
+
+    /* Trim leading whitespace */
+    while (isspace(*ptr)) {
+        ++ptr;
+    }
+
+    if ('\0' != *ptr) {
+        if (isdigit(*ptr)) {
+            *interp = (bool) atoi(ptr);
+        } else if (0 == strncasecmp(ptr, "yes", 3) ||
+                   0 == strncasecmp(ptr, "true", 4)) {
+            *interp = true;
+        } else if (0 == strncasecmp(ptr, "no", 2) &&
+                   0 == strncasecmp(ptr, "false", 5)) {
+            *interp = false;
+        } else {
+            *interp = false;
+            return OPAL_ERR_BAD_PARAM;
+        }
+    }
+    return OPAL_SUCCESS;
+}
+
+int
+opal_cstring_to_bool(opal_cstring_t *string, bool *interp)
+{
+    return opal_str_to_bool_impl(string->string, interp);
+}
+
+bool opal_str_to_bool(const char *string)
+{
+    bool res;
+    opal_str_to_bool_impl(string, &res);
+    return res;
+}

--- a/opal/class/opal_cstring.h
+++ b/opal/class/opal_cstring.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2020      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Implementation of a reference-counted immutable string object.
+ * The string object is created using either \c opal_cstring_create(string) or
+ * \c opal_cstring_create_l(string, len) with the latter accepting the number
+ * of characters to take from the input string.
+ *
+ * The reference counting is done using opal's \c OBJ_RETAIN / \c OBJ_RELEASE mechanism
+ * and it is the user's responsibility to ensure that the string is eventually
+ * free'd by decrementing the reference counter using OBJ_RETAIN.
+ *
+ * The structure contains two relevant members:
+ *
+ * - \c length: the length of the string, i.e., the number of characters in \c string *not*
+ *              including the null-terminator.
+ * - \c string: the array of characters that make up the string.
+ *
+ * Both fields are \c const and should not be altered by the user. If the string
+ * contained in an \c opal_cstring_t object should be modified it has to be copied
+ * to a different buffer (e.g., using strdup).
+ *
+ * The \c string is always guaranteed to be null-terminated, even if the
+ * \c opal_cstring_t object was created using \c OBJ_NEW (which results in an
+ * empty string with the \c length field set to zero and the \c string field
+ * pointing to the null-terminator).
+ *
+ */
+
+#ifndef OPAL_STRING_H
+#define OPAL_STRING_H
+
+#include "opal_config.h"
+#include "opal/class/opal_object.h"
+#include "opal/mca/base/mca_base_var_enum.h"
+
+#include <string.h>
+
+/**
+ * Reference-counted immutable string object.
+ *
+ * The two relevant members are:
+ *
+ * - \c length: the length of the string, i.e., the number of characters in \c string *not*
+ *              including the null-terminator.
+ * - \c string: the array of characters that make up the string.
+ *
+ * The string is eventually free'd by calling \c OBJ_RELEASE on it.
+ *
+ * If allocated using \c OBJ_NEW the object will contain an empty string.
+ * The member field \c _ignored is used to force the existance of padding bytes
+ * that can be used to write the null-terminator even if no additional memory
+ * was allocated succeeding the object itself and is ignored.
+ */
+struct opal_cstring_t {
+    opal_object_t super;
+    const size_t length; //< the number of characters not including the null-terminator
+    char _ignored;       //< single char forcing additional padding to always ensure null-termination
+    const char string[]; //< FMA containing the string, making use of padding bytes
+};
+
+typedef struct opal_cstring_t opal_cstring_t;
+
+
+BEGIN_C_DECLS
+
+/**
+ * \internal
+ *
+ * The class for string objects.
+ */
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_cstring_t);
+
+/**
+ * Create a new instance of a reference-counted immutable string object
+ * (\ref opal_cstring_t) containing the characters of \c string.
+ *
+ * @param string Value of the new string
+ * @return An object representing the null-terminated string with value \c string
+ *
+ * If \c string is \c NULL then the resulting string will be empty.
+ *
+ */
+OPAL_DECLSPEC
+opal_cstring_t* opal_cstring_create(const char *string) __opal_attribute_malloc__;
+
+/**
+ * Create a new instance of a reference-counted immutable string object
+ * (\ref opal_cstring_t) containing the first \c length characters of \c string.
+ *
+ * @param string Value of the new string
+ * @return An object representing null-terminated string with the first
+ *         \c length characters of \c string
+ *
+ * If \c string is \c NULL or \c length is zero the resulting string will be empty.
+ */
+OPAL_DECLSPEC
+opal_cstring_t* opal_cstring_create_l(const char *string, size_t length) __opal_attribute_malloc__;
+
+/**
+ * Convert string to integer
+ *
+ * Convert \c string into an integer, adhering to the
+ * interpretation rules specified in MPI-4 Chapter 10.
+ * All others will return \c OPAL_ERR_BAD_PARAM
+ *
+ * @param string Value string to interpret
+ * @param interp returned interpretation of the value key
+ *
+ * @retval OPAL_SUCCESS string was successfully interpreted
+ * @retval OPAL_ERR_BAD_PARAM string could not be interpreted
+ *
+ */
+OPAL_DECLSPEC
+int opal_cstring_to_int(opal_cstring_t *string, int *interp);
+
+
+/**
+ * Convert string to boolean
+ *
+ * Convert \c string into a boolean, adhering to the
+ * interpretation rules specified in MPI-4 Chapter 10.
+ *
+ * @param value Value string to interpret
+ * @param interp returned interpretation of the value key
+ *
+ * @retval OPAL_SUCCESS string was successfully interpreted
+ * @retval OPAL_ERR_BAD_PARAM string was not able to be interpreted
+ *
+ *   The string value will be cast to the boolen output in
+ *   the following manner:
+ *
+ *   - If the string value is digits, the return value is "(bool)
+ *     atoi(value)"
+ *   - If the string value is (case-insensitive) "yes" or "true", the
+ *     result is true
+ *   - If the string value is (case-insensitive) "no" or "false", the
+ *     result is false
+ *   - All other values will lead to a return value of OPAL_ERR_BAD_PARAM and
+ *     \c interp will be set to false.
+ */
+OPAL_DECLSPEC
+int opal_cstring_to_bool(opal_cstring_t *string, bool *interp);
+
+
+OPAL_DECLSPEC
+bool opal_str_to_bool(const char *string);
+
+END_C_DECLS
+
+#endif // OPAL_STRING_H

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -28,6 +28,7 @@
 
 #include <string.h>
 
+#include "opal/class/opal_cstring.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/mca/threads/mutex.h"
@@ -63,12 +64,11 @@ extern opal_pointer_array_t ompi_info_f_to_c_table;
  * type. It contains (key,value) pairs
  */
 struct opal_info_entry_t {
-    opal_list_item_t super; /**< required for opal_list_t type */
-    char *ie_value; /**< value part of the (key, value) pair.
-                  * Maximum length is MPI_MAX_INFO_VAL */
-    char ie_key[OPAL_MAX_INFO_KEY + 1]; /**< "key" part of the (key, value)
-                                     * pair */
+    opal_list_item_t super;  /**< required for opal_list_t type */
+    opal_cstring_t *ie_value; /**< value part of the (key, value) pair. */
+    opal_cstring_t *ie_key;   /**< "key" part of the (key, value) pair */
 };
+
 /**
  * \internal
  * Convenience typedef
@@ -104,7 +104,7 @@ int opal_mpiinfo_init(void*);
  *   Not only will the (key, value) pairs be duplicated, the order
  *   of keys will be the same in 'newinfo' as it is in 'info'.  When
  *   an info object is no longer being used, it should be freed with
- *   'MPI_Info_free'.
+ *   \c opal_info_free.
  */
 int opal_info_dup (opal_info_t *info, opal_info_t **newinfo);
 
@@ -151,6 +151,21 @@ int opal_info_dup_mpistandard (opal_info_t *info, opal_info_t **newinfo);
  * @retval OPAL_ERR_OUT_OF_RESOURCE if out of memory
  */
 OPAL_DECLSPEC int opal_info_set (opal_info_t *info, const char *key, const char *value);
+
+/**
+ * Set a new key,value pair on info.
+ *
+ * @param info pointer to opal_info_t object
+ * @param key pointer to the new key string
+ * @param value pointer to the new value string object
+ *
+ * @retval OPAL_SUCCESS upon success
+ * @retval OPAL_ERR_OUT_OF_RESOURCE if out of memory
+ *
+ * The \c value string object will be retained and can be safely released if necessary
+ * by the caller.
+ */
+OPAL_DECLSPEC int opal_info_set_cstring (opal_info_t *info, const char *key, opal_cstring_t *value);
 
 /**
  * Set a new key,value pair from a variable enumerator.
@@ -232,18 +247,19 @@ OPAL_DECLSPEC int opal_info_get_value_enum (opal_info_t *info, const char *key,
  *
  *   @param info Pointer to opal_info_t object
  *   @param key null-terminated character string of the index key
- *   @param valuelen maximum length of 'value' (integer)
- *   @param value null-terminated character string of the value
+ *   @param string null-terminated character string of the value
  *   @param flag true (1) if 'key' defined on 'info', false (0) if not
  *               (logical)
  *
  *   @retval OPAL_SUCCESS
  *
- *   In C and C++, 'valuelen' should be one less than the allocated
- *   space to allow for for the null terminator.
+ *   The \c string pointer will only be set if the key is found, i.e., if \c flag
+ *   is set to \c true. It is the caller's responsibility to decremenet the
+ *   reference count of the \c string object by calling \c OBJ_RELEASE on it
+ *   once the object is not needed any more.
  */
-OPAL_DECLSPEC int opal_info_get (opal_info_t *info, const char *key, int valuelen,
-                                 char *value, int *flag);
+OPAL_DECLSPEC int opal_info_get (opal_info_t *info, const char *key,
+                                 opal_cstring_t **string, int *flag);
 
 /**
  * Delete a (key,value) pair from "info"
@@ -276,49 +292,20 @@ OPAL_DECLSPEC int opal_info_get_valuelen (opal_info_t *info, const char *key, in
                                           int *flag);
 
 /**
- *   opal_info_get_nthkey - Get a key indexed by integer from an 'MPI_Info' o
+ *   opal_info_get_nthkey - Get a key indexed by integer from an info object
  *
  *   @param info Pointer to opal_info_t object
  *   @param n index of key to retrieve (integer)
- *   @param key character string of at least 'MPI_MAX_INFO_KEY' characters
+ *   @param key output opal_cstring_t object, set if the n'th key exists
  *
  *   @retval OPAL_SUCCESS
  *   @retval OPAL_ERR_BAD_PARAM
+ *
+ *   It is the caller's responsibility to decremenet the reference count of the
+ *   \c key string by calling \c OBJ_RELEASE on it once the object is not needed
+ *   any more.
  */
-int opal_info_get_nthkey (opal_info_t *info, int n, char *key);
-
-/**
- * Convert value string to boolean
- *
- * Convert value string \c value into a boolean, using the
- * interpretation rules specified in MPI-2 Section 4.10.  The
- * strings "true", "false", and integer numbers can be converted
- * into booleans.  All others will return \c OMPI_ERR_BAD_PARAM
- *
- * @param value Value string for info key to interpret
- * @param interp returned interpretation of the value key
- *
- * @retval OPAL_SUCCESS string was successfully interpreted
- * @retval OPAL_ERR_BAD_PARAM string was not able to be interpreted
- */
-OPAL_DECLSPEC int opal_info_value_to_bool(char *value, bool *interp);
-
-/**
- * Convert value string to integer
- *
- * Convert value string \c value into a integer, using the
- * interpretation rules specified in MPI-2 Section 4.10.
- * All others will return \c OPAL_ERR_BAD_PARAM
- *
- * @param value Value string for info key to interpret
- * @param interp returned interpretation of the value key
- *
- * @retval OPAL_SUCCESS string was successfully interpreted
- * @retval OPAL_ERR_BAD_PARAM string was not able to be interpreted
- */
-int opal_info_value_to_int(char *value, int *interp);
-
-END_C_DECLS
+int opal_info_get_nthkey (opal_info_t *info, int n, opal_cstring_t **key);
 
 /**
  * Get the number of keys defined on on an MPI_Info object
@@ -334,6 +321,8 @@ opal_info_get_nkeys(opal_info_t *info, int *nkeys)
     return OPAL_SUCCESS;
 }
 
-bool opal_str_to_bool(char*);
+
+END_C_DECLS
+
 
 #endif /* OPAL_INFO_H */

--- a/opal/util/info_subscriber.h
+++ b/opal/util/info_subscriber.h
@@ -47,7 +47,7 @@ typedef struct opal_infosubscriber_t opal_infosubscriber_t;
 
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_infosubscriber_t);
 
-typedef char*(opal_key_interest_callback_t)(opal_infosubscriber_t*, char*, char*);
+typedef const char*(opal_key_interest_callback_t)(opal_infosubscriber_t*, const char*, const char*);
 
 /**
  *   opal_infosubscribe_change_info - Make changes to a Comm/Win/File Info
@@ -79,6 +79,6 @@ int opal_infosubscribe_change_info(opal_infosubscriber_t*, opal_info_t *);
  *   Does not try to optimize settings that are the same between old and new
  *   info's.
  */
-int opal_infosubscribe_subscribe(opal_infosubscriber_t*, char *, char *, opal_key_interest_callback_t);
+int opal_infosubscribe_subscribe(opal_infosubscriber_t*, const char *, const char *, opal_key_interest_callback_t);
 
 #endif /* OMPI_INFO_H */


### PR DESCRIPTION
This PR adds a new OPAL class `opal_cstring_t` that represents a reference-counted immutable string. These are used to store and pass info keys and values, which reduces the instances in which strings actually have to copied.

The interface is relatively simple: the `opal_cstring_t` struct contains two relevant members `length` and `string` that contain the number of characters (excl. the null terminator) and the string itself. They are marked `const` so that they cannot be modified once the object has been created. A new object is created using `opal_cstring_create(string)` (creates a new cstring with `string` as its value) or `opal_cstring_create_l(string, len)` (creates a new cstring with the first `len` characters of `string` as its value). The cstring is eventually free'd once a call to `OBJ_RELEASE` on them finds the object unreferenced. 

The function `opal_info_get` now provides a pointer to a cstring if the key is found, with its reference count incremented. It is thus important that the caller releases the object again once processing has completed. The same holds for the key returned by `opal_info_get_nthkey`. If another thread removes the key/value pair from the info object the string remains valid until `OBJ_RELEASE` is called. A new function `opal_info_set_cstring` allows setting a value directly using a cstring, which avoids unnecessary memory allocation and only causes the cstring's reference count to be incremented.


### Some notes

- The `opal_cstring_t` struct contains a single character member that is meant to force the compiler to add padding bytes at the end, which we are used to null-terminate the string even if it is not created through `opal_cstring_create` but through `OBJ_NEW` and thus no additional memory is allocated. The latter will create an empty, null-terminated string. This works because the flexible array member (FAM) `string` points to the first byte following the members of the struct but the compiler has to insert padding bytes to ensure alignment as if the FAM was empty. This provides us with 3B (32bit systems) or 7B (64bit systems), respectively, which are sufficient to store the null-terminator for empty strings. The padding bytes will also be used for non-empty strings and are thus factored in during memory allocation in `opal_cstring_create`.

- The introduction of `const char*` info strings had some ripple effects.
  1) I changed the info subscriber interface to using `const char*` strings (which it should have been from the beginning) and reusing cstring objects where possible (namely when saving old info values).
  2) The `PMIx_Get_attribute_string` function takes a `char*` argument but is passed string constants in many places. Digging into it, it doesn't seem to actually modify the string (which it shouldn't anyway if passed string literals). It really should take a `const char*` argument. Long story short, this currently triggers a warning in `dpm_convert` about a discarded `const` qualifier. @rhc54 do you agree with this analysis?

- The MPI level info handling functions now deal with cstring objects and handle the strings according to their own requirements (C/Fortran). Implementing MPI-4 info string functions on top of this interface should be straight forward without touching the opal layer again.

- I renamed and moved the functions `opal_info_value_to_int` and `opal_info_value_to_bool` to `opal_cstring_to_int` and `opal_cstring_to_bool`. They were not exactly info-specific anyway and are imo better suited in the context of the cstring implementation. I did not change `opal_string_copy` as that operates on `char*` strings.

- This PR touches quite a few places that I am not familiar with (all places that process info values) so having some more eyes look at these changes would be greatly appreciated :)

- This PR supersedes https://github.com/open-mpi/ompi/pull/7972, which contains the initial discussion on this approach. 