### PR TITLE
cleanup: Remove static use_safety_valve variables.

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -16,8 +16,6 @@
 #include "coll_hcoll.h"
 #include "coll_hcoll_dtypes.h"
 
-static int use_safety_valve = 0;
-
 int hcoll_comm_attr_keyval;
 int hcoll_type_attr_keyval;
 mca_coll_hcoll_dtype_t zero_dte_mapping;
@@ -329,7 +327,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
                     cm->using_mem_hooks = 1;
                     opal_mem_hooks_register_release(mca_coll_hcoll_mem_release_cb, NULL);
                     setenv("MXM_HCOLL_MEM_ON_DEMAND_MAP", "y", 0);
-                    use_safety_valve = 1;
                 }
             }
         } else {
@@ -452,7 +449,5 @@ OBJ_CLASS_INSTANCE(mca_coll_hcoll_module_t,
 
 static void safety_valve(void) __attribute__((destructor));
 void safety_valve(void) {
-    if (use_safety_valve) {
-        opal_mem_hooks_unregister_release(mca_coll_hcoll_mem_release_cb);
-    }
+    opal_mem_hooks_unregister_release(mca_coll_hcoll_mem_release_cb);
 }

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -43,8 +43,6 @@
 #include "btl_uct_am.h"
 #include "btl_uct_device_context.h"
 
-static int use_safety_valve = 0;
-
 static int mca_btl_uct_component_register(void)
 {
     mca_btl_uct_module_t *module = &mca_btl_uct_module_template;
@@ -145,7 +143,6 @@ static int mca_btl_uct_component_open(void)
                 & opal_mem_hooks_support_level()))) {
         ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
         opal_mem_hooks_register_release(mca_btl_uct_mem_release_cb, NULL);
-        use_safety_valve = 1;
     }
 
     return OPAL_SUCCESS;
@@ -673,7 +670,5 @@ mca_btl_uct_component_t mca_btl_uct_component = {
 
 static void safety_valve(void) __attribute__((destructor));
 void safety_valve(void) {
-    if (use_safety_valve) {
-        opal_mem_hooks_unregister_release(mca_btl_uct_mem_release_cb);
-    }
+    opal_mem_hooks_unregister_release(mca_btl_uct_mem_release_cb);
 }

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -26,8 +26,6 @@
 #include <stdio.h>
 #include <ucm/api/ucm.h>
 
-static int use_safety_valve = 0;
-
 /***********************************************************************/
 
 extern mca_base_framework_t opal_memory_base_framework;
@@ -181,7 +179,6 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
             MCA_COMMON_UCX_VERBOSE(1, "%s", "using OPAL memory hooks as external events");
             ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
             opal_mem_hooks_register_release(opal_common_ucx_mem_release_cb, NULL);
-            use_safety_valve = 1;
         }
     }
 }
@@ -505,7 +502,5 @@ OPAL_DECLSPEC int opal_common_ucx_del_procs(opal_common_ucx_del_proc_t *procs, s
 
 static void safety_valve(void) __attribute__((destructor));
 void safety_valve(void) {
-    if (use_safety_valve) {
-        opal_mem_hooks_unregister_release(opal_common_ucx_mem_release_cb);
-    }
+    opal_mem_hooks_unregister_release(opal_common_ucx_mem_release_cb);
 }

--- a/opal/mca/rcache/base/rcache_base_create.c
+++ b/opal/mca/rcache/base/rcache_base_create.c
@@ -37,8 +37,6 @@
 #include "opal/memoryhooks/memory.h"
 #include "opal/runtime/opal_params.h"
 
-static int use_safety_valve = 0;
-
 mca_rcache_base_module_t *
 mca_rcache_base_module_create(const char *name, void *user_data,
                               struct mca_rcache_base_resources_t *resources)
@@ -72,7 +70,6 @@ mca_rcache_base_module_create(const char *name, void *user_data,
                     opal_leave_pinned = !opal_leave_pinned_pipeline;
                 }
                 opal_mem_hooks_register_release(mca_rcache_base_mem_cb, NULL);
-                use_safety_valve = 1;
             } else if (1 == opal_leave_pinned || opal_leave_pinned_pipeline) {
                 opal_show_help("help-rcache-base.txt", "leave pinned failed", true, name,
                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), opal_process_info.nodename);
@@ -127,7 +124,5 @@ int mca_rcache_base_module_destroy(mca_rcache_base_module_t *module)
 
 static void safety_valve(void) __attribute__((destructor));
 void safety_valve(void) {
-    if (use_safety_valve) {
-        opal_mem_hooks_unregister_release(mca_rcache_base_mem_cb);
-    }
+    opal_mem_hooks_unregister_release(mca_rcache_base_mem_cb);
 }


### PR DESCRIPTION
This variable isn't doing much of anything, as it doesn't
do any reference counting to make sure it isn't called
more than once.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>