### PR TITLE
delay compiler path search until build

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -623,17 +623,13 @@ end type test_mpi_handle],
     set dummy $OMPI_FC
     OMPI_FC_ARGV0=[$]2
     AS_IF([test -n "$OMPI_FC_ARGV0"],
-          [BASEFC="`basename $OMPI_FC_ARGV0`"
-           OPAL_WHICH([$OMPI_FC_ARGV0], [OMPI_FC_ABSOLUTE])],
+          [BASEFC="`basename $OMPI_FC_ARGV0`"],
           [OMPI_FC=none
-           BASEFC=none
-           OMPI_FC_ABSOLUTE=none])
+           BASEFC=none])
 
+    AM_CONDITIONAL([OMPI_HAVE_FC_COMPILER], [test "$OMPI_FC" != "none"])
     AC_SUBST(OMPI_FC)
-    AC_SUBST(OMPI_FC_ABSOLUTE)
     AC_DEFINE_UNQUOTED(OMPI_FC, ["$OMPI_FC"], [Underlying Fortran compiler])
-    AC_DEFINE_UNQUOTED(OMPI_FC_ABSOLUTE, ["$OMPI_FC_ABSOLUTE"],
-                       [Absolutey path to the underlying Fortran compiler found by configure])
 
     # These go into ompi/info/param.c
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_BUILD_SIZEOF],

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -429,7 +429,5 @@ AC_DEFUN([_OPAL_PROG_CC],[
     AC_DEFINE_UNQUOTED(OPAL_CC, "$CC", [OMPI underlying C compiler])
     set dummy $CC
     opal_cc_argv0=[$]2
-    OPAL_WHICH([$opal_cc_argv0], [OPAL_CC_ABSOLUTE])
-    AC_SUBST(OPAL_CC_ABSOLUTE)
     OPAL_VAR_SCOPE_POP
 ])

--- a/ompi/tools/mpisync/Makefile.am
+++ b/ompi/tools/mpisync/Makefile.am
@@ -26,26 +26,6 @@
 # $HEADER$
 #
 
-
-
-AM_CFLAGS = \
-            -DOPAL_CONFIGURE_USER="\"@OPAL_CONFIGURE_USER@\"" \
-            -DOPAL_CONFIGURE_HOST="\"@OPAL_CONFIGURE_HOST@\"" \
-            -DOPAL_CONFIGURE_DATE="\"@OPAL_CONFIGURE_DATE@\"" \
-            -DOMPI_BUILD_USER="\"$$USER\"" \
-            -DOMPI_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
-            -DOMPI_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
-            -DOMPI_BUILD_CFLAGS="\"@CFLAGS@\"" \
-            -DOMPI_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
-            -DOMPI_BUILD_CXXFLAGS="\"@CXXFLAGS@\"" \
-            -DOMPI_BUILD_CXXCPPFLAGS="\"@CXXCPPFLAGS@\"" \
-            -DOMPI_BUILD_FFLAGS="\"@FFLAGS@\"" \
-            -DOMPI_BUILD_FCFLAGS="\"@FCFLAGS@\"" \
-            -DOMPI_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
-            -DOMPI_BUILD_LIBS="\"@LIBS@\"" \
-            -DOPAL_CC_ABSOLUTE="\"@OPAL_CC_ABSOLUTE@\"" \
-            -DOMPI_CXX_ABSOLUTE="\"@OMPI_CXX_ABSOLUTE@\""
-
 include $(top_srcdir)/Makefile.ompi-rules
 
 man_pages = mpisync.1

--- a/ompi/tools/ompi_info/Makefile.am
+++ b/ompi/tools/ompi_info/Makefile.am
@@ -24,7 +24,7 @@
 # $HEADER$
 #
 
