### PR TITLE
configury: String OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR

### DIFF
--- a/config/opal_check_compiler_version.m4
+++ b/config/opal_check_compiler_version.m4
@@ -4,6 +4,7 @@ dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
+dnl Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -84,7 +85,8 @@ AC_DEFUN([OPAL_CHECK_COMPILER_STRING], [
             ])
             CPPFLAGS=$CPPFLAGS_orig
     ])
-    AC_DEFINE_UNQUOTED([OPAL_BUILD_PLATFORM_COMPILER_$1], [$opal_cv_compiler_$1],
+    opal_cv_compiler_$1_escaped=`echo "$opal_cv_compiler_$1" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g'`
+    AC_DEFINE_UNQUOTED([OPAL_BUILD_PLATFORM_COMPILER_$1], ["$opal_cv_compiler_$1_escaped"],
                        [The compiler $lower which OMPI was built with])
 ])dnl
 

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -15,7 +15,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2018-2021 FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -338,7 +338,7 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("C compiler family name", "compiler:c:familyname",
                   PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_FAMILYNAME));
     opal_info_out("C compiler version", "compiler:c:version",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR));
+                  OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR);
 
     if (want_all) {
         opal_info_out_int("C char size", "compiler:c:sizeof:char", sizeof(char));

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -149,7 +150,7 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("C compiler family name", "compiler:c:familyname",
                   PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_FAMILYNAME));
     opal_info_out("C compiler version", "compiler:c:version",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR));
+                  OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR);
 
     if (want_all) {
         opal_info_out_int("C char size", "compiler:c:sizeof:char", sizeof(char));


### PR DESCRIPTION
Fixes #9494

Before this change, the `OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR` macro is defined as a non-string character sequence (no enclosing double quotes) in `opal_config.h`.

This is problematic if it contains `//` because it is treated as a start of comment. Also, if it contains `(` or `)`, `PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR)` will result in a compilation error. Probably this is the case of the issue #9494 because some builds of Clang/LLVM 9 and 10 set `__clang_version__` like below.

```
clang version 10.0.1 (https://github.com/llvm/llvm-project.git ef32c611aa214dea855364efd7ba451ec5ec3f74)
```

This commit changes `OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR` to a string (enclosing with double quotes).

I think this is a proper approach because it is consistent with the `PLATFORM_COMPILER_VERSION_STR` macro, where `opal/include/opal/opal_portable_platform_real.h` defines it as a string.

Probably regression by d6bfdf2ace.

Need PR to v5.0.x branch.
