### PR TITLE
lanl-ci: move to intel oneapi compilers

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -16,7 +16,7 @@ build:intel:
     - cp $GITSUBMODULEPATCH .gitmodules
     - git submodule update --init
     - ./autogen.pl
-    - ./configure CC=icc FC=ifort CXX=icpc --prefix=$PWD/install_test --with-libevent=internal
+    - ./configure CC=icx FC=ifx CXX=icpx --prefix=$PWD/install_test --with-libevent=internal
     - make -j 8 install
     - make check
     - export PATH=$PWD/install_test/bin:$PATH


### PR DESCRIPTION
well we were thrown into the deep end.  the system
admins moved to the intel oneapi compilers after the
most recent DST, so just say no to icc, etc.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>