### PR TITLE
v5.0.x: Remove -O2 from --enable-debug builds.

### DIFF
--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -72,12 +72,6 @@ AC_DEFUN([OMPI_SETUP_FC],[
            ompi_fc_happy=0],
           [ompi_fc_happy=1])
 
-    AS_IF([test $ompi_fc_happy -eq 1 && test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no"],
-          [FCFLAGS="$FCFLAGS -g"
-           OPAL_FLAGS_UNIQ(FCFLAGS)
-           AC_MSG_WARN([-g has been added to FCFLAGS (--enable-debug)])
-          ])
-
     # Make sure the compiler actually works, if not cross-compiling.
     # Don't just use the AC macro so that we can have a pretty
     # message.

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -276,15 +276,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
         OPAL_FLAGS_UNIQ(LDFLAGS)
         WANT_DEBUG=1
    fi
-    
-
-    # Do we want debugging?
-    if test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no" ; then
-        CFLAGS="$CFLAGS -g"
-
-        OPAL_FLAGS_UNIQ(CFLAGS)
-        AC_MSG_WARN([-g has been added to CFLAGS (--enable-debug)])
-    fi
 
     # These flags are generally gcc-specific; even the
     # gcc-impersonating compilers won't accept them.
@@ -428,20 +419,12 @@ AC_DEFUN([_OPAL_PROG_CC],[
     #
     # Check for the compiler
     #
-    OPAL_VAR_SCOPE_PUSH([opal_cflags_save dummy opal_cc_arvgv0])
+    OPAL_VAR_SCOPE_PUSH([dummy opal_cc_arvgv0])
 
-    # AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
-    opal_cflags_save="$CFLAGS"
     AC_USE_SYSTEM_EXTENSIONS
-    # AC_USE_SYSTEM_EXTENSIONS will modify CFLAGS if nothing was in there
-    # beforehand.  We don't want that.  So if there was nothing in
-    # CFLAGS, put nothing back in there.
-    AS_IF([test -z "$opal_cflags_save"], [CFLAGS=])
 
-    opal_cflags_save="$CFLAGS"
     AC_PROG_CC
     BASECC="`basename $CC`"
-    CFLAGS="$opal_cflags_save"
     OPAL_CC="$CC"
     AC_DEFINE_UNQUOTED(OPAL_CC, "$OPAL_CC", [OMPI underlying C compiler])
     set dummy $CC


### PR DESCRIPTION
This is reverting an accidental change in behavior on master, due
to the fact that autogen can re-order AC_BLAH calls as it sees fit.

Ensure CFLAGS is at least defined per the autogen docs for
debug builds near the top of configure, before AC_PROG_CC. This
should prevent any future configure shuffling and autogen re-ordering
from causing this again.

AC_PROG_CC reference: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 2bc63e7949ed8ae3114497029aa8dcf11802c026)