### PR TITLE
osc/rdma: Handle remote completion behavior 

### DIFF
--- a/ompi/mca/osc/rdma/Makefile.am
+++ b/ompi/mca/osc/rdma/Makefile.am
@@ -11,6 +11,8 @@
 # Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,6 +23,8 @@
 rdma_sources = \
 	osc_rdma.h \
 	osc_rdma_module.c \
+	osc_rdma_btl_comm.h \
+	osc_rdma_btl_comm.c \
 	osc_rdma_comm.h \
 	osc_rdma_comm.c \
 	osc_rdma_accumulate.c \

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -148,9 +148,6 @@ struct ompi_osc_rdma_module_t {
     /** value of same_size info key for this window */
     bool same_size;
 
-    /** CPU atomics can be used */
-    bool use_cpu_atomics;
-
     /** passive-target synchronization will not be used in this window */
     bool no_locks;
 

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -762,9 +762,10 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "RDMA compare-and-swap initiating blocking btl put...");
 
     do {
-        ret = btl->btl_put (btl, peer->data_endpoint, ptr, target_address,
-                            local_handle, target_handle, len, 0, MCA_BTL_NO_ORDER,
-                            ompi_osc_rdma_cas_put_complete, (void *) &complete, NULL);
+        ret = ompi_osc_rdma_btl_put(module, peer->data_btl_index, peer->data_endpoint,
+                                    ptr, target_address, local_handle, target_handle,
+                                    len, 0, MCA_BTL_NO_ORDER,
+                                    ompi_osc_rdma_cas_put_complete, (void *) &complete, NULL);
         if (OPAL_SUCCESS == ret || (OPAL_ERR_OUT_OF_RESOURCE != ret && OPAL_ERR_TEMP_OUT_OF_RESOURCE != ret)) {
             break;
         }

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -164,13 +164,11 @@ static int ompi_osc_rdma_fetch_and_op_atomic (ompi_osc_rdma_sync_t *sync, const 
                                               mca_btl_base_registration_handle_t *target_handle, ompi_op_t *op, ompi_osc_rdma_request_t *req)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = selected_btl->btl_atomic_flags;
     int btl_op, flags;
     int64_t origin;
 
-    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
-        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
+    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags) && 4 == extent)) ||
+        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & module->atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -242,13 +240,11 @@ static int ompi_osc_rdma_acc_single_atomic (ompi_osc_rdma_sync_t *sync, const vo
                                             ompi_op_t *op, ompi_osc_rdma_request_t *req)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = selected_btl->btl_atomic_flags;
     int btl_op, flags;
     int64_t origin;
 
-    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
-        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
+    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags) && 4 == extent)) ||
+        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & module->atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -663,13 +659,11 @@ static inline int ompi_osc_rdma_cas_atomic (ompi_osc_rdma_sync_t *sync, const vo
                                             bool lock_acquired)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = btl->btl_atomic_flags;
     const size_t size = datatype->super.size;
     int64_t compare, source;
     int flags, ret;
 
-    if (8 != size && !(4 == size && (MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags))) {
+    if (8 != size && !(4 == size && (MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags))) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
@@ -717,7 +711,6 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
                             mca_btl_base_registration_handle_t *target_handle, bool lock_acquired)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     unsigned long len = datatype->super.size;
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
@@ -742,18 +735,21 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
         return OMPI_SUCCESS;
     }
 
