### PR TITLE
OSC/UCX: Use existing mem_recs when unpacking the rkey

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -101,11 +101,6 @@ typedef struct {
     char *mem_addrs;
     int *mem_displs;
 
-    /* A list of mem records
-     * We need to kepp trakc o fallocated memory records so that we can free them at the end
-     * if a thread fails to release the memory record */
-    opal_list_t mem_records;
-
     /* TLS item that allows each thread to
      * store endpoints and rkey arrays
      * for faster access */


### PR DESCRIPTION
Digging through the osc ucx code I noticed a major leak of rkeys everytime the target of RMA operations changes: if the rkey for the target is not found in `opal_common_ucx_tlocal_fetch` a call is made into `opal_common_ucx_tlocal_fetch_spath` (the slow path) where a new memory record is allocated and filled with the rkey of the current target. Of course, that discards any of the previously created rkeys so the process starts over again once the target changes. 

The reason this has not lead to complaints from the UCX library is that all allocated memory records were diligently stored in a list and cleaned up when the memory pool is freed. This PR fixes the rkey allocation and removes that list, which is not needed anymore because all rkeys are destroyed once the thread-local storage used to store the memory record is destroyed.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>