### PR TITLE
Optimize repeated pointer accesses in op/base reduction functions

### DIFF
--- a/ompi/mca/op/base/op_base_functions.c
+++ b/ompi/mca/op/base/op_base_functions.c
@@ -42,10 +42,10 @@
                                                       struct ompi_datatype_t **dtype, \
                                                       struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type *a = (type *) in;                                             \
       type *b = (type *) out;                                            \
-      for (i = 0; i < *count; ++i) {                                     \
+      for (i = 0; i < cnt; ++i) {                                        \
           *(b++) op *(a++);                                              \
       }                                                                  \
   }
@@ -62,10 +62,10 @@
                                                 struct ompi_datatype_t **dtype, \
                                                 struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type *a = (type *) in;                                             \
       type *b = (type *) out;                                            \
-      for (i = 0; i < *count; ++i) {                                     \
+      for (i = 0; i < cnt; ++i) {                                        \
           *(b) = current_func(*(b), *(a));                               \
           ++b;                                                           \
           ++a;                                                           \
@@ -90,10 +90,10 @@
                                                         struct ompi_datatype_t **dtype, \
                                                         struct ompi_op_base_module_1_0_0_t *module) \
     {                                                                   \
-        int i;                                                          \
+        int i, cnt = *count;                                            \
         ompi_op_predefined_##type_name##_t *a = (ompi_op_predefined_##type_name##_t*) in; \
         ompi_op_predefined_##type_name##_t *b = (ompi_op_predefined_##type_name##_t*) out; \
-        for (i = 0; i < *count; ++i, ++a, ++b) {                        \
+        for (i = 0; i < cnt; ++i, ++a, ++b) {                           \
             if (a->v op b->v) {                                         \
                 b->v = a->v;                                            \
                 b->k = a->k;                                            \
@@ -114,10 +114,10 @@
                                                  struct ompi_datatype_t **dtype, \
                                                  struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type (*a)[2] = (type (*)[2]) in;                                   \
       type (*b)[2] = (type (*)[2]) out;                                  \
-      for (i = 0; i < *count; ++i, ++a, ++b) {                           \
+      for (i = 0; i < cnt; ++i, ++a, ++b) {                              \
           (*b)[0] += (*a)[0];                                            \
           (*b)[1] += (*a)[1];                                            \
       }                                                                  \
@@ -134,11 +134,11 @@
                                                   struct ompi_datatype_t **dtype, \
                                                   struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type (*a)[2] = (type (*)[2]) in;                                   \
       type (*b)[2] = (type (*)[2]) out;                                  \
       type c[2];                                                         \
-      for (i = 0; i < *count; ++i, ++a, ++b) {                           \
+      for (i = 0; i < cnt; ++i, ++a, ++b) {                              \
           c[0] = (*a)[0] * (*b)[0] - (*a)[1] * (*b)[1];                  \
           c[1] = (*a)[0] * (*b)[1] + (*a)[1] * (*b)[0];                  \
           (*b)[0] = c[0];                                                \
@@ -689,11 +689,11 @@ LOC_FUNC(minloc, long_double_int, <)
                                                         struct ompi_datatype_t **dtype, \
                                                         struct ompi_op_base_module_1_0_0_t *module) \
     {                                                                   \
-        int i;                                                          \
+        int i, cnt = *count;                                            \
         type *a1 = (type *) in1;                                        \
         type *a2 = (type *) in2;                                        \
         type *b = (type *) out;                                         \
-        for (i = 0; i < *count; ++i) {                                  \
+        for (i = 0; i < cnt; ++i) {                                     \
             *(b++) =  *(a1++) op *(a2++);                               \
         }                                                               \
     }
@@ -711,11 +711,11 @@ LOC_FUNC(minloc, long_double_int, <)
                                                         struct ompi_datatype_t **dtype, \
                                                         struct ompi_op_base_module_1_0_0_t *module) \
     {                                                                   \
-        int i;                                                          \
+        int i, cnt = *count;                                            \
         type *a1 = (type *) in1;                                        \
         type *a2 = (type *) in2;                                        \
         type *b = (type *) out;                                         \
-        for (i = 0; i < *count; ++i) {                                  \
+        for (i = 0; i < cnt; ++i) {                                     \
             *(b) = current_func(*(a1), *(a2));                          \
             ++b;                                                        \
             ++a1;                                                       \
@@ -744,11 +744,11 @@ LOC_FUNC(minloc, long_double_int, <)
                                                       struct ompi_datatype_t **dtype, \
                                                       struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                     \
-      int i;                                                            \
+      int i, cnt = *count;                                              \
       ompi_op_predefined_##type_name##_t *a1 = (ompi_op_predefined_##type_name##_t*) in1; \
       ompi_op_predefined_##type_name##_t *a2 = (ompi_op_predefined_##type_name##_t*) in2; \
       ompi_op_predefined_##type_name##_t *b = (ompi_op_predefined_##type_name##_t*) out; \
-      for (i = 0; i < *count; ++i, ++a1, ++a2, ++b ) {                  \
+      for (i = 0; i < cnt; ++i, ++a1, ++a2, ++b ) {                     \
           if (a1->v op a2->v) {                                         \
               b->v = a1->v;                                             \
               b->k = a1->k;                                             \
@@ -774,11 +774,11 @@ LOC_FUNC(minloc, long_double_int, <)
                                                  struct ompi_datatype_t **dtype, \
                                                  struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type (*a1)[2] = (type (*)[2]) in1;                                 \
       type (*a2)[2] = (type (*)[2]) in2;                                 \
       type (*b)[2] = (type (*)[2]) out;                                  \
-      for (i = 0; i < *count; ++i, ++a1, ++a2, ++b) {                    \
+      for (i = 0; i < cnt; ++i, ++a1, ++a2, ++b) {                       \
           (*b)[0] = (*a1)[0] + (*a2)[0];                                 \
           (*b)[1] = (*a1)[1] + (*a2)[1];                                 \
       }                                                                  \
@@ -796,11 +796,11 @@ LOC_FUNC(minloc, long_double_int, <)
                                                   struct ompi_datatype_t **dtype, \
                                                   struct ompi_op_base_module_1_0_0_t *module) \
   {                                                                      \
-      int i;                                                             \
+      int i, cnt = *count;                                               \
       type (*a1)[2] = (type (*)[2]) in1;                                 \
       type (*a2)[2] = (type (*)[2]) in2;                                 \
       type (*b)[2] = (type (*)[2]) out;                                  \
-      for (i = 0; i < *count; ++i, ++a1, ++a2, ++b) {                    \
+      for (i = 0; i < cnt; ++i, ++a1, ++a2, ++b) {                       \
           (*b)[0] = (*a1)[0] * (*a2)[0] - (*a1)[1] * (*a2)[1];           \
           (*b)[1] = (*a1)[0] * (*a2)[1] + (*a1)[1] * (*a2)[0];           \
       }                                                                  \


### PR DESCRIPTION
Hi, this PR changes some repeated pointer accesses in the reduction function range checks, so that they are only performed (the pointer accesses) once. (Hope I didn't miss any, are there any reduction functions in another file?)

I wouldn't expect this change to make a difference, and I probably would expect the compiler to optimize the original code on its own, but I have experimentally observed increased performance with this change. Might well not be the case for a different system or compiler, but the changes shouldn't really have any downside. 

Allreduce performance (latency) before patch
`10 runs: Average 6374.9 us, Stddev 30.2834 us, Min 6327.88 us, Max 6420.74 us`

Allreduce performance (latency) after patch
`10 runs: Average 5776.3 us, Stddev 41.5984 us, Min 5705.17 us, Max 5828.30 us`

Setup
```
osu_allreduce_cc @ 1M (data-altering osu_allreduce variant)
coll: libnbc,basic
pml: ob1
btl: vader,self (xpmem)
bind-to: core
map-to: slot

CentOS 8, GCC 8.5.0, aarch64 (single node)
--enable-debug not specified during config
```

Disclaimer: Tested on v5.0.0rc2

Signed-off-by: George Katevenis <gkatev@ics.forth.gr>