### PR TITLE
Backport/datatype

### DIFF
--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -91,8 +91,8 @@ AS_IF([test "$opal_check_cuda_happy" = "yes"],
 # If we have CUDA support, check to see if we have support for SYNC_MEMOPS
 # which was first introduced in CUDA 6.0.
 AS_IF([test "$opal_check_cuda_happy"="yes"],
-    AC_CHECK_DECL([CU_POINTER_ATTRIBUTE_SYNC_MEMOPS], [CUDA_SYNC_MEMOPS=1], [CUDA_SYNC_MEMOPS=0],
-        [#include <$opal_cuda_incdir/cuda.h>]),
+    [AC_CHECK_DECL([CU_POINTER_ATTRIBUTE_SYNC_MEMOPS], [CUDA_SYNC_MEMOPS=1], [CUDA_SYNC_MEMOPS=0],
+        [#include <$opal_cuda_incdir/cuda.h>])],
     [])
 
 # If we have CUDA support, check to see if we have CUDA 6.0 or later.

--- a/configure.ac
+++ b/configure.ac
@@ -1370,10 +1370,13 @@ OPAL_SETUP_WRAPPER_FINAL
 # autoconf macro defines in mpi.h.  Since AC sometimes changes whether
 # things are defined as null tokens or an integer result, two projects
 # with different versions of AC can cause problems.
-if test $ac_cv_header_stdc = yes; then
-    AC_DEFINE(OPAL_STDC_HEADERS, 1,
-              [Do not use outside of mpi.h.  Define to 1 if you have the ANSI C header files.])
-fi
+
+# According to the autoconf 2.67 documentation the AC_HEADER_STDC macro,
+# and therefore the ac_cv_header_stdc cache variable, is obsolescent, as
+# current systems have conforming header files. Instead of removing the
+# protection completely, let's just make sure it is always on.
+AC_DEFINE(OPAL_STDC_HEADERS, 1,
+          [Do not use outside of mpi.h.  Define to 1 if you have the ANSI C header files.])
 if test $ac_cv_header_sys_time_h = yes ; then
     AC_DEFINE(OPAL_HAVE_SYS_TIME_H, 1,
               [Do not use outside of mpi.h.  Define to 1 if you have the <sys/time.h> header file.])

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -483,7 +483,8 @@ size_t opal_convertor_compute_remote_size( opal_convertor_t* pConvertor )
     pConvertor->remote_size = pConvertor->local_size;
     if( OPAL_UNLIKELY(datatype->bdt_used & pConvertor->master->hetero_mask) ) {
         pConvertor->flags &= (~CONVERTOR_HOMOGENEOUS);
-        if (!(pConvertor->flags & CONVERTOR_SEND && pConvertor->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS)) {
+        /* Can we use the optimized description? */
+        if (pConvertor->flags & OPAL_DATATYPE_OPTIMIZED_RESTRICTED) {
             pConvertor->use_desc = &(datatype->desc);
         }
         if( 0 == (pConvertor->flags & CONVERTOR_HAS_REMOTE_SIZE) ) {

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -75,11 +75,18 @@ BEGIN_C_DECLS
  * We should make the difference here between the predefined contiguous and non contiguous
  * datatypes. The OPAL_DATATYPE_FLAG_BASIC is held by all predefined contiguous datatypes.
  */
-#define OPAL_DATATYPE_FLAG_BASIC         (OPAL_DATATYPE_FLAG_PREDEFINED | \
-                                          OPAL_DATATYPE_FLAG_CONTIGUOUS | \
-                                          OPAL_DATATYPE_FLAG_NO_GAPS |    \
-                                          OPAL_DATATYPE_FLAG_DATA |       \
-                                          OPAL_DATATYPE_FLAG_COMMITTED)
+#define OPAL_DATATYPE_FLAG_BASIC                                                                \
+    (OPAL_DATATYPE_FLAG_PREDEFINED | OPAL_DATATYPE_FLAG_CONTIGUOUS | OPAL_DATATYPE_FLAG_NO_GAPS \
+     | OPAL_DATATYPE_FLAG_DATA | OPAL_DATATYPE_FLAG_COMMITTED)
+/*
+ * If during the datatype optimization process we collapse contiguous elements with
+ * different types, we cannot use this optimized description for any communication
+ * in a heterogeneous setting, especially not for the exteranl32 support.
+ *
+ * A datatype with this flag cannot use the optimized description in heterogeneous
+ * setups.
+ */
+#define OPAL_DATATYPE_OPTIMIZED_RESTRICTED  0x1000
 
 /**
  * The number of supported entries in the data-type definition and the

--- a/opal/datatype/opal_datatype_dump.c
+++ b/opal/datatype/opal_datatype_dump.c
@@ -62,17 +62,39 @@ int opal_datatype_contain_basic_datatypes( const opal_datatype_t* pData, char* p
 int opal_datatype_dump_data_flags( unsigned short usflags, char* ptr, size_t length )
 {
     int index = 0;
-    if( length < 22 ) return 0;
-    index = snprintf( ptr, 22, "-----------[---][---]" );  /* set everything to - */
-    if( usflags & OPAL_DATATYPE_FLAG_COMMITTED )  ptr[1]  = 'c';
-    if( usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS ) ptr[2]  = 'C';
-    if( usflags & OPAL_DATATYPE_FLAG_OVERLAP )    ptr[3]  = 'o';
-    if( usflags & OPAL_DATATYPE_FLAG_USER_LB )    ptr[4]  = 'l';
-    if( usflags & OPAL_DATATYPE_FLAG_USER_UB )    ptr[5]  = 'u';
-    if( usflags & OPAL_DATATYPE_FLAG_PREDEFINED ) ptr[6]  = 'P';
-    if( !(usflags & OPAL_DATATYPE_FLAG_NO_GAPS) ) ptr[7]  = 'G';
-    if( usflags & OPAL_DATATYPE_FLAG_DATA )       ptr[8]  = 'D';
-    if( (usflags & OPAL_DATATYPE_FLAG_BASIC) == OPAL_DATATYPE_FLAG_BASIC ) ptr[9]  = 'B';
+    if (length < 22) {
+        return 0;
+    }
+    index = snprintf(ptr, 22, "-----------[---][---]"); /* set everything to - */
+    if (usflags & OPAL_DATATYPE_FLAG_COMMITTED) {
+        ptr[1] = 'c';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS) {
+        ptr[2] = 'C';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_OVERLAP) {
+        ptr[3] = 'o';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_USER_LB) {
+        ptr[4] = 'l';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_USER_UB) {
+        ptr[5] = 'u';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_PREDEFINED) {
+        ptr[6] = 'P';
+    }
+    if (!(usflags & OPAL_DATATYPE_FLAG_NO_GAPS)) {
+        ptr[7] = 'G';
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_DATA) {
+        ptr[8] = 'D';
+    }
+    if ((usflags & OPAL_DATATYPE_FLAG_BASIC) == OPAL_DATATYPE_FLAG_BASIC) {
+        ptr[9] = 'B';
+    } else if (usflags & OPAL_DATATYPE_OPTIMIZED_RESTRICTED) {
+        ptr[9] = 'H';  /* optimized description restricted to homogeneous cases */
+    }
     /* We know nothing about the upper level language or flags! */
     /* ... */
     return index;

--- a/opal/datatype/opal_datatype_internal.h
+++ b/opal/datatype/opal_datatype_internal.h
@@ -36,51 +36,16 @@
 
 extern int opal_datatype_dfd;
 
-#  define DDT_DUMP_STACK( PSTACK, STACK_POS, PDESC, NAME ) \
-     opal_datatype_dump_stack( (PSTACK), (STACK_POS), (PDESC), (NAME) )
-#  if defined(ACCEPT_C99)
-#    define DUMP( ARGS... )          opal_output(opal_datatype_dfd, __VA_ARGS__)
-#  else
-#    if defined(__GNUC__) && !defined(__STDC__)
-#      define DUMP(ARGS...)          opal_output( opal_datatype_dfd, ARGS)
-#  else
-static inline void DUMP( char* fmt, ... )
-{
-   va_list list;
+#    define DDT_DUMP_STACK(PSTACK, STACK_POS, PDESC, NAME) \
+        opal_datatype_dump_stack((PSTACK), (STACK_POS), (PDESC), (NAME))
 
-   va_start( list, fmt );
-   opal_output_vverbose( 0, opal_datatype_dfd, fmt, list );
-   va_end( list );
-}
-#    endif  /* __GNUC__ && !__STDC__ */
-#  endif  /* ACCEPT_C99 */
+#    define DUMP(...) opal_output(opal_datatype_dfd, __VA_ARGS__)
+
 #else
-#  define DDT_DUMP_STACK( PSTACK, STACK_POS, PDESC, NAME )
-#  if defined(ACCEPT_C99)
-#    define DUMP(ARGS...)
-#  else
-#    if defined(__GNUC__) && !defined(__STDC__)
-#      define DUMP(ARGS...)
-#    else
-       /* If we do not compile with PGI, mark the parameter as unused */
-#      if !defined(__PGI)
-#        define __opal_attribute_unused_tmp__  __opal_attribute_unused__
-#      else
-#        define __opal_attribute_unused_tmp__
-#      endif
-static inline void DUMP( char* fmt __opal_attribute_unused_tmp__, ... )
-{
-#if defined(__PGI)
-           /* Some compilers complain if we have "..." arguments and no
-              corresponding va_start() */
-           va_list arglist;
-           va_start(arglist, fmt);
-           va_end(arglist);
-#endif
-}
-#         undef __opal_attribute_unused_tmp__
-#    endif  /* __GNUC__ && !__STDC__ */
-#  endif  /* ACCEPT_C99 */
+
+#    define DDT_DUMP_STACK(PSTACK, STACK_POS, PDESC, NAME)
+#    define DUMP(...)
+
 #endif  /* VERBOSE */
 
 

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -102,7 +102,7 @@ reduce_local_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
-partial_local_SOURCES = partial.c
+partial_SOURCES = partial.c
 partial_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 partial_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -15,7 +15,7 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial
     MPI_CHECKS = to_self reduce_local
 endif
 TESTS = opal_datatype_test unpack_hetero $(MPI_TESTS)
@@ -99,6 +99,12 @@ unpack_hetero_LDADD = \
 reduce_local_SOURCES = reduce_local.c
 reduce_local_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 reduce_local_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
+
+partial_local_SOURCES = partial.c
+partial_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+partial_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 

--- a/test/datatype/partial.c
+++ b/test/datatype/partial.c
@@ -1,0 +1,171 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "opal/datatype/opal_convertor.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "opal/datatype/opal_datatype_checksum.h"
+#include "opal/runtime/opal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define TYPE_COUNT    3
+#define TYPE_BLEN     2
+#define TYPE_STRIDE   4
+
+#define CONT_COUNT    2
+
+#define COUNT         3
+
+#define CHUNK   ((TYPE_BLEN*8)*2-4)
+
+/**
+ * Print how many elements on both sides of ptr.
+ */
+static void show_neighborhood(double* ptr, int how_many, bool show_hex)
+{
+    int i;
+
+    printf("%12p: ", (void*)ptr);
+    for( i = -how_many; i < how_many;  i++ ) {
+        if( 0 == i ) {
+            printf(" <%g> ", ptr[i]);
+        } else {
+            printf("  %g  ", ptr[i]);
+        }
+    }
+    if( show_hex ) {
+        char* cptr = (char*)ptr;
+        printf("\n            : ");
+        for( i = -how_many; i < how_many;  i++ ) {
+            if( 0 == i ) printf(" <");
+            for( int j = 0; j < sizeof(double); j++ ) {
+                printf("%02x", cptr[i * sizeof(double)+j]);
+            }
+            if( 0 == i ) printf("> ");
+            else printf(" ");
+        }
+    }
+    printf("\n\n");
+}
+
+/**
+ * -------G---[---][---]    OPAL_LOOP_S 19 times the next 2 elements extent 18432
+ * -cC---P-DB-[---][---]    OPAL_FLOAT8 count 72 disp 0x80 (128) blen 16 extent 256 (size 9216)
+ * -------G---[---][---]    OPAL_LOOP_E prev 2 elements first elem displacement 128 size of data 9216
+ * -------G---[---][---]    OPAL_LOOP_E prev 3 elements first elem displacement 128 size of data 175104
+ */
+
+int main( int argc, char* argv[] )
+{
+    opal_datatype_t* vector;
+    ompi_datatype_t* base;
+    uint32_t iov_count;
+    size_t max_data, size, length;
+    struct iovec iov[2];
+    opal_convertor_t* convertor;
+    ptrdiff_t extent, base_extent;
+    double *array, *packed;
+    char* bpacked;
+    int i, j;
+
+    opal_init_util (NULL, NULL);
+    ompi_datatype_init();
+
+    ompi_datatype_create_vector(TYPE_COUNT, TYPE_BLEN, TYPE_STRIDE, MPI_DOUBLE, &base);
+    ompi_datatype_create_contiguous(CONT_COUNT, base, &vector);
+
+    opal_datatype_commit( vector );
+
+    ompi_datatype_dump(vector);
+
+    opal_datatype_type_size(vector, &size);
+    opal_datatype_type_extent(vector, &extent);
+    opal_datatype_type_extent(base, &base_extent);
+
+    array = (double*)malloc( extent * COUNT );
+    packed = (double*)malloc( size * COUNT );
+    bpacked = (char*)packed;
+
+    /**
+     * Initialize the sparse data using the index.
+     */
+    for( i = 0; i < (TYPE_BLEN * TYPE_COUNT * CONT_COUNT * COUNT); i++ ) {
+        packed[i] = (double)(i % TYPE_BLEN);
+    }
+    memset(array, extent * COUNT, TYPE_BLEN + 1);
+
+    /**
+     * Pack the sparse data into the packed array. This simulate the first step
+     * of the buffered operation.
+     */
+    convertor = opal_convertor_create( opal_local_arch, 0 );
+    opal_convertor_prepare_for_recv( convertor, vector, COUNT, array );
+
+    for( length = 0; length < (size * COUNT); ) {
+        iov[0].iov_base = bpacked + length;
+        iov[0].iov_len = CHUNK;
+        max_data = iov[0].iov_len;
+
+        iov_count = 1;
+        opal_convertor_unpack( convertor, iov, &iov_count, &max_data );
+        length += max_data;
+
+        int idx = 0, checked = 0;
+        for( int m = 0; m < COUNT; m++ ) {
+            char* mptr = (char*)array + m * extent;
+            for( int k = 0; k < CONT_COUNT; k++ ) {
+                char* kptr = mptr + k * base_extent;
+                for( j = 0; j < TYPE_COUNT; j++ ) {
+                    double* jarray = (double*)kptr + j * TYPE_STRIDE;
+                    for( i = 0; i < TYPE_BLEN; i++ ) {
+                        checked += sizeof(double);
+                        if( checked > length )
+                            goto next_iteration;
+                        if( jarray[i] != (double)(idx % TYPE_BLEN) ) {
+                            fprintf(stderr, "\n\n\nError during check for the %d element, length %" PRIsize_t " (chunk %d)\n",
+                                    idx, length, CHUNK);
+                            fprintf(stderr, "Error at position %d [%d:%d:%d:%d] found %g expected %g\n\n\n",
+                                    idx, m, k, j, i, jarray[i], (double)(idx % TYPE_BLEN));
+                            show_neighborhood(jarray + i, 4, true);
+                            exit(-1);
+                        }
+                        idx++;
+                    }
+                }
+            }
+        }
+next_iteration:
+        /* nothing special to do here, just move to the next conversion */
+        continue;
+    }
+
+    OBJ_RELEASE(convertor);
+
+    /**
+     * The datatype is not useful anymore
+     */
+    OBJ_RELEASE(vector);
+
+    free(array);
+    free(packed);
+
+    /* clean-ups all data allocations */
+    ompi_datatype_finalize();
+    opal_finalize_util ();
+
+    return 0;
+}


### PR DESCRIPTION
Brings some updates on the datatype engine into the 4.1. Among these the most critical is the partial unpack bug from #8466. 

Here are the commits from master that are covered by this PR:
e8ebe134450752188362c8d5cc524ea79d27fa24
99013253954f383e241fc261f7ca4291e2316ef6
ef28e8d98101d9fcc5e92ff14cbe0afa828f2538
73d64cb97b48c4c6860aa0d49af9705349d6f64b
fb0796020e90ebb068bfda39f8af98c7146ebc9c

It must be noted that this PR does not bring the support for MPI_LONG and MPI_UNSIGNED_LONG in external32, because it would have required to break the ABI (because of the 2 new datatypes #define added).

Unfortunately, I had to import 2 additional commits in order to be able to build and run on an M1: 4f2dde0 and 73aae14.  

Fixes #8466.

One of these commits is intentionally not a cherry pick: bot:notacherrypick