### PR TITLE
v5.0.x: Add a .clang-format file for Open MPI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,188 @@
+# This file represents the coding style enforced by Open MPI. This file
+# is based on the long-held, but not enforced, guidelines from the
+# beginning of the project. We will be requiring that all code going
+# forward uses this style. To check your code before attempting to open
+# a PR install clang-format and run your commits through clang-format.
+#
+# To install clang-format:
+#
+# macOS:
+#   Homebrew: brew install clang-format
+#   Mac Ports: port install clang
+#
+# Linux:
+#   debian/ubuntu/rasbian: apt-get install clang-format
+#   redhat/fedora: yum install clang-format
+#
+# To run against your code changes:
+#
+#   unstaged changes: git clang-format --style file -f
+#   staged changes: git clang-format --style file
+#
+#   For interactive add the -p option.
+#
+# To run against all of Open MPI:
+#
+#   ./contrib/clang-format-ompi.sh
+#
+#   This command is intended to be run only once.
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+  - BOOST_FOREACH
+  - OPAL_LIST_FOREACH
+  - OPAL_LIST_FOREACH_DECL
+  - OPAL_LIST_FOREACH_SAFE
+  - OPAL_LIST_FOREACH_REV
+  - OPAL_LIST_FOREACH_SAFE_REV
+  - OPAL_HASH_TABLE_FOREACH
+  - OPAL_HASH_TABLE_FOREACH_PTR
+IncludeBlocks:   Preserve
+IncludeCategories:
+  # Ensure config includes always come first (opal_config.h, ompi_config.h, etc)
+  - Regex:           '^".*_config\.h"'
+    Priority:        -1
+  # In-tree includes come next (after main include)
+  - Regex:           '^".*"'
+    Priority:        2
+  # System includes come last
+  - Regex:           '^<.*>'
+    Priority:        3
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 300
+PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - BEGIN_C_DECLS
+  - END_C_DECLS
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - _STRINGIZE
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/contrib/clang-format-ompi.sh
+++ b/contrib/clang-format-ompi.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "Running clang-format on code base..."
+
+files=($(git ls-tree -r master --name-only | grep -v '3rd-party/' | grep -v 'contrib' | grep -e '.*\.[ch]$'))
+
+for file in "${files[@]}" ; do
+    if test "$1" = "-d" ; then
+	echo "Would have formatted: ${file}"
+    else
+	clang-format --style=file --verbose -i "${file}"
+    fi
+done
+
+echo "Done"


### PR DESCRIPTION
This file works with clang-format --style=file to reformat code to match the
style used in Open MPI. This type includes:

 - No tabs. They are not recommended for Open MPI and can often screw up the
   formatting.

 - Tab depth: 4. This is what is used throughout the Open MPI code base.

 - Max column width: 100. There currently is no standard for Open MPI but we
   should aim to use something reasonable.

 - Braces following function definitions occur un-indented on the following
   line.

 - Braces following other control statements occur on the same line as the
   control statement.

 - Spaces before open parentheses for control statements. No spaces otherwise.
   This is common accross the code base but not consistent.

 - Sort headers. Put _config headers before any other header. Followed by
   internal ("" headers), then system headers (<> headers).

 - Align consecutive macro definitions.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit c352fba5090ed82cf699779cead5f8532c2f7cc3)