### PR TITLE
[4.0.x] orte/orted: enable OPAL's mutli-thread support

### DIFF
--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -370,6 +370,12 @@ int orte_daemon(int argc, char *argv[])
      */
     opal_finalize_util();
 
+    /* orted uses multiple threads, thus need to enable opal's multi-thread support,
+     * otherwise, OPAL_RELEASE will not use atomic operations to update object's
+     * reference counter, which will lead to double free issue.
+     */
+    opal_set_using_threads(true);
+
     /* bind ourselves if so directed */
     if (NULL != orte_daemon_cores) {
         char **cores=NULL, tmp[128];


### PR DESCRIPTION
This patch added call to opal_set_using_threads() in orted/main.c,
which is to enable OPAL's multi-thread support.

This is because orted used multiple threads.

Without OPAL's multi-thread support, OPAL_RELEASE will not use
atomic operations to update an object's reference count, which
will lead to double free.

cherry-picked from b97838ee45696e88e35e6016f425137d83d9a875

Signed-off-by: Wei Zhang <wzam@amazon.com>