### PR TITLE
v5.0.x: ompi: use best practice when declaring internal-only function pointe types

### DIFF
--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -64,50 +64,34 @@ typedef enum ompi_attribute_type_t ompi_attribute_type_t;
    delete. These will only be used here and not in the front end
    functions. */
 
-typedef void (ompi_fint_copy_attr_function)(MPI_Fint *oldobj,
-                                                    MPI_Fint *keyval,
-                                                    MPI_Fint *extra_state,
-                                                    MPI_Fint *attr_in,
-                                                    MPI_Fint *attr_out,
-                                                    ompi_fortran_logical_t *flag,
-                                                    MPI_Fint *ierr);
-typedef void (ompi_fint_delete_attr_function)(MPI_Fint *obj,
-                                                      MPI_Fint *keyval,
-                                                      MPI_Fint *attr_in,
-                                                      MPI_Fint *extra_state,
-                                                      MPI_Fint *ierr);
+typedef void (*ompi_fint_copy_attr_function)(MPI_Fint *oldobj, MPI_Fint *keyval,
+                                             MPI_Fint *extra_state, MPI_Fint *attr_in,
+                                             MPI_Fint *attr_out, ompi_fortran_logical_t *flag,
+                                             MPI_Fint *ierr);
+typedef void (*ompi_fint_delete_attr_function)(MPI_Fint *obj, MPI_Fint *keyval, MPI_Fint *attr_in,
+                                               MPI_Fint *extra_state, MPI_Fint *ierr);
 
 /* New-style MPI-2 Fortran function pointer declarations for copy and
    delete. These will only be used here and not in the front end
    functions. */
 
-typedef void (ompi_aint_copy_attr_function)(MPI_Fint *oldobj,
-                                            MPI_Fint *keyval,
-                                            void *extra_state,
-                                            void *attr_in,
-                                            void *attr_out,
-                                            ompi_fortran_logical_t *flag,
-                                            MPI_Fint *ierr);
-typedef void (ompi_aint_delete_attr_function)(MPI_Fint *obj,
-                                              MPI_Fint *keyval,
-                                              void *attr_in,
-                                              void *extra_state,
-                                              MPI_Fint *ierr);
+typedef void (*ompi_aint_copy_attr_function)(MPI_Fint *oldobj, MPI_Fint *keyval, void *extra_state,
+                                             void *attr_in, void *attr_out,
+                                             ompi_fortran_logical_t *flag, MPI_Fint *ierr);
+typedef void (*ompi_aint_delete_attr_function)(MPI_Fint *obj, MPI_Fint *keyval, void *attr_in,
+                                               void *extra_state, MPI_Fint *ierr);
 /*
  * Internally the copy function for all kinds of MPI objects has one more
  * argument, the pointer to the new object. Therefore, we can do on the
  * flight modifications of the new communicator based on attributes stored
  * on the main communicator.
  */
-typedef int (MPI_Comm_internal_copy_attr_function)(MPI_Comm, int, void *,
-                                                   void *, void *, int *,
-                                                   MPI_Comm);
-typedef int (MPI_Type_internal_copy_attr_function)(MPI_Datatype, int, void *,
-                                                   void *, void *, int *,
-                                                   MPI_Datatype);
-typedef int (MPI_Win_internal_copy_attr_function)(MPI_Win, int, void *,
-                                                  void *, void *, int *,
-                                                  MPI_Win);
+typedef int (*MPI_Comm_internal_copy_attr_function)(MPI_Comm, int, void *, void *, void *, int *,
+                                                    MPI_Comm);
+typedef int (*MPI_Type_internal_copy_attr_function)(MPI_Datatype, int, void *, void *, void *,
+                                                    int *, MPI_Datatype);
+typedef int (*MPI_Win_internal_copy_attr_function)(MPI_Win, int, void *, void *, void *, int *,
+                                                   MPI_Win);
 
 typedef void (ompi_attribute_keyval_destructor_fn_t)(int);
 
