### PR TITLE
v5.0.x: README: add ifort/macOS linker error note and workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,22 @@ base as of this writing (April 2020):
   version of the Intel 12.1 Linux compiler suite, the problem will go
   away.
 
+* [Users have reported](https://github.com/open-mpi/ompi/issues/7615)
+  that the Intel Fortran compiler will fail to link Fortran-based MPI
+  applications on macOS with linker errors similar to this:
+  ```
+  Undefined symbols for architecture x86_64:
+    "_ompi_buffer_detach_f08", referenced from:
+        import-atom in libmpi_usempif08.dylib
+  ld: symbol(s) not found for architecture x86_64
+  ```
+  It appears that setting the environment variable
+  `lt_cx_ld_force_load=no` before invoking Open MPI's `configure`
+  script works around the issue.  For example:
+  ```
+  shell$ lt_cv_ld_force_load=no ./configure ...
+  ```
+
 * The Portland Group compilers prior to version 7.0 require the
   `-Msignextend` compiler flag to extend the sign bit when converting
   from a shorter to longer integer.  This is is different than other


### PR DESCRIPTION
Per https://github.com/open-mpi/ompi/issues/7615#issuecomment-612583354.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit c1df26562ce1386ef7c1f2689c501cf5f352d3dd)

Note to v5.0.x RMs: this PR should ultimately get replaced by the new RST docs in #8329.  I'm PR'ing this README change to the v5.0.x branch in case the new RST docs aren't ready by the time v5.0.0 is released.