### PR TITLE
lanl-ci: update batch time

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  SCHEDULER_PARAMETERS: "-pgeneral -t 2:00:00 -N 1 --ntasks-per-node=16"
+  SCHEDULER_PARAMETERS: "-pgeneral -t 4:00:00 -N 1 --ntasks-per-node=16"
   GIT_STRATEGY: clone
   NPROCS: 4
 
@@ -34,7 +34,7 @@ build:ibm:
   stage: build
   tags: [darwin-slurm-shared]
   variables:
-    SCHEDULER_PARAMETERS: "-ppower9 -t 2:00:00 -N 1 --ntasks-per-node=16"
+    SCHEDULER_PARAMETERS: "-ppower9 -t 4:00:00 -N 1 --ntasks-per-node=16"
   script:
     - module load ibm
     - rm .gitmodules
@@ -59,7 +59,7 @@ build:amd:
   stage: build
   tags: [darwin-slurm-shared]
   variables:
-    SCHEDULER_PARAMETERS: "-pamd-rome -t 2:00:00 -N 1 --ntasks-per-node=16"
+    SCHEDULER_PARAMETERS: "-pamd-rome -t 4:00:00 -N 1 --ntasks-per-node=16"
   script:
     - module load aocc/3.0.0
     - rm .gitmodules


### PR DESCRIPTION
taking up to 4 hours to build OMPI on darwin NFS file system

Signed-off-by: Howard Pritchard <howardp@lanl.gov>