### PR TITLE
Fix warnings from Autoconf 2.71

### DIFF
--- a/config/extract-3rd-party-configure.pl
+++ b/config/extract-3rd-party-configure.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 #
 # Copyright (c) 2021      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021 Cisco Systems.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -216,7 +217,7 @@ sub process_m4($)
                 # Argument separator
                 # We only care about counting arguments for the outermost
                 # function (e.g., AC_ARG_ENABLE), not the innermost
-                # function (e.g., AC_HELP_STRING) - which we take all of.
+                # function (e.g., AS_HELP_STRING) - which we take all of.
                 # We know we are in the outermost because the '(' will be
                 # only thing on the stack.
                 elsif( scalar(@the_stack) == 1 && $char eq "," ) {

--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2006 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
-# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel Corporation. All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -44,7 +44,7 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
 	OPAL_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
 
         AC_ARG_ENABLE([psm2-version-check],
-                  [AC_HELP_STRING([--disable-psm2-version-check],
+                  [AS_HELP_STRING([--disable-psm2-version-check],
                                   [Disable PSM2 version checking.  Not recommended to disable. (default: enabled)])])
 
 	ompi_check_psm2_$1_save_CPPFLAGS="$CPPFLAGS"

--- a/config/ompi_check_ucc.m4
+++ b/config/ompi_check_ucc.m4
@@ -1,7 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021      Mellanox Technologies. All rights reserved.
-dnl Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
@@ -20,7 +20,7 @@ AC_DEFUN([OMPI_CHECK_UCC],[
     OPAL_VAR_SCOPE_PUSH([ompi_check_ucc_dir ompi_check_ucc_libs ompi_check_ucc_happy CPPFLAGS_save LDFLAGS_save LIBS_save])
 
     AC_ARG_WITH([ucc],
-                [AC_HELP_STRING([--with-ucc(=DIR)],
+                [AS_HELP_STRING([--with-ucc(=DIR)],
                                 [Build UCC (Unified Collective Communication)])])
 
     AS_IF([test "$with_ucc" != "no"],

--- a/config/ompi_interix.m4
+++ b/config/ompi_interix.m4
@@ -3,6 +3,7 @@ dnl
 dnl Copyright (c)      2008 The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
+dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -24,10 +25,10 @@ dnl
 AC_DEFUN([OMPI_INTERIX],[
 
     AC_MSG_CHECKING(for Interix environment)
-    AC_TRY_COMPILE([],
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
                    [#if !defined(__INTERIX)
                     #error Normal Unix environment
-                    #endif],
+                    #endif])],
                    is_interix=yes,
                    is_interix=no)
     AC_MSG_RESULT([$is_interix])

--- a/config/ompi_microsoft.m4
+++ b/config/ompi_microsoft.m4
@@ -3,6 +3,7 @@ dnl
 dnl Copyright (c) 2004-2007 The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
+dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -39,17 +40,17 @@ AC_DEFUN([OMPI_MICROSOFT_COMPILER],[
 
         # The atomic functions are defined in a very unuasual manner.
         # Some of them are intrinsic defined in windows.h others are
-        # exported by kernel32.dll. If we force the usage of AC_TRY_RUN
+        # exported by kernel32.dll. If we force the usage of AC RUN_IFELSE
         # here we will check for both in same time: compilation and run.
 
         AC_MSG_CHECKING(for working InterlockedCompareExchange)
-        AC_TRY_RUN( [#include <windows.h>
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <windows.h>
                      int main() {
                      LONG dest = 1, exchange = 0, comperand = 1;
                      SetErrorMode(SEM_FAILCRITICALERRORS);
                      InterlockedCompareExchange( &dest, exchange, comperand );
                      return (int)dest;
-                    }],
+                    }])],
                     [AC_MSG_RESULT(yes)
                      ompi_windows_have_support_for_32_bits_atomic=1],
                     [AC_MSG_RESULT(no)
@@ -59,13 +60,13 @@ AC_DEFUN([OMPI_MICROSOFT_COMPILER],[
                        [Whether we support 32 bits atomic operations on Windows])
 
         AC_MSG_CHECKING(for working InterlockedCompareExchangeAcquire)
-        AC_TRY_RUN( [#include <windows.h>
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <windows.h>
                  int main() {
                      LONG dest = 1, exchange = 0, comperand = 1;
                      SetErrorMode(SEM_FAILCRITICALERRORS);
                      InterlockedCompareExchangeAcquire( &dest, exchange, comperand );
                      return (int)dest;
-                 }],
+                 }])],
                     [AC_MSG_RESULT(yes)
                      ompi_windows_have_support_for_32_bits_atomic=1],
                     [AC_MSG_RESULT(no)
@@ -75,13 +76,13 @@ AC_DEFUN([OMPI_MICROSOFT_COMPILER],[
                        [Whether we support 32 bits atomic operations on Windows])
 
         AC_MSG_CHECKING(for working InterlockedCompareExchangeRelease)
-        AC_TRY_RUN( [#include <windows.h>
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <windows.h>
                  int main() {
                      LONG dest = 1, exchange = 0, comperand = 1;
                      SetErrorMode(SEM_FAILCRITICALERRORS);
                      InterlockedCompareExchangeRelease( &dest, exchange, comperand );
                      return (int)dest;
-                 }],
+                 }])],
                     [AC_MSG_RESULT(yes)
                      ompi_windows_have_support_for_32_bits_atomic=1],
                     [AC_MSG_RESULT(no)
@@ -91,13 +92,13 @@ AC_DEFUN([OMPI_MICROSOFT_COMPILER],[
                        [Whether we support 32 bits atomic operations on Windows])
 
         AC_MSG_CHECKING(for working InterlockedCompareExchange64)
-        AC_TRY_RUN( [#include <windows.h>
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <windows.h>
                  int main() {
                      LONGLONG dest = 1, exchange = 0, comperand = 1;
                      SetErrorMode(SEM_FAILCRITICALERRORS);
                      InterlockedCompareExchange64( &dest, exchange, comperand );
                      return (int)dest;
-                 }],
+                 }])],
                     [AC_MSG_RESULT(yes)
                      ompi_windows_have_support_for_64_bits_atomic=1],
                     [AC_MSG_RESULT(no)

--- a/config/opal_check_attributes.m4
+++ b/config/opal_check_attributes.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2010-2021 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2013      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
@@ -64,7 +64,7 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
         #
         # Try to compile using the C compiler, then C++
         #
-        AC_TRY_COMPILE([$2],[],
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$2],[])],
                        [
                         #
                         # In case we did succeed: Fine, but was this due to the
@@ -82,10 +82,10 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
         m4_ifdef([project_ompi],
                  [if test "$opal_cv___attribute__[$1]" = "1" ; then
                       AC_LANG_PUSH(C++)
-                      AC_TRY_COMPILE([
+                      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
                            extern "C" {
                            $2
-                           }],[],
+                           }],[])],
                            [
                             opal_cv___attribute__[$1]=1
                             _OPAL_ATTRIBUTE_FAIL_SEARCH([$1])
@@ -103,11 +103,11 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
             CFLAGS_safe=$CFLAGS
             CFLAGS="$CFLAGS [$4]"
 
-            AC_TRY_COMPILE([$3],
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$3],
                 [
                  int i=4711;
                  i=usage(&i);
-                ],
+                ])],
                 [opal_cv___attribute__[$1]=0],
                 [
                  #
@@ -161,7 +161,7 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
   AC_MSG_CHECKING(for __attribute__)
 
   AC_CACHE_VAL(opal_cv___attribute__, [
-    AC_TRY_COMPILE(
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
       [#include <stdlib.h>
        /* Check for the longest available __attribute__ (since gcc-2.3) */
        struct foo {
@@ -169,13 +169,13 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
            int x[2] __attribute__ ((__packed__));
         };
       ],
-      [],
+      [])],
       [opal_cv___attribute__=1],
       [opal_cv___attribute__=0],
     )
 
     if test "$opal_cv___attribute__" = "1" ; then
-        AC_TRY_COMPILE(
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
           [#include <stdlib.h>
            /* Check for the longest available __attribute__ (since gcc-2.3) */
            struct foo {
@@ -183,7 +183,7 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
                int x[2] __attribute__ ((__packed__));
             };
           ],
-          [],
+          [])],
           [opal_cv___attribute__=1],
           [opal_cv___attribute__=0],
         )

--- a/config/opal_check_cflags.m4
+++ b/config/opal_check_cflags.m4
@@ -28,11 +28,12 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
                    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$3])],
                                    [
                                     opal_cv_cc_[$2]=1
-                                    _OPAL_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
+                                    _OPAL_CFLAGS_FAIL_SEARCH(["ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown"], [$2])
                                    ],
