### PR TITLE
OSC/UCX: Use existing mem_recs when unpacking the rkey [5.0.x]

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -101,11 +101,6 @@ typedef struct {
     char *mem_addrs;
     int *mem_displs;
 
-    /* A list of mem records
-     * We need to kepp trakc o fallocated memory records so that we can free them at the end
-     * if a thread fails to release the memory record */
-    opal_list_t mem_records;
-
     /* TLS item that allows each thread to
      * store endpoints and rkey arrays
      * for faster access */


### PR DESCRIPTION
Fix allocation of rkeys to keep using previously unpacked rkeys instead of allocating new memory records on each target change in the UCX osc.

Cherry-pick of https://github.com/open-mpi/ompi/pull/8954 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit ebdc17353c747b72c9a0482f31618ce6b558c1d5)