### PR TITLE
LL/SC: be flexible with ret type

### DIFF
--- a/opal/include/opal/sys/arm64/atomic_llsc.h
+++ b/opal/include/opal/sys/arm64/atomic_llsc.h
@@ -38,11 +38,8 @@
 #        define opal_atomic_ll_32(addr, ret)                                                       \
             do {                                                                                   \
                 opal_atomic_int32_t *_addr = (addr);                                               \
-                int32_t _ret;                                                                      \
                                                                                                    \
-                __asm__ __volatile__("ldaxr    %w0, [%1]          \n" : "=&r"(_ret) : "r"(_addr)); \
-                                                                                                   \
-                ret = (typeof(ret)) _ret;                                                          \
+                __asm__ __volatile__("ldaxr    %w0, [%1]          \n" : "=&r"(ret) : "r"(_addr));  \
             } while (0)
 
 #        define opal_atomic_sc_32(addr, newval, ret)                  \
@@ -62,11 +59,8 @@
 #        define opal_atomic_ll_64(addr, ret)                                                      \
             do {                                                                                  \
                 opal_atomic_int64_t *_addr = (addr);                                              \
-                int64_t _ret;                                                                     \
                                                                                                   \
-                __asm__ __volatile__("ldaxr    %0, [%1]          \n" : "=&r"(_ret) : "r"(_addr)); \
-                                                                                                  \
-                ret = (typeof(ret)) _ret;                                                         \
+                __asm__ __volatile__("ldaxr    %0, [%1]          \n" : "=&r"(ret) : "r"(_addr)); \
             } while (0)
 
 #        define opal_atomic_sc_64(addr, newval, ret)                 \

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -139,9 +139,7 @@ static inline bool opal_atomic_compare_exchange_strong_32(opal_atomic_int32_t *a
 #    define opal_atomic_ll_32(addr, ret)                                                \
         do {                                                                            \
             opal_atomic_int32_t *_addr = (addr);                                        \
-            int32_t _ret;                                                               \
-            __asm__ __volatile__("lwarx   %0, 0, %1  \n\t" : "=&r"(_ret) : "r"(_addr)); \
-            ret = (typeof(ret)) _ret;                                                   \
+            __asm__ __volatile__("lwarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
         } while (0)
 
 #    define opal_atomic_sc_32(addr, value, ret)                         \
@@ -248,9 +246,7 @@ static inline bool opal_atomic_compare_exchange_strong_64(opal_atomic_int64_t *a
 #        define opal_atomic_ll_64(addr, ret)                                                \
             do {                                                                            \
                 opal_atomic_int64_t *_addr = (addr);                                        \
-                int64_t _ret;                                                               \
-                __asm__ __volatile__("ldarx   %0, 0, %1  \n\t" : "=&r"(_ret) : "r"(_addr)); \
-                ret = (typeof(ret)) _ret;                                                   \
+                __asm__ __volatile__("ldarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
             } while (0)
 
 #        define opal_atomic_sc_64(addr, value, ret)                               \


### PR DESCRIPTION
Do not use a temporary variable for holding the loaded value
for ll/sc calls, eliminiating warnings about type mismatches
for places where the compiler can implicitly cast into a
register type anyway.  This likely removes a slight bit of
type safety, but also removes an ugly to fix warning about
the use of typeof() on recent LLVM compilers that would be
near impossible to fix and would hide all other warnings in
noise.  Given the relatively infrequent use of LL/SC and the
ability to pay close attention when using it anyway, this is
probably the more sane call.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>