### PR TITLE
Allow OMPI to build recent PMIX/PRRTE branches

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1647,13 +1647,52 @@ if (list_contains("pmix", @disabled_3rdparty_packages)) {
     if (! -f "3rd-party/openpmix/configure.ac") {
         my_die("Could not find pmix files\n");
     }
-    push(@subdirs, "3rd-party/openpmix/");
     $m4 .= "m4_define([package_pmix], [1])\n";
 
     # Grab the unique configure options from each of the 3rd party packages
     safe_system("./config/extract-3rd-party-configure.pl -p \"3rd-party/openpmix/\" -n \"PMIx\" -e config/auto-generated-ompi-exclude.ini > config/auto-extracted-pmix-configure-args.m4");
     # Add the additional configure options from PMIx
     safe_system("./config/extract-3rd-party-configure.pl -p \"3rd-party/openpmix/\" -n \"PMIx\" -l >> config/auto-generated-ompi-exclude.ini");
+
+    my $start = Cwd::cwd();
+    my $check = chdir("3rd-party/openpmix");
+    if (0 == $check) {
+        my_die "Could not change to 3rd-party/openpmix\n";
+    }
+
+    my $aclocal = "aclocal";
+    my $autoconf = "autoconf";
+
+    my $aclocal_env = $ENV{"ACLOCAL"};
+    my $autoconf_env = $ENV{"AUTOCONF"};
+
+    if (defined($aclocal_env)) {
+	$aclocal = $aclocal_env;
+    }
+    if (defined($autoconf_env)) {
+	$autoconf = $autoconf_env;
+    }
+
+    $ENV{"ACLOCAL"} = "$aclocal -I ../../config/3rd-party/openpmix";
+    $ENV{"AUTOCONF"} = "$autoconf -I ../../config/3rd-party/openpmix";
+
+    # Run an action depending on what we find in that subdir
+    if (-x "autogen.pl") {
+        print "--- Found autogen.pl; running...\n";
+        safe_system("./autogen.pl");
+    } else {
+        my_die "Did not find PMIx's autogenpl";
+    }
+
+    $ENV{"ACLOCAL"} = $aclocal_env;
+    $ENV{"AUTOCONF"} = $autoconf_env;
+
+    # Ensure that we got a good configure executable.
+    my_die "Did not generate a \"configure\" executable in 3rd-party/openpmix.\n"
+        if (! -x "configure");
+
+    # Chdir back to where we came from
+    chdir($start);
 
     verbose "--- PMIx enabled\n";
 }
@@ -1666,11 +1705,51 @@ if (list_contains("prrte", @disabled_3rdparty_packages)) {
     if (! -f "3rd-party/prrte/configure.ac") {
         my_die("Could not find pmix files\n");
     }
-    push(@subdirs, "3rd-party/prrte/");
     $m4 .= "m4_define([package_prrte], [1])\n";
 
     # Grab the unique configure options from each of the 3rd party packages
     safe_system("./config/extract-3rd-party-configure.pl -p \"3rd-party/prrte/\" -n \"PRRTE\" -e config/auto-generated-ompi-exclude.ini > config/auto-extracted-prrte-configure-args.m4");
+
+
+    my $start = Cwd::cwd();
+    my $check = chdir("3rd-party/prrte");
+    if (0 == $check) {
+        my_die "Could not change to 3rd-party/prrte\n";
+    }
+
+    my $aclocal = "aclocal";
+    my $autoconf = "autoconf";
+
+    my $aclocal_env = $ENV{"ACLOCAL"};
+    my $autoconf_env = $ENV{"AUTOCONF"};
+
+    if (defined($aclocal_env)) {
+	$aclocal = $aclocal_env;
+    }
+    if (defined($autoconf_env)) {
+	$autoconf = $autoconf_env;
+    }
+
+    $ENV{"ACLOCAL"} = "$aclocal -I ../../config/3rd-party/prrte";
+    $ENV{"AUTOCONF"} = "$autoconf -I ../../config/3rd-party/prrte";
+
+    # Run an action depending on what we find in that subdir
+    if (-x "autogen.pl") {
+        print "--- Found autogen.pl; running...\n";
+        safe_system("./autogen.pl");
+    } else {
+        my_die "Did not find PRRTE's autogenpl";
+    }
+
+    $ENV{"ACLOCAL"} = $aclocal_env;
+    $ENV{"AUTOCONF"} = $autoconf_env;
+
+    # Ensure that we got a good configure executable.
+    my_die "Did not generate a \"configure\" executable in 3rd-party/prrte.\n"
+        if (! -x "configure");
+
+    # Chdir back to where we came from
+    chdir($start);
 
     verbose "--- PRRTE enabled\n";
 }

