### PR TITLE
v4.1.x: btl/openib: Improve IB fork performance.

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_base.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_base.c
@@ -423,6 +423,14 @@ int opal_btl_openib_connect_base_alloc_cts(mca_btl_base_endpoint_t *endpoint)
         sizeof(mca_btl_openib_control_header_t) +
         sizeof(mca_btl_openib_footer_t) +
         mca_btl_openib_component.qp_infos[mca_btl_openib_component.credits_qp].size;
+    int align_it = 0;
+    int page_size;
+
+    page_size = opal_getpagesize();
+    if (length >= page_size / 2) { align_it = 1; }
+    if (align_it) {
+        length = OPAL_ALIGN(length, page_size, int);
+    }
 
     int align_it = 0;
     int page_size;

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -1048,6 +1048,8 @@ static int udcm_module_allocate_buffers (udcm_module_t *m)
 
     total_size = (udcm_recv_count + 1) * (m->msg_length +
                                           UDCM_GRH_SIZE);
+    page_size = opal_getpagesize();
+    total_size = OPAL_ALIGN(total_size, page_size, size_t);
 
     page_size = opal_getpagesize();
     total_size = OPAL_ALIGN(total_size, page_size, size_t);


### PR DESCRIPTION
The key change was in btl_openib_connect_udcm.c where a buffer was
being pinned with size 65664 (whether openib was being used or not).
The start of the buffer was page aligned, but because of the size
the end wasn't. That makes it too easy for fork() to accidentally
touch pinned memory on the same page as the end of that buffer.

So this change increases the size of the allocated buffer to use the
rest of the page.

I inspected the rest of the ibv_reg_mr() calls and changed one other
place to page align its buffer too, although I think the above is
the one that really matters.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 5c74809ba60cfe47b336f7934b229aee58baff63)