### PR TITLE
Fix segv in OMPI_Affinity_str().

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  */
 #include "ompi_config.h"
@@ -62,7 +63,6 @@
 /* storage to support OMPI */
 opal_process_name_t pmix_name_wildcard = {UINT32_MAX-1, UINT32_MAX-1};
 opal_process_name_t pmix_name_invalid = {UINT32_MAX, UINT32_MAX};
-hwloc_cpuset_t ompi_proc_applied_binding = NULL;
 bool ompi_singleton = false;
 
 static int _setup_top_session_dir(char **sdir);


### PR DESCRIPTION
- 'userdata' is not available when the topology is distributed via
  shared memory. Fix some areas where it wasn't protected.
- Allow users to pass in topo files via --mca opal_hwloc_base_topo_file.
- Consistency: taking an xml file would not filter cpus, so don't
  filter cpus from PMIx either.
- Make sure the cache line is set wherever the topology is taken from.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>