### PR TITLE
Pr/lockedfile fixes v4.1

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -157,6 +157,7 @@ struct ompio_file_t {
     int                    f_perm;
     ompi_communicator_t   *f_comm;
     const char            *f_filename;
+    char                  *f_fullfilename;
     char                  *f_datarep;
     opal_convertor_t      *f_mem_convertor;
     opal_convertor_t      *f_file_convertor;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -37,6 +37,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "opal/util/fd.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/path.h"
+#include "opal/util/os_path.h"
+
 int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
 				       const char* filename,
 				       int amode,
@@ -125,12 +130,19 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
             opal_output(0, "[%d]mca_sharedfp_lockedfile_file_open: Error during file open\n", 
                         fh->f_rank);
             free (sh);
-            free(module_data);
+            free (module_data);
             free (lockedfilename);
             return OMPI_ERROR;
         }
-	write ( handle, &position, sizeof(OMPI_MPI_OFFSET_TYPE) );
-	close ( handle );
+	err = opal_fd_write (handle, sizeof(OMPI_MPI_OFFSET_TYPE), &position);
+        if (OPAL_SUCCESS != err)  {
+            free (sh);
+            free (module_data);
+            free (lockedfilename);
+            close (handle);
+            return err;
+        }
+	close (handle);
     }
     err = comm->c_coll->coll_barrier ( comm, comm->c_coll->coll_barrier_module );
     if ( OMPI_SUCCESS != err ) {

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
@@ -25,6 +25,9 @@
 #include "ompi/constants.h"
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
+#include "opal/util/output.h"
+#include "opal/util/fd.h"
+
 
 /*Use fcntl to lock the hidden file which stores the current position*/
 #include <fcntl.h>
@@ -76,7 +79,10 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
 
     /* read from the file */
     lseek ( fd, 0, SEEK_SET );
-    read ( fd, &buf, sizeof(OMPI_MPI_OFFSET_TYPE));
+    ret = opal_fd_read ( fd,  sizeof(OMPI_MPI_OFFSET_TYPE), &buf);
+    if (OPAL_SUCCESS != ret ) {
+        goto exit;
+    }
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
                     "sharedfp_lockedfile_request_position: Read last_offset=%lld! ret=%d\n",buf, ret);
@@ -92,8 +98,11 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
 
     /* write to the file  */
     lseek ( fd, 0, SEEK_SET );
-    write ( fd, &position, sizeof(OMPI_MPI_OFFSET_TYPE));
-
+    ret = opal_fd_write (fd, sizeof(OMPI_MPI_OFFSET_TYPE), &position);
+    /* No need to handle error case here, the subsequent steps are identical
+       in case of ret != OPAL_SUCCESS, namely release lock and return ret */
+    
+exit:
     /* unlock the file */
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
@@ -115,7 +124,10 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
     if (fcntl(fd, F_SETLK, &fl) == -1) {
         opal_output(0,"sharedfp_lockedfile_request_position:failed to release lock for fd: %d\n",fd);
         opal_output(0,"error(%i): %s", errno, strerror(errno));
-        return OMPI_ERROR;
+        /* Only overwrite error code if it was OPAL_SUCCESS previously */
+        if (OPAL_SUCCESS == ret ) {
+            ret = OMPI_ERROR;
+        }
     }
     else {
 	if ( mca_sharedfp_lockedfile_verbose ) {


### PR DESCRIPTION
Bring over the lockedfile fixes from master to the v4.1.x branch.

Fixes two separate issues in the sharedfp/lockedfile component:

- clean up the utilization of read/write in terms of properly handling the return code of the functions.
- keep track of the full pathname when opening a file (and the sharedfp lockedfile) to be able to clean up all pending issues during File_close, even if the user changed the directory in between.

Note: cherry-picked the individual commits, not the merge pr
Note2: adjusted to make it compile on the 4.1 branch

bot:notacherrypick