### PR TITLE
v5.0.x: Skip running PMIX/PRRTE configure when not needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2017-2020 Amazon.com, Inc. or its affiliates.
+# Copyright (c) 2017-2021 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
@@ -32,6 +32,14 @@ dist-hook:
 	env LS_COLORS= sh "$(top_srcdir)/config/distscript.sh" "$(top_srcdir)" "$(distdir)" "$(OMPI_REPO_REV)"
 	@if test ! -s $(distdir)/AUTHORS ; then \
 		echo "AUTHORS file is empty; aborting distribution"; \
+		exit 1; \
+	fi
+	@if test -n "$(OPAL_MAKEDIST_DISABLE)" ; then \
+		echo "#########################################################################"; \
+		echo "#"; \
+		echo "# make dist is disabled due to the following packages: $(OPAL_MAKEDIST_DISABLE)"; \
+		echo "#"; \
+		echo "#########################################################################"; \
 		exit 1; \
 	fi
 

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -45,15 +45,21 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
 
     OPAL_3RDPARTY_WITH([prrte], [prrte], [package_prrte], [1])
 
-    m4_ifdef([package_prrte],
-         [OMPI_PRRTE_ADD_ARGS])
-
     prrte_setup_internal_happy=0
-    m4_ifdef([package_prrte], [
-         # always configure the internal prrte, so that
-         # make dist always works.
-         AS_IF([test "$opal_prrte_mode" = "disabled"], [prrte_setup_success_var=0], [prrte_setup_success_var=1])
-         _OMPI_SETUP_PRRTE_INTERNAL([prrte_setup_internal_happy=$prrte_setup_success_var])])
+    m4_ifdef([package_prrte],
+        [OMPI_PRRTE_ADD_ARGS
+         AS_IF([test "$opal_prrte_mode" = "unspecified" -o "$opal_prrte_mode" = "internal"],
+               [# Run PRRTE's configure script unless the user
+		# explicitly asked us to use an external PMIX, so that
+		# "make dist" includes PRRTE in the dist tarball.  This
+		# does mean that "make dist" will not work if Open MPI
+		# was configured to use an external PRRTE library, but
+		# we decided this was a reasonable tradeoff for not
+		# having to deal with PRRTE (or PMIx) potentially
+		# failing to configure in a situation where it isn't
+		# desired.
+                _OMPI_SETUP_PRRTE_INTERNAL([prrte_setup_internal_happy=1],
+                                           [prrte_setup_internal_happy=0])])])
 
     # unless internal specifically requested by the user, try to find
     # an external that works.

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -16,7 +16,7 @@ dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
+dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
@@ -43,39 +43,10 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
 
     opal_show_subtitle "Configuring PRRTE"
 
-    # Don't use OPAL_3RDPARTY_WITH because it will not allow packages
-    # to be disabled
-    m4_ifdef([package_prrte],
-        [AC_ARG_WITH([prrte],
-            [AS_HELP_STRING([--with-prrte(=DIR)],
-                           [Build PRTE support.  DIR can take one of four values: "internal", "external", "no", or a valid directory name.  "internal" forces Open MPI to use its internal copy of PRRTE.  "external" forces Open MPI to use an external installation of PRRTE.  Supplying a valid directory name also forces Open MPI to use an external installation of PRRTE, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. If no argument is specified, Open MPI will search default locations for PRRTE and fall back to an internal version if one is not found.])])],
-        [AC_ARG_WITH([prrte],
-            [AS_HELP_STRING([--with-prrte(=DIR)],
-                           [Build PRRTE support.  DIR can take one of three values:  "external", "no", or a valid directory name.  "external" forces Open MPI to use an external installation of PRRTE.  Supplying a valid directory name also forces Open MPI to use an external installation of PRRTE, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. If no argument is specified, Open MPI will search default locations for PRRTE and disable creating mpirun symlinks if one is not found.])])])
+    OPAL_3RDPARTY_WITH([prrte], [prrte], [package_prrte], [1])
 
     m4_ifdef([package_prrte],
          [OMPI_PRRTE_ADD_ARGS])
