### PR TITLE
coll/ucc: adds missing .h to Makefile.am

### DIFF
--- a/ompi/mca/coll/ucc/Makefile.am
+++ b/ompi/mca/coll/ucc/Makefile.am
@@ -16,6 +16,7 @@ coll_ucc_sources =           \
 		coll_ucc.h           \
 		coll_ucc_debug.h     \
 		coll_ucc_dtypes.h    \
+		coll_ucc_common.h    \
 		coll_ucc_module.c    \
 		coll_ucc_component.c \
 		coll_ucc_barrier.c   \


### PR DESCRIPTION
Fixes build from tarball (#9588)

Signed-off-by: Valentin Petrov <valentinp@nvidia.com>