### PR TITLE
Fix regression in MPI_Info_dup

### DIFF
--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -79,6 +79,7 @@ int opal_info_dup(opal_info_t *info, opal_info_t **newinfo)
         OBJ_RETAIN(iterator->ie_key);
         newentry->ie_value = iterator->ie_value;
         OBJ_RETAIN(iterator->ie_value);
+        opal_list_append (&((*newinfo)->super), (opal_list_item_t *) newentry);
     }
     OPAL_THREAD_UNLOCK(info->i_lock);
     return OPAL_SUCCESS;


### PR DESCRIPTION
The newly created info key-value pairs were never added to the duplicated info object.

Regression introduced with #8330 

Fixes https://github.com/open-mpi/ompi/issues/8675

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>