### PR TITLE
Fix a bunch of compiler warnings 

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -303,6 +303,11 @@ AC_DEFUN([OPAL_SETUP_CC],[
         _OPAL_CHECK_SPECIFIC_CFLAGS(-fno-strict-aliasing, fno_strict_aliasing, int main() { long double x; })
         _OPAL_CHECK_SPECIFIC_CFLAGS(-pedantic, pedantic)
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Wall, Wall)
+
+        # There are some warnings that we specifically do not care
+        # about / do not agree that gcc emits warnings about them.  So
+        # we turn them off.
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wformat-truncation=0, format_truncation)
     fi
 
     # Note: Some versions of clang (at least >= 3.5 -- perhaps

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -225,7 +225,11 @@ alloc_ft_req:
      * in error for collection in future wait */
     sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR = ompi_comm_is_revoked(comm)? MPI_ERR_REVOKED: MPI_ERR_PROC_FAILED;
     MCA_PML_OB1_SEND_REQUEST_MPI_COMPLETE(sendreq, false);
-    OPAL_OUTPUT_VERBOSE((2, "Allocating request in error %s (peer %d, seq %d) with error code %d", sendreq, dst, sendreq->req_send.req_base.req_sequence, sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR));
+    OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle, "Allocating request in error %p (peer %d, seq %" PRIu64 ") with error code %d",
+                         (void*) sendreq,
+                         dst,
+                         sendreq->req_send.req_base.req_sequence,
+                         sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR));
     *request = (ompi_request_t *) sendreq;
     return OMPI_SUCCESS;
 #endif /* OPAL_ENABLE_FT_MPI */

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2018      Sandia National Laboratories
  *                         All rights reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -681,7 +682,7 @@ void mca_pml_ob1_recv_frag_callback_ack (mca_btl_base_module_t *btl,
 #if OPAL_ENABLE_FT_MPI
     /* if the req_recv is NULL, the comm has been revoked at the receiver */
     if( OPAL_UNLIKELY(NULL == sendreq->req_recv.pval) ) {
-        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle, "Recvfrag: Received a NACK to the RDV/RGET match to %d for seq %d on comm %d\n", sendreq->req_send.req_base.req_peer, sendreq->req_send.req_base.req_sequence, sendreq->req_send.req_base.req_comm->c_contextid));
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle, "Recvfrag: Received a NACK to the RDV/RGET match to %d for seq %" PRIu64 " on comm %d\n", sendreq->req_send.req_base.req_peer, sendreq->req_send.req_base.req_sequence, sendreq->req_send.req_base.req_comm->c_contextid));
         if (NULL != sendreq->rdma_frag) {
             MCA_PML_OB1_RDMA_FRAG_RETURN(sendreq->rdma_frag);
             sendreq->rdma_frag = NULL;

--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2009 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -112,12 +112,8 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        // Specifically using opal_snprintf() here (instead of
-        // snprintf()) so that over-eager compilers do not warn us
-        // that we may be truncating the output.  We *know* that the
-        // output may be truncated, and that's ok.
-        opal_snprintf(datatype->name, sizeof(datatype->name),
-                      "COMBINER %s", (*newtype)->name);
+        snprintf(datatype->name, sizeof(datatype->name),
+                 "COMBINER %s", (*newtype)->name);
 
         a_i[0] = &p;
         a_i[1] = &r;

--- a/ompi/mpi/c/type_create_f90_integer.c
+++ b/ompi/mpi/c/type_create_f90_integer.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2009 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -104,12 +104,8 @@ int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        // Specifically using opal_snprintf() here (instead of
-        // snprintf()) so that over-eager compilers do not warn us
-        // that we may be truncating the output.  We *know* that the
-        // output may be truncated, and that's ok.
-        opal_snprintf(datatype->name, sizeof(datatype->name),
-                      "COMBINER %s", (*newtype)->name);
+        snprintf(datatype->name, sizeof(datatype->name),
+                 "COMBINER %s", (*newtype)->name);
 
         a_i[0] = &r;
         ompi_datatype_set_args( datatype, 1, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_INTEGER );

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2009 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -112,12 +112,8 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        // Specifically using opal_snprintf() here (instead of
-        // snprintf()) so that over-eager compilers do not warn us
-        // that we may be truncating the output.  We *know* that the
-        // output may be truncated, and it's ok.
-        opal_snprintf(datatype->name, sizeof(datatype->name),
-                      "COMBINER %s", (*newtype)->name);
+        snprintf(datatype->name, sizeof(datatype->name),
+                 "COMBINER %s", (*newtype)->name);
 
         ompi_datatype_set_args( datatype, 2, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_REAL );
 


### PR DESCRIPTION
This fixes a bunch of compiler warnings.  When this PR is complete, it should be cherry picked to v5.0.x.

This PR fixes #9407 (these are legit bugs, not just compiler warnings).

This PR _partially_ fixes #9406.  Need advice from @hjelmn on how to fix the rest of #9406. 