### PR TITLE
v4.1.x: README: update --enable-heterogeneous warning

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2007 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
@@ -1517,10 +1517,10 @@ MISCELLANEOUS FUNCTIONALITY
   with different endian representations).  Heterogeneous support is
   disabled by default because it imposes a minor performance penalty.
 
+  *** THE HETEROGENEOUS FUNCTIONALITY IS CURRENTLY BROKEN - DO NOT USE ***
+
  --enable-spc
   Enable software-based performance counters capability.
-
-  *** THIS FUNCTIONALITY IS CURRENTLY BROKEN - DO NOT USE ***
 
 --with-wrapper-cflags=<cflags>
 --with-wrapper-cxxflags=<cxxflags>


### PR DESCRIPTION
Somehow the "do not use the heterogeneous!" warning ended up in the
wrong section (as evidenced by
https://github.com/open-mpi/ompi/issues/9697#issuecomment-1003746357).
Move it to the correct section, and also make it crystal clear that
the warning is about the heterogeneous functionality.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

bot:notacherrypick

This is not a cherry pick because the warning is in the correct location on master's README.md -- somehow it ended up being in the incorrect location here on the v4.0.x/v4.1.x branches. 🤷‍♂️