### PR TITLE
v5.0.x: ompi: rename assert variables to mpi_assert

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -21,6 +21,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1918,7 +1919,7 @@ OMPI_DECLSPEC  int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_at
 OMPI_DECLSPEC  int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
 OMPI_DECLSPEC  int MPI_Win_detach(MPI_Win win, const void *base);
 OMPI_DECLSPEC  MPI_Win MPI_Win_f2c(MPI_Fint win);
-OMPI_DECLSPEC  int MPI_Win_fence(int assert, MPI_Win win);
+OMPI_DECLSPEC  int MPI_Win_fence(int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_flush(int rank, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_flush_all(MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_flush_local(int rank, MPI_Win win);
@@ -1931,15 +1932,15 @@ OMPI_DECLSPEC  int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandle
 OMPI_DECLSPEC  int MPI_Win_get_group(MPI_Win win, MPI_Group *group);
 OMPI_DECLSPEC  int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
 OMPI_DECLSPEC  int MPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
-OMPI_DECLSPEC  int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
-OMPI_DECLSPEC  int MPI_Win_lock_all(int assert, MPI_Win win);
-OMPI_DECLSPEC  int MPI_Win_post(MPI_Group group, int assert, MPI_Win win);
+OMPI_DECLSPEC  int MPI_Win_lock(int lock_type, int rank, int mpi_assert, MPI_Win win);
+OMPI_DECLSPEC  int MPI_Win_lock_all(int mpi_assert, MPI_Win win);
+OMPI_DECLSPEC  int MPI_Win_post(MPI_Group group, int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
 OMPI_DECLSPEC  int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
 OMPI_DECLSPEC  int MPI_Win_set_info(MPI_Win win, MPI_Info info);
 OMPI_DECLSPEC  int MPI_Win_set_name(MPI_Win win, const char *win_name);
 OMPI_DECLSPEC  int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
-OMPI_DECLSPEC  int MPI_Win_start(MPI_Group group, int assert, MPI_Win win);
+OMPI_DECLSPEC  int MPI_Win_start(MPI_Group group, int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_sync(MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_test(MPI_Win win, int *flag);
 OMPI_DECLSPEC  int MPI_Win_unlock(int rank, MPI_Win win);
@@ -2583,7 +2584,7 @@ OMPI_DECLSPEC  int PMPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_a
 OMPI_DECLSPEC  int PMPI_Win_delete_attr(MPI_Win win, int win_keyval);
 OMPI_DECLSPEC  int PMPI_Win_detach(MPI_Win win, const void *base);
 OMPI_DECLSPEC  MPI_Win PMPI_Win_f2c(MPI_Fint win);
-OMPI_DECLSPEC  int PMPI_Win_fence(int assert, MPI_Win win);
+OMPI_DECLSPEC  int PMPI_Win_fence(int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_flush(int rank, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_flush_all(MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_flush_local(int rank, MPI_Win win);
@@ -2596,15 +2597,15 @@ OMPI_DECLSPEC  int PMPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandl
 OMPI_DECLSPEC  int PMPI_Win_get_group(MPI_Win win, MPI_Group *group);
 OMPI_DECLSPEC  int PMPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
 OMPI_DECLSPEC  int PMPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
-OMPI_DECLSPEC  int PMPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
-OMPI_DECLSPEC  int PMPI_Win_lock_all(int assert, MPI_Win win);
-OMPI_DECLSPEC  int PMPI_Win_post(MPI_Group group, int assert, MPI_Win win);
+OMPI_DECLSPEC  int PMPI_Win_lock(int lock_type, int rank, int mpi_assert, MPI_Win win);
+OMPI_DECLSPEC  int PMPI_Win_lock_all(int mpi_assert, MPI_Win win);
+OMPI_DECLSPEC  int PMPI_Win_post(MPI_Group group, int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
 OMPI_DECLSPEC  int PMPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
 OMPI_DECLSPEC  int PMPI_Win_set_info(MPI_Win win, MPI_Info info);
 OMPI_DECLSPEC  int PMPI_Win_set_name(MPI_Win win, const char *win_name);
 OMPI_DECLSPEC  int PMPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
-OMPI_DECLSPEC  int PMPI_Win_start(MPI_Group group, int assert, MPI_Win win);
+OMPI_DECLSPEC  int PMPI_Win_start(MPI_Group group, int mpi_assert, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_sync(MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_test(MPI_Win win, int *flag);
 OMPI_DECLSPEC  int PMPI_Win_unlock(int rank, MPI_Win win);

--- a/ompi/mca/osc/monitoring/osc_monitoring_active_target.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_active_target.h
@@ -17,14 +17,14 @@
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_ACTIVE_TARGET(template)        \
                                                                         \
-    static int ompi_osc_monitoring_## template ##_post (ompi_group_t *group, int assert, ompi_win_t *win) \
+    static int ompi_osc_monitoring_## template ##_post (ompi_group_t *group, int mpi_assert, ompi_win_t *win) \
     {                                                                   \
-        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_post(group, assert, win); \
+        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_post(group, mpi_assert, win); \
     }                                                                   \
                                                                         \
-    static int ompi_osc_monitoring_## template ##_start (ompi_group_t *group, int assert, ompi_win_t *win) \
+    static int ompi_osc_monitoring_## template ##_start (ompi_group_t *group, int mpi_assert, ompi_win_t *win) \
     {                                                                   \
-        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_start(group, assert, win); \
+        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_start(group, mpi_assert, win); \
     }                                                                   \
                                                                         \
     static int ompi_osc_monitoring_## template ##_complete (ompi_win_t *win) \
@@ -42,9 +42,9 @@
         return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_test(win, flag); \
     }                                                                   \
                                                                         \
-    static int ompi_osc_monitoring_## template ##_fence (int assert, ompi_win_t *win) \
+    static int ompi_osc_monitoring_## template ##_fence (int mpi_assert, ompi_win_t *win) \
     {                                                                   \
-        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_fence(assert, win); \
+        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_fence(mpi_assert, win); \
     }
 
 #endif /* MCA_OSC_MONITORING_ACTIVE_TARGET_H */

--- a/ompi/mca/osc/monitoring/osc_monitoring_passive_target.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_passive_target.h
@@ -41,9 +41,9 @@
         return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_flush_local_all(win); \
     }                                                                   \
                                                                         \
-    static int ompi_osc_monitoring_## template ##_lock (int lock_type, int target, int assert, ompi_win_t *win) \
+    static int ompi_osc_monitoring_## template ##_lock (int lock_type, int target, int mpi_assert, ompi_win_t *win) \
     {                                                                   \
-        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_lock(lock_type, target, assert, win); \
+        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_lock(lock_type, target, mpi_assert, win); \
     }                                                                   \
                                                                         \
     static int ompi_osc_monitoring_## template ##_unlock (int target, ompi_win_t *win) \
@@ -51,9 +51,9 @@
         return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_unlock(target, win); \
     }                                                                   \
                                                                         \
-    static int ompi_osc_monitoring_## template ##_lock_all (int assert, struct ompi_win_t *win) \
+    static int ompi_osc_monitoring_## template ##_lock_all (int mpi_assert, struct ompi_win_t *win) \
     {                                                                   \
-        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_lock_all(assert, win); \
+        return OMPI_OSC_MONITORING_MODULE_VARIABLE(template).osc_lock_all(mpi_assert, win); \
     }                                                                   \
                                                                         \
     static int ompi_osc_monitoring_## template ##_unlock_all (struct ompi_win_t *win) \

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -309,11 +309,11 @@ typedef int (*ompi_osc_base_module_rget_accumulate_fn_t)(const void *origin_addr
                                                          struct ompi_win_t *win,
                                                          struct ompi_request_t **request);
 
-typedef int (*ompi_osc_base_module_fence_fn_t)(int assert, struct ompi_win_t *win);
+typedef int (*ompi_osc_base_module_fence_fn_t)(int mpi_assert, struct ompi_win_t *win);
 
 
 typedef int (*ompi_osc_base_module_start_fn_t)(struct ompi_group_t *group,
-                                              int assert,
+                                              int mpi_assert,
                                               struct ompi_win_t *win);
 
 
@@ -321,7 +321,7 @@ typedef int (*ompi_osc_base_module_complete_fn_t)(struct ompi_win_t *win);
 
 
 typedef int (*ompi_osc_base_module_post_fn_t)(struct ompi_group_t *group,
-                                             int assert,
+                                             int mpi_assert,
                                              struct ompi_win_t *win);
 
 
@@ -334,13 +334,13 @@ typedef int (*ompi_osc_base_module_test_fn_t)(struct ompi_win_t *win,
 
 typedef int (*ompi_osc_base_module_lock_fn_t)(int lock_type,
                                              int target,
-                                             int assert,
+                                             int mpi_assert,
                                              struct ompi_win_t *win);
 
 typedef int (*ompi_osc_base_module_unlock_fn_t)(int target,
                                              struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_lock_all_fn_t)(int assert,
+typedef int (*ompi_osc_base_module_lock_all_fn_t)(int mpi_assert,
                                                   struct ompi_win_t *win);
 
 typedef int (*ompi_osc_base_module_unlock_all_fn_t)(struct ompi_win_t *win);

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -242,16 +242,16 @@ int ompi_osc_portals4_rget_accumulate(const void *origin_addr,
                                       struct ompi_win_t *win,
                                       struct ompi_request_t **request);
 
-int ompi_osc_portals4_fence(int assert, struct ompi_win_t *win);
+int ompi_osc_portals4_fence(int mpi_assert, struct ompi_win_t *win);
 
 int ompi_osc_portals4_start(struct ompi_group_t *group,
-                            int assert,
+                            int mpi_assert,
                             struct ompi_win_t *win);
 
 int ompi_osc_portals4_complete(struct ompi_win_t *win);
 
 int ompi_osc_portals4_post(struct ompi_group_t *group,
-                           int assert,
+                           int mpi_assert,
                            struct ompi_win_t *win);
 
 int ompi_osc_portals4_wait(struct ompi_win_t *win);
@@ -261,14 +261,14 @@ int ompi_osc_portals4_test(struct ompi_win_t *win,
 
 int ompi_osc_portals4_lock(int lock_type,
                            int target,
-                           int assert,
+                           int mpi_assert,
                            struct ompi_win_t *win);
 
 int ompi_osc_portals4_unlock(int target,
                              struct ompi_win_t *win);
 
 
-int ompi_osc_portals4_lock_all(int assert,
+int ompi_osc_portals4_lock_all(int mpi_assert,
                                struct ompi_win_t *win);
 
 int ompi_osc_portals4_unlock_all(struct ompi_win_t *win);

--- a/ompi/mca/osc/portals4/osc_portals4_active_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_active_target.c
@@ -20,7 +20,7 @@
 
 
 int
-ompi_osc_portals4_fence(int assert, struct ompi_win_t *win)
+ompi_osc_portals4_fence(int mpi_assert, struct ompi_win_t *win)
 {
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
@@ -42,7 +42,7 @@ ompi_osc_portals4_fence(int assert, struct ompi_win_t *win)
 
 int
 ompi_osc_portals4_start(struct ompi_group_t *group,
-                        int assert,
+                        int mpi_assert,
                         struct ompi_win_t *win)
 {
     ompi_osc_portals4_module_t *module =
@@ -53,7 +53,7 @@ ompi_osc_portals4_start(struct ompi_group_t *group,
         return OMPI_ERR_RMA_SYNC;
     }
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         int size;
 
         OBJ_RETAIN(group);
@@ -115,14 +115,14 @@ ompi_osc_portals4_complete(struct ompi_win_t *win)
 
 int
 ompi_osc_portals4_post(struct ompi_group_t *group,
-                       int assert,
+                       int mpi_assert,
                        struct ompi_win_t *win)
 {
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
     int ret, i, size;
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         OBJ_RETAIN(group);
         module->post_group = group;
 

--- a/ompi/mca/osc/portals4/osc_portals4_passive_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_passive_target.c
@@ -198,7 +198,7 @@ end_shared(ompi_osc_portals4_module_t *module,
 int
 ompi_osc_portals4_lock(int lock_type,
                        int target,
-                       int assert,
+                       int mpi_assert,
                        struct ompi_win_t *win)
 {
     ompi_osc_portals4_module_t *module =
@@ -211,7 +211,7 @@ ompi_osc_portals4_lock(int lock_type,
     lock = OBJ_NEW(ompi_osc_portals4_outstanding_lock_t);
     lock->target = target;
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         if (MPI_LOCK_EXCLUSIVE == lock_type) {
             lock->lock_type = lock_exclusive;
             ret = start_exclusive(module, target);
@@ -276,7 +276,7 @@ ompi_osc_portals4_unlock(int target,
 
 
 int
-ompi_osc_portals4_lock_all(int assert,
+ompi_osc_portals4_lock_all(int mpi_assert,
                            struct ompi_win_t *win)
 {
     ompi_osc_portals4_module_t *module =
@@ -289,7 +289,7 @@ ompi_osc_portals4_lock_all(int assert,
     lock = OBJ_NEW(ompi_osc_portals4_outstanding_lock_t);
     lock->target = -1;
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         int i, comm_size;
 
         lock->lock_type = lock_shared;

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.h
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.h
@@ -12,6 +12,7 @@
  *                         reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,14 +27,14 @@
 #include "osc_rdma_sync.h"
 #include "osc_rdma_lock.h"
 
-int ompi_osc_rdma_fence_atomic (int assert, struct ompi_win_t *win);
+int ompi_osc_rdma_fence_atomic (int mpi_assert, struct ompi_win_t *win);
 
 int ompi_osc_rdma_start_atomic (struct ompi_group_t *group,
-                                int assert, struct ompi_win_t *win);
+                                int mpi_assert, struct ompi_win_t *win);
 int ompi_osc_rdma_complete_atomic (struct ompi_win_t *win);
 
 int ompi_osc_rdma_post_atomic (struct ompi_group_t *group,
-                               int assert, struct ompi_win_t *win);
+                               int mpi_assert, struct ompi_win_t *win);
 
 int ompi_osc_rdma_wait_atomic (struct ompi_win_t *win);
 

--- a/ompi/mca/osc/rdma/osc_rdma_passive_target.h
+++ b/ompi/mca/osc/rdma/osc_rdma_passive_target.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,13 +22,13 @@
  *
  * @param[in] lock_type        mpi lock type (MPI_LOCK_SHARED, MPI_LOCK_EXCLUSIVE)
  * @param[in] target           target process
- * @param[in] assert           asserts
+ * @param[in] mpi_assert       asserts
  * @param[in] win              mpi window
  *
  * @returns OMPI_SUCCESS on success
  * @returns OMPI_ERR_RMA_SYNC if there is a conflicting RMA epoch
  */
-int ompi_osc_rdma_lock_atomic (int lock_type, int target, int assert, ompi_win_t *win);
+int ompi_osc_rdma_lock_atomic (int lock_type, int target, int mpi_assert, ompi_win_t *win);
 
 /**
  * @brief unlock the target in the window using network/cpu atomics
@@ -43,18 +44,18 @@ int ompi_osc_rdma_unlock_atomic (int target, ompi_win_t *win);
 /**
  * @brief lock all targets in window using network/cpu atomics
  *
- * @param[in] assert           asserts
+ * @param[in] mpi_assert       asserts
  * @param[in] win              mpi window
  *
  * @returns OMPI_SUCCESS on success
  * @returns OMPI_ERR_RMA_SYNC if there is a conflicting RMA epoch
  */
-int ompi_osc_rdma_lock_all_atomic (int assert, struct ompi_win_t *win);
+int ompi_osc_rdma_lock_all_atomic (int mpi_assert, struct ompi_win_t *win);
 
 /**
  * @brief unlock all targets in window using network/cpu atomics
  *
- * @param[in] assert           asserts
+ * @param[in] mpi_assert       asserts
  * @param[in] win              mpi window
  *
  * @returns OMPI_SUCCESS on success

--- a/ompi/mca/osc/rdma/osc_rdma_sync.h
+++ b/ompi/mca/osc/rdma/osc_rdma_sync.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +68,7 @@ struct ompi_osc_rdma_sync_t {
             /** assert specified at lock acquire time. at this time Open MPI
              * only uses 5-bits for asserts. if this number goes over 16 this
              * will need to be changed to accomodate. */
-            int16_t assert;
+            int16_t mpi_assert;
         } lock;
 
         /** post/start/complete/wait specific synchronization data */

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -215,16 +215,16 @@ int ompi_osc_sm_rget_accumulate(const void *origin_addr,
                                       struct ompi_win_t *win,
                                       struct ompi_request_t **request);
 
-int ompi_osc_sm_fence(int assert, struct ompi_win_t *win);
+int ompi_osc_sm_fence(int mpi_assert, struct ompi_win_t *win);
 
 int ompi_osc_sm_start(struct ompi_group_t *group,
-                            int assert,
+                            int mpi_assert,
                             struct ompi_win_t *win);
 
 int ompi_osc_sm_complete(struct ompi_win_t *win);
 
 int ompi_osc_sm_post(struct ompi_group_t *group,
-                           int assert,
+                           int mpi_assert,
                            struct ompi_win_t *win);
 
 int ompi_osc_sm_wait(struct ompi_win_t *win);
@@ -234,14 +234,14 @@ int ompi_osc_sm_test(struct ompi_win_t *win,
 
 int ompi_osc_sm_lock(int lock_type,
                            int target,
-                           int assert,
+                           int mpi_assert,
                            struct ompi_win_t *win);
 
 int ompi_osc_sm_unlock(int target,
                              struct ompi_win_t *win);
 
 
-int ompi_osc_sm_lock_all(int assert,
+int ompi_osc_sm_lock_all(int mpi_assert,
                                struct ompi_win_t *win);
 
 int ompi_osc_sm_unlock_all(struct ompi_win_t *win);

--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -92,7 +92,7 @@ static int *ompi_osc_sm_group_ranks (ompi_group_t *group, ompi_group_t *sub_grou
 
 
 int
-ompi_osc_sm_fence(int assert, struct ompi_win_t *win)
+ompi_osc_sm_fence(int mpi_assert, struct ompi_win_t *win)
 {
     ompi_osc_sm_module_t *module =
         (ompi_osc_sm_module_t*) win->w_osc_module;
@@ -124,7 +124,7 @@ ompi_osc_sm_fence(int assert, struct ompi_win_t *win)
 
 int
 ompi_osc_sm_start(struct ompi_group_t *group,
-                  int assert,
+                  int mpi_assert,
                   struct ompi_win_t *win)
 {
     ompi_osc_sm_module_t *module =
@@ -139,7 +139,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
         return OMPI_ERR_RMA_SYNC;
     }
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         int size;
 
         int *ranks = ompi_osc_sm_group_ranks (module->comm->c_local_group, group);
@@ -215,7 +215,7 @@ ompi_osc_sm_complete(struct ompi_win_t *win)
 
 int
 ompi_osc_sm_post(struct ompi_group_t *group,
-                       int assert,
+                       int mpi_assert,
                        struct ompi_win_t *win)
 {
     ompi_osc_sm_module_t *module =
@@ -236,7 +236,7 @@ ompi_osc_sm_post(struct ompi_group_t *group,
 
     OBJ_RETAIN(group);
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         int *ranks = ompi_osc_sm_group_ranks (module->comm->c_local_group, group);
         if (NULL == ranks) {
             return OMPI_ERR_OUT_OF_RESOURCE;

--- a/ompi/mca/osc/sm/osc_sm_passive_target.c
+++ b/ompi/mca/osc/sm/osc_sm_passive_target.c
@@ -112,7 +112,7 @@ end_shared(ompi_osc_sm_module_t *module,
 int
 ompi_osc_sm_lock(int lock_type,
                  int target,
-                 int assert,
+                 int mpi_assert,
                  struct ompi_win_t *win)
 {
     ompi_osc_sm_module_t *module =
@@ -123,7 +123,7 @@ ompi_osc_sm_lock(int lock_type,
         return OMPI_ERR_RMA_SYNC;
     }
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         if (MPI_LOCK_EXCLUSIVE == lock_type) {
             module->outstanding_locks[target] = lock_exclusive;
             ret = start_exclusive(module, target);
@@ -188,7 +188,7 @@ ompi_osc_sm_unlock(int target,
 
 
 int
-ompi_osc_sm_lock_all(int assert,
+ompi_osc_sm_lock_all(int mpi_assert,
                            struct ompi_win_t *win)
 {
     ompi_osc_sm_module_t *module =
@@ -197,7 +197,7 @@ ompi_osc_sm_lock_all(int assert,
 
     comm_size = ompi_comm_size(module->comm);
     for (i = 0 ; i < comm_size ; ++i) {
-        ret = ompi_osc_sm_lock(MPI_LOCK_SHARED, i, assert, win);
+        ret = ompi_osc_sm_lock(MPI_LOCK_SHARED, i, mpi_assert, win);
         if (OMPI_SUCCESS != ret) return ret;
     }
 

--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -193,16 +193,16 @@ int ompi_osc_ucx_rget_accumulate(const void *origin_addr, int origin_count,
                                  struct ompi_op_t *op, struct ompi_win_t *win,
                                  struct ompi_request_t **request);
 
-int ompi_osc_ucx_fence(int assert, struct ompi_win_t *win);
-int ompi_osc_ucx_start(struct ompi_group_t *group, int assert, struct ompi_win_t *win);
+int ompi_osc_ucx_fence(int mpi_assert, struct ompi_win_t *win);
+int ompi_osc_ucx_start(struct ompi_group_t *group, int mpi_assert, struct ompi_win_t *win);
 int ompi_osc_ucx_complete(struct ompi_win_t *win);
-int ompi_osc_ucx_post(struct ompi_group_t *group, int assert, struct ompi_win_t *win);
+int ompi_osc_ucx_post(struct ompi_group_t *group, int mpi_assert, struct ompi_win_t *win);
 int ompi_osc_ucx_wait(struct ompi_win_t *win);
 int ompi_osc_ucx_test(struct ompi_win_t *win, int *flag);
 
-int ompi_osc_ucx_lock(int lock_type, int target, int assert, struct ompi_win_t *win);
+int ompi_osc_ucx_lock(int lock_type, int target, int mpi_assert, struct ompi_win_t *win);
 int ompi_osc_ucx_unlock(int target, struct ompi_win_t *win);
-int ompi_osc_ucx_lock_all(int assert, struct ompi_win_t *win);
+int ompi_osc_ucx_lock_all(int mpi_assert, struct ompi_win_t *win);
 int ompi_osc_ucx_unlock_all(struct ompi_win_t *win);
 int ompi_osc_ucx_sync(struct ompi_win_t *win);
 int ompi_osc_ucx_flush(int target, struct ompi_win_t *win);

--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -58,7 +58,7 @@ static inline void ompi_osc_ucx_handle_incoming_post(ompi_osc_ucx_module_t *modu
     opal_list_append(&module->pending_posts, &pending_post->super);
 }
 
-int ompi_osc_ucx_fence(int assert, struct ompi_win_t *win) {
+int ompi_osc_ucx_fence(int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
 
@@ -67,13 +67,13 @@ int ompi_osc_ucx_fence(int assert, struct ompi_win_t *win) {
         return OMPI_ERR_RMA_SYNC;
     }
 
-    if (assert & MPI_MODE_NOSUCCEED) {
+    if (mpi_assert & MPI_MODE_NOSUCCEED) {
         module->epoch_type.access = NONE_EPOCH;
     } else {
         module->epoch_type.access = FENCE_EPOCH;
     }
 
-    if (!(assert & MPI_MODE_NOPRECEDE)) {
+    if (!(mpi_assert & MPI_MODE_NOPRECEDE)) {
         ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
         if (ret != OMPI_SUCCESS) {
             return ret;
@@ -84,7 +84,7 @@ int ompi_osc_ucx_fence(int assert, struct ompi_win_t *win) {
                                               module->comm->c_coll->coll_barrier_module);
 }
 
-int ompi_osc_ucx_start(struct ompi_group_t *group, int assert, struct ompi_win_t *win) {
+int ompi_osc_ucx_start(struct ompi_group_t *group, int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int i, size, *ranks_in_grp = NULL, *ranks_in_win_grp = NULL;
     ompi_group_t *win_group = NULL;
@@ -123,7 +123,7 @@ int ompi_osc_ucx_start(struct ompi_group_t *group, int assert, struct ompi_win_t
         return OMPI_ERROR;
     }
 
-    if ((assert & MPI_MODE_NOCHECK) == 0) {
+    if ((mpi_assert & MPI_MODE_NOCHECK) == 0) {
         ompi_osc_ucx_pending_post_t *pending_post, *next;
 
         /* first look through the pending list */
@@ -202,7 +202,7 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
     return ret;
 }
 
-int ompi_osc_ucx_post(struct ompi_group_t *group, int assert, struct ompi_win_t *win) {
+int ompi_osc_ucx_post(struct ompi_group_t *group, int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
 
@@ -213,7 +213,7 @@ int ompi_osc_ucx_post(struct ompi_group_t *group, int assert, struct ompi_win_t 
     OBJ_RETAIN(group);
     module->post_group = group;
 
-    if ((assert & MPI_MODE_NOCHECK) == 0) {
+    if ((mpi_assert & MPI_MODE_NOCHECK) == 0) {
         int i, j, size;
         ompi_group_t *win_group = NULL;
         int *ranks_in_grp = NULL, *ranks_in_win_grp = NULL;

--- a/ompi/mca/osc/ucx/osc_ucx_passive_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_passive_target.c
@@ -81,7 +81,7 @@ static inline int end_exclusive(ompi_osc_ucx_module_t *module, int target) {
                                       sizeof(uint64_t), remote_addr);
 }
 
-int ompi_osc_ucx_lock(int lock_type, int target, int assert, struct ompi_win_t *win) {
+int ompi_osc_ucx_lock(int lock_type, int target, int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t *)win->w_osc_module;
     ompi_osc_ucx_lock_t *lock = NULL;
     ompi_osc_ucx_epoch_t original_epoch = module->epoch_type.access;
@@ -113,7 +113,7 @@ int ompi_osc_ucx_lock(int lock_type, int target, int assert, struct ompi_win_t *
     lock = OBJ_NEW(ompi_osc_ucx_lock_t);
     lock->target_rank = target;
 
-    if ((assert & MPI_MODE_NOCHECK) == 0) {
+    if ((mpi_assert & MPI_MODE_NOCHECK) == 0) {
         lock->is_nocheck = false;
         if (lock_type == MPI_LOCK_EXCLUSIVE) {
             ret = start_exclusive(module, target);
@@ -177,7 +177,7 @@ int ompi_osc_ucx_unlock(int target, struct ompi_win_t *win) {
     return ret;
 }
 
-int ompi_osc_ucx_lock_all(int assert, struct ompi_win_t *win) {
+int ompi_osc_ucx_lock_all(int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
 
@@ -193,7 +193,7 @@ int ompi_osc_ucx_lock_all(int assert, struct ompi_win_t *win) {
 
     module->epoch_type.access = PASSIVE_ALL_EPOCH;
 
-    if (0 == (assert & MPI_MODE_NOCHECK)) {
+    if (0 == (mpi_assert & MPI_MODE_NOCHECK)) {
         int i, comm_size;
         module->lock_all_is_nocheck = false;
         comm_size = ompi_comm_size(module->comm);

--- a/ompi/mpi/c/win_fence.c
+++ b/ompi/mpi/c/win_fence.c
@@ -40,7 +40,7 @@
 static const char FUNC_NAME[] = "MPI_Win_fence";
 
 
-int MPI_Win_fence(int assert, MPI_Win win)
+int MPI_Win_fence(int mpi_assert, MPI_Win win)
 {
     int rc;
 
@@ -49,12 +49,12 @@ int MPI_Win_fence(int assert, MPI_Win win)
 
         if (ompi_win_invalid(win)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_WIN, FUNC_NAME);
-        } else if (0 != (assert & ~(MPI_MODE_NOSTORE | MPI_MODE_NOPUT |
+        } else if (0 != (mpi_assert & ~(MPI_MODE_NOSTORE | MPI_MODE_NOPUT |
                                     MPI_MODE_NOPRECEDE | MPI_MODE_NOSUCCEED))) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ASSERT, FUNC_NAME);
         }
     }
 
-    rc = win->w_osc_module->osc_fence(assert, win);
+    rc = win->w_osc_module->osc_fence(mpi_assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_lock.c
+++ b/ompi/mpi/c/win_lock.c
@@ -40,7 +40,7 @@
 static const char FUNC_NAME[] = "MPI_Win_lock";
 
 
-int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
+int MPI_Win_lock(int lock_type, int rank, int mpi_assert, MPI_Win win)
 {
     int rc;
 
@@ -54,13 +54,13 @@ int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_LOCKTYPE, FUNC_NAME);
         } else if (ompi_win_peer_invalid(win, rank)) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RANK, FUNC_NAME);
-        } else if (0 != (assert & ~(MPI_MODE_NOCHECK))) {
+        } else if (0 != (mpi_assert & ~(MPI_MODE_NOCHECK))) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ASSERT, FUNC_NAME);
         } else if (! ompi_win_allow_locks(win)) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RMA_SYNC, FUNC_NAME);
         }
     }
 
-    rc = win->w_osc_module->osc_lock(lock_type, rank, assert, win);
+    rc = win->w_osc_module->osc_lock(lock_type, rank, mpi_assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_lock_all.c
+++ b/ompi/mpi/c/win_lock_all.c
@@ -37,7 +37,7 @@
 static const char FUNC_NAME[] = "MPI_Win_lock_all";
 
 
-int MPI_Win_lock_all(int assert, MPI_Win win)
+int MPI_Win_lock_all(int mpi_assert, MPI_Win win)
 {
     int rc;
 
@@ -46,13 +46,13 @@ int MPI_Win_lock_all(int assert, MPI_Win win)
 
         if (ompi_win_invalid(win)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_WIN, FUNC_NAME);
-        } else if (0 != (assert & ~(MPI_MODE_NOCHECK))) {
+        } else if (0 != (mpi_assert & ~(MPI_MODE_NOCHECK))) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ASSERT, FUNC_NAME);
         } else if (! ompi_win_allow_locks(win)) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RMA_SYNC, FUNC_NAME);
         }
     }
 
-    rc = win->w_osc_module->osc_lock_all(assert, win);
+    rc = win->w_osc_module->osc_lock_all(mpi_assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_post.c
+++ b/ompi/mpi/c/win_post.c
@@ -37,7 +37,7 @@
 static const char FUNC_NAME[] = "MPI_Win_post";
 
 
-int MPI_Win_post(MPI_Group group, int assert, MPI_Win win)
+int MPI_Win_post(MPI_Group group, int mpi_assert, MPI_Win win)
 {
     int rc;
 
@@ -46,12 +46,12 @@ int MPI_Win_post(MPI_Group group, int assert, MPI_Win win)
 
         if (ompi_win_invalid(win)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_WIN, FUNC_NAME);
-        } else if (0 != (assert & ~(MPI_MODE_NOCHECK | MPI_MODE_NOSTORE |
+        } else if (0 != (mpi_assert & ~(MPI_MODE_NOCHECK | MPI_MODE_NOSTORE |
                                     MPI_MODE_NOPUT))) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ASSERT, FUNC_NAME);
         }
     }
 
-    rc = win->w_osc_module->osc_post(group, assert, win);
+    rc = win->w_osc_module->osc_post(group, mpi_assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_start.c
+++ b/ompi/mpi/c/win_start.c
@@ -37,7 +37,7 @@
 static const char FUNC_NAME[] = "MPI_Win_start";
 
 
-int MPI_Win_start(MPI_Group group, int assert, MPI_Win win)
+int MPI_Win_start(MPI_Group group, int mpi_assert, MPI_Win win)
 {
     int rc;
 
@@ -46,11 +46,11 @@ int MPI_Win_start(MPI_Group group, int assert, MPI_Win win)
 
         if (ompi_win_invalid(win)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_WIN, FUNC_NAME);
-        } else if (0 != (assert & ~(MPI_MODE_NOCHECK))) {
+        } else if (0 != (mpi_assert & ~(MPI_MODE_NOCHECK))) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ASSERT, FUNC_NAME);
         }
     }
 
-    rc = win->w_osc_module->osc_start(group, assert, win);
+    rc = win->w_osc_module->osc_start(group, mpi_assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }


### PR DESCRIPTION
There already exists an identifier with the name assert. It is not
appropriate to use this name for variables in C. This commit changes
these variable names to mpi_assert. This should address an issue where
clang-format gives the wrong result when doing bit-wise-and operations
on these variables.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit aaabe3d141842c925ad6c3b0aab02a9d3b436dda)