### PR TITLE
info_get_nthkey: release the correct object [5.0.x]

### DIFF
--- a/ompi/mpi/c/info_get_nthkey.c
+++ b/ompi/mpi/c/info_get_nthkey.c
@@ -94,7 +94,7 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
     err = ompi_info_get_nthkey (info, n, &key_str);
     if (NULL != key_str) {
         opal_string_copy(key, key_str->string, MPI_MAX_INFO_KEY);
-        OBJ_RELEASE(key);
+        OBJ_RELEASE(key_str);
     }
     OMPI_ERRHANDLER_NOHANDLE_RETURN(err, err, FUNC_NAME);
 }


### PR DESCRIPTION
Fix a regression introduced with #8330 where the wrong object was passed to `OBJ_RELEASE` in `MPI_Info_get_nthkey`

See #8664

Backport of https://github.com/open-mpi/ompi/pull/8665 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 9665467124f4e5c191b2f2d61ec89b2ae15ea9b8)