--- a/config/3rd-party/README.md
+++ b/config/3rd-party/README.md
@@ -1,0 +1,63 @@
+# 3rd-party Build Behavior
+
+This document outlines modifications we have made to the OpenPMIX and
+PRRTE build systems in order to support building Open MPI and its
+dependencies in one shot.  There may be other places these techniques
+are helpful for custom builds of Open MPI.
+
+## Intercepting Macros
+
+The motivation for this work was to allow Open MPI to ship OpenPMIx
+and PRRTE in a way that customers would follow the traditional
+`./configure ; make ; make install` flow, even when Open MPI is
+installing dependencies (like libevent and HWLOC for PMIX and lievent,
+HWLOC, and PMIX for PRRTE).  For development velocity reasons, the
+goal was to 1) not fork either project, 2) be able to use submodules
+to track upstream, and 3) not require any patches that would dirty the
+submodule (from a git standpoint).  The OpenPMIX and PRRTE communities
+were against supporting this feature natively in the upstream, which
+would have been the simplest path forward.
+
+Our solution is to inject customized macros for the Libevent, HWLOC,
+and PMIx checks in both libraries.  We have to stay relatively in sync
+with upstream, in terms of the `AC_DEFINE()`s and `AM_CONDITIONAL()`s
+that are set, but otherwise can change the tests to fit our needs.  We
+do this by taking advantage of aclocal's search pathing.  Aclocal will
+search through the user-defined path, from the start, for each macro
+it finds referenced in configure (or recursively referenced from
+configure).  By injecting a custom search path for aclocal and
+autoconf, we are able to ensure that the macros in this directory are
+found before the macros in PMIX and PRRTE.
+
+To inject the paths, Open MPI's autogen.pl modifies the environment
+for calling PMIX and PRRTE's autogen.pl, setting both the ACLOCAL and
+AUTOCONF environment variables .  Both are set slightly differently.
+Aclocal will always write its output to the current working directory
+from which it is invoked.  So we set `ACLOCAL="$aclocal -I
+../../config/3rd-party/<project>"`.  The path must be relative because
+there is some relative vs. absolute path behavior changes in aclocal.
+`$aclocal` is either `aclocal` or the current value of the `ACLOCAL`
+environment variable, allowing user customizations to still work.
+Likewise, we set `AUTOCONF="$autoconf -B
+../../config/3rd-party/<project>"`  The `-B` option is because
+Autoconf puts its build artifacts in the directory specified by the
+first `-I`.  In retrospect, this was probably a bad decision, so the
+`-B` option acts like `-I`, but does not count towards the output
+directory logic.  We need to set both `AUTOCONF` and `ACLOCAL`,
+because both can cause macro searches, depending on configuration.
+
+## Our Injected Macros
+
+The injected macros (those in this directory) have the same logic for
+external builds as the upstream configure macros.  The one exception
+is the thread checks in Libevent; upstream uses `AC_CHECK_LIB`, which
+requires a library to test against.  These macros use `AC_TRY_COMPILE`
+to check preprocessor macros which provide the same information.
+
+For cobuild cases (ie, running one big stream of configures before we
+build any packages), we can't call CHECK_PACKAGE, because there's no
+library yet (but we also know it will be there.  We also need to be
+careful with libraries.  We won't have a libtool archive to link
+against until make time, so we also don't want to add the dependency
+libraries into the PMIX or PRRTE LIBS until the very end of its
+configure, or any library linking test will fail (and that's no good).

--- a/config/3rd-party/openpmix/pmix_flags_prepend_uniq.m4
+++ b/config/3rd-party/openpmix/pmix_flags_prepend_uniq.m4
@@ -1,0 +1,75 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2017      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+dnl                         reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+dnl Portions of this file derived from GASNet v1.12 (see "GASNet"
+dnl comments, below)
+dnl Copyright 2004,  Dan Bonachea <bonachea@cs.berkeley.edu>
+dnl
+dnl IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+dnl DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
+dnl OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
+dnl CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+dnl
+dnl THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+dnl INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+dnl AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+dnl ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
+dnl PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+dnl
+
+
+dnl
+dnl PMIX_FLAGS_PREPEND_UNIQ was added late in PMIX's history (after
+dnl the v4.2 branch was created).  Prefer to use the version provided
+dnl by PMIX, but provide a version if PMIX does not provide one.
+dnl
+m4_ifdef([PMIX_FLAGS_PREPEND_UNIQ], [], [
+# PMIX_FLAGS_PREPEND_UNIQ(variable, new_argument)
+# ----------------------------------------------
+# Prepend new_argument to variable if:
+#
+# - the argument does not begin with -I, -L, or -l, or
+# - the argument begins with -I, -L, or -l, and it's not already in variable
+#
+# This macro assumes a space seperated list.
+AC_DEFUN([PMIX_FLAGS_PREPEND_UNIQ], [
+    PMIX_VAR_SCOPE_PUSH([pmix_tmp pmix_prepend])
+
+    for arg in $2; do
+        pmix_tmp=`echo $arg | cut -c1-2`
+        pmix_prepend=1
+        AS_IF([test "$pmix_tmp" = "-I" || test "$pmix_tmp" = "-L" || test "$pmix_tmp" = "-l"],
+              [for val in ${$1}; do
+                   AS_IF([test "x$val" = "x$arg"], [pmix_prepend=0])
+               done])
+        AS_IF([test "$pmix_prepend" = "1"],
+              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$arg $$1"])])
+    done
+
+    PMIX_VAR_SCOPE_POP
+])])

--- a/config/3rd-party/openpmix/pmix_setup_hwloc.m4
+++ b/config/3rd-party/openpmix/pmix_setup_hwloc.m4
@@ -1,0 +1,207 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# We have two modes for building hwloc.
+#
+# First is as a co-built hwloc.  In this case, PMIx's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# hwloc headers and LIBS will point to where the .la file for
+# hwloc will exist.  When co-building, hwloc's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-hwloc=cobuild option is specified.
+#
+# Second is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# hwloc.  This mode is used whenever the other modes are not used.
+#
+# PMIX_SETUP_HWLOC()
+# --------------------------------------------------------------------
+AC_DEFUN([PMIX_SETUP_HWLOC],[
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_source])
+
+    AC_ARG_WITH([hwloc],
+                [AS_HELP_STRING([--with-hwloc=DIR],
+                                [Search for hwloc headers and libraries in DIR ])])
+
+    AC_ARG_WITH([hwloc-libdir],
+                [AS_HELP_STRING([--with-hwloc-libdir=DIR],
+                                [Search for hwloc libraries in DIR ])])
+
+    pmix_hwloc_support=1
+    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
+    pmix_check_hwloc_save_LDFLAGS="$LDFLAGS"
+    pmix_check_hwloc_save_LIBS="$LIBS"
+    pmix_have_topology_dup=0
+
+    if test "$with_hwloc" == "no"; then
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
+        AC_MSG_WARN([Please reconfigure so we can find the library.])
+        AC_MSG_ERROR([Cannot continue.])
+    fi
+
+    # if we're cobuild, don't have to do a package search. Otherwise,
+    # search or the package and get the right {CPP,C,LD}FLAGS and
+    # LIBS.
+    AS_IF([test "$with_hwloc" = "cobuild"],
+          [_PMIX_HWLOC_EMBEDDED_MODE()],
+          [_PMIX_HWLOC_EXTERNAL([pmix_hwloc_support=1], [pmix_hwloc_support=0])])
+
+    if test $pmix_hwloc_support -eq 0; then
+        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
+        AC_MSG_WARN([an adequate version of that library was not found.])
+        AC_MSG_WARN([Please reconfigure and point to a location where])
+        AC_MSG_WARN([the HWLOC library can be found.])
+        AC_MSG_ERROR([Cannot continue.])
+    fi
+
+    # update global flags to test for HWLOC version
+    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+    PMIX_FLAGS_PREPEND_UNIQ([LDFLAGS], [$pmix_hwloc_LDFLAGS])
+    PMIX_FLAGS_PREPEND_UNIQ([LIBS], [$pmix_hwloc_LIBS])
+
+    AC_MSG_CHECKING([if hwloc version is 1.5 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010500
+    #error "hwloc API version is less than 0x00010500"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_ERROR([Cannot continue])])
+
+    AC_MSG_CHECKING([if hwloc version is 1.8 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010800
+    #error "hwloc API version is less than 0x00010800"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])
+           pmix_have_topology_dup=1],
+          [AC_MSG_RESULT([no])])
+
+    AC_MSG_CHECKING([if hwloc version is 2.0 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00020000
+    #error "hwloc API version is less than 0x00020000"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])
+           pmix_version_high=1],
+          [AC_MSG_RESULT([no])
+           pmix_version_high=0])
+
+    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
+    LDFLAGS=$pmix_check_hwloc_save_LDFLAGS
+    LIBS=$pmix_check_hwloc_save_LIBS
+
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+    PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LDFLAGS], [$pmix_hwloc_LDFLAGS])
+    PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$pmix_hwloc_LDFLAGS])
+
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$pmix_hwloc_LIBS])
+    PMIX_WRAPPER_FLAGS_ADD([LIBS], [$pmix_hwloc_LIBS])
+
+    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
+                       [Whether or not hwloc_topology_dup is available])
+
+    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
+
+    pmix_hwloc_support_will_build=yes
+    if test -z "$pmix_hwloc_dir"; then
+        pmix_hwloc_source="Standard locations"
+    else
+        pmix_hwloc_source=$pmix_hwloc_dir
+    fi
+
+    PMIX_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [pmix_hwloc], [$pmix_hwloc_support_will_build ($pmix_hwloc_source)])
+
+    PMIX_VAR_SCOPE_POP
+
+    dnl This is needed for backwards comptability with the 4.2 and
+    dnl earlier branches.
+    AC_DEFINE([PMIX_HWLOC_HEADER], [<hwloc.h>], [Location of hwloc.h])
+])dnl
+
+
+AC_DEFUN([_PMIX_HWLOC_EMBEDDED_MODE],[
+    AC_MSG_CHECKING([for hwloc])
+    AC_MSG_RESULT(["cobuild"])
+
+    AC_ARG_WITH([hwloc-cobuild-libs],
+                [AS_HELP_STRING([--with-hwloc-cobuild-libs=LIBS],
+                                [Add the LIBS string to LIBS])])
+    AC_ARG_WITH([hwloc-cobuild-wrapper-libs],
+                [AS_HELP_STRING([--with-hwloc-cobuild-wrapper-libs=LIBS],
+                                [Add the LIBS string to the wrapper compiler LIBS])])
+
+    pmix_hwloc_dir="cobuild"
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_cobuild_libs])
+    PMIX_WRAPPER_FLAGS_ADD([LIBS], [$with_hwloc_cobuild_wrapper_libs])
+])dnl
+
+
+dnl To support cobuilds, any tests that require linking or running (as
+dnl opposed to preprocessing or compiling) should only exist in the
+dnl HWLOC_EXTERNAL section, since cobuild does not guarantee that a
+dnl library will be available at configure time.
+AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
+    PMIX_VAR_SCOPE_PUSH([hwloc_prefix hwlocdir_prefix])
+
+    # get rid of any trailing slash(es)
+    hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
+    hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
+
+    AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                 [pmix_hwloc_dir="$hwloc_prefix"],
+                 [pmix_hwloc_dir=""])
+
+    AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
+                 [pmix_hwloc_libdir="$hwlocdir_prefix"],
+                 [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                        [if test -d $hwloc_prefix/lib64; then
+                            pmix_hwloc_libdir=$hwloc_prefix/lib64
+                         elif test -d $hwloc_prefix/lib; then
+                            pmix_hwloc_libdir=$hwloc_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [pmix_hwloc_libdir=""])])
+
+    PMIX_CHECK_PACKAGE([pmix_hwloc],
+                       [hwloc.h],
+                       [hwloc],
+                       [hwloc_topology_init],
+                       [],
+                       [$pmix_hwloc_dir],
+                       [$pmix_hwloc_libdir],
+                       [pmix_hwloc_support=1],
+                       [pmix_hwloc_support=0],
+                       [])
+
+    PMIX_VAR_SCOPE_POP
+])dnl

