### PR TITLE
op:avx: Remove unused header (and kill warning)

### DIFF
--- a/ompi/mca/op/avx/op_avx_component.c
+++ b/ompi/mca/op/avx/op_avx_component.c
@@ -21,7 +21,6 @@
 #include "ompi_config.h"
 
 #include "opal/util/printf.h"
-#include "ompi/include/mpi_portable_platform.h"
 
 #include "ompi/constants.h"
 #include "ompi/op/op.h"


### PR DESCRIPTION
Including mpi_portable_platform.h directly will always generate
warnings when included outside of mpi.h.  We should use
opal_portable_platform.h instead, although since this file
does not use anything from the portable_platform file, it is
simpler to just remove the include entirely.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>