### PR TITLE
v4.0.x: grequest callback return values and Fortran status

### DIFF
--- a/ompi/request/grequest.c
+++ b/ompi/request/grequest.c
@@ -122,23 +122,22 @@ static void ompi_grequest_construct(ompi_grequest_t* greq)
  */
 static void ompi_grequest_destruct(ompi_grequest_t* greq)
 {
-    int rc = 0;
-    MPI_Fint ierr;
-
     if (greq->greq_free.c_free != NULL) {
+        /* We were already putting query_fn()'s return value into
+         * status.MPI_ERROR but for MPI_{Wait,Test}*.  If there's a
+         * free callback to invoke, the standard says to use the
+         * return value from free_fn() callback, too.
+         */
         if (greq->greq_funcs_are_c) {
-            rc = greq->greq_free.c_free(greq->greq_state);
+            greq->greq_base.req_status.MPI_ERROR =
+                greq->greq_free.c_free(greq->greq_state);
         } else {
+            MPI_Fint ierr;
             greq->greq_free.f_free((MPI_Aint*)greq->greq_state, &ierr);
-            rc = OMPI_FINT_2_INT(ierr);
+            greq->greq_base.req_status.MPI_ERROR =
+                OMPI_FINT_2_INT(ierr);
         }
     }
-
-    /* We were already putting query_fn()'s return value into
-     * status.MPI_ERROR but for MPI_{Wait,Test}* the standard
-     * says use the free_fn() callback too.
-     */
-    greq->greq_base.req_status.MPI_ERROR = rc;
 
     OMPI_REQUEST_FINI(&greq->greq_base);
 }


### PR DESCRIPTION
A little background first: the status object being updated
here based on the callbacks' behavior is an internal
req->req_status.  At this level we're not directly updating
the top level MPI_Status from the user.  And the design is
to put the callback return values in the req->req_status.MPI_ERROR.
(and whether that propagates back into the top level MPI_Status
is handled elsewhere, where the code knows whether it's in
a MPI_Waitall or MPI_Wait etc).

The problems fixed here are:

1. for Fortran the callback uses a stack variable fstatus that's
a Fortran status object, then copies those values back into the
req->req_status.  But that steps on the design described above:
it writes a garbage value from the stack into the MPI_ERROR field
when it was supposed to leave the value untouched.

If I make a test where I manually put garbage into fstatus it does
make its way up the chain and make MPI_Wait fail.  So I fixed this
by initializing fstatus with an MPI_Status_c2f

2. the free_fn() callback never had its return value placed into
any of the status.MPI_ERROR locations, and the standard specifically
calls out that it's the free_fn() return value that's supposed to
go into status.MPI_ERROR.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit 64b7ae047618e8343c6d432310daa31d355d3639)