### PR TITLE
Make sure to never allocate zero-length memory buffer in opal_argv_join_range

### DIFF
--- a/opal/util/argv.c
+++ b/opal/util/argv.c
@@ -343,7 +343,7 @@ char *opal_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
 
     /* Bozo case */
 
-    if (NULL == argv || NULL == argv[0] || (int)start > opal_argv_count(argv)) {
+    if (NULL == argv || NULL == argv[0] || (int)start >= opal_argv_count(argv)) {
         return strdup("");
     }
 
@@ -354,10 +354,15 @@ char *opal_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
         str_len += strlen(*p) + 1;
     }
 
+    if (0 == str_len) {
+        return strdup("");
+    }
+
     /* Allocate the string. */
 
-    if (NULL == (str = (char*) malloc(str_len)))
+    if (NULL == (str = (char*) malloc(str_len))) {
         return NULL;
+    }
 
     /* Loop filling in the string. */
 


### PR DESCRIPTION
This silences a warning issued by GCC 10.2.0, warning about `str[--str_len] = '\0'` writing out of bounds if str_len is 0:

```
../../../opal/util/argv.c: In function ‘opal_argv_join_range’:
../../../opal/util/argv.c:368:20: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  368 |     str[--str_len] = '\0';
      |     ~~~~~~~~~~~~~~~^~~~~~
../../../opal/util/argv.c:363:32: note: at offset -1 to an object with size 0 allocated by ‘malloc’ here
  363 |     if (NULL == (str = (char*) malloc(str_len)))
      |                                ^~~~~~~~~~~~~~~
```

This also ensures that 0 is not passed to `malloc`, which may return `NULL` and lead to a unintended return of `NULL` instead of an empty string.

The change to greater-or-equal in `(int)start >= opal_argv_count(argv)` is meant to catch the case of `argv[start] == NULL` early.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>