### PR TITLE
Make sure opal_start_thread always spawns pthreads

### DIFF
--- a/opal/mca/threads/argobots/threads_argobots_module.c
+++ b/opal/mca/threads/argobots/threads_argobots_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -32,78 +32,6 @@
 #include "opal/prefetch.h"
 #include "opal/util/output.h"
 #include "opal/util/sys_limits.h"
-
-/*
- * Constructor
- */
-static void opal_thread_construct(opal_thread_t *t)
-{
-    t->t_run = 0;
-    t->t_handle = ABT_THREAD_NULL;
-}
-
-OBJ_CLASS_INSTANCE(opal_thread_t, opal_object_t, opal_thread_construct, NULL);
-
-static inline ABT_thread opal_thread_get_argobots_self(void)
-{
-    ABT_thread self;
-    ABT_thread_self(&self);
-    return self;
-}
-
-static void opal_thread_argobots_wrapper(void *arg)
-{
-    opal_thread_t *t = (opal_thread_t *) arg;
-    t->t_ret = ((void *(*) (void *) ) t->t_run)(t);
-}
-
-opal_thread_t *opal_thread_get_self(void)
-{
-    opal_threads_argobots_ensure_init();
-    opal_thread_t *t = OBJ_NEW(opal_thread_t);
-    t->t_handle = opal_thread_get_argobots_self();
-    return t;
-}
-
-bool opal_thread_self_compare(opal_thread_t *t)
-{
-    opal_threads_argobots_ensure_init();
-    return opal_thread_get_argobots_self() == t->t_handle;
-}
-
-int opal_thread_join(opal_thread_t *t, void **thr_return)
-{
-    int rc = ABT_thread_free(&t->t_handle);
-    if (thr_return) {
-        *thr_return = t->t_ret;
-    }
-    t->t_handle = ABT_THREAD_NULL;
-    return (ABT_SUCCESS == rc) ? OPAL_SUCCESS : OPAL_ERROR;
-}
-
-void opal_thread_set_main()
-{
-}
-
-int opal_thread_start(opal_thread_t *t)
-{
-    opal_threads_argobots_ensure_init();
-    int rc;
-    if (OPAL_ENABLE_DEBUG) {
-        if (NULL == t->t_run || ABT_THREAD_NULL != t->t_handle) {
-            return OPAL_ERR_BAD_PARAM;
-        }
-    }
-
-    ABT_xstream self_xstream;
-    ABT_xstream_self(&self_xstream);
-    rc = ABT_thread_create_on_xstream(self_xstream, opal_thread_argobots_wrapper, t,
-                                      ABT_THREAD_ATTR_NULL, &t->t_handle);
-
-    return (ABT_SUCCESS == rc) ? OPAL_SUCCESS : OPAL_ERROR;
-}
-
-OBJ_CLASS_DECLARATION(opal_thread_t);
 
 int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
 {

--- a/opal/mca/threads/argobots/threads_argobots_threads.h
+++ b/opal/mca/threads/argobots/threads_argobots_threads.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2020 High Performance Computing Center Stuttgart,
@@ -27,15 +27,6 @@
 #define OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_THREADS_H
 
 #include "opal/mca/threads/argobots/threads_argobots.h"
-#include <signal.h>
-
-struct opal_thread_t {
-    opal_object_t super;
-    opal_thread_fn_t t_run;
-    void *t_arg;
-    ABT_thread t_handle;
-    void *t_ret;
-};
 
 /* Argobots are cooperatively scheduled so yield when idle */
 #define OPAL_THREAD_YIELD_WHEN_IDLE_DEFAULT true

--- a/opal/mca/threads/base/Makefile.am
+++ b/opal/mca/threads/base/Makefile.am
@@ -24,6 +24,7 @@ headers += \
 
 libmca_threads_la_SOURCES += \
         base/mutex.c \
+        base/create_join.c \
         base/threads_base.c \
         base/tsd.c \
         base/wait_sync.c

--- a/opal/mca/threads/base/create_join.c
+++ b/opal/mca/threads/base/create_join.c
@@ -24,6 +24,7 @@
  */
 
 #include <unistd.h>
+#include <pthread.h>
 
 #include "opal/constants.h"
 #include "opal/mca/threads/threads.h"
@@ -32,9 +33,51 @@
 #include "opal/util/output.h"
 #include "opal/util/sys_limits.h"
 
-int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
+/*
+ * Constructor
+ */
+static void opal_thread_construct(opal_thread_t *t)
+{
+    t->t_run = 0;
+    t->t_handle = (pthread_t) -1;
+}
+
+OBJ_CLASS_INSTANCE(opal_thread_t, opal_object_t, opal_thread_construct, NULL);
+
+int opal_thread_start(opal_thread_t *t)
 {
     int rc;
-    rc = pthread_key_create(key, destructor);
+
+    if (OPAL_ENABLE_DEBUG) {
+        if (NULL == t->t_run || (pthread_t) -1 != t->t_handle) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+    }
+
+    rc = pthread_create(&t->t_handle, NULL, (void *(*) (void *) ) t->t_run, t);
+
     return 0 == rc ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
+}
+
+int opal_thread_join(opal_thread_t *t, void **thr_return)
+{
+    int rc = pthread_join(t->t_handle, thr_return);
+    t->t_handle = (pthread_t) -1;
+    return 0 == rc ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
+}
+
+bool opal_thread_self_compare(opal_thread_t *t)
+{
+    return pthread_self() == t->t_handle;
+}
+
+opal_thread_t *opal_thread_get_self(void)
+{
+    opal_thread_t *t = OBJ_NEW(opal_thread_t);
+    t->t_handle = pthread_self();
+    return t;
+}
+
+void opal_thread_set_main(void)
+{
 }

--- a/opal/mca/threads/pthreads/threads_pthreads_threads.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_threads.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2020 High Performance Computing Center Stuttgart,
@@ -31,13 +31,6 @@
 
 #include "opal/mca/threads/pthreads/threads_pthreads.h"
 #include "opal/mca/threads/threads.h"
-
-struct opal_thread_t {
-    opal_object_t super;
-    opal_thread_fn_t t_run;
-    void *t_arg;
-    pthread_t t_handle;
-};
 
 /* Pthreads do not need to yield when idle */
 #define OPAL_THREAD_YIELD_WHEN_IDLE_DEFAULT false

--- a/opal/mca/threads/qthreads/threads_qthreads_threads.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_threads.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2020 High Performance Computing Center Stuttgart,
@@ -27,16 +27,6 @@
 #define OPAL_MCA_THREADS_QTHREADS_THREADS_QTHREADS_THREADS_H 1
 
 #include "opal/mca/threads/qthreads/threads_qthreads.h"
-#include <signal.h>
-
-struct opal_thread_t {
-    opal_object_t super;
-    opal_thread_fn_t t_run;
-    void *t_arg;
-    void *t_ret;
-    aligned_t t_thread_ret;
-    aligned_t *t_thread_ret_ptr;
-};
 
 /* Qthreads are cooperatively scheduled so yield when idle */
 #define OPAL_THREAD_YIELD_WHEN_IDLE_DEFAULT true

--- a/opal/mca/threads/threads.h
+++ b/opal/mca/threads/threads.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -44,6 +44,13 @@ typedef void *(*opal_thread_fn_t)(opal_object_t *);
 #define OPAL_THREAD_CANCELLED ((void *) 1);
 
 #include MCA_threads_base_include_HEADER
+
+struct opal_thread_t {
+    opal_object_t super;
+    opal_thread_fn_t t_run;
+    void *t_arg;
+    pthread_t t_handle;
+};
 
 typedef struct opal_thread_t opal_thread_t;
 


### PR DESCRIPTION
Users of `opal_start_thread` (btl/tcp, ft, smcuda, progress thread) may spawn threads that may block in functions unaware of argobots or qthreads (e.g., libevent or read(3)). If we spawn an argobot or qthread instead of a pthread the thread
executing the argobot or qthread (potentially the main thread) blocks, leading to a deadlock situation. Open MPI expects the semantics of a pthread so we should handle all internal threads as such. 

This PR moves `opal_start_thread` and thread identification functions into threads/base and makes them operate on pthreads. As a side-effect, even if the main thread executes an argobot or qthread, it will still be considered the main thread, i.e., `MPI_Is_thread_main` will return `flag = 1` (which is a change in behavior from the current implementation). The argobots and qthread integration will still be used to switch between ULTs to avoid blocking.

This should be backported to 5.x once merged.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>