### PR TITLE
v4.0.x: reduce/ireduce: Return MPI_SUCCESS when count == 0 and send == recv.

### DIFF
--- a/ompi/mpi/c/ireduce.c
+++ b/ompi/mpi/c/ireduce.c
@@ -100,7 +100,8 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
             free(msg);
             return ret;
         } else if ((ompi_comm_rank(comm) != root && MPI_IN_PLACE == sendbuf) ||
-                   (ompi_comm_rank(comm) == root && ((MPI_IN_PLACE == recvbuf) || (sendbuf == recvbuf)))) {
+                   (ompi_comm_rank(comm) == root && ((MPI_IN_PLACE == recvbuf) ||
+                   ((sendbuf == recvbuf) && (0 != count))))) {
             err = MPI_ERR_ARG;
         } else {
             OMPI_CHECK_DATATYPE_FOR_SEND(err, datatype, count);

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -98,7 +98,8 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
             free(msg);
             return ret;
         } else if ((ompi_comm_rank(comm) != root && MPI_IN_PLACE == sendbuf) ||
-                   (ompi_comm_rank(comm) == root && ((MPI_IN_PLACE == recvbuf) || (sendbuf == recvbuf)))) {
+                   (ompi_comm_rank(comm) == root && ((MPI_IN_PLACE == recvbuf) ||
+                   ((sendbuf == recvbuf) && (0 != count))))) {
             err = MPI_ERR_ARG;
         } else {
             OMPI_CHECK_DATATYPE_FOR_SEND(err, datatype, count);


### PR DESCRIPTION
This will avoid returning an error for 0 counts when the
send and recv buffers are NULL.

Adding this will avoid skipping existing validations
and drop down to the current count == 0 check.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 715a162fe658aa031378d61a6411904359d9f663)