+                                  [
                                     opal_cv_cc_[$2]=1
-                                    _OPAL_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
-                                 )])
+                                    _OPAL_CFLAGS_FAIL_SEARCH(["ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error"], [$2])
+                                 ])])
             if test "$opal_cv_cc_[$2]" = "0" ; then
                 CFLAGS="$CFLAGS_orig"
                 AC_MSG_RESULT([no])
@@ -59,11 +60,12 @@ AC_MSG_CHECKING(if $CXX supports ([$1]))
                    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$3])],
                                    [
                                     opal_cv_cxx_[$2]=1
-                                    _OPAL_CXXFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
+                                    _OPAL_CXXFLAGS_FAIL_SEARCH(["ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown"], [$2])
                                    ],
+                                  [
                                     opal_cv_cxx_[$2]=1
-                                    _OPAL_CXXFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
-                                 )])
+                                    _OPAL_CXXFLAGS_FAIL_SEARCH(["ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error"], [$2])
+                                 ])])
             if test "$opal_cv_cxx_[$2]" = "0" ; then
                 CXXFLAGS="$CXXFLAGS_orig"
                 AC_MSG_RESULT([no])

--- a/config/opal_check_cflags.m4
+++ b/config/opal_check_cflags.m4
@@ -1,6 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -24,7 +25,7 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
             CFLAGS_orig=$CFLAGS
             CFLAGS="$CFLAGS $1"
             AC_CACHE_VAL(opal_cv_cc_[$2], [
-                   AC_TRY_COMPILE([], [$3],
+                   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$3])],
                                    [
                                     opal_cv_cc_[$2]=1
                                     _OPAL_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
@@ -55,7 +56,7 @@ AC_MSG_CHECKING(if $CXX supports ([$1]))
             CXXFLAGS_orig=$CXXFLAGS
             CXXFLAGS="$CXXFLAGS $1"
             AC_CACHE_VAL(opal_cv_cxx_[$2], [
-                   AC_TRY_COMPILE([], [$3],
+                   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$3])],
                                    [
                                     opal_cv_cxx_[$2]=1
                                     _OPAL_CXXFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])

