### PR TITLE
v5.0.x: Fix opal_progress.h copyright header.

### DIFF
--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -1,34 +1,27 @@
-/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */ /*
-                                                                * Copyright (c) 2004-2005 The
-                                                                * Trustees of Indiana University and
-                                                                * Indiana University Research and
-                                                                * Technology Corporation.  All
-                                                                * rights reserved. Copyright (c)
-                                                                * 2004-2006 The University of
-                                                                * Tennessee and The University of
-                                                                * Tennessee Research Foundation. All
-                                                                * rights reserved. Copyright (c)
-                                                                * 2004-2005 High Performance
-                                                                * Computing Center Stuttgart,
-                                                                *                         University
-                                                                * of Stuttgart.  All rights
-                                                                * reserved. Copyright (c) 2004-2005
-                                                                * The Regents of the University of
-                                                                * California. All rights reserved.
-                                                                * Copyright (c) 2006-2014 Los Alamos
-                                                                * National Security, LLC.  All
-                                                                * rights reserved. Copyright (c)
-                                                                * 2018      Triad National Security,
-                                                                * LLC. All rights reserved.
-                                                                *
-                                                                * Copyright (c) 2020      Intel,
-                                                                * Inc.  All rights reserved.
-                                                                * $COPYRIGHT$
-                                                                *
-                                                                * Additional copyrights may follow
-                                                                *
-                                                                * $HEADER$
-                                                                */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2014 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
 
 /**
  * @file


### PR DESCRIPTION
Fix regression from the opal formatting changes
(4c4d5206fa1369a185cd13ee0db548c475f43c9a) that put the copyright headers into a bad state.

Fixes https://github.com/open-mpi/ompi/issues/8868

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 00d61d081781db04c4919f7dbd8e02cde03794a5)