### PR TITLE
build: Support building against external PRRTE

### DIFF
--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -10,9 +12,9 @@
 
 if OMPI_WANT_PRRTE
 install-exec-hook:
-	(cd $(DESTDIR)$(bindir); rm -f mpirun$(EXEEXT); $(LN_S) prte$(EXEEXT) mpirun$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f mpiexec$(EXEEXT); $(LN_S) prte$(EXEEXT) mpiexec$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f oshrun$(EXEEXT); $(LN_S) prte$(EXEEXT) oshrun$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpirun$(EXEEXT); $(LN_S) $(PRTE_PATH)$(EXEEXT) mpirun$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpiexec$(EXEEXT); $(LN_S) $(PRTE_PATH)$(EXEEXT) mpiexec$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshrun$(EXEEXT); $(LN_S) $(PRTE_PATH)$(EXEEXT) oshrun$(EXEEXT))
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/mpirun$(EXEEXT) \


### PR DESCRIPTION
For reasons that no one can remember, we decided to not support
building against an external PRRTE.  The only integration between
OMPI and PRTTE that isn't through the PMIx interface is the
symlinks for mpirun/mpiexec/oshrun.  To make it easier to package
Open MPI for distros, add support for using an external PRRTE.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>