### PR TITLE
opal: disable the __atomic built-in atomics by default on AArch64

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,8 +22,9 @@ Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
 Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates.  All Rights
                         reserved.
-Copyright (c) 2019-2020 Triad National Security, LLC. All rights
+Copyright (c) 2019-2021 Triad National Security, LLC. All rights
                         reserved.
+Copyright (c) 2021      Google, LLC. All rights reserved.
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -103,6 +104,7 @@ included in the vX.Y.Z section and be denoted as:
 - OFI/libfabric: Added btl for one-sided support
 - OFI/libfabric: Multiple small bugfixes
 - libnbc: Adding numerous performance-improving algorithms
+- AArch64: disable gcc built-in atomics by default.
 
 4.0.5 -- August, 2020
 ---------------------

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
+dnl Copyright (c) 2021      Google, LLC. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -1022,7 +1023,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
 
     AC_ARG_ENABLE([builtin-atomics],
       [AC_HELP_STRING([--enable-builtin-atomics],
-         [Enable use of __sync builtin atomics (default: enabled)])])
+         [Enable use of __atomic builtin atomics (default: enabled)])])
 
     opal_cv_asm_builtin="BUILTIN_NO"
     AS_IF([test "$opal_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_builtin_atomics" != "no"],
@@ -1075,6 +1076,12 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
             OPAL_ASM_ARM_VERSION=8
             AC_DEFINE_UNQUOTED([OPAL_ASM_ARM_VERSION], [$OPAL_ASM_ARM_VERSION],
                                [What ARM assembly version to use])
+	    # If built-in atomics were not specifically request then disable the
+	    # use of built-in atomics. The performance of Open MPI when using the
+	    # built-ins is worse than when they are not in use.
+	    if test "$enable_builtin_atomics" != "yes" ; then
+		opal_cv_asm_builtin="BUILTIN_NO"
+	    fi
             OPAL_GCC_INLINE_ASSIGN='"mov %0, #0" : "=&r"(ret)'
             ;;
 


### PR DESCRIPTION
Benchmarks are showing better performance when not using the __atomic
built-ins on this arch. This PR disables them by default for this
architecture only.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>