### PR TITLE
dist: Add OFI MTL max_msg_size note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,11 @@ All OpenSHMEM-1.3 functionality is supported.
   mechanisms for Open MPI to utilize single-copy semantics for shared
   memory.
 
+* The OFI MTL does not support sending messages larger than the active
+  Libfabric provider's `max_msg_size`.  If you receive an error
+  message about sending too large of a message when using the OFI MTL,
+  please reach out to your networking vendor to ask them to support a
+  larger `max_msg_size` for tagged messages.
 
 ### Open MPI Extensions
 


### PR DESCRIPTION
Following up on discussion around Issue #7058, add a note to the
README about the OFI MTL's handling of max_msg_size.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 51c005342fb9c42ee731e026f6b907c0e52d9713)
Signed-off-by: Brian Barrett <bbarrett@amazon.com>