### PR TITLE
Improvements to MPI_Test and friends

### DIFF
--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -346,6 +346,7 @@ int ompi_request_default_test_some(
         }
         if( REQUEST_COMPLETE(request) ) {
             indices[num_requests_done++] = i;
+            continue;
         }
 #if OPAL_ENABLE_FT_MPI
         /* Check for dead requests due to process failure */

--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -35,7 +35,7 @@ int ompi_request_default_test(ompi_request_t ** rptr,
 #if OPAL_ENABLE_PROGRESS_THREADS == 0
     int do_it_once = 0;
 
- recheck_request_status:
+recheck_request_status:
 #endif
     opal_atomic_mb();
     if( request->req_state == OMPI_REQUEST_INACTIVE ) {
@@ -94,9 +94,10 @@ int ompi_request_default_test(ompi_request_t ** rptr,
          * If we run the opal_progress then check the status of the request before
          * leaving. We will call the opal_progress only once per call.
          */
-        opal_progress();
-        do_it_once++;
-        goto recheck_request_status;
+        ++do_it_once;
+        if (0 != opal_progress()) {
+            goto recheck_request_status;
+        }
     }
 #endif
     *completed = false;

--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -202,15 +202,15 @@ int ompi_request_default_test_all(
     ompi_request_t **rptr;
     size_t num_completed = 0;
     ompi_request_t *request;
+    int do_it_once = 0;
 
     opal_atomic_mb();
-    rptr = requests;
-    for (i = 0; i < count; i++, rptr++) {
-        request = *rptr;
+    for (i = 0; i < count; i++) {
+        request = requests[i];
 
-        if( request->req_state == OMPI_REQUEST_INACTIVE ||
-            REQUEST_COMPLETE(request) ) {
+        if( request->req_state == OMPI_REQUEST_INACTIVE || REQUEST_COMPLETE(request) ) {
             num_completed++;
+            continue;
         }
 #if OPAL_ENABLE_FT_MPI
         /* Check for dead requests due to process failure */
@@ -225,13 +225,22 @@ int ompi_request_default_test_all(
             return MPI_ERR_PROC_FAILED_PENDING;
         }
 #endif /* OPAL_ENABLE_FT_MPI */
+#if OPAL_ENABLE_PROGRESS_THREADS == 0
+        if (0 == do_it_once) {
+            ++do_it_once;
+            if (0 != opal_progress()) {
+                /* continue walking the list, retest the current request */
+                --i;
+                continue;
+            }
+        }
+#endif /* OPAL_ENABLE_PROGRESS_THREADS */
+        /* short-circuit */
+        break;
     }
 
     if (num_completed != count) {
         *completed = false;
-#if OPAL_ENABLE_PROGRESS_THREADS == 0
-        opal_progress();
-#endif
         return OMPI_SUCCESS;
     }
 

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -213,7 +213,7 @@ static int opal_progress_events(void)
  * care, as the cost of that happening is far outweighed by the cost
  * of the if checks (they were resulting in bad pipe stalling behavior)
  */
-void opal_progress(void)
+int opal_progress(void)
 {
     static uint32_t num_calls = 0;
     size_t i;
@@ -250,6 +250,8 @@ void opal_progress(void)
          */
         opal_thread_yield();
     }
+
+    return events;
 }
 
 int opal_progress_set_event_flag(int flag)

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -57,8 +57,10 @@ OPAL_DECLSPEC int opal_progress_init(void);
  * opal_progress_event_users_delete()) or the time since the last call
  * into the event library is greater than the progress tick rate (by
  * default, 10ms).
+ *
+ * Returns 0 if no progress has been observed, non-zero otherwise.
  */
-OPAL_DECLSPEC void opal_progress(void);
+OPAL_DECLSPEC int opal_progress(void);
 
 /**
  * Control how the event library is called


### PR DESCRIPTION
This PR is an attempt to improve MPI_Test and friends after I started looking through the code in the context of an application using `MPI_Testsome`. The main issue I'm trying to address is that the test functions invoke the progress engine and return immediately, without rechecking the requests. The typical use-case for `MPI_Test*` is to hide communication latencies by performing other operations until the requests are complete. By not checking whether a call to `opal_progress` changed the state of requests we're forcing applications into another round-trip, potentially adding latency until they can react to completed operations. And then they will need to be checked anyway...

The changes are as follows;

1) Have `opal_progress()` return the number of events it counted from the invocation of the progress callbacks. This is helpful for upper layers to estimate whether the state of some operations *may* have changed.
2) `MPI_Test`: only recheck the request if `opal_progress()` reported an event happened, no need to recheck otherwise.
3) `MPI_Testall`: when encountering an incomplete request, invoke `opal_progress()` immediately and (if `opal_progress()` signaled some completion) continue walking the list of requests. If another incomplete request is found we can bail out immediately, without running until the end of the list.
4) `MPI_Testsome`: similar to `MPI_Testall`, invoke `opal_progress()` when encountering the first incomplete request but continue walking the list of requests, collecting all requests that are complete. Current behavior of `MPI_Testsome` is to not trigger progress if there is at least one complete request, potentially delaying the progress of other operations (nonblocking collectives for example, which require calls into the progress engine).
5) `MPI_Testany`: call into `opal_progress` if no complete request was found and recheck the list if a state change might have occurred. If a complete request is found, progress is not triggered. I'm not sure whether this is a good idea or not but without traversing the full list of request we won't know whether or not progress is necessary. 

I split the changes to each function into individual commits for easier review. In addition to the changes above, I also tried to avoid redundant checks such as checking for a failed request if the request was found to be complete or inactive.
