### PR TITLE
scoll/ucc: add onesided ucc support

### DIFF
--- a/oshmem/mca/scoll/ucc/scoll_ucc.h
+++ b/oshmem/mca/scoll/ucc/scoll_ucc.h
@@ -61,6 +61,7 @@ struct mca_scoll_ucc_module_t {
 
     oshmem_group_t             *group;
     ucc_team_h                  ucc_team;
+    long                       *pSync;
     
     /* Saved handlers - for fallback */
     mca_scoll_base_module_reduce_fn_t previous_reduce;
@@ -80,6 +81,9 @@ OBJ_CLASS_DECLARATION(mca_scoll_ucc_module_t);
 
 /* API functions */
 int mca_scoll_ucc_init_query(bool enable_progress_threads, bool enable_mpi_threads);
+
+int mca_scoll_ucc_team_create(mca_scoll_ucc_module_t *ucc_module, 
+                              oshmem_group_t *osh_group);
 
 mca_scoll_base_module_t* mca_scoll_ucc_comm_query(oshmem_group_t *osh_group, int *priority);
 

--- a/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
@@ -28,7 +28,7 @@ static inline ucc_status_t mca_scoll_ucc_alltoall_init(const void *sbuf, void *r
     }
 
     ucc_coll_args_t coll = {
-        .mask = 0,
+        .mask = UCC_COLL_ARGS_FIELD_FLAGS | UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER,
         .coll_type = UCC_COLL_TYPE_ALLTOALL,
         .src.info = {
             .buffer = (void *)sbuf,
@@ -42,8 +42,15 @@ static inline ucc_status_t mca_scoll_ucc_alltoall_init(const void *sbuf, void *r
             .datatype = dt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
+        .flags = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS,
+        .global_work_buffer = ucc_module->pSync,
     };
 
+    if (NULL == ucc_module->ucc_team) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:

--- a/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
@@ -19,6 +19,11 @@ static inline ucc_status_t mca_scoll_ucc_barrier_init(mca_scoll_ucc_module_t * u
         .mask = 0,
         .coll_type = UCC_COLL_TYPE_BARRIER
     };
+    if (NULL == ucc_module->ucc_team) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:

--- a/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
@@ -28,6 +28,11 @@ static inline ucc_status_t mca_scoll_ucc_broadcast_init(void * buf, int count,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         }
     };
+    if (NULL == ucc_module->ucc_team) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:

--- a/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
@@ -34,6 +34,11 @@ static inline ucc_status_t mca_scoll_ucc_collect_init(const void * sbuf, void * 
         },
     };
 
+    if (NULL == ucc_module->ucc_team) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:

--- a/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
@@ -54,7 +54,11 @@ static inline ucc_status_t mca_scoll_ucc_reduce_init(const void *sbuf, void *rbu
         coll.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
-
+    if (NULL == ucc_module->ucc_team) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:


### PR DESCRIPTION
This PR enables the one-sided collective support recently added in UCC. In addition, the PR delays UCC team creation until the first collective issued by an OSHMEM group in order to delay UCC team creation overhead.

Signed-off-by: ferrol aderholdt <faderholdt@nvidia.com>