### PR TITLE
orterun man page: fix spelling error

### DIFF
--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -1260,7 +1260,7 @@ with an associated \fI--cpu-list "0,2,5"\fP. In this example, the
 first process on a node will be bound to cpu 0, the second process on
 the node will be bound to cpu 2, and the third process on the node
 will be bound to cpu 5. \fI--bind-to\fP will also accept
-\fIcpulist:ortered\fP as a synonym to \fIcpu-list:ordered\fP.  Note
+\fIcpulist:ordered\fP as a synonym to \fIcpu-list:ordered\fP.  Note
 that an error will result if more processes are assigned to a node
 than cpus are provided.
 .


### PR DESCRIPTION
bot:notacherrypick

Signed-off-by: Jed Brown <jed@jedbrown.org>