### PR TITLE
ompio file_read_all: relocate implementation from base to common

### DIFF
--- a/ompi/mca/common/ompio/Makefile.am
+++ b/ompi/mca/common/ompio/Makefile.am
@@ -35,6 +35,7 @@ sources = \
 	common_ompio_file_open.c   \
 	common_ompio_file_view.c   \
 	common_ompio_file_read.c   \
+	common_ompio_file_read_all.c \
 	common_ompio_buffer.c      \
 	common_ompio_file_write.c
 

--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -323,6 +323,9 @@ OMPI_DECLSPEC int mca_common_ompio_set_file_defaults (ompio_file_t *fh);
 OMPI_DECLSPEC int mca_common_ompio_set_view (ompio_file_t *fh,  OMPI_MPI_OFFSET_TYPE disp,
                                              ompi_datatype_t *etype,  ompi_datatype_t *filetype, const char *datarep,
                                              opal_info_t *info);
+OMPI_DECLSPEC int mca_common_ompio_base_file_read_all (struct ompio_file_t *fh, void *buf, int count,
+                                                       struct ompi_datatype_t *datatype, ompi_status_public_t *status);
+
  
 
 /*

--- a/ompi/mca/common/ompio/common_ompio_file_read_all.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read_all.c
@@ -33,7 +33,7 @@
 #include <unistd.h>
 
 #define DEBUG_ON 0
-#define FCOLL_BASE_SHUFFLE_TAG 123
+#define COMMON_OMPIO_SHUFFLE_TAG 123
 #define INIT_LEN 10
 
 /*Used for loading file-offsets per aggregator*/
@@ -51,11 +51,11 @@ static int read_heap_sort (mca_io_ompio_local_io_array *io_array,
 
 
 int
-mca_fcoll_base_file_read_all (ompio_file_t *fh,
-                                 void *buf,
-                                 int count,
-                                 struct ompi_datatype_t *datatype,
-                                 ompi_status_public_t *status)
+mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
+                                     void *buf,
+                                     int count,
+                                     struct ompi_datatype_t *datatype,
+                                     ompi_status_public_t *status)
 {
     MPI_Aint total_bytes = 0;          /* total bytes to be read */
     MPI_Aint bytes_to_read_in_cycle = 0; /* left to be read in a cycle*/
@@ -743,7 +743,7 @@ mca_fcoll_base_file_read_all (ompio_file_t *fh,
                                                   1,
                                                   sendtype[i],
                                                   fh->f_procs_in_group[i],
-                                                  FCOLL_BASE_SHUFFLE_TAG,
+                                                  COMMON_OMPIO_SHUFFLE_TAG,
                                                   MCA_PML_BASE_SEND_STANDARD,
                                                   fh->f_comm,
                                                   &send_req[i]));
@@ -824,7 +824,7 @@ mca_fcoll_base_file_read_all (ompio_file_t *fh,
                                      1,
                                      newType,
                                      my_aggregator,
-                                     FCOLL_BASE_SHUFFLE_TAG,
+                                     COMMON_OMPIO_SHUFFLE_TAG,
                                      fh->f_comm,
                                      &recv_req));
 

--- a/ompi/mca/fcoll/base/Makefile.am
+++ b/ompi/mca/fcoll/base/Makefile.am
@@ -30,6 +30,5 @@ libmca_fcoll_la_SOURCES += \
         base/fcoll_base_file_select.c \
         base/fcoll_base_file_unselect.c \
         base/fcoll_base_sort.c \
-        base/fcoll_base_file_read_all.c \
         base/fcoll_base_coll_array.c
 endif

--- a/ompi/mca/fcoll/dynamic/Makefile.am
+++ b/ompi/mca/fcoll/dynamic/Makefile.am
@@ -25,6 +25,7 @@ sources = \
         fcoll_dynamic.h \
         fcoll_dynamic_module.c \
         fcoll_dynamic_component.c \
+        fcoll_dynamic_file_read_all.c \
         fcoll_dynamic_file_write_all.c
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
@@ -50,11 +50,17 @@ int mca_fcoll_dynamic_component_file_unquery (ompio_file_t *file);
 int mca_fcoll_dynamic_module_init (ompio_file_t *file);
 int mca_fcoll_dynamic_module_finalize (ompio_file_t *file);
 
-int mca_fcoll_dynamic_file_write_all (ompio_file_t *fh,
+int mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
                                       int count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t * status);