-    if (btl->btl_register_mem && len > btl->btl_put_local_registration_threshold) {
-        do {
-            ret = ompi_osc_rdma_frag_alloc (module, len, &frag, &ptr);
-            if (OPAL_UNLIKELY(OMPI_SUCCESS == ret)) {
-                break;
-            }
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
+        if (len > btl->btl_put_local_registration_threshold) {
+            do {
+                ret = ompi_osc_rdma_frag_alloc(module, len, &frag, &ptr);
+                if (OPAL_UNLIKELY(OMPI_SUCCESS == ret)) {
+                    break;
+                }
 
-            ompi_osc_rdma_progress (module);
-        } while (1);
+                ompi_osc_rdma_progress (module);
+            } while (1);
 
-        memcpy (ptr, source_addr, len);
-        local_handle = frag->handle;
+            memcpy(ptr, source_addr, len);
+            local_handle = frag->handle;
+        }
     }
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "RDMA compare-and-swap initiating blocking btl put...");

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -244,12 +244,6 @@ static int ompi_osc_rdma_acc_single_atomic (ompi_osc_rdma_sync_t *sync, const vo
     int btl_op, flags;
     int64_t origin;
 
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
-        /* btl put atomics not supported or disabled. fall back on fetch-and-op */
-        return ompi_osc_rdma_fetch_and_op_atomic (sync, origin_addr, NULL, dt, extent, peer, target_address, target_handle,
-                                                  op, req);
-    }
-
     if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
         (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -19,12 +19,15 @@
  * $HEADER$
  */
 
+#include "ompi_config.h"
+
 #include "osc_rdma_accumulate.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_comm.h"
 #include "osc_rdma_lock.h"
 #include "osc_rdma_btl_comm.h"
 
+#include "opal/util/minmax.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 
@@ -583,9 +586,9 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
 
             /* determine how much to put in this operation */
             if (source_count) {
-                acc_len = min(min(target_iovec[target_iov_index].iov_len, source_iovec[source_iov_index].iov_len), acc_limit);
+                acc_len = opal_min(opal_min(target_iovec[target_iov_index].iov_len, source_iovec[source_iov_index].iov_len), acc_limit);
             } else {
-                acc_len = min(target_iovec[target_iov_index].iov_len, acc_limit);
+                acc_len = opal_min(target_iovec[target_iov_index].iov_len, acc_limit);
             }
 
             if (0 != acc_len) {

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +22,8 @@
 #include "osc_rdma_accumulate.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_comm.h"
+#include "osc_rdma_lock.h"
+#include "osc_rdma_btl_comm.h"
 
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -77,33 +77,6 @@ OBJ_CLASS_INSTANCE(ompi_osc_rdma_pending_op_t, opal_list_item_t,
                    ompi_osc_rdma_pending_op_construct,
                    ompi_osc_rdma_pending_op_destruct);
 
-/**
- * Dummy completion function for atomic operations
- */
-void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
-                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
-                                    void *context, void *data, int status)
-{
-    ompi_osc_rdma_pending_op_t *pending_op = (ompi_osc_rdma_pending_op_t *) context;
-
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "pending atomic %p complete with status %d", (void*)pending_op, status);
-
-    if (pending_op->op_result) {
-        memmove (pending_op->op_result, pending_op->op_buffer, pending_op->op_size);
-    }
-
-    if (NULL != pending_op->cbfunc) {
-        pending_op->cbfunc (pending_op->cbdata, pending_op->cbcontext, status);
-    }
-
-    if (NULL != pending_op->op_frag) {
-        ompi_osc_rdma_frag_complete (pending_op->op_frag);
-        pending_op->op_frag = NULL;
-    }
-
-    pending_op->op_complete = true;
-    OBJ_RELEASE(pending_op);
-}
 
 /**
  * compare_ranks:

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2004-2005 The Trustees of the University of Tennessee.
+ *                         All rights reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "osc_rdma.h"
+#include "osc_rdma_frag.h"
+#include "osc_rdma_btl_comm.h"
+
+#include "opal/mca/btl/base/base.h"
+
+void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
+                                    void *context, void *data, int status)
+{
+    ompi_osc_rdma_pending_op_t *pending_op = (ompi_osc_rdma_pending_op_t *) context;
+
+    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "pending atomic %p complete with status %d", (void*)pending_op, status);
+
+    if (pending_op->op_result) {
+        memmove (pending_op->op_result, pending_op->op_buffer, pending_op->op_size);
+    }
+
+    if (NULL != pending_op->cbfunc) {
+        pending_op->cbfunc (pending_op->cbdata, pending_op->cbcontext, status);
+    }
+
+    if (NULL != pending_op->op_frag) {
+        ompi_osc_rdma_frag_complete (pending_op->op_frag);
+        pending_op->op_frag = NULL;
+    }
+
+    pending_op->op_complete = true;
+    OBJ_RELEASE(pending_op);
+}

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
@@ -36,11 +36,17 @@ ompi_osc_rdma_btl_put(ompi_osc_rdma_module_t *module, uint8_t btl_index,
 		      mca_btl_base_rdma_completion_fn_t cbfunc,
 		      void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_put(btl, endpoint, local_address, remote_address,
-                        local_handle, remote_handle, size, flags, order,
-                        cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_put(btl, endpoint, local_address, remote_address,
+                            local_handle, remote_handle, size, flags, order,
+                            cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_put(am_rdma, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle, size, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -54,11 +60,18 @@ ompi_osc_rdma_btl_get(ompi_osc_rdma_module_t *module, uint8_t btl_index,
 		      mca_btl_base_rdma_completion_fn_t cbfunc,
 		      void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
 
-    return btl->btl_get(btl, endpoint, local_address, remote_address,
-                        local_handle, remote_handle, size, flags, order,
-                        cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_get(btl, endpoint, local_address, remote_address,
+                            local_handle, remote_handle, size, flags, order,
+                            cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_get(am_rdma, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle, size, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -70,6 +83,9 @@ ompi_osc_rdma_btl_atomic_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
                             mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 {
     mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+
+    /* the AM BTL interface does not currently support op calls */
+    assert(module->use_accelerated_btl);
 
     return btl->btl_atomic_op(btl, endpoint, remote_address, remote_handle,
                               op, operand, flags, order,
@@ -87,12 +103,19 @@ ompi_osc_rdma_btl_atomic_fop(ompi_osc_rdma_module_t *module, uint8_t btl_index,
                              mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_atomic_fop(btl, endpoint, local_address, remote_address,
-                               local_handle, remote_handle,
-                               op, operand, flags, order,
-                               cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_atomic_fop(btl, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle,
+                                   op, operand, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_atomic_fop(am_rdma, endpoint, local_address, remote_address,
+                                          local_handle, remote_handle,
+                                          op, operand, flags, order,
+                                          cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -105,12 +128,19 @@ ompi_osc_rdma_btl_atomic_cswap(ompi_osc_rdma_module_t *module, uint8_t btl_index
                                uint64_t compare, uint64_t value, int flags, int order,
                                mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_atomic_cswap(btl, endpoint, local_address, remote_address,
-                                 local_handle, remote_handle,
-                                 compare, value, flags, order,
-                                 cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_atomic_cswap(btl, endpoint, local_address, remote_address,
+                                     local_handle, remote_handle,
+                                     compare, value, flags, order,
+                                     cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_atomic_cswap(am_rdma, endpoint, local_address, remote_address,
+                                            local_handle, remote_handle,
+                                            compare, value, flags, order,
+                                            cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -195,7 +225,10 @@ ompi_osc_rdma_btl_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
     mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
     int ret;
 
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
+    /* if using the AM RDMA interface with alternate BTLs or if the
+       accelerated BTL does not support atomic ops, emulate the atomic
+       op over a fetch and atomic op */
+    if (!module->use_accelerated_btl || !(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
         return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
                                       NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
     }

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OSC_RDMA_BTL_COMM_H
+#define OSC_RDMA_BTL_COMM_H
+
+#include "osc_rdma_frag.h"
+
+#include "opal/mca/btl/btl.h"
+
+
+void ompi_osc_rdma_atomic_complete(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
+                                    void *context, void *data, int status);
+
+
+static inline int
+ompi_osc_rdma_btl_fop(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+		      struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+		      mca_btl_base_registration_handle_t *address_handle, int op,
+		      int64_t operand, int flags, int64_t *result, const bool wait_for_completion,
+		      ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret = OPAL_ERROR;
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+
+    if (!wait_for_completion) {
+        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
+        pending_op->module = module;
+        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
+    }
+
+    pending_op->op_result = (void *) result;
+    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
+    OBJ_RETAIN(pending_op);
+    if (cbfunc) {
+        pending_op->cbfunc = cbfunc;
+        pending_op->cbdata = cbdata;
+        pending_op->cbcontext = cbcontext;
+    }
+
+    /* spin until the btl has accepted the operation */
+    do {
+        if (NULL == pending_op->op_frag) {
+            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
+        }
+
+        if (NULL != pending_op->op_frag) {
+            ret = selected_btl->btl_atomic_fop (selected_btl, endpoint, pending_op->op_buffer,
+                                                (intptr_t) address, pending_op->op_frag->handle, address_handle,
+                                                op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
+                                                (void *) pending_op, NULL);
+        }
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        if (OPAL_LIKELY(1 == ret)) {
+            *result = ((int64_t *) pending_op->op_buffer)[0];
+            ret = OMPI_SUCCESS;
+            ompi_osc_rdma_atomic_complete (selected_btl, endpoint, pending_op->op_buffer,
+                                           pending_op->op_frag->handle, (void *) pending_op, NULL, OPAL_SUCCESS);
+        } else {
+            /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+            OBJ_RELEASE(pending_op);
+        }
+    } else if (wait_for_completion) {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+
+static inline int
+ompi_osc_rdma_btl_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+		     struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+		     mca_btl_base_registration_handle_t *address_handle,
+		     int op, int64_t operand, int flags, const bool wait_for_completion,
+		     ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret;
+
+    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
+        return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
+                                      NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
+    }
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+    OBJ_RETAIN(pending_op);
+    if (cbfunc) {
+        pending_op->cbfunc = cbfunc;
+        pending_op->cbdata = cbdata;
+        pending_op->cbcontext = cbcontext;
+    }
+
+    if (!wait_for_completion) {
+        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
+        pending_op->module = module;
+        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
+    }
+
+    /* spin until the btl has accepted the operation */
+    do {
+        ret = selected_btl->btl_atomic_op (selected_btl, endpoint, (intptr_t) address, address_handle,
+                                           op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
+                                           (void *) pending_op, NULL);
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+        OBJ_RELEASE(pending_op);
+        if (OPAL_LIKELY(1 == ret)) {
+            if (cbfunc) {
+                cbfunc (cbdata, cbcontext, OMPI_SUCCESS);
+            }
+            ret = OMPI_SUCCESS;
+        }
+    } else if (wait_for_completion) {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+
+static inline int
+ompi_osc_rdma_btl_cswap(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+			struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+			mca_btl_base_registration_handle_t *address_handle,
+			int64_t compare, int64_t value, int flags, int64_t *result)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret;
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+
+    OBJ_RETAIN(pending_op);
+
+    pending_op->op_result = (void *) result;
+    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
+
+    /* spin until the btl has accepted the operation */
+    do {
+        if (NULL == pending_op->op_frag) {
+            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
+        }
+        if (NULL != pending_op->op_frag) {
+            ret = selected_btl->btl_atomic_cswap (selected_btl, endpoint, pending_op->op_buffer,
+                                                  address, pending_op->op_frag->handle, address_handle, compare,
+                                                  value, flags, 0, ompi_osc_rdma_atomic_complete, (void *) pending_op,
+                                                  NULL);
+        }
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        if (OPAL_LIKELY(1 == ret)) {
+            *result = ((int64_t *) pending_op->op_buffer)[0];
+            ret = OMPI_SUCCESS;
+        }
+
+        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+        OBJ_RELEASE(pending_op);
+    } else {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+#endif /* OSC_RDMA_BTL_COMM_H */

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,6 +16,7 @@
  */
 
 #include "osc_rdma_comm.h"
+#include "osc_rdma_frag.h"
 #include "osc_rdma_sync.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_dynamic.h"

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -65,8 +65,7 @@ int ompi_osc_get_data_blocking (ompi_osc_rdma_module_t *module, uint8_t btl_inde
                                 struct mca_btl_base_endpoint_t *endpoint, uint64_t source_address,
                                 mca_btl_base_registration_handle_t *source_handle, void *data, size_t len)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    const size_t btl_alignment_mask = ALIGNMENT_MASK(btl->btl_get_alignment);
+    const size_t btl_alignment_mask = ALIGNMENT_MASK(module->get_alignment);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
     volatile bool read_complete = false;
@@ -82,25 +81,28 @@ int ompi_osc_get_data_blocking (ompi_osc_rdma_module_t *module, uint8_t btl_inde
                      "), len: %lu (aligned: %lu)", (void *) endpoint, source_address, aligned_addr, (unsigned long) len,
                      (unsigned long) aligned_len);
 
-    if (btl->btl_register_mem && len >= btl->btl_get_local_registration_threshold) {
-        do {
-            ret = ompi_osc_rdma_frag_alloc (module, aligned_len, &frag, &ptr);
-            if (OPAL_UNLIKELY(OMPI_ERR_OUT_OF_RESOURCE == ret)) {
-                ompi_osc_rdma_progress (module);
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        if (len >= btl->btl_get_local_registration_threshold) {
+            do {
+                ret = ompi_osc_rdma_frag_alloc(module, aligned_len, &frag, &ptr);
+                if (OPAL_UNLIKELY(OMPI_ERR_OUT_OF_RESOURCE == ret)) {
+                    ompi_osc_rdma_progress(module);
+                }
+            } while (OMPI_ERR_OUT_OF_RESOURCE == ret);
+
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "error allocating temporary buffer");
+                return ret;
             }
-        } while (OMPI_ERR_OUT_OF_RESOURCE == ret);
 
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "error allocating temporary buffer");
-            return ret;
+            local_handle = frag->handle;
+            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocated temporary buffer %p in fragment %p", (void*)ptr,
+                             (void *) frag);
         }
-
-        local_handle = frag->handle;
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocated temporary buffer %p in fragment %p", (void*)ptr,
-                         (void *) frag);
     }
 
-    assert (!(source_address & ALIGNMENT_MASK(btl->btl_get_alignment)));
+    assert (!(source_address & ALIGNMENT_MASK(module->get_alignment)));
 
     do {
         ret = ompi_osc_rdma_btl_get(module, btl_index, endpoint, ptr, aligned_addr,
@@ -487,7 +489,6 @@ int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *
                               ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     mca_btl_base_rdma_completion_fn_t cbfunc = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
@@ -495,16 +496,19 @@ int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *
     void *cbcontext;
     int ret;
 
-    if (btl->btl_register_mem && size > btl->btl_put_local_registration_threshold) {
-        ret = ompi_osc_rdma_frag_alloc (module, size, &frag, &ptr);
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            ret = ompi_osc_rdma_register (module, peer->data_endpoint, source_buffer, size, 0, &local_handle);
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, peer->data_btl_index);
+        if (size > btl->btl_put_local_registration_threshold) {
+            ret = ompi_osc_rdma_frag_alloc(module, size, &frag, &ptr);
             if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                return ret;
+                ret = ompi_osc_rdma_register(module, peer->data_endpoint, source_buffer, size, 0, &local_handle);
+                if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                    return ret;
+                }
+            } else {
+                memcpy(ptr, source_buffer, size);
+                local_handle = frag->handle;
             }
-        } else {
-            memcpy (ptr, source_buffer, size);
-            local_handle = frag->handle;
         }
     }
 
@@ -606,8 +610,7 @@ static int ompi_osc_rdma_get_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_p
                                      ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    const size_t btl_alignment_mask = ALIGNMENT_MASK(btl->btl_get_alignment);
+    const size_t btl_alignment_mask = ALIGNMENT_MASK(module->get_alignment);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
     osc_rdma_size_t aligned_len;
@@ -623,70 +626,73 @@ static int ompi_osc_rdma_get_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_p
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "initiating get of %lu bytes from remote ptr %" PRIx64 " to local ptr %p",
                      size, source_address, target_buffer);
 
-    if ((btl->btl_register_mem && size > btl->btl_get_local_registration_threshold) ||
-        (((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, peer->data_btl_index);
+        if (size > btl->btl_get_local_registration_threshold ||
+            (((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
 
-        ret = ompi_osc_rdma_frag_alloc (module, aligned_len, &frag, &ptr);
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            if (OMPI_ERR_VALUE_OUT_OF_BOUNDS == ret) {
-                /* region is too large for a buffered read */
-                size_t subsize;
+            ret = ompi_osc_rdma_frag_alloc(module, aligned_len, &frag, &ptr);
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                if (OMPI_ERR_VALUE_OUT_OF_BOUNDS == ret) {
+                    /* region is too large for a buffered read */
+                    size_t subsize;
 
-                if ((source_address & btl_alignment_mask) && (source_address & btl_alignment_mask) == ((intptr_t) target_buffer & btl_alignment_mask)) {
-                    /* remote region has the same alignment but the base is not aligned. perform a small
-                     * buffered get of the beginning of the remote region */
-                    aligned_source_base = OPAL_ALIGN(source_address, btl->btl_get_alignment, osc_rdma_base_t);
-                    subsize = (size_t) (aligned_source_base - source_address);
+                    if ((source_address & btl_alignment_mask) && (source_address & btl_alignment_mask) == ((intptr_t) target_buffer & btl_alignment_mask)) {
+                        /* remote region has the same alignment but the base is not aligned. perform a small
+                         * buffered get of the beginning of the remote region */
+                        aligned_source_base = OPAL_ALIGN(source_address, btl->btl_get_alignment, osc_rdma_base_t);
+                        subsize = (size_t) (aligned_source_base - source_address);
 
-                    ret = ompi_osc_rdma_get_partial (sync, peer, source_address, source_handle, target_buffer, subsize, request);
-                    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                        return ret;
+                        ret = ompi_osc_rdma_get_partial(sync, peer, source_address, source_handle, target_buffer, subsize, request);
+                        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                            return ret;
+                        }
+
+                        source_address += subsize;
+                        target_buffer = (void *) ((intptr_t) target_buffer + subsize);
+                        size -= subsize;
+
+                        aligned_len = aligned_source_bound - aligned_source_base;
                     }
 
-                    source_address += subsize;
-                    target_buffer = (void *) ((intptr_t) target_buffer + subsize);
-                    size -= subsize;
-
-                    aligned_len = aligned_source_bound - aligned_source_base;
-                }
-
-                if (!(((uint64_t) target_buffer | source_address) & btl_alignment_mask) &&
-                    (size & btl_alignment_mask)) {
-                    /* remote region bases are aligned but the bounds are not. perform a
-                     * small buffered get of the end of the remote region */
-                    aligned_len = size & ~btl_alignment_mask;
-                    subsize = size - aligned_len;
-                    size = aligned_len;
-                    ret = ompi_osc_rdma_get_partial (sync, peer, source_address + aligned_len, source_handle,
-                                                     (void *) ((intptr_t) target_buffer + aligned_len), subsize, request);
-                    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                        return ret;
+                    if (!(((uint64_t) target_buffer | source_address) & btl_alignment_mask) &&
+                        (size & btl_alignment_mask)) {
+                        /* remote region bases are aligned but the bounds are not. perform a
+                         * small buffered get of the end of the remote region */
+                        aligned_len = size & ~btl_alignment_mask;
+                        subsize = size - aligned_len;
+                        size = aligned_len;
+                        ret = ompi_osc_rdma_get_partial(sync, peer, source_address + aligned_len, source_handle,
+                                                        (void *) ((intptr_t) target_buffer + aligned_len), subsize, request);
+                        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                            return ret;
+                        }
                     }
+                    /* (remaining) user request is now correctly aligned */
                 }
-                /* (remaining) user request is now correctly aligned */
-            }
 
-            if ((((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
-                /* local and remote alignments differ */
-                request->buffer = ptr = malloc (aligned_len);
+                if ((((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
+                    /* local and remote alignments differ */
+                    request->buffer = ptr = malloc(aligned_len);
+                } else {
+                    ptr = target_buffer;
+                }
+
+                if (NULL != ptr) {
+                    (void)ompi_osc_rdma_register(module, peer->data_endpoint, ptr, aligned_len, MCA_BTL_REG_FLAG_LOCAL_WRITE,
+                                                 &local_handle);
+                }
+
+                if (OPAL_UNLIKELY(NULL == local_handle)) {
+                    free(request->buffer);
+                    request->buffer = NULL;
+                    return ret;
+                }
             } else {
-                ptr = target_buffer;
+                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "using internal buffer %p in fragment %p for get of size %lu bytes, source address 0x%lx",
+                                 (void*)ptr, (void *) frag, (unsigned long) aligned_len, (unsigned long) aligned_source_base);
+                local_handle = frag->handle;
             }
-
-            if (NULL != ptr) {
-                (void) ompi_osc_rdma_register (module, peer->data_endpoint, ptr, aligned_len, MCA_BTL_REG_FLAG_LOCAL_WRITE,
-                                               &local_handle);
-            }
-
-            if (OPAL_UNLIKELY(NULL == local_handle)) {
-                free (request->buffer);
-                request->buffer = NULL;
-                return ret;
-            }
-        } else {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "using internal buffer %p in fragment %p for get of size %lu bytes, source address 0x%lx",
-                             (void*)ptr, (void *) frag, (unsigned long) aligned_len, (unsigned long) aligned_source_base);
-            local_handle = frag->handle;
         }
     }
 
@@ -742,7 +748,6 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
                                            ompi_datatype_t *target_datatype, ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *target_handle;
     uint64_t target_address;
     int ret;
@@ -777,7 +782,7 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
 
     return ompi_osc_rdma_master (sync, (void *) origin_addr, origin_count, origin_datatype, peer,
                                  target_address, target_handle, target_count, target_datatype, request,
-                                 btl->btl_put_limit, ompi_osc_rdma_put_contig, false);
+                                 module->put_limit, ompi_osc_rdma_put_contig, false);
 }
 
 static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *origin_addr, int origin_count, ompi_datatype_t *origin_datatype,
@@ -785,7 +790,6 @@ static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *ori
                                            ompi_datatype_t *source_datatype, ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *source_handle;
     uint64_t source_address;
     ptrdiff_t source_span, source_lb;
@@ -818,7 +822,7 @@ static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *ori
 
     return ompi_osc_rdma_master (sync, origin_addr, origin_count, origin_datatype, peer, source_address,
                                  source_handle, source_count, source_datatype, request,
-                                 btl->btl_get_limit, ompi_osc_rdma_get_contig, true);
+                                 module->get_limit, ompi_osc_rdma_get_contig, true);
 }
 int ompi_osc_rdma_put (const void *origin_addr, int origin_count, ompi_datatype_t *origin_datatype,
                        int target_rank, ptrdiff_t target_disp, int target_count,

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -15,6 +15,8 @@
  * $HEADER$
  */
 
+#include "ompi_config.h"
+
 #include "osc_rdma_comm.h"
 #include "osc_rdma_frag.h"
 #include "osc_rdma_sync.h"
@@ -22,8 +24,9 @@
 #include "osc_rdma_dynamic.h"
 #include "osc_rdma_btl_comm.h"
 
-#include "ompi/mca/osc/base/osc_base_obj_convert.h"
 #include "opal/align.h"
+#include "opal/util/minmax.h"
+#include "ompi/mca/osc/base/osc_base_obj_convert.h"
 
 /* helper functions */
 static inline void ompi_osc_rdma_cleanup_rdma (ompi_osc_rdma_sync_t *sync, bool dec_always, ompi_osc_rdma_frag_t *frag,
@@ -246,7 +249,7 @@ static int ompi_osc_rdma_master_noncontig (ompi_osc_rdma_sync_t *sync, void *loc
             assert (0 != local_iov_count);
 
             /* determine how much to transfer in this operation */
-            rdma_len = min(min(local_iovec[local_iov_index].iov_len, remote_iovec[remote_iov_index].iov_len), max_rdma_len);
+            rdma_len = opal_min(opal_min(local_iovec[local_iov_index].iov_len, remote_iovec[remote_iov_index].iov_len), max_rdma_len);
 
             /* execute the get */
             if (!subreq && alloc_reqs) {

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -398,7 +398,7 @@ static void ompi_osc_rdma_put_complete (struct mca_btl_base_module_t *btl, struc
 
     /* the lowest bit is used as a flag indicating this put operation has a request */
     if ((intptr_t) context & 0x1) {
-        ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
+        ompi_osc_rdma_request_t *request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         sync = request->sync;
 
         if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {
@@ -429,7 +429,7 @@ static void ompi_osc_rdma_put_complete_flush (struct mca_btl_base_module_t *btl,
 
     /* the lowest bit is used as a flag indicating this put operation has a request */
     if ((intptr_t) context & 0x1) {
-        ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
+        ompi_osc_rdma_request_t *request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         module = request->module;
 
         if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {

--- a/ompi/mca/osc/rdma/osc_rdma_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.h
@@ -22,7 +22,6 @@
 
 #define OMPI_OSC_RDMA_DECODE_MAX 64
 
-#define min(a,b) ((a) < (b) ? (a) : (b))
 #define ALIGNMENT_MASK(x) ((x) ? (x) - 1 : 0)
 
 /**

--- a/ompi/mca/osc/rdma/osc_rdma_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.h
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +19,6 @@
 #include "osc_rdma_dynamic.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_sync.h"
-#include "osc_rdma_lock.h"
 
 #define OMPI_OSC_RDMA_DECODE_MAX 64
 

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -231,7 +231,7 @@ static int ompi_osc_rdma_component_register (void)
                                            MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.max_attach);
     free(description_str);
 
-    mca_osc_rdma_component.priority = 101;
+    mca_osc_rdma_component.priority = 20;
     opal_asprintf(&description_str, "Priority of the osc/rdma component (default: %d)",
              mca_osc_rdma_component.priority);
     (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "priority", description_str,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -387,15 +387,14 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
     }
 #endif /* OPAL_CUDA_SUPPORT */
 
-    if (OMPI_SUCCESS == ompi_osc_rdma_query_accelerated_btls (comm, NULL)) {
-        return mca_osc_rdma_component.priority;
+    /* verify if we have any btls available.  Since we do not verify
+     * connectivity across all btls in the alternate case, this is as
+     * good a test as we are going to have for success. */
+    if (opal_list_is_empty(&mca_btl_base_modules_initialized)) {
+        return -1;
     }
 
-    if (OMPI_SUCCESS == ompi_osc_rdma_query_alternate_btls (comm, NULL)) {
-        return mca_osc_rdma_component.priority;
-    }
-
-    return -1;
+    return OMPI_SUCCESS;;
 }
 
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {
@@ -914,13 +913,7 @@ static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_o
     mca_btl_base_selected_module_t *item;
     int ret;
 
-    /* shortcut the trivial query case */
-    if (NULL == module) {
-        if (opal_list_is_empty(&mca_btl_base_modules_initialized)) {
-            return OMPI_ERR_UNREACH;
-        }
-        return OMPI_SUCCESS;
-    }
+    assert(NULL != module);
 
     module->btls_in_use = 0;
 
@@ -988,9 +981,6 @@ static bool ompi_osc_rdma_check_accelerated_btl(struct mca_btl_base_module_t *bt
  * Testing (1) is expensive, so as an optimization, the
  * ompi_osc_rdma_full_connectivity_btls list contains the list of BTL
  * components we know can achieve (1) in almost all usage scenarios.
- *
- * If module is NULL, the code acts as a query mechanism to find any
- * potential BTLs, and is used to implement osc_rdma_query().
  */
 static int ompi_osc_rdma_query_accelerated_btls (ompi_communicator_t *comm, ompi_osc_rdma_module_t *module)
 {
@@ -999,11 +989,11 @@ static int ompi_osc_rdma_query_accelerated_btls (ompi_communicator_t *comm, ompi
     mca_bml_base_endpoint_t *base_endpoint;
     char **btls_to_use;
 
-    if (module) {
-        ompi_osc_rdma_selected_btl_insert(module, NULL, 0);
-        module->btls_in_use = 0;
-        module->use_memory_registration = false;
-    }
+    assert(NULL != module);
+
+    ompi_osc_rdma_selected_btl_insert(module, NULL, 0);
+    module->btls_in_use = 0;
+    module->use_memory_registration = false;
 
     /* Check for BTLs in the list of BTLs we know can reach all peers
        in general usage. */
@@ -1116,11 +1106,9 @@ static int ompi_osc_rdma_query_accelerated_btls (ompi_communicator_t *comm, ompi
     }
 
 btl_selection_complete:
-    if (module) {
-        ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0);
-        module->btls_in_use = 1;
-        module->use_memory_registration = selected_btl->btl_register_mem != NULL;
-    }
+    ompi_osc_rdma_selected_btl_insert(module, selected_btl, 0);
+    module->btls_in_use = 1;
+    module->use_memory_registration = selected_btl->btl_register_mem != NULL;
 
     opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
                         "accelerated_query: selected btl: %s",

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -35,6 +35,7 @@
 #include "ompi_config.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "osc_rdma.h"
 #include "osc_rdma_frag.h"
@@ -84,7 +85,6 @@ static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_o
 static const char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, const char *key, const char *value);
 
 static char *ompi_osc_rdma_full_connectivity_btls;
-static char *ompi_osc_rdma_btl_alternate_names;
 
 static const mca_base_var_enum_value_t ompi_osc_rdma_locking_modes[] = {
     {.value = OMPI_OSC_RDMA_LOCKING_TWO_LEVEL, .string = "two_level"},
@@ -255,14 +255,6 @@ static int ompi_osc_rdma_component_register (void)
     (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "btls", description_str,
                                             MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
                                             MCA_BASE_VAR_SCOPE_GROUP, &ompi_osc_rdma_full_connectivity_btls);
-    free(description_str);
-
-    ompi_osc_rdma_btl_alternate_names = "sm,tcp";
-    opal_asprintf(&description_str, "Comma-delimited list of alternate BTL component names to allow without verifying "
-                  "connectivity (default: %s)", ompi_osc_rdma_btl_alternate_names);
-    (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "alternate_btls", description_str,
-                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
-                                            MCA_BASE_VAR_SCOPE_GROUP, &ompi_osc_rdma_btl_alternate_names);
     free(description_str);
 
     if (0 == access ("/dev/shm", W_OK)) {
@@ -875,75 +867,96 @@ static void ompi_osc_rdma_ensure_local_add_procs (void)
     free(procs);
 }
 
+
+/*
+ * qsort() sorting function for ompi_osc_rdma_query_alternate_btls(),
+ * using latency as the sorting metric.
+ */
+static int btl_latency_sort_fn(const void *a, const void *b)
+{
+    const struct mca_btl_base_module_t *btl_a = a;
+    const struct mca_btl_base_module_t *btl_b = b;
+
+    if (btl_a->btl_latency < btl_b->btl_latency) {
+        return -1;
+    } else if (btl_a->btl_latency == btl_b->btl_latency) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+
 /**
  * @brief query for alternate BTLs
  *
  * @in  comm   Communicator to query
- * @out module OSC module to store BTLs/count to (optional)
- * @out 
+ * @inout module OSC module to store BTLs/count to (optional)
  *
  * @return OMPI_SUCCESS if BTLs can be found
  * @return OMPI_ERR_UNREACH if no BTLs can be found that match
  *
- * In this case an "alternate" BTL is a BTL does not meet the
- * requirements of a BTL outlined in ompi_osc_rdma_query_accelerated_btls().
- * Either it does not provide connectivity to all peers, provide
- * remote completion, or natively support put/get/atomic.. Since more
- * than one BTL may be needed for this support the OSC component will
- * disable the use of registration-based RDMA (these BTLs will not be
- * used) and will use any remaining BTL. By default the BTLs used will
- * be tcp and sm but any single (or pair) of BTLs may be used.
+ * We directly use the active message rdma wrappers for alternate
+ * BTLs, in all cases.  This greatly simplifies the alternate BTL
+ * impementation, at the expense of some performance.  With the
+ * AM wrappers, we can always enforce remote completion and the lack
+ * of memory registration, at some performance cost.  But we can use
+ * as many BTLs as we like.  The module's btl list is sorted by
+ * latency, so that ompi_osc_rdma_peer_btl_endpoint() picks the lowest
+ * available latency btl to communicate with the peer.  Unlike the OB1
+ * PML, we only use one BTL per peer.
+ *
+ * Like the OB1 PML, there is no verification that there is at least
+ * one BTL that can communicate with every other peer in the window.
  */
 static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_osc_rdma_module_t *module)
 {
     mca_btl_base_selected_module_t *item;
-    char **btls_to_use = opal_argv_split (ompi_osc_rdma_btl_alternate_names, ',');
-    int btls_found = 0;
+    int ret;
 
-    btls_to_use = opal_argv_split (ompi_osc_rdma_btl_alternate_names, ',');
-    if (NULL == btls_to_use) {
-        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
-                            "no alternate BTLs requested: %s", ompi_osc_rdma_btl_alternate_names);
-        return OMPI_ERR_UNREACH;
-    }
-
-    if (module) {
-        module->btls_in_use = 0;
-    }
-
-    /* rdma and atomics are only supported with BTLs at the moment */
-    for (int i = 0 ; btls_to_use[i] ; ++i) {
-        opal_output_verbose(MCA_BASE_VERBOSE_INFO, "checking for btl %s", btls_to_use[i]);
-        OPAL_LIST_FOREACH(item, &mca_btl_base_modules_initialized, mca_btl_base_selected_module_t) {
-            if (NULL != item->btl_module->btl_register_mem) { 
-                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
-                                    "skipping RDMA btl when searching for alternate BTL");
-                continue;
-            }
-
-            if (0 != strcmp (btls_to_use[i], item->btl_module->btl_component->btl_version.mca_component_name)) {
-                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
-                                    "skipping btl %s",
-                                    item->btl_module->btl_component->btl_version.mca_component_name);
-                continue;
-            }
-
-            opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
-                                "found alternate btl %s", btls_to_use[i]);
-
-            ++btls_found;
-            if (module) {
-                mca_btl_base_am_rdma_init(item->btl_module);
-                ompi_osc_rdma_selected_btl_insert(module, item->btl_module, module->btls_in_use++);
-            }
-            
+    /* shortcut the trivial query case */
+    if (NULL == module) {
+        if (opal_list_is_empty(&mca_btl_base_modules_initialized)) {
+            return OMPI_ERR_UNREACH;
         }
+        return OMPI_SUCCESS;
     }
 
-    opal_argv_free (btls_to_use);
+    module->btls_in_use = 0;
 
-    return btls_found > 0 ? OMPI_SUCCESS : OMPI_ERR_UNREACH;
+    /* add all alternate btls to the selected_btls list, not worrying
+       about ordering yet.  We have to add all btls unless we want to
+       iterate over all endpoints to build the minimum set of btls
+       needed to communicate with all peers.  An MCA parameter just
+       for osc rdma also wouldn't work, as the BML can decide not to
+       add an endpoint for a btl given the priority of another btl.
+       For example, it is not uncommon that the only endpoint created
+       to a peer on the same host is the sm btl's endpoint.  If we
+       had an osc rdma specific parameter list, and the user
+       specified a combination not including sm, that would result in
+       an eventual failure, as no btl would be found to talk to ranks
+       on the same host.*/
+    OPAL_LIST_FOREACH(item, &mca_btl_base_modules_initialized, mca_btl_base_selected_module_t) {
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                            "found alternate btl %s",
+                            item->btl_module->btl_component->btl_version.mca_component_name);
+        ret = mca_btl_base_am_rdma_init(item->btl_module);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+        ompi_osc_rdma_selected_btl_insert(module, item->btl_module, module->btls_in_use++);
+    }
+
+    /* sort based on latency, lowest first */
+    qsort(module->selected_btls, module->btls_in_use,
+          sizeof(struct mca_btl_base_module_t*), btl_latency_sort_fn);
+
+    /* osc/rdma always use active message RDMA/atomics on alternate btls, whic does not require explicit memory registration */
+    module->use_memory_registration = false;
+
+    return module->btls_in_use > 0 ? OMPI_SUCCESS : OMPI_ERR_UNREACH;
 }
+
 
 /* Check for BTL requirements:
  *  1) RDMA (put/get) and ATOMIC operations.  We only require cswap

--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -252,7 +252,8 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
             return OMPI_ERR_RMA_ATTACH;
         }
 
-        memcpy (region->btl_handle_data, handle, module->selected_btls[0]->btl_registration_handle_size);
+        assert(module->use_accelerated_btl);
+        memcpy(region->btl_handle_data, handle, module->accelerated_btl->btl_registration_handle_size);
         rdma_region_handle->btl_handle = handle;
     } else {
         rdma_region_handle->btl_handle = NULL;

--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -5,6 +5,8 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +19,7 @@
 
 #include "osc_rdma_types.h"
 #include "osc_rdma_frag.h"
+#include "osc_rdma_btl_comm.h"
 
 static inline int ompi_osc_rdma_trylock_local (ompi_osc_rdma_atomic_lock_t *lock)
 {
@@ -29,82 +32,6 @@ static inline void ompi_osc_rdma_unlock_local (ompi_osc_rdma_atomic_lock_t *lock
     (void) ompi_osc_rdma_lock_add (lock, -OMPI_OSC_RDMA_LOCK_EXCLUSIVE);
 }
 
-/**
- * Dummy completion function for atomic operations
- */
-void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
-                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
-                                    void *context, void *data, int status);
-
-__opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_fop (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                         struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                         mca_btl_base_registration_handle_t *address_handle, int op,
-                                         int64_t operand, int flags, int64_t *result, const bool wait_for_completion,
-                                         ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret = OPAL_ERROR;
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-
-    if (!wait_for_completion) {
-        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
-        pending_op->module = module;
-        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
-    }
-
-    pending_op->op_result = (void *) result;
-    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
-    OBJ_RETAIN(pending_op);
-    if (cbfunc) {
-        pending_op->cbfunc = cbfunc;
-        pending_op->cbdata = cbdata;
-        pending_op->cbcontext = cbcontext;
-    }
-
-    /* spin until the btl has accepted the operation */
-    do {
-        if (NULL == pending_op->op_frag) {
-            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
-        }
-
-        if (NULL != pending_op->op_frag) {
-            ret = selected_btl->btl_atomic_fop (selected_btl, endpoint, pending_op->op_buffer,
-                                                (intptr_t) address, pending_op->op_frag->handle, address_handle,
-                                                op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
-                                                (void *) pending_op, NULL);
-        }
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        if (OPAL_LIKELY(1 == ret)) {
-            *result = ((int64_t *) pending_op->op_buffer)[0];
-            ret = OMPI_SUCCESS;
-            ompi_osc_rdma_atomic_complete (selected_btl, endpoint, pending_op->op_buffer,
-                                           pending_op->op_frag->handle, (void *) pending_op, NULL, OPAL_SUCCESS);
-        } else {
-            /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-            OBJ_RELEASE(pending_op);
-        }
-    } else if (wait_for_completion) {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
-}
-
 __opal_attribute_always_inline__
 static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer, uint64_t address,
                                               int op, ompi_osc_rdma_lock_t operand, ompi_osc_rdma_lock_t *result,
@@ -115,129 +42,11 @@ static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, om
 }
 
 __opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_op (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                        struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                        mca_btl_base_registration_handle_t *address_handle,
-                                        int op, int64_t operand, int flags, const bool wait_for_completion,
-                                        ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret;
-
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
-        return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
-                                      NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
-    }
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-    OBJ_RETAIN(pending_op);
-    if (cbfunc) {
-        pending_op->cbfunc = cbfunc;
-        pending_op->cbdata = cbdata;
-        pending_op->cbcontext = cbcontext;
-    }
-
-    if (!wait_for_completion) {
-        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
-        pending_op->module = module;
-        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
-    }
-
-    /* spin until the btl has accepted the operation */
-    do {
-        ret = selected_btl->btl_atomic_op (selected_btl, endpoint, (intptr_t) address, address_handle,
-                                           op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
-                                           (void *) pending_op, NULL);
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-        OBJ_RELEASE(pending_op);
-        if (OPAL_LIKELY(1 == ret)) {
-            if (cbfunc) {
-                cbfunc (cbdata, cbcontext, OMPI_SUCCESS);
-            }
-            ret = OMPI_SUCCESS;
-        }
-    } else if (wait_for_completion) {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
-}
-
-__opal_attribute_always_inline__
 static inline int ompi_osc_rdma_lock_btl_op (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer, uint64_t address,
                                              int op, ompi_osc_rdma_lock_t operand, const bool wait_for_completion)
 {
     return ompi_osc_rdma_btl_op (module, peer->state_btl_index, peer->state_endpoint, address, peer->state_handle, op,
                                  operand, 0, wait_for_completion, NULL, NULL, NULL);
-}
-
-__opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_cswap (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                           struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                           mca_btl_base_registration_handle_t *address_handle,
-                                           int64_t compare, int64_t value, int flags, int64_t *result)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret;
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-
-    OBJ_RETAIN(pending_op);
-
-    pending_op->op_result = (void *) result;
-    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
-
-    /* spin until the btl has accepted the operation */
-    do {
-        if (NULL == pending_op->op_frag) {
-            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
-        }
-        if (NULL != pending_op->op_frag) {
-            ret = selected_btl->btl_atomic_cswap (selected_btl, endpoint, pending_op->op_buffer,
-                                                  address, pending_op->op_frag->handle, address_handle, compare,
-                                                  value, flags, 0, ompi_osc_rdma_atomic_complete, (void *) pending_op,
-                                                  NULL);
-        }
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        if (OPAL_LIKELY(1 == ret)) {
-            *result = ((int64_t *) pending_op->op_buffer)[0];
-            ret = OMPI_SUCCESS;
-        }
-
-        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-        OBJ_RELEASE(pending_op);
-    } else {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
 }
 
 __opal_attribute_always_inline__

--- a/ompi/mca/osc/rdma/osc_rdma_module.c
+++ b/ompi/mca/osc/rdma/osc_rdma_module.c
@@ -145,7 +145,10 @@ int ompi_osc_rdma_free(ompi_win_t *win)
     mca_mpool_base_default_module->mpool_free(mca_mpool_base_default_module,
                                               module->free_after);
     if (!module->use_accelerated_btl) {
-        free(module->alternate_btls);
+        for (int i = 0 ; i < module->alternate_btl_count ; ++i) {
+            OBJ_RELEASE(module->alternate_am_rdmas[i]);
+        }
+        free(module->alternate_am_rdmas);
     }
     free (module);
 

--- a/ompi/mca/osc/rdma/osc_rdma_module.c
+++ b/ompi/mca/osc/rdma/osc_rdma_module.c
@@ -144,7 +144,9 @@ int ompi_osc_rdma_free(ompi_win_t *win)
     free (module->outstanding_lock_array);
     mca_mpool_base_default_module->mpool_free(mca_mpool_base_default_module,
                                               module->free_after);
-    free (module->selected_btls);
+    if (!module->use_accelerated_btl) {
+        free(module->alternate_btls);
+    }
     free (module);
 
     return OMPI_SUCCESS;

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -701,7 +701,7 @@ static int am_rdma_target_put(mca_btl_base_module_t *btl,
             (struct mca_btl_base_registration_handle_t *) (*operation)->local_handle_data,
             (struct mca_btl_base_registration_handle_t *) (*operation)->remote_handle_data,
             hdr->data.rdma.size, /*flags=*/0, MCA_BTL_NO_ORDER, am_rdma_rdma_complete,
-            operation, NULL);
+            *operation, NULL);
         if (OPAL_SUCCESS != ret) {
             OBJ_RELEASE(*operation);
         }


### PR DESCRIPTION
This patch series started to address data corruption issues due to BTLs not providing the expected remote completion.  Fixing this required two changes: 1) "accelerated" BTLs (the fast case, OFI, GNI, etc.) require REMOTE_COMPLETION or are disabled and 2) the AM RDMA compatibility interface was refactored to only use the underlying BTL RDMA functions if the BTL provides remote completion.

To implement the alternate BTL AM RDMA behavior, we use the explicit AM RDMA interface (instead of asking AM RDMA to extend the BTL), which required refactoring most of the BTL initialization code.  To use the explicit AM RDMA interface, we ended up refactoring the communication calls a bit to avoid lots of extra if statements through the communication code.

While rewriting the alternate btl initialization, the btl selection bug in https://github.com/open-mpi/ompi/issues/7830 and https://github.com/open-mpi/ompi/issues/9630 should be fixed, including the btl selection impedance mismatch.  It is no longer possible to specify alternate BTLs in osc rdma, as it now follows the active BTL list (similar to the OB1 PML).

