### PR TITLE
v3.0.x: CI: Fix a bug in the cherry pick checker

### DIFF
--- a/.github/workflows/git-commit-checks.py
+++ b/.github/workflows/git-commit-checks.py
@@ -184,6 +184,7 @@ def check_cherry_pick(config, repo, commit):
         return GOOD, "skipped (submodules updates)"
 
     non_existent = dict()
+    unmerged = dict()
     found_cherry_pick_line = False
     for match in prog_cp.findall(commit.message):
         found_cherry_pick_line = True
@@ -193,9 +194,11 @@ def check_cherry_pick(config, repo, commit):
             # These errors mean that the git library recognized the
             # hash as a valid commit, but the GitHub Action didn't
             # fetch the entire repo, so we don't have all the meta
-            # data about this commit.  Bottom line: it's a good hash.
-            # So -- no error here.
-            pass
+            # data about this commit. This occurs because the commit
+            # only exists in an as-yet unmerged pull request on github. Therefore, we
+            # want to fail this commit until the corresponding pull request
+            # is merged.
+            unmerged[match] = True
         except git.BadName as e:
             # Use a dictionary to track the non-existent hashes, just
             # on the off chance that the same non-existent hash exists
@@ -206,14 +209,26 @@ def check_cherry_pick(config, repo, commit):
 
     # Process the results for this commit
     if found_cherry_pick_line:
-        if len(non_existent) == 0:
+        if len(non_existent) == 0 and len(unmerged) == 0:
             return GOOD, None
-        else:
+        elif len(non_existent) > 0 and len(unmerged) == 0:
             str = f"contains a cherry pick message that refers to non-existent commit"
             if len(non_existent) > 1:
                 str += "s"
             str += ": "
             str += ", ".join(non_existent)
+            return BAD, str
+        elif len(non_existent) == 0 and len(unmerged) > 0:
+            str = f"contains a cherry pick message that refers to a commit that exists, but is in an as-yet unmerged pull request"
+            if len(non_existent) > 1:
+                str += "s"
+            str += ": "
+            str += ", ".join(unmerged)
+            return BAD, str
+        else:
+            str = f"contains a cherry pick message that refers to both non-existent commits and commits that exist but are in as-yet unmerged pull requests"
+            str += ": "
+            str += ", ".join(non_existent + unmerged)
             return BAD, str
 
     else:


### PR DESCRIPTION
The check_cherry_pick() function in .github/workflows/git-commit-checks.py
would incorrectly allow some cherry-pick messages referring to commits that
do not exist in the base repository, specifically when the commit exists only
on a pull request that has not been merged. This has been resolved; the
workflow will exit with a failure unless the referenced commit exists in
the base repository.

Note that this approach only works because all commits are introduced to
the open-mpi/ompi through pull requests from forks.

Signed-off-by: Steven Good <steve.good.154@gmail.com>
Signed-off-by: Brett Wiseman <brett.wiseman@comcast.net>
Signed-off-by: Christine Van Kirk <christinenvankirk@gmail.com>
(cherry picked from commit a641680bc7f0f9365d98acfda6c81c61ef6cf5e8) 