### PR TITLE
Add a mfence to opal_atomic_mb() for x86.

### DIFF
--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -52,7 +52,7 @@
 
 static inline void opal_atomic_mb(void)
 {
-    MB();
+    __asm__ __volatile__("mfence": : :"memory");
 }
 
 static inline void opal_atomic_rmb(void)


### PR DESCRIPTION
x86 requires a mfence for it to be a full memory barrier;
a compiler MB is not sufficient.

Co-authored-by: George Katevenis <george_kate@hotmail.com>

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>