### PR TITLE
Drop unknown/ignored info keys on communicators, files, and windows

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -619,6 +619,11 @@ int ompi_comm_split_with_info( ompi_communicator_t* comm, int color, int key,
     /* Activate the communicator and init coll-component */
     rc = ompi_comm_activate (&newcomp, comm, NULL, NULL, NULL, false, mode);
 
+    /* MPI-4 §7.4.4 requires us to remove all unknown keys from the info object */
+    if (NULL != newcomp->super.s_info) {
+        opal_info_remove_unreferenced(newcomp->super.s_info);
+    }
+
  exit:
     free ( results );
     free ( sorted );
@@ -950,6 +955,10 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
         }
 
         if (!need_split) {
+
+            /* MPI-4 §7.4.4 requires us to remove all unknown keys from the info object */
+            opal_info_remove_unreferenced(newcomp->super.s_info);
+
             /* common case. no reordering and no MPI_UNDEFINED */
             *newcomm = newcomp;
 
@@ -1039,6 +1048,9 @@ int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info, omp
         OBJ_RELEASE(newcomp);
         return rc;
     }
+
+    /* MPI-4 §7.4.4 requires us to remove all unknown keys from the info object */
+    opal_info_remove_unreferenced(newcomp->super.s_info);
 
     *newcomm = newcomp;
     return MPI_SUCCESS;
@@ -1194,6 +1206,11 @@ static int ompi_comm_idup_with_info_activate (ompi_comm_request_t *request)
 
 static int ompi_comm_idup_with_info_finish (ompi_comm_request_t *request)
 {
+    ompi_comm_idup_with_info_context_t *context =
+        (ompi_comm_idup_with_info_context_t *) request->context;
+    /* MPI-4 §7.4.4 requires us to remove all unknown keys from the info object */
+    opal_info_remove_unreferenced(context->newcomp->super.s_info);
+
     /* done */
     return MPI_SUCCESS;
 }

--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -137,6 +137,9 @@ int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
         return ret;
     }
 
+    /* MPI-4 §14.2.8 requires us to remove all unknown keys from the info object */
+    opal_info_remove_unreferenced(file->super.s_info);
+
     /* All done */
 
     *fh = file;

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -222,19 +222,19 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
 
     opal_cstring_t *stripe_str;
     /* Check the info object set during File_open */
-    opal_info_get (fh->f_info, "cb_nodes", &stripe_str, &flag);
+    opal_info_get (info, "cb_nodes", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &num_cb_nodes );
         OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
+        /* add the key/value to the file's info object */
+        opal_info_set_cstring(fh->f_info, "cb_nodes", stripe_str);
         OBJ_RELEASE(stripe_str);
     }
     else {
         /* Check the info object set during file_set_view */
-        opal_info_get (info, "cb_nodes", &stripe_str, &flag);
+        opal_info_get (fh->f_info, "cb_nodes", &stripe_str, &flag);
         if ( flag ) {
             sscanf ( stripe_str->string, "%d", &num_cb_nodes );
-            /* add the key/value to the file's info object */
-            opal_info_set_cstring(fh->f_info, "cb_nodes", stripe_str);
             OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
             OBJ_RELEASE(stripe_str);
         }
@@ -327,7 +327,7 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     }
 
     bool info_is_set=false;
-    opal_info_get (fh->f_info, "collective_buffering", &stripe_str, &flag);
+    opal_info_get (info, "collective_buffering", &stripe_str, &flag);
     if ( flag ) {
         if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
             info_is_set = true;
@@ -335,9 +335,11 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
         } else {
             OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
         }
