### PR TITLE
Remove -avoid-version from orted-mpir LDFLAGS

### DIFF
--- a/orte/orted/orted-mpir/Makefile.am
+++ b/orte/orted/orted-mpir/Makefile.am
@@ -19,4 +19,3 @@ noinst_LTLIBRARIES = lib@ORTE_LIB_PREFIX@open-orted-mpir.la
 lib@ORTE_LIB_PREFIX@open_orted_mpir_la_SOURCES = \
         orted_mpir_breakpoint.c \
         orted_mpir.h
-lib@ORTE_LIB_PREFIX@open_orted_mpir_la_LDFLAGS = -avoid-version


### PR DESCRIPTION
Remove -avoid-version from orted-mpir LDFLAGS.  Should fix #9503.  Untested but building locally now.
