### PR TITLE
Pr/lockedfile fixes v5.0

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -158,6 +158,7 @@ struct ompio_file_t {
     int                    f_perm;
     ompi_communicator_t   *f_comm;
     const char            *f_filename;
+    char                  *f_fullfilename;
     char                  *f_datarep;
     opal_convertor_t      *f_mem_convertor;
     opal_convertor_t      *f_file_convertor;


### PR DESCRIPTION
Bring over the lockedfile fixes from master to the v5.0.x branch.

Fixes two separate issues in the sharedfp/lockedfile component:

- clean up the utilization of read/write in terms of properly handling the return code of the functions.
- keep track of the full pathname when opening a file (and the sharedfp lockedfile) to be able to clean up all pending issues during File_close, even if the user changed the directory inbetween.

Note: cherry-picked the individual commits, not the merge pr