### PR TITLE
Fix compiler warnings

### DIFF
--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
- * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -990,15 +990,16 @@ static void mca_btl_base_am_process_atomic(mca_btl_base_module_t *btl,
     switch (hdr->type) {
     case MCA_BTL_BASE_AM_ATOMIC:
         if (4 == hdr->data.atomic.size) {
-            uint32_t tmp = (uint32_t) atomic_response;
-            mca_btl_base_am_atomic_32(&tmp, (opal_atomic_int32_t *) (uintptr_t) hdr->target_address,
+            int32_t tmp = (int32_t) atomic_response;
+            mca_btl_base_am_atomic_32(&tmp, (opal_atomic_int32_t *) hdr->target_address,
                                       hdr->data.atomic.op);
             atomic_response = tmp;
-        }
-        if (8 == hdr->data.atomic.size) {
-            mca_btl_base_am_atomic_64(&atomic_response,
-                                      (opal_atomic_int64_t *) (uintptr_t) hdr->target_address,
+        } else if (8 == hdr->data.atomic.size) {
+            int64_t tmp = (int64_t) atomic_response;
+            mca_btl_base_am_atomic_64(&tmp,
+                                      (opal_atomic_int64_t *) hdr->target_address,
                                       hdr->data.atomic.op);
+            atomic_response = tmp;
         }
         break;
     case MCA_BTL_BASE_AM_CAS:
@@ -1007,8 +1008,7 @@ static void mca_btl_base_am_process_atomic(mca_btl_base_module_t *btl,
             opal_atomic_compare_exchange_strong_32((opal_atomic_int32_t *) hdr->target_address,
                                                    &tmp, (int32_t) hdr->data.atomic.operand[1]);
             atomic_response = tmp;
-        }
-        if (8 == hdr->data.atomic.size) {
+        } else if (8 == hdr->data.atomic.size) {
             opal_atomic_compare_exchange_strong_64((opal_atomic_int64_t *) hdr->target_address,
                                                    &atomic_response, hdr->data.atomic.operand[1]);
         }

--- a/opal/util/malloc.h
+++ b/opal/util/malloc.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -127,7 +128,7 @@ OPAL_DECLSPEC void *opal_realloc(void *ptr, size_t size, const char *file, int l
  * to configure (or by default if you're building in a SVN
  * checkout).
  */
-OPAL_DECLSPEC void opal_free(void *addr, const char *file, int line) __opal_attribute_nonnull__(1);
+OPAL_DECLSPEC void opal_free(void *addr, const char *file, int line);
 
 /**
  * Used to set the debug level for malloc debug.

--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
@@ -640,7 +640,6 @@ int opal_util_register_stackhandlers(void)
         set_stacktrace_filename();
         opal_stacktrace_output_fileno = -1;
     } else if (0 == strncasecmp(opal_stacktrace_output_filename, "file:", 5)) {
-        char *filename_cpy = NULL;
         next = strchr(opal_stacktrace_output_filename, ':');
         next++; // move past the ':' to the filename specified
 
@@ -654,8 +653,6 @@ int opal_util_register_stackhandlers(void)
             sizeof(char) * opal_stacktrace_output_filename_max_len);
         set_stacktrace_filename();
         opal_stacktrace_output_fileno = -1;
-
-        free(filename_cpy);
     } else {
         opal_stacktrace_output_fileno = fileno(stderr);
     }


### PR DESCRIPTION
2 commits:

* Fix some trivial compiler warnings in opal/util.  Note that modern GCC (e.g., 10.x) has some static analysis built-in these days; you have to be a little more aggressive to stomp the compiler warnings.
* Some active message BTL base compiler warnings about differing signedness and illegal use of flexible arrays as a struct member.  Specifically:
```
  CC       base/btl_base_am_rdma.lo
base/btl_base_am_rdma.c:200:29: warning: invalid use of structure with flexible array member [-Wpedantic]
  200 |     mca_btl_base_rdma_hdr_t hdr;
      |                             ^~~
```

**EDIT:** After discussion on this PR, we decided not to fix the above-mentioned flexible array warning.  See https://github.com/open-mpi/ompi/pull/9814#discussion_r777260413 (below) for details.  I filed #9828 to track the issue in case we ever decide to fix it someday.