### PR TITLE
v4.0.x: removing an overly aggressive error check in binding

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -211,7 +211,9 @@ static int bind_generic(orte_job_t *jdata,
                 data = OBJ_NEW(opal_hwloc_obj_data_t);
                 trg_obj->userdata = data;
             }
-            data->num_bound++;
+            if (0 < ncpus) {
+                data->num_bound++;
+            }
             /* error out if adding a proc would cause overload and that wasn't allowed,
              * and it wasn't a default binding policy (i.e., the user requested it)
              */

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -168,8 +168,9 @@ static int bind_generic(orte_job_t *jdata,
         trg_obj = NULL;
         min_bound = UINT_MAX;
         while (NULL != (tmp_obj = hwloc_get_next_obj_by_depth(node->topology->topo, target_depth, tmp_obj))) {
-            if (!hwloc_bitmap_intersects(locale->cpuset, tmp_obj->cpuset))
+            if (!hwloc_bitmap_intersects(locale->cpuset, tmp_obj->cpuset)) {
                 continue;
+            }
             data = (opal_hwloc_obj_data_t*)tmp_obj->userdata;
             if (NULL == data) {
                 data = OBJ_NEW(opal_hwloc_obj_data_t);


### PR DESCRIPTION
In bind_generic() there's a loop that picks a starting trg_obj and then
walks through a loop of next = trg_obj->next_cousin until it has made
total_cpus assignments.  But the code doesn't accept that those assignments
might not be adjacent objects.

Example:
% mpirun -np 2 --report-bindings --map-by ppr:2:node:pe=3 \
    --cpu-set 4,5,7,8,9,11 -bind-to hwthread:overload-allowed
> MCW 0 : [..../BB.B/..../....]
> MCW 1 : [..../..../BB.B/....]

It will want to assign 3 cpus and will loop through
  trg_obj 00001 (with ncpus 1)
  trg_obj 000001 (with ncpus 1)
  trg_obj 0000001 (with ncpus 0)
  trg_obj 000000011 (with ncpus 1)

The original code on the third entry would see num_bound for the
object become too high for its ncpus and think oversubscription was
happening.  I changed it to only ++num_bound eg to use that object
if the object has cpus in its cpuset after intersected with the
allowed/available masks.

The error message from the original code (if you remove the overload-allowed)
would be
> A request was made to bind to that would result in binding more
> processes than cpus on a resource:
>    Bind to:     HWTHREAD
>    Node:        ...
>    #processes:  1
>    #cpus:      0

bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>