### PR TITLE
v4.1.x: README: make the heterogeneous support more clear

### DIFF
--- a/README
+++ b/README
@@ -1529,13 +1529,29 @@ MISCELLANEOUS FUNCTIONALITY
   Enable the PERUSE MPI data analysis interface.
 
 --enable-heterogeneous
-  Enable support for running on heterogeneous clusters (e.g., machines
-  with different endian representations).  Heterogeneous support is
-  disabled by default because it imposes a minor performance penalty.
+  Enable support for running on heterogeneous clusters where data
+  types are equivalent sizes across nodes, but may have differing
+  endian representations.  Heterogeneous support is disabled by
+  default because it imposes a minor performance penalty.
 
-  *** THE HETEROGENEOUS FUNCTIONALITY IS CURRENTLY BROKEN - DO NOT USE ***
+  Note that the MPI standard does not guarantee that all
+  heterogeneous communication will function properly, especially
+  when the conversion between the different representations leads to
+  loss of accuracy or range.  For example, if a message with a
+  16-bit integer datatype is sent with value 0x10000 to a receiver
+  where the same integer datatype is only 8 bits, the value will be
+  truncated at the receiver.  Similarly, problems can occur if a
+  floating point datatype in one MPI process uses X1 bits for its
+  mantissa and Y1 bits for its exponent, but the same floating point
+  datatype in another MPI process uses X2 and Y2 bits, respectively
+  (where X1 != X2 and/or Y1 != Y2).  Type size differences like this
+  can lead to unexpected behavior.
 
- --enable-spc
+  Open MPI's heterogeneous support correctly handles endian
+  differences between datatype representations that are otherwise
+  compatible.
+
+--enable-spc
   Enable software-based performance counters capability.
 
 --with-wrapper-cflags=<cflags>


### PR DESCRIPTION
**NOTE:** This PR is intended to be merged after #9810, just to keep the history a bit simple (because #9809 -- the v4.0.x version of #9810 -- was already merged; it'll be a little easier for someone digging through git history if the same things happened on both v4.0.x and v4.1.x).  This PR includes the commit from #9810 because otherwise there would be a conflict.  That commit will effectively disappear from this PR once #9810 is merged.  Opening this PR in a "draft" state to ensure that #9810 is merged first.

-----

Remove ambiguous warning language (it's not clear if the "THIS
FUNCTIONALITY..." warning applies to the option above or below the
warning) and make it clear exactly what the heterogeneous option
supports and does not support.

This is a port of https://github.com/open-mpi/ompi/commit/6674ba8776fb059f5abdcdc455486d28e0b3fa78 from master; it's not a direct
cherry pick because master has README.md and the v4.1.x branch has
README.

Signed-off-by: Jeff Squyres [jsquyres@cisco.com](mailto:jsquyres@cisco.com)

bot:notacherrypick