### PR TITLE
btl/vader: improve support for dynamic add_procs

### DIFF
--- a/opal/mca/btl/sm/btl_sm.h
+++ b/opal/mca/btl/sm/btl_sm.h
@@ -125,7 +125,6 @@ struct mca_btl_sm_component_t {
     char *my_segment;                       /**< this rank's base pointer */
     size_t segment_size;                    /**< size of my_segment */
     int32_t num_smp_procs;                  /**< current number of smp procs on this host */
-    opal_atomic_int32_t local_rank;         /**< current rank index at add_procs() time */
     opal_free_list_t sm_frags_eager;     /**< free list of sm send frags */
     opal_free_list_t sm_frags_max_send;  /**< free list of sm max send frags (large fragments) */
     opal_free_list_t sm_frags_user;      /**< free list of small inline frags */

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -560,8 +560,6 @@ static mca_btl_base_module_t **mca_btl_sm_component_init (int *num_btls,
     /* no fast boxes allocated initially */
     component->num_fbox_in_endpoints = 0;
 
-    component->local_rank = 0;
-
     mca_btl_sm_check_single_copy ();
 
     if (MCA_BTL_SM_XPMEM != mca_btl_sm_component.single_copy_mechanism) {

--- a/opal/mca/btl/sm/btl_sm_endpoint.h
+++ b/opal/mca/btl/sm/btl_sm_endpoint.h
@@ -64,7 +64,7 @@ typedef struct mca_btl_base_endpoint_t {
         opal_free_list_item_t *fbox; /**< fast-box free list item */
     } fbox_out;
 
-    int32_t peer_smp_rank;  /**< my peer's SMP process rank.  Used for accessing
+    uint16_t peer_smp_rank; /**< my peer's SMP process rank.  Used for accessing
                              *   SMP specfic data structures. */
     opal_atomic_size_t send_count;    /**< number of fragments sent to this peer */
     char *segment_base;     /**< start of the peer's segment (in the address space


### PR DESCRIPTION
This commit updates the fragile add_procs code to allow
local procs to be added in any order. To support this the
process no longer relies on a counter to determine the
local rank but instead uses the local rank provided by
PMIX.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>