### PR TITLE
Hkuno/man pages

### DIFF
--- a/oshmem/shmem/man/man3/shmem_int_xor_to_all.3in
+++ b/oshmem/shmem/man/man3/shmem_int_xor_to_all.3in
@@ -1,1 +1,1 @@
-.so man3/shmem_short_xor_all.3
+.so man3/shmem_short_xor_to_all.3

--- a/oshmem/shmem/man/man3/shmem_long_xor_to_all.3in
+++ b/oshmem/shmem/man/man3/shmem_long_xor_to_all.3in
@@ -1,1 +1,1 @@
-.so man3/shmem_short_xor_all.3
+.so man3/shmem_short_xor_to_all.3

--- a/oshmem/shmem/man/man3/shmem_longlong_xor_to_all.3in
+++ b/oshmem/shmem/man/man3/shmem_longlong_xor_to_all.3in
@@ -1,1 +1,1 @@
-.so man3/shmem_short_xor_all.3
+.so man3/shmem_short_xor_to_all.3

--- a/oshmem/shmem/man/man3/shmem_putmem_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_putmem_nbi.3in
@@ -143,7 +143,7 @@ See \fIintro_shmem\fP(3)
 for a definition of the term remotely accessible.
 .SH EXAMPLES
 
-Consider this simple example for Fortran.
+Consider this simple example for C.
 .Vb
 #include <stdio.h>
 #include <mpp/shmem.h>


### PR DESCRIPTION
Fix minor typographic errors in some man pages:
   * so filenames that were mis-spelt (missing "_to")
   * text describing code snippet called it Fortran not C