### PR TITLE
v5.0: osc/ucx fixes dynamic windows

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -121,3 +121,5 @@ Nick Papior <nickpapior@gmail.com> <zerothi@users.noreply.github.com>
 Wei-keng Liao <wkliao@users.noreply.github.com>
 
 Matthew G. F. Dosanjh <mdosanj@sandia.gov>
+
+Tomislav Janjusic <tomislavj@nvidia.com> Tomislavj Janjusic <tomislavj@nvidia.com>

--- a/ompi/mca/osc/ucx/osc_ucx_passive_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_passive_target.c
@@ -216,8 +216,8 @@ int ompi_osc_ucx_lock_all(int mpi_assert, struct ompi_win_t *win) {
 
 int ompi_osc_ucx_unlock_all(struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*)win->w_osc_module;
-    int comm_size = ompi_comm_size(module->comm);
-    int ret = OMPI_SUCCESS;
+    int comm_size = ompi_comm_size(module->comm),
+        i = 0, ret = OMPI_SUCCESS;
 
     if (module->epoch_type.access != PASSIVE_ALL_EPOCH) {
         return OMPI_ERR_RMA_SYNC;
@@ -225,9 +225,19 @@ int ompi_osc_ucx_unlock_all(struct ompi_win_t *win) {
 
     assert(module->lock_count == 0);
 
-    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
-    if (ret != OMPI_SUCCESS) {
-        return ret;
+    if (module->flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        for (i = 0; i < module->state.dynamic_win_count; i++) {
+            ret = opal_common_ucx_wpmem_flush(module->local_dynamic_win_info[i].mem , OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+            if (ret != OMPI_SUCCESS) {
+                return ret;
+            }
+        }
+    }
+    else {
+        ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+        if (ret != OMPI_SUCCESS) {
+            return ret;
+        }
     }
 
     if (!module->lock_all_is_nocheck) {


### PR DESCRIPTION
Fixes several issues with dynamic windows, 1byte ops, and outstanding inflight ops, which would results in failures during finalize

Fixes: #6987

Co-authored-by: Artem Polyakov <artpol84@gmail.com>

Signed-off-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit 9bd8115627568a53bcc3156169f1b71947caaf61)