### PR TITLE
build: Fix typo that disabled shared components

### DIFF
--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -719,7 +719,7 @@ AC_DEFUN([MCA_COMPONENT_COMPILE_MODE],[
     # static.
     if test "$STATIC_COMPONENT" = "1"; then
         $4=static
-    elif test "SHARED_COMPONENT" = "1"; then
+    elif test "$SHARED_COMPONENT" = "1"; then
         $4=dso
     elif test "$STATIC_FRAMEWORK" = "1"; then
         $4=static


### PR DESCRIPTION
Fix a typo in the MCA configure framework which meant that
users could not specify individual components to be build
as shared objects (only all components or all components in
a framework).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>