### PR TITLE
coll/base: reduce memory consumption in Scatter

### DIFF
--- a/ompi/mca/coll/base/coll_base_scatter.c
+++ b/ompi/mca/coll/base/coll_base_scatter.c
@@ -138,8 +138,14 @@ ompi_coll_base_scatter_intra_binomial(
         scount = (int)packed_sizet;
 
         sdtype = MPI_PACKED;  /* default to MPI_PACKED as the send type */
-        packed_size = scount * (size+1)/2;  /* non-root, non-leaf nodes, allocate temp buffer for recv
-                                             * the most we need is rcount*size/2 */
+
+        /* non-root, non-leaf nodes, allocate temp buffer for recv the most we need is rcount*size/2 (an upper bound) */
+        int vparent = (bmtree->tree_prev - root + size) % size;
+        int subtree_size = vrank - vparent;
+        if (size - vrank < subtree_size)
+            subtree_size = size - vrank;
+        packed_size = scount * subtree_size;
+
         ptmp = tempbuf = (char *)malloc(packed_size);
         if (NULL == tempbuf) {
             err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto err_hndl;


### PR DESCRIPTION
This PR reduces memory consumption in non-root and non-leaf processes of binomial tree algorithm for Scatter operation.
(cherry picked from commit a2cd6a9)

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>