### PR TITLE
Provide support for short float complex on M1.

### DIFF
--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -522,6 +522,14 @@ static inline uint16_t ntohs(uint16_t netvar) { return netvar; }
 #define restrict
 #endif
 
+#ifdef HAVE_OPAL_SHORT_FLOAT_COMPLEX_T
+#undef opal_short_float_complex_t
+typedef struct {
+    opal_short_float_t real;
+    opal_short_float_t imag;
+} opal_short_float_complex_t;
+#endif
+
 #else
 
 /* For a similar reason to what is listed in opal_config_top.h, we


### PR DESCRIPTION
The root cause was the use of the type short float complex type in the #8007 PR mixed with the definition for this type generated during configure (_Float16 [2]). Replacing this typedef with a struct solves the issue.

Thanks @kawashima-fj for the patch.

Fixes #8450 

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>