### PR TITLE
v5.0.x: clang-tidy braces - and other missing deps

### DIFF
--- a/ompi/mca/coll/base/coll_base_topo.h
+++ b/ompi/mca/coll/base/coll_base_topo.h
@@ -20,6 +20,7 @@
 #define MCA_COLL_BASE_TOPO_H_HAS_BEEN_INCLUDED
 
 #include "ompi_config.h"
+#include "ompi/communicator/communicator.h"
 #include <stddef.h>
 
 #define MAXTREEFANOUT 32

--- a/opal/class/opal_bitmap.c
+++ b/opal/class/opal_bitmap.c
@@ -84,8 +84,9 @@ int opal_bitmap_init(opal_bitmap_t *bm, int size)
     bm->array_size = (int) (((size_t) size + SIZE_OF_BASE_TYPE - 1) / SIZE_OF_BASE_TYPE);
     if (NULL != bm->bitmap) {
         free(bm->bitmap);
-        if (bm->max_size < bm->array_size)
+        if (bm->max_size < bm->array_size) {
             bm->max_size = bm->array_size;
+        }
     }
     bm->bitmap = (uint64_t *) malloc(bm->array_size * sizeof(uint64_t));
     if (NULL == bm->bitmap) {
@@ -114,8 +115,9 @@ int opal_bitmap_set_bit(opal_bitmap_t *bm, int bit)
          valid and we simply expand the bitmap */
 
         new_size = index + 1;
-        if (new_size > bm->max_size)
+        if (new_size > bm->max_size) {
             new_size = bm->max_size;
+        }
 
         /* New size is just a multiple of the original size to fit in
          the index. */
@@ -368,8 +370,9 @@ int opal_bitmap_num_set_bits(opal_bitmap_t *bm, int len)
 #endif
 
     for (i = 0; i < len; ++i) {
-        if (0 == (val = bm->bitmap[i]))
+        if (0 == (val = bm->bitmap[i])) {
             continue;
+        }
         /*  Peter Wegner in CACM 3 (1960), 322. This method goes through as many
          *  iterations as there are set bits. */
         for (; val; cnt++) {

--- a/opal/class/opal_cstring.c
+++ b/opal/class/opal_cstring.c
@@ -87,11 +87,13 @@ int opal_cstring_to_int(opal_cstring_t *string, int *interp)
     errno = 0;
     tmp = strtol(string->string, &endp, 10);
     /* we found something not a number */
-    if (*endp != '\0')
+    if (*endp != '\0') {
         return OPAL_ERR_BAD_PARAM;
+    }
     /* underflow */
-    if (tmp == 0 && errno == EINVAL)
+    if (tmp == 0 && errno == EINVAL) {
         return OPAL_ERR_BAD_PARAM;
+    }
 
     *interp = (int) tmp;
 

--- a/opal/class/opal_free_list.c
+++ b/opal/class/opal_free_list.c
@@ -123,8 +123,9 @@ int opal_free_list_init(opal_free_list_t *flist, size_t frag_size, size_t frag_a
 
     if (0 < payload_buffer_size) {
         if (payload_buffer_alignment <= 1
-            || (payload_buffer_alignment & (payload_buffer_alignment - 1)))
+            || (payload_buffer_alignment & (payload_buffer_alignment - 1))) {
             return OPAL_ERROR;
+        }
     }
 
     if (frag_class && frag_size < frag_class->cls_sizeof) {

--- a/opal/class/opal_hash_table.c
+++ b/opal/class/opal_hash_table.c
@@ -426,8 +426,9 @@ int opal_hash_table_remove_value_uint32(opal_hash_table_t *ht, uint32_t key)
     ht->ht_type_methods = &opal_hash_type_methods_uint32;
     for (ii = key % capacity;; ii += 1) {
         opal_hash_element_t *elt;
-        if (ii == capacity)
+        if (ii == capacity) {
             ii = 0;
+        }
         elt = &ht->ht_table[ii];
         if (!elt->valid) {
             return OPAL_ERR_NOT_FOUND;

--- a/opal/class/opal_interval_tree.c
+++ b/opal/class/opal_interval_tree.c
@@ -138,8 +138,8 @@ static opal_interval_tree_token_t opal_interval_tree_reader_get_token(opal_inter
 
     while (
         !OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32((opal_atomic_int32_t *) &tree->reader_epochs[token],
-                                                &(int32_t){UINT_MAX}, tree->epoch))
-        ;
+                                                &(int32_t){UINT_MAX}, tree->epoch)) {
+    }
 
     return token;
 }
@@ -166,8 +166,8 @@ static bool opal_interval_tree_write_trylock(opal_interval_tree_t *tree)
 
 static void opal_interval_tree_write_lock(opal_interval_tree_t *tree)
 {
-    while (!opal_interval_tree_write_trylock(tree))
-        ;
+    while (!opal_interval_tree_write_trylock(tree)) {
+    }
 }
 
 static void opal_interval_tree_write_unlock(opal_interval_tree_t *tree)
@@ -478,8 +478,8 @@ static inline void rp_wait_for_readers(opal_interval_tree_t *tree)
 
     /* wait for all readers to see the new tree version */
     for (int i = 0; i < tree->reader_count; ++i) {
-        while (tree->reader_epochs[i] < epoch_id)
-            ;
+        while (tree->reader_epochs[i] < epoch_id) {
+        }
     }
 }
 

--- a/opal/class/opal_list.c
+++ b/opal/class/opal_list.c
@@ -117,8 +117,9 @@ bool opal_list_insert(opal_list_t *list, opal_list_item_t *item, long long idx)
 #endif
         /* pointer to element 0 */
         ptr = list->opal_list_sentinel.opal_list_next;
-        for (i = 0; i < idx - 1; i++)
+        for (i = 0; i < idx - 1; i++) {
             ptr = ptr->opal_list_next;
+        }
 
         next = ptr->opal_list_next;
         item->opal_list_next = next;

--- a/opal/class/opal_value_array.c
+++ b/opal/class/opal_value_array.c
@@ -30,8 +30,9 @@ static void opal_value_array_construct(opal_value_array_t *array)
 
 static void opal_value_array_destruct(opal_value_array_t *array)
 {
-    if (NULL != array->array_items)
+    if (NULL != array->array_items) {
         free(array->array_items);
+    }
 }
 
 OBJ_CLASS_INSTANCE(opal_value_array_t, opal_object_t, opal_value_array_construct,
@@ -47,13 +48,15 @@ int opal_value_array_set_size(opal_value_array_t *array, size_t size)
 #endif
 
     if (size > array->array_alloc_size) {
-        while (array->array_alloc_size < size)
+        while (array->array_alloc_size < size) {
             array->array_alloc_size <<= 1;
+        }
         array->array_items = (unsigned char *) realloc(array->array_items,
                                                        array->array_alloc_size
                                                            * array->array_item_sizeof);
-        if (NULL == array->array_items)
+        if (NULL == array->array_items) {
             return OPAL_ERR_OUT_OF_RESOURCE;
+        }
     }
     array->array_size = size;
     return OPAL_SUCCESS;

--- a/opal/datatype/opal_convertor_raw.c
+++ b/opal/datatype/opal_convertor_raw.c
@@ -47,8 +47,9 @@ static inline int opal_convertor_merge_iov(struct iovec *iov, uint32_t *iov_coun
             return 0;
         } /* cannot merge, move to the next position */
         *idx = *idx + 1;
-        if (*idx == *iov_count)
+        if (*idx == *iov_count) {
             return 1; /* do not overwrite outside the iovec array boundaries */
+        }
     }
     iov[*idx].iov_base = base;
     iov[*idx].iov_len = len;
@@ -170,8 +171,9 @@ int32_t opal_convertor_raw(opal_convertor_t *pConvertor, struct iovec *iov, uint
                 DO_DEBUG(opal_output(0, "raw 2. iov[%d] = {base %p, length %" PRIsize_t "}\n",
                                      index, (void *) source_base, blength););
                 if (opal_convertor_merge_iov(iov, iov_count, (IOVBASE_TYPE *) source_base, blength,
-                                             &index))
+                                             &index)) {
                     break; /* no more iovec available, bail out */
+                }
 
                 source_base += current->extent;
                 sum_iov_len += blength;

--- a/opal/datatype/opal_datatype_add.c
+++ b/opal/datatype/opal_datatype_add.c
@@ -138,14 +138,16 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
      * non-negative integers. If the value is zero, no elements are generated in
      * the type map and there is no effect on datatype bounds or extent.
      */
-    if (0 == count)
+    if (0 == count) {
         return OPAL_SUCCESS;
+    }
 
     /* the extent should always be positive. So a negative value here have a
      * special meaning ie. default extent as computed by ub - lb
      */
-    if (extent == -1)
+    if (extent == -1) {
         extent = (pdtAdd->ub - pdtAdd->lb);
+    }
 
     /* Deal with the special markers (OPAL_DATATYPE_LB and OPAL_DATATYPE_UB) */
     if (OPAL_DATATYPE_LB == pdtAdd->id) {
@@ -279,10 +281,11 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
      * the data-type we can update the size, true_lb and true_ub.
      */
     pdtBase->size += count * pdtAdd->size;
-    if (0 == pdtBase->nbElems)
+    if (0 == pdtBase->nbElems) {
         old_true_ub = disp;
-    else
+    } else {
         old_true_ub = pdtBase->true_ub;
+    }
     if (0 != pdtBase->size) {
         pdtBase->true_lb = LMIN(true_lb, pdtBase->true_lb);
         pdtBase->true_ub = LMAX(true_ub, pdtBase->true_ub);
@@ -306,8 +309,9 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
      */
     if ((pdtAdd->flags & (OPAL_DATATYPE_FLAG_PREDEFINED | OPAL_DATATYPE_FLAG_DATA))
         == (OPAL_DATATYPE_FLAG_PREDEFINED | OPAL_DATATYPE_FLAG_DATA)) {
-        if (NULL != pdtBase->ptypes)
+        if (NULL != pdtBase->ptypes) {
             pdtBase->ptypes[pdtAdd->id] += count;
+        }
 
         pLast->elem.common.flags = pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITTED);
         pLast->elem.common.type = pdtAdd->id;
@@ -332,9 +336,11 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
         pdtBase->flags |= (pdtAdd->flags & OPAL_DATATYPE_FLAG_USER_LB);
         pdtBase->flags |= (pdtAdd->flags & OPAL_DATATYPE_FLAG_USER_UB);
         if ((NULL != pdtBase->ptypes) && (NULL != pdtAdd->ptypes)) {
-            for (i = OPAL_DATATYPE_FIRST_TYPE; i < OPAL_DATATYPE_MAX_PREDEFINED; i++)
-                if (pdtAdd->ptypes[i] != 0)
+            for (i = OPAL_DATATYPE_FIRST_TYPE; i < OPAL_DATATYPE_MAX_PREDEFINED; i++) {
+                if (pdtAdd->ptypes[i] != 0) {
                     pdtBase->ptypes[i] += (count * pdtAdd->ptypes[i]);
+                }
+            }
         }
         if (1 == pdtAdd->desc.used) {
             pLast->elem = pdtAdd->desc.desc[0].elem;
@@ -393,9 +399,9 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
 
             for (i = 0; i < pdtAdd->desc.used; i++) {
                 pLast->elem = pdtAdd->desc.desc[i].elem;
-                if (OPAL_DATATYPE_FLAG_DATA & pLast->elem.common.flags)
+                if (OPAL_DATATYPE_FLAG_DATA & pLast->elem.common.flags) {
                     pLast->elem.disp += disp;
-                else if (OPAL_DATATYPE_END_LOOP == pLast->elem.common.type) {
+                } else if (OPAL_DATATYPE_END_LOOP == pLast->elem.common.type) {
                     pLast->end_loop.first_elem_disp += disp;
                 }
                 pLast++;
@@ -424,8 +430,9 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
                                                       * added type have to match */
             || (count < 2))) {                       /* if the count is bigger than 2 */
         SET_CONTIGUOUS_FLAG(pdtBase->flags);
-        if ((ptrdiff_t) pdtBase->size == (pdtBase->ub - pdtBase->lb))
+        if ((ptrdiff_t) pdtBase->size == (pdtBase->ub - pdtBase->lb)) {
             SET_NO_GAP_FLAG(pdtBase->flags);
+        }
     }
 
     /* If the NO_GAP flag is set the contiguous have to be set too */

--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -114,8 +114,9 @@ int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, int
     /* empty data ? then do nothing. This should normally be trapped
      * at a higher level.
      */
-    if (0 == count)
+    if (0 == count) {
         return 1;
+    }
 
     /**
      * see discussion in coll_basic_reduce.c for the computation of extent when

--- a/opal/datatype/opal_datatype_create.c
+++ b/opal/datatype/opal_datatype_create.c
@@ -64,8 +64,9 @@ static void opal_datatype_destruct(opal_datatype_t *datatype)
      * same data description we should start by cleaning the optimized description.
      */
     if (NULL != datatype->opt_desc.desc) {
-        if (datatype->opt_desc.desc != datatype->desc.desc)
+        if (datatype->opt_desc.desc != datatype->desc.desc) {
             free(datatype->opt_desc.desc);
+        }
         datatype->opt_desc.length = 0;
         datatype->opt_desc.used = 0;
         datatype->opt_desc.desc = NULL;
@@ -94,8 +95,9 @@ opal_datatype_t *opal_datatype_create(int32_t expectedSize)
 {
     opal_datatype_t *datatype = (opal_datatype_t *) OBJ_NEW(opal_datatype_t);
 
-    if (expectedSize == -1)
+    if (expectedSize == -1) {
         expectedSize = DT_INCREASE_STACK;
+    }
     datatype->desc.length = expectedSize + 1; /* one for the fake elem at the end */
     datatype->desc.used = 0;
     datatype->desc.desc = (dt_elem_desc_t *) calloc(datatype->desc.length, sizeof(dt_elem_desc_t));
@@ -107,12 +109,14 @@ opal_datatype_t *opal_datatype_create(int32_t expectedSize)
 
 int32_t opal_datatype_create_desc(opal_datatype_t *datatype, int32_t expectedSize)
 {
-    if (expectedSize == -1)
+    if (expectedSize == -1) {
         expectedSize = DT_INCREASE_STACK;
+    }
     datatype->desc.length = expectedSize + 1; /* one for the fake elem at the end */
     datatype->desc.used = 0;
     datatype->desc.desc = (dt_elem_desc_t *) calloc(datatype->desc.length, sizeof(dt_elem_desc_t));
-    if (NULL == datatype->desc.desc)
+    if (NULL == datatype->desc.desc) {
         return OPAL_ERR_OUT_OF_RESOURCE;
+    }
     return OPAL_SUCCESS;
 }

--- a/opal/datatype/opal_datatype_destroy.c
+++ b/opal/datatype/opal_datatype_destroy.c
@@ -27,8 +27,9 @@ int32_t opal_datatype_destroy(opal_datatype_t **dt)
 {
     opal_datatype_t *pData = *dt;
 
-    if ((pData->flags & OPAL_DATATYPE_FLAG_PREDEFINED) && (pData->super.obj_reference_count <= 1))
+    if ((pData->flags & OPAL_DATATYPE_FLAG_PREDEFINED) && (pData->super.obj_reference_count <= 1)) {
         return OPAL_ERROR;
+    }
 
     OBJ_RELEASE(pData);
     *dt = NULL;

--- a/opal/datatype/opal_datatype_dump.c
+++ b/opal/datatype/opal_datatype_dump.c
@@ -42,10 +42,12 @@ int opal_datatype_contain_basic_datatypes(const opal_datatype_t *pData, char *pt
     int32_t index = 0;
     uint64_t mask = 1;
 
-    if (pData->flags & OPAL_DATATYPE_FLAG_USER_LB)
+    if (pData->flags & OPAL_DATATYPE_FLAG_USER_LB) {
         index += snprintf(ptr, length - index, "lb ");
-    if (pData->flags & OPAL_DATATYPE_FLAG_USER_UB)
+    }
+    if (pData->flags & OPAL_DATATYPE_FLAG_USER_UB) {
         index += snprintf(ptr + index, length - index, "ub ");
+    }
     for (i = 0; i < OPAL_DATATYPE_MAX_PREDEFINED; i++) {
         if (pData->bdt_used & mask) {
             if (NULL == pData->ptypes) {
@@ -57,8 +59,9 @@ int opal_datatype_contain_basic_datatypes(const opal_datatype_t *pData, char *pt
             }
         }
         mask <<= 1;
-        if (length <= (size_t) index)
+        if (length <= (size_t) index) {
             break;
+        }
     }
     return index;
 }
@@ -66,27 +69,37 @@ int opal_datatype_contain_basic_datatypes(const opal_datatype_t *pData, char *pt
 int opal_datatype_dump_data_flags(unsigned short usflags, char *ptr, size_t length)
 {
     int index = 0;
-    if (length < 22)
+    if (length < 22) {
         return 0;
+    }
     index = snprintf(ptr, 22, "-----------[---][---]"); /* set everything to - */
-    if (usflags & OPAL_DATATYPE_FLAG_COMMITTED)
+    if (usflags & OPAL_DATATYPE_FLAG_COMMITTED) {
         ptr[1] = 'c';
-    if (usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS) {
         ptr[2] = 'C';
-    if (usflags & OPAL_DATATYPE_FLAG_OVERLAP)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_OVERLAP) {
         ptr[3] = 'o';
-    if (usflags & OPAL_DATATYPE_FLAG_USER_LB)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_USER_LB) {
         ptr[4] = 'l';
-    if (usflags & OPAL_DATATYPE_FLAG_USER_UB)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_USER_UB) {
         ptr[5] = 'u';
-    if (usflags & OPAL_DATATYPE_FLAG_PREDEFINED)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_PREDEFINED) {
         ptr[6] = 'P';
-    if (!(usflags & OPAL_DATATYPE_FLAG_NO_GAPS))
+    }
+    if (!(usflags & OPAL_DATATYPE_FLAG_NO_GAPS)) {
         ptr[7] = 'G';
-    if (usflags & OPAL_DATATYPE_FLAG_DATA)
+    }
+    if (usflags & OPAL_DATATYPE_FLAG_DATA) {
         ptr[8] = 'D';
-    if ((usflags & OPAL_DATATYPE_FLAG_BASIC) == OPAL_DATATYPE_FLAG_BASIC)
+    }
+    if ((usflags & OPAL_DATATYPE_FLAG_BASIC) == OPAL_DATATYPE_FLAG_BASIC) {
         ptr[9] = 'B';
+    }
     /* We know nothing about the upper level language or flags! */
     /* ... */
     return index;
@@ -99,22 +112,24 @@ int opal_datatype_dump_data_desc(dt_elem_desc_t *pDesc, int nbElems, char *ptr, 
 
     for (i = 0; i < nbElems; i++) {
         index += opal_datatype_dump_data_flags(pDesc->elem.common.flags, ptr + index, length);
-        if (length <= (size_t) index)
+        if (length <= (size_t) index) {
             break;
+        }
         index += snprintf(ptr + index, length - index, "%15s ",
                           opal_datatype_basicDatatypes[pDesc->elem.common.type]->name);
-        if (length <= (size_t) index)
+        if (length <= (size_t) index) {
             break;
-        if (OPAL_DATATYPE_LOOP == pDesc->elem.common.type)
+        }
+        if (OPAL_DATATYPE_LOOP == pDesc->elem.common.type) {
             index += snprintf(ptr + index, length - index,
                               "%u times the next %u elements extent %td\n", pDesc->loop.loops,
                               pDesc->loop.items, pDesc->loop.extent);
-        else if (OPAL_DATATYPE_END_LOOP == pDesc->elem.common.type)
+        } else if (OPAL_DATATYPE_END_LOOP == pDesc->elem.common.type) {
             index += snprintf(
                 ptr + index, length - index,
                 "prev %u elements first elem displacement %td size of data %" PRIsize_t "\n",
                 pDesc->end_loop.items, pDesc->end_loop.first_elem_disp, pDesc->end_loop.size);
-        else
+        } else {
             index += snprintf(ptr + index, length - index,
                               "count %u disp 0x%tx (%td) blen %" PRIsize_t
                               " extent %td (size %zd)\n",
@@ -122,10 +137,12 @@ int opal_datatype_dump_data_desc(dt_elem_desc_t *pDesc, int nbElems, char *ptr, 
                               pDesc->elem.blocklen, pDesc->elem.extent,
                               (pDesc->elem.count * pDesc->elem.blocklen
                                * opal_datatype_basicDatatypes[pDesc->elem.common.type]->size));
+        }
         pDesc++;
 
-        if (length <= (size_t) index)
+        if (length <= (size_t) index) {
             break;
+        }
     }
     return index;
 }
@@ -149,13 +166,15 @@ void opal_datatype_dump(const opal_datatype_t *pData)
                       pData->true_ub - pData->true_lb, pData->lb, pData->ub, pData->ub - pData->lb,
                       pData->nbElems, pData->loops, (int) pData->flags);
     /* dump the flags */
-    if (pData->flags == OPAL_DATATYPE_FLAG_PREDEFINED)
+    if (pData->flags == OPAL_DATATYPE_FLAG_PREDEFINED) {
         index += snprintf(buffer + index, length - index, "predefined ");
-    else {
-        if (pData->flags & OPAL_DATATYPE_FLAG_COMMITTED)
+    } else {
+        if (pData->flags & OPAL_DATATYPE_FLAG_COMMITTED) {
             index += snprintf(buffer + index, length - index, "committed ");
-        if (pData->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS)
+        }
+        if (pData->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) {
             index += snprintf(buffer + index, length - index, "contiguous ");
+        }
     }
     index += snprintf(buffer + index, length - index, ")");
     index += opal_datatype_dump_data_flags(pData->flags, buffer + index, length - index);

--- a/opal/datatype/opal_datatype_get_count.c
+++ b/opal/datatype/opal_datatype_get_count.c
@@ -54,9 +54,10 @@ ssize_t opal_datatype_get_element_count(const opal_datatype_t *datatype, size_t 
             if (--(pStack->count) == 0) {           /* end of loop */
                 stack_pos--;
                 pStack--;
-                if (stack_pos == -1)
+                if (stack_pos == -1) {
                     return nbElems; /* completed */
-                pos_desc++;         /* advance to the next element after the end loop */
+                }
+                pos_desc++; /* advance to the next element after the end loop */
             } else {
                 pos_desc = pStack->index + 1; /* go back to the begining of the loop */
             }
@@ -123,8 +124,9 @@ int32_t opal_datatype_set_element_count(const opal_datatype_t *datatype, size_t 
             if (--(pStack->count) == 0) {           /* end of loop */
                 stack_pos--;
                 pStack--;
-                if (stack_pos == -1)
+                if (stack_pos == -1) {
                     return 0;
+                }
                 pos_desc++; /* advance to the next element after the end loop */
             } else {
                 pos_desc = pStack->index + 1; /* go back to the begining of the loop */
@@ -169,8 +171,9 @@ int opal_datatype_compute_ptypes(opal_datatype_t *datatype)
     ssize_t nbElems = 0, stack_pos = 0;
     dt_elem_desc_t *pElems;
 
-    if (NULL != datatype->ptypes)
+    if (NULL != datatype->ptypes) {
         return 0;
+    }
     datatype->ptypes = (size_t *) calloc(OPAL_DATATYPE_MAX_SUPPORTED, sizeof(size_t));
 
     DUMP("opal_datatype_compute_ptypes( %p )\n", (void *) datatype);
@@ -187,9 +190,10 @@ int opal_datatype_compute_ptypes(opal_datatype_t *datatype)
             if (--(pStack->count) == 0) {           /* end of loop */
                 stack_pos--;
                 pStack--;
-                if (stack_pos == -1)
+                if (stack_pos == -1) {
                     return 0; /* completed */
-                pos_desc++;   /* advance to the next element after the end loop */
+                }
+                pos_desc++; /* advance to the next element after the end loop */
             } else {
                 pos_desc = pStack->index + 1; /* go back to the begining of the loop */
             }

--- a/opal/datatype/opal_datatype_optimize.c
+++ b/opal/datatype/opal_datatype_optimize.c
@@ -287,8 +287,9 @@ int32_t opal_datatype_commit(opal_datatype_t *pData)
     ddt_endloop_desc_t *pLast = &(pData->desc.desc[pData->desc.used].end_loop);
     ptrdiff_t first_elem_disp = 0;
 
-    if (pData->flags & OPAL_DATATYPE_FLAG_COMMITTED)
+    if (pData->flags & OPAL_DATATYPE_FLAG_COMMITTED) {
         return OPAL_SUCCESS;
+    }
     pData->flags |= OPAL_DATATYPE_FLAG_COMMITTED;
 
     /* We have to compute the displacement of the first non loop item in the

--- a/opal/datatype/opal_datatype_pack.c
+++ b/opal/datatype/opal_datatype_pack.c
@@ -73,10 +73,12 @@ int32_t opal_pack_homogeneous_contig_function(opal_convertor_t *pConv, struct io
      * does not provide a buffer.
      */
     for (iov_count = 0; iov_count < (*out_size); iov_count++) {
-        if (0 == length)
+        if (0 == length) {
             break;
-        if ((size_t) iov[iov_count].iov_len > length)
+        }
+        if ((size_t) iov[iov_count].iov_len > length) {
             iov[iov_count].iov_len = length;
+        }
         if (iov[iov_count].iov_base == NULL) {
             iov[iov_count].iov_base = (IOVBASE_TYPE *) source_base;
             COMPUTE_CSUM(iov[iov_count].iov_base, iov[iov_count].iov_len, pConv);
@@ -148,10 +150,12 @@ int32_t opal_pack_homogeneous_contig_with_gaps_function(opal_convertor_t *pConv,
     for (idx = 0; idx < (*out_size); idx++) {
         /* Limit the amount of packed data to the data left over on this convertor */
         remaining = pConv->local_size - pConv->bConverted;
-        if (0 == remaining)
+        if (0 == remaining) {
             break; /* we're done this time */
-        if (remaining > iov[idx].iov_len)
+        }
+        if (remaining > iov[idx].iov_len) {
             remaining = iov[idx].iov_len;
+        }
         packed_buffer = (unsigned char *) iov[idx].iov_base;
         pConv->bConverted += remaining;
         user_memory = pConv->pBaseBuf + pData->true_lb + stack[0].disp + stack[1].disp;
@@ -178,8 +182,9 @@ int32_t opal_pack_homogeneous_contig_with_gaps_function(opal_convertor_t *pConv,
             if (0 == stack[1].count) { /* one completed element */
                 stack[0].count--;
                 stack[0].disp += extent;
-                if (0 == stack[0].count) /* not yet done */
+                if (0 == stack[0].count) { /* not yet done */
                     break;
+                }
                 stack[1].count = pData->size;
                 stack[1].disp = 0;
             }
@@ -222,8 +227,9 @@ int32_t opal_pack_homogeneous_contig_with_gaps_function(opal_convertor_t *pConv,
 update_status_and_return:
     *out_size = idx;
     *max_data = pConv->bConverted - initial_bytes_converted;
-    if (pConv->bConverted == pConv->local_size)
+    if (pConv->bConverted == pConv->local_size) {
         pConv->flags |= CONVERTOR_COMPLETED;
+    }
     return !!(pConv->flags & CONVERTOR_COMPLETED); /* done or not */
 }
 
@@ -284,8 +290,9 @@ int32_t opal_generic_simple_pack_function(opal_convertor_t *pConvertor, struct i
                 /* we have a partial (less than blocklen) basic datatype */
                 int rc = PACK_PARTIAL_BLOCKLEN(pConvertor, pElem, count_desc, conv_ptr, iov_ptr,
                                                iov_len_local);
-                if (0 == rc) /* not done */
+                if (0 == rc) { /* not done */
                     goto complete_loop;
+                }
                 if (0 == count_desc) {
                     conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                     pos_desc++; /* advance to the next data */
@@ -299,8 +306,9 @@ int32_t opal_generic_simple_pack_function(opal_convertor_t *pConvertor, struct i
                 /* we have a basic datatype (working on full blocks) */
                 PACK_PREDEFINED_DATATYPE(pConvertor, pElem, count_desc, conv_ptr, iov_ptr,
                                          iov_len_local);
-                if (0 != count_desc) /* completed? */
+                if (0 != count_desc) { /* completed? */
                     goto complete_loop;
+                }
                 conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                 pos_desc++; /* advance to the next data */
                 UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
@@ -409,8 +417,9 @@ static inline void pack_predefined_heterogeneous(opal_convertor_t *CONVERTOR,
     _r_blength = master->remote_sizes[_elem->common.type];
     if ((_count * _r_blength) > *(SPACE)) {
         _count = (*(SPACE) / _r_blength);
-        if (0 == _count)
+        if (0 == _count) {
             return; /* nothing to do */
+        }
     }
 
     OPAL_DATATYPE_SAFEGUARD_POINTER(_source, (_count * _elem->extent), (CONVERTOR)->pBaseBuf,

--- a/opal/datatype/opal_datatype_position.c
+++ b/opal/datatype/opal_datatype_position.c
@@ -80,8 +80,9 @@ static inline void position_predefined_data(opal_convertor_t *CONVERTOR, dt_elem
 
     assert(*(COUNT) <= ((size_t) _elem->count * _elem->blocklen));
 
-    if (cando_count > *(COUNT))
+    if (cando_count > *(COUNT)) {
         cando_count = *(COUNT);
+    }
 
     if (1 == _elem->blocklen) {
         DO_DEBUG(opal_output(0,
@@ -111,10 +112,11 @@ static inline void position_predefined_data(opal_convertor_t *CONVERTOR, dt_elem
                                   do_now);
 
             /* compensate if we just completed a blocklen */
-            if (do_now == left_in_block)
+            if (do_now == left_in_block) {
                 _memory += _elem->extent
                            - (_elem->blocklen
                               * opal_datatype_basicDatatypes[_elem->common.type]->size);
+            }
             cando_count -= do_now;
         }
     }
@@ -184,8 +186,9 @@ int opal_convertor_generic_simple_position(opal_convertor_t *pConvertor, size_t 
                              (unsigned long) pConvertor->pDesc->size, (unsigned long) iov_len_local,
                              count_desc););
         /* Update all the stack including the last one */
-        for (pos_desc = 0; pos_desc <= pConvertor->stack_pos; pos_desc++)
+        for (pos_desc = 0; pos_desc <= pConvertor->stack_pos; pos_desc++) {
             pStack[pos_desc].disp += count_desc * extent;
+        }
         pConvertor->bConverted += count_desc * pConvertor->pDesc->size;
         iov_len_local = *position - pConvertor->bConverted;
         pStack[0].count -= count_desc;

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -84,10 +84,12 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
     if ((ptrdiff_t) pData->size == extent) {
         for (iov_idx = 0; iov_idx < (*out_size); iov_idx++) {
             remaining = pConv->local_size - pConv->bConverted;
-            if (0 == remaining)
+            if (0 == remaining) {
                 break; /* we're done this time */
-            if (remaining > iov[iov_idx].iov_len)
+            }
+            if (remaining > iov[iov_idx].iov_len) {
                 remaining = iov[iov_idx].iov_len;
+            }
 
             packed_buffer = (unsigned char *) iov[iov_idx].iov_base;
             user_memory = pConv->pBaseBuf + pData->true_lb + pConv->bConverted;
@@ -104,10 +106,12 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
     } else {
         for (iov_idx = 0; iov_idx < (*out_size); iov_idx++) {
             remaining = pConv->local_size - pConv->bConverted;
-            if (0 == remaining)
+            if (0 == remaining) {
                 break; /* we're done this time */
-            if (remaining > iov[iov_idx].iov_len)
+            }
+            if (remaining > iov[iov_idx].iov_len) {
                 remaining = iov[iov_idx].iov_len;
+            }
 
             packed_buffer = (unsigned char *) iov[iov_idx].iov_base;
             user_memory = pConv->pBaseBuf + pData->true_lb + stack[0].disp + stack[1].disp;
@@ -151,8 +155,9 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
     }
     *out_size = iov_idx; /* we only reach this line after the for loop succesfully complete */
     *max_data = pConv->bConverted - initial_bytes_converted;
-    if (pConv->bConverted == pConv->local_size)
+    if (pConv->bConverted == pConv->local_size) {
         pConv->flags |= CONVERTOR_COMPLETED;
+    }
     return !!(pConv->flags & CONVERTOR_COMPLETED); /* done or not */
 }
 
@@ -235,8 +240,9 @@ find_unused_byte:
     }
 #else
     for (size_t i = 0; i < data_length; i++) {
-        if (unused_byte == user_data[i])
+        if (unused_byte == user_data[i]) {
             user_data[i] = saved_data[i];
+        }
     }
 #endif
 }
@@ -318,8 +324,9 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
                 /* we have a partial (less than blocklen) basic datatype */
                 int rc = UNPACK_PARTIAL_BLOCKLEN(pConvertor, pElem, count_desc, iov_ptr, conv_ptr,
                                                  iov_len_local);
-                if (0 == rc) /* not done */
+                if (0 == rc) { /* not done */
                     goto complete_loop;
+                }
                 if (0 == count_desc) {
                     conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                     pos_desc++; /* advance to the next data */
@@ -333,8 +340,9 @@ int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct
                 /* we have a basic datatype (working on full blocks) */
                 UNPACK_PREDEFINED_DATATYPE(pConvertor, pElem, count_desc, iov_ptr, conv_ptr,
                                            iov_len_local);
-                if (0 != count_desc) /* completed? */
+                if (0 != count_desc) { /* completed? */
                     goto complete_loop;
+                }
                 conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                 pos_desc++; /* advance to the next data */
                 UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
@@ -514,8 +522,9 @@ int32_t opal_unpack_general_function(opal_convertor_t *pConvertor, struct iovec 
                     conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                     pos_desc++; /* advance to the next data */
                     UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
-                    if (0 == iov_len_local)
+                    if (0 == iov_len_local) {
                         goto complete_loop; /* escape if we're done */
+                    }
                     continue;
                 }
                 conv_ptr += rc * description[pos_desc].elem.extent;

--- a/opal/mca/allocator/basic/allocator_basic.c
+++ b/opal/mca/allocator/basic/allocator_basic.c
@@ -215,11 +215,13 @@ void *mca_allocator_basic_realloc(mca_allocator_base_module_t *base, void *ptr, 
 {
     unsigned char *addr = ((unsigned char *) ptr) - sizeof(size_t);
     size_t alloc_size = *(size_t *) addr;
-    if (size <= alloc_size)
+    if (size <= alloc_size) {
         return ptr;
+    }
     addr = (unsigned char *) mca_allocator_basic_alloc(base, size, 0);
-    if (addr == NULL)
+    if (addr == NULL) {
         return addr;
+    }
     memcpy(addr, ptr, alloc_size);
     mca_allocator_basic_free(base, ptr);
     return addr;

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.c
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.c
@@ -328,8 +328,9 @@ int mca_allocator_bucket_cleanup(mca_allocator_base_module_t *mem)
             while (NULL != segment) {
                 next_segment = segment->next_segment;
                 /* free the memory */
-                if (mem_options->free_mem_fn)
+                if (mem_options->free_mem_fn) {
                     mem_options->free_mem_fn(mem->alc_context, segment);
+                }
                 segment = next_segment;
             }
             mem_options->buckets[i].free_chunk = NULL;
@@ -365,8 +366,9 @@ int mca_allocator_bucket_cleanup(mca_allocator_base_module_t *mem)
                     segment = *segment_header;
                     *segment_header = segment->next_segment;
                     /* free the memory */
-                    if (mem_options->free_mem_fn)
+                    if (mem_options->free_mem_fn) {
                         mem_options->free_mem_fn(mem->alc_context, segment);
+                    }
                 } else {
                     /* go to next segment */
                     segment_header = &((*segment_header)->next_segment);

--- a/opal/mca/base/mca_base_alias.c
+++ b/opal/mca/base/mca_base_alias.c
@@ -159,8 +159,9 @@ int mca_base_alias_register(const char *project, const char *framework, const ch
 
     mca_base_alias_item_t *alias_item = OBJ_NEW(mca_base_alias_item_t);
     if (NULL == alias_item) {
-        if (NULL != name)
+        if (NULL != name) {
             free(name);
+        }
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -219,12 +219,13 @@ static void parse_verbose(char *e, opal_output_stream_t *lds)
 #if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
-            if (strcasecmp(ptr + 10, "notice") == 0)
+            if (strcasecmp(ptr + 10, "notice") == 0) {
                 lds->lds_syslog_priority = LOG_NOTICE;
-            else if (strcasecmp(ptr + 10, "INFO") == 0)
+            } else if (strcasecmp(ptr + 10, "INFO") == 0) {
                 lds->lds_syslog_priority = LOG_INFO;
-            else if (strcasecmp(ptr + 10, "DEBUG") == 0)
+            } else if (strcasecmp(ptr + 10, "DEBUG") == 0) {
                 lds->lds_syslog_priority = LOG_DEBUG;
+            }
 #else
             opal_output(0, "syslog support requested but not available on this system");
 #endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
@@ -260,8 +261,9 @@ static void parse_verbose(char *e, opal_output_stream_t *lds)
 
         else if (strncasecmp(ptr, "level", 5) == 0) {
             lds->lds_verbose_level = 0;
-            if (ptr[5] == OPAL_ENV_SEP)
+            if (ptr[5] == OPAL_ENV_SEP) {
                 lds->lds_verbose_level = atoi(ptr + 6);
+            }
         }
 
         if (NULL == next) {

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -337,8 +337,8 @@ int mca_base_var_enum_create(const char *name, const mca_base_var_enum_value_t *
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-    for (i = 0; values[i].string; ++i)
-        ;
+    for (i = 0; values[i].string; ++i) {
+    }
     new_enum->enum_value_count = i;
 
     /* make a copy of the values */
@@ -376,8 +376,8 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-    for (i = 0; flags[i].string; ++i)
-        ;
+    for (i = 0; flags[i].string; ++i) {
+    }
     new_enum->super.enum_value_count = i;
 
     /* make a copy of the values */
@@ -423,8 +423,9 @@ static int enum_dump(mca_base_var_enum_t *self, char **out)
     for (i = 0; i < self->enum_value_count && self->enum_values[i].string; ++i) {
         ret = opal_asprintf(out, "%s%s%d:\"%s\"", tmp ? tmp : "", tmp ? ", " : "",
                             self->enum_values[i].value, self->enum_values[i].string);
-        if (tmp)
+        if (tmp) {
             free(tmp);
+        }
         if (0 > ret) {
             return OPAL_ERR_OUT_OF_RESOURCE;
         }

--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -81,8 +81,9 @@ int mca_btl_tcp_add_procs(struct mca_btl_base_module_t *btl, size_t nprocs,
     int i, rc;
 
     /* get pointer to my proc structure */
-    if (NULL == (my_proc = opal_proc_local_get()))
+    if (NULL == (my_proc = opal_proc_local_get())) {
         return OPAL_ERR_OUT_OF_RESOURCE;
+    }
 
     for (i = 0; i < (int) nprocs; i++) {
 
@@ -323,8 +324,9 @@ int mca_btl_tcp_send(struct mca_btl_base_module_t *btl, struct mca_btl_base_endp
     frag->hdr.base.tag = tag;
     frag->hdr.type = MCA_BTL_TCP_HDR_TYPE_SEND;
     frag->hdr.count = 0;
-    if (endpoint->endpoint_nbo)
+    if (endpoint->endpoint_nbo) {
         MCA_BTL_TCP_HDR_HTON(frag->hdr);
+    }
     return mca_btl_tcp_endpoint_send(endpoint, frag);
 }
 
@@ -371,8 +373,9 @@ int mca_btl_tcp_put(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *
 
     frag->segments[1].seg_addr.lval = remote_address;
     frag->segments[1].seg_len = size;
-    if (endpoint->endpoint_nbo)
+    if (endpoint->endpoint_nbo) {
         MCA_BTL_BASE_SEGMENT_HTON(frag->segments[1]);
+    }
 
     frag->base.des_flags = MCA_BTL_DES_FLAGS_BTL_OWNERSHIP | MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
     frag->base.des_cbfunc = fake_rdma_complete;
@@ -401,8 +404,9 @@ int mca_btl_tcp_put(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *
     frag->hdr.base.tag = MCA_BTL_TAG_BTL;
     frag->hdr.type = MCA_BTL_TCP_HDR_TYPE_PUT;
     frag->hdr.count = 1;
-    if (endpoint->endpoint_nbo)
+    if (endpoint->endpoint_nbo) {
         MCA_BTL_TCP_HDR_HTON(frag->hdr);
+    }
     return ((i = mca_btl_tcp_endpoint_send(endpoint, frag)) >= 0 ? OPAL_SUCCESS : i);
 }
 
@@ -465,8 +469,9 @@ int mca_btl_tcp_get(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *
     frag->hdr.base.tag = MCA_BTL_TAG_BTL;
     frag->hdr.type = MCA_BTL_TCP_HDR_TYPE_GET;
     frag->hdr.count = 1;
-    if (endpoint->endpoint_nbo)
+    if (endpoint->endpoint_nbo) {
         MCA_BTL_TCP_HDR_HTON(frag->hdr);
+    }
     return ((rc = mca_btl_tcp_endpoint_send(endpoint, frag)) >= 0 ? OPAL_SUCCESS : rc);
 }
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -541,8 +541,9 @@ static int mca_btl_tcp_create(const int if_kindex, const char *if_name)
 
     for (i = 0; i < (int) mca_btl_tcp_component.tcp_num_links; i++) {
         btl = (struct mca_btl_tcp_module_t *) malloc(sizeof(mca_btl_tcp_module_t));
-        if (NULL == btl)
+        if (NULL == btl) {
             return OPAL_ERR_OUT_OF_RESOURCE;
+        }
         copied_interface = OBJ_NEW(opal_if_t);
         if (NULL == copied_interface) {
             free(btl);
@@ -841,8 +842,9 @@ static int mca_btl_tcp_component_create_instances(void)
             /* check to see if this interface exists in the exclude list */
             argv = exclude;
             while (argv && *argv) {
-                if (strncmp(*argv, if_name, strlen(*argv)) == 0)
+                if (strncmp(*argv, if_name, strlen(*argv)) == 0) {
                     break;
+                }
                 argv++;
             }
             /* if this interface was not found in the excluded list, create a BTL */
@@ -1337,8 +1339,9 @@ static void mca_btl_tcp_component_accept_handler(int incoming_sd, short ignored,
         mca_btl_tcp_event_t *event;
         int sd = accept(incoming_sd, (struct sockaddr *) &addr, &addrlen);
         if (sd < 0) {
-            if (opal_socket_errno == EINTR)
+            if (opal_socket_errno == EINTR) {
                 continue;
+            }
             if (opal_socket_errno != EAGAIN && opal_socket_errno != EWOULDBLOCK) {
                 opal_show_help("help-mpi-btl-tcp.txt", "accept failed", true,
                                opal_process_info.nodename, getpid(), opal_socket_errno,

--- a/opal/mca/btl/tcp/btl_tcp_frag.c
+++ b/opal/mca/btl/tcp/btl_tcp_frag.c
@@ -87,14 +87,16 @@ size_t mca_btl_tcp_frag_dump(mca_btl_tcp_frag_t *frag, char *msg, char *buf, siz
 
     used = snprintf(buf, length, "%s frag %p iov_cnt %d iov_idx %d size %lu\n", msg, (void *) frag,
                     (int) frag->iov_cnt, (int) frag->iov_idx, frag->size);
-    if ((size_t) used >= length)
+    if ((size_t) used >= length) {
         return length;
+    }
     for (i = 0; i < (int) frag->iov_cnt; i++) {
         used += snprintf(&buf[used], length - used, "[%s%p:%lu] ",
                          (i < (int) frag->iov_idx ? "*" : ""), frag->iov[i].iov_base,
                          frag->iov[i].iov_len);
-        if ((size_t) used >= length)
+        if ((size_t) used >= length) {
             return length;
+        }
     }
     return used;
 }
@@ -172,8 +174,9 @@ repeat:
          */
         cnt = length = btl_endpoint->endpoint_cache_length;
         for (i = 0; i < (int) frag->iov_cnt; i++) {
-            if (length > frag->iov_ptr[i].iov_len)
+            if (length > frag->iov_ptr[i].iov_len) {
                 length = frag->iov_ptr[i].iov_len;
+            }
             if ((0 == dont_copy_data) || (length < frag->iov_ptr[i].iov_len)) {
                 memcpy(frag->iov_ptr[i].iov_base, btl_endpoint->endpoint_cache_pos, length);
             } else {
@@ -202,12 +205,14 @@ repeat:
     /* non-blocking read, but continue if interrupted */
     do {
         cnt = readv(sd, frag->iov_ptr, num_vecs);
-        if (0 < cnt)
+        if (0 < cnt) {
             goto advance_iov_position;
+        }
         if (cnt == 0) {
             OPAL_THREAD_LOCK(&btl_endpoint->endpoint_send_lock);
-            if (MCA_BTL_TCP_CONNECTED == btl_endpoint->endpoint_state)
+            if (MCA_BTL_TCP_CONNECTED == btl_endpoint->endpoint_state) {
                 btl_endpoint->endpoint_state = MCA_BTL_TCP_FAILED;
+            }
             mca_btl_tcp_endpoint_close(btl_endpoint);
             OPAL_THREAD_UNLOCK(&btl_endpoint->endpoint_send_lock);
             return false;
@@ -265,8 +270,9 @@ advance_iov_position:
 
     /* read header */
     if (frag->iov_cnt == 0) {
-        if (btl_endpoint->endpoint_nbo && frag->iov_idx == 1)
+        if (btl_endpoint->endpoint_nbo && frag->iov_idx == 1) {
             MCA_BTL_TCP_HDR_NTOH(frag->hdr);
+        }
         switch (frag->hdr.type) {
         case MCA_BTL_TCP_HDR_TYPE_FIN:
             frag->endpoint->endpoint_state = MCA_BTL_TCP_CLOSED;
@@ -290,8 +296,9 @@ advance_iov_position:
                 goto repeat;
             } else if (frag->iov_idx == 2) {
                 for (i = 0; i < frag->hdr.count; i++) {
-                    if (btl_endpoint->endpoint_nbo)
+                    if (btl_endpoint->endpoint_nbo) {
                         MCA_BTL_BASE_SEGMENT_NTOH(frag->segments[i]);
+                    }
                     frag->iov[i + 2].iov_base = (IOVBASE_TYPE *) frag->segments[i].seg_addr.pval;
                     frag->iov[i + 2].iov_len = frag->segments[i].seg_len;
                 }

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -315,8 +315,9 @@ opal_hwloc_print_buffers_t *opal_hwloc_get_print_buffer(void)
     }
 
     ret = opal_tsd_tracked_key_get(print_tsd_key, (void **) &ptr);
-    if (OPAL_SUCCESS != ret)
+    if (OPAL_SUCCESS != ret) {
         return NULL;
+    }
 
     if (NULL == ptr) {
         ptr = (opal_hwloc_print_buffers_t *) malloc(sizeof(opal_hwloc_print_buffers_t));

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -608,12 +608,14 @@ static hwloc_obj_t df_search(hwloc_topology_t topo, hwloc_obj_t start, hwloc_obj
         search_depth = hwloc_get_cache_type_depth(topo, cache_level, (hwloc_obj_cache_type_t) -1);
 #endif
     }
-    if (HWLOC_TYPE_DEPTH_UNKNOWN == search_depth)
+    if (HWLOC_TYPE_DEPTH_UNKNOWN == search_depth) {
         return NULL;
+    }
 
     if (OPAL_HWLOC_LOGICAL == rtype) {
-        if (num_objs)
+        if (num_objs) {
             *num_objs = hwloc_get_nbobjs_by_depth(topo, search_depth);
+        }
         return hwloc_get_obj_by_depth(topo, search_depth, nobj);
     }
     if (OPAL_HWLOC_PHYSICAL == rtype) {
@@ -630,13 +632,16 @@ static hwloc_obj_t df_search(hwloc_topology_t topo, hwloc_obj_t start, hwloc_obj
          */
         hwloc_obj_t found = NULL;
         obj = NULL;
-        if (num_objs)
+        if (num_objs) {
             *num_objs = 0;
+        }
         while ((obj = hwloc_get_next_obj_by_depth(topo, search_depth, obj)) != NULL) {
-            if (num_objs && obj->os_index > *num_objs)
+            if (num_objs && obj->os_index > *num_objs) {
                 *num_objs = obj->os_index;
-            if (obj->os_index == nobj)
+            }
+            if (obj->os_index == nobj) {
                 found = obj;
+            }
         }
         return found;
     }
@@ -660,9 +665,10 @@ static hwloc_obj_t df_search(hwloc_topology_t topo, hwloc_obj_t start, hwloc_obj
         }
 
         unsigned idx = 0;
-        if (num_objs)
+        if (num_objs) {
             *num_objs = hwloc_get_nbobjs_inside_cpuset_by_depth(topo, constrained_cpuset,
                                                                 search_depth);
+        }
         obj = NULL;
         while ((obj = hwloc_get_next_obj_inside_cpuset_by_depth(topo, constrained_cpuset,
                                                                 search_depth, obj))
@@ -1373,8 +1379,9 @@ int opal_hwloc_base_topology_set_flags(hwloc_topology_t topology, unsigned long 
         flags |= HWLOC_TOPOLOGY_FLAG_IO_DEVICES;
 #else
         int ret = hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
-        if (0 != ret)
+        if (0 != ret) {
             return ret;
+        }
 #endif
     }
     return hwloc_topology_set_flags(topology, flags);

--- a/opal/mca/installdirs/base/installdirs_base_expand.c
+++ b/opal/mca/installdirs/base/installdirs_base_expand.c
@@ -117,8 +117,9 @@ static char *opal_install_dirs_expand_internal(const char *input, bool is_setup)
     }
 
     retval = strdup(input);
-    if (NULL == retval)
+    if (NULL == retval) {
         return NULL;
+    }
 
     if (needs_expand) {
         bool changed = false;

--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -91,8 +91,8 @@ static void mca_rcache_grdma_cache_contructor(mca_rcache_grdma_cache_t *cache)
 static void mca_rcache_grdma_cache_destructor(mca_rcache_grdma_cache_t *cache)
 {
     /* clear the lru before releasing the list */
-    while (NULL != opal_list_remove_first(&cache->lru_list))
-        ;
+    while (NULL != opal_list_remove_first(&cache->lru_list)) {
+    }
 
     OBJ_DESTRUCT(&cache->lru_list);
     OBJ_DESTRUCT(&cache->gc_lifo);
@@ -262,8 +262,8 @@ static inline void mca_rcache_grdma_remove_from_lru(mca_rcache_grdma_module_t *r
      * function to be called then some thread deregistered the region. it may be the
      * case that the deregistration is still ongoing so wait until the deregistration
      * thread has marked this registration as being in the lru before continuing */
-    while (!(grdma_reg->flags & MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU))
-        ;
+    while (!(grdma_reg->flags & MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU)) {
+    }
 
     /* opal lists are not thread safe at this time so we must lock :'( */
     opal_mutex_lock(&rcache_grdma->cache->vma_module->vma_lock);

--- a/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
@@ -39,8 +39,9 @@ void wait_sync_global_wakeup_mt(int status)
          * but as of today we are the only place doing this so it is safe.
          */
         wait_sync_update(sync, 0, status);
-        if (sync->next == wait_sync_list)
+        if (sync->next == wait_sync_list) {
             break; /* special case for rings */
+        }
     }
     opal_mutex_unlock(&wait_sync_lock);
 }

--- a/opal/memoryhooks/memory.c
+++ b/opal/memoryhooks/memory.c
@@ -115,8 +115,9 @@ void opal_mem_hooks_release_hook(void *buf, size_t length, bool from_alloc)
 {
     callback_list_item_t *cbitem, *next;
 
-    if (!release_run_callbacks)
+    if (!release_run_callbacks) {
         return;
+    }
 
     /*
      * This is not really thread safe - but we can't hold the lock

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -900,8 +900,9 @@ void opal_info_out(const char *pretty_message, const char *plain_message, const 
     len = strlen(v);
 
     if (len > 0) {
-        while (len > 0 && isspace(v[len - 1]))
+        while (len > 0 && isspace(v[len - 1])) {
             len--;
+        }
         v[len] = '\0';
     }
 

--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -138,40 +138,54 @@ static void options_data_free(struct options_data_t *data)
     if (NULL != data->compiler_args) {
         opal_argv_free(data->compiler_args);
     }
-    if (NULL != data->language)
+    if (NULL != data->language) {
         free(data->language);
-    if (NULL != data->compiler)
+    }
+    if (NULL != data->compiler) {
         free(data->compiler);
-    if (NULL != data->project)
+    }
+    if (NULL != data->project) {
         free(data->project);
-    if (NULL != data->project_short)
+    }
+    if (NULL != data->project_short) {
         free(data->project_short);
-    if (NULL != data->version)
+    }
+    if (NULL != data->version) {
         free(data->version);
-    if (NULL != data->compiler_env)
+    }
+    if (NULL != data->compiler_env) {
         free(data->compiler_env);
-    if (NULL != data->compiler_flags_env)
+    }
+    if (NULL != data->compiler_flags_env) {
         free(data->compiler_flags_env);
+    }
     opal_argv_free(data->preproc_flags);
     opal_argv_free(data->comp_flags);
     opal_argv_free(data->comp_flags_prefix);
     opal_argv_free(data->link_flags);
     opal_argv_free(data->libs);
     opal_argv_free(data->libs_static);
-    if (NULL != data->dyn_lib_file)
+    if (NULL != data->dyn_lib_file) {
         free(data->dyn_lib_file);
-    if (NULL != data->static_lib_file)
+    }
+    if (NULL != data->static_lib_file) {
         free(data->static_lib_file);
-    if (NULL != data->req_file)
+    }
+    if (NULL != data->req_file) {
         free(data->req_file);
-    if (NULL != data->path_includedir)
+    }
+    if (NULL != data->path_includedir) {
         free(data->path_includedir);
-    if (NULL != data->path_libdir)
+    }
+    if (NULL != data->path_libdir) {
         free(data->path_libdir);
-    if (NULL != data->path_opalincludedir)
+    }
+    if (NULL != data->path_opalincludedir) {
         free(data->path_opalincludedir);
-    if (NULL != data->path_opallibdir)
+    }
+    if (NULL != data->path_opallibdir) {
         free(data->path_opallibdir);
+    }
 }
 
 static void options_data_expand(const char *value)
@@ -261,17 +275,21 @@ static void data_callback(const char *key, const char *value)
     if (0 == strcmp(key, "compiler_args")) {
         options_data_expand(value);
     } else if (0 == strcmp(key, "language")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].language = strdup(value);
+        }
     } else if (0 == strcmp(key, "compiler")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].compiler = strdup(value);
+        }
     } else if (0 == strcmp(key, "project")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].project = strdup(value);
+        }
     } else if (0 == strcmp(key, "version")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].version = strdup(value);
+        }
     } else if (0 == strcmp(key, "preprocessor_flags")) {
         char **values = opal_argv_split(value, ' ');
         opal_argv_insert(&options_data[parse_options_idx].preproc_flags,
@@ -308,23 +326,29 @@ static void data_callback(const char *key, const char *value)
                          opal_argv_count(options_data[parse_options_idx].libs_static), values);
         opal_argv_free(values);
     } else if (0 == strcmp(key, "dyn_lib_file")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].dyn_lib_file = strdup(value);
+        }
     } else if (0 == strcmp(key, "static_lib_file")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].static_lib_file = strdup(value);
+        }
     } else if (0 == strcmp(key, "required_file")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].req_file = strdup(value);
+        }
     } else if (0 == strcmp(key, "project_short")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].project_short = strdup(value);
+        }
     } else if (0 == strcmp(key, "compiler_env")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].compiler_env = strdup(value);
+        }
     } else if (0 == strcmp(key, "compiler_flags_env")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].compiler_flags_env = strdup(value);
+        }
     } else if (0 == strcmp(key, "includedir")) {
         if (NULL != value) {
             options_data[parse_options_idx].path_includedir = opal_install_dirs_expand(value);
@@ -340,8 +364,9 @@ static void data_callback(const char *key, const char *value)
             }
         }
     } else if (0 == strcmp(key, "libdir")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].path_libdir = opal_install_dirs_expand(value);
+        }
         if (0 != strcmp(options_data[parse_options_idx].path_libdir, "/usr/lib")) {
             char *line;
             opal_asprintf(&line, OPAL_LIBDIR_FLAG "%s",
@@ -365,8 +390,9 @@ static void data_callback(const char *key, const char *value)
             }
         }
     } else if (0 == strcmp(key, "opallibdir")) {
-        if (NULL != value)
+        if (NULL != value) {
             options_data[parse_options_idx].path_opallibdir = opal_install_dirs_expand(value);
+        }
         if (0 != strcmp(options_data[parse_options_idx].path_opallibdir, "/usr/lib")) {
             char *line;
             opal_asprintf(&line, OPAL_LIBDIR_FLAG "%s",
@@ -385,8 +411,9 @@ static int data_init(const char *appname)
     /* now load the data */
     opal_asprintf(&datafile, "%s%s%s-wrapper-data.txt", opal_install_dirs.opaldatadir,
                   OPAL_PATH_SEP, appname);
-    if (NULL == datafile)
+    if (NULL == datafile) {
         return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
+    }
 
     ret = opal_util_keyval_parse(datafile, data_callback);
     if (OPAL_SUCCESS != ret) {
@@ -416,15 +443,17 @@ static void print_flags(char **args, char *pattern)
 
     for (i = 0; args[i] != NULL; ++i) {
         if (0 == strncmp(args[i], pattern, strlen(pattern))) {
-            if (found)
+            if (found) {
                 printf(" ");
+            }
             printf("%s", args[i] + strlen(pattern));
             found = true;
         }
     }
 
-    if (found)
+    if (found) {
         printf("\n");
+    }
 }
 
 static void load_env_data(const char *project, const char *flag, char **data)
@@ -432,8 +461,9 @@ static void load_env_data(const char *project, const char *flag, char **data)
     char *envname;
     char *envvalue;
 
-    if (NULL == project || NULL == flag)
+    if (NULL == project || NULL == flag) {
         return;
+    }
 
     opal_asprintf(&envname, "%s_MPI%s", project, flag);
     if (NULL == (envvalue = getenv(envname))) {
@@ -446,8 +476,9 @@ static void load_env_data(const char *project, const char *flag, char **data)
     }
     free(envname);
 
-    if (NULL != *data)
+    if (NULL != *data) {
         free(*data);
+    }
     *data = strdup(envvalue);
 }
 
@@ -456,8 +487,9 @@ static void load_env_data_argv(const char *project, const char *flag, char ***da
     char *envname;
     char *envvalue;
 
-    if (NULL == project || NULL == flag)
+    if (NULL == project || NULL == flag) {
         return;
+    }
 
     opal_asprintf(&envname, "%s_MPI%s", project, flag);
     if (NULL == (envvalue = getenv(envname))) {
@@ -470,8 +502,9 @@ static void load_env_data_argv(const char *project, const char *flag, char ***da
     }
     free(envname);
 
-    if (NULL != *data)
+    if (NULL != *data) {
         opal_argv_free(*data);
+    }
 
     *data = opal_argv_split(envvalue, ' ');
 }
@@ -955,8 +988,9 @@ cleanup:
 
     opal_argv_free(exec_argv);
     opal_argv_free(user_argv);
-    if (NULL != base_argv0)
+    if (NULL != base_argv0) {
         free(base_argv0);
+    }
 
     if (OPAL_SUCCESS != (ret = data_finalize())) {
         return ret;

--- a/opal/util/arch.c
+++ b/opal/util/arch.c
@@ -30,11 +30,13 @@ static inline int32_t opal_arch_isbigendian(void)
     int x = 0;
 
     /* if( sizeof(int) == 8 ) x = 4; */
-    if (ptr[x] == 0x12)
+    if (ptr[x] == 0x12) {
         return 1; /* big endian, true */
-    if (ptr[x] == 0x78)
+    }
+    if (ptr[x] == 0x78) {
         return 0; /* little endian, false */
-    assert(0);    /* unknown architecture not little nor big endian */
+    }
+    assert(0); /* unknown architecture not little nor big endian */
     return -1;
 }
 
@@ -82,8 +84,9 @@ int opal_arch_init(void)
     opal_local_arch = (OPAL_ARCH_HEADERMASK | OPAL_ARCH_UNUSEDMASK);
 
     /* Handle the size of long (can hold a pointer) */
-    if (8 == sizeof(long))
+    if (8 == sizeof(long)) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LONGIS64);
+    }
 
     /* sizeof bool */
     if (1 == sizeof(bool)) {
@@ -98,34 +101,39 @@ int opal_arch_init(void)
        abstractions a little less painful... */
 
     /* Initialize the information regarding the long double */
-    if (12 == sizeof(long double))
+    if (12 == sizeof(long double)) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LONGDOUBLEIS96);
-    else if (16 == sizeof(long double))
+    } else if (16 == sizeof(long double)) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LONGDOUBLEIS128);
+    }
 
     /* Big endian or little endian ? That's the question */
-    if (opal_arch_isbigendian())
+    if (opal_arch_isbigendian()) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_ISBIGENDIAN);
+    }
 
     /* What's the maximum exponent ? */
-    if (LDBL_MAX_EXP == 16384)
+    if (LDBL_MAX_EXP == 16384) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDEXPSIZEIS15);
+    }
 
     /* How about the length in bits of the mantissa */
-    if (LDBL_MANT_DIG == 64)
+    if (LDBL_MANT_DIG == 64) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDMANTDIGIS64);
-    else if (LDBL_MANT_DIG == 105)
+    } else if (LDBL_MANT_DIG == 105) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDMANTDIGIS105);
-    else if (LDBL_MANT_DIG == 106)
+    } else if (LDBL_MANT_DIG == 106) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDMANTDIGIS106);
-    else if (LDBL_MANT_DIG == 107)
+    } else if (LDBL_MANT_DIG == 107) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDMANTDIGIS107);
-    else if (LDBL_MANT_DIG == 113)
+    } else if (LDBL_MANT_DIG == 113) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDMANTDIGIS113);
+    }
 
     /* Intel data representation or Sparc ? */
-    if (opal_arch_ldisintel())
+    if (opal_arch_ldisintel()) {
         opal_arch_setmask(&opal_local_arch, OPAL_ARCH_LDISINTEL);
+    }
 
     return OPAL_SUCCESS;
 }
@@ -154,10 +162,12 @@ int32_t opal_arch_checkmask(uint32_t *var, uint32_t mask)
 
             if ((tmpvar & OPAL_ARCH_HEADERMASK) && (!(tmpvar & OPAL_ARCH_HEADERMASK2))) {
                 *var = tmpvar;
-            } else
+            } else {
                 return -1;
-        } else
+            }
+        } else {
             return -1;
+        }
     }
 
     /* Here is the real evaluation of the bitmask */

--- a/opal/util/argv.c
+++ b/opal/util/argv.c
@@ -156,8 +156,9 @@ void opal_argv_free(char **argv)
 {
     char **p;
 
-    if (NULL == argv)
+    if (NULL == argv) {
         return;
+    }
 
     for (p = argv; NULL != *p; ++p) {
         free(*p);
@@ -192,16 +193,18 @@ static char **opal_argv_split_inter(const char *src_string, int delimiter, int i
         if (src_string == p) {
             if (include_empty) {
                 arg[0] = '\0';
-                if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, arg))
+                if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, arg)) {
                     return NULL;
+                }
             }
         }
 
         /* tail argument, add straight from the original string */
 
         else if ('\0' == *p) {
-            if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, src_string))
+            if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, src_string)) {
                 return NULL;
+            }
             src_string = p;
             continue;
         }
@@ -210,8 +213,9 @@ static char **opal_argv_split_inter(const char *src_string, int delimiter, int i
 
         else if (arglen > (ARGSIZE - 1)) {
             argtemp = (char *) malloc(arglen + 1);
-            if (NULL == argtemp)
+            if (NULL == argtemp) {
                 return NULL;
+            }
 
             opal_string_copy(argtemp, src_string, arglen + 1);
             argtemp[arglen] = '\0';
@@ -230,8 +234,9 @@ static char **opal_argv_split_inter(const char *src_string, int delimiter, int i
             opal_string_copy(arg, src_string, arglen + 1);
             arg[arglen] = '\0';
 
-            if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, arg))
+            if (OPAL_SUCCESS != opal_argv_append(&argc, &argv, arg)) {
                 return NULL;
+            }
         }
 
         src_string = p + 1;
@@ -260,11 +265,13 @@ int opal_argv_count(char **argv)
     char **p;
     int i;
 
-    if (NULL == argv)
+    if (NULL == argv) {
         return 0;
+    }
 
-    for (i = 0, p = argv; *p; i++, p++)
+    for (i = 0, p = argv; *p; i++, p++) {
         continue;
+    }
 
     return i;
 }
@@ -296,8 +303,9 @@ char *opal_argv_join(char **argv, int delimiter)
 
     /* Allocate the string. */
 
-    if (NULL == (str = (char *) malloc(str_len)))
+    if (NULL == (str = (char *) malloc(str_len))) {
         return NULL;
+    }
 
     /* Loop filling in the string. */
 
@@ -392,8 +400,9 @@ size_t opal_argv_len(char **argv)
     char **p;
     size_t length;
 
-    if (NULL == argv)
+    if (NULL == argv) {
         return (size_t) 0;
+    }
 
     length = sizeof(char *);
 
@@ -412,8 +421,9 @@ char **opal_argv_copy(char **argv)
     char **dupv = NULL;
     int dupc = 0;
 
-    if (NULL == argv)
+    if (NULL == argv) {
         return NULL;
+    }
 
     /* create an "empty" list, so that we return something valid if we
        were passed a valid list with no contained elements */
@@ -478,8 +488,9 @@ int opal_argv_delete(int *argc, char ***argv, int start, int num_to_delete)
 
     /* adjust the argv array */
     tmp = (char **) realloc(*argv, sizeof(char *) * (i + 1));
-    if (NULL != tmp)
+    if (NULL != tmp) {
         *argv = tmp;
+    }
 
     /* adjust the argc */
     (*argc) -= num_to_delete;

--- a/opal/util/basename.c
+++ b/opal/util/basename.c
@@ -44,13 +44,15 @@ static inline char *opal_find_last_path_separator(const char *filename, size_t n
 
     /* First skip the latest separators */
     for (; p >= filename; p--) {
-        if (*p != OPAL_PATH_SEP[0])
+        if (*p != OPAL_PATH_SEP[0]) {
             break;
+        }
     }
 
     for (; p >= filename; p--) {
-        if (*p == OPAL_PATH_SEP[0])
+        if (*p == OPAL_PATH_SEP[0]) {
             return p;
+        }
     }
 
     return NULL; /* nothing found inside the filename */

--- a/opal/util/crc.c
+++ b/opal/util/crc.c
@@ -998,10 +998,11 @@ void opal_initialize_crc_table(void)
     for (i = 0; i < 256; i++) {
         crc_accum = (i << 24);
         for (j = 0; j < 8; j++) {
-            if (crc_accum & 0x80000000)
+            if (crc_accum & 0x80000000) {
                 crc_accum = (crc_accum << 1) ^ CRC_POLYNOMIAL;
-            else
+            } else {
                 crc_accum = (crc_accum << 1);
+            }
         }
         _opal_crc_table[i] = crc_accum;
     }

--- a/opal/util/if.c
+++ b/opal/util/if.c
@@ -294,8 +294,9 @@ int opal_ifbegin(void)
     opal_if_t *intf;
 
     intf = (opal_if_t *) opal_list_get_first(&opal_if_list);
-    if (NULL != intf)
+    if (NULL != intf) {
         return intf->if_index;
+    }
     return (-1);
 }
 
@@ -507,9 +508,11 @@ static int parse_ipv4_dots(const char *addr, uint32_t *net, int *dots)
             return OPAL_ERR_NETWORK_NOT_PARSEABLE;
         }
         /* skip all the . */
-        for (start = end; '\0' != *start; start++)
-            if ('.' != *start)
+        for (start = end; '\0' != *start; start++) {
+            if ('.' != *start) {
                 break;
+            }
+        }
     }
     *dots = i;
     *net = OPAL_IF_ASSEMBLE_NETWORK(n[0], n[1], n[2], n[3]);

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -318,8 +318,9 @@ bool opal_net_addr_isipv4public(const struct sockaddr *addr)
         for (i = 0; private_ipv4[i].addr != 0; i++) {
             if (private_ipv4[i].addr
                 == (inaddr->sin_addr.s_addr
-                    & opal_net_prefix2netmask(private_ipv4[i].netmask_bits)))
+                    & opal_net_prefix2netmask(private_ipv4[i].netmask_bits))) {
                 return false;
+            }
         }
     }
         return true;

--- a/opal/util/numtostr.c
+++ b/opal/util/numtostr.c
@@ -30,8 +30,9 @@ char *opal_ltostr(long num)
     int ret = 0;
 
     buf = (char *) malloc(sizeof(char) * buflen);
-    if (NULL == buf)
+    if (NULL == buf) {
         return NULL;
+    }
 
     ret = snprintf(buf, buflen, "%ld", num);
     if (ret < 0) {
@@ -50,8 +51,9 @@ char *opal_dtostr(double num)
     int ret = 0;
 
     buf = (char *) malloc(sizeof(char) * buflen);
-    if (NULL == buf)
+    if (NULL == buf) {
         return NULL;
+    }
 
     ret = snprintf(buf, buflen, "%f", num);
     if (ret < 0) {

--- a/opal/util/opal_environ.c
+++ b/opal/util/opal_environ.c
@@ -229,13 +229,15 @@ int opal_unsetenv(const char *name, char ***env)
 
     found = false;
     for (i = 0; (*env)[i] != NULL; ++i) {
-        if (0 != strncmp((*env)[i], compare, len))
+        if (0 != strncmp((*env)[i], compare, len)) {
             continue;
+        }
         if (environ != *env) {
             free((*env)[i]);
         }
-        for (; (*env)[i] != NULL; ++i)
+        for (; (*env)[i] != NULL; ++i) {
             (*env)[i] = (*env)[i + 1];
+        }
         found = true;
         break;
     }
@@ -250,10 +252,13 @@ const char *opal_tmp_directory(void)
 {
     const char *str;
 
-    if (NULL == (str = getenv("TMPDIR")))
-        if (NULL == (str = getenv("TEMP")))
-            if (NULL == (str = getenv("TMP")))
+    if (NULL == (str = getenv("TMPDIR"))) {
+        if (NULL == (str = getenv("TEMP"))) {
+            if (NULL == (str = getenv("TMP"))) {
                 str = OPAL_DEFAULT_TMPDIR;
+            }
+        }
+    }
     return str;
 }
 

--- a/opal/util/os_path.c
+++ b/opal/util/os_path.c
@@ -49,8 +49,9 @@ char *opal_os_path(int relative, ...)
     while (NULL != (element = va_arg(ap, char *))) {
         num_elements++;
         total_length = total_length + strlen(element);
-        if (path_sep[0] != element[0])
+        if (path_sep[0] != element[0]) {
             total_length++;
+        }
     }
     va_end(ap);
 

--- a/opal/util/path.c
+++ b/opal/util/path.c
@@ -202,8 +202,9 @@ char *opal_path_findv(char *fname, int mode, char **envv, char *wrkdir)
         opal_argv_append(&dirc, &dirv, wrkdir);
     }
 
-    if (NULL == dirv)
+    if (NULL == dirv) {
         return NULL;
+    }
     fullpath = opal_path_find(fname, dirv, mode, envv);
     opal_argv_free(dirv);
     return fullpath;
@@ -393,8 +394,9 @@ char *opal_find_absolute_path(char *app_name)
     if (NULL != abs_app_name) {
         char *resolved_path = (char *) malloc(OPAL_PATH_MAX);
         realpath(abs_app_name, resolved_path);
-        if (abs_app_name != app_name)
+        if (abs_app_name != app_name) {
             free(abs_app_name);
+        }
         return resolved_path;
     }
     return NULL;

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -111,8 +111,9 @@ int opal_proc_local_set(opal_proc_t *proc)
     if (proc != opal_proc_my_name) {
         if (NULL != proc)
             OBJ_RETAIN(proc);
-        if (&opal_local_proc != opal_proc_my_name)
+        if (&opal_local_proc != opal_proc_my_name) {
             OBJ_RELEASE(opal_proc_my_name);
+        }
         if (NULL != proc) {
             opal_proc_my_name = proc;
         } else {


### PR DESCRIPTION
To match Open MPI style guidelines all control statements must use braces
even if they have a single statement. This commit fixes all sources that
compile on macOS (limitation of clang-tidy that sources need to be
compilable) in the opal subdir to match this guideline.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit 5c6c7ff007ad048e83a3f203acc683c0c1790984)