### PR TITLE
MCA parameters vs configuration file priority to select algorithms

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
@@ -62,6 +62,14 @@ ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int c
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "ompi_coll_tuned_allreduce_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[ALLREDUCE].algorithm) {
+        return ompi_coll_tuned_allreduce_intra_do_this(sbuf, rbuf, count, dtype, op, comm, module,
+                                                       tuned_module->user_forced[ALLREDUCE].algorithm,
+                                                       tuned_module->user_forced[ALLREDUCE].tree_fanout,
+                                                       tuned_module->user_forced[ALLREDUCE].segsize);
+    }
+
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[ALLREDUCE]) {
         /* we do, so calc the message size or what ever we need and use this for the evaluation */
@@ -82,12 +90,6 @@ ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int c
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[ALLREDUCE].algorithm) {
-        return ompi_coll_tuned_allreduce_intra_do_this(sbuf, rbuf, count, dtype, op, comm, module,
-                                                       tuned_module->user_forced[ALLREDUCE].algorithm,
-                                                       tuned_module->user_forced[ALLREDUCE].tree_fanout,
-                                                       tuned_module->user_forced[ALLREDUCE].segsize);
-    }
     return ompi_coll_tuned_allreduce_intra_dec_fixed (sbuf, rbuf, count, dtype, op,
                                                       comm, module);
 }
@@ -110,6 +112,17 @@ int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
     mca_coll_tuned_module_t *tuned_module = (mca_coll_tuned_module_t*) module;
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "ompi_coll_tuned_alltoall_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[ALLTOALL].algorithm) {
+        return ompi_coll_tuned_alltoall_intra_do_this(sbuf, scount, sdtype,
+                                                      rbuf, rcount, rdtype,
+                                                      comm, module,
+                                                      tuned_module->user_forced[ALLTOALL].algorithm,
+                                                      tuned_module->user_forced[ALLTOALL].tree_fanout,
+                                                      tuned_module->user_forced[ALLTOALL].segsize,
+                                                      tuned_module->user_forced[ALLTOALL].max_requests);
+    }
 
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[ALLTOALL]) {
@@ -134,15 +147,6 @@ int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[ALLTOALL].algorithm) {
-        return ompi_coll_tuned_alltoall_intra_do_this(sbuf, scount, sdtype,
-                                                      rbuf, rcount, rdtype,
-                                                      comm, module,
-                                                      tuned_module->user_forced[ALLTOALL].algorithm,
-                                                      tuned_module->user_forced[ALLTOALL].tree_fanout,
-                                                      tuned_module->user_forced[ALLTOALL].segsize,
-                                                      tuned_module->user_forced[ALLTOALL].max_requests);
-    }
     return ompi_coll_tuned_alltoall_intra_dec_fixed (sbuf, scount, sdtype,
                                                      rbuf, rcount, rdtype,
                                                      comm, module);
@@ -165,6 +169,14 @@ int ompi_coll_tuned_alltoallv_intra_dec_dynamic(const void *sbuf, const int *sco
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "ompi_coll_tuned_alltoallv_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[ALLTOALLV].algorithm) {
+        return ompi_coll_tuned_alltoallv_intra_do_this(sbuf, scounts, sdisps, sdtype,
+                                                       rbuf, rcounts, rdisps, rdtype,
+                                                       comm, module,
+                                                       tuned_module->user_forced[ALLTOALLV].algorithm);
+    }
+
     /**
      * check to see if we have some filebased rules. As we don't have global
      * knowledge about the total amount of data, use the first available rule.
@@ -186,12 +198,6 @@ int ompi_coll_tuned_alltoallv_intra_dec_dynamic(const void *sbuf, const int *sco
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[ALLTOALLV].algorithm) {
-        return ompi_coll_tuned_alltoallv_intra_do_this(sbuf, scounts, sdisps, sdtype,
-                                                       rbuf, rcounts, rdisps, rdtype,
-                                                       comm, module,
-                                                       tuned_module->user_forced[ALLTOALLV].algorithm);
-    }
     return ompi_coll_tuned_alltoallv_intra_dec_fixed(sbuf, scounts, sdisps, sdtype,
                                                      rbuf, rcounts, rdisps, rdtype,
                                                      comm, module);
@@ -211,6 +217,14 @@ int ompi_coll_tuned_barrier_intra_dec_dynamic(struct ompi_communicator_t *comm,
 
     OPAL_OUTPUT((ompi_coll_tuned_stream,"ompi_coll_tuned_barrier_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[BARRIER].algorithm) {
+        return ompi_coll_tuned_barrier_intra_do_this(comm, module,
+                                                     tuned_module->user_forced[BARRIER].algorithm,
+                                                     tuned_module->user_forced[BARRIER].tree_fanout,
+                                                     tuned_module->user_forced[BARRIER].segsize);
+    }
+
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[BARRIER]) {
         /* we do, so calc the message size or what ever we need and use this for the evaluation */
