### PR TITLE
Fix broken internal pmix configure

### DIFF
--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -164,8 +164,10 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
           [opal_pmix_WRAPPER_LDFLAGS="$pkg_config_ldflags"
            opal_pmix_WRAPPER_LIBS="$pkg_config_libs"],
           [# guess that what we have from compiling OMPI is good enough
-           opal_pmix_WRAPPER_LDFLAGS="$opal_hwloc_LDFLAGS"
-           opal_pmix_WRAPPER_LIBS="$opal_hwloc_LIBS"])
+           AS_IF([test -z "$opal_pmix_WRAPPER_LDFLAGS"],
+                 [opal_pmix_WRAPPER_LDFLAGS="$opal_pmix_LDFLAGS"])
+           AS_IF([test -z "$opal_pmix_WRAPPER_LIBS"],
+                 [opal_pmix_WRAPPER_LIBS="$opal_pmix_LIBS"])])
 
     OPAL_WRAPPER_FLAGS_ADD([LDFLAGS], [$opal_pmix_WRAPPER_LDFLAGS])
     OPAL_WRAPPER_FLAGS_ADD([LIBS], [$opal_pmix_WRAPPER_LIBS])
@@ -251,6 +253,7 @@ AC_DEFUN([_OPAL_CONFIG_PMIX_INTERNAL_POST], [
     opal_pmix_CPPFLAGS="-I$OMPI_TOP_BUILDDIR/3rd-party/openpmix/include -I$OMPI_TOP_SRCDIR/3rd-party/openpmix/include"
     opal_pmix_LDFLAGS=""
     opal_pmix_LIBS="$OMPI_TOP_BUILDDIR/3rd-party/openpmix/src/libpmix.la"
+    opal_pmix_WRAPPER_LIBS="-lpmix $opal_hwloc_WRAPPER_LIBS $opal_libevent_WRAPPER_LIBS"
 
     CPPFLAGS="$CPPFLAGS $opal_pmix_CPPFLAGS"
 

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -45,6 +45,7 @@ AC_DEFUN([OPAL_WRAPPER_FLAGS_ADD], [
           [$1], [LDFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_ldflags], [$2])],
           [$1], [LIBS], [OPAL_FLAGS_APPEND_MOVE([wrapper_extra_libs], [$2])],
           [m4_fatal([Unknown wrapper flag type $1])])
+    opal_show_verbose "Adding \"$2\" to \"$1\""
 ])
 
 


### PR DESCRIPTION
Fix bug in #9688, where I was left a cut-n-paste in between the hwloc and pmix configure checks.

Backport of https://github.com/open-mpi/ompi/pull/9771