### PR TITLE
Revert "v4.1.x: Update Slurm launch support"

### DIFF
--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2019 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -266,9 +266,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* start one orted on each node */
     opal_argv_append(&argc, &argv, "--ntasks-per-node=1");
-
-    /* ensure Slurm adds all CPUs to this task */
-    putenv("SLURM_WHOLE=1");
 
     if (!orte_enable_recovery) {
         /* kill the job if any orteds die */


### PR DESCRIPTION
The functional change that triggered this request in Slurm's srun launcher has been reverted ahead of our 20.11.3 release, and we would rather this environment variable not be propagated through here.

We'd prefer to get this reverted before any OpenMPI release potentially ships with this commit.

A further description of why these changes were made, and why we've reverted them, is captured on the SchedMD ticket:
https://bugs.schedmd.com/show_bug.cgi?id=10383

Reverts open-mpi/ompi#8289