### PR TITLE
Strncat cleanup

### DIFF
--- a/ompi/errhandler/errhandler_predefined.c
+++ b/ompi/errhandler/errhandler_predefined.c
@@ -403,11 +403,11 @@ static void backend_abort_no_aggregate(int fatal, char *type,
 
             len -= strlen(type);
             if (len > 0) {
-                strncat(str, " ", len);
+                strncat(str, " ", len - 1);
 
                 --len;
                 if (len > 0) {
-                    strncat(str, name, len);
+                    strncat(str, name, len - 1);
                 }
             }
             out("*** on %s", str);

--- a/ompi/mpiext/affinity/c/mpiext_affinity_c.h
+++ b/ompi/mpiext/affinity/c/mpiext_affinity_c.h
@@ -11,7 +11,7 @@
  *
  */
 
-#define OMPI_AFFINITY_STRING_MAX 1024
+#define OMPI_AFFINITY_STRING_MAX BUFSIZ
 
 typedef enum ompi_affinity_fmt {
     OMPI_AFFINITY_RSRC_STRING_FMT,

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -62,10 +62,10 @@ static void append(char *dest, size_t max, int *first, char *src)
 
     len = max - strlen(dest);
     if (!(*first)) {
-        strncat(dest, ", ", len);
+        strncat(dest, ", ", len - 1);
         len = max - strlen(dest);
     }
-    strncat(dest, src, len);
+    strncat(dest, src, len - 1);
     *first = 0;
 }
 

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -499,7 +499,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
     int argc;
     size_t j;
     char **argv;
-    char *ret, temp[(MAX_WIDTH * 2) - 1], line[MAX_WIDTH * 2];
+    char *ret, line[(MAX_WIDTH * 2) + 1];
     char *start, *desc, *ptr;
     opal_list_item_t *item;
     ompi_cmd_line_option_t *option, **sorted;
@@ -559,27 +559,27 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                 }
                 if (NULL != option->clo_single_dash_name) {
                     line[2] = (filled) ? '|' : ' ';
-                    strncat(line, "-", sizeof(line) - 1);
-                    strncat(line, option->clo_single_dash_name, sizeof(line) - 1);
+                    strncat(line, "-", sizeof(line) - strlen(line) - 1);
+                    strncat(line, option->clo_single_dash_name, sizeof(line) - strlen(line) - 1);
                     filled = true;
                 }
                 if (NULL != option->clo_long_name) {
                     if (filled) {
-                        strncat(line, "|", sizeof(line) - 1);
+                        strncat(line, "|", sizeof(line) - strlen(line) - 1);
                     } else {
-                        strncat(line, " ", sizeof(line) - 1);
+                        strncat(line, " ", sizeof(line) - strlen(line) - 1);
                     }
-                    strncat(line, "--", sizeof(line) - 1);
-                    strncat(line, option->clo_long_name, sizeof(line) - 1);
+                    strncat(line, "--", sizeof(line) - strlen(line) - 1);
+                    strncat(line, option->clo_long_name, sizeof(line) - strlen(line) - 1);
                 }
-                strncat(line, " ", sizeof(line) - 1);
+                strncat(line, " ", sizeof(line) - strlen(line) - 1);
                 for (i = 0; (int) i < option->clo_num_params; ++i) {
-                    len = sizeof(temp);
-                    snprintf(temp, len, "<arg%d> ", (int) i);
-                    strncat(line, temp, sizeof(line) - 1);
+                    char temp[MAX_WIDTH * 2];
+                    snprintf(temp, MAX_WIDTH * 2, "<arg%d> ", (int) i);
+                    strncat(line, temp, sizeof(line) - strlen(line) - 1);
                 }
                 if (option->clo_num_params > 0) {
-                    strncat(line, " ", sizeof(line) - 1);
+                    strncat(line, " ", sizeof(line) - strlen(line) - 1);
                 }
 
                 /* If we're less than param width, then start adding the
@@ -635,7 +635,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                     /* Last line */
 
                     if (strlen(start) < (MAX_WIDTH - PARAM_WIDTH)) {
-                        strncat(line, start, sizeof(line) - 1);
+                        strncat(line, start, sizeof(line) - strlen(line) - 1);
                         opal_argv_append(&argc, &argv, line);
                         break;
                     }
@@ -647,7 +647,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                     for (ptr = start + (MAX_WIDTH - PARAM_WIDTH); ptr > start; --ptr) {
                         if (isspace(*ptr)) {
                             *ptr = '\0';
-                            strncat(line, start, sizeof(line) - 1);
+                            strncat(line, start, sizeof(line) - strlen(line) - 1);
                             opal_argv_append(&argc, &argv, line);
 
                             start = ptr + 1;
@@ -666,7 +666,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                             if (isspace(*ptr)) {
                                 *ptr = '\0';
 
-                                strncat(line, start, sizeof(line) - 1);
+                                strncat(line, start, sizeof(line) - strlen(line) - 1);
                                 opal_argv_append(&argc, &argv, line);
 
                                 start = ptr + 1;
@@ -680,7 +680,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                            whitespace, then just add it on and be done */
 
                         if (ptr >= start + len) {
-                            strncat(line, start, sizeof(line) - 1);
+                            strncat(line, start, sizeof(line) - strlen(line) - 1);
                             opal_argv_append(&argc, &argv, line);
                             start = desc + len + 1;
                         }

--- a/opal/util/os_path.c
+++ b/opal/util/os_path.c
@@ -88,15 +88,15 @@ char *opal_os_path(int relative, ...)
     va_start(ap, relative);
     if (NULL != (element = va_arg(ap, char *))) {
         if (path_sep[0] != element[0]) {
-            strncat(path, path_sep, total_length);
+            strncat(path, path_sep, total_length - strlen(path) - 1);
         }
-        strcat(path, element);
+        strncat(path, element, total_length - strlen(path) - 1);
     }
     while (NULL != (element = va_arg(ap, char *))) {
         if (path_sep[0] != element[0]) {
-            strncat(path, path_sep, total_length);
+            strncat(path, path_sep, total_length - strlen(path) - 1);
         }
-        strncat(path, element, total_length);
+        strncat(path, element, total_length - strlen(path) - 1);
     }
 
     va_end(ap);


### PR DESCRIPTION
Make sure the length calculation takes prior
calls into consideration, and make sure it will
be '\0' terminated. The basic format for strncat()
calls are:

strncat(dest, source, dest_size-strlen(dest)-1);

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>