### PR TITLE
v5.0.x: btl/uct: add support for UCX 1.10.x

### DIFF
--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -182,12 +182,22 @@ struct mca_btl_uct_conn_completion_t {
 };
 typedef struct mca_btl_uct_conn_completion_t mca_btl_uct_conn_completion_t;
 
-static void mca_btl_uct_endpoint_flush_complete(uct_completion_t *self, ucs_status_t status)
+#if UCT_API >= ((1L<<UCT_MAJOR_BIT)|(10L << UCT_MINOR_BIT))
+static void mca_btl_uct_endpoint_flush_complete(uct_completion_t *self)
 {
     mca_btl_uct_conn_completion_t *completion = (mca_btl_uct_conn_completion_t *) self;
     BTL_VERBOSE(("connection flush complete"));
     completion->complete = true;
 }
+#else
+static void mca_btl_uct_endpoint_flush_complete(uct_completion_t *self, ucs_status_t status)
+{
+    mca_btl_uct_conn_completion_t *completion = (mca_btl_uct_conn_completion_t *) self;
+    (void) status;
+    BTL_VERBOSE(("connection flush complete"));
+    completion->complete = true;
+}
+#endif
 
 static int mca_btl_uct_endpoint_send_conn_req(mca_btl_uct_module_t *uct_btl,
                                               mca_btl_base_endpoint_t *endpoint,

--- a/opal/mca/btl/uct/btl_uct_frag.c
+++ b/opal/mca/btl/uct/btl_uct_frag.c
@@ -11,7 +11,7 @@
 
 #include "btl_uct_frag.h"
 
-static void mca_btl_uct_frag_completion(uct_completion_t *uct_comp, ucs_status_t status)
+static void mca_btl_uct_frag_completion_compat(uct_completion_t *uct_comp, ucs_status_t status)
 {
     mca_btl_uct_uct_completion_t *comp = (mca_btl_uct_uct_completion_t
                                               *) ((uintptr_t) uct_comp
@@ -23,6 +23,16 @@ static void mca_btl_uct_frag_completion(uct_completion_t *uct_comp, ucs_status_t
     comp->status = status;
     opal_fifo_push(&comp->dev_context->completion_fifo, &comp->super.super);
 }
+
+#if UCT_API >= ((1L<<UCT_MAJOR_BIT)|(10L << UCT_MINOR_BIT))
+static void mca_btl_uct_frag_completion(uct_completion_t *uct_comp) {
+    mca_btl_uct_frag_completion_compat(uct_comp, uct_comp->status);
+}
+#else
+static void mca_btl_uct_frag_completion(uct_completion_t *uct_comp, ucs_status_t status) {
+    mca_btl_uct_frag_completion_compat(uct_comp, status);
+}
+#endif
 
 static void mca_btl_uct_base_frag_constructor(mca_btl_uct_base_frag_t *frag)
 {

--- a/opal/mca/btl/uct/btl_uct_rdma.c
+++ b/opal/mca/btl/uct/btl_uct_rdma.c
@@ -11,7 +11,7 @@
 
 #include "btl_uct_device_context.h"
 
-void mca_btl_uct_uct_completion(uct_completion_t *uct_comp, ucs_status_t status)
+static void mca_btl_uct_uct_completion_compat(uct_completion_t *uct_comp, ucs_status_t status)
 {
     mca_btl_uct_uct_completion_t *comp = (mca_btl_uct_uct_completion_t
                                               *) ((uintptr_t) uct_comp
@@ -23,6 +23,16 @@ void mca_btl_uct_uct_completion(uct_completion_t *uct_comp, ucs_status_t status)
     comp->status = status;
     opal_fifo_push(&comp->dev_context->completion_fifo, &comp->super.super);
 }
+
+#if UCT_API >= ((1L<<UCT_MAJOR_BIT)|(10L << UCT_MINOR_BIT))
+static void mca_btl_uct_uct_completion(uct_completion_t *uct_comp) {
+    mca_btl_uct_uct_completion_compat(uct_comp, uct_comp->status);
+}
+#else
+static void mca_btl_uct_uct_completion(uct_completion_t *uct_comp, ucs_status_t status) {
+     mca_btl_uct_uct_completion_compat(uct_comp, status);
+}
+#endif
 
 static void mca_btl_uct_uct_completion_construct(mca_btl_uct_uct_completion_t *comp)
 {

--- a/opal/mca/btl/uct/btl_uct_rdma.h
+++ b/opal/mca/btl/uct/btl_uct_rdma.h
@@ -28,8 +28,6 @@ mca_btl_uct_uct_completion_t *mca_btl_uct_uct_completion_alloc(
  */
 void mca_btl_uct_uct_completion_release(mca_btl_uct_uct_completion_t *comp);
 
-void mca_btl_uct_uct_completion(uct_completion_t *uct_comp, ucs_status_t status);
-
 /**
  * @brief unpack the registration key and ensure the endpoint is connected
  *


### PR DESCRIPTION
This commit adjusts for yet another API break in UCT. This time it is the removal of
a parameter to a callback function. This change should allow btl/uct to be used with
1.10 so bumping to allow version to reflect the change.

Fixes #9743

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit 8fbee98f368528482065d16ead0dea006734c620)