### PR TITLE
Make MPI_[Comm|File|Win]_get_info MPI 4.0 compliant

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -213,9 +213,6 @@ int ompi_mpiinfo_init(void)
 int ompi_info_dup (ompi_info_t *info, ompi_info_t **newinfo) {
     return opal_info_dup (&(info->super), (opal_info_t **)newinfo);
 }
-int ompi_info_dup_mpistandard (ompi_info_t *info, ompi_info_t **newinfo) {
-    return opal_info_dup_mpistandard (&(info->super), (opal_info_t **)newinfo);
-}
 int ompi_info_set (ompi_info_t *info, const char *key, const char *value) {
     return opal_info_set (&(info->super), key, value);
 }

--- a/ompi/mpi/c/comm_get_info.c
+++ b/ompi/mpi/c/comm_get_info.c
@@ -46,9 +46,9 @@ int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used)
     }
 
     if (NULL == comm->super.s_info) {
-/*
- * Setup any defaults if MPI_Win_set_info was never called
- */
+        /*
+        * Setup any defaults if MPI_Win_set_info was never called
+        */
         opal_infosubscribe_change_info(&comm->super, &MPI_INFO_NULL->super);
     }
 
@@ -60,7 +60,7 @@ int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used)
     }
     opal_info_t *opal_info_used = &(*info_used)->super;
 
-    opal_info_dup_mpistandard(comm->super.s_info, &opal_info_used);
+    opal_info_dup(comm->super.s_info, &opal_info_used);
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/file_get_info.c
+++ b/ompi/mpi/c/file_get_info.c
@@ -70,9 +70,9 @@ int MPI_File_get_info(MPI_File fh, MPI_Info *info_used)
     }
 
     if (NULL == fh->super.s_info) {
-/*
- * Setup any defaults if MPI_Win_set_info was never called
- */
+        /*
+         * Setup any defaults if MPI_Win_set_info was never called
+         */
         opal_infosubscribe_change_info(&fh->super, &MPI_INFO_NULL->super);
     }
 
@@ -83,7 +83,7 @@ int MPI_File_get_info(MPI_File fh, MPI_Info *info_used)
     }
     opal_info_t *opal_info_used = &(*info_used)->super;
 
-    opal_info_dup_mpistandard(fh->super.s_info, &opal_info_used);
+    opal_info_dup(fh->super.s_info, &opal_info_used);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mpi/c/info_set.c
+++ b/ompi/mpi/c/info_set.c
@@ -99,17 +99,6 @@ int MPI_Info_set(MPI_Info info, const char *key, const char *value)
         }
     }
 
-// An extra warning condition is a key that uses our reserved prefix "__IN_".
-// That one is used internally to deal with the dynamic nature the key/val
-// pairs where we have callbacks that modify the val, and the MPI standard
-// wants the get_info call to give back the original setting rather than
-// the callback-modified setting. So if a user directly used a key __IN_foo
-// it would confuse our accounting slightly.
-    if (0 == strncmp(key, OPAL_INFO_SAVE_PREFIX, strlen(OPAL_INFO_SAVE_PREFIX))) {
-        opal_show_help("help-mpi-api.txt", "info-set-with-reserved-prefix", true,
-            key, OPAL_INFO_SAVE_PREFIX);
-    }
-
     /*
      * If all is right with the arguments, then call the back-end
      * allocator.

--- a/ompi/mpi/c/win_get_info.c
+++ b/ompi/mpi/c/win_get_info.c
@@ -48,19 +48,19 @@ int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used)
     }
 
     if (NULL == win->super.s_info) {
-/*
- * Setup any defaults if MPI_Win_set_info was never called
- */
-	opal_infosubscribe_change_info(&win->super, &MPI_INFO_NULL->super); 	
+        /*
+         * Setup any defaults if MPI_Win_set_info was never called
+         */
+        opal_infosubscribe_change_info(&win->super, &MPI_INFO_NULL->super);
     }
 
     (*info_used) = OBJ_NEW(ompi_info_t);
     if (NULL == (*info_used)) {
-       return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_NO_MEM, FUNC_NAME);
+        return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_NO_MEM, FUNC_NAME);
     }
     opal_info_t *opal_info_used = &(*info_used)->super;
 
-    ret = opal_info_dup_mpistandard(win->super.s_info, &opal_info_used);
+    ret = opal_info_dup(win->super.s_info, &opal_info_used);
 
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -105,38 +105,6 @@ int opal_mpiinfo_init(void *);
  */
 int opal_info_dup(opal_info_t *info, opal_info_t **newinfo);
 
-// Comments might still say __IN_<key>, but the code should be using the
-// below macro instead.
-#define OPAL_INFO_SAVE_PREFIX "_OMPI_IN_"
-
-/**
- *   opal_info_dup_mpistandard - Duplicate an 'MPI_Info' object
- *
- *   @param info source info object (handle)
- *   @param newinfo pointer to the new info object (handle)
- *
- *   @retval OPAL_SUCCESS upon success
- *   @retval OPAL_ERR_OUT_OF_RESOURCE if out of memory
- *
- *   The user sets an info object with key/value pairs and once processed,
- *   we keep key/val pairs that might have been modified vs what the user
- *   provided, and some user inputs might have been ignored too.  The original
- *   user inpust are kept as __IN_<key>/<val>.
- *
- *   This routine then outputs key/value pairs as:
- *
- *   if <key> and __IN_<key> both exist:
- *       This means the user set a k/v pair and it was used.
- *       output: <key> / value(__IN_<key>), the original user input
- *   if <key> exists but __IN_<key> doesn't:
- *       This is a system-provided setting.
- *       output: <key>/value(<key>)
- *   if __IN_<key> exists but <key> doesn't:
- *       The user provided a setting that was rejected (ignored) by the system
- *       output: nothing for this key
- */
-int opal_info_dup_mpistandard(opal_info_t *info, opal_info_t **newinfo);
-
 /**
  * Set a new key,value pair on info.
  *


### PR DESCRIPTION
So far Open MPI has elected to not hand out values for keys that were modified through `MPI_*_set_info`.
MPI 4.0 requires implementations to reflect such changes in `MPI_*_get_info` if the the new values are supported by the implementation. Hence, it is sufficient to simply duplicate the info object and remove the handling of `OPAL_INFO_SAVE_PREFIX` from OPAL entirely as there are no other users for this mechanism.

Fixes #9207
Closes #8505

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>