### PR TITLE
v4.0.x: atomic/gcc_builtin: only apply the workaround when required.

### DIFF
--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -52,6 +52,14 @@
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 
 
+#if (OPAL_ASSEMBLY_ARCH == OPAL_X86_64) && defined (__GNUC__) && !defined(__llvm) && (__GNUC__ < 6)
+    /* work around a bug in older gcc versions where ACQUIRE seems to get
+     * treated as a no-op instead */
+#define OPAL_BUSTED_ATOMIC_MB 1
+#else
+#define OPAL_BUSTED_ATOMIC_MB 0
+#endif
+
 static inline void opal_atomic_mb(void)
 {
     __atomic_thread_fence (__ATOMIC_SEQ_CST);
@@ -59,10 +67,8 @@ static inline void opal_atomic_mb(void)
 
 static inline void opal_atomic_rmb(void)
 {
-#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
-    /* work around a bug in older gcc versions where ACQUIRE seems to get
-     * treated as a no-op instead */
-    __asm__ __volatile__("": : :"memory");
+#if OPAL_BUSTED_ATOMIC_MB
+    __asm__ __volatile__("" : : : "memory");
 #else
     __atomic_thread_fence (__ATOMIC_ACQUIRE);
 #endif


### PR DESCRIPTION
A performance regression was reported when using the workaround
    `__asm__ __volatile__("" : : : "memory");`
instead of
    `__atomic_thread_fence(__ATOMIC_ACQUIRE);`
on a large SMP with recent GCC compiler.

So only use the workaround on x86_64 when a busted GCC compiler is used.

Thanks S. Biplab Raut for reporting this issue.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@711c8c2c3c2c166082cb8b885e362e376f86c623)

bot:notacherrypick