--- a/config/opal_check_compiler_version.m4
+++ b/config/opal_check_compiler_version.m4
@@ -1,6 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -31,20 +32,16 @@ AC_DEFUN([OPAL_CHECK_COMPILER], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${OPAL_TOP_SRCDIR}/opal/include/opal $CPPFLAGS"
-            AC_TRY_RUN([
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>
 #include "opal_portable_platform.h"
-
-int main (int argc, char * argv[])
-{
+]],[[
     FILE * f;
     f=fopen("conftestval", "w");
     if (!f) exit(1);
     fprintf (f, "%d", PLATFORM_COMPILER_$1);
-    return 0;
-}
-            ], [
+            ]])], [
                 eval opal_cv_compiler_$1=`cat conftestval`;
             ], [
                 eval opal_cv_compiler_$1=0
@@ -63,20 +60,16 @@ AC_DEFUN([OPAL_CHECK_COMPILER_STRING], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${OPAL_TOP_SRCDIR}/opal/include/opal $CPPFLAGS"
-            AC_TRY_RUN([
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>
 #include "opal_portable_platform.h"
-
-int main (int argc, char * argv[])
-{
+]],[[
     FILE * f;
     f=fopen("conftestval", "w");
     if (!f) exit(1);
     fprintf (f, "%s", PLATFORM_COMPILER_$1);
-    return 0;
-}
-            ], [
+            ]])], [
                 eval opal_cv_compiler_$1=`cat conftestval`;
             ], [
                 eval opal_cv_compiler_$1=UNKNOWN
@@ -96,20 +89,16 @@ AC_DEFUN([OPAL_CHECK_COMPILER_STRINGIFY], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${OPAL_TOP_SRCDIR}/opal/include/opal $CPPFLAGS"
-            AC_TRY_RUN([
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>
 #include "opal_portable_platform.h"
-
-int main (int argc, char * argv[])
-{
+]],[[
     FILE * f;
     f=fopen("conftestval", "w");
     if (!f) exit(1);
     fprintf (f, "%s", _STRINGIFY(PLATFORM_COMPILER_$1));
-    return 0;
-}
-            ], [
+            ]])], [
                 eval opal_cv_compiler_$1=`cat conftestval`;
             ], [
                 eval opal_cv_compiler_$1=UNKNOWN

--- a/config/opal_check_icc.m4
+++ b/config/opal_check_icc.m4
@@ -11,6 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -24,7 +25,7 @@ dnl On EM64T, icc-8.1 before version 8.1.027 segfaulted, since
 dnl va_start was miscompiled...
 dnl
 AC_MSG_CHECKING([whether icc-8.1 for EM64T works with variable arguments])
-AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_PROGRAM([
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,7 +47,7 @@ int main ()
   return 0;
 }
 
-],[opal_ac_icc_varargs=`test -f conftestval`],[opal_ac_icc_varargs=1],[opal_ac_icc_varargs=1])
+])],[opal_ac_icc_varargs=`test -f conftestval`],[opal_ac_icc_varargs=1],[opal_ac_icc_varargs=1])
 
 if test "$opal_ac_icc_varargs" = "1"; then
     AC_MSG_WARN([*** Problem running configure test!])

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -9,7 +9,7 @@ dnl Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
@@ -334,7 +334,7 @@ AC_DEFUN([OPAL_CHECK_GCC_ATOMIC_BUILTINS], [
   if test -z "$opal_cv_have___atomic" ; then
     AC_MSG_CHECKING([for 32-bit GCC built-in atomics])
 
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([
 #include <stdint.h>
 uint32_t tmp, old = 0;
 uint64_t tmp64, old64 = 0;], [
@@ -342,7 +342,7 @@ __atomic_thread_fence(__ATOMIC_SEQ_CST);
 __atomic_compare_exchange_n(&tmp, &old, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 __atomic_add_fetch(&tmp, 1, __ATOMIC_RELAXED);
 __atomic_compare_exchange_n(&tmp64, &old64, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-__atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);],
+__atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);])],
 		[opal_cv_have___atomic=yes],
 		[opal_cv_have___atomic=no])
 
