### PR TITLE
v5.0.x: configury: Better support of _Float16

### DIFF
--- a/config/opal_check_alt_short_float.m4
+++ b/config/opal_check_alt_short_float.m4
@@ -2,8 +2,6 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2018-2020 FUJITSU LIMITED.  All rights reserved.
 dnl Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2021      Triad National Security, LLC. All rights
-dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -16,16 +14,7 @@ dnl Check whether the user wants to use an alternate type of C 'short float'.
 dnl OPAL_CHECK_ALT_SHORT_FLOAT
 dnl ------------------------------------------------------------
 AC_DEFUN([OPAL_CHECK_ALT_SHORT_FLOAT], [
-dnl
-dnl Testing for this without checking if compiler generates warnings makes for a messy build.
-dnl Hence the twiddling of the CFLAGS
-dnl
-    OPAL_VAR_SCOPE_PUSH([CFLAGS_save])
-    CFLAGS_save=$CFLAGS
-    CFLAGS="-Werror $CFLAGS"
     AC_CHECK_TYPES(_Float16)
-    CFLAGS=$CFLAGS_save
-    OPAL_VAR_SCOPE_POP
     AC_MSG_CHECKING([if want alternate C type of short float])
     AC_ARG_ENABLE([alt-short-float],
         [AS_HELP_STRING([--enable-alt-short-float=TYPE],

--- a/config/opal_check_alt_short_float.m4
+++ b/config/opal_check_alt_short_float.m4
@@ -1,6 +1,6 @@
 dnl -*- shell-script -*-
 dnl
-dnl Copyright (c) 2018-2020 FUJITSU LIMITED.  All rights reserved.
+dnl Copyright (c) 2018-2021 FUJITSU LIMITED.  All rights reserved.
 dnl Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -47,9 +47,9 @@ AC_DEFUN([OPAL_CHECK_ALT_SHORT_FLOAT], [
         # automagically add that flag -- we'll just emit a warning and
         # point the user to a README where more information is
         # available.
-        AC_MSG_CHECKING([if compiler supports arithmetic operations on $opal_short_float_type])
         AS_IF([test $opal_alt_short_float_exists -eq 1],
-              [AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
+              [AC_MSG_CHECKING([if compiler supports arithmetic operations on $opal_short_float_type])
+               AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
 static $opal_short_float_type a = 2.5, b = 3.8;
 a += b;]])],
                                  [AC_MSG_RESULT([yes])
@@ -74,6 +74,29 @@ a += b;]])],
             AC_CHECK_SIZEOF(opal_short_float_t)
             AC_CHECK_SIZEOF(opal_short_float_complex_t)
             OPAL_C_GET_ALIGNMENT(opal_short_float_t, OPAL_ALIGNMENT_OPAL_SHORT_FLOAT_T)
+
+            # Some versions of GCC (around 9.1.0?) emit a warning for _Float16
+            # when compiling with -pedantic. Using __extension__ can suppress
+            # the warning. The warning can be detected by -Werror in configure.
+            # See https://github.com/open-mpi/ompi/issues/8840
+            AC_MSG_CHECKING([if $opal_short_float_type needs __extension__ keyword])
+            opal_alt_short_float_needs_extension=0
+            OPAL_VAR_SCOPE_PUSH([CFLAGS_save])
+            CFLAGS_save=$CFLAGS
+            CFLAGS="-Werror $CFLAGS"
+            AC_COMPILE_IFELSE([AC_LANG_SOURCE([$opal_short_float_type a;])],
+                              [AC_MSG_RESULT([no])],
+                              [AC_COMPILE_IFELSE([AC_LANG_SOURCE([__extension__ $opal_short_float_type a;])],
+                                                 [opal_alt_short_float_needs_extension=1
+                                                  AC_MSG_RESULT([yes])],
+                                                 [AC_MSG_RESULT([no])])])
+            CFLAGS=$CFLAGS_save
+            OPAL_VAR_SCOPE_POP
+            AC_DEFINE_UNQUOTED(OPAL_SHORT_FLOAT_TYPE, [[$opal_short_float_type]],
+                               [User-selected alternate C type of short float (used to redefine opal_short_float_t in opal_bottom.h)])
+            AC_DEFINE_UNQUOTED(OPAL_SHORT_FLOAT_NEEDS_EXTENSION,
+                               [$opal_alt_short_float_needs_extension],
+                               [Whether $opal_short_float_type needs __extension__ keyword])
         elif test "$enable_alt_short_float" != ""; then
             AC_MSG_ERROR([Alternate C type of short float $opal_short_float_type requested but not available.  Aborting])
         fi

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -535,6 +536,26 @@ static inline uint16_t ntohs(uint16_t netvar)
 #        define restrict
 #    endif
 
+/* We need to define the opal_short_float_t macro in the configure script
+   because we use it in some other places of the configure script. However
+   we cannot define it as a macro like "__extension__ [TYPENAME]" because
+   the __extension__ keyword can only be attached to a C expression. As a
+   workaround, we once define opal_short_float_t as a macro without
+   __extension__ in configure and redefine it using typedef here. */
+#    ifdef HAVE_OPAL_SHORT_FLOAT_T
+#        undef opal_short_float_t
+#        if OPAL_SHORT_FLOAT_NEEDS_EXTENSION
+__extension__ typedef OPAL_SHORT_FLOAT_TYPE opal_short_float_t;
+#        else
+typedef OPAL_SHORT_FLOAT_TYPE opal_short_float_t;
+#        endif
+#    endif
+
+/* We need to define the opal_short_float_complex_t macro in the configure
+   script because we use it in some other places of the configure script.
+   However we cannot define it as a macro like "struct { ... }" in configure.
+   As a workaround, we once define opal_short_float_complex_t as an array
+   in configure and redefine it as a structure using typedef here. */
 #    ifdef HAVE_OPAL_SHORT_FLOAT_COMPLEX_T
 #        undef opal_short_float_complex_t
 typedef struct {


### PR DESCRIPTION
Cherry-pick of 7286aaeeabe05dfff41fc3fa115020a353373b60 (#9000).

Strictly speaking, this PR is an enhancement for the *current* `v5.0.x` branch but not an enhancement after `v5.0.x` branching. Is this PR accepted?

Timeline:

- *At `v5.0.x` branch point*:  
  `_Float16` is enabled but recent GCC emits warnings.
- *At commit dddf636a14 (#8840)*:  
  `_Float16` is disabled when using recent GCC.
- *By this commit*:
  `_Float16` is re-enabled and recent GCC does not emit warnings.
