### PR TITLE
common/ofi: Use opal_show_help() to call out lack of locality info

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -356,7 +356,10 @@ static uint32_t get_package_rank(int32_t num_local_peers, uint16_t my_local_rank
                                        &pname, &locality_string, OPAL_STRING);
         if (OPAL_SUCCESS != rc || NULL == locality_string) {
             // If we don't have information about locality, fall back to procid
-            opal_show_help("help-common-ofi.txt", "package_rank failed", true);
+            int level = 10;
+            if (opal_output_get_verbosity(opal_common_ofi.output) >= level) {
+                opal_show_help("help-common-ofi.txt", "package_rank failed", true, level);
+            }
             return pid;
         }
 

--- a/opal/mca/common/ofi/help-common-ofi.txt
+++ b/opal/mca/common/ofi/help-common-ofi.txt
@@ -12,3 +12,6 @@ Open MPI's OFI driver detected multiple equidistant NICs from the current proces
 but had insufficient information to ensure MPI processes fairly pick a NIC for use.
 This may negatively impact performance. A more modern PMIx server is necessary to
 resolve this issue.
+
+Note: This message is displayed only when the OFI component's verbosity level is
+%d or higher.


### PR DESCRIPTION
    opal_show_help() can dedup output across ranks when using mpirun. Print
    the help text only when the OFI component's verbosity is > 9.

    Signed-off-by: Raghu Raja <craghun@amazon.com>