### PR TITLE
v4.1.x: ofi: prevent issues with multi-plane fabrics

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -701,8 +701,8 @@ opal_mca_common_ofi_select_provider(struct fi_info *provider_list, int32_t num_l
 
 #if OPAL_OFI_PCI_DATA_AVAILABLE
     if (NULL != provider->nic
-        && NULL != current_provider->nic->bus_attr
-        && current_provider->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        && NULL != provider->nic->bus_attr
+        && provider->nic->bus_attr->bus_type == FI_BUS_PCI) {
         pci = provider->nic->bus_attr->attr.pci;
         cpusets_match = compare_cpusets(opal_hwloc_topology, pci);
     }


### PR DESCRIPTION
The OFI provider fabric_attr->name field in fi_info provides a
description of the fabric. Only units whose fabric name matches can be
expected to be able to communicate.

Added some potentially paranoid checks of the fi_bus_attr struct for
NULL and type == FI_BUS_PCI before OpenMPI proceeds to use to compare
PCI NUMA locality. The fi_bus_attr structure is designed as a union and
may eventually list additional bus_type values with different attribute
structures in the union.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>
Signed-off-by: Rimmer, Todd <todd.rimmer@intel.com>
(cherry picked from commit 867e8359357d7d8103ed61cf0489d204abf1ff4f)

---
cherry picked from: #9531 & #9577 
