### PR TITLE
Patched libnbc to not round fractions based on float precision

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_iallreduce.c
+++ b/ompi/mca/coll/libnbc/nbc_iallreduce.c
@@ -366,7 +366,7 @@ static inline int allred_sched_diss(int rank, int p, int count, MPI_Datatype dat
 
   root = 0; /* this makes the code for ireduce and iallreduce nearly identical - could be changed to improve performance */
   RANK2VRANK(rank, vrank, root);
-  maxr = (int)ceil((log((double)p)/LOG2));
+  maxr = ceil_of_log2(p);
   /* ensure the result ends up in recvbuf on vrank 0 */
   if (0 == (maxr%2)) {
     rbuf = (void *)(-gap);

--- a/ompi/mca/coll/libnbc/nbc_ibarrier.c
+++ b/ompi/mca/coll/libnbc/nbc_ibarrier.c
@@ -45,7 +45,7 @@ static int nbc_barrier_init(struct ompi_communicator_t *comm, ompi_request_t ** 
       return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    maxround = (int)ceil((log((double)p)/LOG2)-1);
+    maxround = ceil_of_log2(p) -1;
 
     for (int round = 0 ; round <= maxround ; ++round) {
       sendpeer = (rank + (1 << round)) % p;

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -238,7 +238,7 @@ int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int 
 static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype) {
   int maxr, vrank, peer, res;
 
-  maxr = (int)ceil((log((double)p)/LOG2));
+  maxr = ceil_of_log2(p);
 
   RANK2VRANK(rank, vrank, root);
 

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -51,8 +51,15 @@
 extern "C" {
 #endif
 
-/* log(2) */
-#define LOG2 0.69314718055994530941
+/* Dividing very close floats may lead to unexpected roundings */
+static inline int
+ceil_of_log2 (int val) {
+    int ret = 0;
+    while (1 << ret < val) {
+        ret ++;
+    }
+    return ret;
+}
 
 /* true/false */
 #define true 1

--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -367,7 +367,7 @@ static inline int red_sched_binomial (int rank, int p, int root, const void *sen
     vroot = 0;
   }
   RANK2VRANK(rank, vrank, vroot);
-  maxr = (int)ceil((log((double)p)/LOG2));
+  maxr = ceil_of_log2(p);
 
   if (rank != root) {
     inplace = 0;

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
@@ -83,7 +83,7 @@ static int nbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int
     return nbc_get_noop_request(persistent, request);
   }
 
-  maxr = (int) ceil ((log((double) p) / LOG2));
+  maxr = ceil_of_log2(p);
 
   span = opal_datatype_span(&datatype->super, count, &gap);
   span_align = OPAL_ALIGN(span, datatype->super.align, ptrdiff_t);

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
@@ -68,7 +68,7 @@ static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int
     return OMPI_ERR_OUT_OF_RESOURCE;
   }
 
-  maxr = (int)ceil((log((double)p)/LOG2));
+  maxr = ceil_of_log2(p);
 
   count = p * recvcount;
 


### PR DESCRIPTION
The issue comes with float/double precision when application code uses fesetround(FE_UPWARD):
LOG2 and log(2.0) may differ on the last bits and the ratios me become slightly above the integer, making the ceiling one integer too high. Therefore collective commnications will attempt communications to non-existing peers that will lead to unexpected behaviours, such as segfaults in ompi_comm_peer_lookup.