### PR TITLE
build: mark --enable-heterogeneous as experimental

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -329,7 +329,7 @@ AC_MSG_CHECKING([if want heterogeneous support])
 AC_ARG_ENABLE([heterogeneous],
     [AC_HELP_STRING([--enable-heterogeneous],
                     [Enable features required for heterogeneous
-                     platform support (default: disabled)])])
+                     platform support (default: disabled). Experimental in 4.1.x!])])
 if test "$enable_heterogeneous" = "yes" ; then
      AC_MSG_RESULT([yes])
      opal_want_heterogeneous=1


### PR DESCRIPTION
If this change is accepted, we should do something similar for 4.0.x too.

@jsquyres has very kindly updated the downstream Gentoo bug and the READMEs in the repository to avoid anyone enabling this option downstream, but I think adding this to the `./configure --help` text will be useful too.

We could possibly add a warning to the `./configure` output too (some projects do this if they don't "like" a configuration that's been used / it's experimental) but this is probably enough? Let me know what you think.

Bug: https://github.com/open-mpi/ompi/issues/9697#issuecomment-1003746357
Bug: https://bugs.gentoo.org/828123
Signed-off-by: Sam James <sam@gentoo.org>