### PR TITLE
fix MPI_Sendrecv_replace

### DIFF
--- a/ompi/mpi/c/sendrecv_replace.c
+++ b/ompi/mpi/c/sendrecv_replace.c
@@ -131,10 +131,7 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
     }
     max_data = packed_size;
     iov_count = 1;
-    rc = opal_convertor_pack(&convertor, &iov, &iov_count, &max_data);
-    if(OMPI_SUCCESS != rc) {
-        goto cleanup_and_return;
-    }
+    (void)opal_convertor_pack(&convertor, &iov, &iov_count, &max_data);
 
     /* receive into the buffer */
     rc = MCA_PML_CALL(irecv(buf, count, datatype,


### PR DESCRIPTION
do ignore the status returned by opal_convertor_pack()
since it is *not* MPI_SUCCESS in case of success.

This fixes a regression introduced in open-mpi/ompi@0b3819020971d55c0bd8084f16d9d9eac089fa0e

Refs. open-mpi/ompi#8907

Thanks Lisandro Dalcin for reporting this issue.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>