### PR TITLE
v5.0.x: config/Makefile.am: add missing file to EXTRA_DIST

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -33,7 +33,8 @@ EXTRA_DIST = \
         make_manpage.pl \
         md2nroff.pl \
         from-savannah/upstream-config.guess \
-        from-savannah/upstream-config.sub
+        from-savannah/upstream-config.sub \
+        extract-3rd-party-configure.pl
 
 maintainer-clean-local:
 	rm -f opal_get_version.sh


### PR DESCRIPTION
Add config/extract-3rd-party-configure.pl to EXTRA_DIST so that
autogen.pl works in a tarball.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 66a26c197aafb50bf5db51f9ad39ed270216ab29)