### PR TITLE
Allow explicit use of the Active Message RDMA interface

### DIFF
--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -403,6 +403,8 @@ static inline int am_rdma_advance(mca_btl_base_am_rdma_module_t *am_module,
         hdr->data.rdma.size = packet_size;
         hdr->data.rdma.initiator_address = (uint64_t) context->local_address + context->sent;
     } else {
+        /* atomics today are single datatype entries */
+        assert(packet_size < UINT8_MAX);
         hdr->data.atomic.size = packet_size;
     }
 

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -1145,6 +1145,13 @@ int mca_btl_base_am_rdma_init(mca_btl_base_module_t *btl)
         operation_alignment = btl->btl_put_alignment;
     }
 
+    /* TODO: Ideally, we would swap the BTL's flush for our own
+     * implementation which completed all outstanding transactions on
+     * that BTL and then called the underlying flush().  Given the
+     * work and the lack of use case today, we instead just remove
+     * flush support from the underlying BTL. */
+    btl->btl_flush = NULL;
+
     if (!(btl->btl_flags & MCA_BTL_FLAGS_PUT)) {
         btl->btl_flags |= MCA_BTL_FLAGS_PUT_AM;
         btl->btl_put_limit = max_operation_size - sizeof(am_rdma_hdr_t);

--- a/opal/mca/btl/base/btl_base_am_rdma.h
+++ b/opal/mca/btl/base/btl_base_am_rdma.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,10 +15,46 @@
 /**
  * This file provides support for active-message (send/recv) based RDMA.
  * It can be used with any btl that provides a minimum of send support but
- * can also be used with partial-RDMA BTLs (put only, get only, etc). It
- * will provide support for any RDMA or atomic operation not currently
- * supported by the supplied BTL. For more info see the description of
- * mca_btl_base_am_rdma_init.
+ * can also be used with partial-RDMA BTLs (put only, get only, etc)
+ * to provide a complete RDMA interface.
+ *
+ * There are two modes of using this interface, depending on your
+ * requirements:
+ *
+ * First, this interface can be used to provide a complete
+ * put/get/atomic interface for BTLs which do not natively provide
+ * such an interface.  In this mode, active message rdma functions are
+ * only used if the underlying implementation does not already provide
+ * the required functionality.  For example, if a BTL natively
+ * supports put but not get, the interface would provide an emulated
+ * get.  The registration, completion and atomicity semantics of the
+ * BTL remain the native interface's capabilities.  That is, if the
+ * native interface does not provide remote completion or atomics that
+ * are atomic with processor atomics, neither will the interface after
+ * initializing the am rdma interface for that BTL.  This mode will
+ * likely give better performance than the second mode for transfers
+ * that fit within the BTL's native semantics.  In this mode, the BTL
+ * interface is updated so that the btl_{put, get, atomic_fop,
+ * atomic_cswap} function pointers are usage.  However, the btl
+ * capability flags will not be updated to indicate native support of
+ * the emulated functionality (for example, if btl_get() is emulated,
+ * MCA_BTL_FLAGS_GET will not be set).  Instead, the emulated flags
+ * will be set (MCA_BTL_FLAGS_PUT_AM, MCA_BTL_FLAGS_GET_AM,
+ * MCA_BTL_FLAGS_ATOMIC_AM_FOP, etc.).
+ *
+ * Second, this interface can be used to provide different
+ * sementicsthan a BTL natively provides.  This mode is not
+ * transparent to the caller (unlike the first mode).  Instead, the
+ * caller must manage calling the active message put/get/atomic
+ * interface directly (rather than through the BTL function pointers).
+ * For interfaces which require strict remote completion or require
+ * implicit memory registration, this can greatly simplify the code,
+ * in return for marginally more management complexity and lower
+ * performance.
+ *
+ * While the calling convention and initialization are different, the
+ * communication routines uses by the active message rdma
+ * implementation are identical in both modes of operation.
  */
 
 #include "opal_config.h"
@@ -28,14 +66,86 @@
 /**
  * @brief initialize active-message RDMA/atomic support
  *
- * @inout btl   btl module to augment
+ * @param  btl[in,out]  btl module to augment
+ *
+ * @retval OPAL_SUCCESS  btl successfully updated, btl already
+ *                       updated, or btl has all available
+ *                       functionality natively.
+ * @retval OPAL_ERR_TEMP_OUT_OF_RESOURCE Allocating BTL-level data
+ *                       structure failed.
  *
  * This function adds functionality to the btl for any missing RDMA/atomic
  * operation. Atomic operations are entirely emulated using send/recv and
  * work best with a btl that also has async-progress enabled. Put/get
  * support will use either send/recv or get (for put)/put (for get) (if
  * available).
+ *
+ * Note that calling this function will change the BTL interface.
+ * Care must be taken to not call this function outside of early
+ * initialization routines.
  */
 int mca_btl_base_am_rdma_init(mca_btl_base_module_t *btl);
+
+struct mca_btl_base_am_rdma_module_t;
+
+typedef int (*mca_btl_base_am_rdma_module_put_fn_t)(
+    struct mca_btl_base_am_rdma_module_t *am_btl, struct mca_btl_base_endpoint_t *endpoint,
+    void *local_address, uint64_t remote_address,
+    struct mca_btl_base_registration_handle_t *local_handle,
+    struct mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags, int order,
+    mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+typedef int (*mca_btl_base_am_rdma_module_get_fn_t)(
+    struct mca_btl_base_am_rdma_module_t *am_btl, struct mca_btl_base_endpoint_t *endpoint,
+    void *local_address, uint64_t remote_address,
+    struct mca_btl_base_registration_handle_t *local_handle,
+    struct mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags, int order,
+    mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+typedef int (*mca_btl_base_am_rdma_module_atomic_fop64_fn_t)(
+    struct mca_btl_base_am_rdma_module_t *am_btl, struct mca_btl_base_endpoint_t *endpoint,
+    void *local_address, uint64_t remote_address,
+    struct mca_btl_base_registration_handle_t *local_handle,
+    struct mca_btl_base_registration_handle_t *remote_handle, mca_btl_base_atomic_op_t op,
+    uint64_t operand, int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
+    void *cbcontext, void *cbdata);
+
+typedef int (*mca_btl_base_am_rdma_module_atomic_cswap64_fn_t)(
+    struct mca_btl_base_am_rdma_module_t *am_btl, struct mca_btl_base_endpoint_t *endpoint,
+    void *local_address, uint64_t remote_address,
+    struct mca_btl_base_registration_handle_t *local_handle,
+    struct mca_btl_base_registration_handle_t *remote_handle, uint64_t compare, uint64_t value,
+    int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+struct mca_btl_base_am_rdma_module_t {
+    opal_object_t super;
+    mca_btl_base_module_t *btl;
+    bool use_rdma_put;
+    bool use_rdma_get;
+
+    size_t am_btl_put_limit;
+    size_t am_btl_put_alignment;
+    size_t am_btl_get_limit;
+    size_t am_btl_get_alignment;
+
+    mca_btl_base_am_rdma_module_put_fn_t am_btl_put;
+    mca_btl_base_am_rdma_module_get_fn_t am_btl_get;
+    mca_btl_base_am_rdma_module_atomic_fop64_fn_t am_btl_atomic_fop;
+    mca_btl_base_am_rdma_module_atomic_cswap64_fn_t am_btl_atomic_cswap;
+};
+typedef struct mca_btl_base_am_rdma_module_t mca_btl_base_am_rdma_module_t;
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_btl_base_am_rdma_module_t);
+
+
+/**
+ * @brief create active-message RDMA/atomics functions
+ */
+int opal_btl_base_am_rdma_create(mca_btl_base_module_t *btl,
+                                 uint32_t flags_requested,
+                                 bool no_memory_registration,
+                                 mca_btl_base_am_rdma_module_t **am_module);
+
+int opal_btl_base_am_rdma_destroy(mca_btl_base_am_rdma_module_t *am_module);
 
 #endif /* OPAL_MCA_BTL_BASE_AM_RDMA_H */

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -1239,7 +1239,14 @@ struct mca_btl_base_module_t {
 
     mca_btl_base_module_flush_fn_t btl_flush; /**< flush all previous operations on an endpoint */
 
-    unsigned char padding[256]; /**< padding to future-proof the btl module */
+
+    union {
+        struct {
+            void *btl_am_data;
+        };
+        unsigned char padding[256]; /**< padding to future-proof the
+                                       btl module */
+    };
 };
 typedef struct mca_btl_base_module_t mca_btl_base_module_t;
 


### PR DESCRIPTION
The AM RDMA interface previously only could be used by updating a btl to fill in missing interfaces.  However, it has the capability of providing stronger semantics than the underlying BTL (like providing remote completion even if the underlying BTL doesn't).  Provide an external interface to the AM RDMA code that will be used by the RDMA OSC code when the underlying BTLs don't provide remote completion or the required put/get/atomic interfaces.