### PR TITLE
Configury fixes and cleanup

### DIFF
--- a/config/opal_check_cflags.m4
+++ b/config/opal_check_cflags.m4
@@ -1,0 +1,72 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
+dnl
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([_OPAL_CFLAGS_FAIL_SEARCH],[
+    AC_REQUIRE([AC_PROG_GREP])
+    if test -s conftest.err ; then
+        $GREP -iq $1 conftest.err
+        if test "$?" = "0" ; then
+            opal_cv_cc_[$2]=0
+        fi
+    fi
+])
+
+AC_DEFUN([_OPAL_CHECK_SPECIFIC_CFLAGS], [
+AC_MSG_CHECKING(if $CC supports ([$1]))
+            CFLAGS_orig=$CFLAGS
+            CFLAGS="$CFLAGS $1"
+            AC_CACHE_VAL(opal_cv_cc_[$2], [
+                   AC_TRY_COMPILE([], [$3],
+                                   [
+                                    opal_cv_cc_[$2]=1
+                                    _OPAL_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
+                                   ],
+                                    opal_cv_cc_[$2]=1
+                                    _OPAL_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
+                                 )])
+            if test "$opal_cv_cc_[$2]" = "0" ; then
+                CFLAGS="$CFLAGS_orig"
+                AC_MSG_RESULT([no])
+            else
+                AC_MSG_RESULT([yes])
+            fi
+])
+
+AC_DEFUN([_OPAL_CXXFLAGS_FAIL_SEARCH],[
+    AC_REQUIRE([AC_PROG_GREP])
+    if test -s conftest.err ; then
+        $GREP -iq $1 conftest.err
+        if test "$?" = "0" ; then
+            opal_cv_cxx_[$2]=0
+        fi
+    fi
+])
+
+AC_DEFUN([_OPAL_CHECK_SPECIFIC_CXXFLAGS], [
+AC_MSG_CHECKING(if $CXX supports ([$1]))
+            CXXFLAGS_orig=$CXXFLAGS
+            CXXFLAGS="$CXXFLAGS $1"
+            AC_CACHE_VAL(opal_cv_cxx_[$2], [
+                   AC_TRY_COMPILE([], [$3],
+                                   [
+                                    opal_cv_cxx_[$2]=1
+                                    _OPAL_CXXFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
+                                   ],
+                                    opal_cv_cxx_[$2]=1
+                                    _OPAL_CXXFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
+                                 )])
+            if test "$opal_cv_cxx_[$2]" = "0" ; then
+                CXXFLAGS="$CXXFLAGS_orig"
+                AC_MSG_RESULT([no])
+            else
+                AC_MSG_RESULT([yes])
+            fi
+])

--- a/config/opal_check_vendor.m4
+++ b/config/opal_check_vendor.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved
-dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -123,7 +123,7 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
 
     # IBM XL C/C++
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
-          [OPAL_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__)],
+          [OPAL_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)],
                [opal_check_compiler_vendor_result="ibm"
                 xlc_major_version=`$CC -qversion 2>&1 | tail -n 1 | cut -d ' ' -f 2 | cut -d '.' -f 1`
                 xlc_minor_version=`$CC -qversion 2>&1 | tail -n 1 | cut -d ' ' -f 2 | cut -d '.' -f 2`

--- a/config/opal_check_vendor.m4
+++ b/config/opal_check_vendor.m4
@@ -132,30 +132,6 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
                ],
                [OPAL_IF_IFELSE([defined(_AIX) && !defined(__GNUC__)],
                     [opal_check_compiler_vendor_result="ibm"])])])
