### PR TITLE
Provide show_help if libz is missing on backend node

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -862,7 +863,10 @@ void orte_plm_base_daemon_topology(int status, orte_process_name_t* sender,
             opal_dss.load(&datbuf, cmpdata, cmplen);
             data = &datbuf;
         } else {
-            data = buffer;
+            orte_show_help("help-orte-runtime.txt", "failed-to-uncompress",
+                           true, orte_process_info.nodename);
+            orted_failed_launch = true;
+            goto CLEANUP;
         }
         free(packed_data);
     } else {
@@ -1191,7 +1195,10 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                     opal_dss.load(&datbuf, cmpdata, cmplen);
                     data = &datbuf;
                 } else {
-                    data = buffer;
+                    orte_show_help("help-orte-runtime.txt", "failed-to-uncompress",
+                                   true, orte_process_info.nodename);
+                    orted_failed_launch = true;
+                    goto CLEANUP;
                 }
                 free(packed_data);
             } else {

--- a/orte/runtime/help-orte-runtime.txt
+++ b/orte/runtime/help-orte-runtime.txt
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -61,3 +62,13 @@ as the mapping.
 Open MPI was unable to determine the number of nodes in your allocation. We
 are therefore assuming a very large number to ensure you receive proper error
 messages.
+#
+[failed-to-uncompress]
+A compressed message was received that could not be
+decompressed. This is most likely due to a missing
+libz library on the receiving node:
+
+  node:  %s
+
+Please ensure that the libz library is present on all
+compute nodes.


### PR DESCRIPTION
If libz is present on the frontend, then messages sent to the
backend nodes will be compressed. If the messages are flagged
as having been compressed and we cannot decompress them (e.g.,
if libz isn't present on the backend), then output a help
message and abort. Otherwise, we'll try to unpack the compressed
message and just report an unpack error, which isn't very helpful.

Signed-off-by: Ralph Castain <rhc@pmix.org>