### PR TITLE
sharedfp: fix minor memory leaks

### DIFF
--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -107,6 +107,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(o
     
     asprintf(&sm_filename, "%s/%s_cid-%d-%d.sm", ompi_process_info.job_session_dir,
              filename_basename, comm_cid, pid);
+    free(filename_basename);
 
     int sm_fd = open(sm_filename, O_RDWR | O_CREAT,
                      S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);


### PR DESCRIPTION
Commit c79291ea86d9c9590cf6102c173d3f348b6a463f accidentally
introduced minor memory leaks by calling opal_basename() without
free()ing the results.

Fixes CID 1496830.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>