### PR TITLE
COLL/UCC: disable by default

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -45,9 +45,9 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
         .collm_init_query = mca_coll_ucc_init_query,
         .collm_comm_query = mca_coll_ucc_comm_query,
     },
-    100,               /* ucc_priority                */
+    10,               /* ucc_priority                */
     0,                 /* ucc_verbose                 */
-    1,                 /* ucc_enable                  */
+    0,                 /* ucc_enable                  */
     2,                 /* ucc_np                      */
     "basic",           /* cls                         */
     COLL_UCC_CTS_STR,  /* requested coll_types string */


### PR DESCRIPTION
    Disables coll/ucc component by default and sets low prio (10), so
    that the new component does not ever overwrite default selections
    unless explicitely requested by user.

Signed-off-by: Valentin Petrov <valentinp@nvidia.com>