### PR TITLE
v5.0.x: MPI4: add support for mpi_info_get_string

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1680,6 +1680,8 @@ OMPI_DECLSPEC  int MPI_Info_get_nkeys(MPI_Info info, int *nkeys);
 OMPI_DECLSPEC  int MPI_Info_get_nthkey(MPI_Info info, int n, char *key);
 OMPI_DECLSPEC  int MPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen,
                                          int *flag);
+OMPI_DECLSPEC  int MPI_Info_get_string(MPI_Info info, const char *key, int *buflen,
+                                       char *value, int *flag);
 OMPI_DECLSPEC  int MPI_Info_set(MPI_Info info, const char *key, const char *value);
 OMPI_DECLSPEC  int MPI_Init(int *argc, char ***argv);
 OMPI_DECLSPEC  int MPI_Initialized(int *flag);
@@ -2410,6 +2412,8 @@ OMPI_DECLSPEC  int PMPI_Info_get(MPI_Info info, const char *key, int valuelen,
                                  char *value, int *flag);
 OMPI_DECLSPEC  int PMPI_Info_get_nkeys(MPI_Info info, int *nkeys);
 OMPI_DECLSPEC  int PMPI_Info_get_nthkey(MPI_Info info, int n, char *key);
+OMPI_DECLSPEC  int PMPI_Info_get_string(MPI_Info info, const char *key, int *buflen,
+                                        char *value, int *flag);
 OMPI_DECLSPEC  int PMPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen,
                                           int *flag);
 OMPI_DECLSPEC  int PMPI_Info_set(MPI_Info info, const char *key, const char *value);

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -271,6 +271,7 @@ libmpi_c_mpi_la_SOURCES = \
         info_get.c \
         info_get_nkeys.c \
         info_get_nthkey.c \
+        info_get_string.c \
         info_get_valuelen.c \
         info_set.c \
         init.c \

--- a/ompi/mpi/c/info_get_string.c
+++ b/ompi/mpi/c/info_get_string.c
@@ -1,0 +1,119 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2021      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/info/info.h"
+#include "opal/util/string_copy.h"
+#include <stdlib.h>
+#include <string.h>
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Info_get_string = PMPI_Info_get_string
+#endif
+#define MPI_Info_get_string PMPI_Info_get_string
+#endif
+
+static const char FUNC_NAME[] = "MPI_Info_get_string";
+
+/**
+ *   MPI_Info_get_string - Get a (key, value) pair from an 'MPI_Info' object
+ *
+ *   @param info info object (handle)
+ *   @param key null-terminated character string of the index key
+ *   @param buflen maximum length of 'value' (integer)
+ *   @param value null-terminated character string of the value
+ *   @param flag true (1) if 'key' defined on 'info', false (0) if not
+ *               (logical)
+ *
+ *   @retval MPI_SUCCESS
+ *   @retval MPI_ERR_ARG
+ *   @retval MPI_ERR_INFO
+ *   @retval MPI_ERR_INFO_KEY
+ *   @retval MPI_ERR_INFO_VALUE
+ *
+ */
+int MPI_Info_get_string(MPI_Info info, const char *key, int *buflen,
+                        char *value, int *flag)
+{
+    int err;
+    int key_length;
+    opal_cstring_t *info_str;
+
+    /*
+     * Simple function. All we need to do is search for the value
+     * having the "key" associated with it and then populate the
+     * necessary structures.
+     */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == info || MPI_INFO_NULL == info ||
+            ompi_info_is_freed(info)) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO,
+                                          FUNC_NAME);
+        }
+
+        key_length = (key) ? (int)strlen (key) : 0;
+        if ((NULL == key) || (0 == key_length) ||
+            (MPI_MAX_INFO_KEY <= key_length)) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO_KEY,
+                                          FUNC_NAME);
+        }
+        if (NULL == buflen) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
+                                          FUNC_NAME);
+        }
+        if ((NULL == value) && *buflen) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO_VALUE,
+                                          FUNC_NAME);
+        }
+        if (NULL == flag) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
+                                          FUNC_NAME);
+        }
+    }
+
+    if (0 == *buflen) {
+        err = ompi_info_get_valuelen(info, key, buflen, flag);
+        if (1 == *flag) {
+            *buflen += 1; /* add on for the \0, see MPI 4.0 Standard */
+        }
+    } else {
+        err = ompi_info_get(info, key, &info_str, flag);
+        if (*flag) {
+            opal_string_copy(value, info_str->string, *buflen);
+            *buflen = info_str->length + 1; /* add on for the \0, see MPI 4.0 Standard */
+            OBJ_RELEASE(info_str);
+        }
+    }
+
+    OMPI_ERRHANDLER_NOHANDLE_RETURN(err, err, FUNC_NAME);
+}

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -251,6 +251,7 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pinfo_get.c \
         pinfo_get_nkeys.c \
         pinfo_get_nthkey.c \
