### PR TITLE
v5.0.x: Fix segv when io component can't be opened.

### DIFF
--- a/ompi/mca/io/base/io_base_file_select.c
+++ b/ompi/mca/io/base/io_base_file_select.c
@@ -192,14 +192,8 @@ int mca_io_base_file_select(ompi_file_t *file,
         unquery(avail, file);
         OBJ_RELEASE(item);
     }
+
     OBJ_RELEASE(selectable);
-
-    /* Save the pointers of the selected module on the ompi_file_t */
-
-    file->f_io_version = selected.ai_version;
-    file->f_io_selected_component = selected.ai_component;
-    file->f_io_selected_module = selected.ai_module;
-    file->f_io_selected_data = selected.ai_module_data;
 
     if (!strcmp (selected.ai_component.v2_0_0.io_version.mca_component_name,
                  "ompio")) {
@@ -242,6 +236,14 @@ int mca_io_base_file_select(ompi_file_t *file,
         }
 
     }
+
+    /* Save the pointers of the selected module on the ompi_file_t */
+
+    file->f_io_version = selected.ai_version;
+    file->f_io_selected_component = selected.ai_component;
+    file->f_io_selected_module = selected.ai_module;
+    file->f_io_selected_data = selected.ai_module_data;
+
     /* Finally -- intialize the selected module. */
 
     if (OMPI_SUCCESS != (err = module_init(file))) {


### PR DESCRIPTION
Hold off on initializing these until we're sure
the component can be opened, otherwise it will segv
on a NULL, uninitialized comm in the destructor instead
of returning gracefully.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 2457171906831d052a43d964a4f1796c529b7edc)