-
-    # GNU
-    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
-          [OPAL_IFDEF_IFELSE([__GNUC__],
-               [opal_check_compiler_vendor_result="gnu"
-
-               # We do not support gccfss as a compiler so die if
-               # someone tries to use said compiler.  gccfss (gcc
-               # for SPARC Systems) is a compiler that is no longer
-               # supported by Oracle and it has some major flaws
-               # that prevents it from actually compiling OMPI code.
-               # So if we detect it we automatically bail.
-
-               if ($CC --version | grep gccfss) >/dev/null 2>&1; then
-                   AC_MSG_RESULT([gccfss])
-                   AC_MSG_WARN([Detected gccfss being used to compile Open MPI.])
-                   AC_MSG_WARN([Because of several issues Open MPI does not support])
-                   AC_MSG_WARN([the gccfss compiler.  Please use a different compiler.])
-                   AC_MSG_WARN([If you did not think you used gccfss you may want to])
-                   AC_MSG_WARN([check to see if the compiler you think you used is])
-                   AC_MSG_WARN([actually a link to gccfss.])
-                   AC_MSG_ERROR([Cannot continue])
-               fi])])
-
     # Borland Turbo C
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IFDEF_IFELSE([__TURBOC__],
@@ -278,6 +254,29 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IFDEF_IFELSE([__WATCOMC__],
                [opal_check_compiler_vendor_result="watcom"])])
