### PR TITLE
configury: do not use _Float16 to avoid noisy build on aarch64

### DIFF
--- a/config/opal_check_alt_short_float.m4
+++ b/config/opal_check_alt_short_float.m4
@@ -2,6 +2,8 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2018-2020 FUJITSU LIMITED.  All rights reserved.
 dnl Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -14,7 +16,16 @@ dnl Check whether the user wants to use an alternate type of C 'short float'.
 dnl OPAL_CHECK_ALT_SHORT_FLOAT
 dnl ------------------------------------------------------------
 AC_DEFUN([OPAL_CHECK_ALT_SHORT_FLOAT], [
+dnl
+dnl Testing for this without checking if compiler generates warnings makes for a messy build.
+dnl Hence the twiddling of the CFLAGS
+dnl
+    OPAL_VAR_SCOPE_PUSH([CFLAGS_save])
+    CFLAGS_save=$CFLAGS
+    CFLAGS="-Werror $CFLAGS"
     AC_CHECK_TYPES(_Float16)
+    CFLAGS=$CFLAGS_save
+    OPAL_VAR_SCOPE_POP
     AC_MSG_CHECKING([if want alternate C type of short float])
     AC_ARG_ENABLE([alt-short-float],
         [AS_HELP_STRING([--enable-alt-short-float=TYPE],


### PR DESCRIPTION
Turns out that with more recent gcc compilers at least (9.1.0? and newer)
_Float16 is detected on aarch64, but by default we are compiling OMPI
with -pendantic.

This results in thousands and thousands of warnings of this type to be emitted
while building:

./../../opal/include/opal_config.h:2311:28: warning: ISO C does not support the ‘_Float16’ type [-Wpedantic]
 2311 | #define opal_short_float_t _Float16
      |                            ^~~~~~~~
../../../opal/include/opal_config_bottom.h:541:5: note: in expansion of macro ‘opal_short_float_t’
  541 |     opal_short_float_t real;
      |     ^~~~~~~~~~~~~~~~~~
../../../opal/include/opal_config.h:2311:28: warning: ISO C does not support the ‘_Float16’ type [-Wpedantic]
 2311 | #define opal_short_float_t _Float16
      |                            ^~~~~~~~
../../../opal/include/opal_config_bottom.h:542:5: note: in expansion of macro ‘opal_short_float_t’
  542 |     opal_short_float_t imag;

this patch adds a -Werror to CFLAGS before checking for _Float16 to fail the check
if warnings are emitted by the compiler.

Related to issue #8840

Signed-off-by: Howard Pritchard <howardp@lanl.gov>