### PR TITLE
v4.0.x: Revert "Allow mpi_init_thread to override the MPI_THREAD_LEVEL"

### DIFF
--- a/ompi/mpi/c/init_thread.c
+++ b/ompi/mpi/c/init_thread.c
@@ -48,11 +48,6 @@ int MPI_Init_thread(int *argc, char ***argv, int required,
                     int *provided)
 {
     int err;
-    char *env;
-
-    if (NULL != (env = getenv("OMPI_MPI_THREAD_LEVEL")))  {
-        required = atoi(env);
-    }
 
     ompi_hook_base_mpi_init_thread_top(argc, argv, required, provided);
 


### PR DESCRIPTION
This reverts commit 881979044aa7de2ab3a9d29cb80d459497759c21.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

See https://github.com/open-mpi/ompi/pull/9312#pullrequestreview-741739019 for an explanation.