### PR TITLE
coll/basic: correctly handle zero size datatypes in gatherv/scatterv

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -9,8 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2021 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -49,6 +49,7 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
     int i, rank, size, err;
     char *ptmp;
     ptrdiff_t lb, extent;
+    size_t sdsize;
 
     /* Initialize */
 
@@ -58,12 +59,20 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
     /* If not root, receive data. */
 
     if (rank != root) {
+        size_t rdsize;
+        ompi_datatype_type_size(rdtype, &rdsize);
         /* Only receive if there is something to receive */
-        if (rcount > 0) {
+        if (rcount > 0 && rdsize > 0) {
             return MCA_PML_CALL(recv(rbuf, rcount, rdtype,
                                      root, MCA_COLL_BASE_TAG_SCATTERV,
                                      comm, MPI_STATUS_IGNORE));
         }
+        return MPI_SUCCESS;
+    }
+
+    ompi_datatype_type_size(sdtype, &sdsize);
+    if (OPAL_UNLIKELY(0 == sdsize)) {
+        /* bozzo case */
         return MPI_SUCCESS;
     }
 


### PR DESCRIPTION
Since no message is sent/received when the count is zero,
do not send/receive any message when the datatype size is zero.

Refs. open-mpi/ompi#9619

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>