+        /* add the key/value to the file's info object */
+        opal_info_set_cstring(fh->f_info, "collective_buffering", stripe_str);
         OBJ_RELEASE(stripe_str);
     } else {
-        opal_info_get (info, "collective_buffering", &stripe_str, &flag);
+        opal_info_get (fh->f_info, "collective_buffering", &stripe_str, &flag);
         if ( flag ) {
             if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
                 info_is_set = true;
@@ -345,8 +347,6 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
             } else {
                 OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
             }
-            /* add the key/value to the file's info object */
-            opal_info_set_cstring(fh->f_info, "collective_buffering", stripe_str);
             OBJ_RELEASE(stripe_str);
         }
     }

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -233,6 +233,8 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
         opal_info_get (info, "cb_nodes", &stripe_str, &flag);
         if ( flag ) {
             sscanf ( stripe_str->string, "%d", &num_cb_nodes );
+            /* add the key/value to the file's info object */
+            opal_info_set_cstring(fh->f_info, "cb_nodes", stripe_str);
             OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
             OBJ_RELEASE(stripe_str);
         }
@@ -343,6 +345,8 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
             } else {
                 OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
             }
+            /* add the key/value to the file's info object */
+            opal_info_set_cstring(fh->f_info, "collective_buffering", stripe_str);
             OBJ_RELEASE(stripe_str);
         }
     }

--- a/ompi/mca/osc/base/base.h
+++ b/ompi/mca/osc/base/base.h
@@ -42,7 +42,6 @@ int ompi_osc_base_select(ompi_win_t *win,
                          size_t size,
                          int disp_unit,
                          ompi_communicator_t *comm,
-                         opal_info_t *info,
                          int flavor,
                          int *model);
 

