### PR TITLE
v5.0.x: coll/basic: Correctly handle zero size datatypes in scatterv/gatherv

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -9,8 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2021 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -49,6 +49,7 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
     int i, rank, size, err;
     char *ptmp;
     ptrdiff_t lb, extent;
+    size_t sdsize;
 
     /* Initialize */
 
@@ -58,12 +59,20 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
     /* If not root, receive data. */
 
     if (rank != root) {
+        size_t rdsize;
+        ompi_datatype_type_size(rdtype, &rdsize);
         /* Only receive if there is something to receive */
-        if (rcount > 0) {
+        if (rcount > 0 && rdsize > 0) {
             return MCA_PML_CALL(recv(rbuf, rcount, rdtype,
                                      root, MCA_COLL_BASE_TAG_SCATTERV,
                                      comm, MPI_STATUS_IGNORE));
         }
+        return MPI_SUCCESS;
+    }
+
+    ompi_datatype_type_size(sdtype, &sdsize);
+    if (OPAL_UNLIKELY(0 == sdsize)) {
+        /* bozzo case */
         return MPI_SUCCESS;
     }
 


### PR DESCRIPTION
- coll/basic: correctly handle zero size datatypes in scatterv
- coll/basic: correctly handle zero size datatypes in gatherv 