### PR TITLE
Disable support for GCC < v4.8.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -77,6 +77,7 @@ Master (not on release branches yet)
 
 v5.0.0rc1 -- September, 2021
 --------------------
+
 - ORTE, the underlying OMPI launcher has been removed, and replaced
   with PRTE.
 - Reworked how Open MPI integrates with 3rd party packages.
@@ -94,6 +95,8 @@ v5.0.0rc1 -- September, 2021
 - Various ROMIO v3.4.1 updates.
 - Use Pandoc to generate manpages
 - 32 bit atomics are now only supported via C11 compliant compilers.
+- Explicitly disable support for GNU gcc < v4.8.1 (note: the default
+  gcc compiler that is included in RHEL 7 is v4.8.5).
 - Do not build Open SHMEM layer when there are no SPMLs available.
   Currently, this means the Open SHMEM layer will only build if
   the UCX library is found.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ base as of this writing (April 2020):
 
 * On platforms other than x86-64, AArch64 (64-bit ARM), and PPC64,
   Open MPI requires a compiler that either supports C11 atomics or
-  the GCC `__atomic` atomics (e.g., GCC >= v4.7.2).
+  the GCC `__atomic` atomics (e.g., GCC >= v4.8.1).
 
 * 32-bit platforms are only supported with a recent compiler that
   supports C11 atomics. This includes gcc 4.9.x+ (gcc 6.x or newer

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -416,10 +416,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
 
 AC_DEFUN([_OPAL_START_SETUP_CC],[
     opal_show_subtitle "C compiler and preprocessor"
-
-	# $%@#!@#% AIX!!  This has to be called before anything invokes the C
-    # compiler.
-    dnl AC_AIX
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -600,6 +600,22 @@ opal_show_subtitle "Compiler characteristics"
 OPAL_CHECK_ATTRIBUTES
 OPAL_CHECK_COMPILER_VERSION_ID
 
+# Open MPI only supports GCC >=v4.8.1.  Notes:
+#
+# 1. The default compiler that comes with RHEL 7 is v4.8.5 (version ID
+#    264197).
+# 2. We regularly test with GCC v4.8.1 (version ID 264193).
+# 3. GCC 4.8.0 probably also works; we just haven't tested it.
+#
+# Since we regularly test with 4.8.1, that's what we check for.
+AS_IF([test "$opal_cv_compiler_FAMILYNAME" = "GNU" && \
+       test "$opal_cv_compiler_VERSION" -lt 264193],
+      [AC_MSG_WARN([Open MPI no longer supports versions of the GNU compiler suite])
+       AC_MSG_WARN([less than v4.8.1.])
+       AC_MSG_WARN([Please upgrade your GNU compiler suite, or use])
+       AC_MSG_WARN([a different compiler to build Open MPI.])
+       AC_MSG_ERROR([Cannot continue])
+      ])
 
 ##################################
 # Java MPI Binding request


### PR DESCRIPTION
Two things:

* Per #9392, abort configure if we're using GCC < v4.8.1.
* Trivial update to remove support for AIX (which we haven't supported in years).

These will need to be cherry-picked to v5.0.x.