### PR TITLE
osc/rdma: Make sure the rank_array is initialized [v5.0.x]

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -491,6 +491,7 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
     if (OPAL_UNLIKELY(NULL == module->rank_array)) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
+    memset(module->rank_array, 0, total_size);
 
     /* Note, the extra module->region_size space added after local_rank_array_size
      * is unused but is there to match what happens in allocte_state_shared()


### PR DESCRIPTION
A bug introduced in #7985 where a calloc call was replaced with an allocation that does not initialize the memory.

Fixes #9590

Backport of https://github.com/open-mpi/ompi/pull/9607 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 3c0ec476edc016ab12e388af6005615c1cdc007d)