### PR TITLE
git-commit-checks: use a better name

### DIFF
--- a/.github/workflows/git-commit-checks.yml
+++ b/.github/workflows/git-commit-checks.yml
@@ -1,4 +1,4 @@
-name: Git commit checker
+name: GitHub Action CI
 
 on:
     pull_request:
@@ -11,6 +11,7 @@ on:
 
 jobs:
     ci:
+        name: Git commit checker
         runs-on: ubuntu-latest
         steps:
           - name: Check out the code


### PR DESCRIPTION
Github shows both the "outer" and "inner" names on the CI line in the
Github web UI, so make sure to give good names for both.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>