### PR TITLE
Fix a few misc. build issues

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1409,6 +1409,13 @@ $step. Checking tool versions\n\n";
 ++$step;
 verbose "\n$step. Checking for git submodules\n\n";
 
+my @enabled_3rdparty_packages = ();
+my @disabled_3rdparty_packages = split(/,/, $no_3rdparty_arg);
+if ($no_prrte_arg) {
+    push(@disabled_3rdparty_packages, "prrte");
+}
+
+
 # Make sure we got a submodule-full clone.  If not, abort and let a
 # human figure it out.
 if (-f ".gitmodules") {
@@ -1423,6 +1430,18 @@ if (-f ".gitmodules") {
         my $extra      = $4;
 
         print("=== Submodule: $path\n");
+        if (index($path, "pmix") != -1 and list_contains("pmix", @disabled_3rdparty_packages)) {
+          print("Disabled - skipping openpmix");
+          next;
+        }
+        if (index($path, "prrte") != -1 and list_contains("prrte", @disabled_3rdparty_packages)) {
+          print("Disabled - skipping prrte");
+          next;
+        }
+        if (index($path, "hwloc") != -1 and list_contains("hwloc", @disabled_3rdparty_packages)) {
+          print("Disabled - skipping hwloc");
+          next;
+        }
 
         # Make sure the submodule is there
         if ($status eq "-") {
@@ -1587,12 +1606,6 @@ mca_run_global($projects);
 # Handle 3rd-party packages
 ++$step;
 verbose "\n$step. Setup for 3rd-party packages\n";
-
-my @enabled_3rdparty_packages = ();
-my @disabled_3rdparty_packages = split(/,/, $no_3rdparty_arg);
-if ($no_prrte_arg) {
-    push(@disabled_3rdparty_packages, "prrte");
-}
 
 $m4 .= "\n$dnl_line
 $dnl_line

--- a/config/opal_check_pc.m4
+++ b/config/opal_check_pc.m4
@@ -35,7 +35,7 @@ AC_DEFUN([OPAL_GET_LDFLAGS_FROM_PC], [
   happy=1
   AS_IF([test "$PKG_CONFIG" = ""],
         [happy=0],
-        [OPAL_LOG_COMMAND([pkg_config_results=`$PKG_CONFIG --static --libs-only-L --libs-only-other $1`],
+        [OPAL_LOG_COMMAND([pkg_config_results=`PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig $PKG_CONFIG --static --libs-only-L --libs-only-other $1`],
              [AS_VAR_COPY([$2], [pkg_config_results])],
              [happy=0])])
   AS_IF([test $happy -eq 0],
@@ -59,7 +59,7 @@ AC_DEFUN([OPAL_GET_LIBS_FROM_PC], [
   happy=1
   AS_IF([test "$PKG_CONFIG" = ""],
         [happy=0],
-        [OPAL_LOG_COMMAND([pkg_config_results=`$PKG_CONFIG --libs-only-l $1`],
+        [OPAL_LOG_COMMAND([pkg_config_results=`PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig $PKG_CONFIG --libs-only-l $1`],
              [AS_VAR_COPY([$2], [pkg_config_results])],
              [happy=0])])
   AS_IF([test $happy -eq 0],

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -152,7 +152,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
     AS_IF([test "$opal_pmix_mode" = "internal"],
           [pkg_config_file="${OMPI_TOP_BUILDDIR}/3rd-party/openpmix/maint/pmix.pc"
            PKG_CONFIG_PATH="${OMPI_TOP_BUILDDIR}/3rd-party/openpmix/maint:${PKG_CONFIG_PATH}"],
-          [test -n "$with_hwloc"],
+          [test -n "$with_pmix"],
           [pkg_config_file="${with_pmix}/lib/pkgconfig/pmix.pc"
            PKG_CONFIG_PATH="${with_pmix}/lib/pkgconfig:${PKG_CONFIG_PATH}"],
           [pkg_config_file="pmix"])

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -78,18 +78,14 @@ lib@OPAL_LIB_NAME@_la_LIBADD = \
         mca/base/libmca_base.la \
         util/libopalutil.la \
 	$(MCA_opal_FRAMEWORK_LIBS) \
-	$(opal_libevent_LIBS) \
-	$(opal_hwloc_LIBS) \
-	$(opal_pmix_LIBS)
+        $(OPAL_WRAPPER_EXTRA_LIBS)
 lib@OPAL_LIB_NAME@_la_DEPENDENCIES = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
         $(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_NAME@_la_LDFLAGS = -version-info @libopen_pal_so_version@ \
-	$(opal_libevent_LDFLAGS) \
-	$(opal_hwloc_LDFLAGS) \
-	$(opal_pmix_LDFLAGS)
+	$(OPAL_PKG_CONFIG_LDFLAGS)
 
 # included subdirectory Makefile.am's and appended-to variables
 headers =


### PR DESCRIPTION
- autogen.pl: Allow skipping 3rd-party when in git repo. 
  - Even when passing `--no-3rdparty "pmix,prrte,hwloc"`, autogen insisted that I clone pmix/prrte because I was
    working in a git repo.  ​This patch fixes that bug.
​
​-   Fix typo in opal_config_pmix.m4. 
     ​- `with_hwloc` should be `with_pmix`.

- Fix build with external dependencies.
  - Building with --with-pmix="external" and --with-hwloc=/path/to/hwloc the linker was unable to find -lhwloc when
    making opal. The link command was not including -L/path/to/hwloc/lib in the command. This fixes it.
    
 - pkg-config: Put /usr/local/lib in search path.
   - My setup put pmix.pc into /usr/local/lib. Not sure if this is the best spot for it, but appending it to the pkg-config
     command allows configure to find it there as a last resort.

