### PR TITLE
v4.0.x: Some string cleanup

### DIFF
--- a/ompi/debuggers/ompi_common_dll.c
+++ b/ompi/debuggers/ompi_common_dll.c
@@ -67,9 +67,9 @@ static int host_is_big_endian = 0;
     {                                                                   \
         out_name = mqs_field_offset((qh_type), #field_name);            \
         if (out_name < 0) {                                             \
-            fprintf(stderr, "WARNING: Open MPI is unable to find "      \
+            fprintf(stderr, "WARNING: " OMPI_IDENT_STRING " is unable to find "      \
                     "field " #field_name " in the " #struct_name        \
-                    " type.  This can happen can if Open MPI is built " \
+                    " type.  This can happen if " OMPI_IDENT_STRING " is built " \
                     "without debugging information, or is stripped "    \
                     "after building.\n");                               \
         }                                                               \
@@ -512,7 +512,7 @@ int ompi_fill_in_type_info(mqs_image *image, char **message)
      * did our best but here we're at our limit. Give up!
      */
     *message = missing_in_action;
-    fprintf(stderr, "WARNING: Open MPI is unable to find debugging information about the \"%s\" type.  This can happen if Open MPI was built without debugging information, or was stripped after building.\n",
+    fprintf(stderr, "WARNING: " OMPI_IDENT_STRING " is unable to find debugging information about the \"%s\" type.  This can happen if " OMPI_IDENT_STRING " was built without debugging information, or was stripped after building.\n",
            missing_in_action);
     return err_missing_type;
 }
@@ -634,7 +634,7 @@ int ompi_fetch_opal_pointer_array_item(mqs_process *proc, mqs_taddr_t addr,
 
 int ompi_get_lib_version(char * buf, int size) {
     int ret;
-    ret = snprintf(buf, size-1, "Open MPI v%d.%d.%d%s%s%s%s%s%s%s%s%s",
+    ret = snprintf(buf, size-1, OMPI_IDENT_STRING " v%d.%d.%d%s%s%s%s%s%s%s%s%s",
                    OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION,
                    (strlen(OMPI_GREEK_VERSION) > 0)?OMPI_GREEK_VERSION:"",
                    (strlen(OPAL_PACKAGE_STRING) > 0)?", package: ":"",

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -155,7 +155,7 @@ int ompi_mpi_register_params(void)
         ompi_mpi_param_check = true;
         if (!MPI_PARAM_CHECK) {
             opal_output(0, "WARNING: MCA parameter mpi_no_free_handles set to true, but MPI");
-            opal_output(0, "WARNING: parameter checking has been compiled out of Open MPI.");
+            opal_output(0, "WARNING: parameter checking has been compiled out of " OMPI_IDENT_STRING ".");
             opal_output(0, "WARNING: mpi_no_free_handles is therefore only partially effective!");
         }
     }
@@ -214,7 +214,8 @@ int ompi_mpi_register_params(void)
 
     /* File to use when dumping the parameters */
     (void) mca_base_var_register("ompi", "mpi", NULL, "show_mca_params_file",
-                                 "If mpi_show_mca_params is true, setting this string to a valid filename tells Open MPI to dump all the MCA parameter values into a file suitable for reading via the mca_param_files parameter (good for reproducability of MPI jobs)",
+                                 "If mpi_show_mca_params is true, setting this string to a valid filename tells "
+                                 OMPI_IDENT_STRING " to dump all the MCA parameter values into a file suitable for reading via the mca_param_files parameter (good for reproducability of MPI jobs)",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                  OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY,
@@ -240,7 +241,7 @@ int ompi_mpi_register_params(void)
 
     /* Sparse group storage support */
     (void) mca_base_var_register("ompi", "mpi", NULL, "have_sparse_group_storage",
-                                 "Whether this Open MPI installation supports storing of data in MPI groups in \"sparse\" formats (good for extremely large process count MPI jobs that create many communicators/groups)",
+                                 "Whether this " OMPI_IDENT_STRING " installation supports storing of data in MPI groups in \"sparse\" formats (good for extremely large process count MPI jobs that create many communicators/groups)",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                  MCA_BASE_VAR_FLAG_DEFAULT_ONLY,
                                  OPAL_INFO_LVL_9,

--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -103,8 +103,8 @@ int main(int argc, char *argv[])
     }
 
     if (opal_cmd_line_is_taken(ompi_info_cmd_line, "version")) {
-        fprintf(stdout, "Open MPI v%s\n\n%s\n",
-                OPAL_VERSION, PACKAGE_BUGREPORT);
+        fprintf(stdout, "%s v%s\n\n%s\n",
+                PACKAGE_NAME, OPAL_VERSION, PACKAGE_BUGREPORT);
         exit(0);
     }
 


### PR DESCRIPTION
- ompi_info: Replace hard-coded 'Open MPI' with PACKAGE_NAME.
- Update strings of "Open MPI" to instead use OMPI_IDENT_NAME