### PR TITLE
coll/base: fix header dependency

### DIFF
--- a/ompi/mca/coll/base/coll_base_topo.h
+++ b/ompi/mca/coll/base/coll_base_topo.h
@@ -20,6 +20,7 @@
 #define MCA_COLL_BASE_TOPO_H_HAS_BEEN_INCLUDED
 
 #include "ompi_config.h"
+#include "ompi/communicator/communicator.h"
 #include <stddef.h>
 
 #define MAXTREEFANOUT 32


### PR DESCRIPTION
This commit fixes a dependency issue in coll_base_topo.h. This header
depends on ompi/communicator/communicator.h and is working only because
that header is currently included before this header where used.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>