### PR TITLE
PML/UCX: don't do pml_check_selected call

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -417,13 +417,6 @@ int mca_pml_ucx_add_procs(struct ompi_proc_t **procs, size_t nprocs)
     ompi_proc_t *proc;
     ucp_ep_h ep;
     size_t i;
-    int ret;
-
-    if (OMPI_SUCCESS != (ret = mca_pml_base_pml_check_selected("ucx",
-                                                               procs,
-                                                               nprocs))) {
-        return ret;
-    }
 
     for (i = 0; i < nprocs; ++i) {
         proc = procs[(i + OMPI_PROC_MY_NAME->vpid) % nprocs];
@@ -446,13 +439,6 @@ static inline ucp_ep_h mca_pml_ucx_get_ep(ompi_communicator_t *comm, int rank)
     ep = proc_peer->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PML];
     if (OPAL_LIKELY(NULL != ep)) {
         return ep;
-    }
-
-    /* Note, mca_pml_base_pml_check_selected, doesn't use 3rd argument */
-    if (OMPI_SUCCESS != mca_pml_base_pml_check_selected("ucx",
-                                                        &proc_peer,
-                                                        1)) {
-        return NULL;
     }
 
     return mca_pml_ucx_add_proc_common(proc_peer);


### PR DESCRIPTION
From @rhc54 :

> The flagged lines should be removed because you already checked the PML match when you did "add_procs" during MPI_Init, so this check adds nothing but delay. It also has another side effect that is the cause of what you are seeing in wireup delays. Because you are using the address of the rank=0 proc of the _communicator_, and the communicator is NOT guaranteed to be MPI_COMM_WORLD, it winds up that every proc calls PMIx_Get on the PML selection key for every single process in the job...and so you are doing N-1 dmodex requests since only the rank=0 of MPI_COMM_WORLD actually published that value. This means that every single one of those requests has to be sent to the remote daemon, wait for something that won't be coming, and then return "not found" when it finally times out.


Reverts a change made in #7582