### PR TITLE
v4.1.x: pmix3x: fix slurping of PMIx compiler/linker flags

### DIFF
--- a/opal/mca/pmix/pmix3x/configure.m4
+++ b/opal/mca/pmix/pmix3x/configure.m4
@@ -98,11 +98,15 @@ AC_DEFUN([MCA_opal_pmix_pmix3x_CONFIG],[
    AC_SUBST([opal_pmix_pmix3x_DEPENDENCIES])
 
    # Finally, add some flags to the wrapper compiler so that our
-   # headers can be found.
-   pmix_pmix3x_status_filename="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix3x_basedir/pmix/config.status"
-   pmix_pmix3x_WRAPPER_EXTRA_CPPFLAGS=`egrep PMIX_EMBEDDED_CPPFLAGS $pmix_pmix3x_status_filename | cut -d\" -f4`
-   pmix_pmix3x_WRAPPER_EXTRA_LDFLAGS=`egrep PMIX_EMBEDDED_LDFLAGS $pmix_pmix3x_status_filename | cut -d\" -f4`
-   pmix_pmix3x_WRAPPER_EXTRA_LIBS=`egrep PMIX_EMBEDDED_LIBS $pmix_pmix3x_status_filename | cut -d\" -f4`
+   # headers can be found.  Do not grab them from config.status,
+   # because the value is located in an area that is part of an awk
+   # script, and sometimes autoconf decides to break up super-long
+   # lines into multiple lines (awk has line continuation syntax).
+   # Instead, grab it from the generated Makefile.
+   pmix_pmix3x_makefile_filename="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix3x_basedir/pmix/Makefile"
+   pmix_pmix3x_WRAPPER_EXTRA_CPPFLAGS=`egrep PMIX_EMBEDDED_CPPFLAGS $pmix_pmix3x_makefile_filename | cut -d= -f2-`
+   pmix_pmix3x_WRAPPER_EXTRA_LDFLAGS=`egrep PMIX_EMBEDDED_LDFLAGS $pmix_pmix3x_makefile_filename | cut -d= -f2-`
+   pmix_pmix3x_WRAPPER_EXTRA_LIBS=`egrep PMIX_EMBEDDED_LIBS $pmix_pmix3x_makefile_filename | cut -d= -f2-`
 
    AC_MSG_CHECKING([PMIx extra wrapper CPPFLAGS])
    AC_MSG_RESULT([$pmix_pmix3x_WRAPPER_EXTRA_CPPFLAGS])


### PR DESCRIPTION
Previously, after invoking PMIx's "configure" script, we grep'ed
PMIx's flags from its config.status.  Apparently, the values were
includes in a section of config.status that was actually an awk
script, and if the value got long enough, GNU Autoconf would use awk
line continuation syntax to span multiple lines.  This meant that Open
MPI's grep would basically get an incomplete value.

This commit changes to instead grep the value from a PMIx Makefile,
where the value will never be split across multiple lines.

Thanks to @eschnett for reporting the issue.

This is not a cherry pick from master because the problem does not
exist on master due to the refactoring of how PMIx is configured and
built.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #9162 

bot:notacherrypick