### PR TITLE
v4.0.x: Fix typo in the reorder detection.

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -772,7 +772,7 @@ static int ompi_comm_split_verify (ompi_communicator_t *comm, int split_type, in
     }
 
     for (int i = 0 ; i < size ; ++i) {
-        if (MPI_UNDEFINED == results[i * 2] || (i > 1 && results[i * 2 + 1] < results[i * 2 - 1])) {
+        if (MPI_UNDEFINED == results[i * 2] || (i >= 1 && results[i * 2 + 1] < results[i * 2 - 1])) {
             *need_split = true;
             break;
         }


### PR DESCRIPTION
The result was that only processes with rank >= 2 were counted in the decision,
so if the reorder was decide by the first two processes (as in the example
provided on the issue #8854) the reorder was not correctly determined.

Thanks to @bangerth for raising the issue.

Fixes #8854.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 0f348fd0cc4103c9780bab39f84db934b6e79598)