### PR TITLE
VERSION: Downgrade to v5.1.0a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -15,8 +15,8 @@
 # major, minor, and release are generally combined in the form
 # <major>.<minor>.<release>.
 
-major=6
-minor=0
+major=5
+minor=1
 release=0
 
 # greek is generally used for alpha or beta release tags.  If it is


### PR DESCRIPTION
It was pointed out that we may not need to break backward
compatibility, for our next release.  Lets use v5.1.0a1
until we are sure we need to break API.

[skip ci]
bot:notest

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>