### PR TITLE
endpoint->btl_eager can be empty when the dst has failed

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -88,7 +88,7 @@ static inline int mca_pml_ob1_send_inline (const void *buf, size_t count,
     int rc;
 
     bml_btl = mca_bml_base_btl_array_get_next(&endpoint->btl_eager);
-    if( NULL == bml_btl->btl->btl_sendi)
+    if( NULL == bml_btl || NULL == bml_btl->btl->btl_sendi)
         return OMPI_ERR_NOT_AVAILABLE;
 
     ompi_datatype_type_size (datatype, &size);


### PR DESCRIPTION
endpoint->btl_eager can be empty when the dst has failed (e.g., when using --with-ft=ulfm)
simple fix is to bypass the send_inline fast path when we detect such condition. 

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>