### PR TITLE
master: Portals4: replace comm->c_contextid use with ompi_comm_get_local_cid()

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2015 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2013-2022 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
@@ -135,7 +135,7 @@ ptl_datatype_t ompi_coll_portals4_atomic_datatype [OMPI_DATATYPE_MPI_MAX_PREDEFI
         if (!comm->c_coll->coll_ ## __api || !comm->c_coll->coll_ ## __api ## _module) {      \
             opal_output_verbose(1, ompi_coll_base_framework.framework_output,               \
                     "(%d/%s): no underlying " # __api"; disqualifying myself",              \
-                    __comm->c_contextid, __comm->c_name);                                   \
+                    ompi_comm_get_local_cid(__comm), __comm->c_name);                          \
                     return OMPI_ERROR;                                                      \
         }                                                                                   \
         OBJ_RETAIN(__module->previous_ ## __api ## _module);                                \

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2012-2022 Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ struct ompi_mtl_portals4_pending_request_t {
     mca_pml_base_send_mode_t mode;
     void *start;
     size_t length;
-    int contextid;
+    uint32_t contextid;
     int tag;
     int my_rank;
     int fc_notified;

--- a/ompi/mca/mtl/portals4/mtl_portals4_probe.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_probe.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010-2012 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2010-2022 Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,7 +82,8 @@ ompi_mtl_portals4_iprobe(struct mca_mtl_base_module_t* mtl,
         remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
-    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,
+    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits,
+                               ompi_comm_get_local_cid(comm),
                                src, tag);
 
     me.start = NULL;
@@ -146,7 +147,7 @@ ompi_mtl_portals4_improbe(struct mca_mtl_base_module_t *mtl,
 
     opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                         "%s:%d: improbe %d %d %d",
-                        __FILE__, __LINE__, comm->c_contextid, src, tag);
+                        __FILE__, __LINE__, ompi_comm_get_local_cid(comm), src, tag);
 
     if  (MPI_ANY_SOURCE == src) {
         if (ompi_mtl_portals4.use_logical) {
@@ -162,7 +163,8 @@ ompi_mtl_portals4_improbe(struct mca_mtl_base_module_t *mtl,
         remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
-    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,
+    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits,
+                               ompi_comm_get_local_cid(comm),
                                src, tag);
 
     me.start = NULL;

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010-2012 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2010-2022 Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -457,7 +457,8 @@ ompi_mtl_portals4_irecv(struct mca_mtl_base_module_t* mtl,
         remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
-    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,
+    MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits,
+                               ompi_comm_get_local_cid(comm),
                                src, tag);
 
     ret = ompi_mtl_datatype_recv_buf(convertor, &start, &length, &free_after);

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010      Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2010-2022 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -114,7 +114,7 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
                          ptl_request->opcount, ev->type));
 
     /* First put achieved successfully (In the Priority List), so it may be necessary to decrement the number of pending get
-     * If the protocol is eager, just decrement pending_get 
+     * If the protocol is eager, just decrement pending_get
      * Else (the protocol is rndv), decrement pending_get only if length % max_msg_size <= eager_limit
      * (This is the case where the eager part allows to save one get)
      */
@@ -229,7 +229,7 @@ ompi_mtl_portals4_isend_callback(ptl_event_t *ev,
 
 static inline int
 ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
-                              void *start, int length, int contextid, int tag,
+                              void *start, int length, uint32_t contextid, int tag,
                               int localrank,
                               ptl_process_t ptl_proc,
                               ompi_mtl_portals4_isend_request_t *ptl_request)
@@ -239,7 +239,9 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
     ptl_me_t me;
     ptl_hdr_data_t hdr_data;
 
-    MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, localrank, tag,
+    MTL_PORTALS4_SET_SEND_BITS(match_bits,
+                               contextid,
+                               localrank, tag,
                                MTL_PORTALS4_SHORT_MSG);
 
     MTL_PORTALS4_SET_HDR_DATA(hdr_data, ptl_request->opcount, length,
@@ -316,7 +318,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
 }
 
 static inline int
-ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
+ompi_mtl_portals4_long_isend(void *start, size_t length, uint32_t contextid, int tag,
                              int localrank,
                              ptl_process_t ptl_proc,
                              ompi_mtl_portals4_isend_request_t *ptl_request)
@@ -327,7 +329,9 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
     ptl_hdr_data_t hdr_data;
     ptl_size_t put_length;
 
-    MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, localrank, tag,
+    MTL_PORTALS4_SET_SEND_BITS(match_bits,
+                               contextid,
+                               localrank, tag,
                                MTL_PORTALS4_LONG_MSG);
 
     MTL_PORTALS4_SET_HDR_DATA(hdr_data, ptl_request->opcount, length, 0);
@@ -513,7 +517,7 @@ ompi_mtl_portals4_send_start(struct mca_mtl_base_module_t* mtl,
     pending->mode = mode;
     pending->start = start;
     pending->length = length;
-    pending->contextid = comm->c_contextid;
+    pending->contextid = ompi_comm_get_local_cid(comm);
     pending->tag = tag;
     pending->my_rank = comm->c_my_rank;
     pending->fc_notified = 0;
@@ -546,7 +550,7 @@ ompi_mtl_portals4_send_start(struct mca_mtl_base_module_t* mtl,
         ret = ompi_mtl_portals4_short_isend(mode,
                                             start,
                                             length,
-                                            comm->c_contextid,
+                                            ompi_comm_get_local_cid(comm),
                                             tag,
                                             comm->c_my_rank,
                                             ptl_proc,
@@ -554,7 +558,7 @@ ompi_mtl_portals4_send_start(struct mca_mtl_base_module_t* mtl,
     } else {
         ret = ompi_mtl_portals4_long_isend(start,
                                            length,
-                                           comm->c_contextid,
+                                           ompi_comm_get_local_cid(comm),
                                            tag,
                                            comm->c_my_rank,
                                            ptl_proc,

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2011-2017 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2011-2022 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -523,7 +523,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     me.options = PTL_ME_OP_PUT | PTL_ME_OP_GET | PTL_ME_NO_TRUNCATE | PTL_ME_EVENT_SUCCESS_DISABLE;
     me.match_id.phys.nid = PTL_NID_ANY;
     me.match_id.phys.pid = PTL_PID_ANY;
-    me.match_bits = module->comm->c_contextid;
+    me.match_bits = ompi_comm_get_local_cid(module->comm);
     me.ignore_bits = 0;
 
     ret = PtlMEAppend(module->ni_h,
@@ -546,7 +546,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     me.options = PTL_ME_OP_PUT | PTL_ME_OP_GET | PTL_ME_NO_TRUNCATE | PTL_ME_EVENT_SUCCESS_DISABLE;
     me.match_id.phys.nid = PTL_NID_ANY;
     me.match_id.phys.pid = PTL_PID_ANY;
-    me.match_bits = module->comm->c_contextid | OSC_PORTALS4_MB_CONTROL;
+    me.match_bits = ompi_comm_get_local_cid(module->comm) | OSC_PORTALS4_MB_CONTROL;
     me.ignore_bits = 0;
 
     ret = PtlMEAppend(module->ni_h,
@@ -563,7 +563,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     }
 
     module->opcount = 0;
-    module->match_bits = module->comm->c_contextid;
+    module->match_bits = ompi_comm_get_local_cid(module->comm);
     module->atomic_max = (check_config_value_equal("accumulate_ordering", info, "none")) ?
         mca_osc_portals4_component.matching_atomic_max :
         MIN(mca_osc_portals4_component.matching_atomic_max,


### PR DESCRIPTION
The OMPI communicator was modified in #9097 to have an extended context ID
that is no longer compatible with the uint32_t type previously used.  The
equivalent ID is available using ompi_comm_get_local_cid().
 - change MTL pending request contextid to uint32_t (matches local cid type)
 - replace direct access to c_contextid with ompi_comm_get_local_cid()
