### PR TITLE
osc/rdma: add local leader's pid in shm file name to make it unique

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -650,9 +650,9 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
         if (0 == local_rank) {
             /* allocate the shared memory segment */
-            ret = opal_asprintf (&data_file, "%s" OPAL_PATH_SEP "osc_rdma.%s.%x.%d",
+            ret = opal_asprintf (&data_file, "%s" OPAL_PATH_SEP "osc_rdma.%s.%x.%d.%d",
                             mca_osc_rdma_component.backing_directory, ompi_process_info.nodename,
-                            OMPI_PROC_MY_NAME->jobid, ompi_comm_get_cid(module->comm));
+                            OMPI_PROC_MY_NAME->jobid, ompi_comm_get_cid(module->comm), getpid());
             if (0 > ret) {
                 ret = OMPI_ERR_OUT_OF_RESOURCE;
             } else {


### PR DESCRIPTION
In osc/rdma, each communicator will assign a rank as the local leader
on one node. The local leader will create a shm file, and other ranks
in the same communicator and on the same node will attach to the shm
file.

For osc/rdma to work properly, the shm file name must be unqiue for
each communicator/node. To achieve that, osc/rdma used the following
shm file name:

    osc_rdma.<node_name>.<job_id>.<comm_id>

However, this name format did not achieve the goal, because comm_id
is only unique from process level. It can happen that different
communicator have same comm_id, as long as they do not share process.

To address this issue, this patch used local leader's pid to replace
comm_id in shm file name, because pid is unique on node level.

Signed-off-by: Wei Zhang <wzam@amazon.com>