### PR TITLE
master: portals4: fix include ordering and blocking

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -19,22 +19,25 @@
 
 #include "ompi_config.h"
 
-#include <portals4.h>
-#include "mpi.h"
+//#include "mpi.h"
+
+#include "opal/datatype/opal_convertor.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "ompi/op/op.h"
 #include "ompi/mca/mca.h"
-#include "opal/datatype/opal_convertor.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/request/request.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
+
+#include <portals4.h>
 
 #include "ompi/mca/mtl/portals4/mtl_portals4.h"
+#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
 
 #define MAXTREEFANOUT 32
 

--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -12,20 +12,23 @@
  */
 
 #include "ompi_config.h"
-#include "coll_portals4.h"
-#include "coll_portals4_request.h"
 
 #include <stdio.h>
 
-#include "mpi.h"
+//#include "mpi.h"
+
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "ompi/op/op.h"
-#include "opal/util/bit_ops.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+
+#include "coll_portals4.h"
+#include "coll_portals4_request.h"
 
 
 #define COLL_PORTALS4_ALLREDUCE_MAX_SEGMENT	128

--- a/ompi/mca/coll/portals4/coll_portals4_barrier.c
+++ b/ompi/mca/coll/portals4/coll_portals4_barrier.c
@@ -11,18 +11,19 @@
  * $HEADER$
  */
 
-
 #include "ompi_config.h"
 
-#include "coll_portals4.h"
-#include "coll_portals4_request.h"
+//#include "mpi.h"
 
-#include "mpi.h"
-#include "ompi/constants.h"
 #include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+
+#include "coll_portals4.h"
+#include "coll_portals4_request.h"
 
 
 static int

--- a/ompi/mca/coll/portals4/coll_portals4_bcast.c
+++ b/ompi/mca/coll/portals4/coll_portals4_bcast.c
@@ -10,16 +10,18 @@
 
 #include "ompi_config.h"
 
-#include "coll_portals4.h"
-#include "coll_portals4_request.h"
+//#include "mpi.h"
 
-#include "mpi.h"
-#include "ompi/constants.h"
 #include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/datatype/ompi_datatype.h"
+
+#include "coll_portals4.h"
+#include "coll_portals4_request.h"
 
 /*
  * the bcast communication is based on 1 to N scheme

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -24,14 +24,15 @@
 
 #include "ompi_config.h"
 
-#include "coll_portals4.h"
-#include "coll_portals4_request.h"
+//#include "mpi.h"
 
-#include "mpi.h"
 #include "ompi/op/op.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+
+#include "coll_portals4.h"
+#include "coll_portals4_request.h"
 
 #define REQ_COLL_TABLE_ID           15
 #define REQ_COLL_FINISH_TABLE_ID    16

--- a/ompi/mca/coll/portals4/coll_portals4_gather.c
+++ b/ompi/mca/coll/portals4/coll_portals4_gather.c
@@ -7,13 +7,14 @@
  * $HEADER$
  */
 
-
 #include "ompi_config.h"
 
-#include "mpi.h"
+//#include "mpi.h"
+
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "opal/util/bit_ops.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"

--- a/ompi/mca/coll/portals4/coll_portals4_reduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_reduce.c
@@ -12,20 +12,23 @@
  */
 
 #include "ompi_config.h"
-#include "coll_portals4.h"
-#include "coll_portals4_request.h"
 
-#include <stdio.h>
+//#include <stdio.h>
 
-#include "mpi.h"
+//#include "mpi.h"
+
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "ompi/op/op.h"
-#include "opal/util/bit_ops.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+
+#include "coll_portals4.h"
+#include "coll_portals4_request.h"
 
 #define COLL_PORTALS4_REDUCE_MAX_CHILDREN	2
 

--- a/ompi/mca/coll/portals4/coll_portals4_request.h
+++ b/ompi/mca/coll/portals4/coll_portals4_request.h
@@ -13,7 +13,10 @@
 #ifndef COLL_PORTALS4_REQUEST_H
 #define COLL_PORTALS4_REQUEST_H
 