--- a/config/3rd-party/openpmix/pmix_setup_libevent.m4
+++ b/config/3rd-party/openpmix/pmix_setup_libevent.m4
@@ -1,0 +1,252 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017-2019 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# We have two modes for building libevent.
+#
+# First is as a co-built libevent.  In this case, PMIx's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# libevent headers and LIBS will point to where the .la file for
+# libevent will exist.  When co-building, libevent's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-libevent=cobuild option is specified.
+#
+# Second is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# libevent.  This mode is used whenever the other modes are not used.
+#
+# PMIX_LIBEVENT_CONFIG()
+# --------------------------------------------------------------------
+AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
+    PMIX_VAR_SCOPE_PUSH([pmix_libevent_source])
+
+    AC_ARG_WITH([libevent],
+                [AS_HELP_STRING([--with-libevent=DIR],
+                                [Search for libevent headers and libraries in DIR ])])
+
+    AC_ARG_WITH([libevent-libdir],
+                [AS_HELP_STRING([--with-libevent-libdir=DIR],
+                                [Search for libevent libraries in DIR ])])
+
+    pmix_libevent_support=1
+
+    AS_IF([test "$with_libevent" = "no"],
+          [AC_MSG_NOTICE([Libevent support disabled by user.])
+           pmix_libevent_support=0])
+
+    # figure out our mode...
+    AS_IF([test "$with_libevent" = "cobuild"],
+          [_PMIX_LIBEVENT_EMBEDDED_MODE()],
+          [_PMIX_LIBEVENT_EXTERNAL([pmix_libevent_support=1],
+                                   [pmix_libevent_support=0])])
+    # Check to see if the above check failed because it conflicted with LSF's libevent.so
+    # This can happen if LSF's library is in the LDFLAGS envar or default search
+    # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+    # in Libevent's libevent.so
+    #
+    # Note that even in a cobuild situation, calling AC_CHECK_LIB is
+    # fine here, because we aren't testing Libevent's library, we're
+    # effectively testing LSF's library.  We never cobuild LSF
+    # (please, may that never happen), so there's no cobuild problem.
+    if test $pmix_libevent_support -eq 0; then
+        AC_CHECK_LIB([event], [event_getcode4name],
+                     [AC_MSG_WARN([===================================================================])
+                      AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                      AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                      AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                      AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                      AC_MSG_WARN([LSF library path.])
+                      AC_MSG_WARN([===================================================================])
+                      ])
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        # need to add resulting flags to global ones so we can
+        # test for thread support
+        PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+        PMIX_FLAGS_PREPEND_UNIQ([LDFLAGS], [$pmix_libevent_LDFLAGS])
+        PMIX_FLAGS_PREPEND_UNIQ([LIBS], [$pmix_libevent_LIBS])
+
+        # Check for general threading support
+        AC_MSG_CHECKING([if libevent threads enabled])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <event.h>
+#include <event2/thread.h>
+          ], [[
+#if !(EVTHREAD_LOCK_API_VERSION >= 1)
+#  error "No threads!"
+#endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_WARN([PMIX rquires libevent to be compiled with thread support enabled])
+           pmix_libevent_support=0])
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        AC_MSG_CHECKING([for libevent pthreads support])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <event.h>
+#include <event2/thread.h>
+          ], [[
+#if !defined(EVTHREAD_USE_PTHREADS_IMPLEMENTED) || !EVTHREAD_USE_PTHREADS_IMPLEMENTED
+#  error "No pthreads!"
+#endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_WARN([PMIX requires libevent to be compiled with pthread support enabled])
+           pmix_libevent_support=0])
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        # Pin the "oldest supported" version to 2.0.21
+        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
+                                           [[
+                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #endif
+                                           ]])],
+                          [AC_MSG_RESULT([yes])],
+                          [AC_MSG_RESULT([no])
+                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
+                           pmix_libevent_support=0])
+    fi
+    if test -z "$pmix_event_dir"; then
+        pmix_libevent_source="Standard locations"
+    else
+        pmix_libevent_source=$pmix_event_dir
+    fi
+
+    # restore global flags
+    CPPFLAGS="$pmix_check_libevent_save_CPPFLAGS"
+    LDFLAGS="$pmix_check_libevent_save_LDFLAGS"
+    LIBS="$pmix_check_libevent_save_LIBS"
+
+    AC_MSG_CHECKING([will libevent support be built])
+    if test $pmix_libevent_support -eq 1; then
+        AC_MSG_RESULT([yes])
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+        PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LDFLAGS], [$pmix_libevent_LDFLAGS])
+        PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$pmix_libevent_LDFLAGS])
+
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$pmix_libevent_LIBS])
+        PMIX_WRAPPER_FLAGS_ADD([LIBS], [$pmix_libevent_LIBS])
+        # Set output variables
+        PMIX_SUMMARY_ADD([[Required Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
+
+        $1
+    else
+        AC_MSG_RESULT([no])
+
+        $2
+    fi
+
+    AC_DEFINE_UNQUOTED([PMIX_HAVE_LIBEVENT], [$pmix_libevent_support], [Whether we are building against libevent])
+
+    PMIX_VAR_SCOPE_POP()
+
+    dnl These are needed for backwards comptability with the 4.2 and
+    dnl earlier branches.
+    AC_DEFINE([PMIX_EVENT_HEADER], [<event.h>], [Location of event.h])
+    AC_DEFINE([PMIX_EVENT2_THREAD_HEADER], [<event2/thread.h>], [Location of event.h])
+])dnl
+
+
+AC_DEFUN([_PMIX_LIBEVENT_EMBEDDED_MODE], [
+    AC_MSG_CHECKING([for libevent])
+    AC_MSG_RESULT(["cobuild"])
+
+    pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
+    pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
+    pmix_check_libevent_save_LIBS="$LIBS"
+
+    AC_ARG_WITH([libevent-cobuild-libs],
+                [AS_HELP_STRING([--with-libevent-cobuild-libs=LIBS],
+                                [Add the LIBS string to LIBS])])
+    AC_ARG_WITH([libevent-cobuild-wrapper-libs],
+                [AS_HELP_STRING([--with-libevent-cobuild-wrapper-libs=LIBS],
+                                [Add the LIBS string to the wrapper compiler LIBS])])
+
+    pmix_event_dir=cobuild
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_libevent_cobuild_libs])
+    PMIX_WRAPPER_FLAGS_ADD([LIBS], [$with_libevent_cobuild_wrapper_libs])
+])dnl
+
+
+dnl To support cobuilds, any tests that require linking or running (as
+dnl opposed to preprocessing or compiling) should only exist in the
+dnl LIBEVENT_EXTERNAL section, since cobuild does not guarantee that a
+dnl library will be available at configure time.
+AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
+    PMIX_VAR_SCOPE_PUSH([libevent_prefix libeventdir_prefix])
+
+    AS_IF([test $pmix_libevent_support -eq 1],
+          [PMIX_CHECK_WITHDIR([libevent], [$with_libevent], [include/event.h])
+           PMIX_CHECK_WITHDIR([libevent-libdir], [$with_libevent_libdir], [libevent.*])
+
+           pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
+           pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
+           pmix_check_libevent_save_LIBS="$LIBS"
+
+           # get rid of any trailing slash(es)
+           libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+           libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+
+           AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                 [pmix_event_dir="$libevent_prefix"],
+                 [pmix_event_dir=""])
+
+           AS_IF([test ! -z "$libeventdir_prefix" -a "$libeventdir_prefix" != "yes"],
+                 [pmix_event_libdir="$libeventdir_prefix"],
+                 [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                        [if test -d $libevent_prefix/lib64; then
+                            pmix_event_libdir=$libevent_prefix/lib64
+                         elif test -d $libevent_prefix/lib; then
+                            pmix_event_libdir=$libevent_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [pmix_event_libdir=""])])
+
+           PMIX_CHECK_PACKAGE([pmix_libevent],
+                              [event.h],
+                              [event_core],
+                              [event_config_new],
+                              [-levent_pthreads],
+                              [$pmix_event_dir],
+                              [$pmix_event_libdir],
+                              [],
+                              [pmix_libevent_support=0],
+                              [])])
+
+    PMIX_VAR_SCOPE_POP
+])dnl

