### PR TITLE
ompi/attr: update attribute system to prepare for sessions

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -14,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -242,6 +245,7 @@
 #include "ompi/win/win.h"                    /* ompi_win_t generated in [COPY|DELETE]_ATTR_CALLBACKS */
 #include "ompi/mpi/fortran/base/fint_2_int.h"
 
+
 /*
  * Macros
  */
@@ -256,9 +260,9 @@
 #define attr_datatype_f d_f_to_c_index
 #define attr_win_f w_f_to_c_index
 
-#define CREATE_KEY(key) opal_bitmap_find_and_set_first_unset_bit(key_bitmap, (key))
+#define CREATE_KEY(key) opal_bitmap_find_and_set_first_unset_bit(attr_subsys->key_bitmap, (key))
 
-#define FREE_KEY(key) opal_bitmap_clear_bit(key_bitmap, (key))
+#define FREE_KEY(key) opal_bitmap_clear_bit(attr_subsys->key_bitmap, (key))
 
 
 /* Not checking for NULL_DELETE_FN here, since according to the
@@ -406,6 +410,15 @@ typedef struct attribute_value_t {
     int av_sequence;
 } attribute_value_t;
 
+/*
+ * struct to hold state of attr subsys
+ */
+
+typedef  struct attr_subsys_t {
+    opal_object_t            super;
+    opal_hash_table_t *keyval_hash;
+    opal_bitmap_t *key_bitmap;
+ } attr_subsys_t;
 
 /*
  * Local functions
@@ -413,6 +426,8 @@ typedef struct attribute_value_t {
 static void attribute_value_construct(attribute_value_t *item);
 static void ompi_attribute_keyval_construct(ompi_attribute_keyval_t *keyval);
 static void ompi_attribute_keyval_destruct(ompi_attribute_keyval_t *keyval);
+static void attr_subsys_construct(attr_subsys_t *subsys);
+static void attr_subsys_destruct(attr_subsys_t *subsys);
 static int set_value(ompi_attribute_type_t type, void *object,
                      opal_hash_table_t **attr_hash, int key,
                      attribute_value_t *new_attr,
@@ -425,6 +440,13 @@ static MPI_Aint translate_to_aint(attribute_value_t *val);
 
 static int compare_attr_sequence(const void *attr1, const void *attr2);
 
+/*
+ * attribute_subsys_t class
+ */
+static OBJ_CLASS_INSTANCE(attr_subsys_t,
+                          opal_object_t,
+                          attr_subsys_construct,
+                          attr_subsys_destruct);
 
 /*
  * attribute_value_t class
@@ -443,24 +465,31 @@ static OBJ_CLASS_INSTANCE(ompi_attribute_keyval_t,
                           ompi_attribute_keyval_construct,
                           ompi_attribute_keyval_destruct);
 
+/*
+ * compatibility until sessions work is finished
+ */
+static inline int ompi_mpi_instance_retain(void) {
+    return OMPI_SUCCESS;
+}
+
+static inline void ompi_mpi_instance_release(void) {
+}
 
 /*
  * Static variables
  */
 
-static opal_hash_table_t *keyval_hash;
-static opal_bitmap_t *key_bitmap;
-static int attr_sequence;
+static attr_subsys_t *attr_subsys = NULL;
 static unsigned int int_pos = 12345;
 static unsigned int integer_pos = 12345;
+static int attr_sequence;
 
 /*
  * MPI attributes are *not* high performance, so just use a One Big Lock
  * approach. However, this lock is released before a user provided callback is
  * triggered and acquired right after, allowing for recursive behaviors.
  */
