### PR TITLE
v5.0.x: m4: fix 2 broken uses of AC_LANG_PROGRAM

### DIFF
--- a/config/opal_check_icc.m4
+++ b/config/opal_check_icc.m4
@@ -25,7 +25,7 @@ dnl On EM64T, icc-8.1 before version 8.1.027 segfaulted, since
 dnl va_start was miscompiled...
 dnl
 AC_MSG_CHECKING([whether icc-8.1 for EM64T works with variable arguments])
-AC_RUN_IFELSE([AC_LANG_PROGRAM([
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,18 +36,12 @@ void func (int c, char * f, ...)
   va_start (arglist, f);
   /* vprintf (f, arglist); */
   va_end (arglist);
-}
-
-int main ()
-{
+}]],[[
   FILE *f;
   func (4711, "Help %d [%s]\n", 10, "ten");
   f=fopen ("conftestval", "w");
   if (!f) exit (1);
-  return 0;
-}
-
-])],[opal_ac_icc_varargs=`test -f conftestval`],[opal_ac_icc_varargs=1],[opal_ac_icc_varargs=1])
+]])],[opal_ac_icc_varargs=`test -f conftestval`],[opal_ac_icc_varargs=1],[opal_ac_icc_varargs=1])
 
 if test "$opal_ac_icc_varargs" = "1"; then
     AC_MSG_WARN([*** Problem running configure test!])

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -1195,12 +1195,8 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
           [AC_MSG_CHECKING([for RDTSCP assembly support])
            AC_LANG_PUSH([C])
            AC_RUN_IFELSE([AC_LANG_PROGRAM([[
-int main(int argc, char* argv[])
-{
   unsigned int rax, rdx;
   __asm__ __volatile__ ("rdtscp\n": "=a" (rax), "=d" (rdx):: "%rax", "%rdx");
-  return 0;
-}
            ]])],
            [result=1
             AC_MSG_RESULT([yes])],


### PR DESCRIPTION
Fix 2 places where AC_TRY_RUN was incorrectly converted to
AC_RUN_IFELSE+AC_LANG_PROGRAM in
e0f3ebd94791c6e8d6f683141e56860e45c51c44.

In these 2 cases, AC_LANG_PROGRAM was wrapped around a C code block
that includes main().  This is blatantly wrong, and will cause the
test to unconditionally fail because AC_LANG_PROGRAM will always
include its own definition of main() (thereby causing a link failure
due to 2 definitions of main()).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 734f340c1df57655249c72a4b18b40309f2f9925)

This is the v5.0.x PR for master PR #9839 