### PR TITLE
Fix a crash during CUDA initialization

### DIFF
--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -304,7 +304,7 @@ int ompi_proc_complete_init(void)
     opal_process_name_t wildcard_rank;
     ompi_proc_t *proc;
     int ret, errcode = OMPI_SUCCESS;
-    char *val;
+    char *val = NULL;
 
     opal_mutex_lock (&ompi_proc_lock);
 

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -251,6 +251,7 @@ smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl,
         free(loc);
     } else {
         /* If we have hwloc support, then get accurate information */
+        loc = NULL;
         if (OPAL_SUCCESS == opal_hwloc_base_get_topology()) {
             i = opal_hwloc_base_get_nbobjs_by_type(opal_hwloc_topology,
                                                    HWLOC_OBJ_NODE, 0,


### PR DESCRIPTION
From a valgrind log:

```
==2935008== Conditional jump or move depends on uninitialised value(s)
==2935008==    at 0x54D70D5: pmix_bfrops_base_value_unload (bfrop_base_fns.c:358)
==2935008==    by 0x54D61CB: pmix_value_unload (bfrop_base_fns.c:49)
==2935008==    by 0x527BBD2: smcuda_btl_first_time_init (btl_smcuda.c:269)
==2935008==    by 0x527CA5F: mca_btl_smcuda_add_procs (btl_smcuda.c:597)
==2935011== Conditional jump or move depends on uninitialised value(s)
==2935011==    at 0x54D70D5: pmix_bfrops_base_value_unload (bfrop_base_fns.c:358)
==2935008==    by 0x4F0CB95: mca_bml_r2_add_procs (bml_r2.c:526)
==2935008==    by 0x50B04A4: mca_pml_ob1_add_procs (pml_ob1.c:343)
==2935008==    by 0x4E75867: ompi_mpi_init (ompi_mpi_init.c:853)
==2935008==    by 0x4EC4B30: PMPI_Init (pinit.c:67)
==2935011==    by 0x54D61CB: pmix_value_unload (bfrop_base_fns.c:49)
==2935011==    by 0x527BBD2: smcuda_btl_first_time_init (btl_smcuda.c:269)
==2935011==    by 0x527CA5F: mca_btl_smcuda_add_procs (btl_smcuda.c:597)
==2935011==    by 0x4F0CB95: mca_bml_r2_add_procs (bml_r2.c:526)

==2935010== Conditional jump or move depends on uninitialised value(s)
==2935010==    at 0x54D70D5: pmix_bfrops_base_value_unload (bfrop_base_fns.c:358)
==2935010==    by 0x54D61CB: pmix_value_unload (bfrop_base_fns.c:49)
==2935010==    by 0x52927D4: opal_hwloc_base_get_topology (hwloc_base_util.c:316)
==2935010==    by 0x5280A4B: mca_btl_smcuda_component_init (btl_smcuda_component.c:882)
==2935010==    by 0x526C3F5: mca_btl_base_select (btl_base_select.c:110)
==2935010==    by 0x4F0DEC5: mca_bml_r2_component_init (bml_r2_component.c:88)
==2935010==    by 0x4F0B3A9: mca_bml_base_init (bml_base_init.c:74)
==2935010==    by 0x4E7521E: ompi_mpi_init (ompi_mpi_init.c:609)
==2935010==    by 0x4EC4B30: PMPI_Init (pinit.c:67)
```