--- a/config/3rd-party/prrte/prte_flags_prepend_uniq.m4
+++ b/config/3rd-party/prrte/prte_flags_prepend_uniq.m4
@@ -1,0 +1,75 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2017      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+dnl                         reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+dnl Portions of this file derived from GASNet v1.12 (see "GASNet"
+dnl comments, below)
+dnl Copyright 2004,  Dan Bonachea <bonachea@cs.berkeley.edu>
+dnl
+dnl IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+dnl DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
+dnl OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
+dnl CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+dnl
+dnl THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+dnl INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+dnl AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+dnl ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
+dnl PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+dnl
+
+
+dnl
+dnl PRTE_FLAGS_PREPEND_UNIQ was added late in PRRTE's history (after
+dnl the v2.1 branch was created).  Prefer to use the version provided
+dnl by PRRTE, but provide a version if PRRTE does not provide one.
+dnl
+m4_ifdef([PRTE_FLAGS_PREPEND_UNIQ], [], [
+# PRTE_FLAGS_PREPEND_UNIQ(variable, new_argument)
+# ----------------------------------------------
+# Prepend new_argument to variable if:
+#
+# - the argument does not begin with -I, -L, or -l, or
+# - the argument begins with -I, -L, or -l, and it's not already in variable
+#
+# This macro assumes a space seperated list.
+AC_DEFUN([PRTE_FLAGS_PREPEND_UNIQ], [
+    PRTE_VAR_SCOPE_PUSH([prte_tmp prte_prepend])
+
+    for arg in $2; do
+        prte_tmp=`echo $arg | cut -c1-2`
+        prte_prepend=1
+        AS_IF([test "$prte_tmp" = "-I" || test "$prte_tmp" = "-L" || test "$prte_tmp" = "-l"],
+              [for val in ${$1}; do
+                   AS_IF([test "x$val" = "x$arg"], [prte_prepend=0])
+               done])
+        AS_IF([test "$prte_prepend" = "1"],
+              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$arg $$1"])])
+    done
+
+    PRTE_VAR_SCOPE_POP
+])])

--- a/config/3rd-party/prrte/prte_setup_hwloc.m4
+++ b/config/3rd-party/prrte/prte_setup_hwloc.m4
@@ -1,0 +1,200 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# PRRTE 2.0 branch calls this PRTE_HWLOC_CONFIG.  2.1 and later calls
+# it PRTE_SETUP_HWLOC.
+#
+AC_DEFUN([PRTE_HWLOC_CONFIG], [PRTE_SETUP_HWLOC])
+
+#
+# We have two modes for building hwloc.
+#
+# First is as a co-built hwloc.  In this case, Prte's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# hwloc headers and LIBS will point to where the .la file for
+# hwloc will exist.  When co-building, hwloc's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-hwloc=cobuild option is specified.
+#
+# Second is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# hwloc.  This mode is used whenever the other modes are not used.
+#
+# PRTE_SETUP_HWLOC()
+# --------------------------------------------------------------------
+AC_DEFUN([PRTE_SETUP_HWLOC], [
+    PRTE_VAR_SCOPE_PUSH()
+
+    AC_ARG_WITH([hwloc],
+                [AS_HELP_STRING([--with-hwloc=DIR],
+                                [Search for hwloc headers and libraries in DIR ])])
+
+    AC_ARG_WITH([hwloc-libdir],
+                [AS_HELP_STRING([--with-hwloc-libdir=DIR],
+                                [Search for hwloc libraries in DIR ])])
+
+    prte_hwloc_support=1
+    prte_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
+    prte_check_hwloc_save_LDFLAGS="$LDFLAGS"
+    prte_check_hwloc_save_LIBS="$LIBS"
+    prte_have_topology_dup=0
+
+    if test "$with_hwloc" == "no"; then
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
+        AC_MSG_WARN([Please reconfigure so we can find the library.])
+        AC_MSG_ERROR([Cannot continue.])
+    fi
+
+    # if we're cobuild, don't have to do a package search. Otherwise,
+    # search or the package and get the right {CPP,C,LD}FLAGS and
+    # LIBS.
+    AS_IF([test "$with_hwloc" = "cobuild"],
+          [_PRTE_HWLOC_EMBEDDED_MODE()],
+          [_PRTE_HWLOC_EXTERNAL([prte_hwloc_support=1], [prte_hwloc_support=0])])
+
+    if test $prte_hwloc_support -eq 0; then
+        AC_MSG_WARN([Prte requires HWLOC topology library support, but])
+        AC_MSG_WARN([an adequate version of that library was not found.])
+        AC_MSG_WARN([Please reconfigure and point to a location where])
+        AC_MSG_WARN([the HWLOC library can be found.])
+        AC_MSG_ERROR([Cannot continue.])
+    fi
+
+    # update global flags to test for HWLOC version
+    if test ! -z "$prte_hwloc_CPPFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(CPPFLAGS, $prte_hwloc_CPPFLAGS)
+    fi
+    if test ! -z "$prte_hwloc_LDFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LDFLAGS, $prte_hwloc_LDFLAGS)
+    fi
+    if test ! -z "$prte_hwloc_LIBS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LIBS, $prte_hwloc_LIBS)
+    fi
+
+    AC_MSG_CHECKING([if hwloc version is 1.5 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010500
+    #error "hwloc API version is less than 0x00010500"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_ERROR([Cannot continue])])
+
+    AC_MSG_CHECKING([if hwloc version is 1.8 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010800
+    #error "hwloc API version is less than 0x00010800"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])
+           prte_have_topology_dup=1],
+          [AC_MSG_RESULT([no])])
+
+    CPPFLAGS=$prte_check_hwloc_save_CPPFLAGS
+    LDFLAGS=$prte_check_hwloc_save_LDFLAGS
+    LIBS=$prte_check_hwloc_save_LIBS
+
+    if test ! -z "$prte_hwloc_CPPFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_hwloc_CPPFLAGS)
+    fi
+    if test ! -z "$prte_hwloc_LDFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_hwloc_LDFLAGS)
+    fi
+    if test ! -z "$prte_hwloc_LIBS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_hwloc_LIBS)
+    fi
+
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC_TOPOLOGY_DUP], [$prte_have_topology_dup],
+                       [Whether or not hwloc_topology_dup is available])
+
+    dnl This is needed for backwards comptability with the 2.1 and
+    dnl earlier branches.
+    AC_DEFINE([PRTE_HWLOC_HEADER], [<hwloc.h>], [Location of hwloc.h])
+
+    PRTE_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [prte_hwloc], [yes ($prte_hwloc_source)])
+
+    PRTE_VAR_SCOPE_POP()
+])dnl
+
+
+AC_DEFUN([_PRTE_HWLOC_EMBEDDED_MODE],[
+    AC_MSG_CHECKING([for hwloc])
+    AC_MSG_RESULT(["cobuild"])
+
+    AC_ARG_WITH([hwloc-cobuild-libs],
+                [AS_HELP_STRING([--with-hwloc-cobuild-libs=LIBS],
+                                [Add the LIBS string to LIBS])])
+
+    prte_hwloc_source="cobuild"
+    PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_hwloc_cobuild_libs])
+])dnl
+
+
+dnl To support cobuilds, any tests that require linking or running (as
+dnl opposed to preprocessing or compiling) should only exist in the
+dnl HWLOC_EXTERNAL section, since cobuild does not guarantee that a
+dnl library will be available at configure time.
+AC_DEFUN([_PRTE_HWLOC_EXTERNAL],[
+    PRTE_VAR_SCOPE_PUSH([hwloc_prefix hwlocdir_prefix])
+
+    # get rid of any trailing slash(es)
+    hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
+    hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
+
+    AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                 [prte_hwloc_dir="$hwloc_prefix"],
+                 [prte_hwloc_dir=""])
+
+    AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
+                 [prte_hwloc_libdir="$hwlocdir_prefix"],
+                 [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                        [if test -d $hwloc_prefix/lib64; then
+                            prte_hwloc_libdir=$hwloc_prefix/lib64
+                         elif test -d $hwloc_prefix/lib; then
+                            prte_hwloc_libdir=$hwloc_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [prte_hwloc_libdir=""])])
+
+    PRTE_CHECK_PACKAGE([prte_hwloc],
+                       [hwloc.h],
+                       [hwloc],
+                       [hwloc_topology_init],
+                       [],
+                       [$prte_hwloc_dir],
+                       [$prte_hwloc_libdir],
+                       [$1],
+                       [$2],
+                       [])
+
+    if test -z "$prte_hwloc_dir"; then
+        prte_hwloc_source="Standard locations"
+    else
+        prte_hwloc_source=$prte_hwloc_dir
+    fi
+
+    PRTE_VAR_SCOPE_POP
+])dnl

