### PR TITLE
coll/ucc: replace contextid by function call

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -391,7 +391,7 @@ static int mca_coll_ucc_module_enable(mca_coll_base_module_t *module,
         },
         .ep       = ompi_comm_rank(comm),
         .ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG,
-        .id       = comm->c_contextid
+        .id       = ompi_comm_get_local_cid(comm)
     };
     UCC_VERBOSE(2,"creating ucc_team for comm %p, comm_id %d, comm_size %d",
                  (void*)comm,comm->c_contextid,ompi_comm_size(comm));


### PR DESCRIPTION
to retrieve the communicator context id. Makes the component compile again.

Signed-off-by: Edgar Gabriel <edgar.gabriel1@outlook.com>