### PR TITLE
io/ompio: fix get_byte_offset for 0-size fview

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -507,6 +507,11 @@ int mca_io_ompio_file_get_byte_offset (ompi_file_t *fh,
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     OPAL_THREAD_LOCK(&fh->f_lock);
+    if ( data->ompio_fh.f_view_size == 0 ) {
+        *disp = 0;
+        OPAL_THREAD_UNLOCK(&fh->f_lock);
+        return OMPI_SUCCESS;
+    }
     temp_offset = (long) data->ompio_fh.f_view_extent *
         (offset*data->ompio_fh.f_etype_size / data->ompio_fh.f_view_size);
     if ( 0 > temp_offset ) {


### PR DESCRIPTION
Handle a file view size of 0 correctly in File_get_byte_offset to avoid
a division by zero problem.

Fixes Issue #8841

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
(cherry picked from commit 873a7fadee711d399cc6328f6b0f069edf6db382)