### PR TITLE
bugfix: barrier_intra_doublering would post a recv from -1 (ANY_SOURCE)

### DIFF
--- a/ompi/mca/coll/base/coll_base_barrier.c
+++ b/ompi/mca/coll/base/coll_base_barrier.c
@@ -109,7 +109,7 @@ int ompi_coll_base_barrier_intra_doublering(struct ompi_communicator_t *comm,
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"ompi_coll_base_barrier_intra_doublering rank %d", rank));
 
-    left = ((rank-1)%size);
+    left = ((size+rank-1)%size);
     right = ((rank+1)%size);
 
     if (rank > 0) { /* receive message from the left */


### PR DESCRIPTION
instead of np-1

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>
(cherry picked from commit b682b635c17f9a2b08434bee8929235ee21f2a1d)