### PR TITLE
Pr/lockedfile fixes v4.0

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -155,6 +155,7 @@ struct ompio_file_t {
     int                    f_perm;
     ompi_communicator_t   *f_comm;
     const char            *f_filename;
+    char                  *f_fullfilename;
     char                  *f_datarep;
     opal_convertor_t      *f_convertor;
     opal_info_t           *f_info;

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -41,6 +41,9 @@
 #include <math.h>
 #include "common_ompio.h"
 #include "ompi/mca/topo/topo.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/path.h"
+#include "opal/util/os_path.h"
 
 static mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view_fn;
 static mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value_fn;
@@ -99,6 +102,22 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     ompio_fh->f_get_mca_parameter_value=get_mca_parameter_value_fn;
 
     ompio_fh->f_filename = filename;
+    if (opal_path_is_absolute(filename) ) {
+        ompio_fh->f_fullfilename = strdup(filename);
+    }
+    else {
+        char path[OPAL_PATH_MAX];
+        ret = opal_getcwd(path, OPAL_PATH_MAX);
+        if (OPAL_SUCCESS != ret) {
+            goto fn_fail;
+        }
+        ompio_fh->f_fullfilename = opal_os_path(0, path, filename, NULL);
+        if (NULL == ompio_fh->f_fullfilename){
+            ret = OMPI_ERROR;
+            goto fn_fail;
+        }
+    }
+    
     mca_common_ompio_set_file_defaults (ompio_fh);
 
     ompio_fh->f_split_coll_req    = NULL;
@@ -284,7 +303,7 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
 	ret = ompio_fh->f_fs->fs_file_close (ompio_fh);
     }
     if ( delete_flag ) {
-        ret = mca_common_ompio_file_delete ( ompio_fh->f_filename, &(MPI_INFO_NULL->super) );
+        ret = mca_common_ompio_file_delete ( ompio_fh->f_fullfilename, &(MPI_INFO_NULL->super) );
     }
 
     if ( NULL != ompio_fh->f_fs ) {
@@ -343,7 +362,8 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
         free ( ompio_fh->f_coll_write_time );
         ompio_fh->f_coll_write_time = NULL;
     }
-
+    free (ompio_fh->f_fullfilename);
+    
     if ( NULL != ompio_fh->f_coll_read_time ) {
         free ( ompio_fh->f_coll_read_time );
         ompio_fh->f_coll_read_time = NULL;
@@ -364,8 +384,7 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
     if ( MPI_DATATYPE_NULL != ompio_fh->f_orig_filetype ){
 	ompi_datatype_destroy (&ompio_fh->f_orig_filetype);
     }
-
-
+    
     if (MPI_COMM_NULL != ompio_fh->f_comm && !(ompio_fh->f_flags & OMPIO_SHAREDFP_IS_SET) )  {
         ompi_comm_free (&ompio_fh->f_comm);
     }


### PR DESCRIPTION
Bring over the lockedfile fixes from master to the v4.0.x branch.

Fixes two separate issues in the sharedfp/lockedfile component:

- clean up the utilization of read/write in terms of properly handling the return code of the functions.
- keep track of the full pathname when opening a file (and the sharedfp lockedfile) to be able to clean up all pending issues during File_close, even if the user changed the directory inbetween.

Note: cherry-picked the individual commits, not the merge pr