### PR TITLE
Relax memory order in opal_atomic_lock_init

### DIFF
--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -241,7 +241,7 @@ typedef atomic_flag opal_atomic_lock_t;
  */
 static inline void opal_atomic_lock_init(opal_atomic_lock_t *lock, bool value)
 {
-    atomic_flag_clear(lock);
+    atomic_flag_clear_explicit(lock, memory_order_relaxed);
 }
 
 static inline int opal_atomic_trylock(opal_atomic_lock_t *lock)


### PR DESCRIPTION
Initialization of a lock does not require sequential memory ordering
so relax it to memory_order_relaxed.

Back-port of https://github.com/open-mpi/ompi/pull/9655

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>