### PR TITLE
sharedfp/sm: fix configure

### DIFF
--- a/ompi/mca/sharedfp/sm/configure.m4
+++ b/ompi/mca/sharedfp/sm/configure.m4
@@ -11,7 +11,9 @@
 # Copyright (c) 2004-2012 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2008-2015 University of Houston. All rights reserved.
+# Copyright (c) 2008-2021 University of Houston. All rights reserved.
+# Copyright (c) 2021      Argonne National Laboratory. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/ompi/mca/sharedfp/sm/configure.m4
+++ b/ompi/mca/sharedfp/sm/configure.m4
@@ -30,14 +30,16 @@ AC_DEFUN([MCA_ompi_sharedfp_sm_CONFIG],[
                     [dnl requires potentially pthread library
                      OPAL_SEARCH_LIBS_COMPONENT([sharedfp_sm],
                                     [sem_open], [pthread],
-                                    [sharedfp_sm_happy="yes"])])
-
+                                    [AC_CHECK_FUNCS([sem_open],
+                                                    [sharedfp_sm_happy="yes"],[])]
+                                                )])
     AC_CHECK_HEADER([semaphore.h],
                     [dnl requires potentially pthread library
                      OPAL_SEARCH_LIBS_COMPONENT([sharedfp_sm],
                                     [sem_init], [pthread],
-                                    [sharedfp_sm_happy="yes"])])
-
+                                    [AC_CHECK_FUNCS([sem_init],
+                                                    [sharedfp_sm_happy="yes"],[])]
+                                                )])
     AS_IF([test "$sharedfp_sm_happy" = "yes"],
           [$1],
           [$2])

--- a/ompi/mca/sharedfp/sm/configure.m4
+++ b/ompi/mca/sharedfp/sm/configure.m4
@@ -27,10 +27,16 @@ AC_DEFUN([MCA_ompi_sharedfp_sm_CONFIG],[
 
     sharedfp_sm_happy=no
     AC_CHECK_HEADER([semaphore.h],
-                    [AC_CHECK_FUNCS([sem_open],[sharedfp_sm_happy=yes],[])])
+                    [dnl requires potentially pthread library
+                     OPAL_SEARCH_LIBS_COMPONENT([sharedfp_sm],
+                                    [sem_open], [pthread],
+                                    [sharedfp_sm_happy="yes"])])
 
     AC_CHECK_HEADER([semaphore.h],
-        [AC_CHECK_FUNCS([sem_init],[sharedfp_sm_happy=yes],[])])
+                    [dnl requires potentially pthread library
+                     OPAL_SEARCH_LIBS_COMPONENT([sharedfp_sm],
+                                    [sem_init], [pthread],
+                                    [sharedfp_sm_happy="yes"])])
 
     AS_IF([test "$sharedfp_sm_happy" = "yes"],
           [$1],


### PR DESCRIPTION
## Problem

It closes #8464.

After a certain point (maybe because of the change in `opal/mca/threads`), Open MPI stopped including `-lpthread` in `LIBS`.  As a result, `configure` of `ompi/mca/sharedfp/sm` fails because its `semaphore` depends on `-lpthread`. See #8464 for details.

## Solution

Fix `configure.m4` in `ompi/mca/sharedfp/sm`. This fix has been checked by @edgargabriel who reported this issue. I also checked it on my laptop.

The first commit was written by @edgargabriel. Thank you!

---

Please let me know if I need to change anything for license (though in my experience, a contributor agreement etc was not asked). It's a tiny fix and I do not want to bother you by claiming something regarding copyright etc. For example, if needed, I am willing to remove/modify the copyright lines in `configure.m4`.
