### PR TITLE
ofi: fix typo in macro name

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -316,7 +318,7 @@ static uint32_t get_package_rank(int32_t num_local_peers, uint16_t my_local_rank
 #if HAVE_DECL_PMIX_PACKAGE_RANK
     uint16_t *package_rank_ptr;
     // Try to get the PACKAGE_RANK from PMIx
-    OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, OPAL_PMIX_PACKAGE_RANK,
+    OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PACKAGE_RANK,
                                    &pname, &package_rank_ptr, OPAL_UINT16);
     if (OPAL_SUCCESS == rc) {
         return (uint32_t)*package_rank_ptr;


### PR DESCRIPTION
This is a one-off commit for the release branch.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

bot:notacherrypick