### PR TITLE
Register for the "lost connection" event

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -401,7 +401,11 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     volatile bool active;
     bool background_fence = false;
     pmix_info_t info[2];
-    pmix_status_t codes[1] = { PMIX_ERR_PROC_ABORTED };
+    pmix_status_t codes[] = {
+        PMIX_ERR_PROC_ABORTED,
+        PMIX_ERR_LOST_CONNECTION
+    };
+    size_t ncodes;
     pmix_status_t rc;
     OMPI_TIMING_INIT(64);
     opal_pmix_lock_t mylock;
@@ -581,7 +585,8 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     /* give it a name so we can distinguish it */
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_NAME, "MPI-Default", PMIX_STRING);
     OPAL_PMIX_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(codes, 1, info, 2, ompi_errhandler_callback, evhandler_reg_callbk, (void*)&mylock);
+    ncodes = sizeof(codes)/sizeof(pmix_status_t);
+    PMIx_Register_event_handler(codes, ncodes, info, 2, ompi_errhandler_callback, evhandler_reg_callbk, (void*)&mylock);
     OPAL_PMIX_WAIT_THREAD(&mylock);
     rc = mylock.status;
     OPAL_PMIX_DESTRUCT_LOCK(&mylock);


### PR DESCRIPTION
Register for the "lost connection" event

PMIx generates a "lost connection" event when the connection
from the application proc to the local daemon fails. OMPI needs
to trap that event and invoke its internal error handler to
ensure that the processes properly "suicide".

This raises the question of OMPI event registration in general. I
found that OMPI was registering for one event (PMIX_ERR_PROC_ABORTED)
that isn't being generated by anyone, plus the PMIX_DEBUGGER_RELEASE
event. No default event handler is being registered, nor handlers
for any other common events that might impact the MPI layer.

OMPI folks might want to conduct a review of the code base and
available events to determine which ones they need/want to register
to receive.

Fixes #8925 

Signed-off-by: Ralph Castain <rhc@pmix.org>