### PR TITLE
master: Update README regarding nvfortran fPIC issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,10 +490,8 @@ base as of this writing (April 2020):
   ```
 * As of October 2021, the NVIDIA 'nvfortran' compiler version 21.1
   fails to link `libmpi_usempif08.la` (see
-  https://github.com/open-mpi/ompi/issues/8919).  NVIDIA
-  estimates that a fixed version of the `nvfortran` compiler will
-  be included in version v21.11 at the end of November 2021.
-
+  https://github.com/open-mpi/ompi/issues/8919). One can work-around
+  this issue by explicitely setting `FCFLAGS=-fPIC` during configure.
 
 ### General Run-Time Support Notes
 


### PR DESCRIPTION
The previous update stated incorrectly that the issue is in nvfortran; however, it's the fPIC detection during configure. Changing update to reflect this.