+
+    # GNU
+    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
+          [OPAL_IFDEF_IFELSE([__GNUC__],
+               [opal_check_compiler_vendor_result="gnu"
+
+               # We do not support gccfss as a compiler so die if
+               # someone tries to use said compiler.  gccfss (gcc
+               # for SPARC Systems) is a compiler that is no longer
+               # supported by Oracle and it has some major flaws
+               # that prevents it from actually compiling OMPI code.
+               # So if we detect it we automatically bail.
+
+               if ($CC --version | grep gccfss) >/dev/null 2>&1; then
+                   AC_MSG_RESULT([gccfss])
+                   AC_MSG_WARN([Detected gccfss being used to compile Open MPI.])
+                   AC_MSG_WARN([Because of several issues Open MPI does not support])
+                   AC_MSG_WARN([the gccfss compiler.  Please use a different compiler.])
+                   AC_MSG_WARN([If you did not think you used gccfss you may want to])
+                   AC_MSG_WARN([check to see if the compiler you think you used is])
+                   AC_MSG_WARN([actually a link to gccfss.])
+                   AC_MSG_ERROR([Cannot continue])
+               fi])])
 
     $1="$opal_check_compiler_vendor_result"
     unset opal_check_compiler_vendor_result

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -19,6 +19,7 @@ dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
 dnl Copyright (c) 2020      Google, LLC. All rights reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -1086,6 +1087,7 @@ dnl
 dnl #################################################################
 AC_DEFUN([OPAL_CONFIG_ASM],[
     AC_REQUIRE([OPAL_SETUP_CC])
+    AC_REQUIRE([OPAL_SETUP_CXX])
     AC_REQUIRE([AM_PROG_AS])
 
     AC_ARG_ENABLE([c11-atomics],[AC_HELP_STRING([--enable-c11-atomics],

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -161,6 +161,8 @@ AC_DEFUN([OPAL_SETUP_CC],[
 
     OPAL_CHECK_CC_IQUOTE
 
+    OPAL_C_COMPILER_VENDOR([opal_c_vendor])
+
     if test $opal_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the
         # following lines and update the warning when we require a C11 compiler.
@@ -206,7 +208,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_DEFINE_UNQUOTED([OPAL_C_HAVE___THREAD], [$opal_prog_cc__thread_available],
                        [Whether C compiler supports __thread])
 
-    OPAL_C_COMPILER_VENDOR([opal_c_vendor])
 
     # Check for standard headers, needed here because needed before
     # the types checks.
@@ -244,47 +245,34 @@ AC_DEFUN([OPAL_SETUP_CC],[
 
     # Do we want code coverage
     if test "$WANT_COVERAGE" = "1"; then
-        if test "$opal_c_vendor" = "gnu" ; then
-            # For compilers > gcc-4.x, use --coverage for
-            # compiling and linking to circumvent trouble with
-            # libgcov.
-            CFLAGS_orig="$CFLAGS"
-            LDFLAGS_orig="$LDFLAGS"
+        # For compilers > gcc-4.x, use --coverage for
+        # compiling and linking to circumvent trouble with
+        # libgcov.
+        LDFLAGS_orig="$LDFLAGS"
+        LDFLAGS="$LDFLAGS_orig --coverage"
+        OPAL_COVERAGE_FLAGS=
 
-            CFLAGS="$CFLAGS_orig --coverage"
-            LDFLAGS="$LDFLAGS_orig --coverage"
-            OPAL_COVERAGE_FLAGS=
-
-            AC_CACHE_CHECK([if $CC supports --coverage],
-                      [opal_cv_cc_coverage],
-                      [AC_TRY_COMPILE([], [],
-                                      [opal_cv_cc_coverage="yes"],
-                                      [opal_cv_cc_coverage="no"])])
-
-            if test "$opal_cv_cc_coverage" = "yes" ; then
-                OPAL_COVERAGE_FLAGS="--coverage"
-                CLEANFILES="*.gcno ${CLEANFILES}"
-                CONFIG_CLEAN_FILES="*.gcda *.gcov ${CONFIG_CLEAN_FILES}"
-            else
-                OPAL_COVERAGE_FLAGS="-ftest-coverage -fprofile-arcs"
-                CLEANFILES="*.bb *.bbg ${CLEANFILES}"
-                CONFIG_CLEAN_FILES="*.da *.*.gcov ${CONFIG_CLEAN_FILES}"
-            fi
-            CFLAGS="$CFLAGS_orig $OPAL_COVERAGE_FLAGS"
-            LDFLAGS="$LDFLAGS_orig $OPAL_COVERAGE_FLAGS"
-            OPAL_WRAPPER_FLAGS_ADD([CFLAGS], [$OPAL_COVERAGE_FLAGS])
-            OPAL_WRAPPER_FLAGS_ADD([LDFLAGS], [$OPAL_COVERAGE_FLAGS])
-
-            OPAL_FLAGS_UNIQ(CFLAGS)
-            OPAL_FLAGS_UNIQ(LDFLAGS)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(--coverage, coverage)
+        if test "$opal_cv_cc_coverage" = "1" ; then
+            OPAL_COVERAGE_FLAGS="--coverage"
+            CLEANFILES="*.gcno ${CLEANFILES}"
+            CONFIG_CLEAN_FILES="*.gcda *.gcov ${CONFIG_CLEAN_FILES}"
             AC_MSG_WARN([$OPAL_COVERAGE_FLAGS has been added to CFLAGS (--enable-coverage)])
-
-            WANT_DEBUG=1
         else
-            AC_MSG_WARN([Code coverage functionality is currently available only with GCC])
-            AC_MSG_ERROR([Configure: Cannot continue])
-       fi
-    fi
+            _OPAL_CHECK_SPECIFIC_CFLAGS(-ftest-coverage, ftest_coverage)
+            _OPAL_CHECK_SPECIFIC_CFLAGS(-fprofile-arcs, fprofile_arcs)
+            if test "$opal_cv_cc_ftest_coverage" = "0" || test "opal_cv_cc_fprofile_arcs" = "0" ; then
+                AC_MSG_WARN([Code coverage functionality is not currently available with $CC])
+                AC_MSG_ERROR([Configure: Cannot continue])
+            fi
+            CLEANFILES="*.bb *.bbg ${CLEANFILES}"
+            OPAL_COVERAGE_FLAGS="-ftest-coverage -fprofile-arcs"
+        fi
+        OPAL_FLAGS_UNIQ(CFLAGS)
+        OPAL_FLAGS_UNIQ(LDFLAGS)
+        WANT_DEBUG=1
+   fi
+    
 
     # Do we want debugging?
     if test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no" ; then
@@ -299,120 +287,29 @@ AC_DEFUN([OPAL_SETUP_CC],[
     OPAL_CFLAGS_BEFORE_PICKY="$CFLAGS"
 
     if test $WANT_PICKY_COMPILER -eq 1; then
-        CFLAGS_orig=$CFLAGS
-        add=
-
-        # These flags are likely GCC-specific (or, more specifically,
-        # we don't have general tests for each one, and we know they
-        # work with all versions of GCC that we have used throughout
-        # the years, so we'll keep them limited just to GCC).
-        if test "$opal_c_vendor" = "gnu" ; then
-            add="$add -Wall -Wundef -Wno-long-long -Wsign-compare"
-            add="$add -Wmissing-prototypes -Wstrict-prototypes"
-            add="$add -Wcomment -pedantic"
-        fi
-
-        # see if -Wno-long-double works...
-        # Starting with GCC-4.4, the compiler complains about not
-        # knowing -Wno-long-double, only if -Wstrict-prototypes is set, too.
-        #
-        # Actually, this is not real fix, as GCC will pass on any -Wno- flag,
-        # have fun with the warning: -Wno-britney
-        CFLAGS="$CFLAGS_orig $add -Wno-long-double -Wstrict-prototypes"
-
-        AC_CACHE_CHECK([if $CC supports -Wno-long-double],
-            [opal_cv_cc_wno_long_double],
-            [AC_TRY_COMPILE([], [],
-                [
-                 dnl So -Wno-long-double did not produce any errors...
-                 dnl We will try to extract a warning regarding
-                 dnl unrecognized or ignored options
-                 AC_TRY_COMPILE([], [long double test;],
-                     [
-                      opal_cv_cc_wno_long_double="yes"
-                      if test -s conftest.err ; then
-                          dnl Yes, it should be "ignor", in order to catch ignoring and ignore
-                          for i in unknown invalid ignor unrecognized 'not supported'; do
-                              $GREP -iq $i conftest.err
-                              if test "$?" = "0" ; then
-                                  opal_cv_cc_wno_long_double="no"
-                                  break;
-                              fi
-                          done
-                      fi
-                     ],
-                     [opal_cv_cc_wno_long_double="no"])],
-                [opal_cv_cc_wno_long_double="no"])
-            ])
-
-        if test "$opal_cv_cc_wno_long_double" = "yes" ; then
-            add="$add -Wno-long-double"
-        fi
-
-        # Per above, we know that this flag works with GCC / haven't
-        # really tested it elsewhere.
-        if test "$opal_c_vendor" = "gnu" ; then
-            add="$add -Werror-implicit-function-declaration "
-        fi
-
-        CFLAGS="$CFLAGS_orig $add"
-        OPAL_FLAGS_UNIQ(CFLAGS)
-        AC_MSG_WARN([$add has been added to CFLAGS (--enable-picky)])
-        unset add
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wundef, Wundef)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wno-long-long, Wno_long_long, int main() { long long x; })
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wsign-compare, Wsign_compare)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wmissing-prototypes, Wmissing_prototypes)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wstrict-prototypes, Wstrict_prototypes)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wcomment, Wcomment)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Werror-implicit-function-declaration, Werror_implicit_function_declaration)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wno-long-double, Wno_long_double, int main() { long double x; })
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-fno-strict-aliasing, fno_strict_aliasing, int main() { long double x; })
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-pedantic, pedantic)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wall, Wall)
     fi
 
