### PR TITLE
btl/sm: do not set always callback frag when there is none

### DIFF
--- a/opal/mca/btl/sm/btl_sm_send.c
+++ b/opal/mca/btl/sm/btl_sm_send.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,18 +43,25 @@ int mca_btl_sm_send (struct mca_btl_base_module_t *btl,
     mca_btl_sm_frag_t *frag = (mca_btl_sm_frag_t *) descriptor;
     const size_t total_size = frag->segments[0].seg_len;
 
-    /* in order to work around a long standing ob1 bug (see #3845) we have to always
-     * make the callback. once this is fixed in ob1 we can restore the code below. */
-    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+    if (frag->base.des_cbfunc) {
+        /* in order to work around a long standing ob1 bug (see #3845) we have to always
+         * make the callback. once this is fixed in ob1 we can restore the code below. */
+        frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+    }
 
     /* header (+ optional inline data) */
     frag->hdr->len = total_size;
     /* type of message, pt-2-pt, one-sided, etc */
     frag->hdr->tag = tag;
 
+    /* clear the complete flag if it has been set */
+    frag->hdr->flags &= ~MCA_BTL_SM_FLAG_COMPLETE;
+
     /* post the relative address of the descriptor into the peer's fifo */
     if (opal_list_get_size (&endpoint->pending_frags) || !sm_fifo_write_ep (frag->hdr, endpoint)) {
-        frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+        if (frag->base.des_cbfunc) {
+            frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+        }
         OPAL_THREAD_LOCK(&endpoint->pending_frags_lock);
         opal_list_append (&endpoint->pending_frags, (opal_list_item_t *) frag);
         if (!endpoint->waiting) {
@@ -69,8 +77,9 @@ int mca_btl_sm_send (struct mca_btl_base_module_t *btl,
     return OPAL_SUCCESS;
 
 #if 0
-    if ((frag->hdr->flags & MCA_BTL_SM_FLAG_SINGLE_COPY) ||
-        !(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) {
+    if (((frag->hdr->flags & MCA_BTL_SM_FLAG_SINGLE_COPY) ||
+        !(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) &&
+        frag->base.des_cbfunc) {
         frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
 
         return OPAL_SUCCESS;


### PR DESCRIPTION
This fixes an issue with the btl_send function in btl/sm. The
pml/ob1 usage always provides a callback function which masked
this bug. The btl_send function was unconditionally setting
the MCA_BTL_DES_SEND_ALWAYS_CALLBACK flag for any outgoing
fragment. This is a violation of the interface which allows
the caller to leave the callback function unset. This commit
fixes the issue by protecting the code which set the flag to
first check if the callback function is non-NULL.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>