@@ -351,11 +351,11 @@ __atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);],
     if test $opal_cv_have___atomic = "yes" ; then
 	AC_MSG_CHECKING([for 64-bit GCC built-in atomics])
 
-	AC_TRY_LINK([
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([
 #include <stdint.h>
 uint64_t tmp64, old64 = 0;], [
 __atomic_compare_exchange_n(&tmp64, &old64, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-__atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);],
+__atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);])],
 		    [opal_cv_have___atomic_64=yes],
 		    [opal_cv_have___atomic_64=no])
 
@@ -1194,14 +1194,14 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     AS_IF([test "$opal_cv_asm_arch" = "X86_64" || test "$opal_cv_asm_arch" = "IA32"],
           [AC_MSG_CHECKING([for RDTSCP assembly support])
            AC_LANG_PUSH([C])
-           AC_TRY_RUN([[
+           AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 int main(int argc, char* argv[])
 {
   unsigned int rax, rdx;
   __asm__ __volatile__ ("rdtscp\n": "=a" (rax), "=d" (rdx):: "%rax", "%rdx");
   return 0;
 }
-           ]],
+           ]])],
            [result=1
             AC_MSG_RESULT([yes])],
            [AC_MSG_RESULT([no])],

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -211,10 +211,11 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_DEFINE_UNQUOTED([OPAL_C_HAVE___THREAD], [$opal_prog_cc__thread_available],
                        [Whether C compiler supports __thread])
 
-
     # Check for standard headers, needed here because needed before
