### PR TITLE
Fixing the partial pack unpack issue.

### DIFF
--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -153,7 +153,7 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
             }
         }
     }
-    *out_size = iov_idx; /* we only reach this line after the for loop succesfully complete */
+    *out_size = iov_idx; /* we only reach this line after the for loop successfully complete */
     *max_data = pConv->bConverted - initial_bytes_converted;
     if (pConv->bConverted == pConv->local_size) {
         pConv->flags |= CONVERTOR_COMPLETED;
@@ -173,63 +173,71 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
  * change the content of the data (as in all conversions that require changing the size
  * of the exponent or mantissa).
  */
-static inline void opal_unpack_partial_datatype(opal_convertor_t *pConvertor, dt_elem_desc_t *pElem,
-                                                unsigned char *partial_data,
-                                                ptrdiff_t start_position, size_t length,
-                                                unsigned char **user_buffer)
+static inline void
+opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_t *pElem,
+                               size_t *COUNT, unsigned char **packed,
+                               unsigned char **memory, size_t *SPACE)
 {
     char unused_byte = 0x7F, saved_data[16];
     unsigned char temporary[16], *temporary_buffer = temporary;
-    unsigned char *user_data = *user_buffer + pElem->elem.disp;
-    size_t count_desc = 1;
+    unsigned char *user_data = *memory + pElem->elem.disp;
     size_t data_length = opal_datatype_basicDatatypes[pElem->elem.common.type]->size;
+    unsigned char *partial_data = *packed;
+    ptrdiff_t start_position = pConvertor->partial_length;
+    size_t length = data_length - start_position;
+    size_t count_desc = 1;
+    dt_elem_desc_t single_elem = { .elem = { .common = pElem->elem.common, .count = 1, .blocklen = 1,
+                                   .extent = data_length,  /* advance by a full data element */
+                                   .disp = 0  /* right where the pointer is */ } };
+    if( *SPACE < length ) {
+        length = *SPACE;
+    }
 
-    DO_DEBUG(opal_output(0,
-                         "unpack partial data start %lu end %lu data_length %lu user %p\n"
-                         "\tbConverted %lu total_length %lu count %ld\n",
-                         (unsigned long) start_position, (unsigned long) start_position + length,
-                         (unsigned long) data_length, (void *) *user_buffer,
-                         (unsigned long) pConvertor->bConverted,
-                         (unsigned long) pConvertor->local_size, pConvertor->count););
+    DO_DEBUG( opal_output( 0, "unpack partial data start %lu end %lu data_length %lu user %p\n"
+                           "\tbConverted %lu total_length %lu count %ld\n",
+                           (unsigned long)start_position, (unsigned long)start_position + length,
+                           (unsigned long)data_length, (void*)*memory,
+                           (unsigned long)pConvertor->bConverted,
+                           (unsigned long)pConvertor->local_size, pConvertor->count ); );
+    COMPUTE_CSUM( partial_data, length, pConvertor );
 
-    /* Find a byte that is not used in the partial buffer */
-find_unused_byte:
-    for (size_t i = 0; i < length; i++) {
-        if (unused_byte == partial_data[i]) {
+    /* Find a byte value that is not used in the partial buffer. We use it as a marker
+     * to identify what has not been modified by the unpack call. */
+ find_unused_byte:
+    for (size_t i = 0; i < length; i++ ) {
+        if( unused_byte == partial_data[i] ) {
             unused_byte--;
             goto find_unused_byte;
         }
     }
 
-    /* Copy and fill the rest of the buffer with the unused byte */
-    memset(temporary, unused_byte, data_length);
-    MEMCPY(temporary + start_position, partial_data, length);
+    /* Prepare an full element of the predefined type, by populating an entire type
+     * with the unused byte and then put the partial data at the right position. */
+    memset( temporary, unused_byte, data_length );
+    MEMCPY( temporary + start_position, partial_data, length );
 
+    /* Save the original content of the user memory */
 #if OPAL_CUDA_SUPPORT
     /* In the case where the data is being unpacked from device memory, need to
-     * use the special host to device memory copy.  Note this code path was only
-     * seen on large receives of noncontiguous data via buffered sends. */
-    pConvertor->cbmemcpy(saved_data, user_data, data_length, pConvertor);
+     * use the special host to device memory copy. */
+    pConvertor->cbmemcpy(saved_data, user_data, data_length, pConvertor );
 #else
-    /* Save the content of the user memory */
-    MEMCPY(saved_data, user_data, data_length);
+    MEMCPY( saved_data, user_data, data_length );
 #endif
 
     /* Then unpack the data into the user memory */
-    UNPACK_PREDEFINED_DATATYPE(pConvertor, pElem, count_desc, temporary_buffer, *user_buffer,
+    UNPACK_PREDEFINED_DATATYPE(pConvertor, &single_elem, count_desc, temporary_buffer, user_data,
                                data_length);
 
-    /* reload the length as it is reset by the macro */
+    /* reload the length and user buffer as they have been updated by the macro */
     data_length = opal_datatype_basicDatatypes[pElem->elem.common.type]->size;
+    user_data = *memory + pElem->elem.disp;
 
-    /* For every occurrence of the unused byte move data from the saved
-     * buffer back into the user memory.
-     */
+    /* Rebuild the data by pulling back the unmodified bytes from the original
+     * content in the user memory. */
 #if OPAL_CUDA_SUPPORT
     /* Need to copy the modified user_data again so we can see which
-     * bytes need to be converted back to their original values.  Note
-     * this code path was only seen on large receives of noncontiguous
-     * data via buffered sends. */
+     * bytes need to be converted back to their original values. */
     {
         char resaved_data[16];
         pConvertor->cbmemcpy(resaved_data, user_data, data_length, pConvertor);
@@ -245,6 +253,16 @@ find_unused_byte:
         }
     }
 #endif
+    pConvertor->partial_length = (pConvertor->partial_length + length) % data_length;
+    *SPACE  -= length;
+    *packed += length;
+    if (0 == pConvertor->partial_length) {
+        (*COUNT)--;  /* we have enough to complete one full predefined type */
+        *memory += data_length;
+        if (0 == (*COUNT % pElem->elem.blocklen)) {
+            *memory += pElem->elem.extent - (pElem->elem.blocklen * data_length);
+        }
+    }
 }
 
 /* The pack/unpack functions need a cleanup. I have to create a proper interface to access
@@ -271,9 +289,8 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
     size_t iov_len_local;
     uint32_t iov_count;
 
-    DO_DEBUG(opal_output(0, "opal_convertor_generic_simple_unpack( %p, {%p, %lu}, %u )\n",
-                         (void *) pConvertor, (void *) iov[0].iov_base,
-                         (unsigned long) iov[0].iov_len, *out_size););
+    DO_DEBUG( opal_output( 0, "opal_convertor_generic_simple_unpack( %p, iov[%u] = {%p, %lu} )\n",
+                           (void*)pConvertor, *out_size, (void*)iov[0].iov_base, (unsigned long)iov[0].iov_len ); );
 
     description = pConvertor->use_desc->desc;
 
@@ -300,26 +317,25 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
         iov_ptr = (unsigned char *) iov[iov_count].iov_base;
         iov_len_local = iov[iov_count].iov_len;
 
-        if (0 != pConvertor->partial_length) {
-            size_t element_length = opal_datatype_basicDatatypes[pElem->elem.common.type]->size;
-            size_t missing_length = element_length - pConvertor->partial_length;
-
-            assert(pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA);
-            COMPUTE_CSUM(iov_ptr, missing_length, pConvertor);
-            opal_unpack_partial_datatype(pConvertor, pElem, iov_ptr, pConvertor->partial_length,
-                                         (size_t)(element_length - pConvertor->partial_length),
-                                         &conv_ptr);
-            --count_desc;
-            if (0 == count_desc) {
-                conv_ptr = pConvertor->pBaseBuf + pStack->disp;
-                pos_desc++; /* advance to the next data */
-                UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
-            }
-            iov_ptr += missing_length;
-            iov_len_local -= missing_length;
-            pConvertor->partial_length = 0; /* nothing more inside */
-        }
+        /* Deal with all types of partial predefined datatype unpacking, including when
+         * unpacking a partial predefined element and when unpacking a part smaller than
+         * the blocklen.
+         */
         if (pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA) {
+            if (0 != pConvertor->partial_length) {  /* partial predefined element */
+                assert( pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA );
+                opal_unpack_partial_predefined( pConvertor, pElem, &count_desc,
+                                                &iov_ptr, &conv_ptr, &iov_len_local );
+                if (0 == count_desc) {  /* the end of the vector ? */
+                    assert( 0 == pConvertor->partial_length );
+                    conv_ptr = pConvertor->pBaseBuf + pStack->disp;
+                    pos_desc++; /* advance to the next data */
+                    UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
+                    goto next_vector;
+                }
+                if( 0 == iov_len_local )
+                    goto complete_loop;
+            }
             if (((size_t) pElem->elem.count * pElem->elem.blocklen) != count_desc) {
                 /* we have a partial (less than blocklen) basic datatype */
                 int rc = UNPACK_PARTIAL_BLOCKLEN(pConvertor, pElem, count_desc, iov_ptr, conv_ptr,
@@ -336,6 +352,7 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
         }
 
         while (1) {
+          next_vector:
             while (pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA) {
                 /* we have a basic datatype (working on full blocks) */
                 UNPACK_PREDEFINED_DATATYPE(pConvertor, pElem, count_desc, iov_ptr, conv_ptr,
@@ -401,19 +418,14 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
             }
         }
     complete_loop:
-        assert(pElem->elem.common.type < OPAL_DATATYPE_MAX_PREDEFINED);
-        if ((pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA) && (0 != iov_len_local)) {
-            unsigned char *temp = conv_ptr;
+        assert( pElem->elem.common.type < OPAL_DATATYPE_MAX_PREDEFINED );
+        if( (pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA) && (0 != iov_len_local) ) {
+            unsigned char* temp = conv_ptr;
             /* We have some partial data here. Let's copy it into the convertor
              * and keep it hot until the next round.
              */
-            assert(iov_len_local < opal_datatype_basicDatatypes[pElem->elem.common.type]->size);
-            COMPUTE_CSUM(iov_ptr, iov_len_local, pConvertor);
-
-            opal_unpack_partial_datatype(pConvertor, pElem, iov_ptr, 0, iov_len_local, &temp);
-
-            pConvertor->partial_length = iov_len_local;
-            iov_len_local = 0;
+            assert( iov_len_local < opal_datatype_basicDatatypes[pElem->elem.common.type]->size );
+            opal_unpack_partial_predefined(pConvertor, pElem, &count_desc, &iov_ptr, &temp, &iov_len_local);
         }
 
         iov[iov_count].iov_len -= iov_len_local; /* update the amount of valid data */
@@ -543,11 +555,6 @@ int32_t opal_unpack_general_function(opal_convertor_t *pConvertor, struct iovec 
     unsigned char *conv_ptr, *iov_ptr;
     uint32_t iov_count;
     size_t iov_len_local;
-#if 0
-    const opal_convertor_master_t *master = pConvertor->master;
-    ptrdiff_t advance; /* number of bytes that we should advance the buffer */
-#endif
-    size_t rc;
 
     DO_DEBUG(opal_output(0, "opal_convertor_general_unpack( %p, {%p, %lu}, %d )\n",
                          (void *) pConvertor, (void *) iov[0].iov_base,
@@ -609,13 +616,9 @@ int32_t opal_unpack_general_function(opal_convertor_t *pConvertor, struct iovec 
                      * and keep it hot until the next round.
                      */
                     assert(iov_len_local < opal_datatype_basicDatatypes[pElem->elem.common.type]->size);
-                    COMPUTE_CSUM(iov_ptr, iov_len_local, pConvertor);
-
-                    opal_unpack_partial_datatype(pConvertor, pElem, iov_ptr, 0, iov_len_local,
-                                                 &temp);
-
-                    pConvertor->partial_length = iov_len_local;
-                    iov_len_local = 0;
+                    opal_unpack_partial_predefined(pConvertor, pElem, &count_desc, &iov_ptr,
+                                                   &temp, &iov_len_local);
+                    assert( 0 == iov_len_local );
                 }
                 goto complete_loop;
             }

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -15,7 +15,7 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial
     MPI_CHECKS = to_self reduce_local
 endif
 TESTS = opal_datatype_test unpack_hetero $(MPI_TESTS)
@@ -99,6 +99,12 @@ unpack_hetero_LDADD = \
 reduce_local_SOURCES = reduce_local.c
 reduce_local_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 reduce_local_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
+
+partial_local_SOURCES = partial.c
+partial_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+partial_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 

--- a/test/datatype/partial.c
+++ b/test/datatype/partial.c
@@ -1,0 +1,171 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "opal/datatype/opal_convertor.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "opal/datatype/opal_datatype_checksum.h"
+#include "opal/runtime/opal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define TYPE_COUNT    3
+#define TYPE_BLEN     2
+#define TYPE_STRIDE   4
+
+#define CONT_COUNT    2
+
+#define COUNT         3
+
+#define CHUNK   ((TYPE_BLEN*8)*2-4)
+
+/**
+ * Print how many elements on both sides of ptr.
+ */
+static void show_neighborhood(double* ptr, int how_many, bool show_hex)
+{
+    int i;
+
+    printf("%12p: ", (void*)ptr);
+    for( i = -how_many; i < how_many;  i++ ) {
+        if( 0 == i ) {
+            printf(" <%g> ", ptr[i]);
+        } else {
+            printf("  %g  ", ptr[i]);
+        }
+    }
+    if( show_hex ) {
+        char* cptr = (char*)ptr;
+        printf("\n            : ");
+        for( i = -how_many; i < how_many;  i++ ) {
+            if( 0 == i ) printf(" <");
+            for( int j = 0; j < sizeof(double); j++ ) {
+                printf("%02x", cptr[i * sizeof(double)+j]);
+            }
+            if( 0 == i ) printf("> ");
+            else printf(" ");
+        }
+    }
+    printf("\n\n");
+}
+
+/**
+ * -------G---[---][---]    OPAL_LOOP_S 19 times the next 2 elements extent 18432
+ * -cC---P-DB-[---][---]    OPAL_FLOAT8 count 72 disp 0x80 (128) blen 16 extent 256 (size 9216)
+ * -------G---[---][---]    OPAL_LOOP_E prev 2 elements first elem displacement 128 size of data 9216
+ * -------G---[---][---]    OPAL_LOOP_E prev 3 elements first elem displacement 128 size of data 175104
+ */
+
+int main( int argc, char* argv[] )
+{
+    opal_datatype_t* vector;
+    ompi_datatype_t* base;
+    uint32_t iov_count;
+    size_t max_data, size, length;
+    struct iovec iov[2];
+    opal_convertor_t* convertor;
+    ptrdiff_t extent, base_extent;
+    double *array, *packed;
+    char* bpacked;
+    int i, j;
+
+    opal_init_util (NULL, NULL);
+    ompi_datatype_init();
+
+    ompi_datatype_create_vector(TYPE_COUNT, TYPE_BLEN, TYPE_STRIDE, MPI_DOUBLE, &base);
+    ompi_datatype_create_contiguous(CONT_COUNT, base, &vector);
+
+    opal_datatype_commit( vector );
+
+    ompi_datatype_dump(vector);
+
+    opal_datatype_type_size(vector, &size);
+    opal_datatype_type_extent(vector, &extent);
+    opal_datatype_type_extent(base, &base_extent);
+
+    array = (double*)malloc( extent * COUNT );
+    packed = (double*)malloc( size * COUNT );
+    bpacked = (char*)packed;
+
+    /**
+     * Initialize the sparse data using the index.
+     */
+    for( i = 0; i < (TYPE_BLEN * TYPE_COUNT * CONT_COUNT * COUNT); i++ ) {
+        packed[i] = (double)(i % TYPE_BLEN);
+    }
+    memset(array, extent * COUNT, TYPE_BLEN + 1);
+
+    /**
+     * Pack the sparse data into the packed array. This simulate the first step
+     * of the buffered operation.
+     */
+    convertor = opal_convertor_create( opal_local_arch, 0 );
+    opal_convertor_prepare_for_recv( convertor, vector, COUNT, array );
+
+    for( length = 0; length < (size * COUNT); ) {
+        iov[0].iov_base = bpacked + length;
+        iov[0].iov_len = CHUNK;
+        max_data = iov[0].iov_len;
+
+        iov_count = 1;
+        opal_convertor_unpack( convertor, iov, &iov_count, &max_data );
+        length += max_data;
+
+        int idx = 0, checked = 0;
+        for( int m = 0; m < COUNT; m++ ) {
+            char* mptr = (char*)array + m * extent;
+            for( int k = 0; k < CONT_COUNT; k++ ) {
+                char* kptr = mptr + k * base_extent;
+                for( j = 0; j < TYPE_COUNT; j++ ) {
+                    double* jarray = (double*)kptr + j * TYPE_STRIDE;
+                    for( i = 0; i < TYPE_BLEN; i++ ) {
+                        checked += sizeof(double);
+                        if( checked > length )
+                            goto next_iteration;
+                        if( jarray[i] != (double)(idx % TYPE_BLEN) ) {
+                            fprintf(stderr, "\n\n\nError during check for the %d element, length %" PRIsize_t " (chunk %d)\n",
+                                    idx, length, CHUNK);
+                            fprintf(stderr, "Error at position %d [%d:%d:%d:%d] found %g expected %g\n\n\n",
+                                    idx, m, k, j, i, jarray[i], (double)(idx % TYPE_BLEN));
+                            show_neighborhood(jarray + i, 4, true);
+                            exit(-1);
+                        }
+                        idx++;
+                    }
+                }
+            }
+        }
+next_iteration:
+        /* nothing special to do here, just move to the next conversion */
+        continue;
+    }
+
+    OBJ_RELEASE(convertor);
+
+    /**
+     * The datatype is not useful anymore
+     */
+    OBJ_RELEASE(vector);
+
+    free(array);
+    free(packed);
+
+    /* clean-ups all data allocations */
+    ompi_datatype_finalize();
+    opal_finalize_util ();
+
+    return 0;
+}


### PR DESCRIPTION
When unpacking a partial predefined element check the boundaries of the
description vector type, and adjust the memory pointer accordingly (to
reflect not only when a single basic type was correctly unpacked, but
also when an entire blocklen has been unpacked).

Fixes #8466.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>