### PR TITLE
SPML/UCX: fixed build over older versions of UCX

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -88,7 +88,7 @@ mca_spml_ucx_ctx_t mca_spml_ucx_ctx_default = {
     .synchronized_quiet = false
 };
 
-#if HAVE_DECL_UCP_ATOMIC_OP_NBX
+#ifdef HAVE_UCP_REQUEST_PARAM_T
 static ucp_request_param_t mca_spml_ucx_request_param = {0};
 #endif
 


### PR DESCRIPTION
- updated macro check to instantiate empty op_param_t object

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>