@@ -226,12 +240,6 @@ int ompi_coll_tuned_barrier_intra_dec_dynamic(struct ompi_communicator_t *comm,
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[BARRIER].algorithm) {
-        return ompi_coll_tuned_barrier_intra_do_this(comm, module,
-                                                     tuned_module->user_forced[BARRIER].algorithm,
-                                                     tuned_module->user_forced[BARRIER].tree_fanout,
-                                                     tuned_module->user_forced[BARRIER].segsize);
-    }
     return ompi_coll_tuned_barrier_intra_dec_fixed (comm, module);
 }
 
@@ -250,6 +258,15 @@ int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
     mca_coll_tuned_module_t *tuned_module = (mca_coll_tuned_module_t*) module;
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:bcast_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[BCAST].algorithm) {
+        return ompi_coll_tuned_bcast_intra_do_this(buf, count, dtype,
+                                                   root, comm, module,
+                                                   tuned_module->user_forced[BCAST].algorithm,
+                                                   tuned_module->user_forced[BCAST].chain_fanout,
+                                                   tuned_module->user_forced[BCAST].segsize);
+    }
 
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[BCAST]) {
@@ -272,13 +289,6 @@ int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
     } /*end if any com rules to check */
 
 
-    if (tuned_module->user_forced[BCAST].algorithm) {
-        return ompi_coll_tuned_bcast_intra_do_this(buf, count, dtype,
-                                                   root, comm, module,
-                                                   tuned_module->user_forced[BCAST].algorithm,
-                                                   tuned_module->user_forced[BCAST].chain_fanout,
-                                                   tuned_module->user_forced[BCAST].segsize);
-    }
     return ompi_coll_tuned_bcast_intra_dec_fixed (buf, count, dtype, root,
                                                   comm, module);
 }
@@ -300,6 +310,16 @@ int ompi_coll_tuned_reduce_intra_dec_dynamic( const void *sbuf, void *rbuf,
     mca_coll_tuned_module_t *tuned_module = (mca_coll_tuned_module_t*) module;
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:reduce_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[REDUCE].algorithm) {
+        return ompi_coll_tuned_reduce_intra_do_this(sbuf, rbuf, count, dtype,
+                                                    op, root, comm, module,
+                                                    tuned_module->user_forced[REDUCE].algorithm,
+                                                    tuned_module->user_forced[REDUCE].chain_fanout,
+                                                    tuned_module->user_forced[REDUCE].segsize,
+                                                    tuned_module->user_forced[REDUCE].max_requests);
+    }
 
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[REDUCE]) {
@@ -323,14 +343,6 @@ int ompi_coll_tuned_reduce_intra_dec_dynamic( const void *sbuf, void *rbuf,
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[REDUCE].algorithm) {
-        return ompi_coll_tuned_reduce_intra_do_this(sbuf, rbuf, count, dtype,
-                                                    op, root, comm, module,
-                                                    tuned_module->user_forced[REDUCE].algorithm,
-                                                    tuned_module->user_forced[REDUCE].chain_fanout,
-                                                    tuned_module->user_forced[REDUCE].segsize,
-                                                    tuned_module->user_forced[REDUCE].max_requests);
-    }
     return ompi_coll_tuned_reduce_intra_dec_fixed (sbuf, rbuf, count, dtype,
                                                    op, root, comm, module);
 }
