### PR TITLE
Prototype of 'MPIX_Pbuf_prepare'

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1700,6 +1700,8 @@ OMPI_DECLSPEC  int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatyp
 OMPI_DECLSPEC  int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm,
                                  int *size);
 OMPI_DECLSPEC  int MPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
+OMPI_DECLSPEC  int MPIX_Pbuf_prepare(MPI_Request request);
+OMPI_DECLSPEC  int MPIX_Pbuf_prepareall(int count, MPI_Request* requests);
 OMPI_DECLSPEC  int MPI_Pcontrol(const int level, ...);
 OMPI_DECLSPEC  int MPI_Pready(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
@@ -2321,6 +2323,8 @@ OMPI_DECLSPEC  int PMPI_Isend(const void *buf, int count, MPI_Datatype datatype,
                               int tag, MPI_Comm comm, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request);
+OMPI_DECLSPEC  int PMPIX_Pbuf_prepare(MPI_Request request);
+OMPI_DECLSPEC  int PMPIX_Pbuf_prepareall(int count, MPI_Request* requests);
 OMPI_DECLSPEC  int PMPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
                                   MPI_Request *request);

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1704,9 +1704,13 @@ OMPI_DECLSPEC  int MPIX_Pbuf_prepare(MPI_Request request);
 OMPI_DECLSPEC  int MPIX_Pbuf_prepareall(int count, MPI_Request* requests);
 OMPI_DECLSPEC  int MPI_Pcontrol(const int level, ...);
 OMPI_DECLSPEC  int MPI_Pready(int partitions, MPI_Request request);
+OMPI_DECLSPEC  int MPIX_Pready_fast(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
                                     MPI_Request request);
+OMPI_DECLSPEC  int MPIX_Pready_range_fast(int partition_low, int partition_high,
+                                    MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_list(int length, int partition_list[], MPI_Request request);
+OMPI_DECLSPEC  int MPIX_Pready_list_fast(int length, int partition_list[], MPI_Request request);
 OMPI_DECLSPEC  int MPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
                                   MPI_Request *request);
