### PR TITLE
Select all adapters with IPV4 addresses within specified subnet ranges.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -644,8 +644,8 @@ static int mca_btl_tcp_create(const int if_kindex, const char *if_name)
  */
 static char **split_and_resolve(char **orig_str, char *name, bool reqd)
 {
-    int i, ret, save, if_index;
-    char **argv, *str, *tmp;
+    int i, n, ret, if_index, match_count, interface_count;
+    char **argv, **interfaces, *str, *tmp;
     char if_name[OPAL_IF_NAMESIZE];
     struct sockaddr_storage argv_inaddr, if_inaddr;
     uint32_t argv_prefix;
@@ -659,9 +659,22 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
     if (NULL == argv) {
         return NULL;
     }
-    for (save = i = 0; NULL != argv[i]; ++i) {
+    interface_count = 0;
+    interfaces = NULL;
+    for (i = 0; NULL != argv[i]; ++i) {
         if (isalpha(argv[i][0])) {
-            argv[save++] = argv[i];
+            /* This is an interface name. If not already in the interfaces array, add it */
+            for (n = 0; n < interface_count; n++) {
+                if (0 == strcmp(argv[i], interfaces[n])) {
+                    break;
+                }
+            }
+            if (n == interface_count) {
+                opal_output_verbose(20,
+                                    opal_btl_base_framework.framework_output,
+                                    "btl: tcp: Using interface: %s ", argv[i]);
+                opal_argv_append(&interface_count, &interfaces, strdup(argv[i]));
+            }
             continue;
         }
 
@@ -698,16 +711,37 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
                             opal_net_get_hostname((struct sockaddr *) &argv_inaddr), argv_prefix);
 
         /* Go through all interfaces and see if we can find a match */
-        for (if_index = opal_ifbegin(); if_index >= 0; if_index = opal_ifnext(if_index)) {
-            opal_ifindextoaddr(if_index, (struct sockaddr *) &if_inaddr, sizeof(if_inaddr));
-            if (opal_net_samenetwork((struct sockaddr *) &argv_inaddr,
-                                     (struct sockaddr *) &if_inaddr, argv_prefix)) {
-                break;
+        match_count = 0;
+        for (if_index = opal_ifbegin(); if_index >= 0;
+             if_index = opal_ifnext(if_index)) {
+            opal_ifindextoaddr(if_index,
+                               (struct sockaddr*) &if_inaddr,
+                               sizeof(if_inaddr));
+            if (opal_net_samenetwork((struct sockaddr*) &argv_inaddr,
+                                     (struct sockaddr*) &if_inaddr,
+                                     argv_prefix)) {
+                /* We found a match. If it's not already in the interfaces array,
+                   add it. If it's already in the array, treat it as a match */
+                match_count = match_count + 1;
+                opal_ifindextoname(if_index, if_name, sizeof(if_name));
+                for (n = 0; n < interface_count; n++) {
+                    if (0 == strcmp(if_name, interfaces[n])) {
+                        break;
+                    }
+                }
+                if (n == interface_count) {
+                    opal_output_verbose(20,
+                                        opal_btl_base_framework.framework_output,
+                                        "btl: tcp: Found match: %s (%s)",
+                                        opal_net_get_hostname((struct sockaddr*) &if_inaddr),
+                                        if_name);
+                    opal_argv_append(&interface_count, &interfaces, strdup(if_name));
+                }
             }
         }
 
         /* If we didn't find a match, keep trying */
-        if (if_index < 0) {
+        if (0 == match_count) {
             if (reqd || mca_btl_tcp_component.report_all_unfound_interfaces) {
                 opal_show_help("help-mpi-btl-tcp.txt", "invalid if_inexclude", true, name,
                                opal_process_info.nodename, tmp,
@@ -717,22 +751,15 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
             continue;
         }
 
-        /* We found a match; get the name and replace it in the
-           argv */
-        opal_ifindextoname(if_index, if_name, sizeof(if_name));
-        opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                            "btl: tcp: Found match: %s (%s)",
-                            opal_net_get_hostname((struct sockaddr *) &if_inaddr), if_name);
-        argv[save++] = strdup(if_name);
         free(tmp);
     }
 
-    /* The list may have been compressed if there were invalid
-       entries, so ensure we end it with a NULL entry */
-    argv[save] = NULL;
+    /* Mark the end of the interface name array with NULL */
+    interfaces[interface_count] = NULL;
+    free(argv);
     free(*orig_str);
-    *orig_str = opal_argv_join(argv, ',');
-    return argv;
+    *orig_str = opal_argv_join(interfaces, ',');
+    return interfaces;
 }
 
 /*


### PR DESCRIPTION
Change processing for the --mca btl_tcp_if_include and --mca btl_tcp_if_exclude options so that all adapters that are within the specified subnet range are selected or excluded, respectively.

The changes to the split_and_resolve function create a list of unique adapter names selected for processing in the order they are seen, and that list is returned to the caller.

Signed-off-by: David Wootton <dwootton@us.ibm.com>