### PR TITLE
v5.0.x: btl: introduce flag MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION

### DIFF
--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -410,7 +410,7 @@ static inline int mca_btl_base_am_rdma_advance(mca_btl_base_module_t *btl,
     }
 
     if (send_descriptor) {
-        assert(0 != (descriptor->des_flags && MCA_BTL_DES_SEND_ALWAYS_CALLBACK));
+        assert(0 != (descriptor->des_flags & MCA_BTL_DES_SEND_ALWAYS_CALLBACK));
         ret = btl->btl_send(btl, endpoint, descriptor, mca_btl_base_rdma_tag(hdr->type));
         if (ret == 1) {
             ret = OPAL_SUCCESS;
@@ -800,7 +800,7 @@ static int mca_btl_base_am_rdma_progress(void)
         mca_btl_base_rdma_context_t *context =                          \
             (mca_btl_base_rdma_context_t *)                             \
             descriptor->descriptor->des_context;                        \
-        assert(0 != (descriptor->descriptor->des_flags && MCA_BTL_DES_SEND_ALWAYS_CALLBACK)); \
+        assert(0 != (descriptor->descriptor->des_flags & MCA_BTL_DES_SEND_ALWAYS_CALLBACK)); \
         int ret = descriptor->btl->btl_send(descriptor->btl,            \
                                             descriptor->endpoint,       \
                                             descriptor->descriptor,     \

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -263,6 +263,16 @@ typedef uint8_t mca_btl_base_tag_t;
 /* The BTL has active-message based atomics */
 #define MCA_BTL_FLAGS_ATOMIC_AM_FOP 0x400000
 
+/** Ths BTL's RDMA/atomics operation supports remote completion.
+ * When the BTL reported the completion of a RDMA/atomic operation
+ * on the initator side, the operation also finished on the target side.
+ *
+ * Note, this flag is for put and atomic write operations. Operations
+ * like get, atomic fetch and atomic swap support remote
+ * completion by nature.
+ */
+#define MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION 0x800000
+
 /* Default exclusivity levels */
 #define MCA_BTL_EXCLUSIVITY_HIGH    (64 * 1024) /* internal loopback */
 #define MCA_BTL_EXCLUSIVITY_DEFAULT 1024 /* GM/IB/etc. */

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -390,8 +390,10 @@ mca_btl_ofi_module_t *mca_btl_ofi_module_alloc(int mode)
         module->super.btl_register_mem = mca_btl_ofi_register_mem;
         module->super.btl_deregister_mem = mca_btl_ofi_deregister_mem;
 
+        /* btl/ofi support remote completion because it required FI_DELIVERY_COMPLETE capability
+         */
         module->super.btl_flags |= MCA_BTL_FLAGS_ATOMIC_FOPS | MCA_BTL_FLAGS_ATOMIC_OPS
-                                   | MCA_BTL_FLAGS_RDMA;
+                                   | MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION;
 
         module->super.btl_atomic_flags = MCA_BTL_ATOMIC_SUPPORTS_ADD | MCA_BTL_ATOMIC_SUPPORTS_SWAP
                                          | MCA_BTL_ATOMIC_SUPPORTS_CSWAP

--- a/opal/mca/btl/self/btl_self_component.c
+++ b/opal/mca/btl/self/btl_self_component.c
@@ -107,6 +107,8 @@ static int mca_btl_self_component_register(void)
     mca_btl_self.btl_rdma_pipeline_frag_size = INT_MAX;
     mca_btl_self.btl_min_rdma_pipeline_size = 0;
     mca_btl_self.btl_flags = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND;
+    /* for self, remote completion is local completion */
+    mca_btl_self.btl_flags |= MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION;
     mca_btl_self.btl_bandwidth = 100;
     mca_btl_self.btl_latency = 0;
     mca_btl_base_param_register(&mca_btl_self_component.super.btl_version, &mca_btl_self);

--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -469,6 +469,7 @@ static int btl_ugni_component_register(void)
     mca_btl_ugni_module.super.btl_flags = MCA_BTL_FLAGS_SEND | MCA_BTL_FLAGS_RDMA
                                           | MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_ATOMIC_OPS
                                           | MCA_BTL_FLAGS_ATOMIC_FOPS;
+    mca_btl_ugni_module.super.btl_flags |= MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION;
     mca_btl_ugni_module.super.btl_atomic_flags = MCA_BTL_ATOMIC_SUPPORTS_ADD
                                                  | MCA_BTL_ATOMIC_SUPPORTS_AND
                                                  | MCA_BTL_ATOMIC_SUPPORTS_OR


### PR DESCRIPTION
This patch introduced a new flag MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION,
which is used to indicate whether a btl's RDMA/atomic operations support
remote completion.

btl/self, btl/ofi and btl/ugni support remote completion, thus this patch
added the flags to them.

Active message RDMA/atomic supports remote completion under certain
condition, this patch implemented that logic.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 8f4cda3cc3f5caed1aece9e3c0284e706c0f0893)