### PR TITLE
V5.0.x/coll/ucc: fill count/dtype in dst.info for allreduce/reduce

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -41,6 +41,8 @@ static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *r
         },
         .dst.info = {
             .buffer   = rbuf,
+            .count    = count,
+            .datatype = ucc_dt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
         .reduce = {

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -43,6 +43,8 @@ static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf
         },
         .dst.info = {
             .buffer   = rbuf,
+            .count    = count,
+            .datatype = ucc_dt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
         .reduce = {


### PR DESCRIPTION
V5.0.x of #9352 

(cherry picked from commit 08070454f57ab29a73a5b3f750f04708dc17c5dd)
Signed-off-by: Valentin Petrov <valentinp@nvidia.com>