### PR TITLE
Update mpirun

### DIFF
--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -252,7 +252,7 @@ dnl succeeded.
 AC_DEFUN([_OMPI_SETUP_PRRTE_INTERNAL_POST], [
     OPAL_3RDPARTY_SUBDIRS="$OPAL_3RDPARTY_SUBDIRS prrte"
 
-    PRTE_PATH="prte"
+    PRTE_PATH="$prefix"
 ])
 
 
@@ -288,12 +288,12 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_EXTERNAL], [
 
     AS_IF([test "$setup_prrte_external_happy" = "yes"],
           [AS_IF([test -n "$with_prrte"],
-                 [PRTE_PATH="${with_prrte}/bin/prte"
-                  AS_IF([test ! -r ${PRTE_PATH}], [AC_MSG_ERROR([Could not find prte binary at $PRTE_PATH])])],
+                 [PRTE_PATH="${with_prrte}"
+                  AS_IF([test ! -r ${PRTE_PATH}/bin/prterun], [AC_MSG_ERROR([Could not find prterun binary at $PRTE_PATH])])],
 		 [PRTE_PATH=""
-                  OPAL_WHICH([prte], [PRTE_PATH])
+                  OPAL_WHICH([prterun], [PRTE_PATH])
                   AS_IF([tets -z "$PRTE_PATH"],
-                        [AC_MSG_WARN([Could not find prte in PATH])
+                        [AC_MSG_WARN([Could not find prterun in PATH])
                          setup_prrte_external_happy=no])])])
 
     AS_IF([test "$setup_prrte_external_happy" = "yes"],

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -144,6 +144,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
     AC_SUBST(opal_pmix_CPPFLAGS)
     AC_SUBST(opal_pmix_LDFLAGS)
     AC_SUBST(opal_pmix_LIBS)
+    AC_SUBST(OPAL_PMIX_PATH)
 
     OPAL_SUMMARY_ADD([[Miscellaneous]], [[pmix]], [pmix], [$opal_pmix_mode])
 
@@ -202,9 +203,13 @@ AC_DEFUN([_OPAL_CONFIG_PMIX_EXTERNAL], [
            LIBS="$opal_pmix_LIBS_save"
 
            AS_IF([test "$opal_pmix_external_support" = "yes"],
-                 [$1],
+                 [$1
+                  AS_IF([test -n "$with_pmix"],
+                        [OPAL_PMIX_PATH="${with_pmix}"],
+                        [OPAL_PMIX_PATH=""])],
                  [CPPFLAGS="$opal_pmix_CPPFLAGS_save"
-                  $2])])
+                  $2
+                  OPAL_PMIX_PATH=""])])
 
     OPAL_VAR_SCOPE_POP
 ])
@@ -223,5 +228,6 @@ AC_DEFUN([_OPAL_CONFIG_PMIX_INTERNAL_POST], [
 
     opal_pmix_header="$OMPI_TOP_SRCDIR/opal/mca/pmix/pmix-3rdparty.h"
 
+    OPAL_PMIX_PATH="$prefix"
     OPAL_3RDPARTY_SUBDIRS="$OPAL_3RDPARTY_SUBDIRS openpmix"
 ])

--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -13,6 +13,10 @@
 
 if OMPI_WANT_PRRTE
 
