### PR TITLE
Optimizing use of tags within partitioned operations (perist module)

### DIFF
--- a/ompi/mca/part/persist/part_persist.c
+++ b/ompi/mca/part/persist/part_persist.c
@@ -45,3 +45,8 @@ OBJ_CLASS_INSTANCE(mca_part_persist_list_t,
                    NULL,
                    NULL);
 
+OBJ_CLASS_INSTANCE(mca_part_persist_send_tag_list_t,
+                   opal_list_item_t,
+                   NULL,
+                   NULL);
+

--- a/ompi/mca/part/persist/part_persist_component.c
+++ b/ompi/mca/part/persist/part_persist_component.c
@@ -93,7 +93,6 @@ mca_part_persist_component_open(void)
 {
     OBJ_CONSTRUCT(&ompi_part_persist.lock, opal_mutex_t);
 
-    ompi_part_persist.next_send_tag = 0;                /**< This is a counter for send tags for the actual data transfer. */
     ompi_part_persist.next_recv_tag = 0; 
 
     mca_part_persist_init_lists(); 


### PR DESCRIPTION
The current persist module of partitioned communication uses a single counter to assign send tags to use for the underlying persistent sends. This could create a potential integer overflow problem in cases where a large number of partitioned requests are created. This pull request addresses this by moving to a counter per peer; while rollover is still possible, it's significantly less likely.