### PR TITLE
v4.1.x: use sync_send mask for ofi_create_recv_tag

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -160,7 +160,7 @@ __opal_attribute_always_inline__ static inline void
 mtl_ofi_create_recv_tag_CQD(uint64_t *match_bits, uint64_t *mask_bits,
                             int comm_id, int tag)
 {
-    *mask_bits  = ompi_mtl_ofi.sync_proto_mask;
+    *mask_bits  = ompi_mtl_ofi.sync_send;
     *match_bits = (uint64_t) comm_id;
     *match_bits = (*match_bits << (MTL_OFI_PROTO_BIT_COUNT
                                 +  MTL_OFI_TAG_BIT_COUNT_DATA));
@@ -229,7 +229,7 @@ __opal_attribute_always_inline__ static inline void
 mtl_ofi_create_recv_tag(uint64_t *match_bits, uint64_t *mask_bits,
                             int comm_id, int source, int tag)
 {
-    *mask_bits  = ompi_mtl_ofi.sync_proto_mask;
+    *mask_bits  = ompi_mtl_ofi.sync_send;
     *match_bits = comm_id;
     *match_bits = (*match_bits << ompi_mtl_ofi.num_bits_source_rank);
 


### PR DESCRIPTION
Related to #8051

The upper 2 bits of an ompi tag encode the synchronize send and
synchronize send ack.
Because the mtl_ofi_create_recv_tag_CQD and mtl_ofi_create_recv_tag
functions both use ompi_mtl_ofi.sync_proto_mask instead of
ompi_mtl_ofi.sync_send when generating their "ignore" masks, they hide
the ack bit, turning the tag into an "any tag receive"

This is an issue because ssend is implemented by doing a send and
receive internally.  So if there happens to be an outstanding posted
receive posted before the ssend, that receive will end up consuming the
internal message intended for the ssend's internal receive.

Updating mtl_ofi_create_recv_tag_CQD and mtl_ofi_create_recv_tag functions
to use ompi_mtl_ofi.sync_send fixes this.

Authored-by: John L. Byrne <john.l.byrne@hpe.com>

Signed-off-by: Harumi Kuno <harumi.kuno@hpe.com>
(cherry picked from commit 18baa5e291623169b5c85e3df7e35906a559bb4e)