### PR TITLE
v5.0.x: external prrte: Compile mpirun with PRTE_PATH to find prterun.

### DIFF
--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -99,6 +99,11 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
                        [$OMPI_HAVE_PRRTE],
                        [Whether or not PRRTE is available])
 
+    AS_IF([test "$opal_prrte_mode" = "external"],
+          [AC_DEFINE_UNQUOTED([OMPI_PRTERUN_PATH],
+                      ["$PRTE_PATH"],
+                      [Path to prterun])])
+
     AC_DEFINE_UNQUOTED([OMPI_USING_INTERNAL_PRRTE],
                        [$OMPI_USING_INTERNAL_PRRTE],
                        [Whether or not we are using the internal PRRTE])
@@ -268,13 +273,15 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_EXTERNAL], [
     AS_IF([test "$setup_prrte_external_happy" = "yes"],
           [AS_IF([test -n "$with_prrte"],
                  [PRTE_PATH="${with_prrte}/bin/prte"
-                  AS_IF([test ! -r ${PRTE_PATH}], [AC_MSG_ERROR([Could not find prte binary at $PRTE_PATH])])],
+                  AS_IF([test ! -r ${PRTE_PATH}],
+                        [AC_MSG_ERROR([Could not find prte binary at $PRTE_PATH])],
+                        [PRTE_PATH="${with_prrte}/bin"])],
 		 [PRTE_PATH=""
                   OPAL_WHICH([prte], [PRTE_PATH])
                   AS_IF([tets -z "$PRTE_PATH"],
                         [AC_MSG_WARN([Could not find prte in PATH])
-                         setup_prrte_external_happy=no])])])
-
+                         setup_prrte_external_happy=no],
+                        [PRTE_PATH="`echo $PRTE_PATH | sed -e 's/\/prte//'`"])])])
     AS_IF([test "$setup_prrte_external_happy" = "yes"],
           [$1], [$2])
 

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     char **pargs = NULL;
     char *pfx = NULL;
     int m, param_len;
-    char *truepath;
+    char *truepath = NULL;
 
     if (NULL != (evar = getenv("OPAL_PREFIX"))) {
 
@@ -87,6 +87,14 @@ int main(int argc, char *argv[])
 
     if (NULL == pfx) {
         truepath = opal_path_findv("prterun", X_OK, environ, NULL);
+#if !OMPI_USING_INTERNAL_PRRTE
+        // if OMPI_PRTERUN_PATH is available, try that
+        // for external builds if the user didn't explictly
+        // add a prefix and it isn't in the users path.
+        if((NULL == truepath) && (0 != strlen(OMPI_PRTERUN_PATH))) {
+            truepath = opal_os_path(0, OMPI_PRTERUN_PATH, "prterun", NULL);
+        }
+#endif
     } else {
         truepath = opal_os_path(0, pfx, "prterun", NULL);
         free(pfx);


### PR DESCRIPTION
Fixes a bug where out-of-the-box ompi builds with an
external prrte will fail to find prterun. As a last
resort, check this path in an attempt to find prterun.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 66c76645d05d0406f171a0610108a0a223a61378)