### PR TITLE
btl/uct: Bump supported version to UCX 1.11.x

### DIFF
--- a/opal/mca/btl/uct/configure.m4
+++ b/opal/mca/btl/uct/configure.m4
@@ -52,7 +52,7 @@ dnl
     fi
 
     max_allowed_uct_major=1
-    max_allowed_uct_minor=9
+    max_allowed_uct_minor=11
     if test "$btl_uct_happy" = "yes" && test "$enable_uct_version_check" != "no"; then
         AC_MSG_CHECKING([UCT version compatibility])
         OPAL_VAR_SCOPE_PUSH([CPPFLAGS_save])


### PR DESCRIPTION
I've been able to compile btl/uct against 1.11.2 so it seems we can safely bump the allowed version to UCX 1.11.x. We may want to backport this to 5.0.x.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>