### PR TITLE
sessions:move opal_sma_base_f to ompi_framework

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -38,6 +38,7 @@
 #include "opal/mca/allocator/base/base.h"
 #include "opal/mca/rcache/base/base.h"
 #include "opal/mca/mpool/base/base.h"
+#include "opal/mca/smsc/base/base.h"
 #include "ompi/mca/bml/base/base.h"
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/coll/base/base.h"
@@ -91,7 +92,7 @@ OBJ_CLASS_INSTANCE(ompi_instance_t, opal_infosubscriber_t, ompi_instance_constru
 /* NTH: frameworks needed by MPI */
 static mca_base_framework_t *ompi_framework_dependencies[] = {
     &ompi_hook_base_framework, &ompi_op_base_framework,
-    &opal_allocator_base_framework, &opal_rcache_base_framework, &opal_mpool_base_framework,
+    &opal_allocator_base_framework, &opal_rcache_base_framework, &opal_mpool_base_framework, &opal_smsc_base_framework,
     &ompi_bml_base_framework, &ompi_pml_base_framework, &ompi_coll_base_framework,
     &ompi_osc_base_framework, NULL,
 };

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -622,7 +622,7 @@ static mca_base_framework_t *opal_init_frameworks[] = {
     &opal_memcpy_base_framework, &opal_memchecker_base_framework,
     &opal_backtrace_base_framework, &opal_timer_base_framework,
     &opal_shmem_base_framework, &opal_reachable_base_framework,
-    &opal_pmix_base_framework, &opal_smsc_base_framework,
+    &opal_pmix_base_framework,
     NULL,
 };
 


### PR DESCRIPTION
dependencies array.

If this is not done, then when using a non-ob1 PML, the stages of finalization
have the SMSC framework closed before the btl framework is closed or del_procs invoked
for the btl(s).

When using the --enable-mca_dso this results in a segfault as the code section for the SMSC
framework/components has been dlclosed.

Moving the opal_smc_base_framework from the opal_init_frameworks to the
ompi_framework_dependencies fixes this problem.

Related to #9097

Signed-off-by: Howard Pritchard <howardp@lanl.gov>