### PR TITLE
tools/mpirun: include errno.h explicitly

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <errno.h>
 #if HAVE_SYS_STAT_H
 #    include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */


### PR DESCRIPTION
With some configuration options (e.g., `--with-threads=argobots`), none of the headers here (https://github.com/open-mpi/ompi/blob/master/ompi/tools/mpirun/main.c#L10-L24) includes `errno.h`, causing a compile error because of undefined `errno` here (https://github.com/open-mpi/ompi/blob/master/ompi/tools/mpirun/main.c#L97).
```
main.c: In function ‘main’:
main.c:97:61: error: ‘errno’ undeclared (first use in this function)
                      truepath ? truepath : "NULL", strerror(errno));
```
`errno.h` should be included explicitly.