+        pinfo_get_string.c \
         pinfo_get_valuelen.c \
         pinfo_set.c \
         pinit.c \

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -334,6 +334,7 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         info_get_f.c \
         info_get_nkeys_f.c \
         info_get_nthkey_f.c \
+        info_get_string_f.c \
         info_get_valuelen_f.c \
         info_set_f.c \
         init_f.c \

--- a/ompi/mpi/fortran/mpif-h/info_get_string_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_string_f.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/constants.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/info/info.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_INFO_GET_STRING = ompi_info_get_string_f
+#pragma weak pmpi_info_get_string = ompi_info_get_string_f
+#pragma weak pmpi_info_get_string_ = ompi_info_get_string_f
+#pragma weak pmpi_info_get_string__ = ompi_info_get_string_f
+
+#pragma weak PMPI_Info_get_string_f = ompi_info_get_string_f
+#pragma weak PMPI_Info_get_string_f08 = ompi_info_get_string_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_INFO_GET_STRING,
+                            pmpi_info_get_string,
+                            pmpi_info_get_string_,
+                            pmpi_info_get_string__,
+                            pompi_info_get_string_f,
+                            (MPI_Fint *info, char *key, MPI_Fint *buflen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len),
+                            (info, key, valuelen, value, flag, ierr, key_len, value_len) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_INFO_GET_STRING = ompi_info_get_string_f
+#pragma weak mpi_info_get_string = ompi_info_get_string_f
+#pragma weak mpi_info_get_string_ = ompi_info_get_string_f
+#pragma weak mpi_info_get_string__ = ompi_info_get_string_f
+
+#pragma weak MPI_Info_get_string_f = ompi_info_get_string_f
+#pragma weak MPI_Info_get_string_f08 = ompi_info_get_string_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_INFO_GET_STRING,
+                            mpi_info_get_string,
+                            mpi_info_get_string_,
+                            mpi_info_get_string__,
+                            ompi_info_get_string_f,
+                            (MPI_Fint *info, char *key, MPI_Fint *buflen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len),
+                            (info, key, valuelen, value, flag, ierr, key_len, value_len) )
+#else
+#define ompi_info_get_string_f pompi_info_get_string_f
+#endif
+#endif
+
+
+static const char FUNC_NAME[] = "MPI_INFO_GET_STRING";
+
+/* Note that the key_len and value_len parameters are silently added
+   by the Fortran compiler, and will be filled in with the actual
+   length of the character array from the caller.  Hence, it's the max
+   length of the string that we can use. */
+
+void ompi_info_get_string_f(MPI_Fint *info, char *key, MPI_Fint *buflen,
+                            char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr,
+                            int key_len, int value_len)
+{
+    int c_ierr, ret;
+    MPI_Info c_info;
+    char *c_key = NULL;
+    OMPI_SINGLE_NAME_DECL(buflen);
+    OMPI_LOGICAL_NAME_DECL(flag);
+    opal_cstring_t *info_str;
+
+    if (OMPI_SUCCESS != (ret = ompi_fortran_string_f2c(key, key_len, &c_key))) {
+        c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    c_info = PMPI_Info_f2c(*info);
+
+    if (0 == *buflen) {
+        c_ierr = ompi_info_get_valuelen(c_info, c_key,
+                                       OMPI_SINGLE_NAME_CONVERT(buflen),
+                                       OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+        if (MPI_SUCCESS == c_ierr) {
+            OMPI_SINGLE_INT_2_FINT(buflen);
+            OMPI_SINGLE_INT_2_LOGICAL(flag);
+        }
+    } else { 
+        c_ierr = ompi_info_get(c_info, c_key, &info_str,
+                               OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+        if (NULL != ierr) {
+            *ierr = OMPI_INT_2_FINT(c_ierr);
+        }
+        
+
+        if (MPI_SUCCESS == c_ierr) {
+            OMPI_SINGLE_INT_2_LOGICAL(flag);
+
+            /* If we found the info key, copy the value back to the
+               Fortran string (note: all Fortran compilers have FALSE ==
+               0, so just check for any nonzero value, because not all
+               Fortran compilers have TRUE == 1).  Note: use the full
+               length of the Fortran string, which means adding one to the 3rd arg 
+               to ompi_fortran_string_c2f */
+            if (*flag) {
+                if (OMPI_SUCCESS !=
+                  (ret = ompi_fortran_string_c2f(info_str->string, value, value_len + 1))) {
+                    c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+                    if (NULL != ierr) {
+                        *ierr = OMPI_INT_2_FINT(c_ierr);
+                    }
+                }
+                *buflen = info_str->length;
+                OBJ_RELEASE(info_str);
+            }
+        }
+    }
+
+    if (NULL != c_key) {
+        free(c_key);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/info_get_string_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_string_f.c
@@ -43,7 +43,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_INFO_GET_STRING,
                             pmpi_info_get_string__,
                             pompi_info_get_string_f,
                             (MPI_Fint *info, char *key, MPI_Fint *buflen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len),
-                            (info, key, valuelen, value, flag, ierr, key_len, value_len) )
+                            (info, key, buflen, value, flag, ierr, key_len, value_len) )
 #endif
 #endif
 
@@ -63,7 +63,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_INFO_GET_STRING,
                             mpi_info_get_string__,
                             ompi_info_get_string_f,
                             (MPI_Fint *info, char *key, MPI_Fint *buflen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len),
-                            (info, key, valuelen, value, flag, ierr, key_len, value_len) )
+                            (info, key, buflen, value, flag, ierr, key_len, value_len) )
 #else
 #define ompi_info_get_string_f pompi_info_get_string_f
 #endif

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -247,6 +247,7 @@ linked_files = \
         pinfo_get_f.c \
         pinfo_get_nkeys_f.c \
         pinfo_get_nthkey_f.c \
+        pinfo_get_string_f.c \
         pinfo_get_valuelen_f.c \
         pinfo_set_f.c \
         pinit_f.c \

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -304,6 +304,7 @@ PN2(void, MPI_Info_free, mpi_info_free, MPI_INFO_FREE, (MPI_Fint *info, MPI_Fint
 PN2(void, MPI_Info_get, mpi_info_get, MPI_INFO_GET, (MPI_Fint *info, char *key, MPI_Fint *valuelen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len));
 PN2(void, MPI_Info_get_nkeys, mpi_info_get_nkeys, MPI_INFO_GET_NKEYS, (MPI_Fint *info, MPI_Fint *nkeys, MPI_Fint *ierr));
 PN2(void, MPI_Info_get_nthkey, mpi_info_get_nthkey, MPI_INFO_GET_NTHKEY, (MPI_Fint *info, MPI_Fint *n, char *key, MPI_Fint *ierr, int key_len));
+PN2(void, MPI_Info_get_string, mpi_info_get_string, MPI_INFO_GET_STRING, (MPI_Fint *info, char *key, MPI_Fint *buflen, char *value, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len, int value_len));
 PN2(void, MPI_Info_get_valuelen, mpi_info_get_valuelen, MPI_INFO_GET_VALUELEN, (MPI_Fint *info, char *key, MPI_Fint *valuelen, ompi_fortran_logical_t *flag, MPI_Fint *ierr, int key_len));
 PN2(void, MPI_Info_set, mpi_info_set, MPI_INFO_SET, (MPI_Fint *info, char *key, char *value, MPI_Fint *ierr, int key_len, int value_len));
 PN2(void, MPI_Init, mpi_init, MPI_INIT, (MPI_Fint *ierr));

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -318,6 +318,7 @@ mpi_api_files = \
         info_get_nkeys_f08.F90 \
         info_get_nthkey_f08.F90 \
         info_get_valuelen_f08.F90 \
+        info_get_string_f08.F90 \
         info_set_f08.F90 \
         init_f08.F90 \
         initialized_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/info_get_string_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/info_get_string_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! Copyright (c) 2019-2020 Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! $COPYRIGHT$
+
+#include "mpi-f08-rename.h"
+
+subroutine MPI_Info_get_string_f08(info,key,buflen,value,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Info
+   ! See note in mpi-f-interfaces-bind.h for why we "use mpi" here and
+   ! call a PMPI_* subroutine below.
+   use :: mpi, only : PMPI_Info_get_string
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   CHARACTER(LEN=*), INTENT(IN) :: key
+   INTEGER, INTENT(INOUT) :: buflen
+   CHARACTER(LEN=*), INTENT(OUT) :: value
+   LOGICAL, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call PMPI_Info_get_string(info%MPI_VAL,key,buflen,value,flag,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+end subroutine MPI_Info_get_string_f08

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
@@ -2969,6 +2969,19 @@ subroutine MPI_Info_set_f08(info,key,value,ierror)
 end subroutine MPI_Info_set_f08
 end interface  MPI_Info_set
 
+interface  MPI_Info_get_string
+subroutine MPI_Info_get_string_f08(info,key,buflen,value,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Info
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   CHARACTER(LEN=*), INTENT(IN) :: key
+   INTEGER, INTENT(INOUT) :: buflen
+   CHARACTER(LEN=*), INTENT(OUT) :: value
+   LOGICAL, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Info_get_string_f08
+end interface  MPI_Info_get_string
+
 interface  MPI_Close_port
 subroutine MPI_Close_port_f08(port_name,ierror)
    implicit none

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-rename.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-rename.h
@@ -483,6 +483,8 @@
 #define MPI_Info_get_nkeys_f08 PMPI_Info_get_nkeys_f08
 #define MPI_Info_get_nthkey PMPI_Info_get_nthkey
 #define MPI_Info_get_nthkey_f08 PMPI_Info_get_nthkey_f08
+#define MPI_Info_get_string PMPI_Info_get_string
+#define MPI_Info_get_string_f08 PMPI_Info_get_string_f08
 #define MPI_Info_get_valuelen PMPI_Info_get_valuelen
 #define MPI_Info_get_valuelen_f08 PMPI_Info_get_valuelen_f08
 #define MPI_Info_set PMPI_Info_set

--- a/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
@@ -253,6 +253,7 @@ pmpi_api_files = \
         pinfo_get_f08.F90 \
         pinfo_get_nkeys_f08.F90 \
         pinfo_get_nthkey_f08.F90 \
+        pinfo_get_string_f08.F90 \
         pinfo_get_valuelen_f08.F90 \
         pinfo_set_f08.F90 \
         pinit_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -2195,6 +2195,19 @@ end subroutine MPI_Info_get_nthkey
 
 end interface
 
+interface
+
+subroutine MPI_Info_get_string(info, key, buflen, value, flag, ierror)
+  integer, intent(in) :: info
+  character(len=*), intent(in) :: key
+  integer, intent(inout) :: buflen
+  character(len=*), intent(out) :: value
+  logical, intent(out) :: flag
+  integer, intent(out) :: ierror
+end subroutine MPI_Info_get_string
+
+end interface
+
 
 interface
 

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
@@ -157,6 +157,7 @@
 #define MPI_Info_get PMPI_Info_get
 #define MPI_Info_get_nkeys PMPI_Info_get_nkeys
 #define MPI_Info_get_nthkey PMPI_Info_get_nthkey
+#define MPI_Info_get_string PMPI_Info_get_string
 #define MPI_Info_get_valuelen PMPI_Info_get_valuelen
 #define MPI_Info_set PMPI_Info_set
 #define MPI_Init PMPI_Init

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
@@ -1022,6 +1022,19 @@ end interface
 
 interface
 
+subroutine MPI_Info_get_string(info, key, buflen, value, flag, ierror)
+  integer, intent(in) :: info
+  character(len=*), intent(in) :: key
+  integer, intent(inout) :: buflen
+  character(len=*), intent(out) :: value
+  logical, intent(out) :: flag
+  integer, intent(out) :: ierror
+end subroutine MPI_Info_get_string
+
+end interface
+
+interface
+
 subroutine MPI_Info_get_valuelen(info, key, valuelen, flag, ierror)
   integer, intent(in) :: info
   character(len=*), intent(in) :: key

--- a/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
@@ -92,6 +92,7 @@
 #define MPI_Info_get PMPI_Info_get
 #define MPI_Info_get_nkeys PMPI_Info_get_nkeys
 #define MPI_Info_get_nthkey PMPI_Info_get_nthkey
+#define MPI_Info_get_string PMPI_Info_get_string
 #define MPI_Info_get_valuelen PMPI_Info_get_valuelen
 #define MPI_Info_set PMPI_Info_set
 #define MPI_Init PMPI_Init

--- a/ompi/mpi/man/man3/MPI_Info_get_string.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get_string.3in
@@ -1,0 +1,104 @@
+.\" -*- nroff -*-
+.\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2020      Google, LLC. All rights reserved.
+.\" $COPYRIGHT$
+.TH MPI_Info_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Info_get_string\fP \- Retrieves the value associated with a key in an info object.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Info_get_string(MPI_Info \fIinfo\fP, const char \fI*key\fP, int *\fIbuflen\fP, char \fI*value\fP, int *\fIflag\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_INFO_GET_STRING(\fIINFO, KEY, BUFLEN, VALUE, FLAG, IERROR\fP)
+	INTEGER	\fIINFO, BUFLEN, IERROR\fP
+	CHARACTER*(*) \fIKEY, VALUE\fP
+	LOGICAL \fIFLAG\fP
+
+.fi
+.SH Fortran 2008 Syntax
+.nf
+USE mpi_f08
+MPI_Info_get_string(\fIinfo\fP, \fIkey\fP, \fIbuflen\fP, \fIvalue\fP, \fIflag\fP, \fIierror\fP)
+	TYPE(MPI_Info), INTENT(IN) :: \fIinfo\fP
+	CHARACTER(LEN=*), INTENT(IN) :: \fIkey\fP
+	INTEGER, INTENT(INOUT) :: \fIbuflen\fP
+	CHARACTER(LEN=valuelen), INTENT(OUT) :: \fIvalue\fP
+	LOGICAL, INTENT(OUT) :: \fIflag\fP
+	INTEGER, OPTIONAL, INTENT(OUT) :: \fIierror\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+info
+Info object (handle).
+.ft R
+.TP 1i
+key
+Key (string).
+
+.SH OUTPUT PARAMETER
+.ft R
+.ft 1i
+buflen
+On entry, length of value arg.  On return, set to required size to hold value string (integer).
+.ft R
+.TP 1i
+value
+Value (string).
+.ft R
+.TP 1i
+flag
+Returns true if key defined, false if not (boolean).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+MPI_Info_get_string retrieves the value associated with \fIkey\fP from \fIinfo\fP, if any. If such a key exists in info, it sets \fIflag\fP to true and returns the value in \fIvalue\fP, otherwise it sets 
+flag to false and leaves value unchanged. \fIbuflen\fP on input is the size of the provided buffer, for the output of buflen it is the size of the buffer needed to store the value string. 
+If the buflen passed into the function is less than the actual size needed to store the value string (including null terminator in C), the value is truncated. On return, 
+the value of \fIbuflen\fP will be set to the required buffer size to hold the value string. If buflen is set to 0, value is not changed. In C, \fIbuflen\fP includes the required space for the 
+null terminator. In C, this function returns a null terminated string in all cases where the \fIbuflen\fP input value is greater than 0.
+
+If \fIkey\fP is larger than MPI_MAX_INFO_KEY, the call is erroneous.
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft r
+MPI_Info_create
+.br
+MPI_Info_delete
+.br
+MPI_Info_dup
+.br
+MPI_Info_free
+.br
+MPI_Info_get_valuelen
+.br
+MPI_Info_get_nkeys
+.br
+MPI_Info_get_nthkey
+.br
+MPI_Info_set
+.br
+

--- a/ompi/mpi/man/man3/MPI_Info_get_string.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get_string.3in
@@ -93,8 +93,6 @@ MPI_Info_dup
 .br
 MPI_Info_free
 .br
-MPI_Info_get_valuelen
-.br
 MPI_Info_get_nkeys
 .br
 MPI_Info_get_nthkey

--- a/ompi/mpi/man/man3/Makefile.am
+++ b/ompi/mpi/man/man3/Makefile.am
@@ -247,6 +247,7 @@ TEMPLATE_FILES = \
         MPI_Info_get.3in \
         MPI_Info_get_nkeys.3in \
         MPI_Info_get_nthkey.3in \
+        MPI_Info_get_string.3in \
         MPI_Info_get_valuelen.3in \
         MPI_Info_set.3in \
         MPI_Init.3in \


### PR DESCRIPTION
- MPI4: add support for mpi_info_get_string 
- fix a problem with f77 binding generation 
- add a makefile for MPI_Info_get_string 

cherry-picks of https://github.com/open-mpi/ompi/pull/9546