### PR TITLE
v5.0.x: Makefile.am: s/^I/        /g as relevant

### DIFF
--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2012      Oak Rigde National Laboratory. All rights reserved.
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -148,7 +148,7 @@ libmpi_c_mpi_la_SOURCES = \
         comm_split.c \
         comm_split_type.c \
         comm_test_inter.c \
-	compare_and_swap.c \
+        compare_and_swap.c \
         dims_create.c \
         errhandler_c2f.c \
         errhandler_f2c.c \
@@ -158,7 +158,7 @@ libmpi_c_mpi_la_SOURCES = \
         exscan.c \
         iexscan.c \
         exscan_init.c \
-	fetch_and_op.c \
+        fetch_and_op.c \
         file_c2f.c \
         file_call_errhandler.c \
         file_close.c \
@@ -233,7 +233,7 @@ libmpi_c_mpi_la_SOURCES = \
         get_count.c \
         get_elements.c \
         get_elements_x.c \
-	get_accumulate.c \
+        get_accumulate.c \
         get_library_version.c \
         get_processor_name.c \
         get_version.c \
@@ -320,7 +320,7 @@ libmpi_c_mpi_la_SOURCES = \
         probe.c \
         publish_name.c \
         query_thread.c \
-	raccumulate.c \
+        raccumulate.c \
         recv_init.c \
         recv.c \
         reduce.c \
@@ -338,9 +338,9 @@ libmpi_c_mpi_la_SOURCES = \
         request_f2c.c \
         request_free.c \
         request_get_status.c \
-	rget.c \
-	rget_accumulate.c \
-	rput.c \
+        rget.c \
+        rget_accumulate.c \
+        rput.c \
         rsend_init.c \
         rsend.c \
         scan.c \
@@ -422,24 +422,24 @@ libmpi_c_mpi_la_SOURCES = \
         accumulate.c \
         get.c \
         put.c \
-	win_allocate.c \
-	win_allocate_shared.c \
-	win_attach.c \
+        win_allocate.c \
+        win_allocate_shared.c \
+        win_attach.c \
         win_c2f.c \
         win_call_errhandler.c \
         win_complete.c  \
         win_create_errhandler.c \
         win_create_keyval.c \
         win_create.c \
-	win_create_dynamic.c \
+        win_create_dynamic.c \
         win_delete_attr.c \
-	win_detach.c \
+        win_detach.c \
         win_f2c.c \
         win_fence.c \
-	win_flush.c \
-	win_flush_all.c \
-	win_flush_local.c \
-	win_flush_local_all.c \
+        win_flush.c \
+        win_flush_all.c \
+        win_flush_local.c \
+        win_flush_local_all.c \
         win_free_keyval.c \
         win_free.c \
         win_get_attr.c \
@@ -448,18 +448,18 @@ libmpi_c_mpi_la_SOURCES = \
         win_get_info.c \
         win_get_name.c  \
         win_lock.c \
-	win_lock_all.c \
+        win_lock_all.c \
         win_post.c \
         win_set_attr.c \
         win_set_errhandler.c \
         win_set_info.c \
         win_set_name.c \
-	win_shared_query.c \
-	win_sync.c \
+        win_shared_query.c \
+        win_sync.c \
         win_start.c \
         win_test.c \
         win_unlock.c \
-	win_unlock_all.c \
+        win_unlock_all.c \
         win_wait.c
 
 

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -1,4 +1,4 @@
-# -*- makefile.am	 -*-
+# -*- makefile.am -*-
 #
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
@@ -128,7 +128,7 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pcomm_split.c \
         pcomm_split_type.c \
         pcomm_test_inter.c \
-	pcompare_and_swap.c \
+        pcompare_and_swap.c \
         pdims_create.c \
         perrhandler_c2f.c \
         perrhandler_f2c.c \
@@ -138,7 +138,7 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pexscan.c \
         piexscan.c \
         pexscan_init.c \
-	pfetch_and_op.c \
+        pfetch_and_op.c \
         pfile_c2f.c \
         pfile_call_errhandler.c \
         pfile_close.c \
@@ -213,7 +213,7 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pget_count.c \
         pget_elements.c \
         pget_elements_x.c \
-	pget_accumulate.c \
+        pget_accumulate.c \
         pget_library_version.c \
         pget_processor_name.c \
         pget_version.c \
@@ -240,8 +240,8 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pgroup_translate_ranks.c \
         pgroup_union.c \
         pibsend.c \
-	pimprobe.c \
-	pimrecv.c \
+        pimprobe.c \
+        pimrecv.c \
         pinfo_c2f.c \
         pinfo_create.c \
         pinfo_delete.c \
@@ -300,11 +300,11 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pprobe.c \
         ppublish_name.c \
         pquery_thread.c \
-	praccumulate.c \
+        praccumulate.c \
         precv_init.c \
         precv.c \
         preduce.c \
