### PR TITLE
master: portals4: eliminate header order dependencies in the Portals4 components

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -19,22 +19,22 @@
 
 #include "ompi_config.h"
 
-#include <portals4.h>
-#include "mpi.h"
+#include "opal/datatype/opal_convertor.h"
+
+#include "ompi/communicator/communicator.h"
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
-#include "ompi/op/op.h"
 #include "ompi/mca/mca.h"
-#include "opal/datatype/opal_convertor.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/request/request.h"
-#include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
-#include "ompi/datatype/ompi_datatype.h"
-#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
 
 #include "ompi/mca/mtl/portals4/mtl_portals4.h"
+#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
+
+#include <portals4.h>
 
 #define MAXTREEFANOUT 32
 

--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -12,21 +12,21 @@
  */
 
 #include "ompi_config.h"
+
+#include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/datatype/ompi_datatype_internal.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/op/op.h"
+
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"
 
 #include <stdio.h>
-
-#include "mpi.h"
-#include "ompi/constants.h"
-#include "ompi/datatype/ompi_datatype.h"
-#include "ompi/datatype/ompi_datatype_internal.h"
-#include "ompi/op/op.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/mca/coll/base/base.h"
-
 
 #define COLL_PORTALS4_ALLREDUCE_MAX_SEGMENT	128
 #define COLL_PORTALS4_ALLREDUCE_MAX_CHILDREN	2

--- a/ompi/mca/coll/portals4/coll_portals4_barrier.c
+++ b/ompi/mca/coll/portals4/coll_portals4_barrier.c
@@ -14,16 +14,15 @@
 
 #include "ompi_config.h"
 
