### PR TITLE
v4.0.x: opal/dtype: Optimization of MPI_Type_vector, MPI_Type_hvector

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -124,6 +124,10 @@ OMPI_DECLSPEC int32_t ompi_datatype_default_convertors_fini( void );
 OMPI_DECLSPEC void ompi_datatype_dump (const ompi_datatype_t* pData);
 OMPI_DECLSPEC ompi_datatype_t* ompi_datatype_create( int32_t expectedSize );
 
+ 
+extern ompi_datatype_t * ompi_datatype_create_temp( int32_t expectedSize );
+extern void ompi_datatype_release_temp(ompi_datatype_t * datatype);
+
 static inline int32_t
 ompi_datatype_is_committed( const ompi_datatype_t* type )
 {

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -38,18 +38,20 @@ int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
         return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
-    pData = ompi_datatype_create( oldType->super.desc.used + 2 );
     if( (bLength == stride) || (1 >= count) ) {  /* the elements are contiguous */
+        pData = ompi_datatype_create( oldType->super.desc.used + 2 );
         ompi_datatype_add( pData, oldType, (size_t)count * bLength, 0, extent );
     } else {
         if( 1 == bLength ) {
+            pData = ompi_datatype_create( oldType->super.desc.used + 2 );
             ompi_datatype_add( pData, oldType, count, 0, extent * stride );
         } else {
+            pData = ompi_datatype_create_temp( oldType->super.desc.used + 2 );
             ompi_datatype_add( pData, oldType, bLength, 0, extent );
             pTempData = pData;
             pData = ompi_datatype_create( oldType->super.desc.used + 2 + 2 );
             ompi_datatype_add( pData, pTempData, count, 0, extent * stride );
-            OBJ_RELEASE( pTempData );
+            ompi_datatype_release_temp( pTempData );
         }
     }
     *newType = pData;
@@ -67,19 +69,21 @@ int32_t ompi_datatype_create_hvector( int count, int bLength, ptrdiff_t stride,
         return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
-    pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );
     if( ((extent * bLength) == stride) || (1 >= count) ) {  /* contiguous */
+        pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );
         pData = pTempData;
         ompi_datatype_add( pData, oldType, count * bLength, 0, extent );
     } else {
         if( 1 == bLength ) {
+            pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );
             pData = pTempData;
             ompi_datatype_add( pData, oldType, count, 0, stride );
         } else {
+            pTempData = ompi_datatype_create_temp( oldType->super.desc.used + 2 );
             ompi_datatype_add( pTempData, oldType, bLength, 0, extent );
             pData = ompi_datatype_create( oldType->super.desc.used + 2 + 2 );
             ompi_datatype_add( pData, pTempData, count, 0, stride );
-            OBJ_RELEASE( pTempData );
+            ompi_datatype_release_temp( pTempData );
         }
     }
      *newType = pData;


### PR DESCRIPTION
For derived datatypes.

Skip adding temporarily created datatype to ompi_datatype_f_to_c_table,
thereby reducing the exponential lowest_free
search overhead in opal_pointer_array => add during DDT creation.

bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>