### PR TITLE
btl/base: Fix call to mca_btl_base_am_atomic_64().

### DIFF
--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -976,7 +976,7 @@ static void mca_btl_base_am_process_atomic(mca_btl_base_module_t *btl,
             atomic_response = tmp;
         }
         if (8 == hdr->data.atomic.size) {
-            mca_btl_base_am_atomic_64((int64_t *) hdr->target_address,
+            mca_btl_base_am_atomic_64(&atomic_response,
                                       (opal_atomic_int64_t *) (uintptr_t) hdr->target_address,
                                       hdr->data.atomic.op);
         }

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -458,19 +458,14 @@ mca_btl_base_rdma_start(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint
         if (sizeof(*hdr) + size <= btl->btl_eager_limit) {
             /* just go ahead and send the data */
             packet_size += size;
-        } else if (!mca_btl_base_rdma_use_rdma_get(btl)) {
-            packet_size += size;
         } else if (!mca_btl_base_rdma_use_rdma_get (btl)) {
             packet_size += size_t_min (size, btl->btl_max_send_size - sizeof (*hdr));
         } else {
             use_rdma = true;
         }
     } else if (MCA_BTL_BASE_AM_GET == type) {
-        if (sizeof(mca_btl_base_rdma_response_hdr_t) + size <= btl->btl_eager_limit) {
-            packet_size += size;
-        } else if (!mca_btl_base_rdma_use_rdma_put(btl)) {
-            packet_size += size_t_min(size, btl->btl_max_send_size
-                                             - sizeof(mca_btl_base_rdma_response_hdr_t));
+        if (!mca_btl_base_rdma_use_rdma_put(btl)) {
+            packet_size += size_t_min(size, btl->btl_max_send_size - sizeof(*hdr));
         } else {
             use_rdma = true;
         }
@@ -1094,19 +1089,19 @@ int mca_btl_base_am_rdma_init(mca_btl_base_module_t *btl)
     }
 
     if (!(btl->btl_flags & MCA_BTL_FLAGS_PUT)) {
-        BTL_VERBOSE(("Enabling AM-based RDMA put for BTL %p", btl));
         btl->btl_flags |= MCA_BTL_FLAGS_PUT_AM;
-        btl->btl_put_limit = max_operation_size;
+        btl->btl_put_limit = max_operation_size - sizeof(mca_btl_base_rdma_hdr_t);
         btl->btl_put_alignment = operation_alignment;
         btl->btl_put = mca_btl_base_am_rdma_put;
+        BTL_VERBOSE(("Enabling AM-based RDMA put for BTL %p. max put = %zu", btl, btl->btl_put_limit));
     }
 
     if (!(btl->btl_flags & MCA_BTL_FLAGS_GET)) {
-        BTL_VERBOSE(("Enabling AM-based RDMA get for BTL %p", btl));
         btl->btl_flags |= MCA_BTL_FLAGS_GET_AM;
-        btl->btl_get_limit = max_operation_size;
+        btl->btl_get_limit = max_operation_size - sizeof(mca_btl_base_rdma_response_hdr_t);
         btl->btl_get_alignment = operation_alignment;
         btl->btl_get = mca_btl_base_am_rdma_get;
+        BTL_VERBOSE(("Enabling AM-based RDMA get for BTL %p. max get = %zu", btl, btl->btl_get_limit));
     }
 
     if (!(btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_FOPS)) {


### PR DESCRIPTION
A typo in the call to mca_btl_base_am_atomic_64() was passing
in the same address for the target and operand pointers.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>