### PR TITLE
v4.1.x: PML/UCX/DATATYPE: fixed memory leak - v4.1

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
+++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
@@ -212,14 +212,23 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
         ompi_datatype_type_size(datatype, &size);
         PML_UCX_ASSERT(size > 0);
         ucp_datatype = ucp_dt_make_contig(size);
-        goto out;
-    }
-
-    status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
-                                   datatype, &ucp_datatype);
-    if (status != UCS_OK) {
-        PML_UCX_ERROR("Failed to create UCX datatype for %s", datatype->name);
-        ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
+        PML_UCX_VERBOSE(7, "created contig UCX datatype 0x%"PRIx64,
+                        ucp_datatype)
+    } else {
+        status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
+                                       datatype, &ucp_datatype);
+        if (status != UCS_OK) {
+            int err = MPI_ERR_INTERN;
+            PML_UCX_ERROR("Failed to create UCX datatype for %s",
+                          datatype->name);
+            /* TODO: this error should return to the caller and invoke an error
+             * handler from the MPI API call.
+             * For now, it is fatal. */
+            ompi_mpi_errors_are_fatal_comm_handler(NULL, &err,
+                                                   "Failed to allocate "
+                                                   "datatype structure");
+        }
+        PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
     }
 
     /* Add custom attribute, to clean up UCX resources when OMPI datatype is
@@ -238,8 +247,6 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
             ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
         }
     }
-out:
-    PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
 
 #ifdef HAVE_UCP_REQUEST_PARAM_T
     UCS_STATIC_ASSERT(sizeof(datatype->pml_data) >= sizeof(pml_ucx_datatype_t*));


### PR DESCRIPTION
- fixed memory leak in datatype processing

backport from https://github.com/open-mpi/ompi/pull/8828

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
(cherry picked from commit 4145b9f00b9a9c2e5326044b765ee3d1b743ccbf)