-	pireduce.c \
+        pireduce.c \
         preduce_init.c \
         pregister_datarep.c \
         preduce_local.c \
@@ -318,9 +318,9 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         prequest_f2c.c \
         prequest_free.c \
         prequest_get_status.c \
-	prget.c \
-	prget_accumulate.c \
-	prput.c \
+        prget.c \
+        prget_accumulate.c \
+        prput.c \
         prsend_init.c \
         prsend.c \
         pscan.c \
@@ -397,29 +397,29 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pwaitall.c \
         pwaitany.c \
         pwaitsome.c \
-	pwtime.c \
-	pwtick.c \
+        pwtime.c \
+        pwtick.c \
         paccumulate.c \
         pget.c \
         pput.c \
-	pwin_allocate.c \
-	pwin_allocate_shared.c \
-	pwin_attach.c \
+        pwin_allocate.c \
+        pwin_allocate_shared.c \
+        pwin_attach.c \
         pwin_c2f.c \
         pwin_call_errhandler.c \
         pwin_complete.c  \
         pwin_create_errhandler.c \
         pwin_create_keyval.c \
         pwin_create.c \
-	pwin_create_dynamic.c \
+        pwin_create_dynamic.c \
         pwin_delete_attr.c \
-	pwin_detach.c \
+        pwin_detach.c \
         pwin_f2c.c \
         pwin_fence.c \
-	pwin_flush.c \
-	pwin_flush_all.c \
-	pwin_flush_local.c \
-	pwin_flush_local_all.c \
+        pwin_flush.c \
+        pwin_flush_all.c \
+        pwin_flush_local.c \
+        pwin_flush_local_all.c \
         pwin_free_keyval.c \
         pwin_free.c \
         pwin_get_attr.c \
@@ -428,18 +428,18 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pwin_get_info.c  \
         pwin_get_name.c  \
         pwin_lock.c \
-	pwin_lock_all.c \
+        pwin_lock_all.c \
         pwin_post.c \
         pwin_set_attr.c \
         pwin_set_errhandler.c \
         pwin_set_info.c \
         pwin_set_name.c \
-	pwin_shared_query.c \
+        pwin_shared_query.c \
         pwin_start.c \
-	pwin_sync.c \
+        pwin_sync.c \
         pwin_test.c \
         pwin_unlock.c \
-	pwin_unlock_all.c \
+        pwin_unlock_all.c \
         pwin_wait.c
 
 if OMPI_ENABLE_MPI1_COMPAT

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Inria.  All rights reserved.
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
@@ -136,25 +136,25 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         aint_add_f.c \
         aint_diff_f.c \
         allgather_f.c \
-	allgather_init_f.c \
+        allgather_init_f.c \
         allgatherv_f.c \
-	allgatherv_init_f.c \
+        allgatherv_init_f.c \
         alloc_mem_f.c \
         allreduce_f.c \
-	allreduce_init_f.c \
+        allreduce_init_f.c \
         alltoall_f.c \
-	alltoall_init_f.c \
+        alltoall_init_f.c \
         alltoallv_f.c \
-	alltoallv_init_f.c \
+        alltoallv_init_f.c \
         alltoallw_f.c \
-	alltoallw_init_f.c \
+        alltoallw_init_f.c \
         attr_delete_f.c \
         attr_get_f.c \
         attr_put_f.c \
         barrier_f.c \
-	barrier_init_f.c \
+        barrier_init_f.c \
         bcast_f.c \
-	bcast_init_f.c \
+        bcast_init_f.c \
         bsend_f.c \
         bsend_init_f.c \
         buffer_attach_f.c \
@@ -213,7 +213,7 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         error_class_f.c \
         error_string_f.c \
         exscan_f.c \
-	exscan_init_f.c \
+        exscan_init_f.c \
         f_sync_reg_f.c \
         file_call_errhandler_f.c \
         file_close_f.c \
@@ -278,9 +278,9 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         finalize_f.c \
         free_mem_f.c \
         gather_f.c \
-	gather_init_f.c \
+        gather_init_f.c \
         gatherv_f.c \
-	gatherv_init_f.c \
+        gatherv_init_f.c \
         get_address_f.c \
         get_count_f.c \
         get_elements_f.c \

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -371,8 +371,8 @@ linked_files = \
         pwaitany_f.c \
         pwait_f.c \
         pwaitsome_f.c \
-	pwtick_f.c \
-	pwtime_f.c \
+        pwtick_f.c \
+        pwtime_f.c \
         paccumulate_f.c \
         praccumulate_f.c \
         pregister_datarep_f.c \


### PR DESCRIPTION
In lists of files, replace errant tabs with 8 spaces.

Whitespace changes only; no code or logic changes.

[skip ci]
bot:notest

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 8dbe991a1a6915711273e4e9837b9e4c5b913600)