### PR TITLE
osc/rdma: adjustment on btl selection logic

### DIFF
--- a/ompi/mca/osc/rdma/Makefile.am
+++ b/ompi/mca/osc/rdma/Makefile.am
@@ -41,7 +41,9 @@ rdma_sources = \
 	osc_rdma_dynamic.c \
 	osc_rdma_sync.h \
 	osc_rdma_sync.c \
-	osc_rdma_types.h
+	osc_rdma_types.h \
+	osc_rdma_btl_wrapper.c \
+	osc_rdma_btl_wrapper.h
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.c
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.c
@@ -5,13 +5,80 @@
 
 #include "ompi_config.h"
 #include "osc_rdma_btl_wrapper.h"
+#include "opal/mca/btl/base/btl_base_am_rdma.h"
 
+/**
+ * @brief create a btl wrapper for a btl_module
+ *
+ * For a primary btl, this function simply copy the data from btl_module
+ * to btl_wrapper
+ *
+ * For an alternate btl, this function create a btl wrapper that will
+ * always use active message RDMA/atomics on the selected btl module.
+ * Even when the btl module support RDMA/atomics natively.
+ *
+ * The reason osc/rdma does not use an alternate btl's native atomics is because
+ * When multiple alternate btls are being used, the atomicity accross btl's own
+ * atomics is not guaranteed. Therefore, osc/rdma must use active message atomics.
+ *
+ * The reason osc/rdma does not use an alternate btls' native RDMA put and get is because
+ * it signficantly simplified osc/rdma's completion. The simplication came in two
+ * areas:
+ *
+ * First, active message RDMA supports remote completion. Remote completion
+ * is required by several key components of osc/rdma:
+ *        the usage of cpu atomics to update peer's state,
+ *        the usage of local leader to update peer's state,
+ *        osc/rdma's fence implementation.
+ *
+ * If any alternate does not support remote completionsc/rdma do not use active message RDMAs, it will
+ * have to keep track of each selected btl's support of remote completion.
+ * If any selected btl does not support remote completion, it will have to
+ * disable the usage of cpu atomics, disable the usage of local leader,
+ * and implement a different fence mechanism.
+ *
+ * Second, active message RDMA does not use memory registration explicitly,
+ * therefore using it eliminates the need to store and exchange multiple
+ * memory registrations.
+ */
 ompi_osc_rdma_btl_wrapper_t *ompi_osc_rdma_btl_wrapper_alloc(mca_btl_base_module_t *btl_module, enum ompi_osc_rdma_btl_type_t btl_type)
 {
+    mca_btl_base_module_t btl_module_copy;
     ompi_osc_rdma_btl_wrapper_t *btl_wrapper;
 
     if (NULL == btl_module) {
         return NULL;
+    }
+
+    memcpy(&btl_module_copy, btl_module, sizeof(btl_module_copy));
+    if (OMPI_OSC_RDMA_BTL_ALTERNATE == btl_type) {
+        /* For an alternate btl, osc/rdma must use active message RDMA/atomics on it,
+	 * and not use the btl's native support of RDMA/atomics.
+	 *
+	 * mca_btl_base_am_rdma_init() setup a btl to use AM atomics/RDMA. However,
+	 * if a btl has native RDMA/atomics support, this function will not replace
+	 * them with active message RDMA/atomic. Therefore, to ensure active message
+	 * RDMA/atomic will replace native RDMA/atomics, the input btl_module to
+	 * mca_btl_base_am_rdma_init() must has native RDMA/atomics disabled.
+	 *
+	 * We cannot disable the btl_module's RDMA/atomic though, because btl_module's
+	 * native RDMA/atomic may be used by other modules like pml.
+	 *
+	 * Hence, we created btl_module_copy here, and disabled its native RDMA/atomic
+	 * and call mca_btl_base_am_rdma_init() on it. The resulted btl_module_copy
+	 * has all the correct property test for AM RDMA/atomics. These properties
+	 * are then copied to btl_wrapper.
+	 *
+	 * osc/rdma uses the btl_wrapper to ensure active message RDMA/atomics are
+	 * used for the btl_module.
+	 */
+        btl_module_copy.btl_flags &= ~(MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_GET | MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_ATOMIC_FOPS | MCA_BTL_FLAGS_ATOMIC_OPS);
+        mca_btl_base_am_rdma_init(&btl_module_copy);
+	/* AM rdma/atomics does not need explicit memory registration
+	 */
+	btl_module_copy.btl_register_mem = NULL;
+	btl_module_copy.btl_deregister_mem = NULL;
+	btl_module_copy.btl_registration_handle_size = 0;
     }
 
     btl_wrapper = (ompi_osc_rdma_btl_wrapper_t *)calloc(1, sizeof(ompi_osc_rdma_btl_wrapper_t));
@@ -21,30 +88,30 @@ ompi_osc_rdma_btl_wrapper_t *ompi_osc_rdma_btl_wrapper_alloc(mca_btl_base_module
 
     btl_wrapper->btl_module = btl_module;
 
-    btl_wrapper->btl_atomic_ops = (btl_module->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS);
-    btl_wrapper->btl_atomic_support_glob = (btl_module->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
-    btl_wrapper->btl_rdma_remote_completion = (btl_module->btl_flags & MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION);
+    btl_wrapper->btl_atomic_ops = (btl_module_copy.btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS);
+    btl_wrapper->btl_atomic_support_glob = (btl_module_copy.btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
+    btl_wrapper->btl_rdma_remote_completion = (btl_module_copy.btl_flags & MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION);
 
-    btl_wrapper->btl_put = btl_module->btl_put;
-    btl_wrapper->btl_put_limit = btl_module->btl_put_limit;
-    btl_wrapper->btl_put_alignment = btl_module->btl_put_alignment;
-    btl_wrapper->btl_put_local_registration_threshold = btl_module->btl_put_local_registration_threshold;
+    btl_wrapper->btl_put = btl_module_copy.btl_put;
+    btl_wrapper->btl_put_limit = btl_module_copy.btl_put_limit;
+    btl_wrapper->btl_put_alignment = btl_module_copy.btl_put_alignment;
+    btl_wrapper->btl_put_local_registration_threshold = btl_module_copy.btl_put_local_registration_threshold;
 
-    btl_wrapper->btl_get = btl_module->btl_get;
-    btl_wrapper->btl_get_limit = btl_module->btl_get_limit;
-    btl_wrapper->btl_get_alignment = btl_module->btl_get_alignment;
-    btl_wrapper->btl_get_local_registration_threshold = btl_module->btl_get_local_registration_threshold;
+    btl_wrapper->btl_get = btl_module_copy.btl_get;
+    btl_wrapper->btl_get_limit = btl_module_copy.btl_get_limit;
+    btl_wrapper->btl_get_alignment = btl_module_copy.btl_get_alignment;
+    btl_wrapper->btl_get_local_registration_threshold = btl_module_copy.btl_get_local_registration_threshold;
 
-    btl_wrapper->btl_atomic_op = btl_module->btl_atomic_op;
-    btl_wrapper->btl_atomic_fop = btl_module->btl_atomic_fop;
-    btl_wrapper->btl_atomic_cswap = btl_module->btl_atomic_cswap;
-    btl_wrapper->btl_atomic_flags = btl_module->btl_atomic_flags;
+    btl_wrapper->btl_atomic_op = btl_module_copy.btl_atomic_op;
+    btl_wrapper->btl_atomic_fop = btl_module_copy.btl_atomic_fop;
+    btl_wrapper->btl_atomic_cswap = btl_module_copy.btl_atomic_cswap;
+    btl_wrapper->btl_atomic_flags = btl_module_copy.btl_atomic_flags;
 
-    btl_wrapper->btl_register_mem = btl_module->btl_register_mem;
-    btl_wrapper->btl_deregister_mem = btl_module->btl_deregister_mem;
-    btl_wrapper->btl_registration_handle_size = btl_module->btl_registration_handle_size;
+    btl_wrapper->btl_register_mem = btl_module_copy.btl_register_mem;
+    btl_wrapper->btl_deregister_mem = btl_module_copy.btl_deregister_mem;
+    btl_wrapper->btl_registration_handle_size = btl_module_copy.btl_registration_handle_size;
 
-    btl_wrapper->btl_flush = btl_module->btl_flush;
+    btl_wrapper->btl_flush = btl_module_copy.btl_flush;
     return btl_wrapper;
 }
 

--- a/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.c
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.c
@@ -1,0 +1,50 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2021-2021 Amazon.com, INC. or its affiliates. All rights reserved
+ */
+
+#include "ompi_config.h"
+#include "osc_rdma_btl_wrapper.h"
+
+ompi_osc_rdma_btl_wrapper_t *ompi_osc_rdma_btl_wrapper_alloc(mca_btl_base_module_t *btl_module, enum ompi_osc_rdma_btl_type_t btl_type)
+{
+    ompi_osc_rdma_btl_wrapper_t *btl_wrapper;
+
+    if (NULL == btl_module) {
+        return NULL;
+    }
+
+    btl_wrapper = (ompi_osc_rdma_btl_wrapper_t *)calloc(1, sizeof(ompi_osc_rdma_btl_wrapper_t));
+    if (NULL == btl_wrapper) {
+        return NULL;
+    }
+
+    btl_wrapper->btl_module = btl_module;
+
+    btl_wrapper->btl_atomic_ops = (btl_module->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS);
+    btl_wrapper->btl_atomic_support_glob = (btl_module->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
+    btl_wrapper->btl_rdma_remote_completion = (btl_module->btl_flags & MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION);
+
+    btl_wrapper->btl_put = btl_module->btl_put;
+    btl_wrapper->btl_put_limit = btl_module->btl_put_limit;
+    btl_wrapper->btl_put_alignment = btl_module->btl_put_alignment;
+    btl_wrapper->btl_put_local_registration_threshold = btl_module->btl_put_local_registration_threshold;
+
+    btl_wrapper->btl_get = btl_module->btl_get;
+    btl_wrapper->btl_get_limit = btl_module->btl_get_limit;
+    btl_wrapper->btl_get_alignment = btl_module->btl_get_alignment;
+    btl_wrapper->btl_get_local_registration_threshold = btl_module->btl_get_local_registration_threshold;
+
+    btl_wrapper->btl_atomic_op = btl_module->btl_atomic_op;
+    btl_wrapper->btl_atomic_fop = btl_module->btl_atomic_fop;
+    btl_wrapper->btl_atomic_cswap = btl_module->btl_atomic_cswap;
+    btl_wrapper->btl_atomic_flags = btl_module->btl_atomic_flags;
+
+    btl_wrapper->btl_register_mem = btl_module->btl_register_mem;
+    btl_wrapper->btl_deregister_mem = btl_module->btl_deregister_mem;
+    btl_wrapper->btl_registration_handle_size = btl_module->btl_registration_handle_size;
+
+    btl_wrapper->btl_flush = btl_module->btl_flush;
+    return btl_wrapper;
+}
+

--- a/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.h
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_wrapper.h
@@ -1,0 +1,53 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2021-2021 Amazon.com, INC. or its affiliates. All rights reserved
+ */
+
+#ifndef OMPI_OSC_RDMA_BTL_WRAPPER_T
+#define OMPI_OSC_RDMA_BTL_WRAPPER_T
+
+#include "opal/mca/btl/btl.h"
+
+enum ompi_osc_rdma_btl_type_t {
+    OMPI_OSC_RDMA_BTL_PRIMARY,
+    OMPI_OSC_RDMA_BTL_ALTERNATE,
+};
+
+/**
+ * @brief ompi_osc_rdma_btl_warpper_t is a subset of mca_btl_base_module_t
+ *        that are used by osc/rdma component
+ */
+struct ompi_osc_rdma_btl_wrapper_t {
+    mca_btl_base_module_t *btl_module;
+
+    bool btl_atomic_ops;
+    bool btl_rdma_remote_completion;
+    bool btl_atomic_support_glob;
+
+    mca_btl_base_module_put_fn_t btl_put;
+    size_t btl_put_limit;
+    size_t btl_put_alignment;
+    size_t btl_put_local_registration_threshold;
+
+    mca_btl_base_module_get_fn_t btl_get;
+    size_t btl_get_limit; 
+    size_t btl_get_alignment;
+    size_t btl_get_local_registration_threshold;
+
+    mca_btl_base_module_atomic_op64_fn_t btl_atomic_op;
+    mca_btl_base_module_atomic_fop64_fn_t btl_atomic_fop;
+    mca_btl_base_module_atomic_cswap64_fn_t btl_atomic_cswap;
+    uint32_t btl_atomic_flags;
+
+    mca_btl_base_module_register_mem_fn_t btl_register_mem;
+    mca_btl_base_module_deregister_mem_fn_t btl_deregister_mem;
+    size_t btl_registration_handle_size;
+
+    mca_btl_base_module_flush_fn_t btl_flush;
+};
+
+typedef struct ompi_osc_rdma_btl_wrapper_t ompi_osc_rdma_btl_wrapper_t;
+
+ompi_osc_rdma_btl_wrapper_t *ompi_osc_rdma_btl_wrapper_alloc(mca_btl_base_module_t *btl_module, enum ompi_osc_rdma_btl_type_t btl_type);
+
+#endif

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -610,7 +610,7 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
     if (!module->single_node) {
         for (int i = 0 ; i < module->btls_in_use ; ++i) {
-            module->use_cpu_atomics = module->use_cpu_atomics && !!(module->selected_btls[i]->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
+            module->use_cpu_atomics = module->use_cpu_atomics && !!(module->selected_btls[i]->btl_atomic_support_glob);
         }
     }
 
@@ -962,7 +962,7 @@ static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_o
             ++btls_found;
             if (module) {
                 mca_btl_base_am_rdma_init(item->btl_module);
-                ompi_osc_rdma_selected_btl_insert(module, item->btl_module, module->btls_in_use++);
+                ompi_osc_rdma_selected_btl_insert(module, item->btl_module, module->btls_in_use++, OMPI_OSC_RDMA_BTL_ALTERNATE);
             }
             
         }
@@ -989,7 +989,7 @@ static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, ompi_osc_rdma_mo
     btls_to_use = opal_argv_split (ompi_osc_rdma_btl_names, ',');
 
     if (module) {
-        ompi_osc_rdma_selected_btl_insert(module, NULL, 0);
+        ompi_osc_rdma_selected_btl_insert(module, NULL, 0, OMPI_OSC_RDMA_BTL_PRIMARY);
         module->btls_in_use = 0;
         module->use_memory_registration = false;
     }
@@ -1016,7 +1016,7 @@ static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, ompi_osc_rdma_mo
 
     if (NULL != selected_btl) {
         if (module) {
-            ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0);
+            ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0, OMPI_OSC_RDMA_BTL_PRIMARY);
             module->btls_in_use = 1;
             module->use_memory_registration = selected_btl->btl_register_mem != NULL;
         }
@@ -1133,7 +1133,7 @@ static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, ompi_osc_rdma_mo
     }
 
     if (module) {
-        ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0);
+        ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0, OMPI_OSC_RDMA_BTL_PRIMARY);
         module->btls_in_use = 1;
         module->use_memory_registration = selected_btl->btl_register_mem != NULL;
     }

