### PR TITLE
ompi/runtime: add instead of set opal_progress_event_flags

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -995,7 +995,8 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
        CPU utilization for the remainder of MPI_INIT when we are
        blocking on RTE-level events, but may greatly reduce non-TCP
        latency. */
-    opal_progress_set_event_flag(OPAL_EVLOOP_NONBLOCK);
+    int old_event_flags = opal_progress_set_event_flag(0);
+    opal_progress_set_event_flag(old_event_flags | OPAL_EVLOOP_NONBLOCK);
 #endif
 
     /* wire up the mpi interface, if requested.  Do this after the


### PR DESCRIPTION
Currently, ompi_mpi_init() call

     opal_progress_set_event_flag(OPAL_EVLOOP_NONBLOCK),

whith the intention to ensure OPAL_EVLOOP_NONBLOCK is set
in opal_progress_event_flag.

However, this call will remove other existing flags
(like OPAL_EVLOOP_ONCE) in opal_progress_event_flag,
which can cause deadlock.

This patch address the issue by adding OPAL_EVLOOP_NONBLOCK
to that flag.
 
Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit f22d8975b95668067c5a4702ad61cbb00e5e37a2)