### PR TITLE
consolidated per-host affinity display in --mca ompi_display_comm 1

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method.h
+++ b/ompi/mca/hook/comm_method/hook_comm_method.h
@@ -24,6 +24,8 @@ extern int mca_hook_comm_method_verbose;
 extern int mca_hook_comm_method_output;
 extern bool mca_hook_comm_method_enable_mpi_init;
 extern bool mca_hook_comm_method_enable_mpi_finalize;
+extern bool mca_hook_comm_method_enable_show_aff;
+extern int mca_hook_comm_method_aff_columns;
 extern int mca_hook_comm_method_max;
 extern int mca_hook_comm_method_brief;
 extern char *mca_hook_comm_method_fakefile;


### PR DESCRIPTION
The prrte --display bind option is a per-rank option, but this option
instead consolidates the binding reports on a per-host basis, and
uses a visual display based on the natural hardware ordering of the
hwloc tree.

Example output:
```
$. mpirun --bind-to core --host hostA:4,hostB:4 --mca ompi_display_comm 1 \
   --mca ompi_display_comm_aff_columns 72 ./x

Host 0 [hostA] ranks 0 - 3
Host 1 [hostB] ranks 4 - 7

Affinity per host: (with ompi_display_comm_aff_columns 72)
H0: [<aaaa/cccc/..../..../..../..../..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../....>][<bbbb/dddd/..../..../
      .../..../..../..../..../..../..../..../..../..../..../..../..../..
      ./..../..../..../....>] Lranks 0-3
H1: [<aaaa/cccc/..../..../..../..../..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../....>][<bbbb/dddd/..../..../
      .../..../..../..../..../..../..../..../..../..../..../..../..../..
      ./..../..../..../....>] Lranks 0-3
```

It tries to consolidate all the ranks on a host as shown above, but
if the ranks overlap it will start using multiple lines to display
a host (or if it runs out of letters it goes to another line and
starts over with "a" again).

I think it makes sense to have this option inside the ompi_display_comm
output because the ranks' bindings are a big factor in the communication
between them.

Signed-off-by: Mark Allen <markalle@us.ibm.com>