### PR TITLE
v4.1: Fix segv when launching with static ports

### DIFF
--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -557,29 +557,6 @@ int orte_ess_base_orted_setup(void)
         /* be sure to update the routing tree so any tree spawn operation
          * properly gets the number of children underneath us */
         orte_routed.update_routing_plan(NULL);
-    }
-
-    if (orte_static_ports || orte_fwd_mpirun_port) {
-        if (NULL == orte_node_regex) {
-            /* we didn't get the node info */
-            error = "cannot construct daemon map for static ports - no node map info";
-            goto error;
-        }
-        /* extract the node info from the environment and
-         * build a nidmap from it - this will update the
-         * routing plan as well
-         */
-        if (ORTE_SUCCESS != (ret = orte_regx.build_daemon_nidmap())) {
-            ORTE_ERROR_LOG(ret);
-            error = "construct daemon map from static ports";
-            goto error;
-        }
-        /* be sure to update the routing tree so the initial "phone home"
-         * to mpirun goes through the tree if static ports were enabled
-         */
-        orte_routed.update_routing_plan(NULL);
-        /* routing can be enabled */
-        orte_routed_base.routing_enabled = true;
     }
 
     /* Now provide a chance for the PLM

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1538,16 +1538,9 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         orte_nidmap_communicated = true;
     }
 
-    if (!orte_static_ports && !orte_fwd_mpirun_port) {
-        /* if we are using static ports, or we are forwarding
-         * mpirun's port, then we would have built all the
-         * connection info and so there is nothing to be passed.
-         * Otherwise, we have to pass the HNP uri so we can
-         * phone home */
-        opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
-        opal_argv_append(argc, argv, "orte_hnp_uri");
-        opal_argv_append(argc, argv, orte_process_info.my_hnp_uri);
-    }
+    opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
+    opal_argv_append(argc, argv, "orte_hnp_uri");
+    opal_argv_append(argc, argv, orte_process_info.my_hnp_uri);
 
     /* if requested, pass our port */
     if (orte_fwd_mpirun_port) {

--- a/orte/mca/regx/regx.h
+++ b/orte/mca/regx/regx.h
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,8 +72,6 @@ typedef int (*orte_regx_base_module_encode_nodemap_fn_t)(opal_buffer_t *buffer);
  * into the orte_node_pool array */
 typedef int (*orte_regx_base_module_decode_daemon_nodemap_fn_t)(opal_buffer_t *buffer);
 
-typedef int (*orte_regx_base_module_build_daemon_nidmap_fn_t)(void);
-
 /* create a regular expression describing the ppn for a job */
 typedef int (*orte_regx_base_module_generate_ppn_fn_t)(orte_job_t *jdata, char **ppn);
 
@@ -93,7 +92,6 @@ typedef struct {
     orte_regx_base_module_extract_node_names_fn_t     extract_node_names;
     orte_regx_base_module_encode_nodemap_fn_t         encode_nodemap;
     orte_regx_base_module_decode_daemon_nodemap_fn_t  decode_daemon_nodemap;
-    orte_regx_base_module_build_daemon_nidmap_fn_t    build_daemon_nidmap;
     orte_regx_base_module_generate_ppn_fn_t           generate_ppn;
     orte_regx_base_module_parse_ppn_fn_t              parse_ppn;
     orte_regx_base_module_finalize_fn_t               finalize;

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -19,6 +19,7 @@
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -299,6 +300,14 @@ int orte_daemon(int argc, char *argv[])
     /* purge any ess/pmix flags set in the environ when we were launched */
     opal_unsetenv(OPAL_MCA_PREFIX"ess", &orte_launch_environ);
     opal_unsetenv(OPAL_MCA_PREFIX"pmix", &orte_launch_environ);
+
+    /* We need to parse the MCA parameters to read the debug MCA
+     * parameters used by the plm to relay the debug options.
+     */
+    if (ORTE_SUCCESS != (ret = orte_register_params())) {
+        ORTE_ERROR_LOG(ret);
+        return ret;
+    }
 
     /* if orte_daemon_debug is set, let someone know we are alive right
      * away just in case we have a problem along the way

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -756,7 +756,7 @@ int orte_daemon(int argc, char *argv[])
 
         /* define the target jobid */
         target.jobid = ORTE_PROC_MY_NAME->jobid;
-        if (orte_fwd_mpirun_port || orte_static_ports || NULL != orte_parent_uri) {
+        if (NULL != orte_parent_uri) {
             /* we start by sending to ourselves */
             target.vpid = ORTE_PROC_MY_NAME->vpid;
             /* since we will be waiting for any children to send us


### PR DESCRIPTION
 * Remove `build_daemon_nidmap` function from `regx` framework - as it is not used.
 * Remove static_port optimization path that didn't work for multiple static ports.
