### PR TITLE
shmem: fix `oshmem_shmem_finalize()` when `main()` returns not zero value.

### DIFF
--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -53,7 +53,7 @@
 #include "oshmem/shmem/shmem_lock.h"
 #include "oshmem/runtime/oshmem_shmem_preconnect.h"
 
-extern int oshmem_shmem_globalexit_status;
+extern int oshmem_shmem_inglobalexit;
 
 static int _shmem_finalize(void);
 
@@ -79,7 +79,7 @@ int oshmem_shmem_finalize(void)
     if ((OSHMEM_SUCCESS == ret) &&
         (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
          state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) &&
-        oshmem_shmem_globalexit_status == 0) {
+         (oshmem_shmem_inglobalexit == 0)) {
         PMPI_Comm_free(&oshmem_comm_world);
         ret = ompi_mpi_finalize();
     }


### PR DESCRIPTION
Example:
```C
int main(void) {
    int rc = 0;
    shmem_init();
    if (0 == shmem_my_pe())
        rc = 1;
    shmem_finalize();
    return rc;
}
```

If the user wants to return non-zero status, this leads to
`ompi_mpi_finalize()` won't be called and the program terminates
abnormally.