### PR TITLE
mtl/psm2: provide option to disable psm2 REFCNT check

### DIFF
--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -43,6 +43,10 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
 				    [Search for PSM (Intel PSM2) libraries in DIR])])
 	OPAL_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
 
+        AC_ARG_ENABLE([psm2-version-check],
+                  [AC_HELP_STRING([--disable-psm2-version-check],
+                                  [Disable PSM2 version checking.  Not recommended to disable. (default: enabled)])])
+
 	ompi_check_psm2_$1_save_CPPFLAGS="$CPPFLAGS"
 	ompi_check_psm2_$1_save_LDFLAGS="$LDFLAGS"
 	ompi_check_psm2_$1_save_LIBS="$LIBS"

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -16,6 +16,9 @@
  * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2021      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -195,16 +198,21 @@ static int
 ompi_mtl_psm2_component_query(mca_base_module_t **module, int *priority)
 {
 
+#if HAVE_PSM2_LIB_REFCOUNT_CAP
     /*
      * Mixing the PSM2 MTL with the OFI BTL (using PSM2) 
      * can cause an issue when they both call psm2_finalize
      * in older versions of libpsm2.
+     * 
+     * An installer may know what they are doing and disabled
+     * checking psm2 version, hence making this code conditional.
      */
     if (!psm2_get_capability_mask(PSM2_LIB_REFCOUNT_CAP)) {
         opal_output_verbose(2, ompi_mtl_base_framework.framework_output, 
             "This version of the PSM2 MTL needs version 11.2.173 or later of the libpsm2 library for correct operation.\n");
         return OMPI_ERR_FATAL;
     }   
+#endif
 
     /*
      * if we get here it means that PSM2 is available so give high priority


### PR DESCRIPTION
There are cases where customers may have systems where they don't want to upgrade
lower level system software like PSM2 and now can't install OMPI 4.1 and newer
and still have PSM2 MTL support.

This PR provides a way for knowledgable admins to disable the PSM2 version
checking.

related to issue #8381

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit 6e04f3decd20c16f90b41c6818cf566cb583ce07)