### PR TITLE
v4.1.x: Correctly process 0 slots with -host option.

### DIFF
--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -229,7 +229,7 @@ int orte_util_add_dash_host_nodes(opal_list_t *nodes,
                 found = true;
                 if (slots_given) {
                     node->slots += slots;
-                    if (0 < slots) {
+                    if (0 <= slots) {
                         ORTE_FLAG_SET(node, ORTE_NODE_FLAG_SLOTS_GIVEN);
                     }
                 } else {
@@ -259,7 +259,7 @@ int orte_util_add_dash_host_nodes(opal_list_t *nodes,
             node->slots_max = 0;
             if (slots_given) {
                 node->slots = slots;
-                if (0 < slots) {
+                if (0 <= slots) {
                     ORTE_FLAG_SET(node, ORTE_NODE_FLAG_SLOTS_GIVEN);
                 }
             } else if (slots < 0) {


### PR DESCRIPTION
The following command: 

mpirun -host hostA:0,hostB:6 ./x

was launching: (num_cores on hostA) + (6 hostB ranks)
instead of only the expected 6 ranks on hostB.

This works correctly with -hostfile with "hostA slots=0".
This patch just makes the behaviors consistent.

Co-authored-by: Austen Lauria <awlauria@us.ibm.com>

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 7b6f478cc64fa93a306abfd71518f60c48e3400d)