### PR TITLE
romio321 gpfs, change stat64 to stat

### DIFF
--- a/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_open.c
+++ b/ompi/mca/io/romio321/romio/adio/ad_gpfs/ad_gpfs_open.c
@@ -115,9 +115,9 @@ void ADIOI_GPFS_Open(ADIO_File fd, int *error_code)
 
 	MPI_Comm_rank(fd->comm, &rank);
 	if ((rank == fd->hints->ranklist[0]) || (fd->comm == MPI_COMM_SELF)) {
-	    struct stat64 gpfs_statbuf;
+	    struct stat gpfs_statbuf;
 	    /* Get the (real) underlying file system block size */
-	    rc = stat64(fd->filename, &gpfs_statbuf);
+	    rc = stat(fd->filename, &gpfs_statbuf);
 	    if (rc >= 0)
 	    {
 		fd->blksize = gpfs_statbuf.st_blksize;


### PR DESCRIPTION
bot:notacherrypick

This is a one-off fix for romio321. This comes from ROMIO v3.3
(see: pmodels/mpich@90a0fd5)

Refs #9842
Replaces #9854

Signed-off-by: Mark Allen markalle@us.ibm.com