### PR TITLE
v4.1.x: README: add ifort/macOS linker error note and workaround

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2007 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
@@ -333,6 +333,22 @@ Compiler Notes
   MPI applications.  As of 1 Feb 2012, if you upgrade to the latest
   version of the Intel 12.1 Linux compiler suite, the problem will go
   away.
+
+- Users have reported (see
+  https://github.com/open-mpi/ompi/issues/7615) that the Intel Fortran
+  compiler will fail to link Fortran-based MPI applications on macOS
+  with linker errors similar to this:
+
+      Undefined symbols for architecture x86_64:
+        "_ompi_buffer_detach_f08", referenced from:
+            import-atom in libmpi_usempif08.dylib
+      ld: symbol(s) not found for architecture x86_64
+
+  It appears that setting the environment variable
+  lt_cx_ld_force_load=no before invoking Open MPI's configure script
+  works around the issue.  For example:
+
+      shell$ lt_cv_ld_force_load=no ./configure ...
 
 - Early versions of the Portland Group 6.0 compiler have problems
   creating the C++ MPI bindings as a shared library (e.g., v6.0-1).


### PR DESCRIPTION
Per https://github.com/open-mpi/ompi/issues/7615#issuecomment-612583354.

Back-ported to the README (not README.md) on the v4.1.x branch.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit c1df26562ce1386ef7c1f2689c501cf5f352d3dd)