### PR TITLE
config/opal_setup_man_pages.m4: fix typo

### DIFF
--- a/config/opal_setup_man_pages.m4
+++ b/config/opal_setup_man_pages.m4
@@ -1,6 +1,6 @@
 dnl -*- shell-script -*-
 dnl
-dnl Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2020-2021 Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -68,7 +68,7 @@ AC_DEFUN([_OPAL_SETUP_PANDOC],[
           [AS_IF([test ! -f "$srcdir/ompi/mpi/man/man5/MPI_T.5"],
                  [AC_MSG_WARN([*** Could not find a suitable pandoc on your system.])
                   AC_MSG_WARN([*** You need pandoc >=$min_major_version.$min_minor_version to build Open MPI with man pages.])
-                  AC_MSG_WARN([*** If no man pages are needed, rerun configure with option '--disable-manpages'.])
+                  AC_MSG_WARN([*** If no man pages are needed, rerun configure with option '--disable-man-pages'.])
                   AC_MSG_WARN([*** NOTE: If you are building from a tarball downloaded from www.open-mpi.org, you do not need Pandoc.])
                   AC_MSG_WARN([*** See pandoc.org.])
                   AC_MSG_ERROR([Cannot continue])


### PR DESCRIPTION
Fix typo in help message to indicate the correct CLI option name.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>