### PR TITLE
Fix Fortran preprocessor issue with CPPFLAGS

### DIFF
--- a/ompi/mpiext/example/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/example/use-mpi-f08/Makefile.am
@@ -2,12 +2,21 @@
 # Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+# Note that Automake's Fortran-buidling rules uses CPPFLAGS and
+# AM_CPPFLAGS.  This can cause weirdness (e.g.,
+# https://github.com/open-mpi/ompi/issues/7253 and
+# https://github.com/open-mpi/ompi/issues/9716).  Let's just zero
+# those out and rely on AM_FCFLAGS.
+CPPFLAGS =
+AM_CPPFLAGS =
 
 # This file builds the use_mpi_f08-based bindings for MPI extensions.  It
 # is optional in MPI extensions.

--- a/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
@@ -6,12 +6,21 @@
 # Copyright (c) 2018      The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+# Note that Automake's Fortran-buidling rules uses CPPFLAGS and
+# AM_CPPFLAGS.  This can cause weirdness (e.g.,
+# https://github.com/open-mpi/ompi/issues/7253 and
+# https://github.com/open-mpi/ompi/issues/9716).  Let's just zero
+# those out and rely on AM_FCFLAGS.
+CPPFLAGS =
+AM_CPPFLAGS =
 
 # This file builds the use_mpi_f08-based bindings for MPI extensions.  It
 # is optional in MPI extensions.


### PR DESCRIPTION
 * Some C and Fortran compilers use different preprocessors. If one preprocessor
   accepts `-iquote` and the other does not then a compiler error will occur
   when Open MPI tries to use it.
   - Nvidia/PGI v22.1-0 is one such. The C compiler supports `-iquote`
     while the Fortran compiler does not.
 * Similar to PR #7265 we need to clear the `CPPFLAGS` and `AM_CPPFLAGS`

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>