### PR TITLE
Expose the PMIx/PRRTE unique configure args

### DIFF
--- a/config/ompi_pmix_add_args.m4
+++ b/config/ompi_pmix_add_args.m4
@@ -1,0 +1,45 @@
+AC_DEFUN([OMPI_PMIX_ADD_ARGS],[
+    opal_show_subtitle "PMIx Configuration options"
+
+    AC_ARG_WITH([pmix-platform-patches-dir],
+                [AC_HELP_STRING([--with-pmix-platform-patches-dir=DIR],
+                                [Location of the platform patches directory. If you use this option, you must also use --with-pmix-platform.])])
+
+    AC_ARG_WITH([pmix-platform],
+                [AC_HELP_STRING([--with-pmix-platform=FILE],
+                                [Load options for build from FILE.  Options on the
+                                 command line not in FILE are used.  Options on the
+                                 command line and in FILE are replaced by what is on the command line])])
+
+	AC_ARG_WITH([jansson],
+                [AC_HELP_STRING([--with-jansson(=DIR)],
+                                [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    AC_ARG_WITH([jansson-libdir],
+                [AC_HELP_STRING([--with-jansson-libdir=DIR],
+                                [Search for Jansson libraries in DIR])])
+
+	AC_ARG_WITH([curl],
+                [AC_HELP_STRING([--with-curl(=DIR)],
+                                [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    AC_ARG_WITH([curl-libdir],
+                [AC_HELP_STRING([--with-curl-libdir=DIR],
+                                [Search for Curl libraries in DIR])])
+
+   AC_ARG_WITH([zlib],
+                [AC_HELP_STRING([--with-zlib=DIR],
+                                [Search for zlib headers and libraries in DIR ])])
+    AC_ARG_WITH([zlib-libdir],
+                [AC_HELP_STRING([--with-zlib-libdir=DIR],
+                                [Search for zlib libraries in DIR ])])
+
+    AC_ARG_WITH([munge],
+                [AC_HELP_STRING([--with-munge=DIR],
+                                [Search for munge headers and libraries in DIR ])])
+    AC_ARG_WITH([munge-libdir],
+                [AC_HELP_STRING([--with-munge-libdir=DIR],
+                                [Search for munge libraries in DIR ])])
+
+    AC_ARG_ENABLE([dstore-pthlck],
+                  [AC_HELP_STRING([--disable-dstore-pthlck],
+                                  [Disable pthread-based locking in dstor (default: enabled)])])
+])

--- a/config/ompi_prrte_add_args.m4
+++ b/config/ompi_prrte_add_args.m4
@@ -1,0 +1,53 @@
+AC_DEFUN([OMPI_PRRTE_ADD_ARGS],[
+    opal_show_subtitle "PRRTE Configuration options"
+
+    AC_ARG_WITH([alps],
+                [AC_HELP_STRING([--with-alps(=DIR|yes|no)],
+                                [Build with ALPS scheduler component, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries (default: auto)])],[],with_alps=auto)
+    AC_ARG_WITH([alps-libdir],
+                [AC_HELP_STRING([--with-alps-libdir=DIR],
+                                [Location of alps libraries (alpslli, alpsutil) (default: /usr/lib/alps (/opt/cray/xe-sysroot/default/user on eslogin nodes))])])
+
+	AC_ARG_WITH([sge],
+                [AC_HELP_STRING([--with-sge],
+                               [Build SGE or Grid Engine support (default: no)])])
+
+    AC_ARG_WITH([tm],
+                [AC_HELP_STRING([--with-tm(=DIR)],
+                                [Build TM (Torque, PBSPro, and compatible) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+                                
+    AC_ARG_WITH([moab],
+                [AC_HELP_STRING([--with-moab],
+                                [Build MOAB scheduler component (default: yes)])])
+    AC_ARG_WITH([moab-libdir],
+                [AC_HELP_STRING([--with-moab-libdir=DIR],
+                                [Search for Moab libraries in DIR])])
+
+    AC_ARG_WITH([lsf],
+                [AC_HELP_STRING([--with-lsf(=DIR)],
+                                [Build LSF support])])
+    AC_ARG_WITH([lsf-libdir],
+                [AC_HELP_STRING([--with-lsf-libdir=DIR],
+                                [Search for LSF libraries in DIR])])
+
+    AC_ARG_WITH([slurm],
+                [AC_HELP_STRING([--with-slurm],
+                                [Build SLURM scheduler component (default: yes)])])
+
+    AC_ARG_WITH([singularity],
+                [AC_HELP_STRING([--with-singularity(=DIR)],
+                                [Build support for the Singularity container, optionally adding DIR to the search path])])
+
+    AC_ARG_WITH([prte-platform-patches-dir],
+                [AC_HELP_STRING([--with-prte-platform-patches-dir=DIR],
+                                [Location of the platform patches directory. If you use this option, you must also use --with-prte-platform.])])
+    AC_ARG_WITH([prte-platform],
+                [AC_HELP_STRING([--with-prte-platform=FILE],
+                                [Load options for build from FILE.  Options on the
+                                 command line not in FILE are used.  Options on the
+                                 command line and in FILE are replaced by what is on the command line])])
+
+    AC_ARG_ENABLE([prte-ft],
+                  [AC_HELP_STRING([--enable-prte-ft],
+                  [Enable PRRTE fault tolerance support (default: disabled)])])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@
 #                         reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -295,6 +296,8 @@ OPAL_CHECK_CUDA
 
 m4_ifdef([project_ompi], [OMPI_CONFIGURE_OPTIONS])
 m4_ifdef([project_oshmem], [OSHMEM_CONFIGURE_OPTIONS])
+OMPI_PMIX_ADD_ARGS
+OMPI_PRRTE_ADD_ARGS
 
 # Set up project specific AM_CONDITIONALs
 AS_IF([test "$enable_ompi" != "no"], [project_ompi_amc=true], [project_ompi_amc=false])


### PR DESCRIPTION
Yes, it was done by hand and is therefore fragile - but somebody had to do something as people think we dropped support for various runtime-based things.

Signed-off-by: Ralph Castain <rhc@pmix.org>