### PR TITLE
ompi/util/timings.h: use back-end OMPI calls

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2009 University of Houston. All rights reserved.
@@ -728,7 +728,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     if (OMPI_TIMING_ENABLED && !opal_pmix_base_async_modex &&
             opal_pmix_collect_all_data && !ompi_singleton) {
         if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, NULL, 0))) {
-            ret - opal_pmix_convert_status(rc);
+            ret = opal_pmix_convert_status(rc);
             error = "timing: pmix-barrier-1 failed";
             goto error;
         }

--- a/ompi/util/timings.h
+++ b/ompi/util/timings.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017-2018 Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2021-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +13,6 @@
 #define OMPI_UTIL_TIMING_H
 
 #include "opal/util/timings.h"
-/* TODO: we need access to MPI_* functions */
 
 #if (OPAL_ENABLE_TIMING)
 
@@ -166,14 +166,15 @@ typedef struct ompi_timing_t {
 #define OMPI_TIMING_OUT                                                           \
     do {                                                                          \
         if (OMPI_TIMING.enabled) {                                                \
-            int i, size, rank;                                                    \
-            MPI_Comm_size(MPI_COMM_WORLD, &size);                                 \
-            MPI_Comm_rank(MPI_COMM_WORLD, &rank);                                 \
+            int i;                                                                \
+            int size = ompi_comm_size(MPI_COMM_WORLD);                            \
+            int rank = ompi_comm_rank(MPI_COMM_WORLD);                            \
             int error = 0;                                                        \
             int imported = 0;                                                     \
                                                                                   \
-            MPI_Reduce(&OMPI_TIMING.error, &error, 1,                             \
-                MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);                             \
+            MPI_COMM_WORLD->c_coll->coll_reduce(&OMPI_TIMING.error, &error, 1,    \
+                                                MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD, \
+                                                MPI_COMM_WORLD->c_coll->coll_reduce_module); \
                                                                                   \
             if (error) {                                                          \
                 if (0 == rank) {                                                  \
@@ -196,12 +197,15 @@ typedef struct ompi_timing_t {
                     do {                                                          \
                         int use;                                                  \
                         for (use = 0; use < timing->use; use++) {                 \
-                            MPI_Reduce(&timing->val[use].ts, avg + i, 1,          \
-                                MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);          \
-                            MPI_Reduce(&timing->val[use].ts, min + i, 1,          \
-                                MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);          \
-                            MPI_Reduce(&timing->val[use].ts, max + i, 1,          \
-                                MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);          \
+                            MPI_COMM_WORLD->c_coll->coll_reduce(&timing->val[use].ts, avg + i, 1,         \
+                                                                MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD, \
+                                                                MPI_COMM_WORLD->c_coll->coll_reduce_module); \
+                            MPI_COMM_WORLD->c_coll->coll_reduce(&timing->val[use].ts, min + i, 1, \
+                                                                MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD, \
+                                                                MPI_COMM_WORLD->c_coll->coll_reduce_module); \
+                            MPI_COMM_WORLD->c_coll->coll_reduce(&timing->val[use].ts, max + i, 1, \
+                                                                MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD, \
+                                                                MPI_COMM_WORLD->c_coll->coll_reduce_module); \
                             desc[i] = timing->val[use].desc;                      \
                             prefix[i] = timing->val[use].prefix;                  \
                             file[i] = timing->val[use].file;                      \

--- a/ompi/util/timings.h
+++ b/ompi/util/timings.h
@@ -169,14 +169,14 @@ typedef struct ompi_timing_t {
             int i;                                                                \
             int size = ompi_comm_size(MPI_COMM_WORLD);                            \
             int rank = ompi_comm_rank(MPI_COMM_WORLD);                            \
-            int error = 0;                                                        \
+            int timing_error = 0;                                                 \
             int imported = 0;                                                     \
                                                                                   \
-            MPI_COMM_WORLD->c_coll->coll_reduce(&OMPI_TIMING.error, &error, 1,    \
+            MPI_COMM_WORLD->c_coll->coll_reduce(&OMPI_TIMING.error, &timing_error, 1, \
                                                 MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD, \
                                                 MPI_COMM_WORLD->c_coll->coll_reduce_module); \
                                                                                   \
-            if (error) {                                                          \
+            if (timing_error) {                                                   \
                 if (0 == rank) {                                                  \
                     printf("==OMPI_TIMING== error: something went wrong, timings doesn't work\n"); \
                 }                                                                 \


### PR DESCRIPTION
Noticed this while looking into other things: we have some timing
macros in MPI_INIT and MPI_FINALIZE that were calling MPI_* functions.
Change them to use the corresponding back-end ompi_* and pointer-based
function calls so that we don't accidentally pollute calls to a
profiled MPI library.

Also, in a 2nd commit, fix two trivial bugs in the timings code.