### PR TITLE
Romio fixes from mpich

### DIFF
--- a/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -719,6 +719,7 @@ void ADIOI_GPFS_Calc_others_req(ADIO_File fd, int count_my_req_procs,
 	    others_req[i].count = 0;
 	    others_req[i].offsets = NULL;
 	    others_req[i].lens    = NULL;
+	    others_req[i].mem_ptrs = NULL;
 	}
     }
 

--- a/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -476,8 +476,8 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i=0; i<nprocs; i++) {
 	if (others_req[i].count) {
 	    ADIOI_Free(others_req[i].offsets);
-	    ADIOI_Free(others_req[i].lens);
-	    ADIOI_Free(others_req[i].mem_ptrs);
+	    if (others_req[i].lens) { ADIOI_Free(others_req[i].lens); }
+	    if (others_req[i].mem_ptrs) { ADIOI_Free(others_req[i].mem_ptrs); }
 	}
     }
     ADIOI_Free(others_req);

--- a/ompi/mca/io/romio321/romio/adio/common/ad_darray.c
+++ b/ompi/mca/io/romio321/romio/adio/common/ad_darray.c
@@ -199,6 +199,13 @@ static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs
      /* in terms of no. of elements of type oldtype in this dimension */
     if (mysize == 0) *st_offset = 0;
 
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Datatype type_tmp;
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp;
+
     return MPI_SUCCESS;
 }
 
@@ -286,6 +293,13 @@ static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nproc
     }
 
     if (local_size == 0) *st_offset = 0;
+
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Datatype type_tmp2;
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp2);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp2;
 
     return MPI_SUCCESS;
 }

--- a/ompi/mca/io/romio321/romio/adio/common/flatten.c
+++ b/ompi/mca/io/romio321/romio/adio/common/flatten.c
@@ -98,6 +98,33 @@ int ADIOI_Type_get_contents (MPI_Datatype datatype, int max_integers,
   return rc;
 }
 
+/*
+ * I don't really expect this to ever trigger, but without the below safety
+ * valve, the design relies on the Count function coming out >= whatever
+ * the Flatten function comes up with.  There are enough differences between
+ * the two that it's hard to be positive this will always be true.  So every
+ * time something's added to flat's arrays, let's make sure they're big enough
+ * and re-alloc if not.
+ */
+static void flatlist_node_grow(ADIOI_Flatlist_node * flat, int idx)
+{
+    if (idx >= flat->count) {
+        ADIO_Offset *new_blocklens;
+        ADIO_Offset *new_indices;
+        int new_count = (flat->count * 1.25 + 4);
+        new_blocklens = (ADIO_Offset *) ADIOI_Calloc(new_count * 2, sizeof(ADIO_Offset));
+        new_indices = new_blocklens + new_count;
+        if (flat->count) {
+            memcpy(new_blocklens, flat->blocklens, flat->count * sizeof(ADIO_Offset));
+            memcpy(new_indices, flat->indices, flat->count * sizeof(ADIO_Offset));
+            ADIOI_Free(flat->blocklens);
+        }
+        flat->blocklens = new_blocklens;
+        flat->indices = new_indices;
+        flat->count = new_count;
+    }
+}
+
 void ADIOI_Optimize_flattened(ADIOI_Flatlist_node *flat_type);
 /* flatten datatype and add it to Flatlist */
 void ADIOI_Flatten_datatype(MPI_Datatype datatype)
@@ -167,6 +194,16 @@ void ADIOI_Flatten_datatype(MPI_Datatype datatype)
   #ifdef FLATTEN_DEBUG 
   DBG_FPRINTF(stderr,"ADIOI_Flatten_datatype:: ADIOI_Flatten\n");
   #endif
+
+/*
+ * Setting flat->count to curr_index, since curr_index is the most fundamentally
+ * correct updated value that represents what's in the indices/blocklens arrays.
+ * It would be nice if the counter function and the flatten function were in sync,
+ * but the numerous cases that decrement flat->count in the flatten function show
+ * that syncing them is a hack, and as long as the counter doesn't under-count
+ * it's good enough.
+ */
+    flat->count = curr_index;
 
     ADIOI_Optimize_flattened(flat);
 #endif
