### PR TITLE
libnbc wrong answer (DI) fix for reduce_scatter

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2015      The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -161,7 +161,8 @@ static int nbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int
 
   /* rank 0 is root and sends - all others receive */
   if (rank == 0) {
-    for (long int r = 1, offset = 0 ; r < p ; ++r) {
+    size_t offset = 0;
+    for (long int r = 1 ; r < p ; ++r) {
       offset += recvcounts[r-1];
       sbuf = lbuf + (offset*ext);
       /* root sends the right buffer to the right receiver */
@@ -313,7 +314,8 @@ static int nbc_reduce_scatter_inter_init (const void* sendbuf, void* recvbuf, co
       free(tmpbuf);
       return res;
     }
-    for (int peer = 1, offset = recvcounts[0] * ext; peer < lsize ; ++peer) {
+    size_t offset = recvcounts[0] * ext;
+    for (int peer = 1; peer < lsize ; ++peer) {
       res = NBC_Sched_local_send (lbuf + offset, true, recvcounts[peer], datatype, peer, schedule,
                                   false);
       if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
@@ -10,7 +10,7 @@
  *                         reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -166,7 +166,8 @@ static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int
         return res;
       }
     } else {
-      for (int r = 1, offset = 0 ; r < p ; ++r) {
+      size_t offset = 0;
+      for (int r = 1 ; r < p ; ++r) {
         offset += recvcount;
         sbuf = lbuf + (offset*ext);
         /* root sends the right buffer to the right receiver */


### PR DESCRIPTION
 * If the `count x dt_extent` is greater than INT_MAX then this
   will overflow the `offset` variable used to offset the buffer.
   The result was that the offset overflowed becoming negative
   causing the reduction to be performed in the incorrect memory
   location producing a wrong answer in the resulting buffers.
 * By preserving this value as a size_t we avoid the int overflow
   at the root of the problem.
