### PR TITLE
scoll/ucc: add dst.info count/datatype for reduce

### DIFF
--- a/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
@@ -43,6 +43,8 @@ static inline ucc_status_t mca_scoll_ucc_reduce_init(const void *sbuf, void *rbu
         },
         .dst.info = {
             .buffer = rbuf,
+            .count = count,
+            .datatype = ucc_dt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
         .reduce = {


### PR DESCRIPTION
Adding dst.info count/datatype arguments for reduce operations to keep inline with the UCC specification.

Signed-off-by: ferrol aderholdt <faderholdt@nvidia.com>