### PR TITLE
Fix misc. compiler warnings.

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -690,7 +690,7 @@ static int dpm_convert(opal_list_t *infos,
     char *ck, *ptr, *help_str = NULL;
     int rc;
     char **tmp;
-    dpm_conflicts_t *modifiers;
+    dpm_conflicts_t *modifiers = NULL;
     const char *attr;
 
     /* pick the modifiers to be checked */

--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -22,15 +22,9 @@
 #include "ompi/mca/bml/base/base.h"
 #include "ompi/mca/mtl/base/base.h"
 
-// In regular strncpy up to n bytes are copied, so if the 'to' buffer
-// was char string[16] and you called strncpy(string, , 16) you could
-// get 16 bytes of chars without a null.  My preferred API is to let
-// n be the size of the buffer, and to let n-1 chars be copied, and
-// to guarantee null termination.
 static void
 mystrncpy(char *to, const char *from, int n) {
-    strncpy(to, from, n-1);
-    to[n-1] = 0;
+    snprintf(to, n, "%s", from);
 }
 
 // For converting comm_method strings to comm_method id# and back.

--- a/ompi/mca/osc/base/base.h
+++ b/ompi/mca/osc/base/base.h
@@ -37,6 +37,9 @@ BEGIN_C_DECLS
 int ompi_osc_base_find_available(bool enable_progress_threads,
                                  bool enable_mpi_threads);
 
+void ompi_osc_base_set_memory_alignment(struct opal_info_t *info,
+                                        size_t *memory_alignment);
+
 int ompi_osc_base_select(ompi_win_t *win,
                          void **base,
                          size_t size,

--- a/ompi/mca/osc/base/osc_base_frame.c
+++ b/ompi/mca/osc/base/osc_base_frame.c
@@ -22,7 +22,7 @@
 #include "ompi/mca/mca.h"
 #include "opal/util/output.h"
 #include "opal/mca/base/base.h"
-
+#include "opal/include/opal/align.h"
 
 #include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
@@ -35,6 +35,24 @@
  */
 
 #include "ompi/mca/osc/base/static-components.h"
+
+void
+ompi_osc_base_set_memory_alignment(struct opal_info_t *info,
+                                   size_t *memory_alignment)
+{
+    int flag;
+    opal_cstring_t *align_info_str;
+
+    opal_info_get(info, "mpi_minimum_memory_alignment", &align_info_str, &flag);
+    if (flag) {
+        long long tmp_align = atoll(align_info_str->string);
+        OBJ_RELEASE(align_info_str);
+        if ((long long) OPAL_ALIGN_MIN < tmp_align) {
+            *memory_alignment = tmp_align;
+        }
+    }
+}
+
 
 int
 ompi_osc_base_find_available(bool enable_progress_threads,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -48,7 +48,6 @@
 #include "opal/util/arch.h"
 #include "opal/util/argv.h"
 #include "opal/util/printf.h"
-#include "opal/align.h"
 #include "opal/util/sys_limits.h"
 #if OPAL_CUDA_SUPPORT
 #include "opal/mca/common/cuda/common_cuda.h"
@@ -1321,8 +1320,6 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     int world_size = ompi_comm_size (comm);
     int init_limit = 256;
     int ret;
-    int flag;
-    char infoval[32];
     char *name;
 
     /* the osc/sm component is the exclusive provider for support for shared
@@ -1363,15 +1360,7 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     module->size = size;
     module->memory_alignment = mca_osc_rdma_component.memory_alignment;
     if (NULL != info) {
-        opal_cstring_t *align_info_str;
-        opal_info_get(info, "mpi_minimum_memory_alignment", &align_info_str, &flag);
-        if (flag) {
-            ssize_t tmp_align = atoll(align_info_str->string);
-            OBJ_RELEASE(align_info_str);
-            if (OPAL_ALIGN_MIN < tmp_align) {
-                module->memory_alignment = tmp_align;
-            }
-        }
+        ompi_osc_base_set_memory_alignment(info, &module->memory_alignment);
     }
 
     /* set the module so we properly cleanup */

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -29,7 +29,7 @@
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 #include "ompi/request/request.h"
 #include "opal/util/sys_limits.h"
-#include "opal/include/opal/align.h"
+#include "opal/align.h"
 #include "opal/util/info_subscriber.h"
 #include "opal/util/printf.h"
 #include "opal/mca/mpool/base/base.h"
@@ -196,7 +196,6 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     int comm_size = ompi_comm_size (comm);
     bool unlink_needed = false;
     int ret = OMPI_ERROR;
-    int flag;
     size_t memory_alignment = OPAL_ALIGN_MIN;
 
     if (OMPI_SUCCESS != (ret = check_win_ok(comm, flavor))) {
@@ -216,15 +215,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     if (OPAL_SUCCESS != ret) goto error;
 
     if (NULL != info) {
-        opal_cstring_t *align_info_str;
-        ret = opal_info_get(info, "mpi_minimum_memory_alignment", &align_info_str, &flag);
-        if (flag) {
-            ssize_t tmp_align = atoll(align_info_str->string);
-            OBJ_RELEASE(align_info_str);
-            if (OPAL_ALIGN_MIN < tmp_align) {
-                memory_alignment = tmp_align;
-            }
-        }
+        ompi_osc_base_set_memory_alignment(info, &memory_alignment);
     }
 
     /* fill in the function pointer part */

--- a/ompi/mpi/fortran/mpif-h/init_f.c
+++ b/ompi/mpi/fortran/mpif-h/init_f.c
@@ -22,16 +22,7 @@
 
 #include "ompi_config.h"
 
-#if (OPAL_HAVE_WEAK_SYMBOLS || ! OMPI_BUILD_MPI_PROFILING)
-#if OPAL_CC_USE_PRAGMA_IDENT
-#pragma ident OMPI_IDENT_STRING
-#elif OPAL_CC_USE_IDENT
-#ident OMPI_IDENT_STRING
-#else
 const char ident[] = OMPI_IDENT_STRING;
-#endif
-#endif
-
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 

--- a/ompi/mpiext/affinity/c/mpiext_affinity_str.c
+++ b/ompi/mpiext/affinity/c/mpiext_affinity_str.c
@@ -182,7 +182,7 @@ static int get_rsrc_exists(char str[OMPI_AFFINITY_STRING_MAX])
 {
     bool first = true;
     int i, num_cores, num_pus;
-    char tmp[BUFSIZ];
+    char tmp[OMPI_AFFINITY_STRING_MAX];
     const int stmp = sizeof(tmp) - 1;
     hwloc_obj_t socket, core, c2;
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -117,11 +117,6 @@ OPAL_DECLSPEC void (*__malloc_initialize_hook) (void) =
  */
 #include <float.h>
 
-#if OPAL_CC_USE_PRAGMA_IDENT
-#pragma ident OMPI_IDENT_STRING
-#elif OPAL_CC_USE_IDENT
-#ident OMPI_IDENT_STRING
-#endif
 const char ompi_version_string[] = OMPI_IDENT_STRING;
 
 /*

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1047,7 +1047,7 @@ static char *bitmap2rangestr(int bitmap)
                 } else {
                     snprintf(tmp, stmp, "%d-%d", range_start, range_end);
                 }
-                strncat(ret, tmp, sizeof(ret) - strlen(ret) - 1);
+		snprintf(ret + strlen(ret), BUFSIZ, "%s", tmp);
 
                 range_start = -999;
             }
@@ -1074,7 +1074,7 @@ static char *bitmap2rangestr(int bitmap)
         } else {
             snprintf(tmp, stmp, "%d-%d", range_start, range_end);
         }
-        strncat(ret, tmp, sizeof(ret) - strlen(ret) - 1);
+        snprintf(ret + strlen(ret), BUFSIZ, "%s",  tmp);
     }
 
     return ret;

--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -63,7 +63,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info, const char *hints)
     mca_mpool_base_module_t *mpool;
     void *mem = NULL;
     opal_cstring_t *align_info_str;
-    size_t memory_alignment = OPAL_ALIGN_MIN;
+    long long memory_alignment = OPAL_ALIGN_MIN;
 
     mpool_tree_item = mca_mpool_base_tree_item_get();
     if (!mpool_tree_item) {
@@ -76,7 +76,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info, const char *hints)
                       &align_info_str, &flag);
 
         if (flag) {
-            ssize_t tmp_align = atoll(align_info_str->string);
+            long long tmp_align = atoll(align_info_str->string);
             OBJ_RELEASE(align_info_str);
             if (tmp_align > memory_alignment) {
                 memory_alignment = tmp_align;

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -80,11 +80,6 @@
 #include "opal/util/sys_limits.h"
 #include "opal/util/timings.h"
 
-#if OPAL_CC_USE_PRAGMA_IDENT
-#    pragma ident OPAL_IDENT_STRING
-#elif OPAL_CC_USE_IDENT
-#    ident OPAL_IDENT_STRING
-#endif
 const char opal_version_string[] = OPAL_IDENT_STRING;
 
 int opal_initialized = 0;

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -499,7 +499,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
     int argc;
     size_t j;
     char **argv;
-    char *ret, temp[MAX_WIDTH * 2], line[MAX_WIDTH * 2];
+    char *ret, temp[(MAX_WIDTH * 2) - 1], line[MAX_WIDTH * 2];
     char *start, *desc, *ptr;
     opal_list_item_t *item;
     ompi_cmd_line_option_t *option, **sorted;


### PR DESCRIPTION
Found with gcc (GCC) 8.4.1 20200928 (Red Hat 8.4.1-1).

- cmd_line.c:579: warning: ‘strncat’ output may be truncated copying 151
                   bytes from a string of length 151 [-Wstringop-truncation]
- hwloc_base_util.c:1050: warning: ‘strncat’ output may be truncated
                           copying between 0 and 8191 bytes from a string
                           of length 8191 [-Wstringop-truncation]
- base/hwloc_base_util.c:1077: warning: ‘strncat’ output may be truncated
                                copying between 0 and 8191 bytes from a string
                                of length 8191 [-Wstringop-truncation]
- base/mpool_base_alloc.c:81: warning: comparison of integer expressions of
                               different signedness: ‘ssize_t’ {aka ‘long int’}
                               and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
- runtime/opal_init.c:86: warning: #ident is a GCC extension
- mpiext_affinity_str.c:200: warning: ‘strncat’ output may be truncated copying between
                              0 and 1024 bytes from a string of length 8191
                              [-Wstringop-truncation]
- mpiext_affinity_str.c:235: warning: ‘strncat’ output may be truncated copying between
                              0 and 1024 bytes from a string of length 8191
                              [-Wstringop-truncation]
- mpiext_affinity_str.c:251: warning: ‘strncat’ output may be truncated copying between
                              0 and 1024 bytes from a string of length 8191
                              [-Wstringop-truncation]
- mpiext_affinity_str.c:273: warning: ‘strncat’ output may be truncated copying between
                              0 and 1024 bytes from a string of length 8191
                              [-Wstringop-truncation]
- mpiext_affinity_str.c:226: warning: ‘strncat’ output may be truncated copying between
                              0 and 1024 bytes from a string of length 8191
                              [-Wstringop-truncation]
- hook_comm_method_fns.c:32: warning: ‘strncpy’ output may be truncated copying 15 bytes
                              from a string of length 63 [-Wstringop-truncation]
- osc_sm_component.c:224:32: warning: comparison of integer expressions of different
                              signedness: ‘long unsigned int’ and ‘ssize_t’
                              {aka ‘long int’} [-Wsign-compare]
- osc_sm_component.c:262:16: warning: declaration of ‘flag’ shadows a previous local
                              [-Wshadow]
- osc_sm_component.c:413:13: warning: declaration of ‘flag’ shadows a previous local
                              [-Wshadow]
- osc_rdma_component.c:1371: warning: comparison of integer expressions of different
                              signedness: ‘long unsigned int’ and ‘ssize_t’
                              {aka ‘long int’} [-Wsign-compare]
- osc_rdma_component.c:1325: warning: unused variable ‘infoval’ [-Wunused-variable]
- runtime/ompi_mpi_init.c:123: warning: #ident is a GCC extension
- dpm/dpm.c:667: warning: ‘modifiers’ may be used uninitialized in this function
                  [-Wmaybe-uninitialized]
- pinit_f.c:29: warning: #ident is a GCC extension

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>