### PR TITLE
NEWS: update NEWS and VERSION for v4.0.6rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,10 +57,19 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
-4.0.6 -- December, 2020
+4.0.6 -- March, 2021
 -----------------------
 - Update embedded PMIx to 3.2.2.  This update addresses several
   MPI_COMM_SPAWN problems.
+- Fix a problem when using Flux PMI and UCX.  Thanks to Sami Ilvonen
+  for reporting and supplying a fix.
+- Fix a problem with MPIR breakpoint being compiled out using PGI
+  compilers.  Thanks to @louisespellacy-arm for reporting.
+- Fix some ROMIO issues when using Lustre.  Thanks to Mark Dixon for
+  reporting.
+- Fix a problem using an external PMIx 4 to build Open MPI 4.0.x.
+- Fix a compile problem when using the enable-timing configure option
+  and UCX.  Thanks to Jan Bierbaum for reporting.
 - Fix a symbol name collision when using the Cray compiler to build
   Open SHMEM.  Thanks to Pak Lui for reporting and fixing.
 - Correct an issue encountered when building Open MPI under OSX Big Sur.

--- a/VERSION
+++ b/VERSION
@@ -30,7 +30,7 @@ release=6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -106,8 +106,8 @@ libompitrace_so_version=60:0:20
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=60:4:19
-libmca_ompi_common_monitoring_so_version=60:0:10
+libmca_ompi_common_ompio_so_version=60:5:19
+libmca_ompi_common_monitoring_so_version=60:1:10
 
 # ORTE layer
 libmca_orte_common_alps_so_version=60:0:20


### PR DESCRIPTION
also update VERSION since there were some changes to
some mca common libs now between v4.0.5 and HEAD of v4.0.x.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>