@@ -120,19 +104,19 @@ union ompi_attribute_fn_ptr_union_t {
     MPI_Type_delete_attr_function          *attr_datatype_delete_fn;
     MPI_Win_delete_attr_function           *attr_win_delete_fn;
 
-    MPI_Comm_internal_copy_attr_function   *attr_communicator_copy_fn;
-    MPI_Type_internal_copy_attr_function   *attr_datatype_copy_fn;
-    MPI_Win_internal_copy_attr_function    *attr_win_copy_fn;
+    MPI_Comm_internal_copy_attr_function attr_communicator_copy_fn;
+    MPI_Type_internal_copy_attr_function attr_datatype_copy_fn;
+    MPI_Win_internal_copy_attr_function attr_win_copy_fn;
 
     /* For Fortran old MPI-1 callback functions */
 
-    ompi_fint_delete_attr_function *attr_fint_delete_fn;
-    ompi_fint_copy_attr_function   *attr_fint_copy_fn;
+    ompi_fint_delete_attr_function attr_fint_delete_fn;
+    ompi_fint_copy_attr_function attr_fint_copy_fn;
 
     /* For Fortran new MPI-2 callback functions */
 
-    ompi_aint_delete_attr_function *attr_aint_delete_fn;
-    ompi_aint_copy_attr_function   *attr_aint_copy_fn;
+    ompi_aint_delete_attr_function attr_aint_delete_fn;
+    ompi_aint_copy_attr_function attr_aint_copy_fn;
 };
 
 typedef union ompi_attribute_fn_ptr_union_t ompi_attribute_fn_ptr_union_t;

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -194,8 +194,8 @@ static int create_comm(int target_keyval, bool want_inherit)
     ompi_attribute_fn_ptr_union_t del;
 
     keyval = -1;
-    copy.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*)
-        (want_inherit ? MPI_COMM_DUP_FN : MPI_COMM_NULL_COPY_FN);
+    copy.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function)(
+        want_inherit ? MPI_COMM_DUP_FN : MPI_COMM_NULL_COPY_FN);
     del.attr_communicator_delete_fn = MPI_COMM_NULL_DELETE_FN;
     err = ompi_attr_create_keyval(COMM_ATTR, copy, del,
                                   &keyval, NULL, OMPI_KEYVAL_PREDEFINED, NULL);
@@ -224,7 +224,7 @@ static int create_win(int target_keyval)
     ompi_attribute_fn_ptr_union_t del;
 
     keyval = -1;
-    copy.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function*)MPI_WIN_NULL_COPY_FN;
+    copy.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function) MPI_WIN_NULL_COPY_FN;
     del.attr_win_delete_fn = MPI_WIN_NULL_DELETE_FN;
     err = ompi_attr_create_keyval(WIN_ATTR, copy, del,
                                   &keyval, NULL, OMPI_KEYVAL_PREDEFINED, NULL);

--- a/ompi/mpi/c/comm_create_keyval.c
+++ b/ompi/mpi/c/comm_create_keyval.c
@@ -54,7 +54,7 @@ int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*)comm_copy_attr_fn;
+    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function) comm_copy_attr_fn;
     del_fn.attr_communicator_delete_fn = comm_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn,

--- a/ompi/mpi/c/keyval_create.c
+++ b/ompi/mpi/c/keyval_create.c
@@ -56,7 +56,7 @@ int MPI_Keyval_create(MPI_Copy_function *copy_attr_fn,
         }
     }
 
-    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*)copy_attr_fn;
+    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function) copy_attr_fn;
     del_fn.attr_communicator_delete_fn = delete_attr_fn;
 
     ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn,

