### PR TITLE
WIP: config: default to DSO for plugins with external deps

### DIFF
--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -68,7 +68,8 @@ AC_DEFUN([OPAL_MCA],[
                         type-component pairs that will be built as
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
-                        platform.])])
+                        platform.])],
+                        [], [enable_mca_dso=btl-ugni,rcache-udreg])
     AC_ARG_ENABLE([mca-static],
         [AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or


### PR DESCRIPTION
With the new default to link all plugins as static, the dependencies of all the plugins (e.g. transport plugins) become direct dependencies of top-level binaries (e.g. opal_wrapper aka mpicc).

These direct dependencies are simply bad, because the dependency is false, it is unnecessary for running most binaries.

But if that's not sufficient justification, the current default behavior is
different from old behavior in a user-unfriendly way:

	mpicc --version
	mpicc: error while loading shared libraries:
	libugni.so.0: cannot open shared object file: No such file or directory

The workaround the user needs to figure out is to build with `--enable-mca-dso` set, either for all or for a specific set of components; or set LD_LIBRARY_PATH system-wide or for each usage of `mpicc` and all other binaries, neither of which is reasonable.

In https://github.com/openpmix/prrte/issues/871  it was decided that a behavior that's more user friendly than this can be provided by implementing a smart default for which components should default
to DSO compile mode. This PR implements this default.

One more component that also should default to DSO is `btl-sm` but only when Cray `xpmem` is found (it is enabled by default). This would require some kind of conditional logic. So, this PR is incomplete.

See this issue for rationale: https://github.com/openpmix/prrte/issues/871

This patch to OMPI is a twin to the patches that were already committed to
PRRTE and PMIX:
PRRTE e3914b0ad0df30939d329fe615a0ec37e64dcf2a
PMIX 0b8f747cdc0d2a76ab727e2a18edde2870246521

Signed-off-by: Alexei Colin <acolin@isi.edu>