### PR TITLE
Fix remote daemon connection error when application abnormally terminates

### DIFF
--- a/orte/mca/plm/base/plm_base_orted_cmds.c
+++ b/orte/mca/plm/base/plm_base_orted_cmds.c
@@ -73,7 +73,18 @@ int orte_plm_base_orted_exit(orte_daemon_cmd_flag_t command)
     opal_buffer_t *cmd;
     orte_daemon_cmd_flag_t cmmnd;
     orte_grpcomm_signature_t *sig;
+    static int previously_called = 0;
 
+    /* If this function was previously called, attempting to shut down daemons
+     * again will result in connection failure messages, so do nothing.
+     */
+    if (previously_called) {
+        OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                             "%s plm:base:orted_cmd previously called, do nothing",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+        return ORTE_SUCCESS;
+    }
+    previously_called = 1;
     OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
                          "%s plm:base:orted_cmd sending orted_exit commands",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));


### PR DESCRIPTION
I have the following program
~~~
#include <mpi.h>
int main(int argc, char *argv[]) {
    MPI_Init(&argc, &argv);
    MPI_Abort(MPI_COMM_WORLD, 7);
    MPI_Finalize();
}
~~~
If I run this program using multiple nodes but tasks run on only one node, for instance **mpirun -n 3 --host f8n03:4,f8n04 crash** then the run fails with the message
~~~
A process or daemon was unable to complete a TCP connection
to another process:
Local host: f8n03
Remote host: f8n04
This is usually caused by a firewall on the remote host. Please
check that any firewall (e.g., iptables) has been disabled and
try again.
~~~
If all nodes are used, then the program abnormal termination completes as expected, only displaying the abnormal termination messages.

The problem is that in the abnormal termination process,  orte_plm_base_orted_exit gets called twice, first on a path where default_hnp_abort processes the application abort and then again as part of normal cleanup. The second time it is called, the remote daemons are already shut down so the connection attempt fails, resulting in this message.

The fix checks if this function has been called previously, and just returns if this is the second call to the function.

I tested this with a build using the master branch, and it does not fail at that level. I have not tested with the v4.0.x branch.

bot:notacherrypick

Signed-off-by: David Wootton <dwootton@us.ibm.com>