### PR TITLE
v5.0.x: SPML/UCX: fixed build over older versions of UCX

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -119,7 +119,7 @@ mca_spml_ucx_ctx_t mca_spml_ucx_ctx_default = {
     .strong_sync        = SPML_UCX_STRONG_ORDERING_NONE
 };
 
-#if HAVE_DECL_UCP_ATOMIC_OP_NBX
+#ifdef HAVE_UCP_REQUEST_PARAM_T
 static ucp_request_param_t mca_spml_ucx_request_param = {0};
 static ucp_request_param_t mca_spml_ucx_request_param_b = {
     .op_attr_mask = UCP_OP_ATTR_FLAG_FAST_CMPL


### PR DESCRIPTION
- updated macro check to instantiate empty op_param_t object

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
(cherry picked from commit 89153ac2aed0d71047fbf63b4778b8011212a7e8)