### PR TITLE
clang-format-ompi: do not process fake header files

### DIFF
--- a/contrib/clang-format-ompi.sh
+++ b/contrib/clang-format-ompi.sh
@@ -2,7 +2,7 @@
 
 echo "Running clang-format on code base..."
 
-files=($(git ls-tree -r master --name-only | grep -v '3rd-party/' | grep -v 'contrib' | grep -e '.*\.[ch]$'))
+files=($(git ls-tree -r master --name-only | grep -v '3rd-party/' | grep -v 'contrib' | grep -e '.*\.[ch]$' | xargs grep -L -- "-*- fortran -*-"))
 
 for file in "${files[@]}" ; do
     if test "$1" = "-d" ; then


### PR DESCRIPTION
Open MPI has some "header" files that are really fotran includes but not named
with the expected extension (these are non-standard and sometimes named with .fi
for fortran include). They are not C header files so the clang-format script should
not attempt to format these files. The result is a mess and will fail to compile.

Open MPI should rename these files but for now they all have an emacs mode line
we can use to filter them out.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>