### PR TITLE
v5.0: threads: Fix C++/Fortran pthread tests

### DIFF
--- a/opal/mca/threads/pthreads/configure.m4
+++ b/opal/mca/threads/pthreads/configure.m4
@@ -353,13 +353,11 @@ AC_DEFUN([OPAL_INTL_POSIX_THREADS_PLAIN], [
 OPAL_INTL_POSIX_THREADS_PLAIN_C
 
 AS_IF([test "$CXX" != "no"],
-      [OPAL_INTL_POSIX_THREADS_PLAIN_CXX
-       opal_pthread_cxx_success=1],
+      [OPAL_INTL_POSIX_THREADS_PLAIN_CXX],
       [opal_pthread_cxx_success=0])
 
 AS_IF([test "$FC" != "no"],
-      [OPAL_INTL_POSIX_THREADS_PLAIN_FC
-       opal_pthread_fortran_success=1],
+      [OPAL_INTL_POSIX_THREADS_PLAIN_FC],
       [opal_pthread_fortran_success=0])
 
 # End: OPAL_INTL_POSIX_THREADS_PLAIN
@@ -483,13 +481,11 @@ esac
 OPAL_INTL_POSIX_THREADS_SPECIAL_FLAGS_C
 
 AS_IF([test "$CXX" != "no"],
-      [OPAL_INTL_POSIX_THREADS_SPECIAL_FLAGS_CXX
-       opal_pthread_cxx_success=1],
+      [OPAL_INTL_POSIX_THREADS_SPECIAL_FLAGS_CXX],
       [opal_pthread_cxx_success=0])
 
 AS_IF([test "$FC" != "no"],
-      [OPAL_INTL_POSIX_THREADS_SPECIAL_FLAGS_FC
-       opal_pthread_fortran_success=1],
+      [OPAL_INTL_POSIX_THREADS_SPECIAL_FLAGS_FC],
       [opal_pthread_fortran_success=0])
 
 OPAL_VAR_SCOPE_POP
@@ -675,13 +671,11 @@ plibs="-lpthreads -llthread -lpthread"
 OPAL_INTL_POSIX_THREADS_LIBS_C
 
 AS_IF([test "$CXX" != "no"],
-      [OPAL_INTL_POSIX_THREADS_LIBS_CXX
-       opal_pthread_cxx_success=1],
+      [OPAL_INTL_POSIX_THREADS_LIBS_CXX],
       [opal_pthread_cxx_success=0])
 
 AS_IF([test "$FC" != "no"],
-      [OPAL_INTL_POSIX_THREADS_LIBS_FC
-       opal_pthread_fortran_success=1],
+      [OPAL_INTL_POSIX_THREADS_LIBS_FC],
       [opal_pthread_fortran_success=0])
 
 OPAL_VAR_SCOPE_POP


### PR DESCRIPTION
Commit 38e53f3 introduced a bug in the checks for pthreads when
using C++ or Fortran, resulting in -pthread not being added
to the wrapper compiler flags.  This (on some platforms) lead
to link errors in multi-threaded applications.  Fix the bug by
not declaring success after the check for whether or not pthreads
works without additional libraries; this was overriding the
value set in the plain check.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit cc985b10cd0f239119e9536d81a2f12f8bc0e367)