### PR TITLE
v4.0.x: VERSION: make safe for C++ compilers

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,43 @@
+#if 0
+
+# NOTE: The comments below cannot use tokens that will be intepreted
+# as C++ preprocessor directives.  So when you read "if 0", the reader
+# must mentally prepend a # to the "if" token.
+#
+# This file is carefully constructed so that it can be a) run as a
+# Bourne shell script and b) compiled as a C/C++ header file.
+#
+# Specifically, this file is used in the following ways:
+#
+# 1. This file is executed as a Bourne shell script to assign version
+#    numbers to shell variables in config/opal_get_version.* and
+#    configure.ac.
+# 2. On case-insensitive filesystems, this file can get included by
+#    C++ STL header files when compiling the MPI C++ bindings (i.e.,
+#    when they "include <version>", that will end up including this
+#    file).
+#
+# Case #2 was discovered in
+# https://github.com/open-mpi/ompi/issues/9122.  The obvious fix for
+# this issue would be to rename VERSION (e.g., VERSION.sh).  However,
+# since the MPI C++ bindings were removed in Open MPI v5.0.0, this
+# issue issue only affects legacy Open MPI release series (namely:
+# v4.1.x and v4.0.x).  As such, do something simple / safe to fix it:
+# protect the main body of this file with an "if" preprocessor
+# directive.
+#
+# 1. For case 1, C++ preprocessor directives become Bourne shell comments.
+# 2. For case 2, we "if 0" the main body of the file and in the "else"
+#    block, "include_next<version>" to get the "real" <version> file.
+#
+# This is a bit of a gross (or clever, depending on your viewpoint)
+# hack, but it makes both cases work with minimal changes to the
+# legacy v4.0.x and v4.1.x release series.
+
+############################################################################
+
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2008-2019 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
@@ -118,3 +156,9 @@ libmca_opal_common_sm_so_version=60:0:20
 libmca_opal_common_ucx_so_version=60:2:20
 libmca_opal_common_ugni_so_version=60:0:20
 libmca_opal_common_verbs_so_version=60:0:20
+
+#else
+
+#include_next <version>
+
+#endif


### PR DESCRIPTION
When compiling the MPI C++ bindings on a case-insensitive filesystem,
we #include various STL header files.  At least some versions of Clang
on MacOS have `#include <version>` in their STL header files, which
ends up including the Open MPI VERSION file.

The Open MPI VERSION file is executed as a Bourne shell script during
configure.  We could rename VERSION `-->` VERSION.sh, but this would
touch a lot of places, and doesn't seem worth it (remember: the MPI
C++ bindings have been removed from the Open MPI master and upcoming
v5.0.0 release).

This commit therefore does something small/simple to make the existing
VERSION file also safe to #include as a C/C++ header file.  It
basically uses "#if 0" to comment out the main body of the file, and
then `#include_next <version>` to get the "real" `<version>` file.

This commit is a cherry pick from the v4.1.x branch (since the issue
does not exist on master).

Thanks to @srpgilles for raising the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 4dd5a47a9554b85ca0d6b3d3f5814eaa87198274)

This is a cherry pick from the v4.1.x branch.

Fixes #9122