### PR TITLE
Fix man page for MPI_Win_attach [4.0.x]

### DIFF
--- a/ompi/mpi/man/man3/MPI_Win_attach.3in
+++ b/ompi/mpi/man/man3/MPI_Win_attach.3in
@@ -5,7 +5,7 @@
 .\" $COPYRIGHT$
 .TH MPI_Win_attach 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
-\fBMPI_Win_attach, MPI_Win_detach\fP \- One-sided MPI call that attach / detach a window object for RMA operations.
+\fBMPI_Win_attach, MPI_Win_detach\fP \- One-sided MPI call that attaches / detaches a memory region to / from a window object for RMA operations.
 
 .SH SYNTAX
 .ft R
@@ -61,10 +61,14 @@ Fortran only: Error status (integer).
 
 .SH DESCRIPTION
 .ft R
-MPI_Win_attach is a one-sided MPI communication collective call executed by all processes in the group of \fIcomm\fP. It returns a window object that can be used by these processes to perform RMA operations. Each process specifies a window of existing memory that it exposes to RMA accesses by the processes in the group of \fIcomm\fP. The window consists of \fIsize\fP bytes, starting at address \fIbase\fP. A process may elect to expose no memory by specifying \fIsize\fP = 0.
+MPI_Win_attach is a one-sided MPI communication call used to attach a memory region of \fIsize\fP bytes starting at address \fIbase\fP to a window for RMA access. The window \fIwin\fP must have been created using
+.IR MPI_Win_create_dynamic .
+Multiple non-overlapping memory regions may be attached to the same dynamic window. Attaching overlapping memory regions to the same dynamic window is erroneous.
 .sp
 If the \fIbase\fP value used by MPI_Win_attach was allocated by MPI_Alloc_mem, the size of the window can be no larger than the value set by the MPI_ALLOC_MEM function.
 .sp
+.sp
+MPI_Win_detach can be used to detach a previously attached memory region from \fIwin\fP. The memory address \fIbase\fP and \fIwin\fP must match arguments passed to a previous call to MPI_Win_attach.
 
 .SH NOTES
 Use memory allocated by MPI_Alloc_mem to guarantee properly aligned window boundaries (such as word, double-word, cache line, page frame, and so on).
@@ -77,6 +81,5 @@ Almost all MPI routines return an error value; C routines as the value of the fu
 .sp
 Before the error value is returned, the current MPI error handler is
 called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
-
 
 


### PR DESCRIPTION
The text seems to have been copied from MPI_Win_allocate and was thus incorrect.

Cherry-pick from https://github.com/open-mpi/ompi/pull/8625/commits to v4.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>