### PR TITLE
Fix mpirun --timeout orphan issue

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -80,6 +80,7 @@
 #include "orte/mca/state/base/base.h"
 #include "orte/util/hostfile/hostfile.h"
 #include "orte/mca/odls/odls_types.h"
+#include "orte/orted/orted_submit.h"
 
 #include "orte/mca/plm/base/plm_private.h"
 #include "orte/mca/plm/base/base.h"
@@ -700,6 +701,9 @@ void orte_plm_base_post_launch(int fd, short args, void *cbdata)
                              "%s plm:base:launch job %s is not a dynamic spawn",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                              ORTE_JOBID_PRINT(jdata->jobid)));
+        if (ORTE_PROC_IS_HNP) {
+            orte_submit_job_state_update(jdata, ORTE_JOB_STATE_RUNNING);
+        }
         goto cleanup;
     }
 

--- a/orte/orted/orted_submit.h
+++ b/orte/orted/orted_submit.h
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +38,8 @@ ORTE_DECLSPEC int orte_submit_job(char *cmd[], int *index,
 ORTE_DECLSPEC int orte_submit_halt(void);
 ORTE_DECLSPEC void orte_debugger_init_after_spawn(int fd, short event, void *arg);
 ORTE_DECLSPEC void orte_debugger_detached(int fd, short event, void *arg);
+
+ORTE_DECLSPEC int orte_submit_job_state_update(orte_job_t *jdata, orte_job_state_t state);
 
 extern int orte_debugger_attach_fd;
 extern bool orte_debugger_fifo_active;

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -183,6 +184,10 @@ int orterun(int argc, char *argv[])
                    (NULL == launchst.jdata) ? "UNKNOWN" : ORTE_JOBID_PRINT(launchst.jdata->jobid));
     }
     if (!orte_event_base_active || ORTE_SUCCESS != launchst.status) {
+        if (ORTE_PROC_IS_HNP) {
+            /* ensure all local procs are dead */
+            orte_odls.kill_local_procs(NULL);
+        }
         goto DONE;
     }
 


### PR DESCRIPTION
 * Fixes #9369
 * `mpirun` was idling waiting for the launch to complete because its
   tracker was never triggered once the launch was complete. This caused
   `mpirun` to skip over the code to terminate local children (since it
   assumes that it had a failed launch and the errmgr did that) thus
   orphaning the local children.
   -  This fix activates the tracker in the `mpirun` process causing it
      to correctly move to the waiting for completion state.
 * If the remote daemon is slow launching and the timeout triggers before
   the launch is complete then the `mpirun` process will orphan the local
   processes.
   - This fix will have the `mpirun` process try to kill the local processes
     in this case.
 * Only impacts the `v4.0.x` and `v4.1.x` branches
    
bot:notacherrypick