### PR TITLE
Fix for Ireduce + ANY_SRC.

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -9,7 +9,7 @@
  *                         reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -488,11 +488,20 @@ static inline int red_sched_chain (int rank, int p, int root, const void *sendbu
 
     /* last node does not recv */
     if (vrank != p-1) {
-      if (vrank == 0 && sendbuf != recvbuf) {
+      if (vrank == 0) {
+        if (sendbuf != recvbuf) {
+          // for regular src, recv into recvbuf
           res = NBC_Sched_recv ((char *)recvbuf+offset, false, thiscount, datatype, rpeer, schedule, true);
         } else {
+          // but for any-src, recv into tmpbuf
+          // because for any-src if we recved into recvbuf here we'd be
+          // overwriting our sendbuf, and we use it in the operation
+          // that happens further down
           res = NBC_Sched_recv ((char *)offset, true, thiscount, datatype, rpeer, schedule, true);
         }
+      } else {
+        res = NBC_Sched_recv ((char *)offset, true, thiscount, datatype, rpeer, schedule, true);
+      }
       if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
         return res;
       }
@@ -500,11 +509,16 @@ static inline int red_sched_chain (int rank, int p, int root, const void *sendbu
       /* root reduces into receivebuf */
       if(vrank == 0) {
         if (sendbuf != recvbuf) {
-            res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) recvbuf + offset, false,
-                                 thiscount, datatype, op, schedule, true);
+          // for regular src, add sendbuf into recvbuf
+          // (here recvbuf holds the reduction from 1..n-1)
+          res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) recvbuf + offset, false,
+                             thiscount, datatype, op, schedule, true);
         } else {
-            res = NBC_Sched_op ((char *)offset, true, (char *) recvbuf + offset, false,
-                                 thiscount, datatype, op, schedule, true);
+          // for any-src, add tmpbuf into recvbuf
+          // (here tmpbuf holds the reduction from 1..n-1) and
+          // recvbuf is our sendbuf
+          res = NBC_Sched_op ((char *) offset, true, (char *) recvbuf + offset, false,
+                             thiscount, datatype, op, schedule, true);
         }
       } else {
         res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) offset, true, thiscount,


### PR DESCRIPTION
IBM found a wrong answer from MPI_Ireduce when the red_sched_chain()
path was taken (which only happens for np<=4 and mesgsize>=64k).

The way libnbc treats MPI_ANY_SOURCE is to set sbuf == rbuf, and
whether an algorithm will work cleanly or not after that depends on the
details.

In this case the last steps of the algorithm amounted to
    (right neighbor is sending us reduction results from ranks 1..n-1)
    recv into rbuf from right neighbor
    add the contribution from our sbuf into rbuf
this would be fine in general, but if sbuf==rbuf, that recv overwrites
the sbuf. I changed it to recv into a tmpbuf if ANY_SRC was used.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>