### PR TITLE
v4.1.x: Fix buffer overflow in get_package_rank

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -304,7 +304,7 @@ static uint32_t get_package_rank(int32_t num_local_peers, uint16_t my_local_rank
     int i;
     uint16_t relative_locality;
     uint16_t current_package_rank = 0;
-    uint16_t package_ranks[num_local_peers];
+    uint16_t package_ranks[num_local_peers + 1];
     opal_process_name_t pname;
     opal_status_t rc;
     char **peers = NULL;


### PR DESCRIPTION
The number of local peers does not include the own rank but the own rank
is still written to the array which means an out-of-bounds write
corrupting the stack.
Increase the array size by that missing rank (i.e. +1)

Fixes #9018

Signed-off-by: Alexander Grund <Flamefire@users.noreply.github.com>
(cherry picked from commit b8b95467f7d54660a583ae112251be0bea85a853)
Signed-off-by: Brian Barrett <bbarrett@amazon.com>