### PR TITLE
OMPI: fix build issues in CUDA path 

### DIFF
--- a/contrib/scaling/mpi_memprobe.c
+++ b/contrib/scaling/mpi_memprobe.c
@@ -142,7 +142,7 @@ static void sample(void)
     OBJ_CONSTRUCT(&response, opal_list_t);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_LOG_STDOUT);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = opal_argv_join(answer, '\n');
     opal_list_append(&response, &kv->super);
     opal_argv_free(answer);

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -731,7 +731,7 @@ void mca_pml_ob1_recv_request_progress_rget( mca_pml_ob1_recv_request_t* recvreq
             }
         } else {
             /* Just default back to send and receive.  Must be mix of GPU and HOST memory. */
-            mca_pml_ob1_recv_request_ack(recvreq, &hdr->hdr_rndv, 0);
+            mca_pml_ob1_recv_request_ack(recvreq, btl, &hdr->hdr_rndv, 0);
             return;
         }
     }

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -244,7 +244,7 @@ smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl,
     wildcard_rank.jobid = OPAL_PROC_MY_NAME.jobid;
     wildcard_rank.vpid = OPAL_VPID_WILDCARD;
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_TOPOLOGY_SIGNATURE,
-                                   &wildcard_rank, &loc, OPAL_STRING);
+                                   &wildcard_rank, &loc, PMIX_STRING);
     if (OPAL_SUCCESS == rc) {
         /* the number of NUMA nodes is right at the front */
         mca_btl_smcuda_component.num_mem_nodes = num_mem_nodes = strtoul(loc, NULL, 10);
@@ -267,7 +267,7 @@ smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl,
     }
     /* see if we were given our location */
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_LOCALITY_STRING,
-                                   &OPAL_PROC_MY_NAME, &loc, OPAL_STRING);
+                                   &OPAL_PROC_MY_NAME, &loc, PMIX_STRING);
     if (OPAL_SUCCESS == rc) {
         if (NULL == loc) {
             mca_btl_smcuda_component.mem_node = my_mem_node = -1;

--- a/test/simple/interlib.c
+++ b/test/simple/interlib.c
@@ -42,7 +42,7 @@ static void model_callback(int status,
                 0 == strcmp(val->data.string, "OpenMP")) {
                 goto cback;
             }
-            if (OPAL_STRING == val->type) {
+            if (PMIX_STRING == val->type) {
                 opal_output(0, "Thread Model Callback Key: %s Val %s", val->key, val->data.string);
             }
         }
@@ -99,22 +99,22 @@ static void *mylib(void *ptr)
     OBJ_CONSTRUCT(&info, opal_list_t);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_PROGRAMMING_MODEL);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = strdup("OpenMP");
     opal_list_append(&info, &kv->super);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_MODEL_LIBRARY_NAME);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = strdup("foobar");
     opal_list_append(&info, &kv->super);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_MODEL_LIBRARY_VERSION);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = strdup("1.2.3.4");
     opal_list_append(&info, &kv->super);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_THREADING_MODEL);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = strdup("PTHREAD");
     opal_list_append(&info, &kv->super);
 
@@ -150,7 +150,7 @@ static void *mylib(void *ptr)
     OBJ_CONSTRUCT(&directives, opal_list_t);
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_EVENT_HDLR_NAME);
-    kv->type = OPAL_STRING;
+    kv->type = PMIX_STRING;
     kv->data.string = strdup("My-Declarations");
     opal_list_append(&directives, &kv->super);
     /* specify the event code */
@@ -248,7 +248,7 @@ int main(int argc, char* argv[])
     /* push something the thread can recognize */
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup("WASSUP");
-    kv.type = OPAL_STRING;
+    kv.type = PMIX_STRING;
     kv.data.string = strdup("nothing");
     opal_pmix.put(OPAL_PMIX_LOCAL, &kv);
     OBJ_DESTRUCT(&kv);
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
     OBJ_CONSTRUCT(&list, opal_list_t);
     kptr = OBJ_NEW(opal_value_t);
     kptr->key = strdup("SOMETHING");
-    kptr->type = OPAL_STRING;
+    kptr->type = PMIX_STRING;
     kptr->data.string = strdup("SILLY-THING");
     opal_list_append(&list, &kptr->super);
     opal_pmix.publish(&list);


### PR DESCRIPTION
Fixed the below build issues in CUDA path.

```
pml_ob1_recvreq.c:288:28: note: expected ‘mca_btl_base_module_t *’ {aka ‘struct mca_btl_base_module_t *’} but argument is of type ‘mca_pml_ob1_rendezvous_hdr_t *’ {aka ‘struct mca_pml_ob1_rendezvous_hdr_t *’}
     mca_btl_base_module_t* btl,
     ~~~~~~~~~~~~~~~~~~~~~~~^~~
pml_ob1_recvreq.c:734:13: error: too few arguments to function ‘mca_pml_ob1_recv_request_ack’
             mca_pml_ob1_recv_request_ack(recvreq, &hdr->hdr_rndv, 0);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```



```
In file included from ../../../../opal/mca/pmix/base/base.h:23,
                 from btl_smcuda.c:51:
btl_smcuda.c: In function ‘smcuda_btl_first_time_init’:
btl_smcuda.c:247:58: error: ‘OPAL_STRING’ undeclared (first use in this function); did you mean ‘PMIX_STRING’?
                                    &wildcard_rank, &loc, OPAL_STRING);
```