### PR TITLE
OFI MTL: Fix component selection debug output

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -121,3 +121,6 @@ Nick Papior <nickpapior@gmail.com> <zerothi@users.noreply.github.com>
 Matthew G. F. Dosanjh <mdosanj@sandia.gov>
 
 Wei-keng Liao <wkliao@users.noreply.github.com>
+
+Samuel K. Gutierrez <samuel@lanl.gov> <samuelkgutierrez@users.noreply.github.com>
+Samuel K. Gutierrez <samuel@lanl.gov> <samuel@lanl.gov>

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2020      Triad National Security, LLC. All rights
+ * Copyright (c) 2020-2021 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -340,7 +340,7 @@ select_ofi_provider(struct fi_info *providers,
     }
 
     opal_output_verbose(1, opal_common_ofi.output,
-                        "%s:%d: mtl:ofi:prov: %s\n",
+                        "%s:%d: mtl:ofi:provider: %s\n",
                         __FILE__, __LINE__,
                         (prov ? prov->fabric_attr->prov_name : "none"));
 
@@ -365,7 +365,7 @@ select_ofi_provider(struct fi_info *providers,
     if (NULL != prov) {
         prov = opal_mca_common_ofi_select_provider(prov, &ompi_process_info);
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: mtl:ofi:provider: %s\n",
+                            "%s:%d: mtl:ofi:provider:nic: %s\n",
                             __FILE__, __LINE__,
                             (prov ? prov->domain_attr->name : "none"));
     }

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -364,7 +364,7 @@ select_ofi_provider(struct fi_info *providers,
       */
     if (NULL != prov) {
         prov = opal_mca_common_ofi_select_provider(prov, &ompi_process_info);
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+        opal_output_verbose(1, opal_common_ofi.output,
                             "%s:%d: mtl:ofi:provider:domain: %s\n",
                             __FILE__, __LINE__,
                             (prov ? prov->domain_attr->name : "none"));

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -365,7 +365,7 @@ select_ofi_provider(struct fi_info *providers,
     if (NULL != prov) {
         prov = opal_mca_common_ofi_select_provider(prov, &ompi_process_info);
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: mtl:ofi:provider:nic: %s\n",
+                            "%s:%d: mtl:ofi:provider:domain: %s\n",
                             __FILE__, __LINE__,
                             (prov ? prov->domain_attr->name : "none"));
     }


### PR DESCRIPTION
* Make explicit that a provider's domain is displayed.
* Normalize naming convention in debug output.
* Normalize opal_output_verbose() sinks.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>