### PR TITLE
Start v4.1.3 release prep

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,9 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+4.1.3 -- TBD
+------------
+
 4.1.2 -- November, 2021
 -----------------------
 

--- a/VERSION
+++ b/VERSION
@@ -61,7 +61,7 @@
 
 major=4
 minor=1
-release=2
+release=3
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -70,7 +70,7 @@ release=2
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc4
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Update the VERSION to 4.1.3a1 and add a 4.1.3 section to the NEWS,
now that 4.1.2 has been tagged.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

bot:notacherrypick