### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "prrte"]
 	path = 3rd-party/prrte
-	url = https://github.com/openpmix/prrte
+	url = ../../openpmix/prrte
 	branch = master
 [submodule "openpmix"]
 	path = 3rd-party/openpmix
-	url = https://github.com/openpmix/openpmix.git
+	url = ../../openpmix/openpmix.git
 	branch = master


### PR DESCRIPTION
Changed the submodule paths from absolute https to relative paths, so
that the submodule cloning uses the same protocol as the ompi
cloning. (Some people are not able to access https but only ssh from
where they want to clone)

Signed-off-by: Felix Uhl <Felix.Uhl@emea.nec.com>

I will PR this to v5.0.x when it merges here on master.