### PR TITLE
v5.0.x: coll/base: Fix the error handling in couple of collectives.

### DIFF
--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -474,8 +474,10 @@ int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
         for( ri = 0; ri < nreqs; ri++ ) {
             if (MPI_REQUEST_NULL == reqs[ri]) continue;
             if (MPI_ERR_PENDING == reqs[ri]->req_status.MPI_ERROR) continue;
-            error = reqs[ri]->req_status.MPI_ERROR;
-            break;
+            if (reqs[ri]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                error = reqs[ri]->req_status.MPI_ERROR;
+                break;
+            }
         }
     }
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
@@ -677,8 +679,10 @@ int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
             for( i = 0; i < nreqs; i++ ) {
                 if (MPI_REQUEST_NULL == req[i]) continue;
                 if (MPI_ERR_PENDING == req[i]->req_status.MPI_ERROR) continue;
-                err = req[i]->req_status.MPI_ERROR;
-                break;
+                if (req[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    err = req[i]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         OPAL_OUTPUT( (ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d",

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -281,8 +281,10 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
         for( i = 0; i < nreqs; i++ ) {
             if (MPI_REQUEST_NULL == reqs[i]) continue;
             if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR) continue;
-            err = reqs[i]->req_status.MPI_ERROR;
-            break;
+            if (reqs[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                err = reqs[i]->req_status.MPI_ERROR;
+                break;
+            }
         }
     }
     /* Free the requests in all cases as they are persistent */

--- a/ompi/mca/coll/base/coll_base_barrier.c
+++ b/ompi/mca/coll/base/coll_base_barrier.c
@@ -400,8 +400,10 @@ int ompi_coll_base_barrier_intra_basic_linear(struct ompi_communicator_t *comm,
             for( i = 0; i < size; i++ ) {
                 if (MPI_REQUEST_NULL == requests[i]) continue;
                 if (MPI_ERR_PENDING == requests[i]->req_status.MPI_ERROR) continue;
-                err = requests[i]->req_status.MPI_ERROR;
-                break;
+                if (requests[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    err = requests[i]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         ompi_coll_base_free_reqs(requests, size);

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -218,8 +218,10 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
         for( req_index = 0; req_index < 2; req_index++ ) {
             if (MPI_REQUEST_NULL == recv_reqs[req_index]) continue;
             if (MPI_ERR_PENDING == recv_reqs[req_index]->req_status.MPI_ERROR) continue;
-            err = recv_reqs[req_index]->req_status.MPI_ERROR;
-            break;
+            if (recv_reqs[req_index]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                err = recv_reqs[req_index]->req_status.MPI_ERROR;
+                break;
+            }
         }
     }
     ompi_coll_base_free_reqs( recv_reqs, 2);
@@ -228,8 +230,10 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
             for( req_index = 0; req_index < tree->tree_nextsize; req_index++ ) {
                 if (MPI_REQUEST_NULL == send_reqs[req_index]) continue;
                 if (MPI_ERR_PENDING == send_reqs[req_index]->req_status.MPI_ERROR) continue;
-                err = send_reqs[req_index]->req_status.MPI_ERROR;
-                break;
+                if (send_reqs[req_index]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    err = send_reqs[req_index]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         ompi_coll_base_free_reqs(send_reqs, tree->tree_nextsize);
@@ -679,8 +683,10 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
         for( preq = reqs; preq < reqs+i; preq++ ) {
             if (MPI_REQUEST_NULL == *preq) continue;
             if (MPI_ERR_PENDING == (*preq)->req_status.MPI_ERROR) continue;
-            err = (*preq)->req_status.MPI_ERROR;
-            break;
+            if ((*preq)->req_status.MPI_ERROR != MPI_SUCCESS) {
+                err = (*preq)->req_status.MPI_ERROR;
+                break;
+            }
         }
         ompi_coll_base_free_reqs(reqs, i);
     }

--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -331,8 +331,10 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
             for( i = 0; i < size; i++ ) {
                 if (MPI_REQUEST_NULL == reqs[i]) continue;
                 if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR) continue;
-                ret = reqs[i]->req_status.MPI_ERROR;
-                break;
+                if (reqs[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    ret = reqs[i]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         ompi_coll_base_free_reqs(reqs, size);

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -343,8 +343,10 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
         for( i = 0; i < 2; i++ ) {
             if (MPI_REQUEST_NULL == reqs[i]) continue;
             if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR) continue;
-            ret = reqs[i]->req_status.MPI_ERROR;
-            break;
+            if (reqs[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                ret = reqs[i]->req_status.MPI_ERROR;
+                break;
+            }
         }
     }
     ompi_coll_base_free_reqs(reqs, 2);
@@ -353,8 +355,10 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
             for( i = 0; i < max_outstanding_reqs; i++ ) {
                 if (MPI_REQUEST_NULL == sreq[i]) continue;
                 if (MPI_ERR_PENDING == sreq[i]->req_status.MPI_ERROR) continue;
-                ret = sreq[i]->req_status.MPI_ERROR;
-                break;
+                if (sreq[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    ret = sreq[i]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         ompi_coll_base_free_reqs(sreq, max_outstanding_reqs);

--- a/ompi/mca/coll/base/coll_base_scatter.c
+++ b/ompi/mca/coll/base/coll_base_scatter.c
@@ -377,8 +377,10 @@ err_hndl:
             for (i = 0; i < nreqs; i++) {
                 if (MPI_REQUEST_NULL == reqs[i]) continue;
                 if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR) continue;
-                err = reqs[i]->req_status.MPI_ERROR;
-                break;
+                if (reqs[i]->req_status.MPI_ERROR != MPI_SUCCESS) {
+                    err = reqs[i]->req_status.MPI_ERROR;
+                    break;
+                }
             }
         }
         ompi_coll_base_free_reqs(reqs, nreqs);


### PR DESCRIPTION
In the error handling of ompi_coll_base_alltoallv_intra_basic_linear,
an ompi request's status could be MPI_SUCCESS, and could be returned,
instead of a real error code.

Add a check against ompi request's req_status.MPI_ERROR to ensure
a real error code is returned.

Other collectives (alltoall, barrier, bcast, gather, reduce, scatter)
had the similar error handling, so apply the change as well.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>