### PR TITLE
Fix external PMIx v4.x check

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -16,7 +16,7 @@
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2018 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -328,6 +328,7 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
                                                     ], [])],
                                     [AC_MSG_RESULT([found])
                                      opal_external_pmix_version=4x
+                                     opal_external_pmix_version_major=4
                                      opal_external_pmix_version_found=1
                                      opal_external_pmix_happy=yes],
                                     [AC_MSG_RESULT([not found])])])
@@ -342,6 +343,7 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
                                               ], [])],
                                    [AC_MSG_RESULT([found])
                                     opal_external_pmix_version=3x
+                                    opal_external_pmix_version_major=3
                                     opal_external_pmix_version_found=1
                                     opal_external_pmix_happy=yes],
                                    [AC_MSG_RESULT([not found])])])
@@ -356,6 +358,7 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
                                               ], [])],
                                    [AC_MSG_RESULT([found])
                                     opal_external_pmix_version=2x
+                                    opal_external_pmix_version_major=2
                                     opal_external_pmix_version_found=1
                                     opal_external_pmix_happy=yes],
                                    [AC_MSG_RESULT([not found])])])
@@ -370,6 +373,7 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
                                               ], [])],
                                    [AC_MSG_RESULT([found])
                                     opal_external_pmix_version=1x
+                                    opal_external_pmix_version_major=1
                                     opal_external_pmix_version_found=1
                                     opal_external_have_pmix1=1
                                     opal_external_pmix_happy=yes],

--- a/opal/mca/pmix/ext3x/configure.m4
+++ b/opal/mca/pmix/ext3x/configure.m4
@@ -18,6 +18,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2014-2015 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2021      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,17 +33,19 @@ AC_DEFUN([MCA_opal_pmix_ext3x_CONFIG],[
 
     AS_IF([test "$opal_external_pmix_happy" = "yes"],
           [ # check for the 3.x version
-           AC_MSG_CHECKING([if external component is version 3.x])
-           AS_IF([test "$opal_external_pmix_version" = "3x"],
-                 [AC_MSG_RESULT([yes])
-                  AS_IF([test "$opal_event_external_support" != "yes"],
-                        [AC_MSG_WARN([EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT])
-                         AC_MSG_WARN([LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED])
-                         AC_MSG_WARN([TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT])
-                         AC_MSG_ERROR([PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD])])
-                  opal_pmix_external_3x_happy=yes],
-                 [AC_MSG_RESULT([no])
-                  opal_pmix_external_3x_happy=no])
+           AC_MSG_CHECKING([if external component is version 3.x or higher])
+           if test $opal_external_pmix_version_major -ge 3 ; then
+               AC_MSG_RESULT([yes])
+               AS_IF([test "$opal_event_external_support" != "yes"],
+                   [AC_MSG_WARN([EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT])
+                       AC_MSG_WARN([LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED])
+                       AC_MSG_WARN([TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT])
+                       AC_MSG_ERROR([PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD])])
+               opal_pmix_external_3x_happy=yes
+           else
+               AC_MSG_RESULT([no])
+               opal_pmix_external_3x_happy=no
+           fi
 
            AS_IF([test "$opal_pmix_external_3x_happy" = "yes"],
                  [$1

--- a/opal/mca/pmix/pmix3x/pmix3x.h
+++ b/opal/mca/pmix/pmix3x/pmix3x.h
@@ -7,6 +7,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +35,7 @@
 #include "opal/mca/pmix/base/base.h"
 #include "pmix_server.h"
 #include "pmix_common.h"
+#include "pmix.h"
 
 BEGIN_C_DECLS
 


### PR DESCRIPTION
 * PMIx v4.x is compatible with the external v3 component.