@@ -2332,9 +2336,13 @@ OMPI_DECLSPEC  int PMPI_Psend_init(const void* buf, int partitions, MPI_Count co
                                   MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
                                   MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Pready(int partitions, MPI_Request request);
+OMPI_DECLSPEC  int PMPIX_Pready_fast(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Pready_range(int partition_low, int partition_high,
                                     MPI_Request request);
+OMPI_DECLSPEC  int PMPIX_Pready_range_fast(int partition_low, int partition_high,
+                                    MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Pready_list(int length, int partition_list[], MPI_Request request);
+OMPI_DECLSPEC  int PMPIX_Pready_list_fast(int length, int partition_list[], MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
 OMPI_DECLSPEC  int PMPI_Is_thread_main(int *flag);
 OMPI_DECLSPEC  int PMPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);

--- a/ompi/mca/part/part.h
+++ b/ompi/mca/part/part.h
@@ -238,6 +238,7 @@ struct mca_part_base_module_1_0_1_t {
     mca_part_base_module_psend_init_fn_t   part_psend_init;
     mca_part_base_module_start_fn_t        part_start; 
     mca_part_base_module_pready_fn_t       part_pready;
+    mca_part_base_module_pready_fn_t       part_pready_fast; /* pready_fast is a varient of pready with the same function signature */
     mca_part_base_module_parrived_fn_t     part_parrived;
     mca_part_base_module_pbuf_prepare_fn_t part_pbuf_prepare;
 

--- a/ompi/mca/part/part.h
+++ b/ompi/mca/part/part.h
@@ -211,6 +211,20 @@ typedef int (*mca_part_base_module_parrived_fn_t)(
 );
 
 /**
+ * Block until reciving buffer is ready.
+ *
+ * @param request (IN/OUT) Request
+ * @return                 OMPI_SUCCESS or failure status.
+ *
+ */
+typedef int (*mca_part_base_module_pbuf_prepare_fn_t)(
+    int count,
+    struct ompi_request_t** request
+);
+
+
+
+/**
  *  PART instance.
  */
 
@@ -220,11 +234,13 @@ struct mca_part_base_module_1_0_1_t {
     mca_part_base_module_progress_fn_t    part_progress;
 
     /* downcalls from MPI to PART */
-    mca_part_base_module_precv_init_fn_t  part_precv_init;
-    mca_part_base_module_psend_init_fn_t  part_psend_init;
-    mca_part_base_module_start_fn_t       part_start; 
-    mca_part_base_module_pready_fn_t      part_pready;
-    mca_part_base_module_parrived_fn_t    part_parrived;
+    mca_part_base_module_precv_init_fn_t   part_precv_init;
+    mca_part_base_module_psend_init_fn_t   part_psend_init;
+    mca_part_base_module_start_fn_t        part_start; 
+    mca_part_base_module_pready_fn_t       part_pready;
+    mca_part_base_module_parrived_fn_t     part_parrived;
+    mca_part_base_module_pbuf_prepare_fn_t part_pbuf_prepare;
+
     /* diagnostics */
 
     /* FT Event */

--- a/ompi/mca/part/persist/part_persist.c
+++ b/ompi/mca/part/persist/part_persist.c
@@ -36,6 +36,7 @@ ompi_part_persist_t ompi_part_persist = {
         .part_start = mca_part_persist_start,
         .part_pready = mca_part_persist_pready,
         .part_parrived = mca_part_persist_parrived, 
+        .part_pbuf_prepare = mca_part_persist_pbuf_prepare,
     }
 };
 

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -486,6 +486,7 @@ mca_part_persist_start(size_t count, ompi_request_t** requests)
 
     for(i = 0; i < _count && OMPI_SUCCESS == err; i++) {
         mca_part_persist_request_t *req = (mca_part_persist_request_t *)(requests[i]);
+        req->synched = 0;
         /* First use is a special case, to support lazy initialization */
         if(false == req->first_send)
         {
@@ -494,7 +495,6 @@ mca_part_persist_start(size_t count, ompi_request_t** requests)
                 memset((void*)req->flags,0,sizeof(int32_t)*req->real_parts);
             } else {
                 req->done_count = 0;
-                req->synched = 0;
                 err = req->persist_reqs[0]->req_start(req->real_parts, req->persist_reqs);
                 memset((void*)req->flags,0,sizeof(int32_t)*req->real_parts);
             } 

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -546,6 +546,29 @@ mca_part_persist_pready(size_t min_part,
 }
 
 __opal_attribute_always_inline__ static inline int
+mca_part_persist_pready_fast(size_t min_part,
+                    size_t max_part,
+                    ompi_request_t* request)
+{   
+    int err = OMPI_SUCCESS;
+    size_t i;
+    
+    mca_part_persist_request_t *req = (mca_part_persist_request_t *)(request);
+    if(true == req->initialized)
+    {   
+        err = req->persist_reqs[min_part]->req_start(max_part-min_part+1, (&(req->persist_reqs[min_part])));
+        for(i = min_part; i <= max_part && OMPI_SUCCESS == err; i++) {
+            req->flags[i] = 0; /* Mark partion as ready for testing */
+        }
+    }
+    else
+    {   
+        return OMPI_ERROR; /* This codepath is erronious for pready_fast */
+    }
+    return err;
+}
+
+__opal_attribute_always_inline__ static inline int
 mca_part_persist_parrived(size_t min_part,
                       size_t max_part,
                       int* flag, 

--- a/ompi/mca/part/persist/part_persist_request.h
+++ b/ompi/mca/part/persist/part_persist_request.h
@@ -96,6 +96,7 @@ struct mca_part_persist_request_t {
   
     struct mca_part_persist_list_t* progress_elem; /**< pointer to progress list element for removal durring free. */ 
 
+    int32_t synched;                       /**< Internal flag for pbuf_prepare */
 };
 typedef struct mca_part_persist_request_t mca_part_persist_request_t;
 OBJ_CLASS_DECLARATION(mca_part_persist_request_t);

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -301,6 +301,8 @@ libmpi_c_mpi_la_SOURCES = \
         pack.c \
         pack_size.c \
         parrived.c \
+        pbuf_prepare.c \
+        pbuf_prepareall.c \
         pcontrol.c \
         pready.c \
         pready_list.c \

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -305,8 +305,11 @@ libmpi_c_mpi_la_SOURCES = \
         pbuf_prepareall.c \
         pcontrol.c \
         pready.c \
+        pready_fast.c \
         pready_list.c \
+        pready_list_fast.c \
         pready_range.c \
+        pready_range_fast.c \
         precv_init.c \
         probe.c \
         psend_init.c \

--- a/ompi/mpi/c/pbuf_prepare.c
+++ b/ompi/mpi/c/pbuf_prepare.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Pbuf_prepare = PMPIX_Pbuf_prepare
+#endif
+#define MPIX_Pbuf_prepare PMPIX_Pbuf_prepare
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Pbuf_prepare";
+
+
+int MPIX_Pbuf_prepare(MPI_Request request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PBUF_PREPARE, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    rc = mca_part.part_pbuf_prepare(1, &request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pbuf_prepareall.c
+++ b/ompi/mpi/c/pbuf_prepareall.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Pbuf_prepareall = PMPIX_Pbuf_prepareall
+#endif
+#define MPIX_Pbuf_prepareall PMPIX_Pbuf_prepareall
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Pbuf_prepareall";
+
+
+int MPIX_Pbuf_prepareall(int count, MPI_Request* requests)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PBUF_PREPARE, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        // TODO: Param Check
+ //       if (NULL == requests || OMPI_REQUEST_PART != request->req_type) {
+ //           rc = MPI_ERR_REQUEST;
+ //       }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    rc = mca_part.part_pbuf_prepare(count, requests);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready_fast.c
+++ b/ompi/mpi/c/pready_fast.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Pready_fast = PMPIX_Pready_fast
+#endif
+#define MPIX_Pready_fast PMPIX_Pready_fast
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Pready_fast";
+
+
+int MPIX_Pready_fast(int partition, MPI_Request request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    rc = mca_part.part_pready_fast(partition, partition, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready_list_fast.c
+++ b/ompi/mpi/c/pready_list_fast.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Pready_list_fast = PMPIX_Pready_list_fast
+#endif
+#define MPIX_Pready_list_fast PMPIX_Pready_list_fast
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Pready_list_fast";
+
+
+int MPIX_Pready_list_fast(int length, int* partitions, MPI_Request request)
+{
+    int rc = OMPI_SUCCESS;
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    for(int i = 0; i < length && OMPI_SUCCESS == rc; i++) {
+        rc = mca_part.part_pready_fast(partitions[i], partitions[i], request);
+    }
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/pready_range_fast.c
+++ b/ompi/mpi/c/pready_range_fast.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/mca/part/part.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/ompi_spc.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Pready_range_fast = PMPI_Pready_range_fast
+#endif
+#define MPI_Pready_range_fast PMPI_Pready_range_fast
+#endif
+
+static const char FUNC_NAME[] = "MPI_Pready_range_fast";
+
+
+int MPI_Pready_range_fast(int partition_low, int partition_high, MPI_Request request)
+{
+    int rc;
+
+    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    if (MPI_PARAM_CHECK) {
+        rc = OMPI_SUCCESS;
+
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+            rc = MPI_ERR_REQUEST;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    rc = mca_part.part_pready_fast(partition_low, partition_high, request);
+    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+}

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -285,8 +285,11 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         ppbuf_prepareall.c \
         ppcontrol.c \
         ppready.c \
+        ppready_fast.c \
         ppready_list.c \
+        ppready_list_fast.c \
         ppready_range.c \
+        ppready_range_fast.c \
         pprecv_init.c \
         pprobe.c \
         ppsend_init.c \

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -281,6 +281,8 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         ppack.c \
         ppack_size.c \
         pparrived.c \
+        ppbuf_prepare.c \
+        ppbuf_prepareall.c \
         ppcontrol.c \
         ppready.c \
         ppready_list.c \


### PR DESCRIPTION
This is a prototype of 'MPIX_Pbuf_prepare' a proposed extension of MPI Partitioned communication that acts a request specific barrier after start (to ensure the receive side buffer is posted and ready to receive data). 