### PR TITLE
Some multi-threading fixes

### DIFF
--- a/ompi/mpi/c/init_thread.c
+++ b/ompi/mpi/c/init_thread.c
@@ -48,6 +48,7 @@ int MPI_Init_thread(int *argc, char ***argv, int required,
                     int *provided)
 {
     int err, safe_required = MPI_THREAD_SERIALIZED;
+    char *env;
 
     ompi_hook_base_mpi_init_thread_top(argc, argv, required, provided);
 
@@ -56,7 +57,13 @@ int MPI_Init_thread(int *argc, char ***argv, int required,
      */
     if( (MPI_THREAD_SINGLE == required) || (MPI_THREAD_SERIALIZED == required) ||
         (MPI_THREAD_FUNNELED == required) || (MPI_THREAD_MULTIPLE == required) ) {
-        safe_required = required;
+
+        if (NULL != (env = getenv("OMPI_MPI_THREAD_LEVEL")))  {
+            safe_required = atoi(env);
+        }
+        else {
+            safe_required = required;
+        }
     }
 
     *provided = safe_required;


### PR DESCRIPTION
ompi/request: Add a read memory barrier to sync the receive buffer so… 

…on after wait completes.

We found an issue where with using multiple threads, it is possible for the data
to not be in the buffer before MPI_Wait() returns. Testing the buffer later after
MPI_Wait() returned would show the data arrives eventually without the rmb().

We have seen this issue on Power9 intermittently using PAMI, but in theory could
happen with any transport.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
