### PR TITLE
Wrapper compiler cleanups

### DIFF
--- a/config/opal_config_files.m4
+++ b/config/opal_config_files.m4
@@ -24,7 +24,6 @@ AC_DEFUN([OPAL_CONFIG_FILES],[
         opal/mca/base/Makefile
         opal/tools/wrappers/Makefile
         opal/tools/wrappers/opalcc-wrapper-data.txt
-        opal/tools/wrappers/opalc++-wrapper-data.txt
         opal/tools/wrappers/opal.pc
     ])
 ])

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -94,10 +94,10 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
     # Get the full path to the wrapper compiler. If it doesn't exist
     # assume that the path is not currently valid.
     wrapper_tmp="$(type -p "$with_wrapper_cc")"
-    WRAPPER_CC="${wrapper_tmp:-$with_wrapper_cc}"
     if test -z "$wrapper_tmp" ; then
 	AC_MSG_WARN([could not find \"$with_wrapper_cc\" in path])
     fi
+    WRAPPER_CC=$with_wrapper_cc
 
     AC_MSG_RESULT([$WRAPPER_CC])
 

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -115,19 +115,19 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
     AS_IF([test "$with_wrapper_cflags_prefix" = "yes" || test "$with_wrapper_cflags_prefix" = "no"],
           [AC_MSG_ERROR([--with-wrapper-cflags-prefix must have an argument.])])
 
-    AC_ARG_WITH([wrapper-cxxflags],
-        [AS_HELP_STRING([--with-wrapper-cxxflags],
-                        [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
-    AS_IF([test "$with_wrapper_cxxflags" = "yes" || test "$with_wrapper_cxxflags" = "no"],
-          [AC_MSG_ERROR([--with-wrapper-cxxflags must have an argument.])])
-
-    AC_ARG_WITH([wrapper-cxxflags-prefix],
-        [AS_HELP_STRING([--with-wrapper-cxxflags-prefix],
-                        [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
-    AS_IF([test "$with_wrapper_cxxflags_prefix" = "yes" || test "$with_wrapper_cxxflags_prefix" = "no"],
-          [AC_MSG_ERROR([--with-wrapper-cxxflags-prefix must have an argument.])])
-
     m4_ifdef([project_ompi], [
+            AC_ARG_WITH([wrapper-cxxflags],
+                [AS_HELP_STRING([--with-wrapper-cxxflags],
+                                [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
+            AS_IF([test "$with_wrapper_cxxflags" = "yes" || test "$with_wrapper_cxxflags" = "no"],
+                  [AC_MSG_ERROR([--with-wrapper-cxxflags must have an argument.])])
+
+            AC_ARG_WITH([wrapper-cxxflags-prefix],
+                [AS_HELP_STRING([--with-wrapper-cxxflags-prefix],
+                                [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
+            AS_IF([test "$with_wrapper_cxxflags_prefix" = "yes" || test "$with_wrapper_cxxflags_prefix" = "no"],
+                  [AC_MSG_ERROR([--with-wrapper-cxxflags-prefix must have an argument.])])
+
             AC_ARG_WITH([wrapper-fcflags],
                 [AS_HELP_STRING([--with-wrapper-fcflags],
                         [Extra flags to add to FCFLAGS when using mpifort])])

--- a/opal/tools/wrappers/Makefile.am
+++ b/opal/tools/wrappers/Makefile.am
@@ -40,21 +40,18 @@ dist_opaldata_DATA = help-opal-wrapper.txt
 if WANT_INSTALL_HEADERS
 
 nodist_opaldata_DATA = \
-	opalcc-wrapper-data.txt \
-	opalc++-wrapper-data.txt
+	opalcc-wrapper-data.txt
 
-nodist_man_MANS += opalcc.1 opalc++.1
+nodist_man_MANS += opalcc.1
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = opal.pc
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f opalcc$(EXEEXT); $(LN_S) opal_wrapper$(EXEECT) opalcc$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f opalc++$(EXEEXT); $(LN_S) opal_wrapper$(EXEECT) opalc++$(EXEEXT))
 
 uninstall-local:
-	rm -f $(DESTDIR)$(bindir)/opalcc$(EXEEXT) \
-	$(DESTDIR)$(bindir)/opalc++$(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/opalcc$(EXEEXT)
 
 endif # WANT_INSTALL_HEADERS
 
@@ -73,9 +70,5 @@ opalcc.1: generic_wrapper.1
 	rm -f opalcc.1
 	sed -e 's/#COMMAND#/opalcc/g' -e 's/#PROJECT#/Open PAL/g' -e 's/#PROJECT_SHORT#/OPAL/g' -e 's/#LANGUAGE#/C/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > opalcc.1
 
-opalc++.1: generic_wrapper.1
-	rm -f opalc++.1
-	sed -e 's/#COMMAND#/opalc++/g' -e 's/#PROJECT#/Open PAL/g' -e 's/#PROJECT_SHORT#/OPAL/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > opalc++.1
-
 distclean-local:
-	rm -f $(real_man_pages) opalcc.1 opalc++.1
+	rm -f $(real_man_pages) opalcc.1


### PR DESCRIPTION
Two wrapper compiler cleanups:

1) Use $CC, not the full path CC, for the wrapper compiler, similar to our behavior for Fortran and C++.
2) Do not install the opalc++ wrapper compiler, as we don't initialize C++ for the opal layer.