### PR TITLE
v5.0.x: README: remove openib BTL notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,16 +776,6 @@ All OpenSHMEM-1.3 functionality is supported.
 * uGNI is a Cray library for communicating over the Gemini and Aries
   interconnects.
 
-* The OpenFabrics Enterprise Distribution (OFED) software package v1.0
-  will not work properly with Open MPI v1.2 (and later) due to how its
-  Mellanox InfiniBand plugin driver is created.  The problem is fixed
-  with OFED v1.1 (and later).
-
-* The use of `fork()` with Libiverbs-based networks (i.e., the UCX
-  PML) is only partially supported, and only on Linux kernels >=
-  v2.6.15 with `libibverbs` v1.1 or later (first released as part of
-  OFED v1.2), per restrictions imposed by the OFED network stack.
-
 * Linux `knem` support is used when the `sm` (shared memory) BTL is
   compiled with knem support (see the `--with-knem` configure option)
   and the `knem` Linux module is loaded in the running kernel.  If the


### PR DESCRIPTION
The OpenIB BTL has been removed from master and v5.0; no need
to leave notes about OpenIB BTL requirements.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit da7a4af8b07b9c9b0219bae4a959fc9eaf209679)