-    # the types checks.
-    AC_HEADER_STDC
+    # the types checks.  This is only necessary for Autoconf < v2.70.
+    m4_version_prereq([2.70],
+                      [],
+                      [AC_HEADER_STDC])
 
     # GNU C and autotools are inconsistent about whether this is
     # defined so let's make it true everywhere for now...  However, IBM

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
@@ -332,9 +332,9 @@ AC_DEFUN([OPAL_SETUP_CC],[
     # see if the C compiler supports __builtin_expect
     AC_CACHE_CHECK([if $CC supports __builtin_expect],
         [opal_cv_cc_supports___builtin_expect],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([],
           [void *ptr = (void*) 0;
-           if (__builtin_expect (ptr != (void*) 0, 1)) return 0;],
+           if (__builtin_expect (ptr != (void*) 0, 1)) return 0;])],
           [opal_cv_cc_supports___builtin_expect="yes"],
           [opal_cv_cc_supports___builtin_expect="no"])])
     if test "$opal_cv_cc_supports___builtin_expect" = "yes" ; then
@@ -348,9 +348,9 @@ AC_DEFUN([OPAL_SETUP_CC],[
     # see if the C compiler supports __builtin_prefetch
     AC_CACHE_CHECK([if $CC supports __builtin_prefetch],
         [opal_cv_cc_supports___builtin_prefetch],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([],
           [int ptr;
-           __builtin_prefetch(&ptr,0,0);],
+           __builtin_prefetch(&ptr,0,0);])],
           [opal_cv_cc_supports___builtin_prefetch="yes"],
           [opal_cv_cc_supports___builtin_prefetch="no"])])
     if test "$opal_cv_cc_supports___builtin_prefetch" = "yes" ; then
@@ -364,9 +364,9 @@ AC_DEFUN([OPAL_SETUP_CC],[
     # see if the C compiler supports __builtin_clz
     AC_CACHE_CHECK([if $CC supports __builtin_clz],
         [opal_cv_cc_supports___builtin_clz],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([],
             [int value = 0xffff; /* we know we have 16 bits set */
-             if ((8*sizeof(int)-16) != __builtin_clz(value)) return 0;],
+             if ((8*sizeof(int)-16) != __builtin_clz(value)) return 0;])],
             [opal_cv_cc_supports___builtin_clz="yes"],
             [opal_cv_cc_supports___builtin_clz="no"])])
     if test "$opal_cv_cc_supports___builtin_clz" = "yes" ; then

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
-dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -97,7 +97,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
     # assume that the path is not currently valid.
     wrapper_tmp="$(type -p "$with_wrapper_cc")"
     if test -z "$wrapper_tmp" ; then
