### PR TITLE
clang-format: tweaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,15 +36,15 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
-AlignOperands:   Align
+AlignOperands: true
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
+AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: None
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
@@ -73,7 +73,7 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
+BreakBeforeBinaryOperators: true
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
@@ -92,7 +92,6 @@ Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
@@ -139,8 +138,8 @@ ObjCBlockIndentWidth: 4
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 300
-PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakAssignment: 250
+PenaltyBreakBeforeFirstCallParameter: 301
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000


### PR DESCRIPTION
This commit makes the following changes:

 - Disallow single-line functions. This matches the dominant style used
   in Open MPI.

 - Increase the penalty for breaking on assigment slightly higher than
   breaking before first argument. That will ensure that long assignments
   of the form foo = bar(baz) will break after the = before trying to
   break after the open-paren.

 - Break before binary operators. This is a change in style that I will
   revert if there is any push back. This causes long statements to break
   before the binary operator not after it. This is the currently
   recommended practice.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>