### PR TITLE
lanl-ci: avoid Intel 2021.3.0 oneAPI compilers

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -11,7 +11,7 @@ build:intel:
   stage: build
   tags: [darwin-slurm-shared]
   script:
-    - module load intel/2021.3.0
+    - module load intel/2021.1.1
     - rm .gitmodules
     - cp $GITSUBMODULEPATCH .gitmodules
     - git submodule update --init
@@ -112,7 +112,7 @@ test:intel:
   script:
     - pwd
     - ls
-    - module load intel/2021.3.0
+    - module load intel/2021.1.1
     - export PATH=$PWD/install_test/bin:$PATH
     - which mpirun
     - cd examples


### PR DESCRIPTION
as the icx optimizer goes into some sort of infinite loop
compiling a file in OpenPMIx.  This bug doesn't exist
in 2021.1.1 nor a newer version 2021.10.3 (which is not yet available on Darwin).

Signed-off-by: Howard Pritchard <howardp@lanl.gov>