### PR TITLE
Fix core dump when performing misaligned atomics.

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,6 +158,8 @@ struct ompi_osc_rdma_module_t {
     bool acc_single_intrinsic;
 
     bool acc_use_amo;
+
+    bool acc_use_lock_fallback;
 
     /** whether the group is located on a single node */
     bool single_node;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2012-2015 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
@@ -1333,6 +1333,7 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     module->locking_mode   = mca_osc_rdma_component.locking_mode;
     module->acc_single_intrinsic = check_config_value_bool ("acc_single_intrinsic", info);
     module->acc_use_amo = mca_osc_rdma_component.acc_use_amo;
+    module->acc_use_lock_fallback = false;
     module->network_amo_max_count = mca_osc_rdma_component.network_amo_max_count;
 
     module->all_sync.module = module;

--- a/opal/mca/btl/base/base.h
+++ b/opal/mca/btl/base/base.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,6 +72,8 @@ OPAL_DECLSPEC  int mca_btl_base_param_verify(mca_btl_base_module_t *module);
 /*
  * Globals
  */
+
+extern opal_mutex_t  mca_btl_atomic_fallback_lock;
 extern char* mca_btl_base_include;
 extern char* mca_btl_base_exclude;
 extern int mca_btl_base_warn_component_unused;

--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -121,6 +122,7 @@ char* mca_btl_base_exclude = NULL;
 int mca_btl_base_warn_component_unused = 1;
 int mca_btl_base_warn_peer_error = true;
 opal_list_t mca_btl_base_modules_initialized = {{0}};
+opal_mutex_t mca_btl_atomic_fallback_lock;
 bool mca_btl_base_thread_multiple_override = false;
 
 static int mca_btl_base_register(mca_base_register_flag_t flags)
@@ -216,6 +218,8 @@ static int mca_btl_base_open(mca_base_open_flag_t flags)
   /* get the verbosity so that BTL_VERBOSE will work */
   mca_btl_base_verbose = opal_output_get_verbosity(opal_btl_base_framework.framework_output);
 
+  OBJ_CONSTRUCT(&mca_btl_atomic_fallback_lock, opal_list_t);
+
   /* All done */
   return OPAL_SUCCESS;
 }
@@ -243,6 +247,7 @@ static int mca_btl_base_close(void)
     (void) mca_base_framework_components_close(&opal_btl_base_framework, NULL);
 
     OBJ_DESTRUCT(&mca_btl_base_modules_initialized);
+    OBJ_DESTRUCT(&mca_btl_atomic_fallback_lock);
 
 #if 0
     /* restore event processing */

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -19,6 +19,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -345,9 +346,10 @@ enum {
 
 enum {
     /** Use 32-bit atomics */
-    MCA_BTL_ATOMIC_FLAG_32BIT = 0x00000001,
+    MCA_BTL_ATOMIC_FLAG_32BIT             = 0x00000001,
     /** Use floating-point atomics */
-    MCA_BTL_ATOMIC_FLAG_FLOAT = 0x00000002,
+    MCA_BTL_ATOMIC_FLAG_FLOAT             = 0x00000002,
+    MCA_BTL_ATOMIC_FLAG_USE_LOCK_FALLBACK = 0x00000004,
 };
 
 enum mca_btl_base_atomic_op_t {


### PR DESCRIPTION
c_reqops MTT test has a weird alignment when creating the window,
which is perfectly valid. This will cause a segv
when performing atomic operations. While this was found on
Power, it probably is not limited to it.

Detect a misalignment, and fallback to a lock + copy method.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>