@@ -318,6 +355,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	if (prev_index == *curr_index) {
 /* simplest case, made up of basic or contiguous types */
 	    j = *curr_index;
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset;
 	    MPI_Type_size_x(types[0], &old_size);
 	    flat->blocklens[j] = top_count * old_size;
@@ -335,6 +373,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    MPI_Type_get_extent(types[0], &lb, &old_extent);
 	    for (m=1; m<top_count; m++) {
 		for (i=0; i<num; i++) {
+                    flatlist_node_grow(flat, j);
 		    flat->indices[j] = flat->indices[j-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    flat->blocklens[j] = flat->blocklens[j-num];
           #ifdef FLATTEN_DEBUG 
@@ -366,10 +405,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
          avoid >2G integer arithmetic problems */
     ADIO_Offset blocklength = ints[1], stride = ints[2];
 	    j = *curr_index;
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset;
 	    MPI_Type_size_x(types[0], &old_size);
 	    flat->blocklens[j] = blocklength * old_size;
 	    for (i=j+1; i<j+top_count; i++) {
+                flatlist_node_grow(flat, i);
 		flat->indices[i] = flat->indices[i-1] + stride * old_size;
 		flat->blocklens[i] = flat->blocklens[j];
 	    }
@@ -389,6 +430,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    MPI_Type_get_extent(types[0], &lb, &old_extent);
 	    for (m=1; m<blocklength; m++) {
 		for (i=0; i<num; i++) {
+                    flatlist_node_grow(flat, j);
 		    flat->indices[j] = flat->indices[j-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    flat->blocklens[j] = flat->blocklens[j-num];
 		    j++;
@@ -400,6 +442,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    num = *curr_index - prev_index;
 	    for (i=1; i<top_count; i++) {
  		for (m=0; m<num; m++) {
+                   flatlist_node_grow(flat, j);
 		   flat->indices[j] =  flat->indices[j-num] + stride * ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		   flat->blocklens[j] = flat->blocklens[j-num];
 		   j++;
@@ -429,10 +472,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
          avoid >2G integer arithmetic problems */
     ADIO_Offset blocklength = ints[1];
 	    j = *curr_index;
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset;
 	    MPI_Type_size_x(types[0], &old_size);
 	    flat->blocklens[j] = blocklength * old_size;
 	    for (i=j+1; i<j+top_count; i++) {
+                flatlist_node_grow(flat, i);
 		flat->indices[i] = flat->indices[i-1] + adds[0];
 		flat->blocklens[i] = flat->blocklens[j];
 	    }
@@ -452,6 +497,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    MPI_Type_get_extent(types[0], &lb, &old_extent);
 	    for (m=1; m<blocklength; m++) {
 		for (i=0; i<num; i++) {
+                    flatlist_node_grow(flat, j);
 		    flat->indices[j] = flat->indices[j-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    flat->blocklens[j] = flat->blocklens[j-num];
 		    j++;
@@ -463,6 +509,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    num = *curr_index - prev_index;
 	    for (i=1; i<top_count; i++) {
  		for (m=0; m<num; m++) {
+                   flatlist_node_grow(flat, j);
 		   flat->indices[j] =  flat->indices[j-num] + adds[0];
 		   flat->blocklens[j] = flat->blocklens[j-num];
 		   j++;
@@ -500,16 +547,15 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
          avoid >2G integer arithmetic problems */
     ADIO_Offset blocklength = ints[1+i-j], stride = ints[top_count+1+i-j];
 		if (blocklength > 0) {
+                    flatlist_node_grow(flat, nonzeroth);
 		    flat->indices[nonzeroth] =
 			st_offset + stride* ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    flat->blocklens[nonzeroth] =
 			blocklength* ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    nonzeroth++;
-		} else {
-		    flat->count--; /* don't count/consider any zero-length blocklens */
 		}
 	    }
-	    *curr_index = i;
+	    *curr_index = nonzeroth;
 	}
 	else {
 /* indexed type made up of noncontiguous derived types */
@@ -523,14 +569,13 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    for (m=1; m<ints[1]; m++) {
 		for (i=0, nonzeroth = j; i<num; i++) {
 		    if (flat->blocklens[j-num] > 0) {
+                        flatlist_node_grow(flat, nonzeroth);
 			flat->indices[nonzeroth] =
 			    flat->indices[nonzeroth-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			flat->blocklens[nonzeroth] =
 			    flat->blocklens[nonzeroth-num];
 			j++;
 			nonzeroth++;
-		    } else {
-			flat->count --;
 		    }
 		}
 	    }
@@ -545,26 +590,24 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
          avoid >2G integer arithmetic problems */
       ADIO_Offset stride = ints[top_count+1+i]-ints[top_count+i];
 		    if (flat->blocklens[j-num] > 0 ) {
+                        flatlist_node_grow(flat, nonzeroth);
 			flat->indices[nonzeroth] =
 			    flat->indices[j-num] + stride* ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			flat->blocklens[nonzeroth] = flat->blocklens[j-num];
 			j++;
 			nonzeroth++;
-		    } else {
-			flat->count--;
 		    }
 		}
 		*curr_index = j;
 		for (m=1; m<ints[1+i]; m++) {
                     for (k=0, nonzeroth=j; k<basic_num; k++) {
 			if (flat->blocklens[j-basic_num] > 0) {
+                            flatlist_node_grow(flat, nonzeroth);
 			    flat->indices[nonzeroth] =
 				flat->indices[j-basic_num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			    flat->blocklens[nonzeroth] = flat->blocklens[j-basic_num];
 			    j++;
 			    nonzeroth++;
-			} else {
-			    flat->count --;
 			}
                     }
                 }
@@ -611,9 +654,11 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
          avoid >2G integer arithmetic problems */
 		ADIO_Offset blocklength = ints[1];
 		if (is_hindexed_block) {
+                    flatlist_node_grow(flat, i);
 		    flat->indices[i] = st_offset + adds[i-j];
 		} else {
 		    ADIO_Offset stride = ints[1+1+i-j];
+                    flatlist_node_grow(flat, i);
 		    flat->indices[i] = st_offset +
 			stride* ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		}
@@ -636,6 +681,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 			 * extent of a type */
 			MPI_Type_get_extent(types[0], &lb, &old_extent);
 		    }
+                    flatlist_node_grow(flat, j);
 		    flat->indices[j] = flat->indices[j-num] +
 			ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    flat->blocklens[j] = flat->blocklens[j-num];
@@ -649,12 +695,14 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    for (i=1; i<top_count; i++) {
 		for (m=0; m<num; m++) {
 		    if (is_hindexed_block) {
+                        flatlist_node_grow(flat, j);
 			flat->indices[j] = flat->indices[j-num] +
 			    adds[i] - adds[i-1];
 		    } else {
 			/* By using ADIO_Offset we preserve +/- sign and
 			   avoid >2G integer arithmetic problems */
 			ADIO_Offset stride = ints[2+i]-ints[1+i];
+                        flatlist_node_grow(flat, j);
 			flat->indices[j] = flat->indices[j-num] +
 			    stride* ADIOI_AINT_CAST_TO_OFFSET old_extent;
 		    }
@@ -691,14 +739,13 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 		    /* By using ADIO_Offset we preserve +/- sign and
 		       avoid >2G integer arithmetic problems */
 		    ADIO_Offset blocklength = ints[1+i-j];
+                    flatlist_node_grow(flat, nonzeroth);
 		    flat->indices[nonzeroth] = st_offset + adds[i-j];
 		    flat->blocklens[nonzeroth] = blocklength*old_size;
 		    nonzeroth++;
-		} else {
-		    flat->count--;
 		}
 	    }
-	    *curr_index = i;
+	    *curr_index = nonzeroth;
 	}
 	else {
 /* indexed type made up of noncontiguous derived types */
@@ -713,13 +760,12 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	    for (m=1; m<ints[1]; m++) {
 		for (i=0, nonzeroth=j; i<num; i++) {
 		    if (flat->blocklens[j-num] > 0) {
+                        flatlist_node_grow(flat, nonzeroth);
 			flat->indices[nonzeroth] =
 			    flat->indices[j-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			flat->blocklens[nonzeroth] = flat->blocklens[j-num];
 			j++;
 			nonzeroth++;
-		    } else {
-			flat->count--;
 		    }
 		}
 	    }
@@ -731,19 +777,19 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 		prev_index = *curr_index;
 		for (m=0, nonzeroth=j; m<basic_num; m++) {
 		    if (flat->blocklens[j-num] > 0) {
+                        flatlist_node_grow(flat, nonzeroth);
 			flat->indices[nonzeroth] =
 			    flat->indices[j-num] + adds[i] - adds[i-1];
 			flat->blocklens[nonzeroth] = flat->blocklens[j-num];
 			j++;
 			nonzeroth++;
-		    } else {
-			flat->count--;
 		    }
 		}
 		*curr_index = j;
 		for (m=1; m<ints[1+i]; m++) {
 		    for (k=0,nonzeroth=j; k<basic_num; k++) {
 			if (flat->blocklens[j-basic_num] >0) {
+                            flatlist_node_grow(flat, nonzeroth);
 			    flat->indices[nonzeroth] =
 				flat->indices[j-basic_num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			    flat->blocklens[nonzeroth] = flat->blocklens[j-basic_num];
@@ -779,6 +825,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 		if (ints[1+n] > 0) {
 		    ADIO_Offset blocklength = ints[1+n];
 		    j = *curr_index;
+                    flatlist_node_grow(flat, j);
 		    flat->indices[j] = st_offset + adds[n];
 		    MPI_Type_size_x(types[n], &old_size);
 		    flat->blocklens[j] = blocklength * old_size;
@@ -798,6 +845,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 		MPI_Type_get_extent(types[n], &lb, &old_extent);
 		for (m=1; m<ints[1+n]; m++) {
 		    for (i=0; i<num; i++) {
+                        flatlist_node_grow(flat, j);
 			flat->indices[j] =
 			    flat->indices[j-num] + ADIOI_AINT_CAST_TO_OFFSET old_extent;
 			flat->blocklens[j] = flat->blocklens[j-num];
@@ -827,6 +875,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	 * bound based on the inner type, but the lower bound based on the
 	 * upper type.  check both lb and ub to prevent mixing updates */
 	if (flat->lb_idx == -1 && flat->ub_idx == -1) {
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset + adds[0];
 	    /* this zero-length blocklens[] element, unlike eleswhere in the
 	     * flattening code, is correct and is used to indicate a lower bound
@@ -843,7 +892,6 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	} else {
 	    /* skipped over this chunk because something else higher-up in the
 	     * type construction set this for us already */
-	    flat->count--;
 	    st_offset -= adds[0];
 	}
 
@@ -859,6 +907,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	else {
             /* current type is basic or contiguous */
 	    j = *curr_index;
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset;
 	    MPI_Type_size_x(types[0], &old_size);
 	    flat->blocklens[j] = old_size;
@@ -874,6 +923,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	/* see note above about mixing updates for why we check lb and ub */
 	if ((flat->lb_idx == -1 && flat->ub_idx == -1) || lb_updated) {
 	    j = *curr_index;
+            flatlist_node_grow(flat, j);
 	    flat->indices[j] = st_offset + adds[0] + adds[1];
 	    /* again, zero-element ok: an upper-bound marker explicitly set by the
 	     * constructor of this resized type */
@@ -882,7 +932,6 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node *flat,
 	} else {
 	    /* skipped over this chunk because something else higher-up in the
 	     * type construction set this for us already */
-	    flat->count--;
 	    (*curr_index)--;
 	}
 


### PR DESCRIPTION
These are the fixes from MPICH's romio related to this issue with HDF5:
https://github.com/open-mpi/ompi/issues/6871

I think it's really just the darray + flatten portions of the fix that HDF5 needs, but this includes a couple other small fixes that seem safe and that I wasn't completely sure weren't also hit by HDF5 or similar apps.

The sieving fix isn't merged into mpich at the present time (https://github.com/open-mpi/ompi/issues/6871), but it's gone through some reviews already and I think it's about to get merged.