### PR TITLE
Add opal_recursive_mutex_t support to qthreads

### DIFF
--- a/opal/mca/threads/argobots/threads_argobots_wait_sync.h
+++ b/opal/mca/threads/argobots/threads_argobots_wait_sync.h
@@ -103,4 +103,14 @@ static inline int sync_wait_st(ompi_wait_sync_t *sync)
         }                                                       \
     } while (0)
 
+/**
+ * Wake up all syncs with a particular status. If status is OMPI_SUCCESS this
+ * operation is a NO-OP. Otherwise it will trigger the "error condition" from
+ * all registered sync.
+ */
+OPAL_DECLSPEC void wait_sync_global_wakeup_st(int status);
+OPAL_DECLSPEC void wait_sync_global_wakeup_mt(int status);
+#define wait_sync_global_wakeup(st) (opal_using_threads()? wait_sync_global_wakeup_mt(st): wait_sync_global_wakeup_st(st))
+
+
 #endif /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_WAIT_SYNC_H */

--- a/opal/mca/threads/qthreads/threads_qthreads_mutex.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_mutex.h
@@ -110,6 +110,8 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
 
 static inline void opal_mutex_create(struct opal_mutex_t *m)
 {
+    opal_threads_ensure_init_qthreads();
+
     opal_atomic_lock_init(&m->m_lock, 0);
     opal_atomic_lock_init(&m->m_lock_atomic, 0);
     m->m_recursive = 0;
@@ -120,9 +122,24 @@ static inline void opal_mutex_create(struct opal_mutex_t *m)
 #endif
 }
 
+static inline void opal_mutex_recursive_create(struct opal_mutex_t *m)
+{
+    opal_threads_ensure_init_qthreads();
+
+    opal_atomic_lock_init(&m->m_lock, 0);
+    opal_atomic_lock_init(&m->m_lock_atomic, 0);
+    m->m_recursive = 1;
+#if OPAL_ENABLE_DEBUG
+    m->m_lock_debug = 0;
+    m->m_lock_file = NULL;
+    m->m_lock_line = 0;
+#endif
+}
+
 static inline int opal_mutex_trylock(opal_mutex_t *m)
 {
     opal_threads_ensure_init_qthreads();
+
     int ret = opal_atomic_trylock(&m->m_lock);
     if (0 != ret) {
         /* Yield to avoid a deadlock. */
@@ -134,6 +151,7 @@ static inline int opal_mutex_trylock(opal_mutex_t *m)
 static inline void opal_mutex_lock(opal_mutex_t *m)
 {
     opal_threads_ensure_init_qthreads();
+
     int ret = opal_atomic_trylock(&m->m_lock);
     while (0 != ret) {
         qthread_yield();

--- a/opal/mca/threads/qthreads/threads_qthreads_wait_sync.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_wait_sync.h
@@ -103,4 +103,14 @@ static inline int sync_wait_st(ompi_wait_sync_t *sync)
     } while (0)
 
 
+/**
+ * Wake up all syncs with a particular status. If status is OMPI_SUCCESS this
+ * operation is a NO-OP. Otherwise it will trigger the "error condition" from
+ * all registered sync.
+ */
+OPAL_DECLSPEC void wait_sync_global_wakeup_st(int status);
+OPAL_DECLSPEC void wait_sync_global_wakeup_mt(int status);
+#define wait_sync_global_wakeup(st) (opal_using_threads()? wait_sync_global_wakeup_mt(st): wait_sync_global_wakeup_st(st))
+
+
 #endif /* OPAL_MCA_THREADS_QTHREADS_THREADS_QTHREADS_WAIT_SYNC_H */


### PR DESCRIPTION
- Adds the opal_recursive_mutex_t type to qthreads. 
- Fixes some segfaults when ompi is configured to threads.