### PR TITLE
MPI_Sendrecv_replace: add missing error handling

### DIFF
--- a/ompi/mpi/c/sendrecv_replace.c
+++ b/ompi/mpi/c/sendrecv_replace.c
@@ -114,7 +114,7 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
 
-    /* initialize convertor to unpack recv buffer */
+    /* initialize convertor to pack send buffer */
     OBJ_CONSTRUCT(&convertor, opal_convertor_t);
     opal_convertor_copy_and_prepare_for_send( proc->super.proc_convertor, &(datatype->super),
                                               count, buf, 0, &convertor );
@@ -132,6 +132,9 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
     max_data = packed_size;
     iov_count = 1;
     rc = opal_convertor_pack(&convertor, &iov, &iov_count, &max_data);
+    if(OMPI_SUCCESS != rc) {
+        goto cleanup_and_return;
+    }
 
     /* receive into the buffer */
     rc = MCA_PML_CALL(irecv(buf, count, datatype,


### PR DESCRIPTION
and fix a comment

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>