### PR TITLE
v4.0.x: OFI and usNIC fixes

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -133,7 +133,7 @@ ompi_mtl_ofi_component_register(void)
                                     MCA_BASE_VAR_SCOPE_READONLY,
                                     &prov_include);
 
-    prov_exclude = "shm,sockets,tcp,udp,rstream";
+    prov_exclude = "shm,sockets,tcp,udp,rstream,usnic";
     mca_base_component_var_register(&mca_mtl_ofi_component.super.mtl_version,
                                     "provider_exclude",
                                     "Comma-delimited list of OFI providers that are not considered for use (default: \"sockets,mxm\"; empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_include.",

--- a/opal/mca/btl/usnic/btl_usnic_cagent.c
+++ b/opal/mca/btl/usnic/btl_usnic_cagent.c
@@ -44,7 +44,7 @@ static opal_event_t ipc_event;
 static struct timeval ack_timeout;
 static opal_list_t udp_port_listeners;
 static opal_list_t ipc_listeners;
-static volatile uint32_t ipc_accepts = 0;
+static volatile int32_t ipc_accepts = 0;
 /* JMS The pings_pending and ping_results should probably both be hash
    tables for more efficient lookups */
 static opal_list_t pings_pending;

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -440,7 +440,7 @@ static void setup_mpit_pvars_enum(void)
 
     /* Free the strings (mca_base_var_enum_create() strdup()'ed them
        into private storage, so we don't need them any more) */
-    for (int i = 0; i < mca_btl_usnic_component.num_modules; ++i) {
+    for (i = 0; i < mca_btl_usnic_component.num_modules; ++i) {
         free((char*) devices[i].string);
     }
     free(devices);


### PR DESCRIPTION
This is the v4.0.x PR for #9101.

**NOTE:** This PR does not include the OFA common component compiler warning fixes commit (b1efec9d1f32bad6904fba86fc421947ceba9ae4) because that code does not exist on the v4.0.x branch.

FYI @roguephysicist