### PR TITLE
v5.0.x: Fix --without-ft build

### DIFF
--- a/ompi/mpi/c/sendrecv.c
+++ b/ompi/mpi/c/sendrecv.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,9 +50,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 {
     ompi_request_t* req;
     int rc = MPI_SUCCESS;
-#if OPAL_ENABLE_FT_MPI
     int rcs = MPI_SUCCESS;
-#endif
 
     SPC_RECORD(OMPI_SPC_SENDRECV, 1);
 


### PR DESCRIPTION
Uncover a variable declaration

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit adec38f2e9b2b9ab18b8438524c1a268ac501117)