### PR TITLE
v4.1.x: fix --display-diffable-map free() 

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -596,15 +596,15 @@ void orte_rmaps_base_display_map(orte_job_t *jdata)
                                 ORTE_VPID_PRINT(p0->name.vpid),
                                 ORTE_VPID_PRINT(proc->name.vpid),
                                 opal_hwloc_base_print_locality(locality));
+                    if (NULL != procbitmap) {
+                       free(procbitmap);
+                    }
                 }
             }
             opal_output(orte_clean_output, "\t</locality>\n</map>");
             fflush(stderr);
             if (NULL != p0bitmap) {
                 free(p0bitmap);
-            }
-            if (NULL != procbitmap) {
-                free(procbitmap);
             }
         }
     } else {


### PR DESCRIPTION
The previous code basically amounted to

    void *p;
    for (i=1; i<n; ++i)  {
        p = NULL;
        allocate(&p);
    }
    if (p) {
        free(p);
    }

We only noticed the bug because at n==1 this is freeing at an uninitialized
address, but for other n the above would have still been leaking memory.
So this checking moves the free() inside the loop where the allocate is.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>

Co-authored-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 1ddbef13cdcf36cd043bb18833696c6142fbf90a)