-AM_CFLAGS = \
+AM_CPPFLAGS = \
             -DOPAL_CONFIGURE_USER="\"@OPAL_CONFIGURE_USER@\"" \
             -DOPAL_CONFIGURE_HOST="\"@OPAL_CONFIGURE_HOST@\"" \
             -DOPAL_CONFIGURE_DATE="\"@OPAL_CONFIGURE_DATE@\"" \
@@ -39,8 +39,18 @@ AM_CFLAGS = \
             -DOMPI_BUILD_FCFLAGS="\"@FCFLAGS@\"" \
             -DOMPI_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
             -DOMPI_BUILD_LIBS="\"@LIBS@\"" \
-            -DOPAL_CC_ABSOLUTE="\"@OPAL_CC_ABSOLUTE@\"" \
-            -DOMPI_CXX_ABSOLUTE="\"@OMPI_CXX_ABSOLUTE@\""
+            -DOPAL_CC_ABSOLUTE="\"`which $(CC)`\""
+
+if OMPI_HAVE_CXX_COMPILER
+AM_CPPFLAGS+=-DOMPI_CXX_ABSOLUTE="\"`which $(CXX)`\""
+else
+AM_CPPFLAGS+=-DOMPI_CXX_ABSOLUTE="\"none\""
+endif
+if OMPI_HAVE_FC_COMPILER
+AM_CPPFLAGS+=-DOMPI_FC_ABSOLUTE="\"`which $(FC)`\""
+else
+AM_CPPFLAGS+=-DOMPI_FC_ABSOLUTE="\"none\""
+endif
 
 include $(top_srcdir)/Makefile.ompi-rules
 

--- a/oshmem/tools/oshmem_info/Makefile.am
+++ b/oshmem/tools/oshmem_info/Makefile.am
@@ -28,8 +28,7 @@ AM_CPPFLAGS = \
             -DOMPI_BUILD_FCFLAGS="\"@FCFLAGS@\"" \
             -DOMPI_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
             -DOMPI_BUILD_LIBS="\"@LIBS@\"" \
-            -DOPAL_CC_ABSOLUTE="\"@OPAL_CC_ABSOLUTE@\"" \
-            -DOMPI_CXX_ABSOLUTE="\"@OMPI_CXX_ABSOLUTE@\""
+            -DOPAL_CC_ABSOLUTE="\"`which $(CC)`\""
 if OSHMEM_PROFILING
     AM_CPPFLAGS += -DOSHMEM_PROFILING=1
 else
@@ -37,9 +36,20 @@ else
 endif
 
 if OSHMEM_BUILD_FORTRAN_BINDINGS
-    AM_CPPFLAGS += -DOSHMEM_BUILD_FORTRAN_BINDINGS=1
+    AM_CPPFLAGS += -DOSHMEM_BUILD_FORTRAN_BINDINGS=1 \
 else
     AM_CPPFLAGS += -DOSHMEM_BUILD_FORTRAN_BINDINGS=0
+endif
+
+if OMPI_HAVE_CXX_COMPILER
+AM_CPPFLAGS+=-DOMPI_CXX_ABSOLUTE="\"`which $(CXX)`\""
+else
+AM_CPPFLAGS+=-DOMPI_CXX_ABSOLUTE="\"none\""
+endif
+if OMPI_HAVE_FC_COMPILER
+AM_CPPFLAGS+=-DOMPI_FC_ABSOLUTE="\"`which $(FC)`\""
+else
+AM_CPPFLAGS+=-DOMPI_FC_ABSOLUTE="\"none\""
 endif
 
 include $(top_srcdir)/Makefile.ompi-rules


### PR DESCRIPTION
While unfortunate and broken, the compiler can change between configure and build.  Usually not successfully, but it can happen (as we saw in https://github.com/open-mpi/ompi/issues/8750).  This patch series delays finding the full path to the compiler, which we only use to display in ompi_info, until build time.  There's secondary patch in this series to clean up unneeded code in the mpisync Makefile.am, because it gets in the way of the primary patch.