--- a/ompi/mca/osc/base/osc_base_init.c
+++ b/ompi/mca/osc/base/osc_base_init.c
@@ -36,7 +36,6 @@ ompi_osc_base_select(ompi_win_t *win,
                      size_t size,
                      int disp_unit,
                      ompi_communicator_t *comm,
-                     opal_info_t *info,
                      int flavor,
                      int *model)
 {
@@ -55,7 +54,8 @@ ompi_osc_base_select(ompi_win_t *win,
         ompi_osc_base_component_t *component = (ompi_osc_base_component_t*)
             ((mca_base_component_list_item_t*) item)->cli_component;
 
-        priority = component->osc_query(win, base, size, disp_unit, comm, info, flavor);
+        priority = component->osc_query(win, base, size, disp_unit, comm,
+                                        win->super.s_info, flavor);
         if (priority < 0) {
             if (MPI_WIN_FLAVOR_SHARED == flavor && OMPI_ERR_RMA_SHARED == priority) {
                 /* NTH: quick fix to return OMPI_ERR_RMA_SHARED */
@@ -86,5 +86,6 @@ ompi_osc_base_select(ompi_win_t *win,
                          "select: component %s selected",
                          best_component->osc_version.mca_component_name );
 
-    return best_component->osc_select(win, base, size, disp_unit, comm, info, flavor, model);
+    return best_component->osc_select(win, base, size, disp_unit, comm,
+                                      win->super.s_info, flavor, model);
 }

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -65,6 +65,8 @@ struct opal_info_entry_t {
     opal_list_item_t super;   /**< required for opal_list_t type */
     opal_cstring_t *ie_value; /**< value part of the (key, value) pair. */
     opal_cstring_t *ie_key;   /**< "key" part of the (key, value) pair */
+    uint32_t ie_referenced;   /**< number of times this entry was internally
+                                   referenced */
 };
 
 /**
@@ -87,8 +89,6 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_info_t);
  */
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_info_entry_t);
 
-int opal_mpiinfo_init(void *);
-
 /**
  *   opal_info_dup - Duplicate an 'MPI_Info' object
  *
@@ -106,7 +106,7 @@ int opal_mpiinfo_init(void *);
 int opal_info_dup(opal_info_t *info, opal_info_t **newinfo);
 
 /**
- * Set a new key,value pair on info.
+ * Set a new key,value pair on info and mark it as referenced.
  *
  * @param info pointer to opal_info_t object
  * @param key pointer to the new key object
@@ -165,6 +165,8 @@ int opal_info_free(opal_info_t **info);
  *   Get a (key, value) pair from an 'MPI_Info' object and assign it
  *   into a boolen output.
  *
+ *   This call marks the entry referenced.
+ *
  *   @param info Pointer to opal_info_t object
  *   @param key null-terminated character string of the index key
  *   @param value Boolean output value
@@ -207,7 +209,8 @@ OPAL_DECLSPEC int opal_info_get_value_enum(opal_info_t *info, const char *key, i
                                            int *flag);
 
 /**
- *   Get a (key, value) pair from an 'MPI_Info' object
+ *   Get a (key, value) pair from an 'MPI_Info' object and mark the entry
+ *   as referenced.
  *
  *   @param info Pointer to opal_info_t object
  *   @param key null-terminated character string of the index key
@@ -283,6 +286,43 @@ static inline int opal_info_get_nkeys(opal_info_t *info, int *nkeys)
     *nkeys = (int) opal_list_get_size(&(info->super));
     return OPAL_SUCCESS;
 }
+
+
+/**
+ * Mark the entry \c key as referenced.
+ *
+ * This function is useful for lazily initialized components
+ * that do not read the key immediately but want to make sure
+ * the key is kept by the object owning the info key.
+ *
+ * @param info Pointer to opal_info_t object.
+ * @param key The key which to mark as referenced.
+ *
+ * @retval OPAL_SUCCESS
+ */
+int opal_info_mark_referenced(opal_info_t *info, const char *key);
+
+/**
+ * Remove a reference from the entry \c key.
+ *
+ * This function should be used by components reading the key
+ * without wanting to retain it in the object owning the info.
+ *
+ * @param info Pointer to opal_info_t object.
+ * @param key The key which to unmark as referenced.
+ *
+ * @retval OPAL_SUCCESS
+ */
+int opal_info_unmark_referenced(opal_info_t *info, const char *key);
+
+/**
+ * Remove any entries that are not marked as referenced
+ *
+ * @param info Pointer to opal_info_t object.
+ *
+ * @retval OPAL_SUCCESS
+ */
+int opal_info_remove_unreferenced(opal_info_t *info);
 
 END_C_DECLS
 


### PR DESCRIPTION
MPI-4 mandates that only info keys that are not ignored by the implementation are returned by `MPI_[File|Win|Comm]_get_info`. This means we have to filter out any keys that were left untouched during the creation of files, communicators, and windows. 

This PR adds a field to the info entry struct that is used to track whether the info entry was accessed and allow dropping all entries that were not referenced (either through `opal_info_get` or `opal_info_set`). The info entries are duplicated into the file/win/comm object, leaving all entries untouched initially. During the initialization of the file/window/comm, info keys are read and potentially set, marking them as referenced. At the end of the initialization, we drop all info keys that were never referenced.

This is an attempt to fix https://github.com/open-mpi/ompi/issues/9555. 

This works for windows, as they only have one component that consumes info keys (the `osc` components). For communicators, I believe the pml and coll components are selected during initialization so we should catch all relevant info keys. However, I am not sure this change properly handles file creation as I couldn't figure out which info keys are actually supported and files didn't carry any predefined keys in my tests. This change correctly filters the `foo` info key from the test case in #9555 but  I don't understand the I/O part well enough to judge whether what I did is correct/sufficient (esp. the info duplication in [the romio component](https://github.com/open-mpi/ompi/blob/master/ompi/mca/io/romio341/src/io_romio341_file_open.c#L48) seems suspicious). Can someone with deeper knowledge please take a look?

Note that this PR adds three new functions (`opal_info_mark_referenced`, `opal_info_mark_unreferenced`, and `opal_info_remove_unreferenced`). The latter drops all info entries that were not marked as referenced during calls to `opal_info_get` and `opal_info_set` (or their derivatives such as `opal_info_get_bool`). The other two functions are not actually used but I thought they might be useful for components wishing to retain info entries without reading them or to read an entry and deciding not to retain them. There is no use-case for this at the moment though.

Any feedback on the approach in general is welcome, of course :) 

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>