### PR TITLE
First step in fixing static builds on master/v5.0

### DIFF
--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -92,8 +92,10 @@ AC_DEFUN([OPAL_CONFIG_HWLOC], [
           [opal_hwloc_WRAPPER_LDFLAGS="$pkg_config_ldflags"
            opal_hwloc_WRAPPER_LIBS="$pkg_config_libs"],
           [# guess that what we have from compiling OMPI is good enough
-           opal_hwloc_WRAPPER_LDFLAGS="$opal_hwloc_LDFLAGS"
-           opal_hwloc_WRAPPER_LIBS="$opal_hwloc_LIBS"])
+           AS_IF([test -z "$opal_hwloc_WRAPPER_LDFLAGS"],
+                 [opal_hwloc_WRAPPER_LDFLAGS="$opal_hwloc_LDFLAGS"])
+           AS_IF([test -z "$opal_hwloc_WRAPPER_LIBS"],
+                 [opal_hwloc_WRAPPER_LIBS="$opal_hwloc_LIBS"])])
 
     OPAL_WRAPPER_FLAGS_ADD([LDFLAGS], [$opal_hwloc_WRAPPER_LDFLAGS])
     OPAL_WRAPPER_FLAGS_ADD([LIBS], [$opal_hwloc_WRAPPER_LIBS])
@@ -199,6 +201,7 @@ AC_DEFUN([_OPAL_CONFIG_HWLOC_INTERNAL], [
          # our tree and in the mean time are referenced by their .la
          # files.
          opal_hwloc_LIBS="$OMPI_TOP_BUILDDIR/$internal_hwloc_location/hwloc/libhwloc.la"
+         opal_hwloc_WRAPPER_LIBS="-lhwloc"
 
          opal_hwloc_header="$OMPI_TOP_BUILDDIR/$internal_hwloc_location/include/hwloc.h"
 

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -103,8 +103,10 @@ AC_DEFUN([OPAL_CONFIG_LIBEVENT], [
            opal_libevent_WRAPPER_LIBS="$pkg_config_pthreads_libs"
            OPAL_FLAGS_APPEND_MOVE([opal_libevent_WRAPPER_LIBS], [$pkg_config_core_libs])],
           [# guess that what we have from compiling OMPI is good enough
-           opal_libevent_WRAPPER_LDFLAGS="$opal_libevent_LDFLAGS"
-           opal_libevent_WRAPPER_LIBS="$opal_libevent_LIBS"])
+           AS_IF([test -z "$opal_libevent_WRAPPER_LDFLAGS"],
+                 [opal_libevent_WRAPPER_LDFLAGS="$opal_libevent_LDFLAGS"])
+           AS_IF([test -z "$opal_libevent_WRAPPER_LIBS"],
+                 [opal_libevent_WRAPPER_LIBS="$opal_libevent_LIBS"])])
 
     OPAL_WRAPPER_FLAGS_ADD([LDFLAGS], [$opal_libevent_WRAPPER_LDFLAGS])
     OPAL_WRAPPER_FLAGS_ADD([LIBS], [$opal_libevent_WRAPPER_LIBS])
@@ -239,6 +241,7 @@ AC_DEFUN([_OPAL_CONFIG_LIBEVENT_INTERNAL], [
          # our tree and in the mean time are referenced by their .la
          # files.
          opal_libevent_LIBS="$OMPI_TOP_BUILDDIR/$internal_libevent_location/libevent_core.la $OMPI_TOP_BUILDDIR/$internal_libevent_location/libevent_pthreads.la"
+	 opal_libevent_WRAPPER_LIBS="-levent_core -levent_pthreads"
 
          opal_libevent_header="$OMPI_TOP_BUILDDIR/$internal_libevent_location/event.h"
 

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -515,8 +515,9 @@ AC_DEFUN([OPAL_FLAGS_APPEND_MOVE], [
                      AS_IF([test "x$val" != "x$arg"],
                            [OPAL_APPEND([opal_tmp_variable], [$val])])
                  done
-                 OPAL_APPEND([opal_tmp_variable], [$arg])])
-                 $1="$opal_tmp_variable"
+                 OPAL_APPEND([opal_tmp_variable], [$arg])
+                 $1="$opal_tmp_variable"],
+                [OPAL_APPEND([$1], [$arg])])
     done
 
     OPAL_VAR_SCOPE_POP


### PR DESCRIPTION
Get the simple case static builds working again (which should solve Jeff's MTT problems).  There are still three issues: 1) need to backport some fixes in PMIX so that it declares its dependencies correctly and then bump submodules, 2) need to have a better answer when pkg-config is not installed, especially for PMIX, and 3) when pkg-config is available, we should consider using it for OPAL_CHECK_PACKAGE.

But for now, fix the build.