### PR TITLE
v4.1.x: Fix case where debuggers cannot read the MPIR proctable.

### DIFF
--- a/orte/orted/orted-mpir/orted_mpir.h
+++ b/orte/orted/orted-mpir/orted_mpir.h
@@ -18,6 +18,27 @@ BEGIN_C_DECLS
 #define MPIR_MAX_PATH_LENGTH 512
 #define MPIR_MAX_ARG_LENGTH 1024
 
+
+/* Note to future MPIR maintainers:
+ *
+ * This struct MUST (along with all other MPIR_* symbols) be declared
+ * and defined in this file. Otherwise they may be compiled *without* -g
+ * and *with* optimizations in production. In the case where they are
+ * not here, the debugger won't have the complete definition of the proctable.
+ * This will prevent the debugger from reading it properly.
+ *
+ * It also needs to be seen by multiple files (orted_submih.c and
+ * orted_mpir_breakpoint.c), so this is a better place for it anyway.
+ *
+ * For more info/discussion on this, see the following github issue:
+ * https://github.com/open-mpi/ompi/issues/8563
+ */
+struct MPIR_PROCDESC {
+    char *host_name;        /* something that can be passed to inet_addr */
+    char *executable_name;  /* name of binary */
+    int pid;                /* process pid */
+};
+
 extern struct MPIR_PROCDESC *MPIR_proctable;
 extern int MPIR_proctable_size;
 extern volatile int MPIR_being_debugged;

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -2220,13 +2220,6 @@ static void complete_recv(int status, orte_process_name_t* sender,
 #define DUMP_INT(X) fprintf(stderr, "  %s = %d\n", # X, X);
 #define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
 
-struct MPIR_PROCDESC {
-    char *host_name;        /* something that can be passed to inet_addr */
-    char *executable_name;  /* name of binary */
-    int pid;                /* process pid */
-};
-
-
 /**
  * Initialization of data structures for running under a debugger
  * using the MPICH/TotalView parallel debugger interface.  Before the


### PR DESCRIPTION

Make sure the definition of the MPIR_Proctable
is in a header file that is included in the file
orted_mpir_breakpoint.c, which is compiled with -g
and compiled without optimizations.

Otherwise, the debugger (such as gdb) won't know
the complete definition of the proctable, preventing
it from being able to read it.

Since the MPIR_proctable should be accessed from
orted_submit.c and orted_mpir_breakpoint.c, move it
to the mpir_orted.h header file.

See issue: #8563

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit a71fbaf)

Fixes #8563