### PR TITLE
MPI_T_init_thread() fixup.

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -111,7 +111,7 @@ int ompi_mpi_register_params(void)
     value = 0;
     (void) mca_base_var_register ("ompi", "mpi", "ft", "verbose",
                                   "Verbosity level of the ULFM MPI Fault Tolerance framework",
-                                  MCA_BASE_VAR_TYPE_INT, &mca_base_var_enum_verbose, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                   OPAL_INFO_LVL_8, MCA_BASE_VAR_SCOPE_LOCAL, &value);
 #if OPAL_ENABLE_FT_MPI
     if( 0 < value ) {


### PR DESCRIPTION
- When MPI_Init() is already called, the var will go through
  registration twice, calling OBJ_DESTRUCT() on this global struct.