### PR TITLE
v5.0.x: git-commit-checks.json: force cherry picks

### DIFF
--- a/.github/workflows/git-commit-checks.json
+++ b/.github/workflows/git-commit-checks.json
@@ -1,3 +1,3 @@
 {
-    "cherry pick required" : 0
+    "cherry pick required" : 1
 }


### PR DESCRIPTION
Set git-commit-checks.json to force the use of cherry picks here on
the v5.0.x release branch.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

#8969 caused me to notice that this was not enabled on the v5.0.x branch.

bot:notacherrypick