@@ -355,6 +367,15 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_dynamic(const void *sbuf, void *rbu
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:reduce_scatter_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[REDUCESCATTER].algorithm) {
+        return ompi_coll_tuned_reduce_scatter_intra_do_this(sbuf, rbuf, rcounts, dtype,
+                                                            op, comm, module,
+                                                            tuned_module->user_forced[REDUCESCATTER].algorithm,
+                                                            tuned_module->user_forced[REDUCESCATTER].chain_fanout,
+                                                            tuned_module->user_forced[REDUCESCATTER].segsize);
+    }
+
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[REDUCESCATTER]) {
         /* we do, so calc the message size or what ever we need and use
@@ -377,13 +398,6 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_dynamic(const void *sbuf, void *rbu
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[REDUCESCATTER].algorithm) {
-        return ompi_coll_tuned_reduce_scatter_intra_do_this(sbuf, rbuf, rcounts, dtype,
-                                                            op, comm, module,
-                                                            tuned_module->user_forced[REDUCESCATTER].algorithm,
-                                                            tuned_module->user_forced[REDUCESCATTER].chain_fanout,
-                                                            tuned_module->user_forced[REDUCESCATTER].segsize);
-    }
     return ompi_coll_tuned_reduce_scatter_intra_dec_fixed (sbuf, rbuf, rcounts,
                                                            dtype, op, comm, module);
 }
@@ -408,6 +422,15 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, voi
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:reduce_scatter_block_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[REDUCESCATTERBLOCK].algorithm) {
+        return ompi_coll_tuned_reduce_scatter_block_intra_do_this(sbuf, rbuf, rcount, dtype,
+                                                                  op, comm, module,
+                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].algorithm,
+                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].chain_fanout,
+                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].segsize);
+    }
+
     /* check to see if we have some filebased rules */
     if (tuned_module->com_rules[REDUCESCATTERBLOCK]) {
         /* we do, so calc the message size or what ever we need and use
@@ -429,13 +452,6 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, voi
         } /* found a method */
     } /* end if any com rules to check */
 
-    if (tuned_module->user_forced[REDUCESCATTERBLOCK].algorithm) {
-        return ompi_coll_tuned_reduce_scatter_block_intra_do_this(sbuf, rbuf, rcount, dtype,
-                                                                  op, comm, module,
-                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].algorithm,
-                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].chain_fanout,
-                                                                  tuned_module->user_forced[REDUCESCATTERBLOCK].segsize);
-    }
     return ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed (sbuf, rbuf, rcount,
                                                                  dtype, op, comm, module);
 }
@@ -461,6 +477,17 @@ int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, int scount,
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_allgather_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[ALLGATHER].algorithm) {
+        /* User-forced algorithm */
+        return ompi_coll_tuned_allgather_intra_do_this(sbuf, scount, sdtype,
+                                                       rbuf, rcount, rdtype,
+                                                       comm, module,
+                                                       tuned_module->user_forced[ALLGATHER].algorithm,
+                                                       tuned_module->user_forced[ALLGATHER].tree_fanout,
+                                                       tuned_module->user_forced[ALLGATHER].segsize);
+    }
+
     if (tuned_module->com_rules[ALLGATHER]) {
         /* We have file based rules:
            - calculate message size and other necessary information */
@@ -482,17 +509,6 @@ int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, int scount,
                                                             comm, module,
                                                             alg, faninout, segsize);
         }
-    }
-
-    /* We do not have file based rules */
-    if (tuned_module->user_forced[ALLGATHER].algorithm) {
-        /* User-forced algorithm */
-        return ompi_coll_tuned_allgather_intra_do_this(sbuf, scount, sdtype,
-                                                       rbuf, rcount, rdtype,
-                                                       comm, module,
-                                                       tuned_module->user_forced[ALLGATHER].algorithm,
-                                                       tuned_module->user_forced[ALLGATHER].tree_fanout,
-                                                       tuned_module->user_forced[ALLGATHER].segsize);
     }
 
     /* Use default decision */
@@ -523,6 +539,17 @@ int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, int scount,
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_allgatherv_intra_dec_dynamic"));
 
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[ALLGATHERV].algorithm) {
+        /* User-forced algorithm */
+        return ompi_coll_tuned_allgatherv_intra_do_this(sbuf, scount, sdtype,
+                                                        rbuf, rcounts, rdispls, rdtype,
+                                                        comm, module,
+                                                        tuned_module->user_forced[ALLGATHERV].algorithm,
+                                                        tuned_module->user_forced[ALLGATHERV].tree_fanout,
+                                                        tuned_module->user_forced[ALLGATHERV].segsize);
+    }
+
     if (tuned_module->com_rules[ALLGATHERV]) {
         /* We have file based rules:
            - calculate message size and other necessary information */
@@ -549,18 +576,6 @@ int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, int scount,
                                                              alg, faninout, segsize);
         }
     }
