### PR TITLE
orted-mpir: add version to shared library

### DIFF
--- a/orte/orted/orted-mpir/Makefile.am
+++ b/orte/orted/orted-mpir/Makefile.am
@@ -15,7 +15,7 @@
 
 CFLAGS = $(CFLAGS_WITHOUT_OPTFLAGS) $(DEBUGGER_CFLAGS)
 
-lib_LTLIBRARIES = lib@ORTE_LIB_PREFIX@open-orted-mpir.la
+noinst_LTLIBRARIES = lib@ORTE_LIB_PREFIX@open-orted-mpir.la
 lib@ORTE_LIB_PREFIX@open_orted_mpir_la_SOURCES = \
         orted_mpir_breakpoint.c \
         orted_mpir.h


### PR DESCRIPTION
Because orted-mpir is installed in the public library direrctory, it should have a version. Assign the library libopen_rte_so_version to be consistent with the rest of the RTE.

This is important, *e.g.*, for Void Linux, which tracks shared library versions to avoid broken dependencies. Void splits the core libraries into a `libopenmpi` package so other packages can link against it and avoid pulling in the entire OpenMPI runtime should users not with to use the capability. The runtime modules in `/usr/lib/opempi` are shipped with the broader `openmpi` package, and the  package system must track the `libopen-orted-mpir.so` dependency between these two packages at least.

This may need backporting to `v4.0.x` and earlier.

bot:notacherrypick