### PR TITLE
v5.0.x: btl/ofi: handle case where fi_read doesn't need a local descriptor.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_rdma.c
+++ b/opal/mca/btl/ofi/btl_ofi_rdma.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Intel, Inc, All rights reserved
+ * Copyright (c) 2021      Triad National Security, LLC. All rights
+ *                         reserved.
+ *
  *
  * $COPYRIGHT$
  *
@@ -74,7 +77,10 @@ int mca_btl_ofi_get(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
 
     /* Remote write data across the wire */
     rc = fi_read(ofi_context->tx_ctx, local_address, size, /* payload */
-                 local_handle->desc, btl_endpoint->peer_addr, remote_address, remote_handle->rkey,
+                 (NULL == local_handle ? NULL : local_handle->desc), 
+                 btl_endpoint->peer_addr, 
+                 remote_address, 
+                 remote_handle->rkey,
                  &comp->comp_ctx); /* completion context */
 
     if (-FI_EAGAIN == rc) {


### PR DESCRIPTION
Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 7f293f7e75a2be56d5b42c285d9be269f613a89e)