### PR TITLE
test: Update Makefile.am files to not define distclean target

### DIFF
--- a/test/asm/Makefile.am
+++ b/test/asm/Makefile.am
@@ -90,5 +90,5 @@ maintainer-clean-local:
 	atomic_math_noinline.c \
 	atomic_cmpset_noinline.c
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -97,5 +97,5 @@ opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
 clean-local:
 	rm -f opal_bitmap_test_out.txt opal_hash_table_test_out.txt opal_proc_table_test_out.txt
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.txt *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -108,5 +108,5 @@ partial_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/event/Makefile.am
+++ b/test/event/Makefile.am
@@ -44,5 +44,5 @@ event_test_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 event_test_DEPENDENCIES = $(event_test_LDADD)
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/memchecker/Makefile.am
+++ b/test/memchecker/Makefile.am
@@ -60,5 +60,5 @@ non_blocking_recv_test_LDADD = \
         $(top_builddir)/ompi/lib@OPAL_LIB_NAME@mpi.la
 non_blocking_recv_test_DEPENDENCIES = $(non_blocking_recv_test_LDADD)
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -45,5 +45,5 @@ if PROJECT_OMPI
 	$(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 endif # PROJECT_OMPI
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.la *.lo monitoring_test test_pvar_access test_overhead check_monitoring example_reduce_count prof *.log *.o *.trs Makefile

--- a/test/mpi/environment/Makefile.am
+++ b/test/mpi/environment/Makefile.am
@@ -29,5 +29,5 @@ chello_LDADD = \
 chello_DEPENDENCIES = $(chello_LDADD)
 
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps *.log *.o *.trs $(noinst_PROGRAMS) Makefile

--- a/test/mpool/Makefile.am
+++ b/test/mpool/Makefile.am
@@ -16,6 +16,6 @@ mpool_memkind_SOURCES = mpool_memkind.c
 LDFLAGS = $(OPAL_PKG_CONFIG_LDFLAGS)
 LDADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile
 

--- a/test/runtime/Makefile.am
+++ b/test/runtime/Makefile.am
@@ -56,5 +56,5 @@ opal_init_finalize_LDADD = \
 	$(top_builddir)/test/support/libsupport.a
 opal_init_finalize_DEPENDENCIES = $(opal_init_finalize_LDADD)
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/spc/Makefile.am
+++ b/test/spc/Makefile.am
@@ -20,5 +20,5 @@ if PROJECT_OMPI
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 endif # PROJECT_OMPI
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.la *.lo spc_test prof *.log *.o *.trs Makefile

--- a/test/support/Makefile.am
+++ b/test/support/Makefile.am
@@ -32,5 +32,5 @@ libsupport_a_SOURCES = \
         support.c \
         support.h
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps *.log *.o *.trs $(check_LIBRARIES) Makefile

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -50,5 +50,5 @@ opal_atomic_thread_bench_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 opal_atomic_thread_bench_DEPENDENCIES = $(opal_atomic_thread_bench_LDADD)
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -131,6 +131,6 @@ bipartite_graph_DEPENDENCIES = $(bipartite_graph_LDADD)
 clean-local:
 	rm -f test_session_dir_out test-file opal_path_nfs.out
 
-distclean:
+distclean-local:
 	rm -rf *.dSYM .deps .libs *.out *.log *.o *.trs $(check_PROGRAMS) Makefile
 


### PR DESCRIPTION
This commit fixes warnings issued by automake about overriding the builtin distclean target.
The fix is to use distclean-local instead.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>