--- a/ompi/mpi/c/type_create_keyval.c
+++ b/ompi/mpi/c/type_create_keyval.c
@@ -56,7 +56,7 @@ int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_datatype_copy_fn = (MPI_Type_internal_copy_attr_function*)type_copy_attr_fn;
+    copy_fn.attr_datatype_copy_fn = (MPI_Type_internal_copy_attr_function) type_copy_attr_fn;
     del_fn.attr_datatype_delete_fn = type_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(TYPE_ATTR, copy_fn, del_fn,

--- a/ompi/mpi/c/win_create_keyval.c
+++ b/ompi/mpi/c/win_create_keyval.c
@@ -54,7 +54,7 @@ int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function*)win_copy_attr_fn;
+    copy_fn.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function) win_copy_attr_fn;
     del_fn.attr_win_delete_fn = win_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(WIN_ATTR, copy_fn, del_fn,

--- a/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
@@ -34,13 +34,13 @@
 #pragma weak PMPI_Comm_create_keyval_f = ompi_comm_create_keyval_f
 #pragma weak PMPI_Comm_create_keyval_f08 = ompi_comm_create_keyval_f
 #else
-OMPI_GENERATE_F77_BINDINGS (PMPI_COMM_CREATE_KEYVAL,
-                           pmpi_comm_create_keyval,
-                           pmpi_comm_create_keyval_,
-                           pmpi_comm_create_keyval__,
+OMPI_GENERATE_F77_BINDINGS(PMPI_COMM_CREATE_KEYVAL, pmpi_comm_create_keyval,
+                           pmpi_comm_create_keyval_, pmpi_comm_create_keyval__,
                            pompi_comm_create_keyval_f,
-                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
+                           (ompi_aint_copy_attr_function comm_copy_attr_fn,
+                            ompi_aint_delete_attr_function comm_delete_attr_fn,
+                            MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr))
 #endif
 #endif
 
@@ -54,13 +54,12 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_COMM_CREATE_KEYVAL,
 #pragma weak MPI_Comm_create_keyval_f08 = ompi_comm_create_keyval_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
-OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
-                           mpi_comm_create_keyval,
-                           mpi_comm_create_keyval_,
-                           mpi_comm_create_keyval__,
-                           ompi_comm_create_keyval_f,
-                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(MPI_COMM_CREATE_KEYVAL, mpi_comm_create_keyval, mpi_comm_create_keyval_,
+                           mpi_comm_create_keyval__, ompi_comm_create_keyval_f,
+                           (ompi_aint_copy_attr_function comm_copy_attr_fn,
+                            ompi_aint_delete_attr_function comm_delete_attr_fn,
+                            MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr))
 #else
 #define ompi_comm_create_keyval_f pompi_comm_create_keyval_f
 #endif
@@ -68,11 +67,9 @@ OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
 
 static const char FUNC_NAME[] = "MPI_Comm_create_keyval_f";
 
-
-void ompi_comm_create_keyval_f(ompi_aint_copy_attr_function* comm_copy_attr_fn,
-                              ompi_aint_delete_attr_function* comm_delete_attr_fn,
-                              MPI_Fint *comm_keyval,
-                              MPI_Aint *extra_state, MPI_Fint *ierr)
+void ompi_comm_create_keyval_f(ompi_aint_copy_attr_function comm_copy_attr_fn,
+                               ompi_aint_delete_attr_function comm_delete_attr_fn,
+                               MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
     OMPI_SINGLE_NAME_DECL(comm_keyval);

--- a/ompi/mpi/fortran/mpif-h/keyval_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/keyval_create_f.c
@@ -34,13 +34,12 @@
 #pragma weak PMPI_Keyval_create_f = ompi_keyval_create_f
 #pragma weak PMPI_Keyval_create_f08 = ompi_keyval_create_f
 #else
-OMPI_GENERATE_F77_BINDINGS (PMPI_KEYVAL_CREATE,
-                           pmpi_keyval_create,
-                           pmpi_keyval_create_,
-                           pmpi_keyval_create__,
-                           pompi_keyval_create_f,
-                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
-                           (copy_fn, delete_fn, keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(PMPI_KEYVAL_CREATE, pmpi_keyval_create, pmpi_keyval_create_,
+                           pmpi_keyval_create__, pompi_keyval_create_f,
+                           (ompi_fint_copy_attr_function copy_fn,
+                            ompi_fint_delete_attr_function delete_fn, MPI_Fint *keyval,
+                            MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (copy_fn, delete_fn, keyval, extra_state, ierr))
 #endif
 #endif
 
@@ -54,13 +53,12 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_KEYVAL_CREATE,
 #pragma weak MPI_Keyval_create_f08 = ompi_keyval_create_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
-OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
-                           mpi_keyval_create,
-                           mpi_keyval_create_,
-                           mpi_keyval_create__,
-                           ompi_keyval_create_f,
-                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
-                           (copy_fn, delete_fn, keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(MPI_KEYVAL_CREATE, mpi_keyval_create, mpi_keyval_create_,
+                           mpi_keyval_create__, ompi_keyval_create_f,
+                           (ompi_fint_copy_attr_function copy_fn,
+                            ompi_fint_delete_attr_function delete_fn, MPI_Fint *keyval,
+                            MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (copy_fn, delete_fn, keyval, extra_state, ierr))
 #else
 #define ompi_keyval_create_f pompi_keyval_create_f
 #endif
@@ -68,10 +66,9 @@ OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
 
 static const char FUNC_NAME[] = "MPI_keyval_create_f";
 
-void ompi_keyval_create_f(ompi_fint_copy_attr_function* copy_attr_fn,
-                         ompi_fint_delete_attr_function* delete_attr_fn,
-                         MPI_Fint *keyval, MPI_Fint *extra_state,
-                         MPI_Fint *ierr)
+void ompi_keyval_create_f(ompi_fint_copy_attr_function copy_attr_fn,
+                          ompi_fint_delete_attr_function delete_attr_fn, MPI_Fint *keyval,
+                          MPI_Fint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
     OMPI_SINGLE_NAME_DECL(keyval);

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -1,4 +1,4 @@
-/*
+/* clang-format off
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
@@ -122,7 +122,7 @@ PN2(void, MPI_Comm_call_errhandler, mpi_comm_call_errhandler, MPI_COMM_CALL_ERRH
 PN2(void, MPI_Comm_compare, mpi_comm_compare, MPI_COMM_COMPARE, (MPI_Fint *comm1, MPI_Fint *comm2, MPI_Fint *result, MPI_Fint *ierr));
 PN2(void, MPI_Comm_connect, mpi_comm_connect, MPI_COMM_CONNECT, (char *port_name, MPI_Fint *info, MPI_Fint *root, MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr, int port_name_len));
 PN2(void, MPI_Comm_create_errhandler, mpi_comm_create_errhandler, MPI_COMM_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_aint_copy_attr_function comm_copy_attr_fn, ompi_aint_delete_attr_function comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create, mpi_comm_create, MPI_COMM_CREATE, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create_group, mpi_comm_create_group, MPI_COMM_CREATE_GROUP, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *tag, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_delete_attr, mpi_comm_delete_attr, MPI_COMM_DELETE_ATTR, (MPI_Fint *comm, MPI_Fint *comm_keyval, MPI_Fint *ierr));
@@ -247,7 +247,7 @@ PN2(void, MPI_Graph_neighbors_count, mpi_graph_neighbors_count, MPI_GRAPH_NEIGHB
 PN2(void, MPI_Graph_neighbors, mpi_graph_neighbors, MPI_GRAPH_NEIGHBORS, (MPI_Fint *comm, MPI_Fint *rank, MPI_Fint *maxneighbors, MPI_Fint *neighbors, MPI_Fint *ierr));
 PN2(void, MPI_Graphdims_get, mpi_graphdims_get, MPI_GRAPHDIMS_GET, (MPI_Fint *comm, MPI_Fint *nnodes, MPI_Fint *nedges, MPI_Fint *ierr));
 PN2(void, MPI_Grequest_complete, mpi_grequest_complete, MPI_GREQUEST_COMPLETE, (MPI_Fint *request, MPI_Fint *ierr));
-PN2(void, MPI_Grequest_start, mpi_grequest_start, MPI_GREQUEST_START, (MPI_F_Grequest_query_function* query_fn, MPI_F_Grequest_free_function* free_fn, MPI_F_Grequest_cancel_function* cancel_fn, MPI_Aint *extra_state, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Grequest_start, mpi_grequest_start, MPI_GREQUEST_START, (MPI_F_Grequest_query_function query_fn, MPI_F_Grequest_free_function free_fn, MPI_F_Grequest_cancel_function cancel_fn, MPI_Aint *extra_state, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Group_compare, mpi_group_compare, MPI_GROUP_COMPARE, (MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *result, MPI_Fint *ierr));
 PN2(void, MPI_Group_difference, mpi_group_difference, MPI_GROUP_DIFFERENCE, (MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *newgroup, MPI_Fint *ierr));
 PN2(void, MPI_Group_excl, mpi_group_excl, MPI_GROUP_EXCL, (MPI_Fint *group, MPI_Fint *n, MPI_Fint *ranks, MPI_Fint *newgroup, MPI_Fint *ierr));
@@ -305,7 +305,7 @@ PN2(void, MPI_Irsend, mpi_irsend, MPI_IRSEND, (char *buf, MPI_Fint *count, MPI_F
 PN2(void, MPI_Isend, mpi_isend, MPI_ISEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Issend, mpi_issend, MPI_ISSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Is_thread_main, mpi_is_thread_main, MPI_IS_THREAD_MAIN, (ompi_fortran_logical_t *flag, MPI_Fint *ierr));
-PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_fint_copy_attr_function copy_fn, ompi_fint_delete_attr_function delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Keyval_free, mpi_keyval_free, MPI_KEYVAL_FREE, (MPI_Fint *keyval, MPI_Fint *ierr));
 PN2(void, MPI_Lookup_name, mpi_lookup_name, MPI_LOOKUP_NAME, (char *service_name, MPI_Fint *info, char *port_name, MPI_Fint *ierr, int service_name_len, int port_name_len));
 PN2(void, MPI_Mprobe, mpi_mprobe, MPI_MPROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *message, MPI_Fint *status, MPI_Fint *ierr));
@@ -373,7 +373,7 @@ PN2(void, MPI_Type_create_f90_integer, mpi_type_create_f90_integer, MPI_TYPE_CRE
 PN2(void, MPI_Type_create_f90_real, mpi_type_create_f90_real, MPI_TYPE_CREATE_F90_REAL, (MPI_Fint *p, MPI_Fint *r, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed, mpi_type_create_hindexed, MPI_TYPE_CREATE_HINDEXED, (MPI_Fint *count, MPI_Fint *array_of_blocklengths, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hvector, mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *stride, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
-PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_aint_copy_attr_function type_copy_attr_fn, ompi_aint_delete_attr_function type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_indexed_block, mpi_type_create_indexed_block, MPI_TYPE_CREATE_INDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Fint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed_block, mpi_type_create_hindexed_block, MPI_TYPE_CREATE_HINDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_struct, mpi_type_create_struct, MPI_TYPE_CREATE_STRUCT, (MPI_Fint *count, MPI_Fint *array_of_block_lengths, MPI_Aint *array_of_displacements, MPI_Fint *array_of_types, MPI_Fint *newtype, MPI_Fint *ierr));
@@ -421,7 +421,7 @@ PN2(void, MPI_Win_complete, mpi_win_complete, MPI_WIN_COMPLETE, (MPI_Fint *win, 
 PN2(void, MPI_Win_create, mpi_win_create, MPI_WIN_CREATE, (char *base, MPI_Aint *size, MPI_Fint *disp_unit, MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_dynamic, mpi_win_create_dynamic, MPI_WIN_CREATE_DYNAMIC, (MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_errhandler, mpi_win_create_errhandler, MPI_WIN_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL, (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL,(ompi_aint_copy_attr_function win_copy_attr_fn, ompi_aint_delete_attr_function win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Win_delete_attr, mpi_win_delete_attr, MPI_WIN_DELETE_ATTR, (MPI_Fint *win, MPI_Fint *win_keyval, MPI_Fint *ierr));
 PN2(void, MPI_Win_detach, mpi_win_detach, MPI_WIN_DETACH, (MPI_Fint *win, char *base, MPI_Fint *ierr));
 PN2(void, MPI_Win_fence, mpi_win_fence, MPI_WIN_FENCE, (MPI_Fint *assert, MPI_Fint *win, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
@@ -34,13 +34,13 @@
 #pragma weak PMPI_Type_create_keyval_f = ompi_type_create_keyval_f
 #pragma weak PMPI_Type_create_keyval_f08 = ompi_type_create_keyval_f
 #else
-OMPI_GENERATE_F77_BINDINGS (PMPI_TYPE_CREATE_KEYVAL,
-                           pmpi_type_create_keyval,
-                           pmpi_type_create_keyval_,
-                           pmpi_type_create_keyval__,
+OMPI_GENERATE_F77_BINDINGS(PMPI_TYPE_CREATE_KEYVAL, pmpi_type_create_keyval,
+                           pmpi_type_create_keyval_, pmpi_type_create_keyval__,
                            pompi_type_create_keyval_f,
-                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
+                           (ompi_aint_copy_attr_function type_copy_attr_fn,
+                            ompi_aint_delete_attr_function type_delete_attr_fn,
+                            MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr))
 #endif
 #endif
 
@@ -54,13 +54,12 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_TYPE_CREATE_KEYVAL,
 #pragma weak MPI_Type_create_keyval_f08 = ompi_type_create_keyval_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
-OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
-                           mpi_type_create_keyval,
-                           mpi_type_create_keyval_,
-                           mpi_type_create_keyval__,
-                           ompi_type_create_keyval_f,
-                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(MPI_TYPE_CREATE_KEYVAL, mpi_type_create_keyval, mpi_type_create_keyval_,
+                           mpi_type_create_keyval__, ompi_type_create_keyval_f,
+                           (ompi_aint_copy_attr_function type_copy_attr_fn,
+                            ompi_aint_delete_attr_function type_delete_attr_fn,
+                            MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr))
 #else
 #define ompi_type_create_keyval_f pompi_type_create_keyval_f
 #endif
@@ -68,8 +67,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Type_create_keyval_f";
 
-void ompi_type_create_keyval_f(ompi_aint_copy_attr_function* type_copy_attr_fn,
-                               ompi_aint_delete_attr_function* type_delete_attr_fn,
+void ompi_type_create_keyval_f(ompi_aint_copy_attr_function type_copy_attr_fn,
+                               ompi_aint_delete_attr_function type_delete_attr_fn,
                                MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;

--- a/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
@@ -34,13 +34,12 @@
 #pragma weak PMPI_Win_create_keyval_f = ompi_win_create_keyval_f
 #pragma weak PMPI_Win_create_keyval_f08 = ompi_win_create_keyval_f
 #else
-OMPI_GENERATE_F77_BINDINGS (PMPI_WIN_CREATE_KEYVAL,
-                           pmpi_win_create_keyval,
-                           pmpi_win_create_keyval_,
-                           pmpi_win_create_keyval__,
-                           pompi_win_create_keyval_f,
-                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(PMPI_WIN_CREATE_KEYVAL, pmpi_win_create_keyval, pmpi_win_create_keyval_,
+                           pmpi_win_create_keyval__, pompi_win_create_keyval_f,
+                           (ompi_aint_copy_attr_function win_copy_attr_fn,
+                            ompi_aint_delete_attr_function win_delete_attr_fn, MPI_Fint *win_keyval,
+                            MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr))
 #endif
 #endif
 
@@ -54,13 +53,12 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_WIN_CREATE_KEYVAL,
 #pragma weak MPI_Win_create_keyval_f08 = ompi_win_create_keyval_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
-OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
-                           mpi_win_create_keyval,
-                           mpi_win_create_keyval_,
-                           mpi_win_create_keyval__,
-                           ompi_win_create_keyval_f,
-                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
-                           (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
+OMPI_GENERATE_F77_BINDINGS(MPI_WIN_CREATE_KEYVAL, mpi_win_create_keyval, mpi_win_create_keyval_,
+                           mpi_win_create_keyval__, ompi_win_create_keyval_f,
+                           (ompi_aint_copy_attr_function win_copy_attr_fn,
+                            ompi_aint_delete_attr_function win_delete_attr_fn, MPI_Fint *win_keyval,
+                            MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr))
 #else
 #define ompi_win_create_keyval_f pompi_win_create_keyval_f
 #endif
@@ -68,9 +66,9 @@ OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Win_create_keyval";
 
-void ompi_win_create_keyval_f(ompi_aint_copy_attr_function* win_copy_attr_fn,
-                             ompi_aint_delete_attr_function* win_delete_attr_fn,
-                             MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
+void ompi_win_create_keyval_f(ompi_aint_copy_attr_function win_copy_attr_fn,
+                              ompi_aint_delete_attr_function win_delete_attr_fn,
+                              MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
     OMPI_SINGLE_NAME_DECL(win_keyval);


### PR DESCRIPTION
It is not recommended to declare function typedefs. The MPI external interface makes this
mistake but Open MPI should not makes this mistake for internal typedefs. This commit
updates various internal-only attribute typedefs to declare function pointer types.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit 6c1821380496fd88f1bbeede9fa8d3cdc13ef810)