--- a/config/3rd-party/prrte/prte_setup_libevent.m4
+++ b/config/3rd-party/prrte/prte_setup_libevent.m4
@@ -1,0 +1,249 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017-2019 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# We have two modes for building libevent.
+#
+# First is as a co-built libevent.  In this case, Prte's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# libevent headers and LIBS will point to where the .la file for
+# libevent will exist.  When co-building, libevent's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-libevent=cobuild option is specified.
+#
+# Second is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# libevent.  This mode is used whenever the other modes are not used.
+#
+# PRTE_LIBEVENT_CONFIG()
+# --------------------------------------------------------------------
+AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
+    PRTE_VAR_SCOPE_PUSH()
+
+    AC_ARG_WITH([libevent],
+                [AS_HELP_STRING([--with-libevent=DIR],
+                                [Search for libevent headers and libraries in DIR ])])
+
+    AC_ARG_WITH([libevent-libdir],
+                [AS_HELP_STRING([--with-libevent-libdir=DIR],
+                                [Search for libevent libraries in DIR ])])
+
+    prte_libevent_support=1
+
+    prte_check_libevent_save_CPPFLAGS="$CPPFLAGS"
+    prte_check_libevent_save_LDFLAGS="$LDFLAGS"
+    prte_check_libevent_save_LIBS="$LIBS"
+
+    # figure out our mode...
+    AS_IF([test "$with_libevent" = "cobuild"],
+          [_PRTE_LIBEVENT_EMBEDDED_MODE()],
+          [_PRTE_LIBEVENT_EXTERNAL([prte_libevent_support=1],
+                                   [prte_libevent_support=0])])
+
+    # Check to see if the above check failed because it conflicted with LSF's libevent.so
+    # This can happen if LSF's library is in the LDFLAGS envar or default search
+    # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+    # in Libevent's libevent.so
+    #
+    # Note that even in a cobuild situation, calling AC_CHECK_LIB is
+    # fine here, because we aren't testing Libevent's library, we're
+    # effectively testing LSF's library.  We never cobuild LSF
+    # (please, may that never happen), so there's no cobuild problem.
+    if test $prte_libevent_support -eq 0; then
+        AC_CHECK_LIB([event], [event_getcode4name],
+                     [AC_MSG_WARN([===================================================================])
+                      AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                      AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                      AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                      AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                      AC_MSG_WARN([LSF library path.])
+                      AC_MSG_WARN([===================================================================])
+                      ])
+    fi
+
+    # need to add resulting flags to global ones so we can
+    # test for thread support
+    if test ! -z "$prte_libevent_CPPFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(CPPFLAGS, $prte_libevent_CPPFLAGS)
+    fi
+    if test ! -z "$prte_libevent_LDFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LDFLAGS, $prte_libevent_LDFLAGS)
+    fi
+    if test ! -z "$prte_libevent_LIBS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LIBS, $prte_libevent_LIBS)
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+       AC_MSG_CHECKING([if libevent threads enabled])
+       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [
+         #include <event.h>
+         #include <event2/thread.h>
+        ],
+        [[
+         #if !(EVTHREAD_LOCK_API_VERSION >= 1)
+         #  error "No threads!"
+         #endif
+        ]])],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])
+         AC_MSG_ERROR([PRTE rquires libevent to be compiled with thread support enabled])
+	 prte_libevent_support=0])
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+       AC_MSG_CHECKING([for libevent pthreads support])
+       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [
+         #include <event.h>
+         #include <event2/thread.h>
+        ],
+        [[
+         #if !defined(EVTHREAD_USE_PTHREADS_IMPLEMENTED) || !EVTHREAD_USE_PTHREADS_IMPLEMENTED
+         #  error "No pthreads!"
+         #endif
+        ]])],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])
+         AC_MSG_ERROR([PRTE requires libevent to be compiled with pthread support enabled])
+	 prte_libevent_support=0])
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+        # Pin the "oldest supported" version to 2.0.21
+        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
+                                           [[
+                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #endif
+                                           ]])],
+                          [AC_MSG_RESULT([yes])],
+                          [AC_MSG_RESULT([no])
+                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
+                           prte_libevent_support=0])
+    fi
+
+    PRTE_EVENT_HEADER="<event.h>"
+    PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
+
+    AC_MSG_CHECKING([will libevent support be built])
+    if test $prte_libevent_support -eq 1; then
+        AC_MSG_RESULT([yes])
+        if test ! -z "$prte_libevent_CPPFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_libevent_CPPFLAGS)
+        fi
+        if test ! -z "$prte_libevent_LDFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_libevent_LDFLAGS)
+        fi
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_libevent_LIBS)
+        # Set output variables
+        AC_DEFINE_UNQUOTED([PRTE_EVENT_HEADER], [$PRTE_EVENT_HEADER],
+                           [Location of event.h])
+        AC_DEFINE_UNQUOTED([PRTE_EVENT2_THREAD_HEADER], [$PRTE_EVENT2_THREAD_HEADER],
+                           [Location of event2/thread.h])
+        PRTE_SUMMARY_ADD([[Required Packages]],[[Libevent]], [prte_libevent], [yes ($prte_libevent_source)])
+    else
+        AC_MSG_RESULT([no])
+    fi
+
+    # restore global flags
+    CPPFLAGS="$prte_check_libevent_save_CPPFLAGS"
+    LDFLAGS="$prte_check_libevent_save_LDFLAGS"
+    LIBS="$prte_check_libevent_save_LIBS"
+
+    dnl These are needed for backwards comptability with the 2.1 and
+    dnl earlier branches.
+    AC_DEFINE([PRTE_EVENT_HEADER], [<event.h>], [Location of event.h])
+    AC_DEFINE([PRTE_EVENT2_THREAD_HEADER], [<event2/thread.h>], [Location of event.h])
+
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_LIBEVENT], [$prte_libevent_support], [Whether we are building against libevent])
+
+    PRTE_VAR_SCOPE_POP()
+])dnl
+
+
+AC_DEFUN([_PRTE_LIBEVENT_EMBEDDED_MODE], [
+    AC_MSG_CHECKING([for libevent])
+    AC_MSG_RESULT(["cobuild"])
+
+    AC_ARG_WITH([libevent-cobuild-libs],
+                [AS_HELP_STRING([--with-libevent-cobuild-libs=LIBS],
+                                [Add the LIBS string to LIBS])])
+
+    prte_libevent_source=cobuild
+    PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_libevent_cobuild_libs])
+])dnl
+
+
+dnl To support cobuilds, any tests that require linking or running (as
+dnl opposed to preprocessing or compiling) should only exist in the
+dnl LIBEVENT_EXTERNAL section, since cobuild does not guarantee that a
+dnl library will be available at configure time.
+AC_DEFUN([_PRTE_LIBEVENT_EXTERNAL],[
+    PRTE_VAR_SCOPE_PUSH([libevent_prefix libeventdir_prefix])
+
+    # get rid of any trailing slash(es)
+    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+
+    AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+          [prte_event_dir="$libevent_prefix"],
+          [prte_event_dir=""])
+
+    AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+                 [prte_event_libdir="$libeventdir_prefix"],
+                 [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                        [if test -d $libevent_prefix/lib64; then
+                            prte_event_libdir=$libevent_prefix/lib64
+                         elif test -d $libevent_prefix/lib; then
+                            prte_event_libdir=$libevent_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [prte_event_libdir=""])])
+
+    PRTE_CHECK_PACKAGE([prte_libevent],
+                       [event.h],
+                       [event_core],
+                       [event_config_new],
+                       [-levent_pthreads],
+                       [$prte_event_dir],
+                       [$prte_event_libdir],
+                       [$1],
+                       [$2],
+                       [])
+
+    if test -z "$prte_event_dir"; then
+        prte_libevent_source="Standard locations"
+    else
+        prte_libevent_source=$prte_event_dir
+    fi
+
+    PRTE_VAR_SCOPE_POP
+])dnl

