### PR TITLE
Resolve Coverity problems reported in issue #9705

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -673,7 +673,7 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
                 opal_output_verbose(20,
                                     opal_btl_base_framework.framework_output,
                                     "btl: tcp: Using interface: %s ", argv[i]);
-                opal_argv_append(&interface_count, &interfaces, strdup(argv[i]));
+                opal_argv_append(&interface_count, &interfaces, argv[i]);
             }
             continue;
         }
@@ -735,7 +735,7 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
                                         "btl: tcp: Found match: %s (%s)",
                                         opal_net_get_hostname((struct sockaddr*) &if_inaddr),
                                         if_name);
-                    opal_argv_append(&interface_count, &interfaces, strdup(if_name));
+                    opal_argv_append(&interface_count, &interfaces, if_name);
                 }
             }
         }
@@ -755,7 +755,9 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
     }
 
     /* Mark the end of the interface name array with NULL */
-    interfaces[interface_count] = NULL;
+    if (NULL != interfaces) {
+        interfaces[interface_count] = NULL;
+    }
     free(argv);
     free(*orig_str);
     *orig_str = opal_argv_join(interfaces, ',');


### PR DESCRIPTION
Eliminate redundant use of strdup in call to opal_argv_append, check for possible null pointer following end of main loop in split_and_resolve.

The Coverity CID numbers resolved by this pull request are
CID 1494435
CID 1494436

This resolves issue #9705 

Signed-off-by: David Wootton <dwootton@us.ibm.com>