### PR TITLE
v4.0.x: Add a mfence to opal_atomic_mb() for x86.

### DIFF
--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -53,7 +53,7 @@
 
 static inline void opal_atomic_mb(void)
 {
-    MB();
+    __asm__ __volatile__("mfence": : :"memory");
 }
 
 


### PR DESCRIPTION
x86 requires a mfence for it to be a full memory barrier;
a compiler MB is not sufficient.

Co-authored-by: George Katevenis <george_kate@hotmail.com>

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 8dca246bd515dd73cc6b37751471675d633412ea)

Fixes #8532