### PR TITLE
Allow PSM2 get its TransportKey from PMIx

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -16,6 +16,8 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,7 +103,20 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
     char env_string[256];
     int rc;
 
-    generated_key = getenv("OMPI_MCA_orte_precondition_transports");
+    opal_process_name_t pname;
+
+    generated_key = NULL;
+    pname.jobid = opal_process_info.my_name.jobid;
+    pname.vpid = OPAL_VPID_WILDCARD;
+    OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_CREDENTIAL, &pname,
+                                    (char**)&generated_key, PMIX_STRING);
+
+    char *tmp_key;
+    if (PMIX_SUCCESS != rc || NULL == generated_key) {
+        if (NULL != (tmp_key = getenv("OMPI_MCA_orte_precondition_transports"))) {
+            generated_key = strdup(tmp_key);
+        }
+     }
     memset(uu, 0, sizeof(psm2_uuid_t));
 
     if (!generated_key || (strlen(generated_key) != 33) ||
@@ -111,9 +126,12 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
 		     "no uuid present", true,
 		     generated_key ? "could not be parsed from" :
 		     "not present in", ompi_process_info.nodename);
+      free(generated_key);
       return OMPI_ERROR;
 
     }
+
+    free(generated_key);
 
     /* Handle our own errors for opening endpoints */
     psm2_error_register_handler(ompi_mtl_psm2.ep, ompi_mtl_psm2_errhandler);


### PR DESCRIPTION
This piece removes the need of a psm2 env var for the TransportKey and now it gets it from PMIx.