-
-    /* We do not have file based rules */
-    if (tuned_module->user_forced[ALLGATHERV].algorithm) {
-        /* User-forced algorithm */
-        return ompi_coll_tuned_allgatherv_intra_do_this(sbuf, scount, sdtype,
-                                                        rbuf, rcounts, rdispls, rdtype,
-                                                        comm, module,
-                                                        tuned_module->user_forced[ALLGATHERV].algorithm,
-                                                        tuned_module->user_forced[ALLGATHERV].tree_fanout,
-                                                        tuned_module->user_forced[ALLGATHERV].segsize);
-    }
-
     /* Use default decision */
     return ompi_coll_tuned_allgatherv_intra_dec_fixed (sbuf, scount, sdtype,
                                                        rbuf, rcounts,
@@ -580,6 +595,16 @@ int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
 
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_gather_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[GATHER].algorithm) {
+        return ompi_coll_tuned_gather_intra_do_this(sbuf, scount, sdtype,
+                                                    rbuf, rcount, rdtype,
+                                                    root, comm, module,
+                                                    tuned_module->user_forced[GATHER].algorithm,
+                                                    tuned_module->user_forced[GATHER].tree_fanout,
+                                                    tuned_module->user_forced[GATHER].segsize);
+    }
 
     /**
      * check to see if we have some filebased rules.
@@ -604,15 +629,6 @@ int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[GATHER].algorithm) {
-        return ompi_coll_tuned_gather_intra_do_this(sbuf, scount, sdtype,
-                                                    rbuf, rcount, rdtype,
-                                                    root, comm, module,
-                                                    tuned_module->user_forced[GATHER].algorithm,
-                                                    tuned_module->user_forced[GATHER].tree_fanout,
-                                                    tuned_module->user_forced[GATHER].segsize);
-    }
-
     return ompi_coll_tuned_gather_intra_dec_fixed (sbuf, scount, sdtype,
                                                    rbuf, rcount, rdtype,
                                                    root, comm, module);
@@ -629,6 +645,16 @@ int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
 
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_scatter_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[SCATTER].algorithm) {
+        return ompi_coll_tuned_scatter_intra_do_this(sbuf, scount, sdtype,
+                                                     rbuf, rcount, rdtype,
+                                                     root, comm, module,
+                                                     tuned_module->user_forced[SCATTER].algorithm,
+                                                     tuned_module->user_forced[SCATTER].chain_fanout,
+                                                     tuned_module->user_forced[SCATTER].segsize);
+    }
 
     /**
      * check to see if we have some filebased rules.
@@ -653,15 +679,6 @@ int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[SCATTER].algorithm) {
-        return ompi_coll_tuned_scatter_intra_do_this(sbuf, scount, sdtype,
-                                                     rbuf, rcount, rdtype,
-                                                     root, comm, module,
-                                                     tuned_module->user_forced[SCATTER].algorithm,
-                                                     tuned_module->user_forced[SCATTER].chain_fanout,
-                                                     tuned_module->user_forced[SCATTER].segsize);
-    }
-
     return ompi_coll_tuned_scatter_intra_dec_fixed (sbuf, scount, sdtype,
                                                     rbuf, rcount, rdtype,
                                                     root, comm, module);
@@ -677,6 +694,13 @@ int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int c
 
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_exscan_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[EXSCAN].algorithm) {
+        return ompi_coll_tuned_exscan_intra_do_this(sbuf, rbuf, count, dtype,
+                                                    op, comm, module,
+                                                    tuned_module->user_forced[EXSCAN].algorithm);
+    }
 
     /**
      * check to see if we have some filebased rules.
@@ -700,12 +724,6 @@ int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int c
         } /* found a method */
     } /*end if any com rules to check */
 
-    if (tuned_module->user_forced[EXSCAN].algorithm) {
-        return ompi_coll_tuned_exscan_intra_do_this(sbuf, rbuf, count, dtype,
-                                                    op, comm, module,
-                                                    tuned_module->user_forced[EXSCAN].algorithm);
-    }
-
     return ompi_coll_base_exscan_intra_linear(sbuf, rbuf, count, dtype,
                                               op, comm, module);
 }
@@ -720,6 +738,13 @@ int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, int cou
 
     OPAL_OUTPUT((ompi_coll_tuned_stream,
                  "ompi_coll_tuned_scan_intra_dec_dynamic"));
+
+    /* Check first if an algorithm is set explicitly for this collective */
+    if (tuned_module->user_forced[SCAN].algorithm) {
+        return ompi_coll_tuned_scan_intra_do_this(sbuf, rbuf, count, dtype,
+                                                  op, comm, module,
+                                                  tuned_module->user_forced[SCAN].algorithm);
+    }
 
     /**
      * check to see if we have some filebased rules.
@@ -742,12 +767,6 @@ int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, int cou
                                                        alg);
         } /* found a method */
     } /*end if any com rules to check */
-
-    if (tuned_module->user_forced[SCAN].algorithm) {
-        return ompi_coll_tuned_scan_intra_do_this(sbuf, rbuf, count, dtype,
-                                                  op, comm, module,
-                                                  tuned_module->user_forced[SCAN].algorithm);
-    }
 
     return ompi_coll_base_scan_intra_linear(sbuf, rbuf, count, dtype,
                                             op, comm, module);


### PR DESCRIPTION
The priorities for MCA parameter make Ompi to look first at user environment settings and next for any configuration file.
From my understanding, one of the reason is to let end-users override cluster-wide configurations file. Following this logic, this patch takes first MCA collective algorithm selection (in coll tuned) before looking for any collective _tuned_ file configuration.