### PR TITLE
v4.1.x: Add support for FI_CONTEXT2 in OFI MTL and BTL.

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -613,7 +613,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     }
     /* Make sure to get a RDM provider that can do the tagged matching
        interface and local communication and remote communication. */
-    hints->mode               = FI_CONTEXT;
+    hints->mode               = FI_CONTEXT | FI_CONTEXT2;
     hints->ep_attr->type      = FI_EP_RDM;
     hints->caps               = FI_TAGGED | FI_LOCAL_COMM | FI_REMOTE_COMM | FI_DIRECTED_RECV;
     hints->tx_attr->msg_order = FI_ORDER_SAS;

--- a/ompi/mca/mtl/ofi/mtl_ofi_request.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_request.h
@@ -34,7 +34,7 @@ struct ompi_mtl_ofi_request_t {
     ompi_mtl_ofi_request_type_t type;
 
     /** OFI context */
-    struct fi_context ctx;
+    struct fi_context2 ctx;
 
     /** Completion count used by blocking and/or synchronous operations */
     volatile int completion_count;

--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -205,7 +205,7 @@ OBJ_CLASS_DECLARATION(mca_btl_ofi_base_frag_t);
 
 
 struct mca_btl_ofi_completion_context_t {
-    struct fi_context ctx;
+    struct fi_context2 ctx;
     void *comp;
 };
 

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -332,10 +332,9 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     /* ask for capabilities */
     /* TODO: catch the caps here. */
     hints.caps = required_caps;
-    hints.mode = FI_CONTEXT;
 
     /* Ask for completion context */
-    hints.mode = FI_CONTEXT;
+    hints.mode = FI_CONTEXT | FI_CONTEXT2;
 
     hints.fabric_attr = &fabric_attr;
     hints.domain_attr = &domain_attr;


### PR DESCRIPTION
This change reserves more space, allowing the OFI MTL and BTL to work
with both providers that use FI_CONTEXT and those that use FI_CONTEXT2.

Signed-off-by: Michael Heinz <mheinz@cornelisnetworks.com>
(cherry picked from commit 648fb8c18d75ea7c191c66efeae43cde93b6d8a2)