--- a/config/3rd-party/prrte/prte_setup_pmix.m4
+++ b/config/3rd-party/prrte/prte_setup_pmix.m4
@@ -1,0 +1,244 @@
+# -*- shell-script ; indent-tabs-mode:nil -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# We have two modes for building pmix.
+#
+# First is as a co-built pmix.  In this case, Prte's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# pmix headers and LIBS will point to where the .la file for
+# pmix will exist.  When co-building, pmix's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-pmix=cobuild option is specified.
+#
+# Second is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# pmix.  This mode is used whenever the other modes are not used.
+#
+# PRTE_SETUP_PMIX()
+# --------------------------------------------------------------------
+AC_DEFUN([PRTE_CHECK_PMIX],[
+    PRTE_VAR_SCOPE_PUSH([prte_external_pmix_save_CPPFLAGS prte_external_pmix_save_LDFLAGS prte_external_pmix_save_LIBS prte_external_pmix_version_found prte_external_pmix_version])
+
+    AC_ARG_WITH([pmix],
+                [AS_HELP_STRING([--with-pmix(=DIR)],
+                                [Where to find PMIx support, optionally adding DIR to the search path])])
+
+    AC_ARG_WITH([pmix-libdir],
+                [AS_HELP_STRING([--with-pmix-libdir=DIR],
+                                [Look for libpmix in the given directory DIR, DIR/lib or DIR/lib64])])
+
+    AC_ARG_ENABLE([pmix-devel-support],
+                  [AS_HELP_STRING([--enable-pmix-devel-support],
+                                  [Add necessary wrapper flags to enable access to PMIx devel headers])])
+
+    prte_pmix_support=0
+
+    if test "$with_pmix" = "no"; then
+        AC_MSG_WARN([PRTE requires PMIx support using])
+        AC_MSG_WARN([an external copy that you supply.])
+        AC_MSG_ERROR([Cannot continue])
+    fi
+
+    prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
+    prte_external_pmix_save_LDFLAGS=$LDFLAGS
+    prte_external_pmix_save_LIBS=$LIBS
+
+    # figure out our mode...
+    AS_IF([test "$with_pmix" = "cobuild"],
+          [_PRTE_PMIX_EMBEDDED_MODE()],
+          [_PRTE_PMIX_EXTERNAL()])
+
+    # need to add resulting flags to global ones so we can
+    # test the version
+    if test ! -z "$prte_pmix_CPPFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LDFLAGS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LIBS"; then
+        PRTE_FLAGS_PREPEND_UNIQ(LIBS, $prte_pmix_LIBS)
+    fi
+
+    # if the version file exists, then we need to parse it to find
+    # the actual release series
+    AC_MSG_CHECKING([version 4x])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <pmix_version.h>
+                                        #if (PMIX_VERSION_MAJOR < 4L)
+                                        #error "not version 4 or above"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([found])
+                       prte_external_pmix_version=4x
+                       prte_external_pmix_version_found=4],
+                      [AC_MSG_RESULT([not found])
+                       prte_external_pmix_version_found=0])
+
+    AS_IF([test "$prte_external_pmix_version_found" = "4"],
+          [AC_MSG_CHECKING([version 4.1 or greater])
+            AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                #include <pmix_version.h>
+                                                #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+                                                #error "not version 4.1 or above"
+                                                #endif
+                                               ], [])],
+                              [AC_MSG_RESULT([found])],
+                              [AC_MSG_RESULT([not found])
+                               prte_external_pmix_version_found=0])])
+
+    # restore the global flags
+    CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
+    LDFLAGS=$prte_external_pmix_save_LDFLAGS
+    LIBS=$prte_external_pmix_save_LIBS
+
+    AS_IF([test "$prte_external_pmix_version_found" = "0"],
+          [AC_MSG_WARN([PRTE does not support PMIx versions])
+           AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
+           AC_MSG_WARN([can connect to the server.])
+           AC_MSG_ERROR([Please select a newer version and configure again])])
+
+    if test ! -z "$prte_pmix_CPPFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LDFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LIBS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
+    fi
+
+    PMIXCC_PATH=""
+    if test -z "$pmix_ext_install_dir"; then
+        PRTE_WHICH([pmixcc], [PMIXCC_PATH])
+        AS_IF([test -z "$PMIXCC_PATH"],
+                [AC_MSG_WARN([Could not find pmixcc in PATH])
+                 prte_pmixcc_happy=no],
+                [prte_pmixcc_happy=yes])
+    else
+        PMIXCC_PATH=$pmix_ext_install_dir/bin
+        if test -d $PMIXCC_PATH; then
+            PMIXCC_PATH=$PMIXCC_PATH/pmixcc
+            if test -e $PMIXCC_PATH; then
+                prte_pmixcc_happy=yes
+
+            else
+                AC_MSG_WARN([Could not find usable $PMIXCC_PATH])
+                prte_pmixcc_happy=no
+            fi
+        else
+            AC_MSG_WARN([Could not find $PMIXCC_PATH])
+            prte_pmixcc_happy=no
+        fi
+    fi
+    AM_CONDITIONAL(PRTE_HAVE_PMIXCC, test "$prte_pmixcc_happy" = "yes")
+    AC_SUBST(PMIXCC_PATH)
+
+    PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]],[pmix],[yes ($prte_pmix_source)])
+
+    PRTE_VAR_SCOPE_POP
+
+    dnl This is needed for backwards comptability with the 2.1 and
+    dnl earlier branches.
+    AC_DEFINE([PRTE_PMIX_HEADER], [<pmix.h>], [PMIx header to use])
+])dnl
+
+
+AC_DEFUN([_PRTE_PMIX_EMBEDDED_MODE],[
+    AC_MSG_CHECKING([for PMIX])
+    AC_MSG_RESULT(["cobuild"])
+
+    AC_ARG_WITH([pmix-cobuild-libs],
+                [AS_HELP_STRING([--with-pmix-cobuild-libs=LIBS],
+                                [Add the LIBS string to LIBS])])
+
+    prte_pmix_source="cobuild"
+    PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_pmix_cobuild_libs])
+])dnl
+
+
+dnl To support cobuilds, any tests that require linking or running (as
+dnl opposed to preprocessing or compiling) should only exist in the
+dnl PMIX_EXTERNAL section, since cobuild does not guarantee that a
+dnl library will be available at configure time.
+AC_DEFUN([_PRTE_PMIX_EXTERNAL],[
+    PRTE_VAR_SCOPE_PUSH([pmix_prefix pmixdir_prefix pmix_ext_install_libdir])
+
+    # get rid of any trailing slash(es)
+    pmix_prefix=$(echo $with_pmix | sed -e 'sX/*$XXg')
+    pmixdir_prefix=$(echo $with_pmix_libdir | sed -e 'sX/*$XXg')
+
+    # check for external pmix header */
+    AS_IF([test ! -z "$pmix_prefix" && test "$pmix_prefix" != "yes"],
+                 [pmix_ext_install_dir="$pmix_prefix"],
+                 [pmix_ext_install_dir=""])
+
+    AS_IF([test ! -z "$pmixdir_prefix" && test "$pmixdir_prefix" != "yes"],
+                 [pmix_ext_install_libdir="$pmixdir_prefix"],
+                 [AS_IF([test ! -z "$pmix_prefix" && test "$pmix_prefix" != "yes"],
+                        [if test -d $pmix_prefix/lib64; then
+                            pmix_ext_install_libdir=$pmix_prefix/lib64
+                         elif test -d $pmix_prefix/lib; then
+                            pmix_ext_install_libdir=$pmix_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $pmix_prefix/lib or $pmix_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [pmix_ext_install_libdir=""])])
+
+    PRTE_CHECK_PACKAGE([prte_pmix],
+                       [pmix.h],
+                       [pmix],
+                       [PMIx_Init],
+                       [],
+                       [$pmix_ext_install_dir],
+                       [$pmix_ext_install_libdir],
+                       [],
+                       [],
+                       [AC_MSG_WARN([PRTE requires PMIx support using])
+                        AC_MSG_WARN([an external copy that you supply.])
+                        if test -z "$pmix_ext_install_libdir"; then
+                            AC_MSG_WARN([The library was not found in standard locations.])
+                        else
+                            AC_MSG_WARN([The library was not found in $pmix_ext_install_libdir.])
+                        fi
+                        AC_MSG_ERROR([Cannot continue])])
+
+    if test -z "$pmix_ext_install_dir"; then
+        prte_pmix_source="Standard locations"
+    else
+        prte_pmix_source=$pmix_ext_install_dir
+    fi
+
+    PRTE_VAR_SCOPE_POP
+])dnl

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -159,19 +159,19 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_INTERNAL], [
               [internal_prrte_args="$internal_prrte_args --enable-prte-prefix-by-default"])
 
     AS_IF([test "$opal_libevent_mode" = "internal"],
-          [internal_prrte_args="$internal_prrte_args --with-libevent-header=$opal_libevent_header"
-           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_libevent_CPPFLAGS"
-           internal_prrte_libs="$internal_prrte_libs $opal_libevent_LIBS"])
+          [internal_prrte_args="$internal_prrte_args --with-libevent=cobuild"
+           internal_prrte_args="$internal_prrte_args --with-libevent-cobuild-libs=\"$opal_libevent_LIBS\""
+           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_libevent_CPPFLAGS"])
 
     AS_IF([test "$opal_hwloc_mode" = "internal"],
-          [internal_prrte_args="$internal_prrte_args --with-hwloc-header=$opal_hwloc_header"
-           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_hwloc_CPPFLAGS"
-           internal_prrte_libs="$internal_prrte_libs $opal_hwloc_LIBS"])
+          [internal_prrte_args="$internal_prrte_args --with-hwloc=cobuild"
+           internal_prrte_args="$internal_prrte_args --with-hwloc-cobuild-libs=\"$opal_hwloc_LIBS\""
+           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_hwloc_CPPFLAGS"])
 
     AS_IF([test "$opal_pmix_mode" = "internal"],
-          [internal_prrte_args="$internal_prrte_args --with-pmix-header=$opal_pmix_header"
-           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_pmix_CPPFLAGS"
-           internal_prrte_libs="$internal_prrte_libs $opal_pmix_LIBS"])
+          [internal_prrte_args="$internal_prrte_args --with-pmix=cobuild"
+           internal_prrte_args="$internal_prrte_args --with-pmix-cobuild-libs=\"$opal_pmix_LIBS\""
+           internal_prrte_CPPFLAGS="$internal_prrte_CPPFLAGS $opal_pmix_CPPFLAGS"])
 
     AC_MSG_CHECKING([if PMIx version is 4.0.0 or greater])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <pmix_version.h>]],
