### PR TITLE
v4.0.x: set MPIR_dll_name dynamically for totalview

### DIFF
--- a/ompi/debuggers/debuggers.h
+++ b/ompi/debuggers/debuggers.h
@@ -31,6 +31,11 @@
 BEGIN_C_DECLS
 
 /**
+ * Setup the debugger defaults
+ */
+extern void ompi_debugger_setup_defaults(void);
+
+/**
  * Setup the magic constants so that the debugger can find the DLL
  * necessary for understanding the queues and other structures.
  */

--- a/ompi/debuggers/ompi_debuggers.c
+++ b/ompi/debuggers/ompi_debuggers.c
@@ -78,7 +78,8 @@
 #if defined(OMPI_MSGQ_DLL)
 /* This variable is old/deprecated -- the mpimsgq_dll_locations[]
    method is preferred because it's more flexible */
-OMPI_DECLSPEC char MPIR_dll_name[] = OMPI_MSGQ_DLL;
+#define MAX_DLL_NAME_LENGTH 2048
+OMPI_DECLSPEC char MPIR_dll_name[MAX_DLL_NAME_LENGTH] = OMPI_MSGQ_DLL;
 #endif  /* defined(OMPI_MSGQ_DLL) */
 OMPI_DECLSPEC char **mpidbg_dll_locations = NULL;
 OMPI_DECLSPEC char **mpimsgq_dll_locations = NULL;
@@ -158,6 +159,19 @@ static void check(char *dir, char *file, char **locations)
     free(str);
 }
 
+/**
+ * The initial setting of MPIR_dll_name is
+ * <libdir>/<OPAL_DYN_LIB_PREFIX>/libompi_dbg_msgq.so
+ * but we'd rather have a dynamic setting.
+ * ompi_debugger_dll_path should be the right dir and
+ * OMPI_MSGQ_DLL_PREFIX.so should be the library
+ */
+extern void
+ompi_debugger_setup_defaults(void)
+{
+    snprintf(MPIR_dll_name, MAX_DLL_NAME_LENGTH, "%s/%s.so",
+        opal_install_dirs.opallibdir, OMPI_MSGQ_DLL_PREFIX);
+}
 
 extern void
 ompi_debugger_setup_dlls(void)

--- a/ompi/mca/rte/orte/rte_orte_module.c
+++ b/ompi/mca/rte/orte/rte_orte_module.c
@@ -144,6 +144,9 @@ void ompi_rte_wait_for_debugger(void)
     if (1 == MPIR_being_debugged) {
         debugger = 1;
     }
+    /* Setup the defaults in case we attach a
+       debugger only at a later point in time */
+    ompi_debugger_setup_defaults();
 
     if (!debugger && NULL == getenv("ORTE_TEST_DEBUGGER_ATTACH")) {
         /* if not, just return */


### PR DESCRIPTION
Previously MPIR_dll_name was set statically to its final value, ex
    char MPIR_dll_name[] = "/path/to/libompi_dbg_msgq.so";
but we want to be able to relocate the product, so we want it dynamic.

To set it dynamically this checkin over-sizes the initial array and copies
a new string into that space at runtime.

* Initialize MPIR_dll_name even if a debugger has not attached

Co-authored-by: Nysal Jan K.A <jnysal@in.ibm.com>

bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>