### PR TITLE
OPAL/COMMON/UCX: added fallback to OPAL memory hooks

### DIFF
--- a/contrib/platform/mellanox/optimized.conf
+++ b/contrib/platform/mellanox/optimized.conf
@@ -63,6 +63,7 @@ hwloc_base_binding_policy = core
 btl = self
 pml_ucx_tls = any
 pml_ucx_devices = any
+opal_common_ucx_opal_mem_hooks = 0
 # Basic behavior to smooth startup
 mca_base_component_show_load_errors = 0
 orte_abort_timeout = 10

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -35,7 +35,7 @@ extern mca_base_framework_t opal_memory_base_framework;
 opal_common_ucx_module_t opal_common_ucx = {.verbose = 0,
                                             .progress_iterations = 100,
                                             .registered = 0,
-                                            .opal_mem_hooks = 0,
+                                            .opal_mem_hooks = 1,
                                             .tls = NULL};
 
 static opal_mutex_t opal_common_ucx_mutex = OPAL_MUTEX_STATIC_INIT;


### PR DESCRIPTION
- in case if UCX memory hooks could not be used try to fallback
  into OPAL memory hooks

fixes https://github.com/open-mpi/ompi/issues/9859