-
-    # clean up $with_prrte so that it contains only a path or empty
-    # string.  To determine internal or external preferences, use
-    # $opal_prrte_mode.
-    AS_IF([test "$with_prrte" = "yes"], [with_prrte=])
-    AS_CASE([$with_prrte],
-            ["internal"], [with_prrte=""
-                           opal_prrte_mode="internal"],
-            ["external"], [with_prrte=""
-                           opal_prrte_mode="external"],
-            [""], [opal_prrte_mode="unspecified"],
-            ["no"], [opal_prrte_mode="disabled"],
-            [opal_prrte_mode="external"])
-
-    echo "with_prrte: $with_prrte"
-    echo "opal_prrte_mode: $opal_prrte_mode"
-
-    m4_ifdef([package_prrte], [],
-             [AS_IF([test "$opal_prrte_mode" = "internal"],
-                    [AC_MSG_WARN([Invalid argument to --with-prrte: internal.])
-                     AC_MSG_ERROR([Cannot continue])])])
 
     prrte_setup_internal_happy=0
     m4_ifdef([package_prrte], [

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -59,7 +59,12 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
 		# failing to configure in a situation where it isn't
 		# desired.
                 _OMPI_SETUP_PRRTE_INTERNAL([prrte_setup_internal_happy=1],
-                                           [prrte_setup_internal_happy=0])])])
+                                           [prrte_setup_internal_happy=0])])
+
+         # if we have a pmix package and configure did not complete
+         # successfullly (or wasn't started), then disable make dist.
+         AS_IF([test $prrte_setup_internal_happy != 1],
+               [OPAL_MAKEDIST_DISABLE="$OPAL_MAKEDIST_DISABLE PRRTE"])])
 
     # unless internal specifically requested by the user, try to find
     # an external that works.

--- a/config/opal_config_3rdparty.m4
+++ b/config/opal_config_3rdparty.m4
@@ -4,7 +4,7 @@ dnl Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
@@ -13,44 +13,58 @@ dnl
 dnl $HEADER$
 dnl
 
-dnl OPAL_3RDPARTY_WITH(short package name, long package name, internal supported)
+dnl OPAL_3RDPARTY_WITH(short package name, long package name,
+dnl                    internal supported, disabled ok)
 dnl
 dnl Basic --with-pkg/--with-pkg-libdir handling for 3rd party
 dnl packages, with the big long description of internal/external/path
 dnl handling.
 dnl
 dnl At the end of this macro, with_pkg will contain an empty string or
-dnl a path (implying external).  Further, the shell variable opal_pkg_mode
-dnl will be set to "internal", "external", or "unspecified".  If a path is
-dnl given to --with-pkg, then opal_pkg_mode will be set to external.
+dnl a path (the later implying external).  Further, the shell variable
+dnl opal_pkg_mode will be set to "internal", "external",
+dnl "unspecified", or "disabled".  If a path is given to --with-pkg, then
+dnl opal_pkg_mode will be set to external.  If "internal supported" is
+dnl not defined, then opal_pkg_mode will not be internal.  If
+dnl "disabled ok" is not defined, then opal_pkg_mode will not be
+dnl "disabled".
 dnl
 dnl If m4_ifdef(internal support) does not evaluate to true (ie, at
 dnl autogen time), the references to internal in the help strings will
 dnl be removed and internal will not be a supported option.
 dnl
