### PR TITLE
add lanl gitlab-ci yml for darwin system

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -1,0 +1,112 @@
+variables:
+  SCHEDULER_PARAMETERS: "-pgeneral -t 1:00:00 -N 1 --ntasks-per-node=16"
+  GIT_STRATEGY: clone
+  NPROCS: 4
+
+stages:
+  - build
+  - test
+
+build:intel:
+  stage: build
+  tags: [darwin-slurm-shared]
+  script:
+    - module load intel
+    - git submodule update --init
+    - ./autogen.pl
+    - ./configure CC=icc FC=ifort CXX=icpc --prefix=$PWD/install_test --with-libevent=internal
+    - make -j 8 install
+    - make check
+    - export PATH=$PWD/install_test/bin:$PATH
+    - cd examples 
+    - make
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
+    untracked: true
+    paths:
+      - examples
+      - install_test
+    expire_in: 1 week
+  only:
+    - scheduled
+
+build:gnu:
+  stage: build
+  tags: [darwin-slurm-shared]
+  script:
+    - module load gcc
+    - git submodule update --init
+    - ./autogen.pl
+    - ./configure --prefix=$PWD/install_test --with-libevent=internal
+    - make -j 8 install
+    - make check
+    - export PATH=$PWD/install_test/bin:$PATH
+    - cd examples 
+    - make
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
+    untracked: true
+    paths:
+      - examples
+      - install_test
+    expire_in: 1 week
+  only:
+    - scheduled
+
+test:intel:
+  stage: test
+  tags: [darwin-slurm-shared]
+  dependencies:
+    - build:intel
+  needs: ["build:intel"]
+  script:
+    - pwd
+    - ls
+    - module load intel
+    - export PATH=$PWD/install_test/bin:$PATH
+    - which mpirun
+    - cd examples
+    - mpirun -np 4 hostname
+    - mpirun -np 4 ./hello_c
+    - mpirun -np 4 ./ring_c
+    - mpirun -np 4 ./hello_mpifh
+    - mpirun -np 4 ./ring_mpifh
+    - mpirun -np 4 ./hello_usempi
+    - mpirun -np 4 ./ring_usempi
+    - mpirun -np 4 ./hello_usempif08
+    - mpirun -np 4 ./ring_usempif08
+    - mpirun -np 4 ./connectivity_c
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
+    expire_in: 1 week
+  only:
+    - scheduled
+
+test:gnu:
+  stage: test
+  tags: [dawrin-slurm-shared]
+  dependencies:
+    - build:gnu
+  needs: ["build:gnu"]
+  script:
+    - pwd
+    - ls
+    - module load gcc
+    - export PATH=$PWD/install_test/bin:$PATH
+    - which mpirun
+    - cd examples
+    - mpirun -np 4 hostname
+    - mpirun -np 4 ./hello_c
+    - mpirun -np 4 ./ring_c
+    - mpirun -np 4 ./hello_mpifh
+    - mpirun -np 4 ./ring_mpifh
+    - mpirun -np 4 ./hello_usempi
+    - mpirun -np 4 ./ring_usempi
+    - mpirun -np 4 ./hello_usempif08
+    - mpirun -np 4 ./ring_usempif08
+    - mpirun -np 4 ./connectivity_c
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
+    expire_in: 1 week
+  only:
+    - scheduled


### PR DESCRIPTION
This is only going to be used for nightly sanity checks of the
release branches on various darwin node types.

Not intended for CI at this time.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>