### PR TITLE
Fixed C/Fortran linking to include module parameters in Psend/Precv_init

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -24,6 +24,7 @@
  * Copyright (c) 2021      Google, LLC. All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1776,11 +1777,11 @@ OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
 OMPI_DECLSPEC  int MPI_Pready_list(int length, int partition_list[], MPI_Request request);
 OMPI_DECLSPEC  int MPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
-                                  MPI_Request *request);
+                                  MPI_Info info, MPI_Request *request);
 OMPI_DECLSPEC  int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status);
 OMPI_DECLSPEC  int MPI_Psend_init(const void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
-                                  MPI_Request *request);
+                                  MPI_Info info, MPI_Request *request);
 OMPI_DECLSPEC  int MPI_Publish_name(const char *service_name, MPI_Info info,
                                     const char *port_name);
 OMPI_DECLSPEC  int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
@@ -2433,10 +2434,10 @@ OMPI_DECLSPEC  int PMPI_Issend(const void *buf, int count, MPI_Datatype datatype
                                int tag, MPI_Comm comm, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Precv_init(void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
-                                  MPI_Request *request);
+                                  MPI_Info info, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Psend_init(const void* buf, int partitions, MPI_Count count,
                                   MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
-                                  MPI_Request *request);
+                                  MPI_Info info, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Pready(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Pready_range(int partition_low, int partition_high,
                                     MPI_Request request);

--- a/ompi/mca/part/part.h
+++ b/ompi/mca/part/part.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2011-2020 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -141,6 +142,7 @@ typedef int (*mca_part_base_module_precv_init_fn_t)(
     int src,
     int tag,
     struct ompi_communicator_t* comm,
+    struct ompi_info_t * info,
     struct ompi_request_t **request
 );
 
@@ -166,6 +168,7 @@ typedef int (*mca_part_base_module_psend_init_fn_t)(
     int dst,
     int tag,
     struct ompi_communicator_t* comm,
+    struct ompi_info_t * info,
     struct ompi_request_t **request
 );
 

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2021      University of Alabama at Birmingham. All rights reserved.
  * Copyright (c) 2021      Tennessee Technological University. All rights reserved.
  * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -331,6 +332,7 @@ mca_part_persist_precv_init(void *buf,
                         int src,
                         int tag,
                         struct ompi_communicator_t *comm,
+                        struct ompi_info_t * info,
                         struct ompi_request_t **request)
 {
     int err = OMPI_SUCCESS;
@@ -398,6 +400,7 @@ mca_part_persist_psend_init(const void* buf,
                         int dst,
                         int tag,
                         ompi_communicator_t* comm,
+                        struct ompi_info_t * info,
                         ompi_request_t** request)
 {
     int err = OMPI_SUCCESS;

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +44,7 @@
 static const char FUNC_NAME[] = "MPI_Precv_init";
 
 
-int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request)
+int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request)
 {
     int rc;
 
@@ -59,6 +60,6 @@ int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype data
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    rc = mca_part.part_precv_init(buf, partitions, count, datatype, source, tag, comm, request);
+    rc = mca_part.part_precv_init(buf, partitions, count, datatype, source, tag, comm, info, request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/psend_init.c
+++ b/ompi/mpi/c/psend_init.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +44,7 @@
 static const char FUNC_NAME[] = "MPI_Psend_init";
 
 
-int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request)
+int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request)
 {
     int rc;
 
@@ -59,6 +60,6 @@ int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatyp
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    rc = mca_part.part_psend_init(buf, partitions, count, datatype, dest, tag, comm, request);
+    rc = mca_part.part_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/fortran/mpif-h/precv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/precv_init_f.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,8 +41,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_PRECV_INIT,
                            pmpi_precv_init_,
                            pmpi_precv_init__,
                            pompi_precv_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
-                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #endif
 #endif
 
@@ -60,21 +61,23 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PRECV_INIT,
                            mpi_precv_init_,
                            mpi_precv_init__,
                            ompi_precv_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
-                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #else
 #define ompi_precv_init_f pompi_precv_init_f
 #endif
 #endif
 
 
-void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr)
+void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
 {
    int c_ierr;
+   MPI_Info c_info;
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_req;
    MPI_Comm c_comm;
 
+   c_info = PMPI_Info_f2c(*info);
    c_comm = PMPI_Comm_f2c (*comm);
 
    c_ierr = PMPI_Precv_init(OMPI_F2C_BOTTOM(buf), 
@@ -82,7 +85,7 @@ void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fin
                       OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag),
-                      c_comm, &c_req);
+                      c_comm, c_info, &c_req);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
    if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -344,8 +345,8 @@ PN2(void, MPI_Pcontrol, mpi_pcontrol, MPI_PCONTROL, (MPI_Fint *level));
 PN2(void, MPI_Pready, mpi_pready, MPI_PREADY, (MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Pready_list, mpi_pready_list, MPI_PREADY_LIST, (MPI_Fint *length, MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Pready_range, mpi_pready_range, MPI_PREADY_RANGE, (MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr));
-PN2(void, MPI_Precv_init, mpi_precv_init, MPI_PRECV_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *src, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
-PN2(void, MPI_Psend_init, mpi_psend_init, MPI_PSEND_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Precv_init, mpi_precv_init, MPI_PRECV_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *src, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Psend_init, mpi_psend_init, MPI_PSEND_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Probe, mpi_probe, MPI_PROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *status, MPI_Fint *ierr));
 PN2(void, MPI_Publish_name, mpi_publish_name, MPI_PUBLISH_NAME, (char *service_name, MPI_Fint *info, char *port_name, MPI_Fint *ierr, int service_name_len, int port_name_len));
 PN2(void, MPI_Put, mpi_put, MPI_PUT, (char *origin_addr, MPI_Fint *origin_count, MPI_Fint *origin_datatype, MPI_Fint *target_rank, MPI_Aint *target_disp, MPI_Fint *target_count, MPI_Fint *target_datatype, MPI_Fint *win, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/psend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/psend_init_f.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,8 +41,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_PSEND_INIT,
                            pmpi_psend_init_,
                            pmpi_psend_init__,
                            pompi_psend_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
-                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #endif
 #endif
 
@@ -60,21 +61,23 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PSEND_INIT,
                            mpi_psend_init_,
                            mpi_psend_init__,
                            ompi_psend_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr),
-                           (buf, partitions, count, datatype, dest, tag, comm, request, ierr) )
+                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #else
 #define ompi_psend_init_f pompi_psend_init_f
 #endif
 #endif
 
 
-void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr)
+void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
 {
    int c_ierr;
+   MPI_Info c_info;
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_req;
    MPI_Comm c_comm;
 
+   c_info = PMPI_Info_f2c(*info);
    c_comm = PMPI_Comm_f2c (*comm);
 
    c_ierr = PMPI_Psend_init(OMPI_F2C_BOTTOM(buf), 
@@ -82,7 +85,7 @@ void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fin
                       OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag),
-                      c_comm, &c_req);
+                      c_comm, c_info, &c_req);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
    if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -9,6 +9,7 @@
 ! Copyright (c) 2012      Inria.  All rights reserved.
 ! Copyright (c) 2015-2020 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2021      Bull S.A.S. All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -145,6 +146,7 @@
 ! MPI_Is_thread_main
 ! MPI_Op_commutative
 ! MPI_Op_create
+! MPI_Parrived
 ! MPI_Type_get_attr
 ! MPI_Win_get_attr
 ! MPI_Win_test
@@ -276,24 +278,26 @@ subroutine ompi_issend_f(buf,count,datatype,dest,tag,comm,request,ierror) &
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_issend_f
 
-subroutine ompi_psend_init_f(buf,partitions,count,datatype,dest,tag,comm,request,ierror) &
+subroutine ompi_psend_init_f(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror) &
    BIND(C, name="ompi_psend_init_f")
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions, count, dest, tag
    INTEGER, INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: comm
+   INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: request
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_psend_init_f
 
-subroutine ompi_precv_init_f(buf,partitions,count,datatype,dest,tag,comm,request,ierror) &
+subroutine ompi_precv_init_f(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror) &
    BIND(C, name="ompi_precv_init_f")
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions, count, dest, tag
    INTEGER, INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: comm
+   INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: request
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_precv_init_f

--- a/ompi/mpi/fortran/use-mpi-f08/parrived_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/parrived_f08.F90
@@ -11,6 +11,8 @@
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPI_Parrived_f08(request,partition,flag,ierror)
+   ! See note in mpi-f-interfaces-bind.h for why we "use mpi" here and
+   ! call a PMPI_* subroutine below.
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi, only : PMPI_Parrived
    implicit none

--- a/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
@@ -6,25 +6,28 @@
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! Copyright (c) 2021      Bull S.A.S. All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 #include "mpi-f08-rename.h"
 
-subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: ompi_mpifh_bindings, only : ompi_precv_init_f
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions,count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_precv_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   call ompi_precv_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL, &
+                          info%MPI_VAL,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Precv_init_f08

--- a/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
@@ -6,23 +6,26 @@
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! Copyright (c) 2021      Bull S.A.S. All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror)
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: ompi_mpifh_bindings, only : ompi_psend_init_f
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions,count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_psend_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL,request%MPI_VAL,c_ierror)
+   call ompi_psend_init_f(buf,partitions,count,datatype%MPI_VAL,dest,tag,comm%MPI_VAL, &
+                          info%MPI_VAL,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Psend_init_f08

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -11,6 +11,7 @@
 !                         reserved.
 ! Copyright (c) 2015-2020 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2021      Bull S.A.S. All rights reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -2498,7 +2499,7 @@ end interface
 interface
 
 subroutine MPI_Psend_init(buf, partitions, count, datatype, dest, tag, &
-        comm, request, ierror)
+        comm, info, request, ierror)
   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
   integer, intent(in) :: partitions 
@@ -2507,6 +2508,7 @@ subroutine MPI_Psend_init(buf, partitions, count, datatype, dest, tag, &
   integer, intent(in) :: dest
   integer, intent(in) :: tag
   integer, intent(in) :: comm
+  integer, intent(in) :: info
   integer, intent(out) :: request
   integer, intent(out) :: ierror
 end subroutine MPI_Psend_init
@@ -2517,7 +2519,7 @@ end interface
 interface
 
 subroutine MPI_Precv_init(buf, partitions, count, datatype, dest, tag, &
-        comm, request, ierror)
+        comm, info, request, ierror)
   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
   integer, intent(in) :: partitions
@@ -2526,6 +2528,7 @@ subroutine MPI_Precv_init(buf, partitions, count, datatype, dest, tag, &
   integer, intent(in) :: dest
   integer, intent(in) :: tag
   integer, intent(in) :: comm
+  integer, intent(in) :: info
   integer, intent(out) :: request
   integer, intent(out) :: ierror
 end subroutine MPI_Precv_init


### PR DESCRIPTION
Signed-off-by: Emmanuel Brelle <emmanuel.brelle@atos.net>

Suggestion to fix #9534 