### PR TITLE
MPI_Type_get_envelope.3in: update for MPI-3.0

### DIFF
--- a/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2022 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2020      Google, LLC. All rights reserved.
@@ -77,20 +77,14 @@ MPI_COMBINER_NAMED              a named predefined data type
 MPI_COMBINER_DUP                MPI_Type_dup
 MPI_COMBINER_CONTIGUOUS         MPI_Type_contiguous
 MPI_COMBINER_VECTOR             MPI_Type_vector
-MPI_COMBINER_HVECTOR_INTEGER    MPI_Type_hvector from Fortran
-MPI_COMBINER_HVECTOR            MPI_Type_hvector from C
-                                  and MPI_Type_create for
-                                  all languages
+MPI_COMBINER_HVECTOR            MPI_Type_hvector
+                                  and MPI_Type_create_hvector
 MPI_COMBINER_INDEXED            MPI_Type_indexed
-MPI_COMBINER_HINDEXED_INTEGER   MPI_Type_hindexed from Fortran
-MPI_COMBINER_HINDEXED           MPI_Type_hindexed from C
+MPI_COMBINER_HINDEXED           MPI_Type_hindexed
                                   and MPI_Type_create_hindexed
-                                  for all languages
 MPI_COMBINER_INDEXED_BLOCK      MPI_Type_create_indexed_block
-MPI_COMBINER_STRUCT_INTEGER     MPI_Type_struct from Fortran
-MPI_COMBINER_STRUCT             MPI_Type_struct from C
+MPI_COMBINER_STRUCT             MPI_Type_struct
                                   and MPI_Type_create_struct
-                                  for all languages
 MPI_COMBINER_SUBARRAY           MPI_Type_create_subarray
 MPI_COMBINER_DARRAY             MPI_Type_create_darray
 MPI_COMBINER_F90_REAL           MPI_Type_create_f90_real


### PR DESCRIPTION
Fix some information in the MPI_Type_get_envelope.3in man page.  Note
that all man pages are in the process of being converted to
ReStructured Text; this commit allows us to update the information
before the automated conversion is complete (and the generated
ReStructured Text man pages will therefore automatically include this
update).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>