### PR TITLE
build: Improve handling of compiler version string

### DIFF
--- a/config/opal_check_compiler_version.m4
+++ b/config/opal_check_compiler_version.m4
@@ -22,9 +22,7 @@ dnl
 AC_DEFUN([OPAL_CHECK_COMPILER_VERSION_ID],
 [
     OPAL_CHECK_COMPILER(FAMILYID)
-    OPAL_CHECK_COMPILER_STRINGIFY(FAMILYNAME)
     OPAL_CHECK_COMPILER(VERSION)
-    OPAL_CHECK_COMPILER_STRING(VERSION_STR)
 ])dnl
 
 
@@ -51,67 +49,6 @@ AC_DEFUN([OPAL_CHECK_COMPILER], [
                 opal_cv_compiler_$1=0
             ], [
                 opal_cv_compiler_$1=0
-            ])
-            CPPFLAGS=$CPPFLAGS_orig
-    ])
-    AC_DEFINE_UNQUOTED([OPAL_BUILD_PLATFORM_COMPILER_$1], [$opal_cv_compiler_$1],
-                       [The compiler $lower which OMPI was built with])
-])dnl
-
-AC_DEFUN([OPAL_CHECK_COMPILER_STRING], [
-    AS_LITERAL_IF([$1], [],
-                  [m4_fatal([OPAL_CHECK_COMPILER_STRING argument must be a literal])])
-    lower=m4_tolower([$1])
-    AC_CACHE_CHECK([for compiler $lower], [opal_cv_compiler_$1],
-    [
-            CPPFLAGS_orig=$CPPFLAGS
-            CPPFLAGS="-I${OPAL_TOP_SRCDIR}/opal/include $CPPFLAGS"
-            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
-#include <stdio.h>
-#include <stdlib.h>
-#include "opal/opal_portable_platform.h"
-]],[[
-    FILE * f;
-    f=fopen("conftestval", "w");
-    if (!f) exit(1);
-    fprintf (f, "%s", PLATFORM_COMPILER_$1);
-            ]])], [
-                opal_cv_compiler_$1=`cat conftestval`
-            ], [
-                opal_cv_compiler_$1=UNKNOWN
-            ], [
-                opal_cv_compiler_$1=UNKNOWN
-            ])
-            CPPFLAGS=$CPPFLAGS_orig
-    ])
-    AC_DEFINE_UNQUOTED([OPAL_BUILD_PLATFORM_COMPILER_$1], [$opal_cv_compiler_$1],
-                       [The compiler $lower which OMPI was built with])
-])dnl
-
-
-AC_DEFUN([OPAL_CHECK_COMPILER_STRINGIFY], [
-    AS_LITERAL_IF([$1], [],
-                  [m4_fatal([OPAL_CHECK_COMPILER_STRINGIFY argument must be a literal])])
-    lower=m4_tolower([$1])
-    AC_CACHE_CHECK([for compiler $lower], [opal_cv_compiler_$1],
-    [
-            CPPFLAGS_orig=$CPPFLAGS
-            CPPFLAGS="-I${OPAL_TOP_SRCDIR}/opal/include $CPPFLAGS"
-            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
-#include <stdio.h>
-#include <stdlib.h>
-#include "opal/opal_portable_platform.h"
-]],[[
-    FILE * f;
-    f=fopen("conftestval", "w");
-    if (!f) exit(1);
-    fprintf (f, "%s", PLATFORM_STRINGIFY(PLATFORM_COMPILER_$1));
-            ]])], [
-                opal_cv_compiler_$1=`cat conftestval`
-            ], [
-                opal_cv_compiler_$1=UNKNOWN
-            ], [
-                opal_cv_compiler_$1=UNKNOWN
             ])
             CPPFLAGS=$CPPFLAGS_orig
     ])

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -40,6 +40,7 @@
 
 #include MCA_timer_IMPLEMENTATION_HEADER
 #include "opal/include/opal/version.h"
+#include "opal/opal_portable_platform.h"
 #include "opal/class/opal_value_array.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/util/printf.h"
@@ -47,7 +48,6 @@
 #include "opal/runtime/opal_info_support.h"
 
 #include "ompi/tools/ompi_info/ompi_info.h"
-#include "ompi/include/mpi_portable_platform.h"
 
 
 const char *ompi_info_deprecated_value = "deprecated-ompi-info-value";
@@ -336,9 +336,9 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("C compiler absolute", "compiler:c:absolute",
                   OPAL_CC_ABSOLUTE);
     opal_info_out("C compiler family name", "compiler:c:familyname",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_FAMILYNAME));
+                  PLATFORM_STRINGIFY(PLATFORM_COMPILER_FAMILYNAME));
     opal_info_out("C compiler version", "compiler:c:version",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR));
+                  PLATFORM_COMPILER_VERSION_STR);
 
     if (want_all) {
         opal_info_out_int("C char size", "compiler:c:sizeof:char", sizeof(char));

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -147,9 +147,9 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("C compiler absolute", "compiler:c:absolute",
                   OPAL_CC_ABSOLUTE);
     opal_info_out("C compiler family name", "compiler:c:familyname",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_FAMILYNAME));
+                  PLATFORM_STRINGIFY(PLATFORM_COMPILER_FAMILYNAME));
     opal_info_out("C compiler version", "compiler:c:version",
-                  PLATFORM_STRINGIFY(OPAL_BUILD_PLATFORM_COMPILER_VERSION_STR));
+                  PLATFORM_COMPILER_VERSION_STR);
 
     if (want_all) {
         opal_info_out_int("C char size", "compiler:c:sizeof:char", sizeof(char));


### PR DESCRIPTION
Stop saving the build compiler name and version string during
configure and move that detection to build time.  Expanding
out the version string in particular was causing escaping issues
that will not exist when the string is only expanded at use.
We need to check the compiler id and version integers during
configure, so that we can define them in mpi.h to compare
against the running compiler at application (not OMPI) build
time, but the strings were not being used in those situations.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>