### PR TITLE
v4.0.x: Add support for FI_CONTEXT2 to the OFI MTL.

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -462,7 +462,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                             __FILE__, __LINE__);
         goto error;
     }
-    hints->mode               = FI_CONTEXT;
+    hints->mode               = FI_CONTEXT | FI_CONTEXT2;
     hints->ep_attr->type      = FI_EP_RDM;      /* Reliable datagram         */
     hints->caps               = FI_TAGGED;      /* Tag matching interface    */
     hints->tx_attr->msg_order = FI_ORDER_SAS;

--- a/ompi/mca/mtl/ofi/mtl_ofi_request.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_request.h
@@ -34,7 +34,7 @@ struct ompi_mtl_ofi_request_t {
     ompi_mtl_ofi_request_type_t type;
 
     /** OFI context */
-    struct fi_context ctx;
+    struct fi_context2 ctx;
 
     /** Completion count used by blocking and/or synchronous operations */
     volatile int completion_count;


### PR DESCRIPTION
This change reserves more space, allowing the OFI MTL to work
with both providers that use FI_CONTEXT and those that use FI_CONTEXT2.

This is a backport of patches previously accepted for 4.1.x and 5.0.x.

Refs: #8928

Signed-off-by: Michael Heinz <mheinz@cornelisnetworks.com>

bot:notacherrypick