### PR TITLE
Fix OFI/common compile error for old LIbfabric and DSO runtime cleanup error

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -187,9 +187,9 @@ err:
         if (NULL != opal_common_ofi_monitor) {
             free(opal_common_ofi_monitor);
         }
-    }
 
-    opal_common_ofi_installed_memory_monitor = false;
+        opal_common_ofi_installed_memory_monitor = false;
+    }
 
     OPAL_THREAD_UNLOCK(&opal_common_ofi_mutex);
 #endif


### PR DESCRIPTION
Two bugfixes, one of which is for https://github.com/open-mpi/ompi/issues/9511, the other is a segfault during MPI_Finalize when ofi/common is built as a DSO.