### PR TITLE
OSC RDMA initialization cleanups

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,9 +109,6 @@ struct ompi_osc_rdma_component_t {
 
     /** Priority of the osc/rdma component */
     unsigned int priority;
-
-    /** Priority of the osc/rdma component when using non-RDMA BTLs */
-    unsigned int alternate_priority;
 
     /** directory where to place backing files */
     char *backing_directory;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -18,7 +18,8 @@
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
@@ -83,7 +84,7 @@ static int ompi_osc_rdma_query_mtls (void);
 
 static const char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, const char *key, const char *value);
 
-static char *ompi_osc_rdma_btl_names;
+static char *ompi_osc_rdma_full_connectivity_btls;
 static char *ompi_osc_rdma_mtl_names;
 static char *ompi_osc_rdma_btl_alternate_names;
 
@@ -256,14 +257,14 @@ static int ompi_osc_rdma_component_register (void)
                                             MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.locking_mode);
     OBJ_RELEASE(new_enum);
 
-    ompi_osc_rdma_btl_names = "ugni,uct";
+    ompi_osc_rdma_full_connectivity_btls = "ugni,uct,ofi";
     opal_asprintf(&description_str, "Comma-delimited list of BTL component names to allow without verifying "
              "connectivity. Do not add a BTL to to this list unless it can reach all "
              "processes in any communicator used with an MPI window (default: %s)",
-             ompi_osc_rdma_btl_names);
+             ompi_osc_rdma_full_connectivity_btls);
     (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "btls", description_str,
                                             MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
-                                            MCA_BASE_VAR_SCOPE_GROUP, &ompi_osc_rdma_btl_names);
+                                            MCA_BASE_VAR_SCOPE_GROUP, &ompi_osc_rdma_full_connectivity_btls);
     free(description_str);
 
     ompi_osc_rdma_btl_alternate_names = "sm,tcp";
@@ -986,7 +987,7 @@ static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, ompi_osc_rdma_mo
     char **btls_to_use;
     void *tmp;
 
-    btls_to_use = opal_argv_split (ompi_osc_rdma_btl_names, ',');
+    btls_to_use = opal_argv_split (ompi_osc_rdma_full_connectivity_btls, ',');
 
     if (module) {
         ompi_osc_rdma_selected_btl_insert(module, NULL, 0);

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -238,14 +238,6 @@ static int ompi_osc_rdma_component_register (void)
                                             MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.priority);
     free(description_str);
 
-    mca_osc_rdma_component.alternate_priority = 37;
-    opal_asprintf(&description_str, "Priority of the osc/rdma component when using non-RDMA btls (default: %d)",
-             mca_osc_rdma_component.alternate_priority);
-    (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "alternate_priority", description_str,
-                                            MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0, OPAL_INFO_LVL_3,
-                                            MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.alternate_priority);
-    free(description_str);
-
     (void) mca_base_var_enum_create ("osc_rdma_locking_mode", ompi_osc_rdma_locking_modes, &new_enum);
 
     mca_osc_rdma_component.locking_mode = OMPI_OSC_RDMA_LOCKING_TWO_LEVEL;
@@ -408,10 +400,10 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
     }
 
     if (OMPI_SUCCESS == ompi_osc_rdma_query_alternate_btls (comm, NULL)) {
-        return mca_osc_rdma_component.alternate_priority;
+        return mca_osc_rdma_component.priority;
     }
 
-    return mca_osc_rdma_component.priority;
+    return OMPI_ERROR;
 }
 
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {


### PR DESCRIPTION
This is the first chunk of PRs aimed at fixing https://github.com/open-mpi/ompi/issues/8983.  This will ensure that "accelerated" BTLs (those that have native RDMA and can reach all peers) also provide the required remote completion.  This is not a complete fix for https://github.com/open-mpi/ompi/issues/8983, as the alternate BTL path in the osc rdma component still has a remote completion failure mode.  Patches for that will be coming as a follow-on patch series.