### PR TITLE
v5.0.x: Fortran logical fix.

### DIFF
--- a/ompi/mpi/fortran/mpif-h/improbe_f.c
+++ b/ompi/mpi/fortran/mpif-h/improbe_f.c
@@ -95,7 +95,7 @@ void ompi_improbe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     if (MPI_SUCCESS == c_ierr) {
         OMPI_SINGLE_INT_2_LOGICAL(flag);
-        if (OMPI_FORTRAN_VALUE_TRUE == *flag) {
+        if (1 == OMPI_LOGICAL_2_INT(*flag)) {
             OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)
             *message = PMPI_Message_c2f(c_message);
         }


### PR DESCRIPTION
I don't have a testcase for this, I just found the bug while inspecting
OMPI's use of OMPI_FORTRAN_VALUE_TRUE. The following line:
   if (OMPI_FORTRAN_VALUE_TRUE == *flag) ...
is okay in the model where users build a whole new
OMPI depending on what fortran compiler they're using. But for a general
purpose build, it requires OMPI_LOGICAL_2_INT(), which
converts the incoming fortran-logical to 0 or 1 for C, eg
    if (1 == OMPI_LOGICAL_2_INT(*flag)) ...

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit ec9c28f95b56e3880862bf146b8d1ac064a9fc4c)