### PR TITLE
VERSION: Bump to 6.0.0a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -3,7 +3,7 @@
 # Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 
@@ -15,7 +15,7 @@
 # major, minor, and release are generally combined in the form
 # <major>.<minor>.<release>.
 
-major=5
+major=6
 minor=0
 release=0
 


### PR DESCRIPTION
We've now branched for v5.0.x, so reving master to v6.0.0a1

[skip ci]
bot:notest

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>