### PR TITLE
Fix a bunch of compiler warnings

### DIFF
--- a/3rd-party/treematch/fibo.h
+++ b/3rd-party/treematch/fibo.h
@@ -101,13 +101,13 @@ typedef struct FiboTree_ {
    the algorithms have been de-recursived
    and written as macros.                 */
 
-#define fiboTreeLinkAfter(o,n)      do {                              \
-                                      FiboNode *        nextptr;      \
-                                      nextptr = (o)->linkdat.nextptr; \
-                                      (n)->linkdat.nextptr = nextptr; \
-                                      (n)->linkdat.prevptr = (o);     \
-                                      nextptr->linkdat.prevptr = (n); \
-                                      (o)->linkdat.nextptr = (n);     \
+#define fiboTreeLinkAfter(o,n)      do {                                  \
+                                      FiboNode *        nextptr_loc;      \
+                                      nextptr_loc = (o)->linkdat.nextptr; \
+                                      (n)->linkdat.nextptr = nextptr_loc; \
+                                      (n)->linkdat.prevptr = (o);         \
+                                      nextptr_loc->linkdat.prevptr = (n); \
+                                      (o)->linkdat.nextptr = (n);         \
                                     } while (0)
 
 #define fiboTreeUnlink(n)           do {                                                            \

--- a/3rd-party/treematch/tm_topology.c
+++ b/3rd-party/treematch/tm_topology.c
@@ -575,7 +575,7 @@ int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology
 }
 
 
-void topology_numbering_cpy(tm_topology_t *topology,int **numbering,int *nb_nodes)
+void topology_numbering_cpy(tm_topology_t *topology,int **numbering_loc,int *nb_nodes)
 {
   int nb_levels;
   unsigned int vl = tm_get_verbose_level();
@@ -584,8 +584,8 @@ void topology_numbering_cpy(tm_topology_t *topology,int **numbering,int *nb_node
   *nb_nodes = topology->nb_nodes[nb_levels-1];
   if(vl >= INFO)
     printf("nb_nodes=%d\n",*nb_nodes);
-  *numbering = (int*)MALLOC(sizeof(int)*(*nb_nodes));
-  memcpy(*numbering,topology->node_id,sizeof(int)*(*nb_nodes));
+  *numbering_loc = (int*)MALLOC(sizeof(int)*(*nb_nodes));
+  memcpy(*numbering_loc,topology->node_id,sizeof(int)*(*nb_nodes));
 }
 
 void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels)