-    # See if this version of gcc allows -finline-functions and/or
-    # -fno-strict-aliasing.  Even check the gcc-impersonating compilers.
-    if test "$GCC" = "yes"; then
-        CFLAGS_orig="$CFLAGS"
-
-        # Note: Some versions of clang (at least >= 3.5 -- perhaps
-        # older versions, too?) and xlc with -g (v16.1, perhaps older)
-        # will *warn* about -finline-functions, but still allow it.
-        # This is very annoying, so check for that warning, too.
-        # The clang warning looks like this:
-        # clang: warning: optimization flag '-finline-functions' is not supported
-        # clang: warning: argument unused during compilation: '-finline-functions'
-        # the xlc warning looks like this:
-        # warning: "-qinline" is not compatible with "-g". "-qnoinline" is being set.
-        CFLAGS="$CFLAGS_orig -finline-functions"
-        add=
-        AC_CACHE_CHECK([if $CC supports -finline-functions],
-                   [opal_cv_cc_finline_functions],
-                   [AC_TRY_COMPILE([], [],
-                                   [opal_cv_cc_finline_functions="yes"
-                                    if test -s conftest.err ; then
-                                        for i in unused 'not supported\|not compatible' ; do
-                                            if $GREP -iq "$i" conftest.err; then
-                                                opal_cv_cc_finline_functions="no"
-                                                break;
-                                            fi
-                                        done
-                                    fi
-                                   ],
-                                   [opal_cv_cc_finline_functions="no"])])
-        if test "$opal_cv_cc_finline_functions" = "yes" ; then
-            add=" -finline-functions"
-        fi
-        CFLAGS="$CFLAGS_orig$add"
-
-        CFLAGS_orig="$CFLAGS"
-        CFLAGS="$CFLAGS_orig -fno-strict-aliasing"
-        add=
-        AC_CACHE_CHECK([if $CC supports -fno-strict-aliasing],
-                   [opal_cv_cc_fno_strict_aliasing],
-                   [AC_TRY_COMPILE([], [],
-                                   [opal_cv_cc_fno_strict_aliasing="yes"],
-                                   [opal_cv_cc_fno_strict_aliasing="no"])])
-        if test "$opal_cv_cc_fno_strict_aliasing" = "yes" ; then
-            add=" -fno-strict-aliasing"
-        fi
-        CFLAGS="$CFLAGS_orig$add"
-
-        OPAL_FLAGS_UNIQ(CFLAGS)
-        AC_MSG_WARN([$add has been added to CFLAGS])
-        unset add
-    fi
+    # Note: Some versions of clang (at least >= 3.5 -- perhaps
+    # older versions, too?) and xlc with -g (v16.1, perhaps older)
+    # will *warn* about -finline-functions, but still allow it.
+    # This is very annoying, so check for that warning, too.
+    # The clang warning looks like this:
+    # clang: warning: optimization flag '-finline-functions' is not supported
+    # clang: warning: argument unused during compilation: '-finline-functions'
+    # the xlc warning looks like this:
+    # warning: "-qinline" is not compatible with "-g". "-qnoinline" is being set.
+    _OPAL_CHECK_SPECIFIC_CFLAGS(-finline-functions, finline_functions)
 
     # Try to enable restrict keyword
     RESTRICT_CFLAGS=
