### PR TITLE
v4.1.x: scoll/mpi: Correct allreduce call for in-place buffers

### DIFF
--- a/oshmem/mca/scoll/mpi/scoll_mpi_ops.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_ops.c
@@ -256,9 +256,9 @@ int mca_scoll_mpi_reduce(struct oshmem_group_t *group,
                 SCOLL_DEFAULT_ALG);
         return rc;
     }
-    rc = mpi_module->comm->c_coll->coll_allreduce(sbuf, rbuf, (int)count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
+    rc = mpi_module->comm->c_coll->coll_allreduce( (sbuf == rbuf ? MPI_IN_PLACE : sbuf) , rbuf, (int)count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
 #else
-    rc = mpi_module->comm->c_coll->coll_allreduce(sbuf, rbuf, count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
+    rc = mpi_module->comm->c_coll->coll_allreduce( (sbuf == rbuf ? MPI_IN_PLACE : sbuf), rbuf, count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
 #endif
     if (OMPI_SUCCESS != rc){
         MPI_COLL_VERBOSE(20,"RUNNING FALLBACK REDUCE");


### PR DESCRIPTION
Calling functions like shmem_complexf_sum_to_all or shmem_complexf_prod_to_all with equal
send/recv buffers was causing data errors because we were calling into MPI collectives
libraries without MPI_IN_PLACE option.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 1ddcfccd1a94eadb02f124525b88f3d7892afdf6)