### PR TITLE
lanl/ci: fix for changes to gitsubmodules

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -12,7 +12,6 @@ build:intel:
   tags: [darwin-slurm-shared]
   script:
     - module load intel
-    - git submodule update --init
     - ./autogen.pl
     - ./configure CC=icc FC=ifort CXX=icpc --prefix=$PWD/install_test --with-libevent=internal
     - make -j 8 install
@@ -35,7 +34,6 @@ build:ibm:
     SCHEDULER_PARAMETERS: "-ppower9 -t 1:00:00 -N 1 --ntasks-per-node=16"
   script:
     - module load ibm
-    - git submodule update --init
     - ./autogen.pl
     - ./configure CC=xlc FC=xlf CXX=xlc++ --prefix=$PWD/install_test --with-libevent=internal
     - make -j 8 install
@@ -58,7 +56,6 @@ build:amd:
     SCHEDULER_PARAMETERS: "-pamd-rome -t 1:00:00 -N 1 --ntasks-per-node=16"
   script:
     - module load aocc/3.0.0
-    - git submodule update --init
     - ./autogen.pl
     - ./configure CC=clang FC=flang CXX=clang++ --prefix=$PWD/install_test --with-libevent=internal
     - make -j 8 install
@@ -79,7 +76,6 @@ build:gnu:
   tags: [darwin-slurm-shared]
   script:
     - module load gcc
-    - git submodule update --init
     - ./autogen.pl
     - ./configure --prefix=$PWD/install_test --with-libevent=internal
     - make -j 8 install


### PR DESCRIPTION
The change introduced by PR #9485 broke things for our
gitlab based ci.

Remove the git submodule update --init to workaround this problem.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>