### PR TITLE
clang-format-ompi: do not format files that have -*- f90 -*-

### DIFF
--- a/contrib/clang-format-ompi.sh
+++ b/contrib/clang-format-ompi.sh
@@ -2,7 +2,7 @@
 
 echo "Running clang-format on code base..."
 
-files=($(git ls-tree -r master --name-only | grep -v '3rd-party/' | grep -v 'contrib' | grep -e '.*\.[ch]$' | xargs grep -L -- "-*- fortran -*-"))
+files=($(git ls-tree -r master --name-only | grep -v -E '3rd-party/|contrib/' | grep -e '.*\.[ch]$' | xargs grep -E -L -- "-*- fortran -*-|-*- f90 -*-"))
 
 for file in "${files[@]}" ; do
     if test "$1" = "-d" ; then


### PR DESCRIPTION
One more commit to ensure we don't try to format files that have a fortran emacs
mode line. Priot commit checked for fortran but Open MPI also uses f90 mode for
some files.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>