### PR TITLE
lanl/ci: switch to using intel 2022.0.1

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -11,7 +11,7 @@ build:intel:
   stage: build
   tags: [darwin-slurm-shared]
   script:
-    - module load intel/2021.1.1
+    - module load intel/2022.0.1
     - rm .gitmodules
     - cp $GITSUBMODULEPATCH .gitmodules
     - git submodule update --init
@@ -112,7 +112,7 @@ test:intel:
   script:
     - pwd
     - ls
-    - module load intel/2021.1.1
+    - module load intel/2022.0.1
     - export PATH=$PWD/install_test/bin:$PATH
     - which mpirun
     - cd examples


### PR DESCRIPTION
icx no longer goes into infinite loop compiling a pmix file
using the 2022.0.1 version.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>