+dnl If m4_ifval(ddisbaled ok) does not evaluete to true (ie, at autogen
+dnl time), then --without-pkg will not be a valid configure option and
+dnl will raise an error.
+dnl
 dnl $1: short package name
 dnl $2: long pacakage name
 AC_DEFUN([OPAL_3RDPARTY_WITH], [
-    m4_ifdef([$3],
-        [AC_ARG_WITH([$1],
-            [AS_HELP_STRING([--with-$1(=DIR)],
-                           [Build $2 support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" forces Open MPI to use its internal copy of $2.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI no longer supports --without-$1.  If no argument is specified, Open MPI will search default locations for $2 and fall back to an internal version if one is not found.])])
+    m4_ifval([$4],
+        [m4_ifdef([$3],
+            [AC_ARG_WITH([$1],
+                [AS_HELP_STRING([--with-$1(=DIR)],
+                                [Build $2 support.  DIR can take one of four values: "internal", "external", "no", or a valid directory name.  "internal" forces Open MPI to use its internal copy of $2.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. "no" means that Open MPI will not build components that require this package.  If no argument is specified, Open MPI will search default locations for $2 and fall back to an internal version if one is not found.])])],
+            [AC_ARG_WITH([$1],
+                [AS_HELP_STRING([--with-$1(=DIR)],
+                                [Build $2 support.  DIR can take one of three values: "external", "no", or a valid directory name.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. "no" means that Open MPI will not build components that require this package.  If no argument is specified, Open MPI will search default locations for $2 and error if one is not found.])])])],
+        [m4_ifdef([$3],
+            [AC_ARG_WITH([$1],
+                [AS_HELP_STRING([--with-$1(=DIR)],
+                                [Build $2 support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" forces Open MPI to use its internal copy of $2.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI no longer supports --without-$1.  If no argument is specified, Open MPI will search default locations for $2 and fall back to an internal version if one is not found.])])],
+            [AC_ARG_WITH([$1],
+                [AS_HELP_STRING([--with-$1(=DIR)],
+                                [Build $2 support.  DIR can take one of two values: "external" or a valid directory name.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI no longer supports --without-$1.  If no argument is specified, Open MPI will search default locations for $2 and error if one is not found.])])])])
 
-         AC_ARG_WITH([$1-libdir],
-            [AS_HELP_STRING([--with-$1-libdir=DIR],
-             [Search for $2 libraries in DIR.  Should only be used if an external copy of $2 is being used.])])],
-        [AC_ARG_WITH([$1],
-            [AS_HELP_STRING([--with-$1(=DIR)],
-                           [Build $2 support.  DIR can take one of two values:  "external" or a valid directory name.  "external" forces Open MPI to use an external installation of $2.  Supplying a valid directory name also forces Open MPI to use an external installation of $2, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI no longer supports --without-$1.  If no argument is specified, Open MPI will search default locations for $2 and error if one is not found.])])
-
-         AC_ARG_WITH([$1-libdir],
-            [AS_HELP_STRING([--with-$1-libdir=DIR],
-             [Search for $2 libraries in DIR.  Should only be used if an external copy of $2 is being used.])])])
+    AC_ARG_WITH([$1-libdir],
+       [AS_HELP_STRING([--with-$1-libdir=DIR],
+           [Search for $2 libraries in DIR.  Should only be used if an external copy of $2 is being used.])])
 
     # Bozo check
-    AS_IF([test "$with_$1" = "no"],
-          [AC_MSG_WARN([It is not possible to configure Open MPI --without-$1])
-           AC_MSG_ERROR([Cannot continue])])
+    m4_ifval([$4], [],
+        [AS_IF([test "$with_$1" = "no"],
+               [AC_MSG_WARN([It is not possible to configure Open MPI --without-$1])
+                AC_MSG_ERROR([Cannot continue])])])
 
     AS_IF([test "$with_$1_libdir" = "no" -o "$with_$1_libdir" = "yes"],
           [AC_MSG_WARN([yes/no are invalid responses for --with-$1-libdir.  Please specify a path.])
@@ -73,6 +87,8 @@ AC_DEFUN([OPAL_3RDPARTY_WITH], [
                            opal_$1_mode="internal"],
             ["external"], [with_$1=""
                            opal_$1_mode="external"],
+            ["no"],       [with_$1=""
+                           opal_$1_mode="disabled"],
             [""], [opal_$1_mode="unspecified"],
             [opal_$1_mode="external"])
 

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -19,7 +19,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
-dnl Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
@@ -68,45 +68,53 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
 
     internal_pmix_happy=0
     m4_ifdef([package_pmix],
-        [# always configure the internal pmix, so that
-         # make dist always works.
-	 internal_pmix_args="--without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
-         internal_pmix_libs=
-         internal_pmix_CPPFLAGS=
+        [OMPI_PMIX_ADD_ARGS
+         AS_IF([test "$opal_pmix_mode" = "unspecified" -o "$opal_pmix_mode" = "internal"],
+               [# Run PMIx's configure script unless the user
+		# explicitly asked us to use an external PMIX, so that
+		# "make dist" includes PMIx in the dist tarball.  This
+		# does mean that "make dist" will not work if Open MPI
+		# was configured to use an external PMIx library, but
+		# we decided this was a reasonable tradeoff for not
+		# having to deal with PMIx (or PRRTE) potentially
+		# failing to configure in a situation where it isn't
+		# desired.
 
-         OMPI_PMIX_ADD_ARGS
+                internal_pmix_args="--without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
+                internal_pmix_libs=
+                internal_pmix_CPPFLAGS=
 
-         AS_IF([test "$opal_libevent_mode" = "internal"],
-               [internal_pmix_args="$internal_pmix_args --with-libevent=cobuild"
-                internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_libevent_CPPFLAGS"
-                internal_pmix_libs="$internal_pmix_libs $opal_libevent_LIBS"])
+                AS_IF([test "$opal_libevent_mode" = "internal"],
+                      [internal_pmix_args="$internal_pmix_args --with-libevent=cobuild"
+                       internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_libevent_CPPFLAGS"
+                       internal_pmix_libs="$internal_pmix_libs $opal_libevent_LIBS"])
 
-         AS_IF([test "$opal_hwloc_mode" = "internal"],
-               [internal_pmix_args="$internal_pmix_args --with-hwloc=cobuild"
-                internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_hwloc_CPPFLAGS"
-                internal_pmix_libs="$internal_pmix_libs $opal_hwloc_LIBS"])
+                AS_IF([test "$opal_hwloc_mode" = "internal"],
+                      [internal_pmix_args="$internal_pmix_args --with-hwloc=cobuild"
+                      internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_hwloc_CPPFLAGS"
+                      internal_pmix_libs="$internal_pmix_libs $opal_hwloc_LIBS"])
 
-         AS_IF([test ! -z "$internal_pmix_libs"],
-               [internal_pmix_args="$internal_pmix_args --with-pmix-extra-lib=\"$internal_pmix_libs\""])
+                AS_IF([test ! -z "$internal_pmix_libs"],
+                      [internal_pmix_args="$internal_pmix_args --with-pmix-extra-lib=\"$internal_pmix_libs\""])
 
-         if test "$WANT_DEBUG" = "1"; then
-             internal_pmix_args="$internal_pmix_args --enable-debug"
-         fi
+                if test "$WANT_DEBUG" = "1"; then
+                     internal_pmix_args="$internal_pmix_args --enable-debug"
+                fi
 
-         # Pass all our compiler/linker flags to PMIx, so that it
-         # picks up how to build an internal HWLOC and libevent, plus
-         # picks up any user-specified compiler flags from the master
-         # configure run.
-         OPAL_SUBDIR_ENV_CLEAN([opal_pmix_configure])
-         AS_IF([test -n "$internal_pmix_CPPFLAGS"],
-               [OPAL_SUBDIR_ENV_APPEND([CPPFLAGS], [$internal_pmix_CPPFLAGS])])
-         PAC_CONFIG_SUBDIR_ARGS([3rd-party/openpmix], [$internal_pmix_args],
-                           [[--with-libevent=internal], [--with-hwloc=internal],
-                            [--with-libevent=external], [--with-hwloc=external],
-                            [--with-pmix=[[^ 	]]*], [--with-platform=[[^ 	]]*]],
-                           [internal_pmix_happy=1])
-         OPAL_SUBDIR_ENV_RESTORE([opal_pmix_configure])
-         OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])
+                # Pass all our compiler/linker flags to PMIx, so that it
+                # picks up how to build an internal HWLOC and libevent, plus
+                # picks up any user-specified compiler flags from the master
+                # configure run.
+                OPAL_SUBDIR_ENV_CLEAN([opal_pmix_configure])
+                AS_IF([test -n "$internal_pmix_CPPFLAGS"],
+                      [OPAL_SUBDIR_ENV_APPEND([CPPFLAGS], [$internal_pmix_CPPFLAGS])])
+                PAC_CONFIG_SUBDIR_ARGS([3rd-party/openpmix], [$internal_pmix_args],
+                                       [[--with-libevent=internal], [--with-hwloc=internal],
+                                        [--with-libevent=external], [--with-hwloc=external],
+                                        [--with-pmix=[[^ 	]]*], [--with-platform=[[^ 	]]*]],
+                                       [internal_pmix_happy=1])
+                OPAL_SUBDIR_ENV_RESTORE([opal_pmix_configure])
+                OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])])
 
     # unless internal specifically requested by the user, try to find
     # an external that works.

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -114,7 +114,12 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
                                         [--with-pmix=[[^ 	]]*], [--with-platform=[[^ 	]]*]],
                                        [internal_pmix_happy=1])
                 OPAL_SUBDIR_ENV_RESTORE([opal_pmix_configure])
-                OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])])
+                OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])
+
+         # if we have a pmix package and configure did not complete
+         # successfullly (or wasn't started), then disable make dist.
+         AS_IF([test $internal_pmix_happy != 1],
+               [OPAL_MAKEDIST_DISABLE="$OPAL_MAKEDIST_DISABLE PMIX"])])
 
     # unless internal specifically requested by the user, try to find
     # an external that works.

--- a/configure.ac
+++ b/configure.ac
@@ -23,13 +23,11 @@
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
-# Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
+# Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # Copyright (c) 2019      Triad National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
-#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -67,6 +65,9 @@ OPAL_CAPTURE_CONFIGURE_CLI([OPAL_CONFIGURE_CLI])
 # Get our platform support file.  This has to be done very, very early
 # because it twiddles random bits of autoconf
 OPAL_LOAD_PLATFORM
+
+# Start a list of packages / modules / etc. that want to disable "make dist".
+OPAL_MAKEDIST_DISABLE=""
 
 #
 # Start it up
@@ -1518,6 +1519,10 @@ AC_CONFIG_FILES([contrib/dist/mofed/debian/rules],
                 [chmod +x contrib/dist/mofed/debian/rules])
 AC_CONFIG_FILES([contrib/dist/mofed/compile_debian_mlnx_example],
                 [chmod +x contrib/dist/mofed/compile_debian_mlnx_example])
+
+AS_IF([test -n "$OPAL_MAKEDIST_DISABLE"],
+      [AC_MSG_WARN(["make dist" will be disabled due to: $OPAL_MAKEDIST_DISABLE])])
+AC_SUBST([OPAL_MAKEDIST_DISABLE])
 
 OPAL_CONFIG_FILES
 m4_ifdef([project_ompi], [OMPI_CONFIG_FILES])


### PR DESCRIPTION
We recently had a problem where Open MPI ran the internal PRRTE configure, even when `--with-prrte=external` was specified. The root cause was a bug in library searching, but there was no reason for Open MPI to even be running the internal configure script to get into that mess. Instead, make the tradeoff to not run configure (which will also make configure faster for those of us with external PMIX/PRRTE builds), but will break `make dist`.

Backport of https://github.com/open-mpi/ompi/pull/9649