### PR TITLE
Require HWLOC 1.11.0 or later

### DIFF
--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -144,16 +144,16 @@ AC_DEFUN([_OPAL_CONFIG_HWLOC_EXTERNAL], [
     LIBS="$opal_hwloc_LIBS_save $opal_hwloc_LIBS"
 
     AS_IF([test "$opal_hwloc_external_support" = "yes"],
-          [AC_MSG_CHECKING([if external hwloc version is 1.6 or greater])
+          [AC_MSG_CHECKING([if external hwloc version is 1.11.0 or greater])
            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <hwloc.h>]],
                                [[
 #if HWLOC_API_VERSION < 0x00010500
-#error "hwloc API version is less than 0x00010500"
+#error "hwloc API version is less than 0x00011100"
 #endif
                                ]])],
                    [AC_MSG_RESULT([yes])],
                    [AC_MSG_RESULT([no])
-                    AC_MSG_WARN([external hwloc version is too old (1.5 or later required)])
+                    AC_MSG_WARN([external hwloc version is too old (1.11.0 or later required)])
                     opal_hwloc_external_support="no"])])
 
     AS_IF([test "$opal_hwloc_external_support" = "yes"],


### PR DESCRIPTION
1.11.8 appears to be the oldest version of HWLOC shipped by currently
supported Linux distros, so bump our requirements to 1.11.0.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 6a934a5faaf3aa22977514c46392a096ec9db159)