### PR TITLE
Pr/lockedfile fixes v4.0

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -155,6 +155,7 @@ struct ompio_file_t {
     int                    f_perm;
     ompi_communicator_t   *f_comm;
     const char            *f_filename;
+    char                  *f_fullfilename;
     char                  *f_datarep;
     opal_convertor_t      *f_convertor;
     opal_info_t           *f_info;

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -41,6 +41,9 @@
 #include <math.h>
 #include "common_ompio.h"
 #include "ompi/mca/topo/topo.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/path.h"
+#include "opal/util/os_path.h"
 
 static mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view_fn;
 static mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value_fn;
@@ -99,6 +102,22 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     ompio_fh->f_get_mca_parameter_value=get_mca_parameter_value_fn;
 
     ompio_fh->f_filename = filename;
+    if (opal_path_is_absolute(filename) ) {
+        ompio_fh->f_fullfilename = strdup(filename);
+    }
+    else {
+        char path[OPAL_PATH_MAX];
+        ret = opal_getcwd(path, OPAL_PATH_MAX);
+        if (OPAL_SUCCESS != ret) {
+            goto fn_fail;
+        }
+        ompio_fh->f_fullfilename = opal_os_path(0, path, filename, NULL);
+        if (NULL == ompio_fh->f_fullfilename){
+            ret = OMPI_ERROR;
+            goto fn_fail;
+        }
+    }
+    
     mca_common_ompio_set_file_defaults (ompio_fh);
 
     ompio_fh->f_split_coll_req    = NULL;
@@ -284,7 +303,7 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
 	ret = ompio_fh->f_fs->fs_file_close (ompio_fh);
     }
     if ( delete_flag ) {
-        ret = mca_common_ompio_file_delete ( ompio_fh->f_filename, &(MPI_INFO_NULL->super) );
+        ret = mca_common_ompio_file_delete ( ompio_fh->f_fullfilename, &(MPI_INFO_NULL->super) );
     }
 
     if ( NULL != ompio_fh->f_fs ) {
@@ -343,7 +362,8 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
         free ( ompio_fh->f_coll_write_time );
         ompio_fh->f_coll_write_time = NULL;
     }
-
+    free (ompio_fh->f_fullfilename);
+    
     if ( NULL != ompio_fh->f_coll_read_time ) {
         free ( ompio_fh->f_coll_read_time );
         ompio_fh->f_coll_read_time = NULL;
@@ -364,8 +384,7 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
     if ( MPI_DATATYPE_NULL != ompio_fh->f_orig_filetype ){
 	ompi_datatype_destroy (&ompio_fh->f_orig_filetype);
     }
-
-
+    
     if (MPI_COMM_NULL != ompio_fh->f_comm && !(ompio_fh->f_flags & OMPIO_SHAREDFP_IS_SET) )  {
         ompi_comm_free (&ompio_fh->f_comm);
     }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -37,7 +37,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-
 #include "opal/util/fd.h"
 #include "opal/util/opal_getcwd.h"
 #include "opal/util/path.h"
@@ -116,8 +115,26 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
     snprintf(lockedfilename, filenamelen, "%s-%u-%d%s",filename,masterjobid,int_pid,".lock");
-    module_data->filename = lockedfilename;
-    
+    if (opal_path_is_absolute(lockedfilename) ) {
+        module_data->filename = lockedfilename;
+    } else {
+        char path[OPAL_PATH_MAX];
+        err = opal_getcwd(path, OPAL_PATH_MAX);
+        if (OPAL_SUCCESS != err) {
+            free (sh);
+            free (module_data);
+            free (lockedfilename);
+            return err;
+        }
+        module_data->filename = opal_os_path(0, path, lockedfilename, NULL);
+        if (NULL == module_data->filename){
+            free (sh);
+            free (module_data);
+            free (lockedfilename);
+            return OMPI_ERROR;
+        }
+    }
+
     /*-------------------------------------------------*/
     /*Open the lockedfile without shared file pointer  */
     /*-------------------------------------------------*/
@@ -135,6 +152,7 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
             free (lockedfilename);
             return OMPI_ERROR;
         }
+
 	err = opal_fd_write (handle, sizeof(OMPI_MPI_OFFSET_TYPE), &position);
         if (OPAL_SUCCESS != err)  {
             free (sh);

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
@@ -25,6 +25,9 @@
 #include "ompi/constants.h"
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
+#include "opal/util/output.h"
+#include "opal/util/fd.h"
+
 
 /*Use fcntl to lock the hidden file which stores the current position*/
 #include <fcntl.h>
@@ -76,7 +79,10 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
 
     /* read from the file */
     lseek ( fd, 0, SEEK_SET );
-    read ( fd, &buf, sizeof(OMPI_MPI_OFFSET_TYPE));
+    ret = opal_fd_read ( fd,  sizeof(OMPI_MPI_OFFSET_TYPE), &buf);
+    if (OPAL_SUCCESS != ret ) {
+        goto exit;
+    }
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
                     "sharedfp_lockedfile_request_position: Read last_offset=%lld! ret=%d\n",buf, ret);
@@ -92,8 +98,11 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
 
     /* write to the file  */
     lseek ( fd, 0, SEEK_SET );
-    write ( fd, &position, sizeof(OMPI_MPI_OFFSET_TYPE));
-
+    ret = opal_fd_write (fd, sizeof(OMPI_MPI_OFFSET_TYPE), &position);
+    /* No need to handle error case here, the subsequent steps are identical
+       in case of ret != OPAL_SUCCESS, namely release lock and return ret */
+    
+exit:
     /* unlock the file */
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
@@ -115,7 +124,10 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
     if (fcntl(fd, F_SETLK, &fl) == -1) {
         opal_output(0,"sharedfp_lockedfile_request_position:failed to release lock for fd: %d\n",fd);
         opal_output(0,"error(%i): %s", errno, strerror(errno));
-        return OMPI_ERROR;
+        /* Only overwrite error code if it was OPAL_SUCCESS previously */
+        if (OPAL_SUCCESS == ret ) {
+            ret = OMPI_ERROR;
+        }
     }
     else {
 	if ( mca_sharedfp_lockedfile_verbose ) {


### PR DESCRIPTION
Bring over the lockedfile fixes from master to the v4.1.x branch.

Fixes two separate issues in the sharedfp/lockedfile component:

- clean up the utilization of read/write in terms of properly handling the return code of the functions.
- keep track of the full pathname when opening a file (and the sharedfp lockedfile) to be able to clean up all pending issues during File_close, even if the user changed the directory in between.

Note: cherry-picked the individual commits, not the merge pr
Note2: adjusted to make it compile on the 4.0 branch