### PR TITLE
build: Remove C++ cruft

### DIFF
--- a/ompi/tools/mpisync/Makefile.am
+++ b/ompi/tools/mpisync/Makefile.am
@@ -78,8 +78,5 @@ mpisync_SOURCES = \
 mpisync_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 mpisync_LDADD += $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
-clean-local:
-	test -z "$(OMPI_CXX_TEMPLATE_REPOSITORY)" || rm -rf $(OMPI_CXX_TEMPLATE_REPOSITORY)
-
 distclean-local:
 	rm -f $(man_pages)

--- a/ompi/tools/ompi_info/Makefile.am
+++ b/ompi/tools/ompi_info/Makefile.am
@@ -68,8 +68,5 @@ ompi_info_SOURCES = \
 ompi_info_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 ompi_info_LDADD += $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
-clean-local:
-	test -z "$(OMPI_CXX_TEMPLATE_REPOSITORY)" || rm -rf $(OMPI_CXX_TEMPLATE_REPOSITORY)
-
 distclean-local:
 	rm -f $(man_pages)

--- a/oshmem/tools/oshmem_info/Makefile.am
+++ b/oshmem/tools/oshmem_info/Makefile.am
@@ -74,8 +74,5 @@ oshmem_info_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 oshmem_info_LDADD += $(top_builddir)/oshmem/liboshmem.la
 oshmem_info_LDADD += $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
-clean-local:
-	test -z "$(OMPI_CXX_TEMPLATE_REPOSITORY)" || rm -rf $(OMPI_CXX_TEMPLATE_REPOSITORY)
-
 distclean-local:
 	rm -f $(man_pages)


### PR DESCRIPTION
Remove the template repository cleanup code from when ompi_info
was written in C++.  It looks like the code to actually
AC_SUBST the template variable was removed long ago, with
only these clean rules remaining from the dark days.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>