### PR TITLE
Fix a bug in the cherry pick checker

### DIFF
--- a/.github/workflows/git-commit-checks.py
+++ b/.github/workflows/git-commit-checks.py
@@ -186,6 +186,7 @@ def check_cherry_pick(config, repo, commit):
         return GOOD, "skipped (submodules updates)"
 
     non_existent = dict()
+    unmerged = dict()
     found_cherry_pick_line = False
     for match in prog_cp.findall(commit.message):
         found_cherry_pick_line = True
@@ -195,9 +196,11 @@ def check_cherry_pick(config, repo, commit):
             # These errors mean that the git library recognized the
             # hash as a valid commit, but the GitHub Action didn't
             # fetch the entire repo, so we don't have all the meta
-            # data about this commit.  Bottom line: it's a good hash.
-            # So -- no error here.
-            pass
+            # data about this commit. This occurs because the commit
+            # only exists in a pull request on github. Therefore, we
+            # want to fail this commit until the referenced commit
+            # is merged.
+            unmerged[match] = True
         except git.BadName as e:
             # Use a dictionary to track the non-existent hashes, just
             # on the off chance that the same non-existent hash exists
@@ -208,14 +211,26 @@ def check_cherry_pick(config, repo, commit):
 
     # Process the results for this commit
     if found_cherry_pick_line:
-        if len(non_existent) == 0:
+        if len(non_existent) == 0 and len(unmerged) == 0:
             return GOOD, None
-        else:
+        elif len(non_existent) > 0 and len(unmerged) == 0:
             str = f"contains a cherry pick message that refers to non-existent commit"
             if len(non_existent) > 1:
                 str += "s"
             str += ": "
             str += ", ".join(non_existent)
+            return BAD, str
+        elif len(non_existent) == 0 and len(unmerged) > 0:
+            str = f"contains a cherry pick message that refers to unmerged commit"
+            if len(non_existent) > 1:
+                str += "s"
+            str += ": "
+            str += ", ".join(unmerged)
+            return BAD, str
+        else:
+            str = f"contains a cherry pick message that refers to non-existent and unmerged commits"
+            str += ": "
+            str += ", ".join(non_existent + unmerged)
             return BAD, str
 
     else:


### PR DESCRIPTION
The check_cherry_pick function in .github/workflows/git-commit-checks.py
would not function propperly in the case where the commit being checked
is a cherry-pick from a commit that is on an unmerged pull request on
github. This has been resolved, so that the workflow will exit with a
failure unless the referenced commit has been successfully merged.

Signed-off-by: StevenGood154 <steve.good.154@gmail.com>
Signed-off-by: bwiseman77 <brett.wiseman@comcast.net>
Signed-off-by: cvankirk2 <christinenvankirk@gmail.com>