### PR TITLE
SPML/UCX: removed direct dependency to SPML UCX - v4.0

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -80,14 +80,14 @@ mca_spml_ucx_t mca_spml_ucx = {
     .num_disconnect         = 1,
     .heap_reg_nb            = 0,
     .enabled                = 0,
-    .get_mkey_slow          = NULL,
-    .synchronized_quiet     = false
+    .get_mkey_slow          = NULL
 };
 
 mca_spml_ucx_ctx_t mca_spml_ucx_ctx_default = {
-    .ucp_worker = NULL,
-    .ucp_peers  = NULL,
-    .options    = 0
+    .ucp_worker         = NULL,
+    .ucp_peers          = NULL,
+    .options            = 0,
+    .synchronized_quiet = false
 };
 
 int mca_spml_ucx_enable(bool enable)
@@ -671,6 +671,7 @@ static int mca_spml_ucx_ctx_create_common(long options, mca_spml_ucx_ctx_t **ucx
     ucx_ctx->options = options;
     ucx_ctx->ucp_worker = calloc(1, sizeof(ucp_worker_h));
     ucx_ctx->ucp_workers = 1;
+    ucx_ctx->synchronized_quiet = mca_spml_ucx_ctx_default.synchronized_quiet;
 
     params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
     if (oshmem_mpi_thread_provided == SHMEM_THREAD_SINGLE || options & SHMEM_CTX_PRIVATE || options & SHMEM_CTX_SERIALIZED) {

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -76,6 +76,7 @@ struct mca_spml_ucx_ctx {
     unsigned int             ucp_workers;
     int                     *put_proc_indexes;
     unsigned                 put_proc_count;
+    bool                     synchronized_quiet;
 };
 typedef struct mca_spml_ucx_ctx mca_spml_ucx_ctx_t;
 
@@ -256,7 +257,7 @@ static inline int ucx_status_to_oshmem_nb(ucs_status_t status)
 
 static inline void mca_spml_ucx_remote_op_posted(mca_spml_ucx_ctx_t *ctx, int dst)
 {
-    if (OPAL_UNLIKELY(mca_spml_ucx.synchronized_quiet)) {
+    if (OPAL_UNLIKELY(ctx->synchronized_quiet)) {
         if (!opal_bitmap_is_set_bit(&ctx->put_op_bitmap, dst)) {
             ctx->put_proc_indexes[ctx->put_proc_count++] = dst;
             opal_bitmap_set_bit(&ctx->put_op_bitmap, dst);

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -159,7 +159,7 @@ static int mca_spml_ucx_component_register(void)
 
     mca_spml_ucx_param_register_bool("synchronized_quiet", 0,
                                      "Use synchronized quiet on shmem_quiet or shmem_barrier_all operations",
-                                     &mca_spml_ucx.synchronized_quiet);
+                                     &mca_spml_ucx_ctx_default.synchronized_quiet);
 
     mca_spml_ucx_param_register_ulong("nb_progress_thresh_global", 0,
                                     "Number of nb_put or nb_get operations before ucx progress is triggered. Disabled by default (0)",


### PR DESCRIPTION
- added synchronise_quiet parameter to local
  context object

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
(cherry picked from commit 01d716433a69138a2084d75f5935d630550a6b44)

backport from https://github.com/open-mpi/ompi/pull/8567