+#include "ompi_config.h"
+
 #include "ompi/request/request.h"
+
 #include "coll_portals4.h"
 
 

--- a/ompi/mca/coll/portals4/coll_portals4_scatter.c
+++ b/ompi/mca/coll/portals4/coll_portals4_scatter.c
@@ -7,13 +7,14 @@
  * $HEADER$
  */
 
-
 #include "ompi_config.h"
 
-#include "mpi.h"
+//#include "mpi.h"
+
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "opal/util/bit_ops.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"

--- a/ompi/mca/mtl/portals4/mtl_portals4.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4.c
@@ -20,13 +20,12 @@
 
 #include "ompi_config.h"
 
-#include <portals4.h>
+#include "opal/class/opal_list.h"
+#include "opal/mca/pmix/pmix-internal.h"
 
 #include "ompi/communicator/communicator.h"
 #include "ompi/proc/proc.h"
 #include "ompi/mca/mtl/mtl.h"
-#include "opal/class/opal_list.h"
-#include "opal/mca/pmix/pmix-internal.h"
 
 #include "mtl_portals4.h"
 #include "mtl_portals4_recv_short.h"

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -20,17 +20,19 @@
 #ifndef MTL_PORTALS_H_HAS_BEEN_INCLUDED
 #define MTL_PORTALS_H_HAS_BEEN_INCLUDED
 
-#include <portals4.h>
+#include "ompi_config.h"
 
 #include "opal/include/opal_config.h"
 #include "opal/class/opal_free_list.h"
 #include "opal/class/opal_list.h"
 #include "opal/datatype/opal_convertor.h"
+
 #include "ompi/proc/proc.h"
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
-
 #include "ompi/communicator/communicator.h"
+
+#include <portals4.h>
 
 #include "mtl_portals4_flowctl.h"
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_cancel.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_cancel.c
@@ -9,11 +9,8 @@
 
 #include "ompi_config.h"
 
-#include <portals4.h>
-
 #include "mtl_portals4.h"
 #include "mtl_portals4_request.h"