-static opal_mutex_t attribute_lock;
-
+static opal_mutex_t attribute_lock = OPAL_MUTEX_STATIC_INIT; 
 
 /*
  * attribute_value_t constructor function
@@ -507,33 +536,68 @@ ompi_attribute_keyval_destruct(ompi_attribute_keyval_t *keyval)
             free(keyval->bindings_extra_state);
         }
 
-        opal_hash_table_remove_value_uint32(keyval_hash, keyval->key);
+        opal_hash_table_remove_value_uint32(attr_subsys->keyval_hash, keyval->key);
         FREE_KEY(keyval->key);
     }
 }
 
 
-/*
- * This will initialize the main list to store key- attribute
- * items. This will be called one time, during MPI_INIT().
- */
-int ompi_attr_init(void)
+int ompi_attr_get_ref(void)
+{
+    int ret = OMPI_SUCCESS;
+
+    OPAL_THREAD_LOCK(&attribute_lock);
+
+    if (NULL == attr_subsys) {
+        attr_subsys = OBJ_NEW(attr_subsys_t);
+        if (NULL == attr_subsys) {
+            ret = OMPI_ERR_OUT_OF_RESOURCE;
+            goto fn_exit;
+        }
+        if ((NULL == attr_subsys->keyval_hash) || (NULL == attr_subsys->key_bitmap)) {
+            OBJ_RELEASE(attr_subsys);
+            attr_subsys = NULL;
+            ret = OMPI_ERR_OUT_OF_RESOURCE;
+            goto fn_exit;
+        }
+    } else {
+        OBJ_RETAIN(attr_subsys);
+    }
+
+fn_exit:
+    OPAL_THREAD_UNLOCK(&attribute_lock);
+
+    return ret;
+}
+
+int ompi_attr_put_ref(void)
+{
+    if (NULL != attr_subsys) {
+        OBJ_RELEASE(attr_subsys);
+    }
+    return OMPI_SUCCESS;
+}
+
+static void attr_subsys_construct(attr_subsys_t *subsys)
 {
     int ret;
     void *bogus = (void*) 1;
     int *p = (int *) &bogus;
 
-    keyval_hash = OBJ_NEW(opal_hash_table_t);
-    if (NULL == keyval_hash) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-    key_bitmap = OBJ_NEW(opal_bitmap_t);
+    subsys->keyval_hash = OBJ_NEW(opal_hash_table_t);
+
+    subsys->key_bitmap = OBJ_NEW(opal_bitmap_t);
+
     /*
      * Set the max size to OMPI_FORTRAN_HANDLE_MAX to enforce bound
      */
-    opal_bitmap_set_max_size (key_bitmap, OMPI_FORTRAN_HANDLE_MAX);
-    if (0 != opal_bitmap_init(key_bitmap, 32)) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
+    opal_bitmap_set_max_size (subsys->key_bitmap, 
+                              OMPI_FORTRAN_HANDLE_MAX);
+    ret = opal_bitmap_init(subsys->key_bitmap, 32);
+    assert(OPAL_SUCCESS == ret);
+
+    for (int i = 0; i < MPI_ATTR_PREDEFINED_KEY_MAX; i++) {
+        opal_bitmap_set_bit(subsys->key_bitmap, i);
     }
 
     for (int_pos = 0; int_pos < (sizeof(void*) / sizeof(int));
@@ -550,31 +614,21 @@ int ompi_attr_init(void)
         }
     }
 
-    OBJ_CONSTRUCT(&attribute_lock, opal_mutex_t);
+    ret = opal_hash_table_init(subsys->keyval_hash, ATTR_TABLE_SIZE);
+    assert (OPAL_SUCCESS == ret);
 
-    if (OMPI_SUCCESS != (ret = opal_hash_table_init(keyval_hash,
-                                                    ATTR_TABLE_SIZE))) {
-        return ret;
-    }
-    if (OMPI_SUCCESS != (ret = ompi_attr_create_predefined())) {
-        return ret;
-    }
-
-    return OMPI_SUCCESS;
+    attr_sequence = 0;    
 }
 
 
 /*
- * Cleanup everything during MPI_Finalize().
+ * Cleanup everything when no more refs to the attr subsys
  */
-int ompi_attr_finalize(void)
+static void attr_subsys_destruct(attr_subsys_t *subsys)
 {
     ompi_attr_free_predefined();
-    OBJ_DESTRUCT(&attribute_lock);
-    OBJ_RELEASE(keyval_hash);
-    OBJ_RELEASE(key_bitmap);
-
-    return OMPI_SUCCESS;
+    OBJ_RELEASE(subsys->keyval_hash);
+    OBJ_RELEASE(subsys->key_bitmap);
 }
 
 /*****************************************************************************/