-	AC_MSG_WARN([could not find \"$with_wrapper_cc\" in path])
+        AC_MSG_WARN([could not find "$with_wrapper_cc" in path])
     fi
     WRAPPER_CC=$with_wrapper_cc
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -872,7 +872,8 @@ AC_MSG_CHECKING([the linker for support for the -fini option])
 OPAL_VAR_SCOPE_PUSH([LDFLAGS_save])
 LDFLAGS_save=$LDFLAGS
 LDFLAGS="$LDFLAGS_save -Wl,-fini -Wl,finalize"
-AC_TRY_LINK([void finalize (void) {}], [], [AC_MSG_RESULT([yes])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([void finalize (void) {}], [])],
+               [AC_MSG_RESULT([yes])
         opal_ld_have_fini=1], [AC_MSG_RESULT([no])
         opal_ld_have_fini=0])
 LDFLAGS=$LDFLAGS_save

--- a/configure.ac
+++ b/configure.ac
@@ -1004,10 +1004,14 @@ AC_PROG_GREP
 AC_PROG_EGREP
 
 #
-# We need as and lex
+# We need as and flex
 #
 AM_PROG_AS
-AM_PROG_LEX
+
+dnl Note that prior to AC v2.70, PROG_LEX did not take any arguments.
+dnl But it is harmless to pass an argument to it ($1 will just be
+dnl ignored).
+AC_PROG_LEX([noyywrap])
 
 # If we don't have Flex and we don't have a generated .c file
 # (distribution tarballs will have the .c file included, but git
@@ -1015,18 +1019,17 @@ AM_PROG_LEX
 # Lex are not workable (all things being equal, since this is *only*
 # required for developers, we decided that it really was not worth it
 # to be portable between different versions of lex ;-).
-
-if test -z "$LEX" || \
+AS_IF([test -z "$LEX" || \
    test -n "`echo $LEX | $GREP missing`" || \
-   test "`basename $LEX`" != "flex"; then
-    if test ! -f "$srcdir/opal/util/show_help_lex.c"; then
-        AC_MSG_WARN([*** Could not find Flex on your system.])
+   test "`basename $LEX`" != "flex"],
+    [AS_IF([test ! -f "$srcdir/opal/util/show_help_lex.c"],
+       [AC_MSG_WARN([*** Could not find Flex on your system.])
         AC_MSG_WARN([*** Flex is required for developer builds of Open MPI.])
         AC_MSG_WARN([*** Other versions of Lex are not supported.])
         AC_MSG_WARN([*** NOTE: If you are building a tarball downloaded from www.open-mpi.org, you do not need Flex])
         AC_MSG_ERROR([Cannot continue])
-    fi
-fi
+       ])
+    ])
 
 #
 # Setup man page processing

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2012      Oak Ridge National Laboratory. All rights reserved.
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -480,11 +480,3 @@ endif
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_libmpi_c_pmpi_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Inria.  All rights reserved.
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
@@ -494,11 +494,3 @@ endif
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_libmpi_mpifh_pmpi_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:

--- a/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
@@ -11,7 +11,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2012      Oak Ridge National Laboratory. All rights reserved.
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -445,11 +445,3 @@ $(nodist_libmpi_usempif08_pmpi_la_SOURCES):
 MAINTAINERCLEANFILES = $(nodist_libmpi_usempif08_pmpi_la_SOURCES)
 
 endif
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:

--- a/ompi/mpi/tool/profile/Makefile.am
+++ b/ompi/mpi/tool/profile/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2012      Oak Rigde National Laboratory. All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
@@ -96,11 +96,3 @@ endif
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_libmpi_pmpit_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:

--- a/ompi/mpiext/ftmpi/c/profile/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/profile/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2016-2018 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,11 +39,3 @@ $(nodist_libpmpiext_ftmpi_c_la_SOURCES):
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_libpmpiext_ftmpi_c_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-:
-GTAGS:
-ID:

--- a/oshmem/shmem/c/profile/Makefile.am
+++ b/oshmem/shmem/c/profile/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2013-2016 Mellanox Technologies, Inc.
 #                         All rights reserved
-# Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014-2021 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -106,11 +106,3 @@ endif
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_liboshmem_c_pshmem_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:

--- a/oshmem/shmem/fortran/profile/Makefile.am
+++ b/oshmem/shmem/fortran/profile/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved
-# Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013-2021 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -149,11 +149,3 @@ endif
 # These files were created by targets above
 
 MAINTAINERCLEANFILES = $(nodist_liboshmem_fortran_pshmem_la_SOURCES)
-
-# Don't want these targets in here
-
-tags-recursive:
-tags:
-TAGS:
-GTAGS:
-ID:


### PR DESCRIPTION
Per #9404, fix a bunch of warnings in Open MPI from Autoconf 2.71.

See individual commit messages for details.

Note that I did a bunch of testing before pushing up here to give me confidence that this PR is actually correct:

1. I ran `./configure` from master and saved a bunch of output
2. I git checked out this branch, ran autogen, and re-ran `./configure` and saved a bunch of output
3. Comparing the `./configure` stdout from the 2 runs, and comparing the `config.status` from the two runs, I could only see the following differences:
    * git hash and build date differences
    * Addition of `ALIGNOF_*` macros in `config.status` / `*_config.h` files (due to now using `AC_CHECK_ALIGNOF`)
4. I also ran some MPI app tests, and all seemed to work properly.

While I'm not going to claim that this is comprehensive, I did run with several different compilers and versions, and I saw consistency across all the versions.  Hence, I think this PR is probably in good shape.  Let's see how it fares against CI...