+AM_CFLAGS = \
+            -DPRTE_PATH="\"@PRTE_PATH@\"" \
+            -DOPAL_PMIX_PATH="\"@OPAL_PMIX_PATH@\""
+
 bin_PROGRAMS = mpirun
 
 mpirun_SOURCES = \

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char *argv[])
 {
-    char *evar, *pvar;
+    char *evar;
     char **pargs = NULL;
     char *pfx = NULL;
     int m, param_len;
@@ -35,16 +35,16 @@ int main(int argc, char *argv[])
     if (NULL != (evar = getenv("OPAL_PREFIX"))) {
 
 #if OMPI_USING_INTERNAL_PRRTE
-        (void)asprintf(&pvar, "PRTE_PREFIX=%s", evar);
-        putenv(pvar);
+        setenv("PRTE_PREFIX", evar, true);
 #endif
 
 #if OPAL_USING_INTERNAL_PMIX
-        (void)asprintf(&pvar, "PMIX_PREFIX=%s", evar);
-        putenv(pvar);
+        setenv("PMIX_PREFIX", evar, true);
 #endif
     }
-    putenv("PRTE_MCA_schizo_proxy=ompi");
+    setenv("PRTE_MCA_schizo_proxy", "ompi", true);
+    // set the PRRTE basename to match ours
+    setenv("PRTE_BASENAME", argv[0], true);
 
     opal_argv_append_nosize(&pargs, "prterun");
     for (m=1; NULL != argv[m]; m++) {
@@ -78,6 +78,32 @@ int main(int argc, char *argv[])
         if (NULL != opal_install_dirs.bindir) {
             pfx = strdup(opal_install_dirs.bindir);
         }
+#else
+    } else {
+        char *tmp, *t2;
+        /* for external PRRTE, use the full path to prterun and set the lib */
+        if (NULL != PRTE_PATH) {
+            tmp = opal_basename(PRTE_PATH);
+            if (NULL != tmp && 0 != strcmp(tmp, "prterun")) {
+                /* this is a pure path */
+                asprintf(&pfx, "%s/bin", PRTE_PATH);
+                free(tmp);
+                tmp = opal_dirname(PRTE_PATH);
+            } else {
+                pfx = opal_dirname(PRTE_PATH);
+                /* we need to move up one more level to get to the lib directory */
+                t2 = opal_dirname(pfx);
+                asprintf(&tmp, "%s/lib", t2);
+                free(t2);
+            }
+        }
+        if (NULL != (evar = getenv("LD_LIBRARY_PATH"))) {
+            asprintf(&t2, "%s:%s", tmp, evar);
+            free(tmp);
+            tmp = t2;
+        }
+        setenv("LD_LIBRARY_PATH", tmp, true);
+        free(tmp);
 #endif
     }
 
@@ -93,6 +119,55 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
+    /* handle any external PMIx library path */
+#if !OPAL_USING_INTERNAL_PMIX
+    if (NULL != OPAL_PMIX_PATH) {
+        char *tmp;
+        asprintf(&tmp, "%s/lib", OPAL_PMIX_PATH);
+        if (NULL != (evar = getenv("LD_LIBRARY_PATH"))) {
+            char *t2;
+            asprintf(&t2, "%s:%s", tmp, evar);
+            free(tmp);
+            tmp = t2;
+        }
+        setenv("LD_LIBRARY_PATH", tmp, true);
+        free(tmp);
+    }
+#endif
+
+    /* handle any opal_output directives */
+    if (NULL != (evar = getenv("OPAL_OUTPUT_STDERR_FD"))) {
+        setenv("PRTE_OUTPUT_STDERR_FD", evar, true);
+        setenv("PMIX_OUTPUT_STDERR_FD", evar, true);
+
+    }
+    if (NULL != (evar = getenv("OPAL_OUTPUT_REDIRECT"))) {
+        setenv("PRTE_OUTPUT_REDIRECT", evar, true);
+        setenv("PMIX_OUTPUT_REDIRECT", evar, true);
+
+    }
+    if (NULL != (evar = getenv("OPAL_OUTPUT_SYSLOG_PRI"))) {
+        setenv("PRTE_OUTPUT_SYSLOG_PRI", evar, true);
+        setenv("PMIX_OUTPUT_SYSLOG_PRI", evar, true);
+
+    }
+    if (NULL != (evar = getenv("OPAL_OUTPUT_SYSLOG_IDENT"))) {
+        setenv("PRTE_OUTPUT_SYSLOG_IDENT", evar, true);
+        setenv("PMIX_OUTPUT_SYSLOG_IDENT", evar, true);
+
+    }
+    if (NULL != (evar = getenv("OPAL_OUTPUT_INTERNAL_TO_STDOUT"))) {
+        setenv("PRTE_OUTPUT_INTERNAL_TO_STDOUT", evar, true);
+        setenv("PMIX_OUTPUT_INTERNAL_TO_STDOUT", evar, true);
+
+    }
+    if (NULL != (evar = getenv("OPAL_OUTPUT_SUFFIX"))) {
+        setenv("PRTE_OUTPUT_SUFFIX", evar, true);
+        setenv("PMIX_OUTPUT_SUFFIX", evar, true);
+
+    }
+
+    /* exec prterun */
     execve(truepath, pargs, environ);
     fprintf(stderr, "The mpirun (\"%s\") cmd failed to exec its actual executable - your application will NOT execute. Error: %s\n",
                      truepath ? truepath : "NULL", strerror(errno));


### PR DESCRIPTION
Avoid use of "putenv" and use the safer "setenv" so we
don't have to worry about overwriting the envars we set.
Fix configure to look for the correct "prterun" binary
instead of "prte". Pass PRTE_PATH and OPAL_PMIX_PATH to
mpirun for use in defining paths.

Add PRTE_BASENAME envar so output from things like
"mpirun --help" show the correct basename.

Signed-off-by: Ralph Castain <rhc@pmix.org>