### PR TITLE
Fix definition of start_dvm when PRRTE is disabled

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -2140,7 +2140,7 @@ static int start_dvm(char **hostfiles, char **dash_host)
     return OMPI_SUCCESS;
 }
 #else
-static int start_dvm(char *hostfile, char *dash_host)
+static int start_dvm(char **hostfiles, char **dash_host)
 {
     return OMPI_ERROR;
 }


### PR DESCRIPTION
Signed-off-by: Michael Karo <mike0042@gmail.com>