### PR TITLE
fix hugepage allocator assert in finalize

### DIFF
--- a/opal/mca/mpool/hugepage/mpool_hugepage_module.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -245,11 +245,11 @@ static void mca_mpool_hugepage_finalize(struct mca_mpool_base_module_t *mpool)
 {
     mca_mpool_hugepage_module_t *hugepage_module = (mca_mpool_hugepage_module_t *) mpool;
 
-    OBJ_DESTRUCT(&hugepage_module->lock);
-    OBJ_DESTRUCT(&hugepage_module->allocation_tree);
-
     if (hugepage_module->allocator) {
         (void) hugepage_module->allocator->alc_finalize(hugepage_module->allocator);
         hugepage_module->allocator = NULL;
     }
+    OBJ_DESTRUCT(&hugepage_module->lock);
+    OBJ_DESTRUCT(&hugepage_module->allocation_tree);
+
 }


### PR DESCRIPTION
Do not de-initialize the lock before the mpool in huge page allocator finalize. 

Corrects the following error in DEBUG builds on NERSC Cori:

```
osu_gather: ../../../../../opal/mca/threads/pthreads/threads_pthreads_mutex.h:115: opal_thread_internal_mutex_lock: Assertion `0 == ret' failed.
[nid02560:187756] *** Process received signal ***
[nid02560:187756] Signal: Aborted (6)
[nid02560:187756] Signal code:  (-6)
[nid02560:187756] [ 0] /lib64/libc.so.6(+0x394a0)[0x2aaaacb344a0]
[nid02560:187756] [ 1] /lib64/libc.so.6(gsignal+0x110)[0x2aaaacb34420]
[nid02560:187756] [ 2] /lib64/libc.so.6(abort+0x151)[0x2aaaacb35a01]
[nid02560:187756] [ 3] /lib64/libc.so.6(+0x31a1a)[0x2aaaacb2ca1a]
[nid02560:187756] [ 4] /lib64/libc.so.6(+0x31a92)[0x2aaaacb2ca92]
[nid02560:187756] [ 5] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_mpool_hugepage_seg_free+0x10c)[0x2aaaad3d37bc]
[nid02560:187756] [ 6] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_allocator_bucket_cleanup+0x1b3)[0x2aaaad38c5e3]
[nid02560:187756] [ 7] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_allocator_bucket_finalize+0xd)[0x2aaaad38bc3d]
[nid02560:187756] [ 8] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(+0xfa8e0)[0x2aaaad3d38e0]
[nid02560:187756] [ 9] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(+0xfb3fa)[0x2aaaad3d43fa]
[nid02560:187756] [10] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_base_component_close+0x1a)[0x2aaaad35932a]
[nid02560:187756] [11] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_base_components_close+0x65)[0x2aaaad359075]
[nid02560:187756] [12] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(+0xf7faf)[0x2aaaad3d0faf]
[nid02560:187756] [13] /global/homes/b/bouteill/ompi/debug.build/lib/libopen-pal.so.0(mca_base_framework_close+0x73)[0x2aaaad36a5e3]
[nid02560:187756] [14] /global/homes/b/bouteill/ompi/debug.build/lib/libmpi.so.0(ompi_mpi_finalize+0x920)[0x2aaaab18a550]
[nid02560:187756] [15] /global/homes/b/bouteill/ompi/3rd-party/ulfm-testing/benchmarks/osu-micro-benchmarks-5.7.1/mpi/collective/osu_gather[0x20002d2b]
[nid02560:187756] [16] /lib64/libc.so.6(__libc_start_main+0xea)[0x2aaaacb1f34a]
[nid02560:187756] [17] /global/homes/b/bouteill/ompi/3rd-party/ulfm-testing/benchmarks/osu-micro-benchmarks-5.7.1/mpi/collective/osu_gather[0x2000276a]
[nid02560:187756] *** End of error message ***
[mom5:24325] [mpiexec-mom5-24325@0,0]:../../../../../../../3rd-party/prrte/src/mca/state/dvm/state_dvm.c(588) updating exit status to 134
--------------------------------------------------------------------------
mpiexec noticed that process rank 41 with PID 0 on node nid02557 exited on signal 6 (Aborted).
--------------------------------------------------------------------------
```