### PR TITLE
v4.0.x: Improve MPI_Waitall performance for MPI_THREAD_MULTIPLE

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -215,7 +215,7 @@ int ompi_request_default_wait_all( size_t count,
             continue;
         }
 
-        if (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&request->req_complete, &_tmp_ptr, &sync)) {
+        if (REQUEST_COMPLETE(request) || !OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&request->req_complete, &_tmp_ptr, &sync)) {
             if( OPAL_UNLIKELY( MPI_SUCCESS != request->req_status.MPI_ERROR ) ) {
                 failed++;
             }


### PR DESCRIPTION
Avoid atomic cmpxchng operations for MPI requests that are already
complete. This improves the performance in message rate benchmarks.

bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>