### PR TITLE
    Check for allocator bucket overflow

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -126,3 +126,5 @@ Samuel K. Gutierrez <samuel@lanl.gov> <samuelkgutierrez@users.noreply.github.com
 Samuel K. Gutierrez <samuel@lanl.gov> <samuel@lanl.gov>
 
 Tomislav Janjusic <tomislavj@nvidia.com> Tomislavj Janjusic <tomislavj@nvidia.com>
+
+William P. LePera <lepera@us.ibm.com>

--- a/opal/mca/allocator/bucket/Makefile.am
+++ b/opal/mca/allocator/bucket/Makefile.am
@@ -18,6 +18,8 @@
 # $HEADER$
 #
 
+dist_opaldata_DATA = help-mca-allocator-bucket.txt
+
 sources = \
         allocator_bucket.c \
         allocator_bucket_alloc.c \

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.c
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.c
@@ -20,6 +20,8 @@
 #include "opal_config.h"
 #include "opal/mca/allocator/bucket/allocator_bucket_alloc.h"
 #include "opal/constants.h"
+#include "opal/util/show_help.h"
+
 /**
  * The define controls the size in bytes of the 1st bucket and hence every one
  * afterwards.
@@ -30,6 +32,8 @@
  * bytes in the initial memory buckets
  */
 #define MCA_ALLOCATOR_BUCKET_1_BITSHIFTS 3
+
+static int max_bucket_idx;
 
 /*
  * Initializes the mca_allocator_bucket_options_t data structure for the passed
@@ -47,6 +51,9 @@ mca_allocator_bucket_init(mca_allocator_base_module_t *mem, int num_buckets,
     if (num_buckets <= 0) {
         num_buckets = 30;
     }
+
+    max_bucket_idx = num_buckets - 1;
+
     /* initialize the array of buckets */
     size = sizeof(mca_allocator_bucket_bucket_t) * num_buckets;
     mem_options->buckets = (mca_allocator_bucket_bucket_t *) malloc(size);
@@ -87,6 +94,13 @@ void *mca_allocator_bucket_alloc(mca_allocator_base_module_t *mem, size_t size)
     while (size > bucket_size) {
         bucket_num++;
         bucket_size <<= 1;
+    }
+
+    if( bucket_num > max_bucket_idx ) {
+        size_t sz_bucket = MCA_ALLOCATOR_BUCKET_1_SIZE;
+        opal_show_help ("help-mca-allocator-bucket.txt", "buffer too large", size, sz_bucket << max_bucket_idx,
+                        "allocator_bucket_num_buckets", bucket_num + 1);
+        return (NULL);
     }
 
     /* now that we know what bucket it will come from, we must get the lock */
@@ -191,6 +205,14 @@ void *mca_allocator_bucket_alloc_align(mca_allocator_base_module_t *mem, size_t 
         bucket_size >>= 1;
         bucket_num++;
     }
+
+    if( bucket_num > max_bucket_idx ) {
+        size_t sz_bucket = MCA_ALLOCATOR_BUCKET_1_SIZE;
+        opal_show_help ("help-mca-allocator-bucket.txt", "aligned buffer too large", allocated_size, sz_bucket << max_bucket_idx,
+                        "allocator_bucket_num_buckets", bucket_num + 1);
+        return (NULL);
+    }
+
     bucket_size = 1;
     bucket_size <<= MCA_ALLOCATOR_BUCKET_1_BITSHIFTS + bucket_num;
 

--- a/opal/mca/allocator/bucket/help-mca-allocator-bucket.txt
+++ b/opal/mca/allocator/bucket/help-mca-allocator-bucket.txt
@@ -1,0 +1,19 @@
+# -*- text -*-
+#
+# Copyright (c) 2021      IBM Corporation.  All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI's allocator bucket support
+#
+[buffer too large]
+ERROR: Requested buffer size %zu exceeds limit of %zu
+Consider setting "%s" to %d
+#
+[aligned buffer too large]
+ERROR: Requested aligned buffer size %zu exceeds limit of %zu
+Consider setting "%s" to %d
+#


### PR DESCRIPTION
    Ensure requested memory size can be accommodated by the current number
    of memory allocator buckets

Signed-off-by: William P. LePera <lepera@us.ibm.com>