### PR TITLE
v4.1.x: Silence some ppc atomics warnings

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -98,27 +98,7 @@ void opal_atomic_isync(void)
     ISYNC();
 }
 
-#elif OPAL_XLC_INLINE_ASSEMBLY /* end OPAL_GCC_INLINE_ASSEMBLY */
-
-/* Yeah, I don't know who thought this was a reasonable syntax for
- * inline assembly.  Do these because they are used so often and they
- * are fairly simple (aka: there is a tech pub on IBM's web site
- * containing the right hex for the instructions).
- */
-
-#undef OPAL_HAVE_INLINE_ATOMIC_MEM_BARRIER
-#define OPAL_HAVE_INLINE_ATOMIC_MEM_BARRIER 0
-
-#pragma mc_func opal_atomic_mb { "7c0004ac" }          /* sync  */
-#pragma reg_killed_by opal_atomic_mb                   /* none */
-
-#pragma mc_func opal_atomic_rmb { "7c2004ac" }         /* lwsync  */
-#pragma reg_killed_by opal_atomic_rmb                  /* none */
-
-#pragma mc_func opal_atomic_wmb { "7c2004ac" }         /* lwsync */
-#pragma reg_killed_by opal_atomic_wmb                  /* none */
-
-#endif
+#endif /* end OPAL_GCC_INLINE_ASSEMBLY */
 
 /**********************************************************************
  *

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -276,7 +276,7 @@ static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *add
 #define opal_atomic_sc_64(addr, value, ret)                             \
     do {                                                                \
         volatile int64_t *_addr = (addr);                               \
-        int64_t _foo, _newval = (int64_t) value;                        \
+        int64_t _newval = (int64_t) value;                              \
         int32_t _ret;                                                   \
                                                                         \
         __asm__ __volatile__ ("   stdcx.  %2, 0, %1  \n\t"              \


### PR DESCRIPTION
opal/asm: Fix a compiler warning on POWER arch

OPAL_XLC_INLINE_ASSEMBLY was removed in commit ebce88b.
Removing dead code, which also fixes a compiler warning.

Signed-off-by: Nysal Jan K.A jnysal@in.ibm.com
(cherry picked from commit 5ffde16)

opal/asm: Remove an unused variable

Signed-off-by: Nysal Jan K.A jnysal@in.ibm.com
(cherry picked from commit da6d038)

Conflicts:
opal/include/opal/sys/powerpc/atomic.h