### PR TITLE
Resolve duplicate symbols problem

### DIFF
--- a/ompi/mpi/c/isendrecv.c
+++ b/ompi/mpi/c/isendrecv.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -53,7 +53,7 @@ struct ompi_isendrecv_context_t {
 };
 
 typedef struct ompi_isendrecv_context_t ompi_isendrecv_context_t;
-OBJ_CLASS_INSTANCE(ompi_isendrecv_context_t, opal_object_t, NULL, NULL);
+static OBJ_CLASS_INSTANCE(ompi_isendrecv_context_t, opal_object_t, NULL, NULL);
 
 static int ompi_isendrecv_complete_func (ompi_comm_request_t *request)
 {

--- a/ompi/mpi/c/isendrecv_replace.c
+++ b/ompi/mpi/c/isendrecv_replace.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,7 +72,7 @@ static void ompi_isendrecv_context_destructor(ompi_isendrecv_replace_context_t *
     OBJ_DESTRUCT(&context->convertor);
 }
 
-OBJ_CLASS_INSTANCE(ompi_isendrecv_replace_context_t, 
+static OBJ_CLASS_INSTANCE(ompi_isendrecv_replace_context_t, 
                    opal_object_t, 
                    ompi_isendrecv_context_constructor,
                    ompi_isendrecv_context_destructor);


### PR DESCRIPTION
On the Mac at least, the current HEAD of master branch
fails to build due to duplicate symbols:

```text
duplicate symbol '_ompi_isendrecv_context_t_class' in:
    mpi/c/.libs/libmpi_c.a(libmpi_c_profile_la-isendrecv.o)
    mpi/c/.libs/libmpi_c.a(libmpi_c_noprofile_la-isendrecv.o)
duplicate symbol '_ompi_isendrecv_replace_context_t_class' in:
    mpi/c/.libs/libmpi_c.a(libmpi_c_profile_la-isendrecv_replace.o)
    mpi/c/.libs/libmpi_c.a(libmpi_c_noprofile_la-isendrecv_replace.o)
ld: 2 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libmpi.la] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1
```

The problem is caused by non-static declaration of OBJ_CLASS_INSTANCE
of a statically-defined object in the mpi/c area. These files get built
twice - once for the non-profile code, and again for the profile code.
Thus, one must preface the class instance with "static" to avoid
duplicate symbols.

Signed-off-by: Ralph Castain <rhc@pmix.org>