+int mca_fcoll_dynamic_file_read_all (struct ompio_file_t *fh,
+                                     void *buf,
+                                     int count,
+                                     struct ompi_datatype_t *datatype,
+                                     ompi_status_public_t * status);
+
 
 
 END_C_DECLS

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "fcoll_dynamic.h"
+
+#include "mpi.h"
+#include "ompi/mca/common/ompio/common_ompio.h"
+
+
+
+int
+mca_fcoll_dynamic_file_read_all (struct ompio_file_t *fh,
+                                 void *buf,
+                                 int count,
+                                 struct ompi_datatype_t *datatype,
+                                 ompi_status_public_t *status)
+{
+    return mca_common_ompio_base_file_read_all (fh, buf, count, datatype, status);
+}
+
+

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -51,7 +51,7 @@ static int local_heap_sort (mca_io_ompio_local_io_array *io_array,
 
 
 int
-mca_fcoll_dynamic_file_write_all (ompio_file_t *fh,
+mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                                   const void *buf,
                                   int count,
                                   struct ompi_datatype_t *datatype,

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_module.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_module.c
@@ -37,7 +37,7 @@
 static mca_fcoll_base_module_1_0_0_t dynamic =  {
     mca_fcoll_dynamic_module_init,
     mca_fcoll_dynamic_module_finalize,
-    mca_fcoll_base_file_read_all,
+    mca_fcoll_dynamic_file_read_all,
     NULL, /* iread_all */
     mca_fcoll_dynamic_file_write_all,
     NULL, /*iwrite_all */

--- a/ompi/mca/fcoll/dynamic_gen2/Makefile.am
+++ b/ompi/mca/fcoll/dynamic_gen2/Makefile.am
@@ -25,6 +25,7 @@ sources = \
         fcoll_dynamic_gen2.h \
         fcoll_dynamic_gen2_module.c \
         fcoll_dynamic_gen2_component.c \
+        fcoll_dynamic_gen2_file_read_all.c \
         fcoll_dynamic_gen2_file_write_all.c
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
@@ -54,11 +54,17 @@ int mca_fcoll_dynamic_gen2_component_file_unquery (ompio_file_t *file);
 int mca_fcoll_dynamic_gen2_module_init (ompio_file_t *file);
 int mca_fcoll_dynamic_gen2_module_finalize (ompio_file_t *file);
 
-int mca_fcoll_dynamic_gen2_file_write_all (ompio_file_t *fh,
+int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
                                       int count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t * status);
+int mca_fcoll_dynamic_gen2_file_read_all (struct ompio_file_t *fh,
+                                          void *buf,
+                                          int count,
+                                          struct ompi_datatype_t *datatype,
+                                          ompi_status_public_t * status);
+
 
 
 END_C_DECLS

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2021 University of Houston. All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "fcoll_dynamic_gen2.h"
+
+#include "mpi.h"
+#include "ompi/mca/common/ompio/common_ompio.h"
+
+
+
+int mca_fcoll_dynamic_gen2_file_read_all (struct ompio_file_t *fh,
+                                          void *buf,
+                                          int count,
+                                          struct ompi_datatype_t *datatype,
+                                          ompi_status_public_t *status)
+{
+    return mca_common_ompio_base_file_read_all (fh, buf, count, datatype, status);
+}
+

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -112,7 +112,7 @@ int mca_fcoll_dynamic_gen2_split_iov_array ( ompio_file_t *fh, mca_common_ompio_
                                              int num_entries, int *last_array_pos, int *last_pos_in_field );
 
 
-int mca_fcoll_dynamic_gen2_file_write_all (ompio_file_t *fh,
+int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
                                       int count,
                                       struct ompi_datatype_t *datatype,

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_module.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_module.c
@@ -37,7 +37,7 @@
 static mca_fcoll_base_module_1_0_0_t dynamic_gen2 =  {
     mca_fcoll_dynamic_gen2_module_init,
     mca_fcoll_dynamic_gen2_module_finalize,
-    mca_fcoll_base_file_read_all,
+    mca_fcoll_dynamic_gen2_file_read_all,
     NULL, /* iread_all */
     mca_fcoll_dynamic_gen2_file_write_all,
     NULL, /*iwrite_all */

--- a/ompi/mca/fcoll/vulcan/Makefile.am
+++ b/ompi/mca/fcoll/vulcan/Makefile.am
@@ -24,6 +24,7 @@ sources = \
         fcoll_vulcan.h \
         fcoll_vulcan_module.c \
         fcoll_vulcan_component.c \
+        fcoll_vulcan_file_read_all.c \
         fcoll_vulcan_file_write_all.c
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
@@ -56,11 +56,16 @@ int mca_fcoll_vulcan_component_file_unquery (ompio_file_t *file);
 int mca_fcoll_vulcan_module_init (ompio_file_t *file);
 int mca_fcoll_vulcan_module_finalize (ompio_file_t *file);
 
-int mca_fcoll_vulcan_file_write_all (ompio_file_t *fh,
+int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
                                      const void *buf,
                                      int count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t * status);
+int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
+                                    void *buf,
+                                    int count,
+                                    struct ompi_datatype_t *datatype,
+                                    ompi_status_public_t * status);
 
 
 END_C_DECLS

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2021 University of Houston. All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "fcoll_vulcan.h"
+
+#include "mpi.h"
+#include "ompi/mca/common/ompio/common_ompio.h"
+
+
+int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
+                                    void *buf,
+                                    int count,
+                                    struct ompi_datatype_t *datatype,
+                                    ompi_status_public_t *status)
+{
+    return mca_common_ompio_base_file_read_all (fh, buf, count, datatype, status);
+}
+
+

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -116,7 +116,7 @@ static int mca_fcoll_vulcan_minmax ( ompio_file_t *fh, struct iovec *iov, int io
                                      long *new_stripe_size);
 
 
-int mca_fcoll_vulcan_file_write_all (ompio_file_t *fh,
+int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
                                       int count,
                                       struct ompi_datatype_t *datatype,

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_module.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_module.c
@@ -37,7 +37,7 @@
 static mca_fcoll_base_module_1_0_0_t vulcan =  {
     mca_fcoll_vulcan_module_init,
     mca_fcoll_vulcan_module_finalize,
-    mca_fcoll_base_file_read_all,
+    mca_fcoll_vulcan_file_read_all,
     NULL, /* iread_all */
     mca_fcoll_vulcan_file_write_all,
     NULL, /*iwrite_all */


### PR DESCRIPTION
Move the default implementation of the read_all function used by some components
from fcoll/base to common/ompio, in order to resolve dependency problems with fcoll/base.
Re-introduce per-component read_all functions, which are however only stubs calling
the common/ompio implementation.

Tested with static and dynamic builds. Also ensured that the --disable-io-ompio flag
still works correctly.

Signed-off-by: Edgar Gabriel <edgar.gabriel1@outlook.com>