-
 
 int
 ompi_mtl_portals4_cancel(struct mca_mtl_base_module_t* mtl,

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -29,11 +29,12 @@
 #include "opal/util/output.h"
 #include "opal/mca/pmix/pmix-internal.h"
 
-#include "mtl_portals4.h"
-#include "mtl_portals4_request.h"
-#include "mtl_portals4_recv_short.h"
-#include "mtl_portals4_message.h"
 #include "ompi/runtime/mpiruntime.h"
+
+#include "mtl_portals4.h"
+#include "mtl_portals4_message.h"
+#include "mtl_portals4_recv_short.h"
+#include "mtl_portals4_request.h"
 
 static int param_priority;
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
@@ -20,8 +20,11 @@
 #ifndef OMPI_MTL_PORTALS_ENDPOINT_H
 #define OMPI_MTL_PORTALS_ENDPOINT_H
 
+#include "ompi_config.h"
+
 #include "ompi/mca/pml/pml.h"
-#include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
+#include "mtl_portals4.h"
 
 struct mca_mtl_base_endpoint_t {
     ptl_process_t ptl_proc;

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
@@ -10,8 +10,11 @@
 #ifndef MTL_PORTALS_FLOWCTL_H
 #define MTL_PORTALS_FLOWCTL_H
 
+#include "ompi_config.h"
+
 #include "opal/class/opal_free_list.h"
 
+#include "mtl_portals4.h"
 #include "mtl_portals4_request.h"
 
 struct mca_mtl_base_endpoint_t;

--- a/ompi/mca/mtl/portals4/mtl_portals4_message.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_message.h
@@ -13,6 +13,11 @@
 #ifndef MTL_PORTALS4_MESSAGE_H
 #define MTL_PORTALS4_MESSAGE_H
 
+#include "ompi_config.h"
+
+#include "opal/class/opal_free_list.h"
+
+
 struct ompi_mtl_portals4_message_t {
     opal_free_list_item_t super;
     ptl_event_t ev;

--- a/ompi/mca/mtl/portals4/mtl_portals4_probe.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_probe.c
@@ -18,13 +18,14 @@
  */
 
 #include "ompi_config.h"
+
 #include "ompi/communicator/communicator.h"
 #include "ompi/message/message.h"
 
 #include "mtl_portals4.h"
 #include "mtl_portals4_endpoint.h"
-#include "mtl_portals4_request.h"
 #include "mtl_portals4_message.h"
+#include "mtl_portals4_request.h"
 
 static int
 completion_fn(ptl_event_t *ev, ompi_mtl_portals4_base_request_t *ptl_base_request)

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -21,19 +21,20 @@
 #include "ompi_config.h"
 
 #include "opal/class/opal_list.h"
+#include "opal/datatype/opal_convertor.h"
+#include "opal/mca/timer/base/base.h"
+
 #include "ompi/communicator/communicator.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "opal/datatype/opal_convertor.h"
 #include "ompi/mca/mtl/base/base.h"
 #include "ompi/mca/mtl/base/mtl_base_datatype.h"
 #include "ompi/message/message.h"
-#include "opal/mca/timer/base/base.h"
 
 #include "mtl_portals4.h"
 #include "mtl_portals4_endpoint.h"
-#include "mtl_portals4_request.h"
-#include "mtl_portals4_recv_short.h"
 #include "mtl_portals4_message.h"
+#include "mtl_portals4_recv_short.h"
+#include "mtl_portals4_request.h"
 
 
 static int

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
@@ -17,7 +17,6 @@
  * $HEADER$
  */
 
-
 #include "ompi_config.h"
 
 #include "ompi/constants.h"

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv_short.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv_short.h
@@ -20,6 +20,9 @@
 #ifndef OMPI_MTL_PORTALS_RECV_SHORT_H
 #define OMPI_MTL_PORTALS_RECV_SHORT_H
 
+#include "ompi_config.h"
+
+#include "mtl_portals4.h"
 #include "mtl_portals4_request.h"
 
 struct ompi_mtl_portals4_recv_short_block_t {

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -20,9 +20,12 @@
 #ifndef OMPI_MTL_PORTALS_REQUEST_H
 #define OMPI_MTL_PORTALS_REQUEST_H
 
+#include "ompi_config.h"
+
 #include "opal/datatype/opal_convertor.h"
-#include "ompi/mca/mtl/mtl.h"
 #include "opal/mca/timer/base/base.h"
+
+#include "ompi/mca/mtl/mtl.h"
 
 struct ompi_mtl_portals4_message_t;
 struct ompi_mtl_portals4_pending_request_t;

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -22,14 +22,16 @@
 
 #include "ompi_config.h"
 
-#include "ompi/communicator/communicator.h"
 #include "opal/datatype/opal_convertor.h"
+
+#include "ompi/communicator/communicator.h"
 #include "ompi/mca/mtl/base/base.h"
 #include "ompi/mca/mtl/base/mtl_base_datatype.h"
 
 #include "mtl_portals4.h"
 #include "mtl_portals4_endpoint.h"
 #include "mtl_portals4_request.h"
+
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
 #include "mtl_portals4_flowctl.h"
 #endif

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -16,9 +16,10 @@
 #ifndef OSC_PORTALS4_PORTALS4_H
 #define OSC_PORTALS4_PORTALS4_H
 
-#include <portals4.h>
 #include "ompi/group/group.h"
 #include "ompi/communicator/communicator.h"
+
+#include <portals4.h>
 
 #include "ompi/mca/mtl/portals4/mtl_portals4.h"
 

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -24,8 +24,7 @@
 #ifndef BTL_PORTALS_H_HAS_BEEN_INCLUDED
 #define BTL_PORTALS_H_HAS_BEEN_INCLUDED
 
-#include <btl_portals4_frag.h>
-#include <portals4.h>
+#include "opal_config.h"
 
 #include "opal/class/opal_free_list.h"
 #include "opal/class/opal_list.h"
@@ -33,6 +32,10 @@
 #include "opal/mca/btl/base/base.h"
 #include "opal/mca/btl/base/btl_base_error.h"
 #include "opal/mca/btl/btl.h"
+
+#include <portals4.h>
+
+#include "btl_portals4_frag.h"
 
 BEGIN_C_DECLS
 

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -38,7 +38,6 @@
 #include "btl_portals4.h"
 #include "btl_portals4_frag.h"
 #include "btl_portals4_recv.h"
-#include "portals4.h"
 
 static int mca_btl_portals4_component_register(void);
 static int mca_btl_portals4_component_open(void);
@@ -638,7 +637,7 @@ int mca_btl_portals4_component_progress(void)
 
                 OPAL_OUTPUT_VERBOSE((50, opal_btl_base_framework.framework_output,
                                      "PTL_EVENT_PUT: tag=%x base_descriptor=%p cbfunc: %lx\n", tag,
-                                     (void *) &btl_base_descriptor, (uint64_t) reg->cbfunc));
+                                     (void *) &recv_descriptor, (uint64_t) reg->cbfunc));
                 reg->cbfunc(&portals4_btl->super, &recv_descriptor);
 
                 goto done;

--- a/opal/mca/btl/portals4/btl_portals4_endpoint.h
+++ b/opal/mca/btl/portals4/btl_portals4_endpoint.h
@@ -21,6 +21,8 @@
 #ifndef OPAL_BTL_PORTALS4_ENDPOINT_H
 #define OPAL_BTL_PORTALS4_ENDPOINT_H
 
+#include "opal_config.h"
+
 #include "btl_portals4.h"
 
 BEGIN_C_DECLS

--- a/opal/mca/btl/portals4/btl_portals4_frag.h
+++ b/opal/mca/btl/portals4/btl_portals4_frag.h
@@ -23,6 +23,8 @@
 #ifndef OPAL_BTL_PORTALS4_FRAG_H
 #define OPAL_BTL_PORTALS4_FRAG_H
 
+#include "opal_config.h"
+
 #include "opal/mca/btl/btl.h"
 
 BEGIN_C_DECLS

--- a/opal/mca/btl/portals4/btl_portals4_rdma.c
+++ b/opal/mca/btl/portals4/btl_portals4_rdma.c
@@ -19,8 +19,10 @@
  */
 
 #include "opal_config.h"
-#include "btl_portals4.h"
+
 #include "opal/constants.h"
+
+#include "btl_portals4.h"
 
 int mca_btl_portals4_put(struct mca_btl_base_module_t *btl_base,
                          struct mca_btl_base_endpoint_t *btl_peer,

--- a/opal/mca/btl/portals4/btl_portals4_recv.h
+++ b/opal/mca/btl/portals4/btl_portals4_recv.h
@@ -20,6 +20,8 @@
 #ifndef OPAL_BTL_PORTALS4_RECV_H
 #define OPAL_BTL_PORTALS4_RECV_H
 
+#include "opal_config.h"
+
 #include "btl_portals4_frag.h"
 
 struct mca_btl_portals4_recv_block_t {


### PR DESCRIPTION
After running clang-format in #8647 and #8816, the `portals4.h` header was moved after the Portals4 component includes which caused compilation failures.  This PR reorders the headers to be correct and puts `portals4.h` in its own header block before the Portals4 component headers.

This PR fixes the ordering in portals4-btl and preemptively fixes portals4-mtl, portals4-coll and portals4-osc.  Our clang-format configuration only reorders within header blocks so the headers should stay in the correct order when clang-format is run on the ompi hierarchy.
