### PR TITLE
configure.ac: refuse to build on 32 bit platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,11 +384,6 @@ opal_show_title "Compiler and preprocessor tests"
 
 OPAL_SETUP_CC
 
-# If we build on a windows environment with the windows compiler and linker
-# then we need some translation functions from the opal/win32 directory.
-AM_CONDITIONAL(OMPI_NEED_WINDOWS_REPLACEMENTS,
-               test "$opal_cv_c_compiler_vendor" = "microsoft" )
-
 # Do all Interix detections if necessary
 OMPI_INTERIX
 

--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,15 @@ opal_show_title "Compiler and preprocessor tests"
 
 OPAL_SETUP_CC
 
+# Open MPI no longer supports 32 bit builds
+AC_CHECK_SIZEOF(void *)
+AC_MSG_CHECKING([if build environment is 32 bit])
+AS_IF([test "$ac_cv_sizeof_void_p" = "4"],
+      [AC_MSG_RESULT([yes])
+       AC_MSG_WARN([Sorry, this version of Open MPI does not support building on 32-bit platforms.])
+       AC_MSG_ERROR([Cannot continue])])
+AC_MSG_RESULT([no (good)])
+
 # Do all Interix detections if necessary
 OMPI_INTERIX
 
@@ -476,7 +485,6 @@ AC_CHECK_SIZEOF(float _Complex)
 AC_CHECK_SIZEOF(double _Complex)
 AC_CHECK_SIZEOF(long double _Complex)
 
-AC_CHECK_SIZEOF(void *)
 AC_CHECK_SIZEOF(size_t)
 if test "$ac_cv_type_ssize_t" = yes ; then
     AC_CHECK_SIZEOF(ssize_t)


### PR DESCRIPTION
There's a 2nd commit on this PR that piggybacked on editing configure.ac: remove some dead Windows configury kruft.

This PR is created in the Draft state so that we can decide whether the community wants to actually disable 32 bit support for v5.0.x or not.