### PR TITLE
pml/ucx: ignore request leak by default, override by mca param

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -136,7 +136,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                          UCP_ATOMIC_FETCH_OP_FAND,
                                          UCP_ATOMIC_FETCH_OP_FOR,
                                          UCP_ATOMIC_FETCH_OP_FXOR,
-                                         UCP_PARAM_FIELD_ESTIMATED_NUM_PPN],
+                                         UCP_PARAM_FIELD_ESTIMATED_NUM_PPN,
+                                         UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK],
                                         [], [],
                                         [#include <ucp/api/ucp.h>])
                          AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -299,6 +299,13 @@ int mca_pml_ucx_init(int enable_mpi_threads)
         params.thread_mode = UCS_THREAD_MODE_SINGLE;
     }
 
+#if HAVE_DECL_UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK
+    if (!ompi_pml_ucx.request_leak_check) {
+        params.field_mask |= UCP_WORKER_PARAM_FIELD_FLAGS;
+        params.flags      |= UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK;
+    }
+#endif
+
     status = ucp_worker_create(ompi_pml_ucx.ucp_context, &params,
                                &ompi_pml_ucx.ucp_worker);
     if (UCS_OK != status) {

--- a/ompi/mca/pml/ucx/pml_ucx.h
+++ b/ompi/mca/pml/ucx/pml_ucx.h
@@ -58,6 +58,7 @@ struct mca_pml_ucx_module {
 
     int                       priority;
     bool                      cuda_initialized;
+    bool                      request_leak_check;
 };
 
 extern mca_pml_base_component_2_1_0_t mca_pml_ucx_component;

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -64,6 +64,21 @@ static int mca_pml_ucx_component_register(void)
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &ompi_pml_ucx.num_disconnect);
+
+#if HAVE_DECL_UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK
+    ompi_pml_ucx.request_leak_check = false;
+    (void) mca_base_component_var_register(&mca_pml_ucx_component.pmlm_version, "request_leak_check",
+                                           "Enable showing a warning during MPI_Finalize if some "
+                                           "non-blocking MPI requests have not been released",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_3,
+                                           MCA_BASE_VAR_SCOPE_LOCAL,
+                                           &ompi_pml_ucx.request_leak_check);
+#else
+    /* If UCX does not support ignoring leak check, then it's always enabled */
+    ompi_pml_ucx.request_leak_check = true;
+#endif
+
     opal_common_ucx_mca_var_register(&mca_pml_ucx_component.pmlm_version);
     return 0;
 }


### PR DESCRIPTION
Use the API exposed by https://github.com/openucx/ucx/pull/6232, to align with other transports in OpenMPI and not complain about leaks of non-blocking MPI requests.

Example of MPI program:
```c
#include <mpi.h>

int main(int argc, char**argv) {
   MPI_Request req;
   int i = 0;

   MPI_Init(&argc, &argv);
   MPI_Irecv(&i, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, &req); // not waited
   return MPI_Finalize();
}
```

Behavior before this PR:
```
$ mpirun -n 1 ./a.out 
[1616177111.163179] [host:128963:0]           mpool.c:44   UCX  WARN  object 0x155cec0 was not returned to mpool ucp_requests
```