### PR TITLE
Fixing envvar names to OMPI_MCA_orte_precondition_transports

### DIFF
--- a/ompi/mca/mtl/psm2/help-mtl-psm2.txt
+++ b/ompi/mca/mtl/psm2/help-mtl-psm2.txt
@@ -25,7 +25,7 @@ active on the node and the hardware is functioning.
   Error: %s
 #
 [no uuid present]
-Error obtaining unique transport key from PMIX (PMIX_MCA_opa_precondition_transports %s
+Error obtaining unique transport key from PMIX (OMPI_MCA_orte_precondition_transports %s
 the environment).
 
   Local host: %s

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -101,7 +101,7 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
     char env_string[256];
     int rc;
 
-    generated_key = getenv("OPA_TRANSPORT_KEY");
+    generated_key = getenv("OMPI_MCA_orte_precondition_transports");
     memset(uu, 0, sizeof(psm2_uuid_t));
 
     if (!generated_key || (strlen(generated_key) != 33) ||


### PR DESCRIPTION
  Setting PMIX transport key envvars to a single name
  OMPI_MCA_orte_precondition_transports