### PR TITLE
v4.0.x: Fix launch when set -u is in users login .rc file.

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -502,8 +502,8 @@ static int setup_launch(int *argcptr, char ***argvptr,
              */
             (void)asprintf (&final_cmd,
                             "%s%s%s%s%s%s PATH=%s%s$PATH ; export PATH ; "
-                            "LD_LIBRARY_PATH=%s%s$LD_LIBRARY_PATH ; export LD_LIBRARY_PATH ; "
-                            "DYLD_LIBRARY_PATH=%s%s$DYLD_LIBRARY_PATH ; export DYLD_LIBRARY_PATH ; "
+                            "LD_LIBRARY_PATH=%s%s${LD_LIBRARY_PATH:-} ; export LD_LIBRARY_PATH ; "
+                            "DYLD_LIBRARY_PATH=%s%s${DYLD_LIBRARY_PATH:-} ; export DYLD_LIBRARY_PATH ; "
                             "%s %s",
                             (NULL != mca_plm_rsh_component.chdir ? "cd " : " "),
                             (NULL != mca_plm_rsh_component.chdir ? mca_plm_rsh_component.chdir : " "),


### PR DESCRIPTION
With set -u bash will show an error if any variable is not set, causing
orted launch to fail. This change sets the variables to an empty string
if not set.

bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>