### PR TITLE
v5.0.x: configure: fix --enable-mca-direct

### DIFF
--- a/opal/util/minmax.h
+++ b/opal/util/minmax.h
@@ -16,6 +16,8 @@
 #ifndef OPAL_MINMAX_H
 #define OPAL_MINMAX_H
 
+#include "opal_stdint.h"
+
 #define OPAL_DEFINE_MINMAX(type, suffix)                                   \
     static inline const type opal_min_##suffix(const type a, const type b) \
     {                                                                      \


### PR DESCRIPTION
This option appears to have been silently broken for some time due to the following
issues:

 - The cut tool returns the entire input if no delimiter exists despite the -f sswitch.
   Added -s to ensure the output is empty in this case as expected. Without this fix
   it would erroneously accept --enable-mca-direct=foo.

 - Use braces around expansion of local variables. Without this the DIRECT_whatever
   variables are not set properly.

 - Check if more than one direct component has been specified for a framework.

 - Check if a direct component actually exists.

- opal/minmax: add missing header dependency

Tested the fix with pml-ob1 and it now works as expected.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit c153220)