### PR TITLE
AVX2 and AVX512* off by default to prevent frequency scaling

### DIFF
--- a/ompi/mca/op/avx/op_avx.h
+++ b/ompi/mca/op/avx/op_avx.h
@@ -46,7 +46,8 @@ typedef struct {
        avxs; replace them with whatever is relevant for your
        component. */
 
-    uint32_t flags; /* AVX capabilities supported by the processor */
+    uint32_t supported; /* AVX capabilities supported by the environment */
+    uint32_t flags; /* AVX capabilities requested by this process */
 } ompi_op_avx_component_t;
 
 /**

--- a/ompi/mca/op/avx/op_avx_component.c
+++ b/ompi/mca/op/avx/op_avx_component.c
@@ -178,6 +178,14 @@ static int
 avx_component_register(void)
 {
     int32_t requested_flags = mca_op_avx_component.flags = has_intel_AVX_features();
+
+    /**
+     * Due to frequency scaling during AVX2 and AVX512 operations, it has been
+     * decided in January 2021 to restrict the AVX module to simple AVX usage.
+     * If users want to enable AVX2 and/or AVX512 capabilities, they will need
+     * to manually enable them.
+     */
+    requested_flags = requested_flags & ~(OMPI_OP_AVX_HAS_AVX512F_FLAG | OMPI_OP_AVX_HAS_AVX512BW_FLAG | OMPI_OP_AVX_HAS_AVX2_FLAG);
     (void) mca_base_component_var_register(&mca_op_avx_component.super.opc_version,
                                            "support",
                                            "Level of SSE/MMX/AVX support to be used (combination of processor capabilities as follow SSE 0x01, SSE2 0x02, SSE3 0x04, SSE4.1 0x08, AVX 0x010, AVX2 0x020, AVX512F 0x100, AVX512BW 0x200) capped by the local architecture capabilities",

--- a/ompi/mca/op/avx/op_avx_component.c
+++ b/ompi/mca/op/avx/op_avx_component.c
@@ -37,6 +37,18 @@ static struct ompi_op_base_module_1_0_0_t *
     avx_component_op_query(struct ompi_op_t *op, int *priority);
 static int avx_component_register(void);
 
+static mca_base_var_enum_value_flag_t avx_support_flags[] = {
+    { .flag = 0x001, .string = "SSE" },
+    { .flag = 0x002, .string = "SSE2" },
+    { .flag = 0x004, .string = "SSE3" },
+    { .flag = 0x008, .string = "SSE4.1" },
+    { .flag = 0x010, .string = "AVX" },
+    { .flag = 0x020, .string = "AVX2" },
+    { .flag = 0x100, .string = "AVX512F" },
+    { .flag = 0x200, .string = "AVX512BW" },
+    { .flag = 0,     .string = NULL },
+};
+
 /**
  * A slightly modified code from
  * https://software.intel.com/en-us/articles/how-to-detect-new-instruction-support-in-the-4th-generation-intel-core-processor-family
@@ -182,6 +194,14 @@ avx_component_register(void)
     mca_op_avx_component.supported =
         mca_op_avx_component.flags = has_intel_AVX_features();
 
+    // MCA var enum flag for conveniently seeing SSE/MMX/AVX support
+    // values
+    mca_base_var_enum_flag_t *new_enum_flag;
+    (void) mca_base_var_enum_create_flag("op_avx_support_flags",
+                                         avx_support_flags, &new_enum_flag);
+    (void) mca_base_var_enum_register("ompi", "op", "avx", "support_flags",
+                                      &new_enum_flag);
+
     /**
      * In January 2021, testing showed that using AVX512 with at least
      * one application (LAMPS) when Open MPI was compiled with
@@ -216,22 +236,23 @@ avx_component_register(void)
     }
     (void) mca_base_component_var_register(&mca_op_avx_component.super.opc_version,
                                            "available",
-                                           "Level of SSE/MMX/AVX support available (combination of processor capabilities as follow SSE 0x01, SSE2 0x02, SSE3 0x04, SSE4.1 0x08, AVX 0x010, AVX2 0x020, AVX512F 0x100, AVX512BW 0x200)",
+                                           "Level of SSE/MMX/AVX support available",
                                            MCA_BASE_VAR_TYPE_INT,
-                                           NULL, 0, 0,
+                                           &(new_enum_flag->super), 0, 0,
                                            OPAL_INFO_LVL_4,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_op_avx_component.supported);
 
     (void) mca_base_component_var_register(&mca_op_avx_component.super.opc_version,
                                            "support",
-                                           "Level of SSE/MMX/AVX support to be used (combination of processor capabilities as follow SSE 0x01, SSE2 0x02, SSE3 0x04, SSE4.1 0x08, AVX 0x010, AVX2 0x020, AVX512F 0x100, AVX512BW 0x200), capped by the local architecture capabilities",
+                                           "Level of SSE/MMX/AVX support to be used, capped by the local architecture capabilities",
                                            MCA_BASE_VAR_TYPE_INT,
-                                           NULL, 0,
+                                           &(new_enum_flag->super), 0,
                                            MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_4,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_op_avx_component.flags);
+    OBJ_RELEASE(new_enum_flag);
 
     mca_op_avx_component.flags &= mca_op_avx_component.supported;
 


### PR DESCRIPTION
As discussed in #8334 the intensive use of AVX2 and AVX512 will lead to a
significant frequency scaling, with drastic impact on application performance.
Until a better way to prevent this come up, we decided to artificially disable
support for AVX2 and AVX512.

The support for AVX2 and AVX512 can be enabled by users via the corresponding
MCA parameter (op_avx_support).

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>