### PR TITLE
v4.0.x: sharedfp_sm_file_component_query: add file open to ensure correct ope…

### DIFF
--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -107,6 +107,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(o
     
     asprintf(&sm_filename, "%s/%s_cid-%d-%d.sm", ompi_process_info.job_session_dir,
              filename_basename, comm_cid, pid);
+    free(filename_basename);
 
     int sm_fd = open(sm_filename, O_RDWR | O_CREAT,
                      S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,8 @@
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
 #include "ompi/mca/sharedfp/sm/sharedfp_sm.h"
+
+#include "opal/util/basename.h"
 
 /*
  * *******************************************************************
@@ -97,7 +100,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(o
 
 
     /* Check that we can actually open the required file */
-    char *filename_basename = basename((char*)fh->f_filename);
+    char *filename_basename = opal_basename((char*)fh->f_filename);
     char *sm_filename;
     int comm_cid = -1;
     int pid = ompi_comm_rank (comm);

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -114,7 +114,6 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     if ( OMPI_SUCCESS != err ) {
         opal_output(0,"mca_sharedfp_sm_file_open: Error in bcast operation \n");
         free(filename_basename);
-        free(sm_filename);
         free(sm_data);
         free(sh);
         return err;

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013-2018 University of Houston. All rights reserved.
+ * Copyright (c) 2013-2021 University of Houston. All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -59,7 +59,6 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     struct mca_sharedfp_sm_data * sm_data = NULL;
     char * filename_basename;
     char * sm_filename;
-    int sm_filename_length;
     struct mca_sharedfp_sm_offset * sm_offset_ptr;
     struct mca_sharedfp_sm_offset sm_offset;
     int sm_fd;
@@ -105,15 +104,6 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     */
     filename_basename = opal_basename((char*)filename);
     /* format is "%s/%s_cid-%d-%d.sm", see below */
-    sm_filename_length = strlen(ompi_process_info.job_session_dir) + 1 + strlen(filename_basename) + 5 + (3*sizeof(uint32_t)+1) + 4;
-    sm_filename = (char*) malloc( sizeof(char) * sm_filename_length);
-    if (NULL == sm_filename) {
-        opal_output(0, "mca_sharedfp_sm_file_open: Error, unable to malloc sm_filename\n");
-        free(filename_basename);
-        free(sm_data);
-        free(sh);
-        return OMPI_ERR_OUT_OF_RESOURCE;
-    }
 
     comm_cid = ompi_comm_get_cid(comm);
     if ( 0 == fh->f_rank ) {
@@ -130,7 +120,7 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
         return err;
     }
 
-    snprintf(sm_filename, sm_filename_length, "%s/%s_cid-%d-%d.sm", ompi_process_info.job_session_dir,
+    asprintf(&sm_filename, "%s/%s_cid-%d-%d.sm", ompi_process_info.job_session_dir,
              filename_basename, comm_cid, int_pid);
     /* open shared memory file, initialize to 0, map into memory */
     sm_fd = open(sm_filename, O_RDWR | O_CREAT,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013      Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -40,6 +40,8 @@
 #include "ompi/proc/proc.h"
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
+
+#include "opal/util/basename.h"
 
 #include <semaphore.h>
 #include <sys/mman.h>
@@ -101,7 +103,7 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     ** and then mapping it to memory
     ** For sharedfp we also want to put the file backed shared memory into the tmp directory
     */
-    filename_basename = basename((char*)filename);
+    filename_basename = opal_basename((char*)filename);
     /* format is "%s/%s_cid-%d-%d.sm", see below */
     sm_filename_length = strlen(ompi_process_info.job_session_dir) + 1 + strlen(filename_basename) + 5 + (3*sizeof(uint32_t)+1) + 4;
     sm_filename = (char*) malloc( sizeof(char) * sm_filename_length);


### PR DESCRIPTION
…rations

try to actually open the sharedfp/sm file during the query operation to ensure
that the component can actually run. This is based on some reports on the mailing list that
the sharedfp/sm operation causes problems in certain circumstances.

Fixes issue #9656

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
(cherry picked from commit d8464d2df5355d6c51d0c91def33e146fecedfa2)