### PR TITLE
v5.0.x: pml/ucx: added `ud_mlx5` to default tls list

### DIFF
--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -45,7 +45,7 @@ static void opal_common_ucx_mem_release_cb(void *buf, size_t length, void *cbdat
 
 OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *component)
 {
-    static const char *default_tls = "rc_verbs,ud_verbs,rc_mlx5,dc_mlx5,cuda_ipc,rocm_ipc";
+    static const char *default_tls = "rc_verbs,ud_verbs,rc_mlx5,dc_mlx5,ud_mlx5,cuda_ipc,rocm_ipc";
     static const char *default_devices = "mlx*";
     static int hook_index;
     static int verbose_index;


### PR DESCRIPTION
Corresponds to #9376 