--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -50,7 +50,7 @@ static int ompi_osc_rdma_peer_btl_endpoint (struct ompi_osc_rdma_module_t *modul
 
     for (int module_btl_index = 0 ; module_btl_index < module->btls_in_use ; ++module_btl_index) {
         for (int btl_index = 0 ; btl_index < num_btls ; ++btl_index) {
-            if (bml_endpoint->btl_rdma.bml_btls[btl_index].btl == module->selected_btls[module_btl_index]) {
+            if (bml_endpoint->btl_rdma.bml_btls[btl_index].btl == module->selected_btls[module_btl_index]->btl_module) {
                 *btl_index_out = module_btl_index;
                 *endpoint = bml_endpoint->btl_rdma.bml_btls[btl_index].btl_endpoint;
                 return OMPI_SUCCESS;
@@ -63,7 +63,7 @@ static int ompi_osc_rdma_peer_btl_endpoint (struct ompi_osc_rdma_module_t *modul
 
     for (int module_btl_index = 0 ; module_btl_index < module->btls_in_use ; ++module_btl_index) {
         for (int btl_index = 0 ; btl_index < num_btls ; ++btl_index) {
-            if (bml_endpoint->btl_eager.bml_btls[btl_index].btl == module->selected_btls[module_btl_index]) {
+            if (bml_endpoint->btl_eager.bml_btls[btl_index].btl == module->selected_btls[module_btl_index]->btl_module) {
                 *btl_index_out = module_btl_index;
                 *endpoint = bml_endpoint->btl_eager.bml_btls[btl_index].btl_endpoint;
                 return OMPI_SUCCESS;

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -465,10 +465,8 @@ mca_btl_base_rdma_start(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint
         if (sizeof(*hdr) + size <= btl->btl_eager_limit) {
             /* just go ahead and send the data */
             packet_size += size;
-        } else if (!mca_btl_base_rdma_use_rdma_get (btl)) {
-            packet_size += size_t_min (size, btl->btl_max_send_size - sizeof (*hdr));
         } else {
-            use_rdma = true;
+            packet_size += size_t_min (size, btl->btl_max_send_size - sizeof (*hdr));
         }
     } else if (MCA_BTL_BASE_AM_GET == type) {
         if (!mca_btl_base_rdma_use_rdma_put(btl)) {


### PR DESCRIPTION
This PR contain 3 commits:

first one update btl's active message so it always support remote completion

The other 2 update the btl selection logic in osc/rdma.