### PR TITLE
v5.0.x: Install pmix tools into ompi exports/bin

### DIFF
--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -87,7 +87,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
                 internal_pmix_libs="$internal_pmix_libs $opal_hwloc_LIBS"])
 
          AS_IF([test ! -z "$internal_pmix_libs"],
-               [internal_pmix_args="$internal_pmix_args --with-prte-extra-lib=\"$internal_pmix_libs\""])
+               [internal_pmix_args="$internal_pmix_args --with-pmix-extra-lib=\"$internal_pmix_libs\""])
 
          if test "$WANT_DEBUG" = "1"; then
              internal_pmix_args="$internal_pmix_args --enable-debug"

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -70,7 +70,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
     m4_ifdef([package_pmix],
         [# always configure the internal pmix, so that
          # make dist always works.
-	 internal_pmix_args="--without-tests-examples --disable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
+	 internal_pmix_args="--without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
          internal_pmix_libs=
          internal_pmix_CPPFLAGS=
 


### PR DESCRIPTION
config/pmix: Fix typo bug with internal_pmix_args. 

prte -> pmix

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 3349a8d)
 
Enable pmix binaries in ompi builds. 

Related to open-mpi#7285.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 5a2f50d)