### PR TITLE
ofi_common: fix minor compiler warning

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -41,7 +41,9 @@ opal_common_ofi_module_t opal_common_ofi = {.prov_include = NULL,
 static const char default_prov_exclude_list[] = "shm,sockets,tcp,udp,rstream,usnic";
 static opal_mutex_t opal_common_ofi_mutex = OPAL_MUTEX_STATIC_INIT;
 static int opal_common_ofi_init_ref_cnt = 0;
+#ifdef HAVE_STRUCT_FI_OPS_MEM_MONITOR
 static bool opal_common_ofi_installed_memory_monitor = false;
+#endif
 
 #ifdef HAVE_STRUCT_FI_OPS_MEM_MONITOR
 


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bwbarrett I note two additional warnings in OFI common that this PR does not fix:

1. From the Coverity build last night -- I don't know if this has something to do with the version of libfabric used with the Coverity build...?

```
common_ofi.c: In function ‘opal_common_ofi_export_memory_monitor’:
common_ofi.c:116:16: error: ‘FI_ENOSYS’ undeclared (first use in this function); did you mean ‘ENOSYS’?
 116 |     int ret = -FI_ENOSYS;
     |                ^~~~~~~~~
     |                ENOSYS
common_ofi.c:116:16: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [Makefile:1539: common_ofi.lo] Error 1
make[2]: Leaving directory '/mnt/data/nightly-tarball/scratch/openmpi/master-202110010241/openmpi-master-202110010241-374e5c9/opal/mca/common/ofi'
```

2. This is from my own build of master.  I don't quite know how to fix this, because the PMIX macro is checking one of the macro parameters for NULL, but that particular macro parameter is `&locality_string`, which will obviously never be NULL:

```
  CC       common_ofi.lo
In file included from ../../../../opal/util/proc.h:26:0,
                 from common_ofi.h:21,
                 from common_ofi.c:28:
common_ofi.c: In function ‘get_package_rank’:
../../../../opal/mca/pmix/pmix-internal.h:304:48: warning: the comparison will always evaluate as ‘true’ for the address of ‘package_rank_ptr’ will never be NULL [-Waddress]
         } else if (PMIX_SUCCESS == (r) && NULL != (d)) {                               \
                                                ^
common_ofi.c:516:5: note: in expansion of macro ‘OPAL_MODEX_RECV_VALUE_OPTIONAL’
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PACKAGE_RANK, &pname, &package_rank_ptr, PMIX_UINT16);
     ^
../../../../opal/mca/pmix/pmix-internal.h:304:48: warning: the comparison will always evaluate as ‘true’ for the address of ‘locality_string’ will never be NULL [-Waddress]
         } else if (PMIX_SUCCESS == (r) && NULL != (d)) {                               \
                                                ^
common_ofi.c:536:9: note: in expansion of macro ‘OPAL_MODEX_RECV_VALUE_OPTIONAL’
         OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_LOCALITY_STRING, &pname, &locality_string,
         ^
```