### PR TITLE
v5.0.x: autogen.pl: ignore all excluded components

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -5,7 +5,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2015-2020 Research Organization for Information Science
+# Copyright (c) 2015-2021 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2015-2021 IBM Corporation.  All rights reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
@@ -348,10 +348,18 @@ sub mca_process_framework {
                 verbose "--- Found $pname / $framework / $d component\n";
 
                 # Skip if specifically excluded
-                if (exists($exclude_list->{$framework}) &&
-                    $exclude_list->{$framework}[0] eq $d) {
-                    verbose "    => Excluded\n";
-                    next;
+                if (exists($exclude_list->{$framework})) {
+                    my $tst = 0;
+                    foreach my $ck (@{$exclude_list->{$framework}}) {
+                        if ($ck eq $d) {
+                            verbose "    => Excluded\n";
+                            $tst = 1;
+                            last;
+                        }
+                    }
+                    if ($tst) {
+                        next;
+                    }
                 }
 
                 # Skip if the framework is on the include list, but


### PR DESCRIPTION
If multiple components in a framework were excluded, then only the
first one in the list was being checked - which means that only the
first one in the list was actually being excluded. All others were
missed by the current code. This change actually searches the entire
list of excluded components to see if the one we found matches any
of the list members.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit 0b80a1d206b3ffb648033237344349742c63ee87)