### PR TITLE
Silence gcc on the use of the GNU typeof extension.

### DIFF
--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -216,6 +216,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic(opal_fifo_t *fifo)
     const opal_list_item_t *const ghost = &fifo->opal_fifo_ghost;
 
 #    if OPAL_HAVE_ATOMIC_LLSC_PTR
+
     register opal_list_item_t *item, *next;
     int attempt = 0, ret = 0;
 
@@ -228,7 +229,10 @@ static inline opal_list_item_t *opal_fifo_pop_atomic(opal_fifo_t *fifo)
             attempt = 0;
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlanguage-extension-token"
         opal_atomic_ll_ptr(&fifo->opal_fifo_head.data.item, item);
+#pragma GCC diagnostic pop
         if (ghost == item) {
             if ((intptr_t) ghost == fifo->opal_fifo_tail.data.item) {
                 return NULL;

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -213,6 +213,9 @@ static inline opal_list_item_t *opal_lifo_push_atomic(opal_lifo_t *lifo, opal_li
 
 #    if OPAL_HAVE_ATOMIC_LLSC_PTR
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlanguage-extension-token"
+
 /* Retrieve one element from the LIFO. If we reach the ghost element then the LIFO
  * is empty so we return NULL.
  */
@@ -243,6 +246,8 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
     item->opal_list_next = NULL;
     return item;
 }
+
+#pragma GCC diagnostic pop
 
 #    else
 


### PR DESCRIPTION
The compilation on the M1 laptops was extremely verbose, with hundreds of warnings about using non-standard extensions. This patch disable this warning for the LL/SC atomic  load/store.

The same can be done for different compiler (clang supports the same mechanism as gcc).

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>