### PR TITLE
Fix --disable-ompio builds.

### DIFF
--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -231,9 +231,18 @@ AC_DEFINE_UNQUOTED(MPI_PARAM_CHECK, $mpi_param_check,
 AC_DEFINE_UNQUOTED(OMPI_PARAM_CHECK, $ompi_param_check,
     [Whether we want to check MPI parameters never or possible (an integer constant)])
 
+AC_MSG_CHECKING([if want ompio support])
 AC_ARG_ENABLE([io-ompio],
     [AS_HELP_STRING([--disable-io-ompio],
         [Disable the ompio MPI-IO component])])
+if test "$enable_io_ompio" = "no" ; then
+   AC_MSG_RESULT([no])
+   ompi_want_ompio=0
+else
+   AC_MSG_RESULT([yes])
+   ompi_want_ompio=1
+fi
+AM_CONDITIONAL(OMPI_OMPIO_SUPPORT, test "$ompi_want_ompio" = "1")
 
 ])dnl
 

--- a/ompi/mca/fbtl/base/Makefile.am
+++ b/ompi/mca/fbtl/base/Makefile.am
@@ -22,6 +22,10 @@ headers += \
 
 libmca_fbtl_la_SOURCES += \
         base/fbtl_base_frame.c \
-        base/fbtl_base_file_select.c \
-        base/fbtl_base_file_unselect.c \
         base/fbtl_base_find_available.c
+
+if OMPI_OMPIO_SUPPORT
+libmca_fbtl_la_SOURCES += \
+        base/fbtl_base_file_select.c \
+        base/fbtl_base_file_unselect.c
+endif

--- a/ompi/mca/fcoll/base/Makefile.am
+++ b/ompi/mca/fcoll/base/Makefile.am
@@ -23,9 +23,13 @@ headers += \
 
 libmca_fcoll_la_SOURCES += \
         base/fcoll_base_frame.c \
+        base/fcoll_base_find_available.c
+
+if OMPI_OMPIO_SUPPORT
+libmca_fcoll_la_SOURCES += \
         base/fcoll_base_file_select.c \
         base/fcoll_base_file_unselect.c \
-        base/fcoll_base_find_available.c \
         base/fcoll_base_sort.c \
         base/fcoll_base_file_read_all.c \
         base/fcoll_base_coll_array.c
+endif

--- a/ompi/mca/fs/base/Makefile.am
+++ b/ompi/mca/fs/base/Makefile.am
@@ -22,12 +22,16 @@ headers += \
 
 libmca_fs_la_SOURCES += \
         base/fs_base_frame.c \
+        base/fs_base_find_available.c
+
+if OMPI_OMPIO_SUPPORT
+libmca_fs_la_SOURCES += \
         base/fs_base_file_select.c \
         base/fs_base_file_unselect.c \
-        base/fs_base_find_available.c \
         base/fs_base_get_parent_dir.c \
         base/fs_base_file_close.c \
         base/fs_base_file_sync.c \
         base/fs_base_file_delete.c \
         base/fs_base_file_set_size.c \
         base/fs_base_file_get_size.c
+endif

--- a/ompi/mca/sharedfp/base/Makefile.am
+++ b/ompi/mca/sharedfp/base/Makefile.am
@@ -22,7 +22,11 @@ headers += \
         base/base.h
 
 libmca_sharedfp_la_SOURCES += \
+        base/sharedfp_base_frame.c \
+        base/sharedfp_base_find_available.c
+
+if OMPI_OMPIO_SUPPORT
+libmca_sharedfp_la_SOURCES += \
         base/sharedfp_base_file_select.c \
-        base/sharedfp_base_file_unselect.c \
-        base/sharedfp_base_find_available.c \
-        base/sharedfp_base_frame.c
+        base/sharedfp_base_file_unselect.c
+endif


### PR DESCRIPTION
Make base directories compile only the bare minimum
when disabling ompio. These can make mca_ompio calls, which will
lead to a linking error.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>