### PR TITLE
don't add ref to attr subsys twice

### DIFF
--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -686,12 +686,6 @@ int32_t ompi_datatype_init( void )
 
     ompi_datatype_default_convertors_init();
 
-    /* get a reference to the attributes subsys */
-    ret = ompi_attr_get_ref();
-    if (OMPI_SUCCESS != ret) {
-        return ret;
-    }
-
     ompi_mpi_instance_append_finalize (ompi_datatype_finalize);
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
looks like there may have been a rebase mess up at some point.
related to #9097

Signed-off-by: Howard Pritchard <howardp@lanl.gov>