+#include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
+
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"
-
-#include "mpi.h"
-#include "ompi/constants.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/mca/coll/base/base.h"
-
 
 static int
 barrier_hypercube_top(struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/portals4/coll_portals4_bcast.c
+++ b/ompi/mca/coll/portals4/coll_portals4_bcast.c
@@ -10,16 +10,16 @@
 
 #include "ompi_config.h"
 
+#include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
+
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"
-
-#include "mpi.h"
-#include "ompi/constants.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/mca/coll/base/base.h"
-#include "ompi/datatype/ompi_datatype.h"
 
 /*
  * the bcast communication is based on 1 to N scheme

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -24,14 +24,14 @@
 
 #include "ompi_config.h"
 
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/datatype/ompi_datatype_internal.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/op/op.h"
+
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"
-
-#include "mpi.h"
-#include "ompi/op/op.h"
-#include "ompi/datatype/ompi_datatype_internal.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/mca/coll/base/base.h"
 
 #define REQ_COLL_TABLE_ID           15
 #define REQ_COLL_FINISH_TABLE_ID    16

--- a/ompi/mca/coll/portals4/coll_portals4_gather.c
+++ b/ompi/mca/coll/portals4/coll_portals4_gather.c
@@ -10,13 +10,13 @@
 
 #include "ompi_config.h"
 
-#include "mpi.h"
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
 
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"

--- a/ompi/mca/coll/portals4/coll_portals4_reduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_reduce.c
@@ -12,20 +12,21 @@
  */
 
 #include "ompi_config.h"
+
+#include "opal/util/bit_ops.h"
+
+#include "ompi/constants.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/datatype/ompi_datatype_internal.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/op/op.h"
+
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"
 
 #include <stdio.h>
-
-#include "mpi.h"
-#include "ompi/constants.h"
-#include "ompi/datatype/ompi_datatype.h"
-#include "ompi/datatype/ompi_datatype_internal.h"
-#include "ompi/op/op.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
-#include "ompi/mca/coll/base/base.h"
 
 #define COLL_PORTALS4_REDUCE_MAX_CHILDREN	2
 

--- a/ompi/mca/coll/portals4/coll_portals4_request.h
+++ b/ompi/mca/coll/portals4/coll_portals4_request.h
@@ -13,7 +13,10 @@
 #ifndef COLL_PORTALS4_REQUEST_H
 #define COLL_PORTALS4_REQUEST_H
 
+#include "ompi_config.h"
+
 #include "ompi/request/request.h"
+
 #include "coll_portals4.h"
 
 

--- a/ompi/mca/coll/portals4/coll_portals4_scatter.c
+++ b/ompi/mca/coll/portals4/coll_portals4_scatter.c
@@ -10,13 +10,13 @@
 
 #include "ompi_config.h"
 
-#include "mpi.h"
+#include "opal/util/bit_ops.h"
+
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "opal/util/bit_ops.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/pml/pml.h"
 
 #include "coll_portals4.h"
 #include "coll_portals4_request.h"

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -20,19 +20,21 @@
 #ifndef MTL_PORTALS_H_HAS_BEEN_INCLUDED
 #define MTL_PORTALS_H_HAS_BEEN_INCLUDED
 
-#include <portals4.h>
+#include "ompi_config.h"
 
-#include "opal/include/opal_config.h"
 #include "opal/class/opal_free_list.h"
 #include "opal/class/opal_list.h"
 #include "opal/datatype/opal_convertor.h"
-#include "ompi/proc/proc.h"
-#include "ompi/mca/mtl/mtl.h"
-#include "ompi/mca/mtl/base/base.h"
 
 #include "ompi/communicator/communicator.h"
+#include "ompi/mca/mtl/base/base.h"
+#include "ompi/mca/mtl/mtl.h"
+#include "ompi/proc/proc.h"
 
 #include "mtl_portals4_flowctl.h"
+#include "mtl_portals4_request.h"
+
+#include <portals4.h>
 
 BEGIN_C_DECLS
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
@@ -20,8 +20,11 @@
 #ifndef OMPI_MTL_PORTALS_ENDPOINT_H
 #define OMPI_MTL_PORTALS_ENDPOINT_H
 
+#include "ompi_config.h"
+
 #include "ompi/mca/pml/pml.h"
-#include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
+#include "mtl_portals4.h"
 
 struct mca_mtl_base_endpoint_t {
     ptl_process_t ptl_proc;

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
@@ -10,9 +10,14 @@
 #ifndef MTL_PORTALS_FLOWCTL_H
 #define MTL_PORTALS_FLOWCTL_H
 
+#include "ompi_config.h"
+
 #include "opal/class/opal_free_list.h"
 
+#include "mtl_portals4.h"
 #include "mtl_portals4_request.h"
+
+#include <portals4.h>
 
 struct mca_mtl_base_endpoint_t;
 struct ompi_mtl_portals4_isend_request_t;

--- a/ompi/mca/mtl/portals4/mtl_portals4_message.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_message.h
@@ -13,6 +13,10 @@
 #ifndef MTL_PORTALS4_MESSAGE_H
 #define MTL_PORTALS4_MESSAGE_H
 
+#include "ompi_config.h"
+
+#include "mtl_portals4.h"
+
 struct ompi_mtl_portals4_message_t {
     opal_free_list_item_t super;
     ptl_event_t ev;

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv_short.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv_short.h
@@ -20,7 +20,9 @@
 #ifndef OMPI_MTL_PORTALS_RECV_SHORT_H
 #define OMPI_MTL_PORTALS_RECV_SHORT_H
 
-#include "mtl_portals4_request.h"
+#include "ompi_config.h"
+
+#include "mtl_portals4.h"
 
 struct ompi_mtl_portals4_recv_short_block_t {
     opal_list_item_t base;

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -20,9 +20,16 @@
 #ifndef OMPI_MTL_PORTALS_REQUEST_H
 #define OMPI_MTL_PORTALS_REQUEST_H
 
+#include "ompi_config.h"
+
 #include "opal/datatype/opal_convertor.h"
-#include "ompi/mca/mtl/mtl.h"
 #include "opal/mca/timer/base/base.h"
+
+#include "ompi/mca/mtl/mtl.h"
+
+#include "mtl_portals4.h"
+
+#include <portals4.h>
 
 struct ompi_mtl_portals4_message_t;
 struct ompi_mtl_portals4_pending_request_t;

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -16,11 +16,14 @@
 #ifndef OSC_PORTALS4_PORTALS4_H
 #define OSC_PORTALS4_PORTALS4_H
 
-#include <portals4.h>
-#include "ompi/group/group.h"
+#include "ompi_config.h"
+
 #include "ompi/communicator/communicator.h"
+#include "ompi/group/group.h"
 
 #include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
+#include <portals4.h>
 
 #define REQ_OSC_TABLE_ID     4
 

--- a/ompi/mca/osc/portals4/osc_portals4_active_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_active_target.c
@@ -12,9 +12,9 @@
 
 #include "ompi_config.h"
 
-#include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
+#include "ompi/mca/osc/osc.h"
 
 #include "osc_portals4.h"
 

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -14,9 +14,9 @@
 
 #include "ompi_config.h"
 
-#include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
+#include "ompi/mca/osc/osc.h"
 
 #include "osc_portals4.h"
 #include "osc_portals4_request.h"

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -21,9 +21,9 @@
 
 #include "opal/util/printf.h"
 
-#include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
+#include "ompi/mca/osc/osc.h"
 #include "ompi/request/request.h"
 
 #include "osc_portals4.h"

--- a/ompi/mca/osc/portals4/osc_portals4_passive_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_passive_target.c
@@ -12,9 +12,9 @@
 
 #include "ompi_config.h"
 
-#include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
+#include "ompi/mca/osc/osc.h"
 
 #include "osc_portals4.h"
 

--- a/ompi/mca/osc/portals4/osc_portals4_request.c
+++ b/ompi/mca/osc/portals4/osc_portals4_request.c
@@ -9,10 +9,10 @@
 
 #include "ompi_config.h"
 
-#include "ompi/request/request.h"
-#include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
+#include "ompi/mca/osc/osc.h"
+#include "ompi/request/request.h"
 
 #include "osc_portals4.h"
 #include "osc_portals4_request.h"

--- a/ompi/mca/osc/portals4/osc_portals4_request.h
+++ b/ompi/mca/osc/portals4/osc_portals4_request.h
@@ -13,6 +13,8 @@
 #ifndef OSC_PORTALS4_REQUEST_H
 #define OSC_PORTALS4_REQUEST_H
 
+#include "ompi_config.h"
+
 #include "ompi/request/request.h"
 
 struct ompi_osc_portals4_request_t {

--- a/opal/mca/btl/portals4/btl_portals4.c
+++ b/opal/mca/btl/portals4/btl_portals4.c
@@ -37,6 +37,7 @@
 #include "opal/util/proc.h"
 
 #include "btl_portals4.h"
+#include "btl_portals4_frag.h"
 #include "btl_portals4_recv.h"
 
 mca_btl_base_registration_handle_t *mca_btl_portals4_register_mem(mca_btl_base_module_t *btl,

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -24,15 +24,17 @@
 #ifndef BTL_PORTALS_H_HAS_BEEN_INCLUDED
 #define BTL_PORTALS_H_HAS_BEEN_INCLUDED
 
-#include <btl_portals4_frag.h>
-#include <portals4.h>
+#include "opal_config.h"
 
 #include "opal/class/opal_free_list.h"
 #include "opal/class/opal_list.h"
 #include "opal/datatype/opal_convertor.h"
+
 #include "opal/mca/btl/base/base.h"
 #include "opal/mca/btl/base/btl_base_error.h"
 #include "opal/mca/btl/btl.h"
+
+#include <portals4.h>
 
 BEGIN_C_DECLS
 

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -38,7 +38,6 @@
 #include "btl_portals4.h"
 #include "btl_portals4_frag.h"
 #include "btl_portals4_recv.h"
-#include "portals4.h"
 
 static int mca_btl_portals4_component_register(void);
 static int mca_btl_portals4_component_open(void);

--- a/opal/mca/btl/portals4/btl_portals4_endpoint.h
+++ b/opal/mca/btl/portals4/btl_portals4_endpoint.h
@@ -21,6 +21,10 @@
 #ifndef OPAL_BTL_PORTALS4_ENDPOINT_H
 #define OPAL_BTL_PORTALS4_ENDPOINT_H
 
+#include "opal_config.h"
+
+#include "opal/mca/btl/btl.h"
+
 #include "btl_portals4.h"
 
 BEGIN_C_DECLS

--- a/opal/mca/btl/portals4/btl_portals4_frag.h
+++ b/opal/mca/btl/portals4/btl_portals4_frag.h
@@ -23,7 +23,9 @@
 #ifndef OPAL_BTL_PORTALS4_FRAG_H
 #define OPAL_BTL_PORTALS4_FRAG_H
 
-#include "opal/mca/btl/btl.h"
+#include "opal_config.h"
+
+#include "btl_portals4.h"
 
 BEGIN_C_DECLS
 

--- a/opal/mca/btl/portals4/btl_portals4_rdma.c
+++ b/opal/mca/btl/portals4/btl_portals4_rdma.c
@@ -19,8 +19,11 @@
  */
 
 #include "opal_config.h"
-#include "btl_portals4.h"
+
 #include "opal/constants.h"
+
+#include "btl_portals4.h"
+#include "btl_portals4_frag.h"
 
 int mca_btl_portals4_put(struct mca_btl_base_module_t *btl_base,
                          struct mca_btl_base_endpoint_t *btl_peer,

--- a/opal/mca/btl/portals4/btl_portals4_recv.h
+++ b/opal/mca/btl/portals4/btl_portals4_recv.h
@@ -20,7 +20,9 @@
 #ifndef OPAL_BTL_PORTALS4_RECV_H
 #define OPAL_BTL_PORTALS4_RECV_H
 
-#include "btl_portals4_frag.h"
+#include "opal_config.h"
+
+#include "btl_portals4.h"
 
 struct mca_btl_portals4_recv_block_t {
     opal_list_item_t base;

--- a/opal/mca/btl/portals4/btl_portals4_send.c
+++ b/opal/mca/btl/portals4/btl_portals4_send.c
@@ -22,10 +22,12 @@
  */
 
 #include "opal_config.h"
+
 #include "opal/constants.h"
 #include "opal/datatype/opal_convertor.h"
 
 #include "btl_portals4.h"
+#include "btl_portals4_frag.h"
 
 int mca_btl_portals4_send(struct mca_btl_base_module_t *btl_base,
                           struct mca_btl_base_endpoint_t *endpoint,


### PR DESCRIPTION
After running clang-format in #8647, the portals4.h header was moved after the Portals4 component includes which caused compilation failures. This PR reorder headers to match the style of #8647 and adds includes where necessary to remove ordering dependencies.

~~This PR is blocked by #9006.~~
