### PR TITLE
v4.1.x: fix several compiler warnings

### DIFF
--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2004-2010 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -1165,7 +1165,7 @@ static int fetch_request( mqs_process *proc, mpi_process_info *p_info,
             // data_name in res->extra_text[2] (vs. extra_text[1]),
             // where it is guaranteed to fit.
             data_name[4] = '\0';
-            snprintf( (char*)res->extra_text[1], 64, "Data: %d",
+            snprintf( (char*)res->extra_text[1], 64, "Data: %d instances of MPI datatype",
                       (int)res->desired_length);
             snprintf( (char*)res->extra_text[2], 64, "%s",
                       data_name );

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2004-2010 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -1157,8 +1157,18 @@ static int fetch_request( mqs_process *proc, mpi_process_info *p_info,
         mqs_fetch_data( proc, ompi_datatype + i_info->ompi_datatype_t.offset.name,
                         64, data_name );
         if( '\0' != data_name[0] ) {
-            snprintf( (char*)res->extra_text[1], 64, "Data: %d * %s",
-                      (int)res->desired_length, data_name );
+            // res->extra_text[x] is only 64 chars long -- same as
+            // data_name.  If you try to snprintf it into
+            // res->extra_text with additional text, some compilers
+            // will warn that we might truncate the string (because it
+            // can see the static char array lengths).  So just put
+            // data_name in res->extra_text[2] (vs. extra_text[1]),
+            // where it is guaranteed to fit.
+            data_name[4] = '\0';
+            snprintf( (char*)res->extra_text[1], 64, "Data: %d",
+                      (int)res->desired_length);
+            snprintf( (char*)res->extra_text[2], 64, "%s",
+                      data_name );
         }
         /* And now compute the real length as specified by the user */
         res->desired_length *=

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -8,6 +8,8 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -192,9 +194,9 @@ static int ompi_osc_rdma_fetch_and_op_cas (ompi_osc_rdma_sync_t *sync, const voi
         new_value = old_value;
 
         if (&ompi_mpi_op_replace.op == op) {
-            memcpy ((void *)((intptr_t) &new_value + offset), (void *)((intptr_t) origin_addr + dt->super.true_lb), extent);
+            memcpy ((void *)((ptrdiff_t) &new_value + offset), (void *)((ptrdiff_t) origin_addr + dt->super.true_lb), extent);
         } else if (&ompi_mpi_op_no_op.op != op) {
-            ompi_op_reduce (op, (void *) ((intptr_t) origin_addr + dt->super.true_lb), (void*)((intptr_t) &new_value + offset), 1, dt);
+            ompi_op_reduce (op, (void *) ((ptrdiff_t) origin_addr + dt->super.true_lb), (void*)((ptrdiff_t) &new_value + offset), 1, dt);
         }
 
         ret = ompi_osc_rdma_btl_cswap (module, peer->data_endpoint, address, target_handle,

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -192,9 +192,9 @@ static int ompi_osc_rdma_fetch_and_op_cas (ompi_osc_rdma_sync_t *sync, const voi
         new_value = old_value;
 
         if (&ompi_mpi_op_replace.op == op) {
-            memcpy ((void *)((intptr_t) &new_value + offset), origin_addr + dt->super.true_lb, extent);
+            memcpy ((void *)((intptr_t) &new_value + offset), (void *)((intptr_t) origin_addr + dt->super.true_lb), extent);
         } else if (&ompi_mpi_op_no_op.op != op) {
-            ompi_op_reduce (op, (void *) origin_addr + dt->super.true_lb, (void*)((intptr_t) &new_value + offset), 1, dt);
+            ompi_op_reduce (op, (void *) ((intptr_t) origin_addr + dt->super.true_lb), (void*)((intptr_t) &new_value + offset), 1, dt);
         }
 
         ret = ompi_osc_rdma_btl_cswap (module, peer->data_endpoint, address, target_handle,
@@ -219,7 +219,7 @@ static int ompi_osc_rdma_acc_single_atomic (ompi_osc_rdma_sync_t *sync, const vo
 {
     ompi_osc_rdma_module_t *module = sync->module;
     int32_t atomic_flags = module->selected_btl->btl_atomic_flags;
-    int ret, btl_op, flags;
+    int btl_op, flags;
     int64_t origin;
 
     if (!(module->selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
@@ -261,7 +261,6 @@ static inline int ompi_osc_rdma_gacc_amo (ompi_osc_rdma_module_t *module, ompi_o
     const bool use_amo = module->acc_use_amo;
     const size_t dt_size = datatype->super.size;
     void *to_free = NULL;
-    uint64_t offset = 0;
     int ret;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "using network atomics for accumulate operation with count %d", count);
@@ -339,7 +338,7 @@ static inline int ompi_osc_rdma_gacc_contig (ompi_osc_rdma_sync_t *sync, const v
     /* if the datatype is small enough (and the count is 1) then try to directly use the hardware to execute
      * the atomic operation. this should be safe in all cases as either 1) the user has assured us they will
      * never use atomics with count > 1, 2) we have the accumulate lock, or 3) we have an exclusive lock */
-    if (target_datatype->super.size <= 8 && target_count <= module->network_amo_max_count) {
+    if ((target_datatype->super.size <= 8) && (((unsigned long) target_count) <= module->network_amo_max_count)) {
         ret = ompi_osc_rdma_gacc_amo (module, sync, source, result, result_count, result_datatype, result_convertor,
                                       peer, target_address, target_handle, target_count, target_datatype, op, request);
         if (OPAL_LIKELY(OMPI_SUCCESS == ret)) {
@@ -858,7 +857,7 @@ int ompi_osc_rdma_rget_accumulate_internal (ompi_win_t *win, const void *origin_
     ompi_osc_rdma_module_t *module = GET_MODULE(win);
     mca_btl_base_registration_handle_t *target_handle;
     uint64_t target_address;
-    ptrdiff_t lb, target_lb, target_span;
+    ptrdiff_t target_lb, target_span;
     ompi_osc_rdma_request_t *rdma_request = NULL;
     bool lock_acquired = false;
     ompi_osc_rdma_sync_t *sync;

--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -167,7 +167,7 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
     ompi_osc_rdma_handle_t *rdma_region_handle;
     osc_rdma_counter_t region_count;
     osc_rdma_counter_t region_id;
-    intptr_t bound, aligned_base, aligned_bound;
+    intptr_t aligned_base, aligned_bound;
     intptr_t page_size = opal_getpagesize ();
     int region_index, ret;
     size_t aligned_len;
@@ -197,7 +197,6 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
 
     /* it is wasteful to register less than a page. this may allow the remote side to access more
      * memory but the MPI standard covers this with calling the calling behavior erroneous */
-    bound = (intptr_t) base + len;
     aligned_bound = OPAL_ALIGN((intptr_t) base + len, page_size, intptr_t);
     aligned_base = (intptr_t) base & ~(page_size - 1);
     aligned_len = (size_t)(aligned_bound - aligned_base);
@@ -234,7 +233,7 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
     region->len  = aligned_len;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "attaching dynamic memory region {%p, %p} aligned {%p, %p}, at index %d",
-                     base, (void *) bound, (void *) aligned_base, (void *) aligned_bound, region_index);
+                     base, (void *) ((intptr_t) base + len), (void *) aligned_base, (void *) aligned_bound, region_index);
 
     /* add RDMA region handle to track this region */
     rdma_region_handle = OBJ_NEW(ompi_osc_rdma_handle_t);

--- a/opal/mca/btl/ofi/btl_ofi_frag.c
+++ b/opal/mca/btl/ofi/btl_ofi_frag.c
@@ -64,7 +64,7 @@ mca_btl_ofi_frag_completion_t *mca_btl_ofi_frag_completion_alloc
 mca_btl_base_descriptor_t *mca_btl_ofi_alloc(
                                 mca_btl_base_module_t *btl,
                                 mca_btl_base_endpoint_t *endpoint,
-                                uint64_t order, size_t size, uint32_t flags)
+                                uint8_t order, size_t size, uint32_t flags)
 {
     mca_btl_ofi_module_t *ofi_btl = (mca_btl_ofi_module_t*) btl;
     mca_btl_ofi_base_frag_t *frag = NULL;

--- a/opal/mca/btl/ofi/btl_ofi_frag.h
+++ b/opal/mca/btl/ofi/btl_ofi_frag.h
@@ -32,7 +32,7 @@
 mca_btl_base_descriptor_t *mca_btl_ofi_alloc(
                                 mca_btl_base_module_t *btl,
                                 mca_btl_base_endpoint_t *endpoint,
-                                uint64_t order, size_t size, uint32_t flags);
+                                uint8_t order, size_t size, uint32_t flags);
 
 int mca_btl_ofi_free (mca_btl_base_module_t *btl, mca_btl_base_descriptor_t *des);
 

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -62,7 +62,7 @@ static int mca_btl_ofi_add_procs (mca_btl_base_module_t *btl,
         } else {
             /* We don't have this endpoint yet, create one */
             peers[i] = mca_btl_ofi_endpoint_create (proc, ofi_btl->ofi_endpoint);
-            BTL_VERBOSE(("creating peer %p", peers[i]));
+            BTL_VERBOSE(("creating peer %p", (void*) peers[i]));
 
             if (OPAL_UNLIKELY(NULL == peers[i])) {
                 return OPAL_ERR_OUT_OF_RESOURCE;

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2006-2015 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2006-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -1868,7 +1868,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
                        "eager RDMA and progress threads", true);
     }
 
-    asprintf (&rcache_resources.cache_name, "verbs.%" PRIu64, device->ib_dev_attr.node_guid);
+    asprintf (&rcache_resources.cache_name, "verbs.%" PRIu64, (uint64_t) device->ib_dev_attr.node_guid);
     rcache_resources.reg_data = (void*)device;
     rcache_resources.sizeof_reg = sizeof(mca_btl_openib_reg_t);
     rcache_resources.register_mem = openib_reg_mr;

--- a/opal/mca/pmix/flux/pmix_flux.c
+++ b/opal/mca/pmix/flux/pmix_flux.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -682,7 +682,6 @@ static int flux_fencenb(opal_list_t *procs, int collect_data,
                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    int status;
     if (PMI_SUCCESS != (rc = PMI_Barrier())) {
         OPAL_PMI_ERROR(rc, "PMI_Barrier");
         return OPAL_ERROR;
@@ -690,7 +689,7 @@ static int flux_fencenb(opal_list_t *procs, int collect_data,
     if (NULL == cbfunc) {
         return OPAL_ERROR;
     } else {
-        cbfunc(status, cbdata);
+        cbfunc(rc, cbdata);
     }
     return OPAL_SUCCESS;
 }

--- a/opal/mca/pmix/pmix3x/pmix3x_component.c
+++ b/opal/mca/pmix/pmix3x/pmix3x_component.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2016-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -141,7 +141,7 @@ static int external_close(void)
 
 static int external_component_query(mca_base_module_t **module, int *priority)
 {
-    char *t, *id;
+    char *t;
 
     /* see if a PMIx server is present */
     if (NULL != (t = getenv("PMIX_NAMESPACE"))) {


### PR DESCRIPTION
Several compiler fixes for the v4.1.x tree.  See individual commit messages for details.

* 3 of the commits on this PR are *not* cherry picks because they are fixing warnings of code that is no longer on master.
* 2 of the commits on this PR are cherry picks that were missed / forgotten until now.

bot:notacherrypick