@@ -699,7 +699,7 @@ void optimize_arity(int **arity, double **cost, int *nb_levels,int n)
 
 void tm_optimize_topology(tm_topology_t **topology){
   int *arity = NULL,nb_levels;
-  int *numbering = NULL,nb_nodes;
+  int *numbering_loc = NULL,nb_nodes;
   tm_topology_t *new_topo;
   double *cost;
   unsigned int vl = tm_get_verbose_level();
@@ -710,13 +710,13 @@ void tm_optimize_topology(tm_topology_t **topology){
     tm_display_arity(*topology);
 
   topology_arity_cpy(*topology,&arity,&nb_levels);
-  topology_numbering_cpy(*topology,&numbering,&nb_nodes);
+  topology_numbering_cpy(*topology,&numbering_loc,&nb_nodes);
   topology_constraints_cpy(*topology,&constraints,&nb_constraints);
   topology_cost_cpy(*topology,&cost);
 
 
   optimize_arity(&arity,&cost,&nb_levels,nb_levels-2);
-  new_topo = tm_build_synthetic_topology(arity, NULL, nb_levels,numbering,nb_nodes);
+  new_topo = tm_build_synthetic_topology(arity, NULL, nb_levels,numbering_loc,nb_nodes);
   new_topo->cost = cost;
   new_topo->constraints    = constraints;
   new_topo->nb_constraints = nb_constraints;
@@ -736,7 +736,7 @@ void tm_optimize_topology(tm_topology_t **topology){
     tm_display_arity(new_topo);
   }
   FREE(arity);
-  FREE(numbering);
+  FREE(numbering_loc);
   tm_free_topology(*topology);
 
   *topology = new_topo;

--- a/3rd-party/treematch/tm_tree.c
+++ b/3rd-party/treematch/tm_tree.c
@@ -1793,7 +1793,7 @@ void group_nodes(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_node, tm_tree_t *new
   /*  if(nb_groups>30000||depth>5){*/
   if( nbg > 30000 ){
 
-    double duration;
+    double duration_loc;
 
     TIC;
     if( arity <= 2 ){
@@ -1811,9 +1811,9 @@ void group_nodes(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_node, tm_tree_t *new
       val = k_partition_grouping(cost_mat, tab_node, new_tab_node, arity, solution_size);
     }
 
-    duration = TOC;
+    duration_loc = TOC;
     if(verbose_level >= INFO)
-      printf("Fast grouping duration=%f\n", duration);
+      printf("Fast grouping duration=%f\n", duration_loc);
 
     if(verbose_level >= INFO)
       display_grouping(new_tab_node, solution_size, arity, val);

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2007-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
  * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
@@ -1705,7 +1705,7 @@ OMPI_DECLSPEC  int MPI_Pready(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
                                     MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_list(int length, int partition_list[], MPI_Request request);
-OMPI_DECLSPEC  int MPI_Precv_init(const void* buf, int partitions, MPI_Count count,
+OMPI_DECLSPEC  int MPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
                                   MPI_Request *request);
 OMPI_DECLSPEC  int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status);
@@ -2321,7 +2321,7 @@ OMPI_DECLSPEC  int PMPI_Isend(const void *buf, int count, MPI_Datatype datatype,
                               int tag, MPI_Comm comm, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request);
-OMPI_DECLSPEC  int PMPI_Precv_init(const void* buf, int partitions, MPI_Count count,
+OMPI_DECLSPEC  int PMPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
                                   MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Psend_init(const void* buf, int partitions, MPI_Count count,

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -3332,6 +3332,11 @@ int mca_coll_ftagree_iera_intra(void *contrib,
     return OMPI_SUCCESS;
 }
 
+#if 0
+// Per @bosilca and @jsquyres discussion 29 Apr 2021: there is
+// probably a memory leak in MPI_FINALIZE right now, because this
+// function does not appear to be being called from anywhere.
+// @bosilca's team is looking into it.
 int mca_coll_ftagree_era_free_comm(ompi_communicator_t* comm,
                                    mca_coll_base_module_t *module)
 {
@@ -3369,3 +3374,4 @@ int mca_coll_ftagree_era_free_comm(ompi_communicator_t* comm,
 
     return OMPI_SUCCESS;
 }
+#endif

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -222,8 +223,6 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
     han_module->topologic_level = GLOBAL_COMMUNICATOR;
 
     if (NULL != comm->super.s_info) {
-        char info_val[OPAL_MAX_INFO_VAL+1];
-
         /* Get the info value disaqualifying coll components */
         opal_cstring_t *info_str;
         opal_info_get(comm->super.s_info, "ompi_comm_coll_han_topo_level",

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2019-2021 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2021      University of Alabama at Birmingham. All rights reserved.
  * Copyright (c) 2021      Tennessee Technological University. All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -313,8 +314,10 @@ mca_part_persist_progress(void)
     OPAL_THREAD_UNLOCK(&ompi_part_persist.lock);
     block_entry = opal_atomic_add_fetch_32(&(ompi_part_persist.block_entry), -1);
     if(to_delete) {
-        int err = mca_part_persist_free_req(to_delete);
-        if(OMPI_SUCCESS != err) return OMPI_ERROR;
+        err =  mca_part_persist_free_req(to_delete);
+        if (OMPI_SUCCESS != err) {
+            return OMPI_ERROR;
+        }
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_wait.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_wait.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +20,7 @@ static int vprotocol_pessimist_request_no_free(ompi_request_t **req) {
 }
 
 #define PREPARE_REQUESTS_WITH_NO_FREE(count, requests) do { \
-    for(int i = 0; i < count; i++) \
+    for (typeof(count) i = 0; i < count; i++)     \
     { \
         if(requests[i] == MPI_REQUEST_NULL) continue; \
         requests[i]->req_free = vprotocol_pessimist_request_no_free; \

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -43,7 +43,7 @@
 static const char FUNC_NAME[] = "MPI_Precv_init";
 
 
-int MPI_Precv_init(const void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request)
+int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request)
 {
     int rc;
 

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
@@ -1543,12 +1543,12 @@ int mca_base_var_register(const char *project_name, const char *framework_name,
     }
 
     OPAL_LIST_FOREACH_DECL(alias_item, &alias->component_aliases, mca_base_alias_item_t) {
-        mca_base_var_syn_flag_t flags_tmp = 0;
+        mca_base_var_syn_flag_t flags_derived = flags;
         if (alias_item->alias_flags & MCA_BASE_ALIAS_FLAG_DEPRECATED) {
-            flags_tmp = MCA_BASE_VAR_SYN_FLAG_DEPRECATED;
+            flags_derived = MCA_BASE_VAR_SYN_FLAG_DEPRECATED;
         }
         (void) mca_base_var_register_synonym(ret, project_name, framework_name,
-                                             alias_item->component_alias, variable_name, flags);
+                                             alias_item->component_alias, variable_name, flags_derived);
     }
 
     return ret;

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -480,7 +481,7 @@ mca_btl_base_rdma_start(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint
 
     BTL_VERBOSE(("Initiating RDMA operation. context=%p, size=%" PRIsize_t
                  ", packet_size=%" PRIsize_t,
-                 context, size, packet_size));
+                 (void*) context, size, packet_size));
 
     descriptor = btl->btl_alloc(btl, endpoint, order, packet_size,
                                 MCA_BTL_DES_SEND_ALWAYS_CALLBACK | MCA_BTL_DES_FLAGS_SIGNAL);
@@ -609,7 +610,7 @@ static int mca_btl_base_am_rdma_respond(mca_btl_base_module_t *btl,
         }
     }
 
-    BTL_VERBOSE(("sending descriptor %p", send_descriptor));
+    BTL_VERBOSE(("sending descriptor %p", (void*) send_descriptor));
 
     send_descriptor->des_cbfunc = NULL;
 
@@ -638,7 +639,7 @@ mca_btl_base_am_rmda_rdma_complete(mca_btl_base_module_t *btl,
     if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
         BTL_VERBOSE(
             ("could not send a response. queueing the response for later. endpoint=%p, ret=%d",
-             endpoint, ret));
+             (void*) endpoint, ret));
         mca_btl_base_rdma_queue_operation(btl, NULL, NULL, 0, NULL, operation);
     }
 
@@ -873,7 +874,7 @@ static void mca_btl_base_am_rdma_response(mca_btl_base_module_t *btl,
     mca_btl_base_rdma_context_t *context = (mca_btl_base_rdma_context_t *) (uintptr_t)
                                                resp_hdr->context;
 
-    BTL_VERBOSE(("received response for RDMA operation. context=%p, size=%" PRIu64, context,
+    BTL_VERBOSE(("received response for RDMA operation. context=%p, size=%" PRIu64, (void*) context,
                  resp_hdr->response_size));
 
     if (MCA_BTL_BASE_AM_PUT != context->type) {
@@ -890,7 +891,7 @@ static void mca_btl_base_am_rdma_response(mca_btl_base_module_t *btl,
     }
 
     if (context->total_size
-        == opal_atomic_add_fetch_64(&context->acknowledged, resp_hdr->response_size)) {
+        == (uint64_t) opal_atomic_add_fetch_64(&context->acknowledged, resp_hdr->response_size)) {
         context->cbfunc(btl, desc->endpoint, context->local_address, context->local_handle,
                         context->cbcontext, context->cbdata, OPAL_SUCCESS);
         OBJ_RELEASE(context);
@@ -1001,7 +1002,7 @@ static void mca_btl_base_am_process_atomic(mca_btl_base_module_t *btl,
     }
 }
 
-void mca_btl_sm_sc_emu_init(void)
+static void mca_btl_sm_sc_emu_init(void)
 {
     mca_btl_base_active_message_trigger[MCA_BTL_BASE_TAG_RDMA].cbfunc
         = mca_btl_base_am_process_rdma;
@@ -1093,7 +1094,7 @@ int mca_btl_base_am_rdma_init(mca_btl_base_module_t *btl)
         btl->btl_put_limit = max_operation_size - sizeof(mca_btl_base_rdma_hdr_t);
         btl->btl_put_alignment = operation_alignment;
         btl->btl_put = mca_btl_base_am_rdma_put;
-        BTL_VERBOSE(("Enabling AM-based RDMA put for BTL %p. max put = %zu", btl, btl->btl_put_limit));
+        BTL_VERBOSE(("Enabling AM-based RDMA put for BTL %p. max put = %zu", (void*) btl, btl->btl_put_limit));
     }
 
     if (!(btl->btl_flags & MCA_BTL_FLAGS_GET)) {
@@ -1101,11 +1102,11 @@ int mca_btl_base_am_rdma_init(mca_btl_base_module_t *btl)
         btl->btl_get_limit = max_operation_size - sizeof(mca_btl_base_rdma_response_hdr_t);
         btl->btl_get_alignment = operation_alignment;
         btl->btl_get = mca_btl_base_am_rdma_get;
-        BTL_VERBOSE(("Enabling AM-based RDMA get for BTL %p. max get = %zu", btl, btl->btl_get_limit));
+        BTL_VERBOSE(("Enabling AM-based RDMA get for BTL %p. max get = %zu", (void*) btl, btl->btl_get_limit));
     }
 
     if (!(btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_FOPS)) {
-        BTL_VERBOSE(("Enabling AM-based FOPs get for BTL %p", btl));
+        BTL_VERBOSE(("Enabling AM-based FOPs get for BTL %p", (void*) btl));
         btl->btl_flags |= MCA_BTL_FLAGS_ATOMIC_AM_FOP;
 
         btl->btl_atomic_fop = mca_btl_base_am_fop;

--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
@@ -940,14 +940,9 @@ int main(int argc, char *argv[])
     if (flags & COMP_DRY_RUN) {
         exec_command = opal_argv_join(exec_argv, ' ');
         printf("%s\n", exec_command);
+        free(exec_command);
     } else {
         char *tmp;
-
-#if 0
-        exec_command = opal_argv_join(exec_argv, ' ');
-        printf("command: %s\n", exec_command);
-#endif
-
         tmp = opal_path_findv(exec_argv[0], 0, environ, NULL);
         if (NULL == tmp) {
             opal_show_help("help-opal-wrapper.txt", "no-compiler-found", true, exec_argv[0], NULL);
@@ -964,17 +959,12 @@ int main(int argc, char *argv[])
                                                    ? WTERMSIG(status)
                                                    : (WIFSTOPPED(status) ? WSTOPSIG(status) : 255));
             if ((OPAL_SUCCESS != ret) || ((0 != exit_status) && (flags & COMP_SHOW_ERROR))) {
-                char* exec_cmd = opal_argv_join(exec_argv, ' ');
                 if (OPAL_SUCCESS != ret) {
+                    exec_command = opal_argv_join(exec_argv, ' ');
                     opal_show_help("help-opal-wrapper.txt", "spawn-failed", true, exec_argv[0],
                                    strerror(status), exec_command, NULL);
-                } else {
-#if 0
-                    opal_show_help("help-opal-wrapper.txt", "compiler-failed", true,
-                                   exec_argv[0], exit_status, exec_cmd, NULL);
-#endif
+                    free(exec_command);
                 }
-                free(exec_cmd);
             }
         }
     }


### PR DESCRIPTION
This doesn't make master compiler-warning free, but it does both remove a bunch of warnings and fix a few genuine (minor) bugs.

See individual commit messages for more details.

NOTE: This PR contains changes to 3rd-party/treematch.  @bosilca has previously stated that we have effectively forked from the upstream treematch, so I assume that this is ok.  If that's wrong, we can roll the tree match change commit out of this PR.