### PR TITLE
oshmem: Reduce the service memory footprint during communicator creation

### DIFF
--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -151,9 +151,6 @@ static void unpack_remote_mkeys(shmem_ctx_t ctx, pmix_data_buffer_t *msg, int re
     int32_t n;
     int32_t tr_id;
     int i;
-    ompi_proc_t *proc;
-
-    proc = oshmem_proc_group_find(oshmem_group_all, remote_pe);
     cnt = 1;
     PMIx_Data_unpack(NULL, msg, &n, &cnt, PMIX_UINT32);
     for (i = 0; i < n; i++) {
@@ -168,7 +165,7 @@ static void unpack_remote_mkeys(shmem_ctx_t ctx, pmix_data_buffer_t *msg, int re
         if (0 == memheap_oob.mkeys[tr_id].va_base) {
             cnt = 1;
             PMIx_Data_unpack(NULL, msg, &memheap_oob.mkeys[tr_id].u.key, &cnt, PMIX_UINT64);
-            if (OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
+            if (oshmem_proc_on_local_node(remote_pe)) {
                 memheap_attach_segment(&memheap_oob.mkeys[tr_id], tr_id);
             }
         } else {

--- a/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
@@ -116,7 +116,7 @@ get_dst_pe(struct oshmem_group_t *group, int src_blk_idx, int dst_blk_idx, int *
     (*dst_pe_idx) = (dst_blk_idx + src_blk_idx) % group->proc_count;
 
     /* convert to the global pe */
-    return oshmem_proc_pe(group->proc_array[*dst_pe_idx]);
+    return oshmem_proc_pe_vpid(group, *dst_pe_idx);
 }
 
 static int a2as_alg_simple(struct oshmem_group_t *group,

--- a/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
@@ -144,7 +144,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
                       "[#%d] send data to all PE in the group",
                       group->my_pe);
         for (i = 0; (i < group->proc_count) && (rc == OSHMEM_SUCCESS); i++) {
-            pe_cur = oshmem_proc_pe(group->proc_array[i]);
+            pe_cur = oshmem_proc_pe_vpid(group, i);
             if (pe_cur != PE_root) {
                 SCOLL_VERBOSE(15,
                               "[#%d] send data to #%d",
@@ -233,7 +233,7 @@ static int _algorithm_binomial_tree(struct oshmem_group_t *group,
         if (peer_id < group->proc_count) {
             /* Wait for the child to be ready to receive (pSync must have the initial value) */
             peer_id = (peer_id + root_id) % group->proc_count;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             SCOLL_VERBOSE(14,
                           "[#%d] check remote pe is ready to receive #%d",

--- a/oshmem/mca/scoll/basic/scoll_basic_reduce.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_reduce.c
@@ -186,7 +186,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
 {
     int rc = OSHMEM_SUCCESS;
     int i = 0;
-    int PE_root = oshmem_proc_pe(group->proc_array[0]);
+    int PE_root = oshmem_proc_pe_vpid(group, 0);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Central Counter", group->my_pe);
 
@@ -204,7 +204,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
             for (i = 0; (i < group->proc_count) && (rc == OSHMEM_SUCCESS);
                     i++) {
                 /* Get PE ID of a peer from the group */
-                pe_cur = oshmem_proc_pe(group->proc_array[i]);
+                pe_cur = oshmem_proc_pe_vpid(group, i);
 
                 if (pe_cur == group->my_pe)
                     continue;
@@ -265,7 +265,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
     int peer_id = 0;
     int peer_pe = 0;
     void *target_cur = NULL;
-    int PE_root = oshmem_proc_pe(group->proc_array[0]);
+    int PE_root = oshmem_proc_pe_vpid(group, 0);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Tournament", group->my_pe);
     SCOLL_VERBOSE(15, "[#%d] pSync[0] = %ld", group->my_pe, pSync[0]);
@@ -304,7 +304,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
                 op->o_func.c_fn(target, target_cur, nlong / op->dt_size);
             }
         } else {
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
 #if 1 /* It is ugly implementation of compare and swap operation
          Usage of this hack does not give performance improvement but
@@ -345,7 +345,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
         for (peer_id = 1;
                 (peer_id < group->proc_count) && (rc == OSHMEM_SUCCESS);
                 peer_id++) {
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
             rc = MCA_SPML_CALL(put(oshmem_ctx_default, (void*)pSync, sizeof(value), (void*)&value, peer_pe));
         }
     }
@@ -416,7 +416,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
     if (my_id >= floor2_proc) {
         /* I am in extra group, my partner is node (my_id-y) in basic group */
         peer_id = my_id - floor2_proc;
-        peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+        peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
         /* Special procedure is needed in case target and source are the same */
         if (source == target) {
@@ -448,7 +448,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
         if ((group->proc_count - floor2_proc) > my_id) {
             /* I am in basic group, my partner is node (my_id+y) in extra group */
             peer_id = my_id + floor2_proc;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             /* Special procedure is needed in case target and source are the same */
             if (source == target) {
@@ -481,8 +481,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
             /* Update exit condition and round counter */
             exit_flag >>= 1;
             round++;
-
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
 #if 1 /* It is ugly implementation of compare and swap operation
          Usage of this hack does not give performance improvement but
@@ -524,7 +523,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
         if ((group->proc_count - floor2_proc) > my_id) {
             /* I am in basic group, my partner is node (my_id+y) in extra group */
             peer_id = my_id + floor2_proc;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             SCOLL_VERBOSE(14,
                           "[#%d] is extra send data to #%d",
@@ -566,7 +565,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
     rank = group->my_pe;
     size = group->proc_count;
     int root_id = size - 1;
-    int root_pe = oshmem_proc_pe(group->proc_array[root_id]);
+    int root_pe = oshmem_proc_pe_vpid(group, root_id);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Basic", group->my_pe);
 
@@ -592,7 +591,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
             memcpy(target, (void *) source, nlong);
         } else {
             peer_id = size - 1;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
             rc = MCA_SPML_CALL(recv(target, nlong, peer_pe));
         }
         if (OSHMEM_SUCCESS != rc) {
@@ -609,7 +608,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
                 inbuf = (char*) source;
             } else {
                 peer_id = i;
-                peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+                peer_pe = oshmem_proc_pe_vpid(group, peer_id);
                 rc = MCA_SPML_CALL(recv(pml_buffer, nlong, peer_pe));
                 if (OSHMEM_SUCCESS != rc) {
                     if (NULL != free_buffer) {
@@ -671,7 +670,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
     int peer_id = 0;
     int peer_pe = 0;
     int root_id = 0;
-    int root_pe = oshmem_proc_pe(group->proc_array[root_id]);
+    int root_pe = oshmem_proc_pe_vpid(group, root_id);
     int dim = 0;
 
     /* Initialize */
@@ -719,7 +718,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
         if (vrank & mask) {
             peer_id = vrank & ~mask;
             peer_id = (peer_id + root_id) % size;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             rc = MCA_SPML_CALL(send((void*)snd_buffer, nlong, peer_pe, MCA_SPML_BASE_PUT_STANDARD));
             if (OSHMEM_SUCCESS != rc) {
@@ -738,7 +737,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
                 continue;
             }
             peer_id = (peer_id + root_id) % size;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             /* Most of the time (all except the first one for commutative
              * operations) we receive in the user provided buffer

--- a/oshmem/mca/scoll/mpi/scoll_mpi_module.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_module.c
@@ -145,7 +145,7 @@ mca_scoll_mpi_comm_query(oshmem_group_t *osh_group, int *priority)
 
         /* Fill the map "group_rank-to-world_rank" in order to create a new proc group */
         for (i = 0; i < osh_group->proc_count; i++) {
-            ranks[i] = osh_group->proc_array[i]->super.proc_name.vpid;
+            ranks[i] = oshmem_proc_pe_vpid(osh_group, i);
         }
 
         OPAL_TIMING_ENV_NEXT(comm_query, "build_ranks");

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -193,9 +193,9 @@ typedef int (*mca_spml_base_module_oob_get_mkeys_fn_t)(shmem_ctx_t ctx, int pe,
  * @return OSHMEM_SUCCESS or failure status.
  *
  */
-typedef int (*mca_spml_base_module_add_procs_fn_t)(ompi_proc_t** procs,
+typedef int (*mca_spml_base_module_add_procs_fn_t)(struct oshmem_group_t* group,
                                                    size_t nprocs);
-typedef int (*mca_spml_base_module_del_procs_fn_t)(ompi_proc_t** procs,
+typedef int (*mca_spml_base_module_del_procs_fn_t)(struct oshmem_group_t* group,
                                                    size_t nprocs);
 
 

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -249,7 +249,7 @@ int mca_spml_ucx_ctx_mkey_del(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segn
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs)
 {
     size_t ucp_workers = mca_spml_ucx.ucp_workers;
     opal_common_ucx_del_proc_t *del_procs;
@@ -431,7 +431,7 @@ int mca_spml_ucx_clear_put_op_mask(mca_spml_ucx_ctx_t *ctx)
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
 {
     int rc                  = OSHMEM_ERROR;
     int my_rank             = oshmem_my_proc_id();
@@ -505,9 +505,6 @@ int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
                     ucs_status_string(err));
             goto error2;
         }
-
-        OSHMEM_PROC_DATA(procs[i])->num_transports = 1;
-        OSHMEM_PROC_DATA(procs[i])->transport_ids = spml_ucx_transport_ids;
 
         /* Initialize mkeys as NULL for all processes */
         mca_spml_ucx_peer_mkey_cache_init(&mca_spml_ucx_ctx_default, i);

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -10,7 +10,7 @@
  *
  * $HEADER$
  */
-
+ 
 #define _GNU_SOURCE
 #include <stdio.h>
 

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -193,8 +193,8 @@ extern void mca_spml_ucx_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint
 extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey, int pe);
 extern void *mca_spml_ucx_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *, int pe);
 
-extern int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs);
-extern int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs);
+extern int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs);
+extern int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs);
 extern int mca_spml_ucx_fence(shmem_ctx_t ctx);
 extern int mca_spml_ucx_quiet(shmem_ctx_t ctx);
 extern int spml_ucx_default_progress(void);

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -261,7 +261,7 @@ mca_spml_ucx_ctx_mkey_by_va(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_s
 {
     spml_ucx_cached_mkey_t **mkey;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
-    int i;
+    size_t i;
 
     mkey = ucx_ctx->ucp_peers[pe].mkeys;
     for (i = 0; i < ucx_ctx->ucp_peers[pe].mkeys_cnt; i++) {

--- a/oshmem/proc/proc.c
+++ b/oshmem/proc/proc.c
@@ -31,10 +31,52 @@
 
 
 static opal_mutex_t oshmem_proc_lock;
+static opal_bitmap_t _oshmem_local_vpids;       /* Track the vpids in local node */
+int oshmem_proc_init_set_local_vpids()
+{
+    opal_process_name_t wildcard_rank;
+    int ret = OMPI_SUCCESS;
+    char *val = NULL;
+    
+    ret = opal_bitmap_init(&_oshmem_local_vpids, ompi_comm_size(oshmem_comm_world));
+    if (OSHMEM_SUCCESS != ret) {
+        return ret;
+    }
+    /* Add all local peers first */
+    wildcard_rank.jobid = OMPI_PROC_MY_NAME->jobid;
+    wildcard_rank.vpid = OMPI_NAME_WILDCARD->vpid;
+    /* retrieve the local peers */
+    OPAL_MODEX_RECV_VALUE(ret, PMIX_LOCAL_PEERS,
+                          &wildcard_rank, &val, PMIX_STRING);
+
+    if (OPAL_SUCCESS == ret && NULL != val) {
+        char **peers = opal_argv_split(val, ',');
+        int i;
+        free(val);
+        for (i=0; NULL != peers[i]; i++) {
+            ompi_vpid_t local_rank = strtoul(peers[i], NULL, 10);
+            opal_bitmap_set_bit(&_oshmem_local_vpids, local_rank);
+        }
+        opal_argv_free(peers);
+    }
+    return OSHMEM_SUCCESS;
+}
+
+bool oshmem_proc_on_local_node(int pe)
+{
+    return opal_bitmap_is_set_bit(&_oshmem_local_vpids, pe);
+}
 
 int oshmem_proc_init(void)
 {
+    int ret;
     OBJ_CONSTRUCT(&oshmem_proc_lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&_oshmem_local_vpids, opal_bitmap_t);
+
+    ret = oshmem_proc_init_set_local_vpids();
+    if(OSHMEM_SUCCESS != ret) {
+        return ret;
+    }
 
     /* check oshmem_proc_data_t can fit within ompi_proc_t padding */
     assert(sizeof(oshmem_proc_data_t) <= OMPI_PROC_PADDING_SIZE);
@@ -150,7 +192,6 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     int cur_pe, count_pe;
     int i;
     oshmem_group_t* group = NULL;
-    ompi_proc_t** proc_array = NULL;
     ompi_proc_t* proc = NULL;
 
     assert(oshmem_proc_local());
@@ -171,37 +212,26 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     OPAL_THREAD_LOCK(&oshmem_proc_lock);
 
     /* allocate an array */
-    proc_array = (ompi_proc_t**) malloc(pe_size * sizeof(ompi_proc_t*));
-    if (NULL == proc_array) {
-        OBJ_RELEASE(group);
-        OPAL_THREAD_UNLOCK(&oshmem_proc_lock);
-        return NULL ;
+    group->proc_vpids = (opal_vpid_t *) malloc(pe_size * sizeof(group->proc_vpids[0]));
+    if (NULL == group->proc_vpids) {
+        return NULL;
     }
 
     group->my_pe = oshmem_proc_pe(oshmem_proc_local());
     group->is_member = 0;
     for (i = 0 ; i < ompi_comm_size(oshmem_comm_world) ; i++) {
-        proc = oshmem_proc_find(i);
-        if (NULL == proc) {
-            opal_output(0,
-                    "Error: Can not find proc object for pe = %d", i);
-            free(proc_array);
-            OBJ_RELEASE(group);
-            OPAL_THREAD_UNLOCK(&oshmem_proc_lock);
-            return NULL;
-        }
         if (count_pe >= (int) pe_size) {
             break;
         } else if ((cur_pe >= pe_start)
                 && ((pe_stride == 0)
                     || (((cur_pe - pe_start) % pe_stride) == 0))) {
-            proc_array[count_pe++] = proc;
-            if (oshmem_proc_pe(proc) == group->my_pe)
+            group->proc_vpids[count_pe] = i;
+            count_pe ++;
+            if (i == group->my_pe)
                 group->is_member = 1;
         }
         cur_pe++;
     }
-    group->proc_array = proc_array;
     group->proc_count = (int) count_pe;
     group->ompi_comm = NULL;
 
@@ -212,8 +242,8 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
 
         for (i = 0; i < group->proc_count; i++) {
             peer = OBJ_NEW(opal_namelist_t);
-            peer->name.jobid = OSHMEM_PROC_JOBID(group->proc_array[i]);
-            peer->name.vpid = OSHMEM_PROC_VPID(group->proc_array[i]);
+            peer->name.jobid = group->proc_vpids[i];
+            peer->name.vpid = OMPI_PROC_MY_NAME->jobid;
             opal_list_append(&(group->peer_list), &peer->super);
         }
     }
@@ -252,8 +282,9 @@ oshmem_proc_group_destroy_internal(oshmem_group_t* group, int scoll_unselect)
     }
 
     /* Destroy proc array */
-    if (group->proc_array) {
-        free(group->proc_array);
+    OBJ_DESTRUCT(&_oshmem_local_vpids);
+    if (group->proc_vpids) {
+        free(group->proc_vpids);
     }
 
     /* Destroy peer list */

--- a/oshmem/proc/proc.c
+++ b/oshmem/proc/proc.c
@@ -78,8 +78,6 @@ int oshmem_proc_init(void)
         return ret;
     }
 
-    /* check oshmem_proc_data_t can fit within ompi_proc_t padding */
-    assert(sizeof(oshmem_proc_data_t) <= OMPI_PROC_PADDING_SIZE);
     /* check ompi_proc_t padding is aligned on a pointer */
     assert(0 == (offsetof(ompi_proc_t, padding) & (sizeof(char *)-1)));
 
@@ -192,7 +190,6 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     int cur_pe, count_pe;
     int i;
     oshmem_group_t* group = NULL;
-    ompi_proc_t* proc = NULL;
 
     assert(oshmem_proc_local());
 
@@ -234,19 +231,6 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     }
     group->proc_count = (int) count_pe;
     group->ompi_comm = NULL;
-
-    /* Prepare peers list */
-    OBJ_CONSTRUCT(&(group->peer_list), opal_list_t);
-    {
-        opal_namelist_t *peer = NULL;
-
-        for (i = 0; i < group->proc_count; i++) {
-            peer = OBJ_NEW(opal_namelist_t);
-            peer->name.jobid = group->proc_vpids[i];
-            peer->name.vpid = OMPI_PROC_MY_NAME->jobid;
-            opal_list_append(&(group->peer_list), &peer->super);
-        }
-    }
     group->id = opal_pointer_array_add(&oshmem_group_array, group);
 
     memset(&group->g_scoll, 0, sizeof(mca_scoll_base_group_scoll_t));
@@ -285,17 +269,6 @@ oshmem_proc_group_destroy_internal(oshmem_group_t* group, int scoll_unselect)
     OBJ_DESTRUCT(&_oshmem_local_vpids);
     if (group->proc_vpids) {
         free(group->proc_vpids);
-    }
-
-    /* Destroy peer list */
-    {
-        opal_list_item_t *item;
-
-        while (NULL != (item = opal_list_remove_first(&(group->peer_list)))) {
-            /* destruct the item (we constructed it), then free the memory chunk */
-            OBJ_RELEASE(item);
-        }
-        OBJ_DESTRUCT(&(group->peer_list));
     }
 
     /* reset the oshmem_group_array entry - make sure that the

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -19,7 +19,9 @@
 #include "oshmem/constants.h"
 
 #include "opal/class/opal_list.h"
+#include "opal/class/opal_bitmap.h"
 #include "opal/util/proc.h"
+#include "opal/util/argv.h"
 #include "opal/mca/hwloc/hwloc-internal.h"
 
 #include "ompi/proc/proc.h"
@@ -61,8 +63,7 @@ struct oshmem_group_t {
     int                         my_pe;
     int                         proc_count;     /**< number of processes in group */
     int                         is_member;   /* true if my_pe is part of the group, participate in collectives */
-    struct ompi_proc_t          **proc_array; /**< list of pointers to ompi_proc_t structures
-                                                   for each process in the group */
+    opal_vpid_t                 *proc_vpids; /* vpids of each process in group */
     opal_list_t                 peer_list;
 
     /* Collectives module interface and data */
@@ -149,14 +150,22 @@ static inline ompi_proc_t *oshmem_proc_find(int pe)
     return oshmem_proc_for_find(name);
 }
 
+static inline int oshmem_proc_pe_vpid(oshmem_group_t *group, int pe)
+{
+    if (OPAL_LIKELY(pe < group->proc_count)) {
+        return (group->proc_vpids[pe]);
+    } else {
+        return -1;
+    }
+}
+
 static inline int oshmem_proc_pe(ompi_proc_t *proc)
 {
     return (proc ? (int) ((ompi_process_name_t*)&proc->super.proc_name)->vpid : -1);
 }
 
-#define OSHMEM_PROC_JOBID(PROC)    (((ompi_process_name_t*)&((PROC)->super.proc_name))->jobid)
-#define OSHMEM_PROC_VPID(PROC)     (((ompi_process_name_t*)&((PROC)->super.proc_name))->vpid)
-
+int oshmem_proc_init_set_local_vpids();
+bool oshmem_proc_on_local_node(int pe);
 /**
  * Initialize the OSHMEM process predefined groups
  *
@@ -232,40 +241,6 @@ fatal:
  */
 OSHMEM_DECLSPEC void oshmem_proc_group_destroy(oshmem_group_t* group);
 
-static inline ompi_proc_t *oshmem_proc_group_all(int pe)
-{
-    return oshmem_group_all->proc_array[pe];
-}
-
-static inline ompi_proc_t *oshmem_proc_group_find(oshmem_group_t* group,
-                                                    int pe)
-{
-    int i = 0;
-    ompi_proc_t* proc = NULL;
-
-    if (OPAL_LIKELY(group)) {
-        if (OPAL_LIKELY(group == oshmem_group_all)) {
-            /* To improve performance use direct index. It is feature of oshmem_group_all */
-            proc = group->proc_array[pe];
-        } else {
-            for (i = 0; i < group->proc_count; i++) {
-                if (pe == oshmem_proc_pe(group->proc_array[i])) {
-                    proc = group->proc_array[i];
-                    break;
-                }
-            }
-        }
-    } else {
-        ompi_process_name_t name;
-
-        name.jobid = OMPI_PROC_MY_NAME->jobid;
-        name.vpid = pe;
-        proc = oshmem_proc_for_find(name);
-    }
-
-    return proc;
-}
-
 static inline int oshmem_proc_group_find_id(oshmem_group_t* group, int pe)
 {
     int i = 0;
@@ -273,7 +248,7 @@ static inline int oshmem_proc_group_find_id(oshmem_group_t* group, int pe)
 
     if (group) {
         for (i = 0; i < group->proc_count; i++) {
-            if (pe == oshmem_proc_pe(group->proc_array[i])) {
+            if (pe == oshmem_proc_pe_vpid(group, i)) {
                 id = i;
                 break;
             }
@@ -297,22 +272,6 @@ static inline int oshmem_num_procs(void)
 static inline int oshmem_my_proc_id(void)
 {
     return oshmem_group_self->my_pe;
-}
-
-static inline int oshmem_get_transport_id(int pe)
-{
-    ompi_proc_t *proc;
-
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-
-    return (int) OSHMEM_PROC_DATA(proc)->transport_ids[0];
-}
-
-static inline int oshmem_get_transport_count(int pe)
-{
-    ompi_proc_t *proc;
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-    return OSHMEM_PROC_DATA(proc)->num_transports;
 }
 
 END_C_DECLS

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -39,19 +39,6 @@ struct oshmem_group_t;
 
 #define OSHMEM_PE_INVALID   (-1)
 
-/* This struct will be copied into the padding field of an ompi_proc_t
- * so the size of oshmem_proc_data_t must be less or equal than
- * OMPI_PROC_PADDING_SIZE */
-struct oshmem_proc_data_t {
-    char * transport_ids;
-    int num_transports;
-};
-
-typedef struct oshmem_proc_data_t oshmem_proc_data_t;
-
-#define OSHMEM_PROC_DATA(proc) \
-    ((oshmem_proc_data_t *)(proc)->padding)
-
 /**
  * Group of Open SHMEM processes structure
  *
@@ -64,7 +51,6 @@ struct oshmem_group_t {
     int                         proc_count;     /**< number of processes in group */
     int                         is_member;   /* true if my_pe is part of the group, participate in collectives */
     opal_vpid_t                 *proc_vpids; /* vpids of each process in group */
-    opal_list_t                 peer_list;
 
     /* Collectives module interface and data */
     mca_scoll_base_group_scoll_t g_scoll;
@@ -164,7 +150,6 @@ static inline int oshmem_proc_pe(ompi_proc_t *proc)
     return (proc ? (int) ((ompi_process_name_t*)&proc->super.proc_name)->vpid : -1);
 }
 
-int oshmem_proc_init_set_local_vpids();
 bool oshmem_proc_on_local_node(int pe);
 /**
  * Initialize the OSHMEM process predefined groups

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -126,7 +126,7 @@ static int _shmem_finalize(void)
 
     if (OSHMEM_SUCCESS
             != (ret =
-                    MCA_SPML_CALL(del_procs(oshmem_group_all->proc_array, oshmem_group_all->proc_count)))) {
+                    MCA_SPML_CALL(del_procs(oshmem_group_all, oshmem_group_all->proc_count)))) {
         return ret;
     }
 

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -347,7 +347,7 @@ static int _shmem_init(int argc, char **argv, int requested, int *provided)
     OPAL_TIMING_ENV_NEXT(timing, "MCA_SPML_CALL(enable())");
 
     ret =
-            MCA_SPML_CALL(add_procs(oshmem_group_all->proc_array, oshmem_group_all->proc_count));
+            MCA_SPML_CALL(add_procs(oshmem_group_all, oshmem_group_all->proc_count));
     if (OSHMEM_SUCCESS != ret) {
         error = "SPML add procs failed";
         goto error;

--- a/oshmem/shmem/c/shmem_broadcast.c
+++ b/oshmem/shmem/c/shmem_broadcast.c
@@ -69,7 +69,7 @@ static void _shmem_broadcast(void *target,
         }
 
         /* Define actual PE using relative in active set */
-        PE_root = oshmem_proc_pe(group->proc_array[PE_root]);
+        PE_root = oshmem_proc_pe_vpid(group, PE_root);
 
         /* Call collective broadcast operation */
         rc = group->g_scoll.scoll_broadcast(group,

--- a/oshmem/shmem/c/shmem_ptr.c
+++ b/oshmem/shmem/c/shmem_ptr.c
@@ -31,7 +31,6 @@
 
 void *shmem_ptr(const void *dst_addr, int pe)
 {
-    ompi_proc_t *proc;
     sshmem_mkey_t *mkey;
     int i;
     void *rva;
@@ -46,8 +45,7 @@ void *shmem_ptr(const void *dst_addr, int pe)
     }
 
     /* The memory must be on the local node */
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-    if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
+    if (!oshmem_proc_on_local_node(pe)) {
         return NULL;
     }
 

--- a/oshmem/shmem/fortran/shmem_broadcast_f.c
+++ b/oshmem/shmem/fortran/shmem_broadcast_f.c
@@ -85,7 +85,7 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
         }\
         \
         /* Define actual PE using relative in active set */\
-        rel_PE_root = oshmem_proc_pe(group->proc_array[OMPI_FINT_2_INT(*PE_root)]);\
+        rel_PE_root = oshmem_proc_pe_vpid(group, OMPI_FINT_2_INT(*PE_root));\
         \
         /* Call collective broadcast operation */\
         rc = group->g_scoll.scoll_broadcast( group, \


### PR DESCRIPTION
oshmem uses ompi_proc structure during group creation. However,
only vpids and locality information is used inside oshmem internally.
Removing the proc_array from oshmem_group and replacing it with a
array to hold the vpids. A static array is used to keep track of
locality information which we collect from PMIx.

Moreover, peer_list field in oshmem_group_t is not used anywhere internally in
oshmem. Removing this field will further reduce memory consumption in
oshmem_proc_group_create flow.

Example: The original ompi_proc_t structure in proc_array was about 112 bytes,
while each entry in vpid array will be 4 byte. We use a bitmap
to track locality information which is around 1/8 bytes. So,
we reduces the memory usage from 112 to ~4.13 per proc in each pe.
With 100 nodes and 40 PPN, each proc used to utilize (112*40) = 4480 bytes.
Now, after this PR, it can come down to (4.13 * 40) = 165 bytes.
So, the total memory utilization per node (w/ 40 ppn) in this codeflow
will come down from 179,200 bytes to 6,600 bytes.


Co-authored-by: Artem Y. Polyakov <artemp@nvidia.com>
Signed-off-by: Subhadeep Bhattacharya <subhadeepb@nvidia.com>
Signed-off-by: Artem Polyakov <artemp@nvidia.com>