### PR TITLE
pml/ucx: fix object retain for predefined data types

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -697,12 +697,12 @@ int mca_pml_ucx_isend_init(const void *buf, size_t count, ompi_datatype_t *datat
     req->send.mode                = mode;
     req->send.ep                  = ep;
     req->ompi_datatype            = datatype;
+    OMPI_DATATYPE_RETAIN(datatype);
 
     if (MCA_PML_BASE_SEND_BUFFERED == mode) {
-        OBJ_RETAIN(datatype);
+        req->datatype = NULL;
     } else {
         req->datatype = mca_pml_ucx_get_datatype(datatype);
-        OMPI_DATATYPE_RETAIN(datatype);
     }
 
     *request = &req->ompi;

--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -216,12 +216,7 @@ static int mca_pml_ucx_persistent_request_free(ompi_request_t **rptr)
         mca_pml_ucx_persistent_request_detach(preq, tmp_req);
         ucp_request_free(tmp_req);
     }
-    if ((preq->flags & MCA_PML_UCX_REQUEST_FLAG_SEND) &&
-         (MCA_PML_BASE_SEND_BUFFERED == preq->send.mode)) {
-        OBJ_RELEASE(preq->ompi_datatype);
-    } else {
-        OMPI_DATATYPE_RELEASE(preq->ompi_datatype);
-    }
+    OMPI_DATATYPE_RELEASE(preq->ompi_datatype);
     PML_UCX_FREELIST_RETURN(&ompi_pml_ucx.persistent_reqs, &preq->ompi.super);
     *rptr = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;


### PR DESCRIPTION
Corresponds to https://github.com/open-mpi/ompi/pull/9183