@@ -190,8 +190,6 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_INTERNAL], [
              AC_MSG_WARN([--without-prrte option.])
              AC_MSG_ERROR([Cannot continue])])
 
-    # add the extra libs
-    internal_prrte_args="$internal_prrte_args --with-prte-extra-lib=\"$internal_prrte_libs\" --with-prte-extra-ltlib=\"$internal_prrte_libs\""
     AS_IF([test "$with_ft" != "no"],
           [internal_prrte_args="--enable-prte-ft $internal_prrte_args"],
           [])

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -64,7 +64,7 @@ dnl         application when opal is built as a static library.
 dnl   * CPPFLAGS, LDFLAGS - Updated opal_pmix_CPPFLAGS and
 dnl         opal_pmix_LDFLAGS.
 AC_DEFUN([OPAL_CONFIG_PMIX], [
-    OPAL_VAR_SCOPE_PUSH([external_pmix_happy internal_pmix_happy internal_pmix_args internal_pmix_libs internal_pmix_CPPFLAGS])
+    OPAL_VAR_SCOPE_PUSH([external_pmix_happy internal_pmix_happy internal_pmix_args internal_pmix_CPPFLAGS])
 
     opal_show_subtitle "Configuring PMIx"
 
@@ -92,16 +92,15 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
 
                 AS_IF([test "$opal_libevent_mode" = "internal"],
                       [internal_pmix_args="$internal_pmix_args --with-libevent=cobuild"
-                       internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_libevent_CPPFLAGS"
-                       internal_pmix_libs="$internal_pmix_libs $opal_libevent_LIBS"])
+                       internal_pmix_args="$internal_pmix_args --with-libevent-cobuild-libs=\"$opal_libevent_LIBS\""
+                       internal_pmix_args="$internal_pmix_args --with-libevent-cobuild-wrapper-libs=\"$opal_libevent_WRAPPER_LIBS\""
+                       internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_libevent_CPPFLAGS"])
 
                 AS_IF([test "$opal_hwloc_mode" = "internal"],
                       [internal_pmix_args="$internal_pmix_args --with-hwloc=cobuild"
-                      internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_hwloc_CPPFLAGS"
-                      internal_pmix_libs="$internal_pmix_libs $opal_hwloc_LIBS"])
-
-                AS_IF([test ! -z "$internal_pmix_libs"],
-                      [internal_pmix_args="$internal_pmix_args --with-pmix-extra-lib=\"$internal_pmix_libs\""])
+                       internal_pmix_args="$internal_pmix_args --with-hwloc-cobuild-libs=\"$opal_hwloc_LIBS\""
+                       internal_pmix_args="$internal_pmix_args --with-hwloc-cobuild-wrapper-libs=\"$opal_hwloc_WRAPPER_LIBS\""
+                       internal_pmix_CPPFLAGS="$internal_pmix_CPPFLAGS $opal_hwloc_CPPFLAGS"])
 
                 if test "$WANT_DEBUG" = "1"; then
                      internal_pmix_args="$internal_pmix_args --enable-debug"


### PR DESCRIPTION
Infrastructure to allow Open MPI 5.0.x / master to build using submodules from recent PMIX/PRRTE branches (as well as the current branches)