@@ -609,10 +663,15 @@ static int ompi_attr_create_keyval_impl(ompi_attribute_type_t type,
 
     /* Create a new unique key and fill the hash */
     OPAL_THREAD_LOCK(&attribute_lock);
-    ret = CREATE_KEY(key);
+    ret = MPI_SUCCESS;
+    if (!(flags & OMPI_KEYVAL_PREDEFINED)) {
+        ret = CREATE_KEY(key);
+    }
+    
     if (OMPI_SUCCESS == ret) {
         keyval->key = *key;
-        ret = opal_hash_table_set_value_uint32(keyval_hash, *key, keyval);
+        ret = opal_hash_table_set_value_uint32(attr_subsys->keyval_hash,
+                                               *key, keyval);
     }
 
     if (OMPI_SUCCESS != ret) {
@@ -635,11 +694,22 @@ int ompi_attr_create_keyval(ompi_attribute_type_t type,
                             void *bindings_extra_state)
 {
     ompi_attribute_fortran_ptr_t es_tmp;
+    int rc;
+
+    rc = ompi_mpi_instance_retain ();
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
+        return rc;
+    }
 
     es_tmp.c_ptr = extra_state;
-    return ompi_attr_create_keyval_impl(type, copy_attr_fn, delete_attr_fn,
-                                        key, &es_tmp, flags,
-                                        bindings_extra_state);
+    rc = ompi_attr_create_keyval_impl(type, copy_attr_fn, delete_attr_fn,
+                                      key, &es_tmp, flags,
+                                      bindings_extra_state);
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
+        ompi_mpi_instance_release ();
+    }
+
+    return rc;
 }
 
 int ompi_attr_create_keyval_fint(ompi_attribute_type_t type,
@@ -651,6 +721,12 @@ int ompi_attr_create_keyval_fint(ompi_attribute_type_t type,
                                  void *bindings_extra_state)
 {
     ompi_attribute_fortran_ptr_t es_tmp;
+    int rc;
+
+    rc = ompi_mpi_instance_retain ();
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
+        return rc;
+    }
 
     es_tmp.f_integer = extra_state;
 #if SIZEOF_INT == OMPI_SIZEOF_FORTRAN_INTEGER
@@ -670,6 +746,12 @@ int ompi_attr_create_keyval_aint(ompi_attribute_type_t type,
                                  void *bindings_extra_state)
 {
     ompi_attribute_fortran_ptr_t es_tmp;
+    int rc;
+
+    rc = ompi_mpi_instance_retain ();
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
+        return rc;
+    }
 
     es_tmp.f_address = extra_state;
     return ompi_attr_create_keyval_impl(type, copy_attr_fn, delete_attr_fn,
@@ -687,7 +769,7 @@ int ompi_attr_free_keyval(ompi_attribute_type_t type, int *key,
 
     /* Find the key-value pair */
     OPAL_THREAD_LOCK(&attribute_lock);
-    ret = opal_hash_table_get_value_uint32(keyval_hash, *key,
+    ret = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, *key,
                                            (void **) &keyval);
     if ((OMPI_SUCCESS != ret) || (NULL == keyval) ||
         (keyval->attr_type != type) ||
@@ -707,6 +789,9 @@ int ompi_attr_free_keyval(ompi_attribute_type_t type, int *key,
     opal_atomic_wmb();
     OPAL_THREAD_UNLOCK(&attribute_lock);
 
+    /* balance out retain in keyval_create */
+    ompi_mpi_instance_release ();
+
     return MPI_SUCCESS;
 }
 
@@ -720,7 +805,7 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
                     opal_hash_table_t **attr_hash,
                     int key, void *attribute, bool predefined)
 {
-    int ret;
+    int ret = MPI_SUCCESS;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
     if (NULL == new_attr) {
         return OMPI_ERR_OUT_OF_RESOURCE;
@@ -942,7 +1027,7 @@ int ompi_attr_copy_all(ompi_attribute_type_t type, void *old_object,
 
         /* Get the keyval in the main keyval hash - so that we know
            what the copy_attr_fn is */
-        err = opal_hash_table_get_value_uint32(keyval_hash, key,
+        err = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, key,
                                                (void **) &hash_value);
         if (OMPI_SUCCESS != err) {
             /* This should not happen! */
@@ -1037,7 +1122,7 @@ static int ompi_attr_delete_impl(ompi_attribute_type_t type, void *object,
     attribute_value_t *attr;
 
     /* Check if the key is valid in the master keyval hash */
-    ret = opal_hash_table_get_value_uint32(keyval_hash, key,
+    ret = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, key,
                                            (void **) &keyval);
 
     if ((OMPI_SUCCESS != ret) || (NULL == keyval) ||
@@ -1053,7 +1138,7 @@ static int ompi_attr_delete_impl(ompi_attribute_type_t type, void *object,
         goto exit;
     }
 
-    /* Check if the key is valid for the communicator/window/dtype. If
+    /* Check if the key is valid for the communicator/window/dtype/instance. If
        yes, then delete the attribute and key entry from the object's
        hash */
     ret = opal_hash_table_get_value_uint32(attr_hash, key, (void**) &attr);
@@ -1198,7 +1283,7 @@ static int set_value(ompi_attribute_type_t type, void *object,
     /* Note that this function can be invoked by ompi_attr_copy_all()
        to set attributes on the new object (in addition to the
        top-level MPI_* functions that set attributes). */
-    ret = opal_hash_table_get_value_uint32(keyval_hash, key,
+    ret = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, key,
                                            (void **) &keyval);
 
     /* If key not found */
@@ -1242,7 +1327,7 @@ static int set_value(ompi_attribute_type_t type, void *object,
         had_old = true;
     }
 
-    ret = opal_hash_table_get_value_uint32(keyval_hash, key,
+    ret = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, key,
                                            (void **) &keyval);
     if ((OMPI_SUCCESS != ret ) || (NULL == keyval)) {
         /* Keyval has disappeared underneath us -- this shouldn't
@@ -1288,7 +1373,7 @@ static int get_value(opal_hash_table_t *attr_hash, int key,
        with the key, then the call is valid and returns FALSE in the
        flag argument */
     *flag = 0;
-    ret = opal_hash_table_get_value_uint32(keyval_hash, key,
+    ret = opal_hash_table_get_value_uint32(attr_subsys->keyval_hash, key,
                                            (void**) &keyval);
     if (OMPI_ERR_NOT_FOUND == ret) {
         return MPI_KEYVAL_INVALID;

--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,7 +58,7 @@ enum ompi_attribute_type_t {
                       * with 1 so that we can have it initialized to 0
                       * using memset in the constructor */
     TYPE_ATTR,       /**< The attribute belongs to datatype object */
-    WIN_ATTR         /**< The attribute belongs to a win object */
+    WIN_ATTR,        /**< The attribute belongs to a win object */
 };
 typedef enum ompi_attribute_type_t ompi_attribute_type_t;
 
@@ -185,22 +188,26 @@ int ompi_attr_hash_init(opal_hash_table_t **hash)
 }
 
 /**
- * Initialize the main attribute hash that stores the keyvals and meta data
+ * Increase the reference count on the attributes subsystem.  Instantiate subsys if
+ * not yet instantiated.
  *
  * @return OMPI return code
  */
 
-int ompi_attr_init(void);
+int ompi_attr_get_ref(void);
+
 
 /**
- * Destroy the main attribute hash that stores the keyvals and meta data
+ * Decrease the reference count on the attributes subsystem.  Attributes subsystem
+ * resources are released when the count drops to zero.
+ *
+ * @return OMPI return code
  */
 
-int ompi_attr_finalize(void);
-
+int ompi_attr_put_ref(void);
 
 /**
- * Create a new key for use by attribute of Comm/Win/Datatype
+ * Create a new key for use by attribute of Comm/Win/Datatype/Instance
  *
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
  * @param copy_attr_fn   Union variable containing the function pointer
@@ -273,7 +280,7 @@ int ompi_attr_free_keyval(ompi_attribute_type_t type, int *key,
  * Set an attribute on the comm/win/datatype in a form valid for C.
  *
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
- * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param object         The actual Comm/Win/Datatype/Instance object (IN)
  * @param attr_hash      The attribute hash table hanging on the object(IN/OUT)
  * @param key            Key val for the attribute (IN)
  * @param attribute      The actual attribute pointer (IN)
@@ -302,7 +309,7 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
  * Set an int predefined attribute in a form valid for C.
  *
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
- * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param object         The actual Comm/Win/Datatype/Instance object (IN)
  * @param attr_hash      The attribute hash table hanging on the object(IN/OUT)
  * @param key            Key val for the attribute (IN)
  * @param attribute      The actual attribute value (IN)
@@ -332,7 +339,7 @@ int ompi_attr_set_int(ompi_attribute_type_t type, void *object,
  * Fortran MPI-1.
  *
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
- * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param object         The actual Comm/Win/Datatype/Instance object (IN)
  * @param attr_hash      The attribute hash table hanging on the object(IN/OUT)
  * @param key            Key val for the attribute (IN)
  * @param attribute      The actual attribute pointer (IN)
@@ -363,7 +370,7 @@ OMPI_DECLSPEC int ompi_attr_set_fint(ompi_attribute_type_t type, void *object,
  * Fortran MPI-2.
  *
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
- * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param object         The actual Comm/Win/Datatype/Instance object (IN)
  * @param attr_hash      The attribute hash table hanging on the object(IN/OUT)
  * @param key            Key val for the attribute (IN)
  * @param attribute      The actual attribute pointer (IN)
@@ -472,7 +479,7 @@ OMPI_DECLSPEC int ompi_attr_get_aint(opal_hash_table_t *attr_hash, int key,
 /**
  * Delete an attribute on the comm/win/datatype
  * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
- * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param object         The actual Comm/Win/Datatype/Instance object (IN)
  * @param attr_hash      The attribute hash table hanging on the object(IN)
  * @param key            Key val for the attribute (IN)
  * @param predefined     Whether the key is predefined or not 0/1 (IN)
@@ -487,7 +494,7 @@ int ompi_attr_delete(ompi_attribute_type_t type, void *object,
 
 /**
  * This to be used from functions like MPI_*_DUP in order to copy all
- * the attributes from the old Comm/Win/Dtype object to a new
+ * the attributes from the old Comm/Win/Dtype/Instance object to a new
  * object.
  * @param type         Type of attribute (COMM/WIN/DTYPE) (IN)
  * @param old_object   The old COMM/WIN/DTYPE object (IN)
@@ -504,7 +511,7 @@ int ompi_attr_copy_all(ompi_attribute_type_t type, void *old_object,
 
 
 /**
- * This to be used to delete all the attributes from the Comm/Win/Dtype
+ * This to be used to delete all the attributes from the Comm/Win/Dtype/Instance
  * object in one shot
  * @param type         Type of attribute (COMM/WIN/DTYPE) (IN)
  * @param object       The COMM/WIN/DTYPE object (IN)

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -197,6 +197,7 @@ static int create_comm(int target_keyval, bool want_inherit)
     copy.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function)(
         want_inherit ? MPI_COMM_DUP_FN : MPI_COMM_NULL_COPY_FN);
     del.attr_communicator_delete_fn = MPI_COMM_NULL_DELETE_FN;
+    keyval = target_keyval;
     err = ompi_attr_create_keyval(COMM_ATTR, copy, del,
                                   &keyval, NULL, OMPI_KEYVAL_PREDEFINED, NULL);
     if (MPI_SUCCESS != err) {
@@ -226,6 +227,7 @@ static int create_win(int target_keyval)
     keyval = -1;
     copy.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function) MPI_WIN_NULL_COPY_FN;
     del.attr_win_delete_fn = MPI_WIN_NULL_DELETE_FN;
+    keyval = target_keyval;
     err = ompi_attr_create_keyval(WIN_ATTR, copy, del,
                                   &keyval, NULL, OMPI_KEYVAL_PREDEFINED, NULL);
     if (MPI_SUCCESS != err) {

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -147,6 +147,9 @@ int ompi_comm_init(void)
     ompi_mpi_comm_world.comm.c_flags |= OMPI_COMM_NAMEISSET;
     ompi_mpi_comm_world.comm.c_flags |= OMPI_COMM_INTRINSIC;
 
+    /* get a reference on the attributes subsys */
+    ompi_attr_get_ref();
+
     /* We have to create a hash (although it is legal to leave this
        filed NULL -- the attribute accessor functions will intepret
        this as "there are no attributes cached on this object")
@@ -237,6 +240,11 @@ int ompi_comm_init(void)
 
     /* initialize communicator requests (for ompi_comm_idup) */
     ompi_comm_request_init ();
+
+    /*
+     * finally here we set the predefined attribute keyvals
+     */
+    ompi_attr_create_predefined();
 
     return OMPI_SUCCESS;
 }
@@ -360,7 +368,7 @@ int ompi_comm_finalize(void)
     /* finalize communicator requests */
     ompi_comm_request_fini ();
 
-    return OMPI_SUCCESS;
+    return ompi_attr_put_ref();
 }
 
 /********************************************************************************/

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -34,6 +34,7 @@
 #include "opal/util/output.h"
 #include "opal/util/string_copy.h"
 #include "opal/class/opal_pointer_array.h"
+#include "ompi/attribute/attribute.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 
@@ -669,6 +670,13 @@ int32_t ompi_datatype_init( void )
             datatype->flags &= ~OPAL_DATATYPE_FLAG_NO_GAPS;
         }
     }
+
+    /* get a reference to the attributes subsys */
+    int ret = ompi_attr_get_ref();
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
     ompi_datatype_default_convertors_init();
     return OMPI_SUCCESS;
 }
@@ -697,7 +705,8 @@ int32_t ompi_datatype_finalize( void )
     /* don't call opal_datatype_finalize () as it no longer exists. the function will be called
      * opal_finalize_util (). */
 
-    return OMPI_SUCCESS;
+    /* release a reference to the attributes subsys */
+    return ompi_attr_put_ref();
 }
 
 

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -386,11 +386,6 @@ int ompi_mpi_finalize(void)
 
     /* Free secondary resources */
 
-    /* free attr resources */
-    if (OMPI_SUCCESS != (ret = ompi_attr_finalize())) {
-        goto done;
-    }
-
     /* free group resources */
     if (OMPI_SUCCESS != (ret = ompi_group_finalize())) {
         goto done;

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -878,12 +878,6 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
         goto error;
     }
 
-    /* initialize attribute meta-data structure for comm/win/dtype */
-    if (OMPI_SUCCESS != (ret = ompi_attr_init())) {
-        error = "ompi_attr_init() failed";
-        goto error;
-    }
-
     /* identify the architectures of remote procs and setup
      * their datatype convertors, if required
      */

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -106,6 +106,11 @@ ompi_win_init(void)
         return ret;
     }
 
+    ret = ompi_attr_get_ref();
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
     return OMPI_SUCCESS;
 }
 
@@ -137,7 +142,7 @@ int ompi_win_finalize(void)
     OBJ_RELEASE(ompi_win_accumulate_ops);
     OBJ_RELEASE(ompi_win_accumulate_order);
 
-    return OMPI_SUCCESS;
+    return ompi_attr_put_ref();
 }
 
 static int alloc_window(struct ompi_communicator_t *comm, opal_info_t *info, int flavor, ompi_win_t **win_out)


### PR DESCRIPTION
This commit updates how the attribute system is initialized. Instead of
being set up in MPI_Init it is initialized by the subsystems (communicator,
windows, datatypes) that use it. To keep the delta from the sessions PR
minimal the ompi_mpi_instance_retain() and ompi_mpi_instance_release()
functions are stubbed out as no-ops. This will be removed once the instance
system is added.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>