### PR TITLE
Unable to compile the PSM2 MTL due to missing include file.

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -31,6 +31,7 @@
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/mtl_base_datatype.h"
 #include "opal/util/show_help.h"
+#include "opal/util/minmax.h"
 #include "ompi/proc/proc.h"
 
 #include "mtl_psm2.h"


### PR DESCRIPTION
2nd try... 

Fixes issue #8684.