### PR TITLE
mtl/ofi: call fi_setopt to state MPI p2p requirements for CUDA

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -142,6 +142,10 @@ AC_DEFUN([_OPAL_CHECK_OFI],[
                           [],
                           [#include <pmix.h>])
 
+           AC_CHECK_DECLS([FI_OPT_FI_HMEM_P2P],
+                          [], [],
+                          [#include <rdma/fi_endpoint.h>])
+
            AC_CHECK_TYPES([struct fi_ops_mem_monitor], [], [],
                           [#ifdef HAVE_RDMA_FI_EXT_H
 #include <rdma/fi_ext.h>


### PR DESCRIPTION
Call fi_setopt after endpoint initialization to tell Libfabric that while
device peer to peer support should be enabled when possible for network
transfers, it is not required and copies may be used instead.

An MCA parameter needs to be added for this in the future so that users can
toggle this option.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Tested both success and unsupported cases with the EFA provider. Also checked over the `fi_setopt` handlers for other providers in LIbfabric, to ensure they all return `-FI_ENOPROTOOPT` when this option is not supported.