### PR TITLE
external prrte: Create symlink to prrterun in bindir.

### DIFF
--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -95,6 +95,9 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
     AM_CONDITIONAL([OMPI_WANT_PRRTE],
            [test "$prrte_setup_internal_happy" = "1" -o "$prrte_setup_external_happy" = "1"])
 
+    AM_CONDITIONAL([OMPI_EXTERNAL_PRRTE],
+           [test "$opal_prrte_mode" = "external"])
+
     AC_DEFINE_UNQUOTED([OMPI_HAVE_PRRTE],
                        [$OMPI_HAVE_PRRTE],
                        [Whether or not PRRTE is available])
@@ -268,13 +271,15 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_EXTERNAL], [
     AS_IF([test "$setup_prrte_external_happy" = "yes"],
           [AS_IF([test -n "$with_prrte"],
                  [PRTE_PATH="${with_prrte}/bin/prte"
-                  AS_IF([test ! -r ${PRTE_PATH}], [AC_MSG_ERROR([Could not find prte binary at $PRTE_PATH])])],
+                  AS_IF([test ! -r ${PRTE_PATH}],
+                        [AC_MSG_ERROR([Could not find prte binary at $PRTE_PATH])],
+                        [PRTE_PATH="${with_prrte}/bin"])],
 		 [PRTE_PATH=""
                   OPAL_WHICH([prte], [PRTE_PATH])
                   AS_IF([tets -z "$PRTE_PATH"],
                         [AC_MSG_WARN([Could not find prte in PATH])
-                         setup_prrte_external_happy=no])])])
-
+                         setup_prrte_external_happy=no],
+                        [PRTE_PATH="`echo $PRTE_PATH | sed -e 's/\/prte//'`"])])])
     AS_IF([test "$setup_prrte_external_happy" = "yes"],
           [$1], [$2])
 

--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -24,9 +24,15 @@ mpirun_LDADD = \
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f mpiexec$(EXEEXT); $(LN_S) mpirun$(EXEEXT) mpiexec$(EXEEXT))
 	(cd $(DESTDIR)$(bindir); rm -f oshrun$(EXEEXT); $(LN_S) mpirun$(EXEEXT) oshrun$(EXEEXT))
+if OMPI_EXTERNAL_PRRTE
+	(cd $(DESTDIR)$(bindir); rm -f prterun$(EXEEXT); $(LN_S) $(PRTE_PATH)/prterun prterun$(EXEEXT))
+endif
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/mpirun$(EXEEXT) \
 		$(DESTDIR)$(bindir)/mpiexec$(EXEEXT)  \
 		$(DESTDIR)$(bindir)/oshrun$(EXEEXT)
+if OMPI_EXTERNAL_PRRTE
+	\     $(DESTDIR)$(bindir)/prterun$(EXEEXT)
+endif
 endif

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -85,6 +85,18 @@ int main(int argc, char *argv[])
 #endif
     }
 
+#if !OMPI_USING_INTERNAL_PRRTE
+    if(NULL == pfx) {
+        // In the external PRRTE case, a symlink
+        // should have been created placing prterun
+        // in bindir.
+        mca_base_framework_open(&opal_installdirs_base_framework, 0);  // fill in the installdirs
+        if (NULL != opal_install_dirs.bindir) {
+            pfx = strdup(opal_install_dirs.bindir);
+        }
+    }
+#endif
+
     if (NULL == pfx) {
         truepath = opal_path_findv("prterun", X_OK, environ, NULL);
     } else {


### PR DESCRIPTION
Fixes a bug where out-of-the-box ompi builds with an
external prrte will fail to find prterun.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>