### PR TITLE
op_avx: use MCA enum flags instead of integer values

### DIFF
--- a/ompi/mca/op/avx/op_avx.h
+++ b/ompi/mca/op/avx/op_avx.h
@@ -46,7 +46,8 @@ typedef struct {
        avxs; replace them with whatever is relevant for your
        component. */
 
-    uint32_t flags; /* AVX capabilities supported by the processor */
+    uint32_t supported; /* AVX capabilities supported by the environment */
+    uint32_t flags; /* AVX capabilities requested by this process */
 } ompi_op_avx_component_t;
 
 /**


### PR DESCRIPTION
MCA enums make it easier for users to see/set MCA flag values.  Also
add "op_avx_capabilities" read-only MCA var that shows what is supported
on your platform, regardless of what value the user has set in
"opal_avx_support".

For example, ompi_output shows all the valid values:

```
$ ompi_info --all --parsable | grep _avx_
mca:op:avx:param:op_avx_capabilities:value:SSE,SSE2,SSE3,SSE4.1,AVX
mca:op:avx:param:op_avx_capabilities:source:default
mca:op:avx:param:op_avx_capabilities:status:read-only
mca:op:avx:param:op_avx_capabilities:level:4
mca:op:avx:param:op_avx_capabilities:help:Level of SSE/MMX/AVX support available in the current environment
mca:op:avx:param:op_avx_capabilities:enumerator:value:1:SSE
mca:op:avx:param:op_avx_capabilities:enumerator:value:2:SSE2
mca:op:avx:param:op_avx_capabilities:enumerator:value:4:SSE3
mca:op:avx:param:op_avx_capabilities:enumerator:value:8:SSE4.1
mca:op:avx:param:op_avx_capabilities:enumerator:value:16:AVX
mca:op:avx:param:op_avx_capabilities:enumerator:value:32:AVX2
mca:op:avx:param:op_avx_capabilities:enumerator:value:256:AVX512F
mca:op:avx:param:op_avx_capabilities:enumerator:value:512:AVX512BW
mca:op:avx:param:op_avx_capabilities:deprecated:no
mca:op:avx:param:op_avx_capabilities:type:int
mca:op:avx:param:op_avx_capabilities:disabled:false
mca:op:avx:param:op_avx_support:value:SSE,SSE2,SSE3,SSE4.1,AVX
mca:op:avx:param:op_avx_support:source:default
mca:op:avx:param:op_avx_support:status:read-only
mca:op:avx:param:op_avx_support:level:4
mca:op:avx:param:op_avx_support:help:Level of SSE/MMX/AVX support to be used, capped by the local architecture capabilities
mca:op:avx:param:op_avx_support:enumerator:value:1:SSE
mca:op:avx:param:op_avx_support:enumerator:value:2:SSE2
mca:op:avx:param:op_avx_support:enumerator:value:4:SSE3
mca:op:avx:param:op_avx_support:enumerator:value:8:SSE4.1
mca:op:avx:param:op_avx_support:enumerator:value:16:AVX
mca:op:avx:param:op_avx_support:enumerator:value:32:AVX2
mca:op:avx:param:op_avx_support:enumerator:value:256:AVX512F
mca:op:avx:param:op_avx_support:enumerator:value:512:AVX512BW
mca:op:avx:param:op_avx_support:deprecated:no
mca:op:avx:param:op_avx_support:type:int
mca:op:avx:param:op_avx_support:disabled:false
```

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>