### PR TITLE
opal: add min and max implementations

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -250,14 +250,6 @@ ompi_mtl_psm2_connect_error_msg(psm2_error_t err)
     }
 }
 
-#ifndef min
-#  define min(a,b) ((a) < (b) ? (a) : (b))
-#endif
-
-#ifndef max
-#  define max(a,b) ((a) > (b) ? (a) : (b))
-#endif
-
 int
 ompi_mtl_psm2_add_procs(struct mca_mtl_base_module_t *mtl,
                       size_t nprocs,
@@ -312,7 +304,7 @@ ompi_mtl_psm2_add_procs(struct mca_mtl_base_module_t *mtl,
 	mask_in[i] = 1;
     }
 
-    timeout_in_secs = max(ompi_mtl_psm2.connect_timeout, 0.5 * nprocs);
+    timeout_in_secs = opal_max(ompi_mtl_psm2.connect_timeout, 0.5 * nprocs);
 
     psm2_error_register_handler(ompi_mtl_psm2.ep, PSM2_ERRHANDLER_NOP);
 

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -25,15 +25,13 @@
 
 #include "opal/class/opal_pointer_array.h"
 #include "opal/class/opal_hash_table.h"
+#include "opal/util/minmax.h"
 #include "opal/util/printf.h"
 
 static opal_hash_table_t mca_base_pvar_index_hash;
 static opal_pointer_array_t registered_pvars;
 static bool mca_base_pvar_initialized = false;
 static int pvar_count = 0;
-
-#define min(a,b) ((a) < (b) ? (a) : (b))
-#define max(a,b) ((a) > (b) ? (a) : (b))
 
 static int mca_base_pvar_get_internal (int index, mca_base_pvar_t **pvar, bool invalidok);
 
@@ -610,20 +608,20 @@ int mca_base_pvar_handle_update (mca_base_pvar_handle_t *handle)
                 if (MCA_BASE_PVAR_CLASS_LOWWATERMARK == handle->pvar->var_class) {
                     switch (handle->pvar->type) {
                     case MCA_BASE_VAR_TYPE_UNSIGNED_INT:
-                        ((unsigned *) handle->current_value)[i] = min(((unsigned *) handle->tmp_value)[i],
-                                                                      ((unsigned *) handle->current_value)[i]);
+                        ((unsigned *) handle->current_value)[i] = opal_min(((unsigned *) handle->tmp_value)[i],
+                                                                           ((unsigned *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_UNSIGNED_LONG:
-                        ((unsigned long *) handle->current_value)[i] = min(((unsigned long *) handle->tmp_value)[i],
-                                                                           ((unsigned long *) handle->current_value)[i]);
+                        ((unsigned long *) handle->current_value)[i] = opal_min(((unsigned long *) handle->tmp_value)[i],
+                                                                                ((unsigned long *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG:
-                        ((unsigned long long *) handle->current_value)[i] = min(((unsigned long long *) handle->tmp_value)[i],
-                                                                                ((unsigned long long *) handle->current_value)[i]);
+                        ((unsigned long long *) handle->current_value)[i] = opal_min(((unsigned long long *) handle->tmp_value)[i],
+                                                                                     ((unsigned long long *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_DOUBLE:
-                        ((double *) handle->current_value)[i] = min(((double *) handle->tmp_value)[i],
-                                                                    ((double *) handle->current_value)[i]);
+                        ((double *) handle->current_value)[i] = opal_min(((double *) handle->tmp_value)[i],
+                                                                         ((double *) handle->current_value)[i]);
                         break;
                     default:
                         /* shouldn't happen */
@@ -632,20 +630,20 @@ int mca_base_pvar_handle_update (mca_base_pvar_handle_t *handle)
                 } else {
                     switch (handle->pvar->type) {
                     case MCA_BASE_VAR_TYPE_UNSIGNED_INT:
-                        ((unsigned *) handle->current_value)[i] = max(((unsigned *) handle->tmp_value)[i],
-                                                                      ((unsigned *) handle->current_value)[i]);
+                        ((unsigned *) handle->current_value)[i] = opal_max(((unsigned *) handle->tmp_value)[i],
+                                                                           ((unsigned *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_UNSIGNED_LONG:
-                        ((unsigned long *) handle->current_value)[i] = max(((unsigned long *) handle->tmp_value)[i],
-                                                                           ((unsigned long *) handle->current_value)[i]);
+                        ((unsigned long *) handle->current_value)[i] = opal_max(((unsigned long *) handle->tmp_value)[i],
+                                                                                ((unsigned long *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG:
-                        ((unsigned long long *) handle->current_value)[i] = max(((unsigned long long *) handle->tmp_value)[i],
-                                                                                ((unsigned long long *) handle->current_value)[i]);
+                        ((unsigned long long *) handle->current_value)[i] = opal_max(((unsigned long long *) handle->tmp_value)[i],
+                                                                                     ((unsigned long long *) handle->current_value)[i]);
                         break;
                     case MCA_BASE_VAR_TYPE_DOUBLE:
-                        ((double *) handle->current_value)[i] = max(((double *) handle->tmp_value)[i],
-                                                                    ((double *) handle->current_value)[i]);
+                        ((double *) handle->current_value)[i] = opal_max(((double *) handle->tmp_value)[i],
+                                                                         ((double *) handle->current_value)[i]);
                         break;
                     default:
                         /* shouldn't happen */

--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -19,6 +19,7 @@
 # Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2021      Google, LLC. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -78,7 +79,8 @@ headers = \
         timings.h \
         uri.h \
         info_subscriber.h \
-	info.h
+	info.h \
+	minmax.h
 
 libopalutil_la_SOURCES = \
         $(headers) \

--- a/opal/util/minmax.h
+++ b/opal/util/minmax.h
@@ -1,0 +1,82 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * @file
+ */
+
+/**
+ * @file Contains implementations of opal_min(a,b) and opal_max(a,b).
+ */
+#ifndef OPAL_MINMAX_H
+#define OPAL_MINMAX_H
+
+#define OPAL_DEFINE_MINMAX(type, suffix)                                                           \
+    static inline const type opal_min_##suffix(const type a, const type b)                         \
+    {                                                                                              \
+        return (a < b) ? a : b;                                                                    \
+    }                                                                                              \
+    static inline const type opal_max_##suffix(const type a, const type b)                         \
+    {                                                                                              \
+        return (a > b) ? a : b;                                                                    \
+    }
+
+OPAL_DEFINE_MINMAX(int8_t, 8)
+OPAL_DEFINE_MINMAX(uint8_t, u8)
+OPAL_DEFINE_MINMAX(int16_t, 16)
+OPAL_DEFINE_MINMAX(uint16_t, u16)
+OPAL_DEFINE_MINMAX(int32_t, 32)
+OPAL_DEFINE_MINMAX(uint32_t, u32)
+OPAL_DEFINE_MINMAX(int64_t, 64)
+OPAL_DEFINE_MINMAX(uint64_t, u64)
+OPAL_DEFINE_MINMAX(size_t, size_t)
+OPAL_DEFINE_MINMAX(ssize_t, ssize_t)
+OPAL_DEFINE_MINMAX(float, float)
+OPAL_DEFINE_MINMAX(double, double)
+OPAL_DEFINE_MINMAX(void *, ptr)
+
+#if OPAL_C_HAVE__GENERIC
+#define opal_min(a, b)                                                  \
+    (_Generic((a) + (b),                                                \
+                                 int8_t: opal_min_8,                    \
+                                 uint8_t: opal_min_u8,                  \
+                                 int16_t: opal_min_16,                  \
+                                 uint16_t: opal_min_u16,                \
+                                 int32_t: opal_min_32,                  \
+                                 uint32_t: opal_min_u32,                \
+                                 int64_t: opal_min_64,                  \
+                                 uint64_t: opal_min_u64,                \
+                                 float: opal_min_float,                 \
+                                 double: opal_min_double,               \
+                                 void *: opal_min_ptr,                  \
+                                 default: opal_min_64)((a), (b)))
+
+#define opal_max(a, b)                                                  \
+    (_Generic((a) + (b),                                                \
+                                 int8_t: opal_max_8,                    \
+                                 uint8_t: opal_max_u8,                  \
+                                 int16_t: opal_max_16,                  \
+                                 uint16_t: opal_max_u16,                \
+                                 int32_t: opal_max_32,                  \
+                                 uint32_t: opal_max_u32,                \
+                                 int64_t: opal_max_64,                  \
+                                 uint64_t: opal_max_u64,                \
+                                 float: opal_max_float,                 \
+                                 double: opal_max_double,               \
+                                 void *: opal_max_ptr,                  \
+                                 default: opal_max_64)((a), (b)))
+#else
+
+/* these versions suffer from double-evaluation. please upgrade to a modern compiler */
+
+#define opal_min(a, b) (((a) < (b)) ? (a) : (b))
+#define opal_max(a, b) (((a) > (b)) ? (a) : (b))
+
+#endif
+
+#endif /* OPAL_MINMAX_H */

--- a/opal/util/qsort.c
+++ b/opal/util/qsort.c
@@ -37,13 +37,12 @@
 
 #include <stdlib.h>
 
+#include "opal/util/minmix.h"
 #include "opal/util/qsort.h"
 
 typedef int		 cmp_t(const void *, const void *);
 static inline char	*med3(char *, char *, char *, cmp_t *, void *);
 static inline void	 swapfunc(char *, char *, int, int);
-
-#define min(a, b)	(a) < (b) ? a : b
 
 /*
  * Qsort routine from Bentley & McIlroy's "Engineering a Sort Function".
@@ -160,9 +159,9 @@ loop:	SWAPINIT(a, es);
 	}
 
 	pn = (char *)a + n * es;
-	r = (int) min(pa - (char *)a, pb - pa);
+	r = (int) opal_min(pa - (char *)a, pb - pa);
 	vecswap(a, pb - r, r);
-	r = (int) (min((char*) (pd - pc), (char*) (pn - pd - es)));
+	r = (int) (opal_min((char*) (pd - pc), (char*) (pn - pd - es)));
 	vecswap(pb, pn - r, r);
 	if ((size_t) (r = pb - pa) > es)
 		opal_qsort(a, r / es, es, cmp);


### PR DESCRIPTION
This commit adds various flavors of min and max. The initial implementations
included are 32 and 64-bit integer, float, double, and pointer. These versions
can be called directly or indirectly using the opal_min or opal_max macros.
These macros use C11 generics if available otherwise fall back to the sub-
standard macro version. The non-C11 version suffers from the usual double-
evaluation problem common with min/max macros. The min/max macros the new
version replaces already suffered from this issue.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>