### PR TITLE
Fix unimplemented op functions for MPI_LONG.

### DIFF
--- a/ompi/mca/op/base/op_base_functions.c
+++ b/ompi/mca/op/base/op_base_functions.c
@@ -161,6 +161,9 @@ FUNC_FUNC(max,  int32_t,  int32_t)
 FUNC_FUNC(max, uint32_t, uint32_t)
 FUNC_FUNC(max,  int64_t,  int64_t)
 FUNC_FUNC(max, uint64_t, uint64_t)
+FUNC_FUNC(max,  long,  long)
+FUNC_FUNC(max,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC(max, fortran_integer, ompi_fortran_integer_t)
@@ -224,6 +227,9 @@ FUNC_FUNC(min,  int32_t,  int32_t)
 FUNC_FUNC(min, uint32_t, uint32_t)
 FUNC_FUNC(min,  int64_t,  int64_t)
 FUNC_FUNC(min, uint64_t, uint64_t)
+FUNC_FUNC(min,  long,  long)
+FUNC_FUNC(min,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC(min, fortran_integer, ompi_fortran_integer_t)
@@ -284,6 +290,9 @@ OP_FUNC(sum,  int32_t,  int32_t, +=)
 OP_FUNC(sum, uint32_t, uint32_t, +=)
 OP_FUNC(sum,  int64_t,  int64_t, +=)
 OP_FUNC(sum, uint64_t, uint64_t, +=)
+OP_FUNC(sum,  long,  long, +=)
+OP_FUNC(sum,  unsigned_long,  long, +=)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 OP_FUNC(sum, fortran_integer, ompi_fortran_integer_t, +=)
@@ -353,6 +362,9 @@ OP_FUNC(prod,  int32_t,  int32_t, *=)
 OP_FUNC(prod, uint32_t, uint32_t, *=)
 OP_FUNC(prod,  int64_t,  int64_t, *=)
 OP_FUNC(prod, uint64_t, uint64_t, *=)
+OP_FUNC(prod,  long,  long, *=)
+OP_FUNC(prod,  unsigned_long,  long, *=)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 OP_FUNC(prod, fortran_integer, ompi_fortran_integer_t, *=)
@@ -424,6 +436,9 @@ FUNC_FUNC(land,  int32_t,  int32_t)
 FUNC_FUNC(land, uint32_t, uint32_t)
 FUNC_FUNC(land,  int64_t,  int64_t)
 FUNC_FUNC(land, uint64_t, uint64_t)
+FUNC_FUNC(land,  long,  long)
+FUNC_FUNC(land,  unsigned_long,  long)
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC(land, fortran_logical, ompi_fortran_logical_t)
@@ -446,6 +461,9 @@ FUNC_FUNC(lor,  int32_t,  int32_t)
 FUNC_FUNC(lor, uint32_t, uint32_t)
 FUNC_FUNC(lor,  int64_t,  int64_t)
 FUNC_FUNC(lor, uint64_t, uint64_t)
+FUNC_FUNC(lor,  long,  long)
+FUNC_FUNC(lor,  unsigned_long,  long)
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC(lor, fortran_logical, ompi_fortran_logical_t)
@@ -468,6 +486,10 @@ FUNC_FUNC(lxor,  int32_t,  int32_t)
 FUNC_FUNC(lxor, uint32_t, uint32_t)
 FUNC_FUNC(lxor,  int64_t,  int64_t)
 FUNC_FUNC(lxor, uint64_t, uint64_t)
+FUNC_FUNC(lxor,  long,  long)
+FUNC_FUNC(lxor,  unsigned_long,  long)
+
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC(lxor, fortran_logical, ompi_fortran_logical_t)
@@ -490,6 +512,9 @@ FUNC_FUNC(band,  int32_t,  int32_t)
 FUNC_FUNC(band, uint32_t, uint32_t)
 FUNC_FUNC(band,  int64_t,  int64_t)
 FUNC_FUNC(band, uint64_t, uint64_t)
+FUNC_FUNC(band,  long,  long)
+FUNC_FUNC(band,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC(band, fortran_integer, ompi_fortran_integer_t)
@@ -527,6 +552,9 @@ FUNC_FUNC(bor,  int32_t,  int32_t)
 FUNC_FUNC(bor, uint32_t, uint32_t)
 FUNC_FUNC(bor,  int64_t,  int64_t)
 FUNC_FUNC(bor, uint64_t, uint64_t)
+FUNC_FUNC(bor,  long,  long)
+FUNC_FUNC(bor,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC(bor, fortran_integer, ompi_fortran_integer_t)
@@ -564,6 +592,9 @@ FUNC_FUNC(bxor,  int32_t,  int32_t)
 FUNC_FUNC(bxor, uint32_t, uint32_t)
 FUNC_FUNC(bxor,  int64_t,  int64_t)
 FUNC_FUNC(bxor, uint64_t, uint64_t)
+FUNC_FUNC(bxor,  long,  long)
+FUNC_FUNC(bxor,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC(bxor, fortran_integer, ompi_fortran_integer_t)
@@ -605,6 +636,7 @@ LOC_STRUCT(long_int, long, int)
 LOC_STRUCT(2int, int, int)
 LOC_STRUCT(short_int, short, int)
 LOC_STRUCT(long_double_int, long double, int)
+LOC_STRUCT(unsigned_long, unsigned long, int)
 
 /*************************************************************************
  * Max location
@@ -789,6 +821,9 @@ FUNC_FUNC_3BUF(max,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(max, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(max,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(max, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(max,  long,  long)
+FUNC_FUNC_3BUF(max,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC_3BUF(max, fortran_integer, ompi_fortran_integer_t)
@@ -852,6 +887,9 @@ FUNC_FUNC_3BUF(min,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(min, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(min,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(min, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(min,  long,  long)
+FUNC_FUNC_3BUF(min,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC_3BUF(min, fortran_integer, ompi_fortran_integer_t)
@@ -912,6 +950,9 @@ OP_FUNC_3BUF(sum,  int32_t,  int32_t, +)
 OP_FUNC_3BUF(sum, uint32_t, uint32_t, +)
 OP_FUNC_3BUF(sum,  int64_t,  int64_t, +)
 OP_FUNC_3BUF(sum, uint64_t, uint64_t, +)
+OP_FUNC_3BUF(sum,  long,  long, +)
+OP_FUNC_3BUF(sum,  unsigned_long,  long, +)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 OP_FUNC_3BUF(sum, fortran_integer, ompi_fortran_integer_t, +)
@@ -981,6 +1022,9 @@ OP_FUNC_3BUF(prod,  int32_t,  int32_t, *)
 OP_FUNC_3BUF(prod, uint32_t, uint32_t, *)
 OP_FUNC_3BUF(prod,  int64_t,  int64_t, *)
 OP_FUNC_3BUF(prod, uint64_t, uint64_t, *)
+OP_FUNC_3BUF(prod,  long,  long, *)
+OP_FUNC_3BUF(prod,  unsigned_long,  long, *)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 OP_FUNC_3BUF(prod, fortran_integer, ompi_fortran_integer_t, *)
@@ -1052,6 +1096,9 @@ FUNC_FUNC_3BUF(land,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(land, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(land,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(land, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(land,  long,  long)
+FUNC_FUNC_3BUF(land,  unsigned_long,  long)
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC_3BUF(land, fortran_logical, ompi_fortran_logical_t)
@@ -1074,6 +1121,9 @@ FUNC_FUNC_3BUF(lor,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(lor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(lor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(lor, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(lor,  long,  long)
+FUNC_FUNC_3BUF(lor,  unsigned_long,  long)
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC_3BUF(lor, fortran_logical, ompi_fortran_logical_t)
@@ -1096,6 +1146,9 @@ FUNC_FUNC_3BUF(lxor,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(lxor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(lxor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(lxor, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(lxor,  long,  long)
+FUNC_FUNC_3BUF(lxor,  unsigned_long,  long)
+
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
 FUNC_FUNC_3BUF(lxor, fortran_logical, ompi_fortran_logical_t)
@@ -1118,6 +1171,9 @@ FUNC_FUNC_3BUF(band,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(band, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(band,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(band, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(band,  long,  long)
+FUNC_FUNC_3BUF(band,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC_3BUF(band, fortran_integer, ompi_fortran_integer_t)
@@ -1155,6 +1211,9 @@ FUNC_FUNC_3BUF(bor,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(bor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(bor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(bor, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(bor,  long,  long)
+FUNC_FUNC_3BUF(bor,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC_3BUF(bor, fortran_integer, ompi_fortran_integer_t)
@@ -1192,6 +1251,9 @@ FUNC_FUNC_3BUF(bxor,  int32_t,  int32_t)
 FUNC_FUNC_3BUF(bxor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(bxor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(bxor, uint64_t, uint64_t)
+FUNC_FUNC_3BUF(bxor,  long,  long)
+FUNC_FUNC_3BUF(bxor,  unsigned_long,  long)
+
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
 FUNC_FUNC_3BUF(bxor, fortran_integer, ompi_fortran_integer_t)
@@ -1293,6 +1355,8 @@ LOC_FUNC_3BUF(minloc, long_double_int, <)
   [OMPI_OP_BASE_TYPE_INT32_T] = ompi_op_base_##ftype##_##name##_int32_t,   \
   [OMPI_OP_BASE_TYPE_UINT32_T] = ompi_op_base_##ftype##_##name##_uint32_t, \
   [OMPI_OP_BASE_TYPE_INT64_T] = ompi_op_base_##ftype##_##name##_int64_t,   \
+  [OMPI_OP_BASE_TYPE_LONG] = ompi_op_base_##ftype##_##name##_long,   \
+  [OMPI_OP_BASE_TYPE_UNSIGNED_LONG] = ompi_op_base_##ftype##_##name##_unsigned_long,   \
   [OMPI_OP_BASE_TYPE_UINT64_T] = ompi_op_base_##ftype##_##name##_uint64_t
 
 /** All the Fortran integers ********************************************/

--- a/ompi/mca/op/op.h
+++ b/ompi/mca/op/op.h
@@ -191,6 +191,11 @@ enum {
     /** 2 location C: long double int */
     OMPI_OP_BASE_TYPE_LONG_DOUBLE_INT,
 
+    /** long */
+    OMPI_OP_BASE_TYPE_LONG,
+    /** unsigned long */
+    OMPI_OP_BASE_TYPE_UNSIGNED_LONG,
+
     /** 2 location C: wchar_t */
     OMPI_OP_BASE_TYPE_WCHAR,
 

--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -228,6 +228,9 @@ int ompi_op_init(void)
     ompi_op_ddt_map[OMPI_DATATYPE_MPI_SHORT_FLOAT] = OMPI_OP_BASE_TYPE_SHORT_FLOAT;
     ompi_op_ddt_map[OMPI_DATATYPE_MPI_C_SHORT_FLOAT_COMPLEX] = OMPI_OP_BASE_TYPE_C_SHORT_FLOAT_COMPLEX;
 
+    ompi_op_ddt_map[OMPI_DATATYPE_MPI_LONG] = OMPI_OP_BASE_TYPE_LONG;
+    ompi_op_ddt_map[OMPI_DATATYPE_MPI_UNSIGNED_LONG] = OMPI_OP_BASE_TYPE_UNSIGNED_LONG;
+
     /* Create the intrinsic ops */
 
     if (OMPI_SUCCESS !=


### PR DESCRIPTION
When performing an op with MPI_LONG, for example,
an MPI_Allreduce() with MPI_MIN, this would segv when performing
the op, since there is no longer an op function
for this type.

I followed the blueprint for int64_t/uint64_t.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>