### PR TITLE
osc/ucx: Detach dynamic window memory when freeing a window

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -671,6 +671,7 @@ int ompi_osc_ucx_win_detach(struct ompi_win_t *win, const void *base) {
 int ompi_osc_ucx_free(struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret;
+    uint64_t i;
 
     assert(module->lock_count == 0);
     assert(opal_list_is_empty(&module->pending_posts) == true);
@@ -686,6 +687,13 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
+
+   /* MPI_Win_free should detach any memory attached to dynamic windows */
+    for (i = 0; i < module->state.dynamic_win_count; i++) {
+        assert(module->local_dynamic_win_info[i].refcnt == 1);
+        opal_common_ucx_wpmem_free(module->local_dynamic_win_info[i].mem);
+    }
+    module->state.dynamic_win_count = 0;
 
     free(module->addrs);
     free(module->state_addrs);


### PR DESCRIPTION
Refs: https://github.com/open-mpi/ompi/issues/8774
v4.0.x PR: https://github.com/open-mpi/ompi/pull/8922

Memory attached to a dynamic window should be unmapped (deregistered) when a window is freed. Currently, it is done only in win_detach.
