### PR TITLE
oshmem: v4.1x: Reduce the service memory footprint

### DIFF
--- a/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
@@ -48,7 +48,8 @@ int mca_atomic_ucx_cswap(shmem_ctx_t ctx,
     assert(NULL != prev);
 
     *prev      = value;
-    ucx_mkey   = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey   = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn,
                                    UCP_ATOMIC_OP_CSWAP, &cond, 1, rva,

--- a/oshmem/mca/atomic/ucx/atomic_ucx_module.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_module.c
@@ -65,8 +65,8 @@ int mca_atomic_ucx_op(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
-
+    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn,
                                    op, &value, 1, rva, ucx_mkey->rkey,
@@ -115,7 +115,8 @@ int mca_atomic_ucx_fop(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn, op, &value, 1,
                                    rva, ucx_mkey->rkey, &param);

--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -200,22 +200,6 @@ static inline void *map_segment_va2rva(mkey_segment_t *seg, void *va)
     return memheap_va2rva(va, seg->super.va_base, seg->rva_base);
 }
 
-static inline map_base_segment_t *map_segment_find_va(map_base_segment_t *segs,
-                                                      size_t elem_size, void *va)
-{
-    map_base_segment_t *rseg;
-    int i;
-
-    for (i = 0; i < MCA_MEMHEAP_MAX_SEGMENTS; i++) {
-        rseg = (map_base_segment_t *)((char *)segs + elem_size * i);
-        if (OPAL_LIKELY(map_segment_is_va_in(rseg, va))) {
-            return rseg;
-        }
-    }
-
-    return NULL;
-}
-
 void mkey_segment_init(mkey_segment_t *seg, sshmem_mkey_t *mkey, uint32_t segno);
 
 static inline map_segment_t *memheap_find_va(void* va)

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -774,7 +774,6 @@ void mkey_segment_init(mkey_segment_t *seg, sshmem_mkey_t *mkey, uint32_t segno)
 
     s = memheap_find_seg(segno);
     assert(NULL != s);
-
     seg->super.va_base = s->super.va_base;
     seg->super.va_end  = s->super.va_end;
     seg->rva_base      = mkey->va_base;

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -150,9 +150,6 @@ static void unpack_remote_mkeys(shmem_ctx_t ctx, opal_buffer_t *msg, int remote_
     int32_t n;
     int32_t tr_id;
     int i;
-    ompi_proc_t *proc;
-
-    proc = oshmem_proc_group_find(oshmem_group_all, remote_pe);
     cnt = 1;
     opal_dss.unpack(msg, &n, &cnt, OPAL_UINT32);
     for (i = 0; i < n; i++) {
@@ -167,7 +164,7 @@ static void unpack_remote_mkeys(shmem_ctx_t ctx, opal_buffer_t *msg, int remote_
         if (0 == memheap_oob.mkeys[tr_id].va_base) {
             cnt = 1;
             opal_dss.unpack(msg, &memheap_oob.mkeys[tr_id].u.key, &cnt, OPAL_UINT64);
-            if (OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
+            if (oshmem_proc_on_local_node(remote_pe)) {
                 memheap_attach_segment(&memheap_oob.mkeys[tr_id], tr_id);
             }
         } else {

--- a/oshmem/mca/memheap/base/memheap_base_register.c
+++ b/oshmem/mca/memheap/base/memheap_base_register.c
@@ -86,7 +86,7 @@ static int _dereg_segment(map_segment_t *s)
                 continue;
             if (s->mkeys_cache[j]) {
                 if (s->mkeys_cache[j]->len) {
-                    MCA_SPML_CALL(rmkey_free(s->mkeys_cache[j]));
+                    MCA_SPML_CALL(rmkey_free(s->mkeys_cache[j], j));
                     free(s->mkeys_cache[j]->u.data);
                     s->mkeys_cache[j]->len = 0;
                 }

--- a/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
@@ -116,7 +116,7 @@ get_dst_pe(struct oshmem_group_t *group, int src_blk_idx, int dst_blk_idx, int *
     (*dst_pe_idx) = (dst_blk_idx + src_blk_idx) % group->proc_count;
 
     /* convert to the global pe */
-    return oshmem_proc_pe(group->proc_array[*dst_pe_idx]);
+    return oshmem_proc_pe_vpid(group, *dst_pe_idx);
 }
 
 static int a2as_alg_simple(struct oshmem_group_t *group,

--- a/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
@@ -144,7 +144,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
                       "[#%d] send data to all PE in the group",
                       group->my_pe);
         for (i = 0; (i < group->proc_count) && (rc == OSHMEM_SUCCESS); i++) {
-            pe_cur = oshmem_proc_pe(group->proc_array[i]);
+            pe_cur = oshmem_proc_pe_vpid(group, i);
             if (pe_cur != PE_root) {
                 SCOLL_VERBOSE(15,
                               "[#%d] send data to #%d",
@@ -233,7 +233,7 @@ static int _algorithm_binomial_tree(struct oshmem_group_t *group,
         if (peer_id < group->proc_count) {
             /* Wait for the child to be ready to receive (pSync must have the initial value) */
             peer_id = (peer_id + root_id) % group->proc_count;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             SCOLL_VERBOSE(14,
                           "[#%d] check remote pe is ready to receive #%d",

--- a/oshmem/mca/scoll/basic/scoll_basic_reduce.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_reduce.c
@@ -186,7 +186,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
 {
     int rc = OSHMEM_SUCCESS;
     int i = 0;
-    int PE_root = oshmem_proc_pe(group->proc_array[0]);
+    int PE_root = oshmem_proc_pe_vpid(group, 0);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Central Counter", group->my_pe);
 
@@ -204,7 +204,7 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
             for (i = 0; (i < group->proc_count) && (rc == OSHMEM_SUCCESS);
                     i++) {
                 /* Get PE ID of a peer from the group */
-                pe_cur = oshmem_proc_pe(group->proc_array[i]);
+                pe_cur = oshmem_proc_pe_vpid(group, i);
 
                 if (pe_cur == group->my_pe)
                     continue;
@@ -265,7 +265,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
     int peer_id = 0;
     int peer_pe = 0;
     void *target_cur = NULL;
-    int PE_root = oshmem_proc_pe(group->proc_array[0]);
+    int PE_root = oshmem_proc_pe_vpid(group, 0);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Tournament", group->my_pe);
     SCOLL_VERBOSE(15, "[#%d] pSync[0] = %ld", group->my_pe, pSync[0]);
@@ -304,7 +304,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
                 op->o_func.c_fn(target, target_cur, nlong / op->dt_size);
             }
         } else {
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
 #if 1 /* It is ugly implementation of compare and swap operation
          Usage of this hack does not give performance improvement but
@@ -345,7 +345,7 @@ static int _algorithm_tournament(struct oshmem_group_t *group,
         for (peer_id = 1;
                 (peer_id < group->proc_count) && (rc == OSHMEM_SUCCESS);
                 peer_id++) {
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
             rc = MCA_SPML_CALL(put(oshmem_ctx_default, (void*)pSync, sizeof(value), (void*)&value, peer_pe));
         }
     }
@@ -416,7 +416,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
     if (my_id >= floor2_proc) {
         /* I am in extra group, my partner is node (my_id-y) in basic group */
         peer_id = my_id - floor2_proc;
-        peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+        peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
         /* Special procedure is needed in case target and source are the same */
         if (source == target) {
@@ -448,7 +448,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
         if ((group->proc_count - floor2_proc) > my_id) {
             /* I am in basic group, my partner is node (my_id+y) in extra group */
             peer_id = my_id + floor2_proc;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             /* Special procedure is needed in case target and source are the same */
             if (source == target) {
@@ -481,8 +481,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
             /* Update exit condition and round counter */
             exit_flag >>= 1;
             round++;
-
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
 #if 1 /* It is ugly implementation of compare and swap operation
          Usage of this hack does not give performance improvement but
@@ -524,7 +523,7 @@ static int _algorithm_recursive_doubling(struct oshmem_group_t *group,
         if ((group->proc_count - floor2_proc) > my_id) {
             /* I am in basic group, my partner is node (my_id+y) in extra group */
             peer_id = my_id + floor2_proc;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             SCOLL_VERBOSE(14,
                           "[#%d] is extra send data to #%d",
@@ -566,7 +565,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
     rank = group->my_pe;
     size = group->proc_count;
     int root_id = size - 1;
-    int root_pe = oshmem_proc_pe(group->proc_array[root_id]);
+    int root_pe = oshmem_proc_pe_vpid(group, root_id);
 
     SCOLL_VERBOSE(12, "[#%d] Reduce algorithm: Basic", group->my_pe);
 
@@ -592,7 +591,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
             memcpy(target, (void *) source, nlong);
         } else {
             peer_id = size - 1;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
             rc = MCA_SPML_CALL(recv(target, nlong, peer_pe));
         }
         if (OSHMEM_SUCCESS != rc) {
@@ -609,7 +608,7 @@ static int _algorithm_linear(struct oshmem_group_t *group,
                 inbuf = (char*) source;
             } else {
                 peer_id = i;
-                peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+                peer_pe = oshmem_proc_pe_vpid(group, peer_id);
                 rc = MCA_SPML_CALL(recv(pml_buffer, nlong, peer_pe));
                 if (OSHMEM_SUCCESS != rc) {
                     if (NULL != free_buffer) {
@@ -671,7 +670,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
     int peer_id = 0;
     int peer_pe = 0;
     int root_id = 0;
-    int root_pe = oshmem_proc_pe(group->proc_array[root_id]);
+    int root_pe = oshmem_proc_pe_vpid(group, root_id);
     int dim = 0;
 
     /* Initialize */
@@ -719,7 +718,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
         if (vrank & mask) {
             peer_id = vrank & ~mask;
             peer_id = (peer_id + root_id) % size;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             rc = MCA_SPML_CALL(send((void*)snd_buffer, nlong, peer_pe, MCA_SPML_BASE_PUT_STANDARD));
             if (OSHMEM_SUCCESS != rc) {
@@ -738,7 +737,7 @@ static int _algorithm_log(struct oshmem_group_t *group,
                 continue;
             }
             peer_id = (peer_id + root_id) % size;
-            peer_pe = oshmem_proc_pe(group->proc_array[peer_id]);
+            peer_pe = oshmem_proc_pe_vpid(group, peer_id);
 
             /* Most of the time (all except the first one for commutative
              * operations) we receive in the user provided buffer

--- a/oshmem/mca/scoll/mpi/scoll_mpi_module.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_module.c
@@ -145,7 +145,7 @@ mca_scoll_mpi_comm_query(oshmem_group_t *osh_group, int *priority)
 
         /* Fill the map "group_rank-to-world_rank" in order to create a new proc group */
         for (i = 0; i < osh_group->proc_count; i++) {
-            ranks[i] = osh_group->proc_array[i]->super.proc_name.vpid;
+            ranks[i] = oshmem_proc_pe_vpid(osh_group, i);
         }
 
         OPAL_TIMING_ENV_NEXT(comm_query, "build_ranks");

--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -78,7 +78,7 @@ OSHMEM_DECLSPEC int mca_spml_base_oob_get_mkeys(shmem_ctx_t ctx,
                                                 sshmem_mkey_t *mkeys);
 
 OSHMEM_DECLSPEC void mca_spml_base_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t seg, int pe, int tr_id);
-OSHMEM_DECLSPEC void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey);
+OSHMEM_DECLSPEC void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey, int pe);
 OSHMEM_DECLSPEC void *mca_spml_base_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *mkey, int pe);
 
 OSHMEM_DECLSPEC int mca_spml_base_put_nb(void *dst_addr,

--- a/oshmem/mca/spml/base/spml_base.c
+++ b/oshmem/mca/spml/base/spml_base.c
@@ -256,7 +256,7 @@ void mca_spml_base_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t s
 {
 }
 
-void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey)
+void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey, int pe)
 {
 }
 

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -150,7 +150,7 @@ typedef void * (*mca_spml_base_module_mkey_ptr_fn_t)(const void *dst_addr, sshme
  *
  * @param mkey remote mkey
  */
-typedef void (*mca_spml_base_module_mkey_free_fn_t)(sshmem_mkey_t *);
+typedef void (*mca_spml_base_module_mkey_free_fn_t)(sshmem_mkey_t *, int pe);
 
 /**
  * Register (Pinn) a buffer of 'size' bits starting in address addr

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -193,9 +193,9 @@ typedef int (*mca_spml_base_module_oob_get_mkeys_fn_t)(shmem_ctx_t ctx, int pe,
  * @return OSHMEM_SUCCESS or failure status.
  *
  */
-typedef int (*mca_spml_base_module_add_procs_fn_t)(ompi_proc_t** procs,
+typedef int (*mca_spml_base_module_add_procs_fn_t)(struct oshmem_group_t* group,
                                                    size_t nprocs);
-typedef int (*mca_spml_base_module_del_procs_fn_t)(ompi_proc_t** procs,
+typedef int (*mca_spml_base_module_del_procs_fn_t)(struct oshmem_group_t* group,
                                                    size_t nprocs);
 
 

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -106,6 +106,151 @@ int mca_spml_ucx_enable(bool enable)
     return OSHMEM_SUCCESS;
 }
 
+/* initialize the mkey cache */
+void mca_spml_ucx_peer_mkey_cache_init(mca_spml_ucx_ctx_t *ucx_ctx, int pe)
+{
+    ucx_ctx->ucp_peers[pe].mkeys = NULL;
+    ucx_ctx->ucp_peers[pe].mkeys_cnt = 0;
+}
+
+/* add a new mkey and update the mkeys_cnt */
+int mca_spml_ucx_peer_mkey_cache_add(ucp_peer_t *ucp_peer, int index)
+{
+    /* Allocate an array to hold the pointers to the ucx_cached_mkey */
+    if (index >= ucp_peer->mkeys_cnt){
+        int old_size = ucp_peer->mkeys_cnt;
+        if (MCA_MEMHEAP_MAX_SEGMENTS <= (index + 1)) {
+            SPML_UCX_ERROR("Failed to get new mkey for segment: max number (%d) of segment descriptor is exhausted",
+                        MCA_MEMHEAP_MAX_SEGMENTS);
+            return OSHMEM_ERROR;
+        }
+        ucp_peer->mkeys_cnt = index + 1;
+        ucp_peer->mkeys = realloc(ucp_peer->mkeys, sizeof(ucp_peer->mkeys[0]) * ucp_peer->mkeys_cnt);
+        if (NULL == ucp_peer->mkeys) {
+            SPML_UCX_ERROR("Failed to obtain new mkey: OOM - failed to expand the descriptor buffer");
+            return OSHMEM_ERR_OUT_OF_RESOURCE;
+        }
+        /* NOTE: release code checks for the rkey != NULL as a sign of used element:
+        Account for the following scenario below by zero'ing the unused elements:
+        |MKEY1|00000|MKEY2|??????|NEW-MKEY|
+        |<--- old_size -->|
+        */
+        memset(ucp_peer->mkeys + old_size, 0, (ucp_peer->mkeys_cnt - old_size) * sizeof(ucp_peer->mkeys[0]));
+    } else {
+        /* Make sure we don't leak memory */
+        assert(NULL == ucp_peer->mkeys[index]);
+    }
+
+    ucp_peer->mkeys[index] = (spml_ucx_cached_mkey_t *) malloc(sizeof(*ucp_peer->mkeys[0]));
+    if (NULL == ucp_peer->mkeys[index]) {
+        SPML_UCX_ERROR("Failed to obtain new ucx_cached_mkey: OOM - failed to expand the descriptor buffer");
+        return OSHMEM_ERR_OUT_OF_RESOURCE;
+    }
+    return OSHMEM_SUCCESS;
+}
+
+/* Release individual mkeys */
+int mca_spml_ucx_peer_mkey_cache_del(ucp_peer_t *ucp_peer, int segno)
+{
+    if ((ucp_peer->mkeys_cnt <= segno) || (segno < 0)) {
+        return OSHMEM_ERR_NOT_AVAILABLE;
+    }
+    if (NULL != ucp_peer->mkeys[segno]) {
+        free(ucp_peer->mkeys[segno]);
+        ucp_peer->mkeys[segno] = NULL;
+    }
+    return OSHMEM_SUCCESS;
+}
+
+/* Release the memkey map from a ucp_peer if it has any element in memkey */
+void mca_spml_ucx_peer_mkey_cache_release(ucp_peer_t *ucp_peer)
+{
+    int i;
+    if (ucp_peer->mkeys_cnt) {
+        for(i = 0; i < ucp_peer->mkeys_cnt; i++) {
+            assert(NULL == ucp_peer->mkeys[i]);
+        }
+        free(ucp_peer->mkeys);
+        ucp_peer->mkeys = NULL;
+    }
+}
+
+int mca_spml_ucx_ctx_mkey_new(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t **mkey)
+{
+    ucp_peer_t *ucp_peer;
+    spml_ucx_cached_mkey_t *ucx_cached_mkey;
+    int rc;
+    ucp_peer = &(ucx_ctx->ucp_peers[pe]);
+    rc = mca_spml_ucx_peer_mkey_cache_add(ucp_peer, segno);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+    rc = mca_spml_ucx_peer_mkey_get(ucp_peer, segno, &ucx_cached_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+    *mkey = &(ucx_cached_mkey->key);
+    return OSHMEM_SUCCESS;
+}
+
+int mca_spml_ucx_ctx_mkey_cache(mca_spml_ucx_ctx_t *ucx_ctx, sshmem_mkey_t *mkey, uint32_t segno, int dst_pe)
+{
+    ucp_peer_t *peer;
+    spml_ucx_cached_mkey_t *ucx_cached_mkey;
+    int rc;
+
+    peer = &(ucx_ctx->ucp_peers[dst_pe]);
+    rc = mca_spml_ucx_peer_mkey_get(peer, segno, &ucx_cached_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_peer_mkey_get failed");
+        return rc;
+    }
+    mkey_segment_init(&ucx_cached_mkey->super, mkey, segno);
+    return OSHMEM_SUCCESS;
+}
+
+int mca_spml_ucx_ctx_mkey_add(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, sshmem_mkey_t *mkey, spml_ucx_mkey_t **ucx_mkey)
+{
+    int rc;
+    ucs_status_t err;
+
+    rc = mca_spml_ucx_ctx_mkey_new(ucx_ctx, pe, segno, ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_new failed");
+        return rc;
+    }
+
+    if (mkey->u.data) {
+        err = ucp_ep_rkey_unpack(ucx_ctx->ucp_peers[pe].ucp_conn, mkey->u.data, &((*ucx_mkey)->rkey));
+        if (UCS_OK != err) {
+            SPML_UCX_ERROR("failed to unpack rkey: %s", ucs_status_string(err));
+            return OSHMEM_ERROR;
+        }
+        rc = mca_spml_ucx_ctx_mkey_cache(ucx_ctx, mkey, segno, pe);
+        if (OSHMEM_SUCCESS != rc) {
+            SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_cache failed");
+            return rc;
+        }
+    }
+    return OSHMEM_SUCCESS;
+}
+
+int mca_spml_ucx_ctx_mkey_del(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t *ucx_mkey)
+{
+    ucp_peer_t *ucp_peer;
+    spml_ucx_cached_mkey_t *ucx_cached_mkey;
+    int rc;
+    ucp_peer = &(ucx_ctx->ucp_peers[pe]);
+    ucp_rkey_destroy(ucx_mkey->rkey);
+    ucx_mkey->rkey = NULL;
+    rc = mca_spml_ucx_peer_mkey_cache_del(ucp_peer, segno);
+    if(OSHMEM_SUCCESS != rc){
+        SPML_UCX_ERROR("mca_spml_ucx_peer_mkey_cache_del failed");
+        return rc;
+    }
+    return OSHMEM_SUCCESS;
+}
+
 int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
 {
     opal_common_ucx_del_proc_t *del_procs;
@@ -130,6 +275,8 @@ int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
 
         /* mark peer as disconnected */
         mca_spml_ucx_ctx_default.ucp_peers[i].ucp_conn = NULL;
+        /* release the cached_ep_mkey buffer */
+        mca_spml_ucx_peer_mkey_cache_release(&(mca_spml_ucx_ctx_default.ucp_peers[i]));
     }
 
     ret = opal_common_ucx_del_procs_nofence(del_procs, nprocs, oshmem_my_proc_id(),
@@ -364,9 +511,8 @@ int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
         OSHMEM_PROC_DATA(procs[i])->num_transports = 1;
         OSHMEM_PROC_DATA(procs[i])->transport_ids = spml_ucx_transport_ids;
 
-        for (j = 0; j < MCA_MEMHEAP_MAX_SEGMENTS; j++) {
-            mca_spml_ucx_ctx_default.ucp_peers[i].mkeys[j].key.rkey = NULL;
-        }
+        /* Initialize mkeys as NULL for all processes */
+        mca_spml_ucx_peer_mkey_cache_init(&mca_spml_ucx_ctx_default, i);
     }
 
     for (i = 0; i < mca_spml_ucx.ucp_workers; i++) {
@@ -421,15 +567,21 @@ error:
 
 }
 
-void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey)
+void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey, int pe)
 {
     spml_ucx_mkey_t   *ucx_mkey;
+    uint32_t segno;
+    int rc;
 
     if (!mkey->spml_context) {
         return;
     }
+    segno = memheap_find_segnum(mkey->va_base);
     ucx_mkey = (spml_ucx_mkey_t *)(mkey->spml_context);
-    ucp_rkey_destroy(ucx_mkey->rkey);
+    rc = mca_spml_ucx_ctx_mkey_del(&mca_spml_ucx_ctx_default, pe, segno, ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_del failed\n");
+    }
 }
 
 void *mca_spml_ucx_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *mkey, int pe)
@@ -453,22 +605,16 @@ void mca_spml_ucx_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t se
 {
     spml_ucx_mkey_t   *ucx_mkey;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
-    ucs_status_t err;
-    
-    ucx_mkey = &ucx_ctx->ucp_peers[pe].mkeys[segno].key;
+    int rc;
 
-    err = ucp_ep_rkey_unpack(ucx_ctx->ucp_peers[pe].ucp_conn,
-            mkey->u.data,
-            &ucx_mkey->rkey); 
-    if (UCS_OK != err) {
-        SPML_UCX_ERROR("failed to unpack rkey: %s", ucs_status_string(err));
+    rc = mca_spml_ucx_ctx_mkey_add(ucx_ctx, pe, segno, mkey, &ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_cache failed");
         goto error_fatal;
     }
-
     if (ucx_ctx == &mca_spml_ucx_ctx_default) {
         mkey->spml_context = ucx_mkey;
     }
-    mca_spml_ucx_cache_mkey(ucx_ctx, mkey, segno, pe);
     return;
 
 error_fatal:
@@ -482,14 +628,18 @@ void mca_spml_ucx_memuse_hook(void *addr, size_t length)
     spml_ucx_mkey_t *ucx_mkey;
     ucp_mem_advise_params_t params;
     ucs_status_t status;
+    int rc;
 
     if (!(mca_spml_ucx.heap_reg_nb && memheap_is_va_in_segment(addr, HEAP_SEG_INDEX))) {
         return;
     }
 
-    my_pe    = oshmem_my_proc_id();
-    ucx_mkey = &mca_spml_ucx_ctx_default.ucp_peers[my_pe].mkeys[HEAP_SEG_INDEX].key;
-
+    my_pe = oshmem_my_proc_id();
+    rc = mca_spml_ucx_ctx_mkey_by_seg(&mca_spml_ucx_ctx_default, my_pe, HEAP_SEG_INDEX, &ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_by_seg failed");
+        return;
+    }
     params.field_mask = UCP_MEM_ADVISE_PARAM_FIELD_ADDRESS |
                         UCP_MEM_ADVISE_PARAM_FIELD_LENGTH |
                         UCP_MEM_ADVISE_PARAM_FIELD_ADVICE;
@@ -515,10 +665,12 @@ sshmem_mkey_t *mca_spml_ucx_register(void* addr,
     spml_ucx_mkey_t   *ucx_mkey;
     size_t len;
     ucp_mem_map_params_t mem_map_params;
-    int segno;
+    uint32_t segno;
     map_segment_t *mem_seg;
     unsigned flags;
     int my_pe = oshmem_my_proc_id();
+    int rc;
+    ucp_mem_h mem_h;
 
     *count = 0;
     mkeys = (sshmem_mkey_t *) calloc(1, sizeof(*mkeys));
@@ -528,9 +680,6 @@ sshmem_mkey_t *mca_spml_ucx_register(void* addr,
 
     segno   = memheap_find_segnum(addr);
     mem_seg = memheap_find_seg(segno);
-
-    ucx_mkey = &mca_spml_ucx_ctx_default.ucp_peers[my_pe].mkeys[segno].key;
-    mkeys[0].spml_context = ucx_mkey;
 
     /* if possible use mem handle already created by ucx allocator */
     if (MAP_SEGMENT_ALLOC_UCX != mem_seg->type) {
@@ -546,18 +695,18 @@ sshmem_mkey_t *mca_spml_ucx_register(void* addr,
         mem_map_params.length     = size;
         mem_map_params.flags      = flags;
 
-        status = ucp_mem_map(mca_spml_ucx.ucp_context, &mem_map_params, &ucx_mkey->mem_h);
+        status = ucp_mem_map(mca_spml_ucx.ucp_context, &mem_map_params, &mem_h);
         if (UCS_OK != status) {
             goto error_out;
         }
 
     } else {
         mca_sshmem_ucx_segment_context_t *ctx = mem_seg->context;
-        ucx_mkey->mem_h = ctx->ucp_memh;
+        mem_h  = ctx->ucp_memh;
     }
 
-    status = ucp_rkey_pack(mca_spml_ucx.ucp_context, ucx_mkey->mem_h,
-                           &mkeys[0].u.data, &len);
+    status = ucp_rkey_pack(mca_spml_ucx.ucp_context, mem_h,
+                           &mkeys[SPML_UCX_TRANSP_IDX].u.data, &len);
     if (UCS_OK != status) {
         goto error_unmap;
     }
@@ -567,19 +716,16 @@ sshmem_mkey_t *mca_spml_ucx_register(void* addr,
                 0xffff);
         oshmem_shmem_abort(-1);
     }
-
-    status = ucp_ep_rkey_unpack(mca_spml_ucx_ctx_default.ucp_peers[oshmem_group_self->my_pe].ucp_conn,
-                                mkeys[0].u.data,
-                                &ucx_mkey->rkey);
-    if (UCS_OK != status) {
-        SPML_UCX_ERROR("failed to unpack rkey");
+    mkeys[SPML_UCX_TRANSP_IDX].len     = len;
+    mkeys[SPML_UCX_TRANSP_IDX].va_base = addr;
+    *count = SPML_UCX_TRANSP_CNT;
+    rc = mca_spml_ucx_ctx_mkey_add(&mca_spml_ucx_ctx_default, my_pe, segno, &mkeys[SPML_UCX_TRANSP_IDX], &ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_cache failed");
         goto error_unmap;
     }
-
-    mkeys[0].len     = len;
-    mkeys[0].va_base = addr;
-    *count = 1;
-    mca_spml_ucx_cache_mkey(&mca_spml_ucx_ctx_default, &mkeys[0], segno, my_pe);
+    ucx_mkey->mem_h = mem_h;
+    mkeys[SPML_UCX_TRANSP_IDX].spml_context = ucx_mkey;
     return mkeys;
 
 error_unmap:
@@ -594,16 +740,20 @@ int mca_spml_ucx_deregister(sshmem_mkey_t *mkeys)
 {
     spml_ucx_mkey_t   *ucx_mkey;
     map_segment_t *mem_seg;
+    int my_pe = oshmem_my_proc_id();
+    int rc;
+    uint32_t segno;
 
     MCA_SPML_CALL(quiet(oshmem_ctx_default));
     if (!mkeys)
         return OSHMEM_SUCCESS;
 
-    if (!mkeys[0].spml_context)
+    if (!mkeys[SPML_UCX_TRANSP_IDX].spml_context)
         return OSHMEM_SUCCESS;
 
-    mem_seg  = memheap_find_va(mkeys[0].va_base);
-    ucx_mkey = (spml_ucx_mkey_t*)mkeys[0].spml_context;
+    mem_seg  = memheap_find_va(mkeys[SPML_UCX_TRANSP_IDX].va_base);
+    ucx_mkey = (spml_ucx_mkey_t*)mkeys[SPML_UCX_TRANSP_IDX].spml_context;
+    segno = memheap_find_segnum(mkeys[SPML_UCX_TRANSP_IDX].va_base);
 
     if (OPAL_UNLIKELY(NULL == mem_seg)) {
         return OSHMEM_ERROR;
@@ -612,11 +762,14 @@ int mca_spml_ucx_deregister(sshmem_mkey_t *mkeys)
     if (MAP_SEGMENT_ALLOC_UCX != mem_seg->type) {
         ucp_mem_unmap(mca_spml_ucx.ucp_context, ucx_mkey->mem_h);
     }
-    ucp_rkey_destroy(ucx_mkey->rkey);
-    ucx_mkey->rkey = NULL;
 
-    if (0 < mkeys[0].len) {
-        ucp_rkey_buffer_release(mkeys[0].u.data);
+    rc = mca_spml_ucx_ctx_mkey_del(&mca_spml_ucx_ctx_default, my_pe, segno, ucx_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_del failed\n");
+        return rc;
+    }
+    if (0 < mkeys[SPML_UCX_TRANSP_IDX].len) {
+        ucp_rkey_buffer_release(mkeys[SPML_UCX_TRANSP_IDX].u.data);
     }
 
     free(mkeys);
@@ -715,16 +868,10 @@ static int mca_spml_ucx_ctx_create_common(long options, mca_spml_ucx_ctx_t **ucx
 
         for (j = 0; j < memheap_map->n_segments; j++) {
             mkey = &memheap_map->mem_segs[j].mkeys_cache[i][0];
-            ucx_mkey = &ucx_ctx->ucp_peers[i].mkeys[j].key;
-            if (mkey->u.data) {
-                err = ucp_ep_rkey_unpack(ucx_ctx->ucp_peers[i].ucp_conn,
-                                         mkey->u.data,
-                                         &ucx_mkey->rkey);
-                if (UCS_OK != err) {
-                    SPML_UCX_ERROR("failed to unpack rkey");
-                    goto error2;
-                }
-                mca_spml_ucx_cache_mkey(ucx_ctx, mkey, j, i);
+            rc = mca_spml_ucx_ctx_mkey_add(ucx_ctx, i, j, mkey, &ucx_mkey);
+            if (OSHMEM_SUCCESS != rc) {
+                SPML_UCX_ERROR("mca_spml_ucx_ctx_mkey_add failed");
+                goto error2;
             }
         }
     }
@@ -818,7 +965,8 @@ void mca_spml_ucx_ctx_destroy(shmem_ctx_t ctx)
 int mca_spml_ucx_get(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_addr, int src)
 {
     void *rva;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if (HAVE_DECL_UCP_GET_NBX || HAVE_DECL_UCP_GET_NB)
     ucs_status_ptr_t request;
@@ -845,7 +993,8 @@ int mca_spml_ucx_get_nb(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_
 {
     void *rva;
     ucs_status_t status;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_GET_NBX
     ucs_status_ptr_t status_ptr;
@@ -872,7 +1021,8 @@ int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx, void *src_addr, size_t size, 
     unsigned int i;
     void *rva;
     ucs_status_t status;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_GET_NBX
     ucs_status_ptr_t status_ptr;
@@ -908,7 +1058,8 @@ int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx, void *src_addr, size_t size, 
 int mca_spml_ucx_put(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst)
 {
     void *rva;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
     int res;
 #if (HAVE_DECL_UCP_PUT_NBX || HAVE_DECL_UCP_PUT_NB)
@@ -941,7 +1092,8 @@ int mca_spml_ucx_put(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_add
 int mca_spml_ucx_put_nb(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst, void **handle)
 {
     void *rva;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
     ucs_status_t status;
 #if HAVE_DECL_UCP_PUT_NBX
@@ -974,7 +1126,8 @@ int mca_spml_ucx_put_nb_wprogress(shmem_ctx_t ctx, void* dst_addr, size_t size, 
     unsigned int i;
     void *rva;
     ucs_status_t status;
-    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_get_mkey(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_PUT_NBX
     ucs_status_ptr_t status_ptr;
@@ -1043,7 +1196,7 @@ int mca_spml_ucx_quiet(shmem_ctx_t ctx)
         for (i = 0; i < ucx_ctx->put_proc_count; i++) {
             idx = ucx_ctx->put_proc_indexes[i];
             ret = mca_spml_ucx_get_nb(ctx,
-                                      ucx_ctx->ucp_peers[idx].mkeys->super.super.va_base,
+                                      ucx_ctx->ucp_peers[idx].mkeys[SPML_UCX_SERVICE_SEG]->super.super.va_base,
                                       sizeof(flush_get_data), &flush_get_data, idx, NULL);
             if (OMPI_SUCCESS != ret) {
                 oshmem_shmem_abort(-1);

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -251,7 +251,7 @@ int mca_spml_ucx_ctx_mkey_del(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segn
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs)
 {
     opal_common_ucx_del_proc_t *del_procs;
     size_t i, w, n;
@@ -433,7 +433,7 @@ int mca_spml_ucx_clear_put_op_mask(mca_spml_ucx_ctx_t *ctx)
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
 {
     size_t i, j, k, w, n;
     int rc = OSHMEM_ERROR;
@@ -507,9 +507,6 @@ int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
                     ucs_status_string(err));
             goto error2;
         }
-
-        OSHMEM_PROC_DATA(procs[i])->num_transports = 1;
-        OSHMEM_PROC_DATA(procs[i])->transport_ids = spml_ucx_transport_ids;
 
         /* Initialize mkeys as NULL for all processes */
         mca_spml_ucx_peer_mkey_cache_init(&mca_spml_ucx_ctx_default, i);

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -10,7 +10,7 @@
  *
  * $HEADER$
  */
-
+ 
 #define _GNU_SOURCE
 #include <stdio.h>
 

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -194,8 +194,8 @@ extern void mca_spml_ucx_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint
 extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey, int pe);
 extern void *mca_spml_ucx_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *, int pe);
 
-extern int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs);
-extern int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs);
+extern int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs);
+extern int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs);
 extern int mca_spml_ucx_fence(shmem_ctx_t ctx);
 extern int mca_spml_ucx_quiet(shmem_ctx_t ctx);
 extern int spml_ucx_default_progress(void);

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -45,6 +45,9 @@ BEGIN_C_DECLS
 #define SPML_UCX_ASSERT  MCA_COMMON_UCX_ASSERT
 #define SPML_UCX_ERROR   MCA_COMMON_UCX_ERROR
 #define SPML_UCX_VERBOSE MCA_COMMON_UCX_VERBOSE
+#define SPML_UCX_TRANSP_IDX 0
+#define SPML_UCX_TRANSP_CNT 1
+#define SPML_UCX_SERVICE_SEG 0
 
 /**
  * UCX SPML module
@@ -63,7 +66,8 @@ typedef struct spml_ucx_cached_mkey spml_ucx_cached_mkey_t;
 
 struct ucp_peer {
     ucp_ep_h                 ucp_conn;
-    spml_ucx_cached_mkey_t   mkeys[MCA_MEMHEAP_MAX_SEGMENTS];
+    spml_ucx_cached_mkey_t **mkeys;
+    size_t                   mkeys_cnt;
 };
 typedef struct ucp_peer ucp_peer_t;
  
@@ -187,7 +191,7 @@ extern int mca_spml_ucx_deregister(sshmem_mkey_t *mkeys);
 extern void mca_spml_ucx_memuse_hook(void *addr, size_t length);
 
 extern void mca_spml_ucx_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t segno, int pe, int tr_id);
-extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey);
+extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey, int pe);
 extern void *mca_spml_ucx_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *, int pe);
 
 extern int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs);
@@ -201,6 +205,23 @@ void mca_spml_ucx_async_cb(int fd, short event, void *cbdata);
 
 int mca_spml_ucx_init_put_op_mask(mca_spml_ucx_ctx_t *ctx, size_t nprocs);
 int mca_spml_ucx_clear_put_op_mask(mca_spml_ucx_ctx_t *ctx);
+int mca_spml_ucx_peer_mkey_cache_add(ucp_peer_t *ucp_peer, int index);
+int mca_spml_ucx_peer_mkey_cache_del(ucp_peer_t *ucp_peer, int segno);
+void mca_spml_ucx_peer_mkey_cache_release(ucp_peer_t *ucp_peer);
+void mca_spml_ucx_peer_mkey_cache_init(mca_spml_ucx_ctx_t *ucx_ctx, int pe);
+
+static inline int
+mca_spml_ucx_peer_mkey_get(ucp_peer_t *ucp_peer, int index, spml_ucx_cached_mkey_t **out_rmkey)
+{
+    *out_rmkey = NULL;
+    if (OPAL_UNLIKELY((index >= ucp_peer->mkeys_cnt) || (MCA_MEMHEAP_MAX_SEGMENTS <= index) || (0 > index))) {
+        SPML_UCX_ERROR("Failed to get mkey for segment: bad index = %d, MAX = %d, cached mkeys count: %d",
+                        index, MCA_MEMHEAP_MAX_SEGMENTS, ucp_peer->mkeys_cnt);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    *out_rmkey = ucp_peer->mkeys[index];
+    return OSHMEM_SUCCESS;
+}
 
 static inline void mca_spml_ucx_aux_lock(void)
 {
@@ -216,25 +237,44 @@ static inline void mca_spml_ucx_aux_unlock(void)
     }
 }
 
-static void mca_spml_ucx_cache_mkey(mca_spml_ucx_ctx_t *ucx_ctx, sshmem_mkey_t *mkey, uint32_t segno, int dst_pe)
-{
-    ucp_peer_t *peer;
+int mca_spml_ucx_ctx_mkey_new(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t **mkey);
+int mca_spml_ucx_ctx_mkey_cache(mca_spml_ucx_ctx_t *ucx_ctx, sshmem_mkey_t *mkey, uint32_t segno, int dst_pe);
+int mca_spml_ucx_ctx_mkey_add(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, sshmem_mkey_t *mkey, spml_ucx_mkey_t **ucx_mkey);
+int mca_spml_ucx_ctx_mkey_del(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t *ucx_mkey);
 
-    peer = &(ucx_ctx->ucp_peers[dst_pe]);
-    mkey_segment_init(&peer->mkeys[segno].super, mkey, segno);
+static inline int
+mca_spml_ucx_ctx_mkey_by_seg(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t **mkey)
+{
+    ucp_peer_t *ucp_peer;
+    spml_ucx_cached_mkey_t *ucx_cached_mkey;
+    int rc;
+    ucp_peer = &(ucx_ctx->ucp_peers[pe]);
+    rc = mca_spml_ucx_peer_mkey_get(ucp_peer, segno, &ucx_cached_mkey);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+    *mkey = &(ucx_cached_mkey->key);
+    return OSHMEM_SUCCESS;
 }
 
 static inline spml_ucx_mkey_t * 
-mca_spml_ucx_get_mkey(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_spml_ucx_t* module)
+mca_spml_ucx_ctx_mkey_by_va(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_spml_ucx_t* module)
 {
-    spml_ucx_cached_mkey_t *mkey;
+    spml_ucx_cached_mkey_t **mkey;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
+    int i;
 
     mkey = ucx_ctx->ucp_peers[pe].mkeys;
-    mkey = (spml_ucx_cached_mkey_t *)map_segment_find_va(&mkey->super.super, sizeof(*mkey), va);
-    assert(mkey != NULL);
-    *rva = map_segment_va2rva(&mkey->super, va);
-    return &mkey->key;
+    for (i = 0; i < ucx_ctx->ucp_peers[pe].mkeys_cnt; i++) {
+        if (NULL == mkey[i]) {
+            continue;
+        }
+        if (OPAL_LIKELY(map_segment_is_va_in(&mkey[i]->super.super, va))) {
+            *rva = map_segment_va2rva(&mkey[i]->super, va);
+            return &mkey[i]->key;
+        }
+    }
+    return NULL;
 }
 
 static inline int ucx_status_to_oshmem(ucs_status_t status)
@@ -271,4 +311,3 @@ static inline void mca_spml_ucx_remote_op_posted(mca_spml_ucx_ctx_t *ctx, int ds
 END_C_DECLS
 
 #endif
-

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -262,7 +262,7 @@ mca_spml_ucx_ctx_mkey_by_va(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_s
 {
     spml_ucx_cached_mkey_t **mkey;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
-    int i;
+    size_t i;
 
     mkey = ucx_ctx->ucp_peers[pe].mkeys;
     for (i = 0; i < ucx_ctx->ucp_peers[pe].mkeys_cnt; i++) {

--- a/oshmem/proc/proc.c
+++ b/oshmem/proc/proc.c
@@ -38,10 +38,52 @@
 
 
 static opal_mutex_t oshmem_proc_lock;
+static opal_bitmap_t _oshmem_local_vpids;       /* Track the vpids in local node */
+int oshmem_proc_init_set_local_vpids()
+{
+    opal_process_name_t wildcard_rank;
+    int ret = OMPI_SUCCESS;
+    char *val = NULL;
+    
+    ret = opal_bitmap_init(&_oshmem_local_vpids, ompi_comm_size(oshmem_comm_world));
+    if (OSHMEM_SUCCESS != ret) {
+        return ret;
+    }
+    /* Add all local peers first */
+    wildcard_rank.jobid = OMPI_PROC_MY_NAME->jobid;
+    wildcard_rank.vpid = OMPI_NAME_WILDCARD->vpid;
+    /* retrieve the local peers */
+    OPAL_MODEX_RECV_VALUE(ret, OPAL_PMIX_LOCAL_PEERS,
+                          &wildcard_rank, &val, OPAL_STRING);
+
+    if (OPAL_SUCCESS == ret && NULL != val) {
+        char **peers = opal_argv_split(val, ',');
+        int i;
+        free(val);
+        for (i=0; NULL != peers[i]; i++) {
+            ompi_vpid_t local_rank = strtoul(peers[i], NULL, 10);
+            opal_bitmap_set_bit(&_oshmem_local_vpids, local_rank);
+        }
+        opal_argv_free(peers);
+    }
+    return OSHMEM_SUCCESS;
+}
+
+bool oshmem_proc_on_local_node(int pe)
+{
+    return opal_bitmap_is_set_bit(&_oshmem_local_vpids, pe);
+}
 
 int oshmem_proc_init(void)
 {
+    int ret;
     OBJ_CONSTRUCT(&oshmem_proc_lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&_oshmem_local_vpids, opal_bitmap_t);
+
+    ret = oshmem_proc_init_set_local_vpids();
+    if(OSHMEM_SUCCESS != ret) {
+        return ret;
+    }
 
     /* check oshmem_proc_data_t can fit within ompi_proc_t padding */
     assert(sizeof(oshmem_proc_data_t) <= OMPI_PROC_PADDING_SIZE);
@@ -157,7 +199,6 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     int cur_pe, count_pe;
     int i;
     oshmem_group_t* group = NULL;
-    ompi_proc_t** proc_array = NULL;
     ompi_proc_t* proc = NULL;
 
     assert(oshmem_proc_local());
@@ -178,37 +219,26 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
     OPAL_THREAD_LOCK(&oshmem_proc_lock);
 
     /* allocate an array */
-    proc_array = (ompi_proc_t**) malloc(pe_size * sizeof(ompi_proc_t*));
-    if (NULL == proc_array) {
-        OBJ_RELEASE(group);
-        OPAL_THREAD_UNLOCK(&oshmem_proc_lock);
-        return NULL ;
+    group->proc_vpids = (opal_vpid_t *) malloc(pe_size * sizeof(group->proc_vpids[0]));
+    if (NULL == group->proc_vpids) {
+        return NULL;
     }
 
     group->my_pe = oshmem_proc_pe(oshmem_proc_local());
     group->is_member = 0;
     for (i = 0 ; i < ompi_comm_size(oshmem_comm_world) ; i++) {
-        proc = oshmem_proc_find(i);
-        if (NULL == proc) {
-            opal_output(0,
-                    "Error: Can not find proc object for pe = %d", i);
-            free(proc_array);
-            OBJ_RELEASE(group);
-            OPAL_THREAD_UNLOCK(&oshmem_proc_lock);
-            return NULL;
-        }
         if (count_pe >= (int) pe_size) {
             break;
         } else if ((cur_pe >= pe_start)
                 && ((pe_stride == 0)
                     || (((cur_pe - pe_start) % pe_stride) == 0))) {
-            proc_array[count_pe++] = proc;
-            if (oshmem_proc_pe(proc) == group->my_pe)
+            group->proc_vpids[count_pe] = i;
+            count_pe ++;
+            if (i == group->my_pe)
                 group->is_member = 1;
         }
         cur_pe++;
     }
-    group->proc_array = proc_array;
     group->proc_count = (int) count_pe;
     group->ompi_comm = NULL;
 
@@ -218,9 +248,9 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start, int pe_stride, int pe_siz
         orte_namelist_t *peer = NULL;
 
         for (i = 0; i < group->proc_count; i++) {
-            peer = OBJ_NEW(orte_namelist_t);
-            peer->name.jobid = OSHMEM_PROC_JOBID(group->proc_array[i]);
-            peer->name.vpid = OSHMEM_PROC_VPID(group->proc_array[i]);
+            peer = OBJ_NEW(opal_namelist_t);
+            peer->name.jobid = group->proc_vpids[i];
+            peer->name.vpid = OMPI_PROC_MY_NAME->jobid;
             opal_list_append(&(group->peer_list), &peer->super);
         }
     }
@@ -259,8 +289,9 @@ oshmem_proc_group_destroy_internal(oshmem_group_t* group, int scoll_unselect)
     }
 
     /* Destroy proc array */
-    if (group->proc_array) {
-        free(group->proc_array);
+    OBJ_DESTRUCT(&_oshmem_local_vpids);
+    if (group->proc_vpids) {
+        free(group->proc_vpids);
     }
 
     /* Destroy peer list */

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -42,19 +42,6 @@ struct oshmem_group_t;
 
 #define OSHMEM_PE_INVALID   (-1)
 
-/* This struct will be copied into the padding field of an ompi_proc_t
- * so the size of oshmem_proc_data_t must be less or equal than
- * OMPI_PROC_PADDING_SIZE */
-struct oshmem_proc_data_t {
-    char * transport_ids;
-    int num_transports;
-};
-
-typedef struct oshmem_proc_data_t oshmem_proc_data_t;
-
-#define OSHMEM_PROC_DATA(proc) \
-    ((oshmem_proc_data_t *)(proc)->padding)
-
 /**
  * Group of Open SHMEM processes structure
  *
@@ -67,7 +54,6 @@ struct oshmem_group_t {
     int                         proc_count;     /**< number of processes in group */
     int                         is_member;   /* true if my_pe is part of the group, participate in collectives */
     opal_vpid_t                 *proc_vpids; /* vpids of each process in group */
-    opal_list_t                 peer_list;
 
     /* Collectives module interface and data */
     mca_scoll_base_group_scoll_t g_scoll;
@@ -167,7 +153,6 @@ static inline int oshmem_proc_pe(ompi_proc_t *proc)
     return (proc ? (int) ((orte_process_name_t*)&proc->super.proc_name)->vpid : -1);
 }
 
-int oshmem_proc_init_set_local_vpids();
 bool oshmem_proc_on_local_node(int pe);
 /**
  * Initialize the OSHMEM process predefined groups

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -18,8 +18,10 @@
 #include "oshmem/constants.h"
 
 #include "opal/class/opal_list.h"
+#include "opal/class/opal_bitmap.h"
 #include "opal/util/proc.h"
 #include "opal/dss/dss_types.h"
+#include "opal/util/argv.h"
 #include "opal/mca/hwloc/hwloc-internal.h"
 
 #include "orte/types.h"
@@ -64,8 +66,7 @@ struct oshmem_group_t {
     int                         my_pe;
     int                         proc_count;     /**< number of processes in group */
     int                         is_member;   /* true if my_pe is part of the group, participate in collectives */
-    struct ompi_proc_t          **proc_array; /**< list of pointers to ompi_proc_t structures
-                                                   for each process in the group */
+    opal_vpid_t                 *proc_vpids; /* vpids of each process in group */
     opal_list_t                 peer_list;
 
     /* Collectives module interface and data */
@@ -152,14 +153,22 @@ static inline ompi_proc_t *oshmem_proc_find(int pe)
     return oshmem_proc_for_find(name);
 }
 
+static inline int oshmem_proc_pe_vpid(oshmem_group_t *group, int pe)
+{
+    if (OPAL_LIKELY(pe < group->proc_count)) {
+        return (group->proc_vpids[pe]);
+    } else {
+        return -1;
+    }
+}
+
 static inline int oshmem_proc_pe(ompi_proc_t *proc)
 {
     return (proc ? (int) ((orte_process_name_t*)&proc->super.proc_name)->vpid : -1);
 }
 
-#define OSHMEM_PROC_JOBID(PROC)    (((orte_process_name_t*)&((PROC)->super.proc_name))->jobid)
-#define OSHMEM_PROC_VPID(PROC)     (((orte_process_name_t*)&((PROC)->super.proc_name))->vpid)
-
+int oshmem_proc_init_set_local_vpids();
+bool oshmem_proc_on_local_node(int pe);
 /**
  * Initialize the OSHMEM process predefined groups
  *
@@ -235,40 +244,6 @@ fatal:
  */
 OSHMEM_DECLSPEC void oshmem_proc_group_destroy(oshmem_group_t* group);
 
-static inline ompi_proc_t *oshmem_proc_group_all(int pe)
-{
-    return oshmem_group_all->proc_array[pe];
-}
-
-static inline ompi_proc_t *oshmem_proc_group_find(oshmem_group_t* group,
-                                                    int pe)
-{
-    int i = 0;
-    ompi_proc_t* proc = NULL;
-
-    if (OPAL_LIKELY(group)) {
-        if (OPAL_LIKELY(group == oshmem_group_all)) {
-            /* To improve performance use direct index. It is feature of oshmem_group_all */
-            proc = group->proc_array[pe];
-        } else {
-            for (i = 0; i < group->proc_count; i++) {
-                if (pe == oshmem_proc_pe(group->proc_array[i])) {
-                    proc = group->proc_array[i];
-                    break;
-                }
-            }
-        }
-    } else {
-        orte_process_name_t name;
-
-        name.jobid = ORTE_PROC_MY_NAME->jobid;
-        name.vpid = pe;
-        proc = oshmem_proc_for_find(name);
-    }
-
-    return proc;
-}
-
 static inline int oshmem_proc_group_find_id(oshmem_group_t* group, int pe)
 {
     int i = 0;
@@ -276,7 +251,7 @@ static inline int oshmem_proc_group_find_id(oshmem_group_t* group, int pe)
 
     if (group) {
         for (i = 0; i < group->proc_count; i++) {
-            if (pe == oshmem_proc_pe(group->proc_array[i])) {
+            if (pe == oshmem_proc_pe_vpid(group, i)) {
                 id = i;
                 break;
             }
@@ -300,22 +275,6 @@ static inline int oshmem_num_procs(void)
 static inline int oshmem_my_proc_id(void)
 {
     return oshmem_group_self->my_pe;
-}
-
-static inline int oshmem_get_transport_id(int pe)
-{
-    ompi_proc_t *proc;
-
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-
-    return (int) OSHMEM_PROC_DATA(proc)->transport_ids[0];
-}
-
-static inline int oshmem_get_transport_count(int pe)
-{
-    ompi_proc_t *proc;
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-    return OSHMEM_PROC_DATA(proc)->num_transports;
 }
 
 END_C_DECLS

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -132,7 +132,7 @@ static int _shmem_finalize(void)
 
     if (OSHMEM_SUCCESS
             != (ret =
-                    MCA_SPML_CALL(del_procs(oshmem_group_all->proc_array, oshmem_group_all->proc_count)))) {
+                    MCA_SPML_CALL(del_procs(oshmem_group_all, oshmem_group_all->proc_count)))) {
         return ret;
     }
 

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -357,7 +357,7 @@ static int _shmem_init(int argc, char **argv, int requested, int *provided)
     OPAL_TIMING_ENV_NEXT(timing, "MCA_SPML_CALL(enable())");
 
     ret =
-            MCA_SPML_CALL(add_procs(oshmem_group_all->proc_array, oshmem_group_all->proc_count));
+            MCA_SPML_CALL(add_procs(oshmem_group_all, oshmem_group_all->proc_count));
     if (OSHMEM_SUCCESS != ret) {
         error = "SPML add procs failed";
         goto error;

--- a/oshmem/shmem/c/shmem_broadcast.c
+++ b/oshmem/shmem/c/shmem_broadcast.c
@@ -69,7 +69,7 @@ static void _shmem_broadcast(void *target,
         }
 
         /* Define actual PE using relative in active set */
-        PE_root = oshmem_proc_pe(group->proc_array[PE_root]);
+        PE_root = oshmem_proc_pe_vpid(group, PE_root);
 
         /* Call collective broadcast operation */
         rc = group->g_scoll.scoll_broadcast(group,

--- a/oshmem/shmem/c/shmem_ptr.c
+++ b/oshmem/shmem/c/shmem_ptr.c
@@ -31,7 +31,6 @@
 
 void *shmem_ptr(const void *dst_addr, int pe)
 {
-    ompi_proc_t *proc;
     sshmem_mkey_t *mkey;
     int i;
     void *rva;
@@ -46,8 +45,7 @@ void *shmem_ptr(const void *dst_addr, int pe)
     }
 
     /* The memory must be on the local node */
-    proc = oshmem_proc_group_find(oshmem_group_all, pe);
-    if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
+    if (!oshmem_proc_on_local_node(pe)) {
         return NULL;
     }
 

--- a/oshmem/shmem/fortran/shmem_broadcast_f.c
+++ b/oshmem/shmem/fortran/shmem_broadcast_f.c
@@ -85,7 +85,7 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
         }\
         \
         /* Define actual PE using relative in active set */\
-        rel_PE_root = oshmem_proc_pe(group->proc_array[OMPI_FINT_2_INT(*PE_root)]);\
+        rel_PE_root = oshmem_proc_pe_vpid(group, OMPI_FINT_2_INT(*PE_root));\
         \
         /* Call collective broadcast operation */\
         rc = group->g_scoll.scoll_broadcast( group, \


### PR DESCRIPTION
**Tracking Issue Reference: https://github.com/open-mpi/ompi/issues/9035**

1. Current implementation is maintaining a static cache of 32 entries
per remote peer containing memory key information.
In practice, only 2-3 entries are used. At scale, however this leads
to a significant overhead.

> Example:
> one cache entry is 40B
> with default 32 entries per peer it is 1280B per peer.
> on cluster with 1000 nodes and 40 PPN it results in 51MB per process
> Cumulatively, per node (given 40PPN) its 51MB x 40 = 2GB of overhead
> This commit introduces dynamic cache that contains only required number
> of entries. With 2 entries by default this leads to 16x reduction in the
> cache memory footprint.

Master PR Reference: https://github.com/open-mpi/ompi/pull/9058

2. oshmem uses ompi_proc structure during group creation. However,
only vpids and locality information is used inside oshmem internally.
Removing the proc_array from oshmem_group and replacing it with a
array to hold the vpids. A static array is used to keep track of
locality information which we collect from PMIx.

    Moreover, peer_list field in oshmem_group_t is not used anywhere internally in
    oshmem. Removing this field will further reduce memory consumption in
    oshmem_proc_group_create flow.

> Example: The original ompi_proc_t structure in proc_array was about 112 bytes,
> while each entry in vpid array will be 4 byte. We use a bitmap
> to track locality information which is around 1/8 bytes. So,
> we reduces the memory usage from 112 to ~4.13 per proc in each pe.
> With 100 nodes and 40 PPN, each proc used to utilize (112*40) = 4480 bytes.
> Now, after this PR, it can come down to (4.13 * 40) = 165 bytes.
> So, the total memory utilization per node (w/ 40 ppn) in this codeflow
> will come down from 179,200 bytes to 6,600 bytes.

Master PR Reference: https://github.com/open-mpi/ompi/pull/9112

Co-authored-by: Artem Y. Polyakov <artemp@nvidia.com>
Signed-off-by: Subhadeep Bhattacharya <subhadeepb@nvidia.com>
Signed-off-by: Artem Polyakov <artemp@nvidia.com>