### PR TITLE
btl/tcp: MPI_Put/Accumulate(): Fix pre-mature completeion callback.

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -758,7 +758,7 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
 
     do {
         ret = btl->btl_put (btl, peer->data_endpoint, ptr, target_address,
-                            local_handle, target_handle, len, 0, MCA_BTL_NO_ORDER,
+                            local_handle, target_handle, len, MCA_BTL_TAG_OSC_RDMA, MCA_BTL_NO_ORDER,
                             ompi_osc_rdma_cas_put_complete, (void *) &complete, NULL);
         if (OPAL_SUCCESS == ret || (OPAL_ERR_OUT_OF_RESOURCE != ret && OPAL_ERR_TEMP_OUT_OF_RESOURCE != ret)) {
             break;

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -455,7 +455,7 @@ static int ompi_osc_rdma_put_real (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_pee
 
     do {
         ret = btl->btl_put (btl, peer->data_endpoint, ptr, target_address,
-                            local_handle, target_handle, size, 0, MCA_BTL_NO_ORDER,
+                            local_handle, target_handle, size, MCA_BTL_TAG_OSC_RDMA, MCA_BTL_NO_ORDER,
                             cb, context, cbdata);
         if (OPAL_UNLIKELY(OMPI_SUCCESS == ret)) {
             return OMPI_SUCCESS;

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -55,6 +55,8 @@
 #define MCA_BTL_TCP_STATISTICS 0
 BEGIN_C_DECLS
 
+#define MCA_BTL_TCP_TAG_PUT_RESP (MCA_BTL_TAG_OSC_RDMA + 1)
+
 extern opal_event_base_t *mca_btl_tcp_event_base;
 
 #define MCA_BTL_TCP_COMPLETE_FRAG_SEND(frag)                                            \
@@ -335,6 +337,9 @@ int mca_btl_tcp_send_blocking(int sd, const void *data, size_t size);
  * non-blocking most of the time.
  */
 int mca_btl_tcp_recv_blocking(int sd, void *data, size_t size);
+
+void mca_btl_tcp_put_response(mca_btl_base_module_t *btl,
+                                          const mca_btl_base_receive_descriptor_t *desc);
 
 END_C_DECLS
 #endif

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -1220,6 +1220,12 @@ static int mca_btl_tcp_component_exchange(void)
     return rc;
 }
 
+
+static void mca_btl_tcp_emu_init(void)
+{
+    mca_btl_base_active_message_trigger[MCA_BTL_TCP_TAG_PUT_RESP].cbfunc = mca_btl_tcp_put_response;
+}
+
 /*
  *  TCP module initialization:
  *  (1) read interface list from kernel and compare against module parameters
@@ -1318,6 +1324,9 @@ mca_btl_base_module_t **mca_btl_tcp_component_init(int *num_btl_modules,
     memcpy(btls, mca_btl_tcp_component.tcp_btls,
            mca_btl_tcp_component.tcp_num_btls * sizeof(mca_btl_tcp_module_t *));
     *num_btl_modules = mca_btl_tcp_component.tcp_num_btls;
+
+    mca_btl_tcp_emu_init();
+
     return btls;
 }
 

--- a/opal/mca/btl/tcp/btl_tcp_frag.c
+++ b/opal/mca/btl/tcp/btl_tcp_frag.c
@@ -306,6 +306,7 @@ advance_iov_position:
                 goto repeat;
             }
             break;
+        case MCA_BTL_TCP_HDR_TYPE_PUT_ACK:
         case MCA_BTL_TCP_HDR_TYPE_GET:
         default:
             break;

--- a/opal/mca/btl/tcp/btl_tcp_hdr.h
+++ b/opal/mca/btl/tcp/btl_tcp_hdr.h
@@ -28,11 +28,14 @@ BEGIN_C_DECLS
 /**
  * TCP header.
  */
+typedef enum {
+     MCA_BTL_TCP_HDR_TYPE_SEND = 1,
+     MCA_BTL_TCP_HDR_TYPE_PUT,
+     MCA_BTL_TCP_HDR_TYPE_GET,
+     MCA_BTL_TCP_HDR_TYPE_FIN,
+     MCA_BTL_TCP_HDR_TYPE_PUT_ACK
+} mca_btl_tcp_hdr_type_t;
 
-#define MCA_BTL_TCP_HDR_TYPE_SEND 1
-#define MCA_BTL_TCP_HDR_TYPE_PUT  2
-#define MCA_BTL_TCP_HDR_TYPE_GET  3
-#define MCA_BTL_TCP_HDR_TYPE_FIN  4
 /* The MCA_BTL_TCP_HDR_TYPE_FIN is a special kind of message sent during normal
  * connexion closing. Before the endpoint closes the socket, it performs a
  * 1-way handshake by sending a FIN message in the socket. This lets the other
@@ -50,6 +53,7 @@ struct mca_btl_tcp_hdr_t {
     uint8_t type;
     uint16_t count;
     uint32_t size;
+    void *myself_on_origin; /* Pointer back to frag on Put initiator */
 };
 typedef struct mca_btl_tcp_hdr_t mca_btl_tcp_hdr_t;
 


### PR DESCRIPTION
- Send an ack back to the origin letting it know when it is
  safe to invoke the completion callback. Otherwise it
  can be called before the data has arrived.

  Found with test accfence1.c.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>