### PR TITLE
v5.0.x: build: Avoid accidental calls to AC_PROG_CC 

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -341,29 +341,6 @@ AC_DEFINE_UNQUOTED([OPAL_ENABLE_HETEROGENEOUS_SUPPORT],
                    [Enable features required for heterogeneous support])
 
 
-if test "$opal_want_heterogeneous" = 1; then
-    ompi_cv_c_word_size_align=yes
-else
-    AC_CACHE_CHECK([if word-sized integers must be word-size aligned],
-        [ompi_cv_c_word_size_align],
-        [AC_LANG_PUSH(C)
-         AC_RUN_IFELSE([AC_LANG_PROGRAM([dnl
-#include <stdlib.h>], [[    long data[2] = {0, 0};
-    long *lp;
-    int *ip;
-    ip = (int*) data;
-    ip++;
-    lp = (long*) ip;
-    return lp[0]; ]])],
-            [ompi_cv_c_word_size_align=no],
-            [ompi_cv_c_word_size_align=yes],
-            [ompi_cv_c_word_size_align=yes])])
-fi
-AS_IF([test $ompi_cv_c_word_size_align = yes], [results=1], [results=0])
-AC_DEFINE_UNQUOTED([OPAL_ALIGN_WORD_SIZE_INTEGERS], [$results],
-    [set to 1 if word-size integers must be aligned to word-size padding to prevent bus errors])
-
-
 #
 # Cross-compile data
 #

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -43,6 +43,8 @@ AC_DEFUN([OPAL_EVAL_ARG], [$1])
 AC_DEFUN([OPAL_MCA],[
     dnl for OPAL_CONFIGURE_USER env variable
     AC_REQUIRE([OPAL_CONFIGURE_SETUP])
+    dnl For all the path management
+    AC_REQUIRE([OPAL_SETUP_WRAPPER_INIT])
 
     # Set a special flag so that we can detect if the user calls
     # OPAL_WRAPPER_FLAGS_ADD and error.

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -420,18 +420,34 @@ AC_DEFUN([_OPAL_START_SETUP_CC],[
 
 
 AC_DEFUN([_OPAL_PROG_CC],[
+    dnl It is really easy to accidently call AC_PROG_CC implicitly through
+    dnl some other test run before OPAL_SETUP_CC.  Try to make that harder.
+    m4_provide_if([AC_PROG_CC],
+                  [m4_fatal([AC_PROG_CC called before OPAL_SETUP_CC])])
+
     #
     # Check for the compiler
     #
     OPAL_VAR_SCOPE_PUSH([opal_cflags_save dummy opal_cc_arvgv0])
+
+    # AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
+    opal_cflags_save="$CFLAGS"
+    AC_USE_SYSTEM_EXTENSIONS
+    # AC_USE_SYSTEM_EXTENSIONS will modify CFLAGS if nothing was in there
+    # beforehand.  We don't want that.  So if there was nothing in
+    # CFLAGS, put nothing back in there.
+    AS_IF([test -z "$opal_cflags_save"], [CFLAGS=])
+
     opal_cflags_save="$CFLAGS"
     AC_PROG_CC
     BASECC="`basename $CC`"
     CFLAGS="$opal_cflags_save"
-    AC_DEFINE_UNQUOTED(OPAL_CC, "$CC", [OMPI underlying C compiler])
+    OPAL_CC="$CC"
+    AC_DEFINE_UNQUOTED(OPAL_CC, "$OPAL_CC", [OMPI underlying C compiler])
     set dummy $CC
     opal_cc_argv0=[$]2
     OPAL_WHICH([$opal_cc_argv0], [OPAL_CC_ABSOLUTE])
     AC_SUBST(OPAL_CC_ABSOLUTE)
+
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -79,13 +79,16 @@ AC_DEFUN([OPAL_WRAPPER_FLAGS_ADD], [
 #     <flag>_prefix, configure is not.  There's no known use case for
 #     doing so, and we'd like to force the issue.
 AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
+    dnl for OPAL_CC
+    AC_REQUIRE([OPAL_SETUP_CC])
+
+    opal_show_subtitle "Wrapper compiler setup"
+
     OPAL_VAR_SCOPE_PUSH([wrapper_cc_tmp])
-    # AC_PROG_CC_C99 changes CC (instead of CFLAGS) so this method
-    # must be called before OPAL_SETUP_CC.
     AC_ARG_WITH([wrapper_cc],
 		[AS_HELP_STRING([--with-wrapper-cc=path],
 				[Set a different wrapper C compiler than the one used to build Open MPI])],
-		[], [with_wrapper_cc="$CC"])
+		[], [with_wrapper_cc="$OPAL_CC"])
 
     AC_MSG_CHECKING([for wrapper C compiler])
 

--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -28,22 +28,30 @@ AC_MSG_CHECKING([if want oshmem])
 AC_ARG_ENABLE([oshmem],
               [AS_HELP_STRING([--enable-oshmem],
                               [Enable building the OpenSHMEM interface (available on Linux only, where it is enabled by default)])])
+
 if test "$enable_oshmem" = "no"; then
     AC_MSG_RESULT([no])
 elif test "$enable_oshmem" = ""; then
-    if test "$opal_found_linux" = "yes"; then
+    case $host_os in
+    linux*)
         AC_MSG_RESULT([yes])
-    else
+        ;;
+    *)
         enable_oshmem=no
         AC_MSG_RESULT([not supported on this platform])
-    fi
+        ;;
+    esac
 else
     AC_MSG_RESULT([yes])
-    if test "$opal_found_linux" != "yes"; then
+    case $host_os in
+    linux*)
+	;;
+    *)
         AC_MSG_WARN([OpenSHMEM support was requested, but currently])
         AC_MSG_WARN([only supports Linux.])
         AC_MSG_ERROR([Cannot continue])
-    fi
+        ;;
+    esac
 fi
 
 #
@@ -90,11 +98,6 @@ else
 fi
 AC_DEFINE_UNQUOTED(OSHMEM_PARAM_CHECK, $shmem_param_check,
     [Whether we want to check OSHMEM parameters always or never])
-
-#
-# check for on_exit
-#
-AC_CHECK_FUNCS([on_exit])
 
 #
 #  OSHMEM profiling support

--- a/configure.ac
+++ b/configure.ac
@@ -94,15 +94,6 @@ AS_IF([test "$host" != "$target"],
        AC_MSG_WARN([Cross-compiling is only partially supported])
        AC_MSG_WARN([Proceed at your own risk!])])
 
-# AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
-OPAL_VAR_SCOPE_PUSH([CFLAGS_save])
-CFLAGS_save=$CFLAGS
-AC_USE_SYSTEM_EXTENSIONS
-# AC_USE_SYSTEM_EXTENSIONS will modify CFLAGS if nothing was in there
-# beforehand.  We don't want that.  So if there was nothing in
-# CFLAGS, put nothing back in there.
-AS_IF([test -z "$CFLAGS_save"], [CFLAGS=])
-OPAL_VAR_SCOPE_POP
 
 #
 # Init automake
@@ -291,8 +282,6 @@ m4_ifdef([project_oshmem],
 ############################################################################
 
 OPAL_CONFIGURE_OPTIONS
-OPAL_CHECK_OS_FLAVORS
-OPAL_CHECK_CUDA
 
 m4_ifdef([project_ompi], [OMPI_CONFIGURE_OPTIONS])
 m4_ifdef([project_oshmem], [OSHMEM_CONFIGURE_OPTIONS])
@@ -346,10 +335,6 @@ m4_ifdef([project_ompi],
 
 AC_ENABLE_SHARED
 AC_DISABLE_STATIC
-
-# Must be called before OPAL_SETUP_CC to get the value of CC
-# before it is modified by the C99/C11 checks.
-OPAL_SETUP_WRAPPER_INIT
 
 ##################################
 # Check for known incompatibility
@@ -547,6 +532,29 @@ OPAL_C_GET_ALIGNMENT(size_t, OPAL_ALIGNMENT_SIZE_T)
 
 OPAL_CHECK_ALT_SHORT_FLOAT
 
+# Check system alignment requirements
+if test "$opal_want_heterogeneous" = 1; then
+    ompi_cv_c_word_size_align=yes
+else
+    AC_CACHE_CHECK([if word-sized integers must be word-size aligned],
+        [ompi_cv_c_word_size_align],
+        [AC_LANG_PUSH(C)
+         AC_RUN_IFELSE([AC_LANG_PROGRAM([dnl
+#include <stdlib.h>], [[    long data[2] = {0, 0};
+    long *lp;
+    int *ip;
+    ip = (int*) data;
+    ip++;
+    lp = (long*) ip;
+    return lp[0]; ]])],
+            [ompi_cv_c_word_size_align=no],
+            [ompi_cv_c_word_size_align=yes],
+            [ompi_cv_c_word_size_align=yes])])
+fi
+AS_IF([test $ompi_cv_c_word_size_align = yes], [results=1], [results=0])
+AC_DEFINE_UNQUOTED([OPAL_ALIGN_WORD_SIZE_INTEGERS], [$results],
+    [set to 1 if word-size integers must be aligned to word-size padding to prevent bus errors])
+
 #
 # Check for other compiler characteristics
 #
@@ -662,6 +670,14 @@ AM_CONDITIONAL(OSHMEM_BUILD_FORTRAN_BINDINGS,
 
 # checkpoint results
 AC_CACHE_SAVE
+
+
+##################################
+# Wrapper compilers.
+#
+# Must be called before MCA system
+##################################
+OPAL_SETUP_WRAPPER_INIT
 
 
 ##################################
@@ -917,7 +933,7 @@ OPAL_SEARCH_LIBS_CORE([ceil], [m])
 # -lrt might be needed for clock_gettime
 OPAL_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
-AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf openpty isatty getpwuid fork waitpid execve pipe ptsname setsid mmap tcgetpgrp posix_memalign strsignal sysconf syslog vsyslog regcmp regexec regfree _NSGetEnviron socketpair usleep mkfifo dbopen dbm_open statfs statvfs setpgid setenv __malloc_initialize_hook __clear_cache])
+AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf openpty isatty getpwuid fork waitpid execve pipe ptsname setsid mmap tcgetpgrp posix_memalign strsignal sysconf syslog vsyslog regcmp regexec regfree _NSGetEnviron socketpair usleep mkfifo dbopen dbm_open statfs statvfs setpgid setenv __malloc_initialize_hook __clear_cache on_exit])
 
 # Sanity check: ensure that we got at least one of statfs or statvfs.
 if test $ac_cv_func_statfs = no && test $ac_cv_func_statvfs = no; then
@@ -975,6 +991,9 @@ AC_CACHE_SAVE
 ##################################
 
 opal_show_title "System-specific tests"
+
+OPAL_CHECK_CUDA
+OPAL_CHECK_OS_FLAVORS
 
 # Do we have _SC_NPROCESSORS_ONLN? (only going to pass if we also have
 # <unistd.h> and sysconf(), which is ok) OS X 10.4 has <unistd.h> and


### PR DESCRIPTION
Reorder some of the early configure tests to avoid
accidently calling AC_PROG_CC before the C compiler
section, which will also ensure those tests are run
with the same option flags as the rest of the tests.

Reorder the wrapper compiler initialization, as it
depended on these accidental calls to AC_PROG_CC.
To make the late call to the wrapper compiler
code work, save the "bare" CC (before Autoconf
macros add stuff to it) in the env variable
OPAL_CC, similar to the AC_DEFINE of the same
name.

To keep this from happening again, cause an Autoconf
error if Autoconf expands AC_PROG_CC before the
call to OPAL_SETUP_CC, and put in some AC_REQUIRE
statements to better state dependencies.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit fcbec275228b9b402c999ab6d11bb4d66df37b1e)