### PR TITLE
sharedfp_sm_file_open: remove illegal free

### DIFF
--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -114,7 +114,6 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     if ( OMPI_SUCCESS != err ) {
         opal_output(0,"mca_sharedfp_sm_file_open: Error in bcast operation \n");
         free(filename_basename);
-        free(sm_filename);
         free(sm_data);
         free(sh);
         return err;


### PR DESCRIPTION
accidentally left an invalid free after rewriting the code section to use asprintf.
Fixes Coverty CID 1496849

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>