### PR TITLE
v5.0.x: help-smsc-knem.txt: fix incorrect messages, remove stale messages

### DIFF
--- a/opal/mca/smsc/knem/help-smsc-knem.txt
+++ b/opal/mca/smsc/knem/help-smsc-knem.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2004-2009 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2014 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014      Research Organization for Information Science
@@ -14,26 +14,13 @@
 #
 # $HEADER$
 #
-# This is the US/English help file for Open MPI's shared memory support.
-#
-[sys call fail]
-A system call failed during sm shared memory BTL initialization
-that should not have.  It is likely that your MPI job will now either
-abort or experience performance degradation.
-
-  System call: %s
-  Error:       %s (errno %d)
-#
-[no locality]
-WARNING: Missing locality information required for sm shared memory
-BTL initialization. Continuing without shared memory support.
+# This is the US/English help file for Open MPI's KNEM smsc support.
 #
 [knem permission denied]
-WARING: Open MPI failed to open the /dev/knem device due to a
+WARNING: Open MPI failed to open the /dev/knem device due to a
 permissions problem.  Please check with your system administrator to
-get the permissions fixed, or set the btl_sm_single_copy_mechanism
-MCA variable to none to silence this warning and run without knem
-support.
+get the permissions fixed, or set the smsc MCA variable to "^knem" to
+silence this warning and run without knem support.
 
   Local host:            %s
   /dev/knem permissions: 0%o
@@ -41,11 +28,11 @@ support.
 [knem fail open]
 WARNING: Open MPI failed to open the /dev/knem device due to a local
 error. Please check with your system administrator to get the problem
-fixed, or set the btl_sm_single_copy_mechanism MCA variable to none
-to silence this warning and run without knem support.
+fixed, or set the smsc MCA variable to "^knem" to silence this warning
+and run without knem support.
 
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
+Open MPI will try to fall back on another single-copy mechanism if one
+is available.  This may result in lower performance.
 
   Local host: %s
   Errno:      %d (%s)
@@ -54,11 +41,11 @@ mechanism if one is available. This may result in lower performance.
 WARNING: Open MPI failed to retrieve the ABI version from the
 /dev/knem device due to a local error.  This usually indicates an
 error in your knem installation; please check with your system
-administrator, or set the btl_sm_single_copy_mechanism MCA variable
-to none to silence this warning and run without knem support.
+administrator, or set the smsc MCA variable to "^knem" to silence this
+warning and run without knem support.
 
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
+Open MPI will try to fall back on another single-copy mechanism if one
+is available.  This may result in lower performance.
 
   Local host: %s
   Errno:      %d (%s)
@@ -68,12 +55,11 @@ WARNING: Open MPI was compiled with support for one version of the
 knem kernel module, but it discovered a different version running in
 /dev/knem. Open MPI needs to be installed with support for the same
 version of knem as is in the running Linux kernel. Please check with
-your system administrator, or set the btl_sm_single_copy_mechanism
-MCA variable to none to silence this warning and run without knem
-support.
+your system administrator, or set the smsc MCA variable to "^knem" to
+silence this warning and run without knem support.
 
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
+Open MPI will try to fall back on another single-copy mechanism if one
+is available.  This may result in lower performance.
 
   Local host:              %s
   Open MPI's knem version: 0x%x
@@ -82,11 +68,11 @@ mechanism if one is available. This may result in lower performance.
 [knem mmap fail]
 Open MPI failed to map support from the knem Linux kernel module; this
 shouldn't happen. Please check with your system administrator, or set
-the btl_sm_single_copy_mechanism MCA variable to none to silence
-this warning and run without knem support.
+the smsc MCA variable to "^knem" to silence this warning and run
+without knem support.
 
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
+Open MPI will try to fall back on another single-copy mechanism if one
+is available.  This may result in lower performance.
 
   Local host:  %s
   System call: mmap()
@@ -94,63 +80,12 @@ mechanism if one is available. This may result in lower performance.
 #
 [knem init error]
 Open MPI encountered an error during the knem initialization. Please
-check with your system administrator, or set the
-btl_sm_single_copy_mechanism MCA variable to none to silence this
-warning and run without knem support.
+check with your system administrator, or set the smsc MCA variable to
+"^knem" to silence this warning and run without knem support.
 
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
+Open MPI will try to fall back on another single-copy mechanism if one
+is available.  This may result in lower performance.
 
   Local host:  %s
   System call: %s
   Errno:       %d (%s)
-#
-[knem requested but not available]
-WARNING: Linux kernel knem support was requested via the
-btl_sm_single_copy_mechanism MCA parameter, but Knem support was either not
-compiled into this Open MPI installation, or Knem support was unable
-to be activated in this process.
-
-The sm BTL will fall back on another single-copy mechanism if one
-is available. This may result in lower performance.
-
-  Local host: %s
-#
-[cma-permission-denied]
-WARNING: Linux kernel CMA support was requested via the
-btl_sm_single_copy_mechanism MCA variable, but CMA support is
-not available due to restrictive ptrace settings.
-
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
-
-  Local host: %s
-#
-[cma-different-user-namespace-error]
-ERROR: Linux kernel CMA support was requested via the
-btl_sm_single_copy_mechanism MCA variable, but CMA support is
-not available due to different user namespaces.
-
-Your MPI job will abort now. Please select another value for
-btl_sm_single_copy_mechanism.
-
-  Local host: %s
-#
-[cma-different-user-namespace-warning]
-WARNING: The default btl_sm_single_copy_mechanism CMA is
-not available due to different user namespaces.
-
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
-
-  Local host: %s
-#
-[xpmem-make-failed]
-WARNING: Could not generate an xpmem segment id for this process'
-address space.
-
-The sm shared memory BTL will fall back on another single-copy
-mechanism if one is available. This may result in lower performance.
-
-  Local host: %s
-  Error code: %d (%s)


### PR DESCRIPTION
Removed a bunch of stale messages that are not relevant to this
show_help text file any more (they were left over from before the smsc
framework).

Additionally, update the knem show help messages to show the correct
MCA varable name and value.  Also fudge the message a bit to no longer
specifically mention the sm BTL.

Thanks to Benjamin Kitor @BKitor for reporting the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 53f09f72c09063988ab1ed887f2f54444918c7c0)

Fixes #9802 