@@ -425,24 +322,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
         ;;
     esac
     if test ! -z "$RESTRICT_CFLAGS" ; then
-        CFLAGS_orig="$CFLAGS"
-        CFLAGS="$CFLAGS_orig $RESTRICT_CFLAGS"
-        add=
-        AC_CACHE_CHECK([if $CC supports $RESTRICT_CFLAGS],
-                   [opal_cv_cc_restrict_cflags],
-                   [AC_TRY_COMPILE([], [],
-                                   [opal_cv_cc_restrict_cflags="yes"],
-                                   [opal_cv_cc_restrict_cflags="no"])])
-        if test "$opal_cv_cc_restrict_cflags" = "yes" ; then
-            add=" $RESTRICT_CFLAGS"
-        fi
-
-        CFLAGS="${CFLAGS_orig}${add}"
-        OPAL_FLAGS_UNIQ([CFLAGS])
-        if test "$add" != "" ; then
-            AC_MSG_WARN([$add has been added to CFLAGS])
-        fi
-        unset add
+        _OPAL_CHECK_SPECIFIC_CFLAGS($RESTRICT_CFLAGS, restrict)
     fi
 
     # see if the C compiler supports __builtin_expect
@@ -518,6 +398,8 @@ AC_DEFUN([OPAL_SETUP_CC],[
     OPAL_ENSURE_CONTAINS_OPTFLAGS(["$CFLAGS"])
     AC_MSG_RESULT([$co_result])
     CFLAGS="$co_result"
+    OPAL_FLAGS_UNIQ([CFLAGS])
+    AC_MSG_RESULT(CFLAGS result: $CFLAGS)
     OPAL_VAR_SCOPE_POP
 ])
 

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -18,6 +18,7 @@ dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -366,11 +367,14 @@ AC_DEFUN([OPAL_SETUP_CC],[
         CFLAGS_orig="$CFLAGS"
 
         # Note: Some versions of clang (at least >= 3.5 -- perhaps
-        # older versions, too?) will *warn* about -finline-functions,
-        # but still allow it.  This is very annoying, so check for
-        # that warning, too.  The clang warning looks like this:
+        # older versions, too?) and xlc with -g (v16.1, perhaps older)
+        # will *warn* about -finline-functions, but still allow it.
+        # This is very annoying, so check for that warning, too.
+        # The clang warning looks like this:
         # clang: warning: optimization flag '-finline-functions' is not supported
         # clang: warning: argument unused during compilation: '-finline-functions'
+        # the xlc warning looks like this:
+        # warning: "-qinline" is not compatible with "-g". "-qnoinline" is being set.
         CFLAGS="$CFLAGS_orig -finline-functions"
         add=
         AC_CACHE_CHECK([if $CC supports -finline-functions],
@@ -378,7 +382,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
                    [AC_TRY_COMPILE([], [],
                                    [opal_cv_cc_finline_functions="yes"
                                     if test -s conftest.err ; then
-                                        for i in unused 'not supported' ; do
+                                        for i in unused 'not supported\|not compatible' ; do
                                             if $GREP -iq "$i" conftest.err; then
                                                 opal_cv_cc_finline_functions="no"
                                                 break;

--- a/ompi/runtime/Makefile.am
+++ b/ompi/runtime/Makefile.am
@@ -32,6 +32,7 @@ headers += \
 	runtime/ompi_rte.h
 
 lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
+        runtime/ompi_mpi_init.c \
         runtime/ompi_mpi_abort.c \
         runtime/ompi_mpi_dynamics.c \
         runtime/ompi_mpi_finalize.c \
@@ -41,13 +42,3 @@ lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
 	runtime/ompi_info_support.c \
 	runtime/ompi_spc.c \
 	runtime/ompi_rte.c
-
-# The MPIR portion of the library must be built with flags to
-# enable stepping out of MPI_INIT into main.
-# Use an intermediate library to isolate the debug object.
-noinst_LTLIBRARIES += libompi_mpir.la
-libompi_mpir_la_SOURCES = \
-	runtime/ompi_mpi_init.c
-libompi_mpir_la_CFLAGS = $(MPIR_UNWIND_CFLAGS)
-
-lib@OMPI_LIBMPI_NAME@_la_LIBADD += libompi_mpir.la

--- a/opal/include/opal/opal_portable_platform.h
+++ b/opal/include/opal/opal_portable_platform.h
@@ -171,7 +171,7 @@
        /* XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX */
 #    endif
 
-#elif defined(__xlC__)
+#elif defined(__xlC__) || defined(__ibmxl__) || defined(__IBMC__) || defined(__IBMCPP__)
 #    define PLATFORM_COMPILER_XLC  1
 #    define PLATFORM_COMPILER_FAMILYNAME XLC
 #    define PLATFORM_COMPILER_FAMILYID 5

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -107,7 +107,7 @@ void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-#ifdef __xlC__
+#if defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)
 /* work-around bizzare xlc bug in which it sign-extends
    a pointer to a 32-bit signed integer */
 #define OPAL_ASM_ADDR(a) ((uintptr_t)a)


### PR DESCRIPTION
- Fix check for IBM xl compilers for v13.1 and later.
- Fix configury where most compilers will get mislabeled as 'gnu'. 
- Silence -qinline xlc compiler warning.
- Add _OPAL_CHECK_SPECIFIC_*FLAGS to check compiler flags.

Most of these fixes are already in pmix/prrte, bringing them over to ompi.