### PR TITLE
v4.1.x/UCX/PML/SPML/OSC: fix compiler warnings

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -705,7 +705,7 @@ int mca_pml_ucx_isend_init(const void *buf, size_t count, ompi_datatype_t *datat
     OMPI_DATATYPE_RETAIN(datatype);
 
     if (MCA_PML_BASE_SEND_BUFFERED == mode) {
-        req->datatype = NULL;
+        req->datatype = (ucp_datatype_t)NULL;
     } else {
         req->datatype = mca_pml_ucx_get_datatype(datatype);
     }

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -49,7 +49,9 @@ mca_pml_base_component_2_0_0_t mca_pml_ucx_component = {
 
 static int mca_pml_ucx_component_register(void)
 {
+#if HAVE_DECL_UCP_OP_ATTR_FLAG_MULTI_SEND
     int multi_send_op_attr_enable;
+#endif
 
     ompi_pml_ucx.priority = 51;
     (void) mca_base_component_var_register(&mca_pml_ucx_component.pmlm_version, "priority",

--- a/ompi/mca/pml/ucx/pml_ucx_request.h
+++ b/ompi/mca/pml/ucx/pml_ucx_request.h
@@ -180,10 +180,9 @@ static inline int mca_pml_ucx_set_recv_status(ompi_status_public_t* mpi_status,
                                                ucs_status_t ucp_status,
                                                const ucp_tag_recv_info_t *info)
 {
-    int64_t tag;
+    int64_t tag = info->sender_tag;
 
     if (OPAL_LIKELY(ucp_status == UCS_OK)) {
-        tag = info->sender_tag;
         mpi_status->MPI_ERROR  = MPI_SUCCESS;
         mpi_status->MPI_SOURCE = PML_UCX_TAG_GET_SOURCE(tag);
         mpi_status->MPI_TAG    = PML_UCX_TAG_GET_MPI_TAG(tag);

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -113,9 +113,11 @@ static int mca_btl_uct_component_open(void)
         int core_count = 36;
 
         (void) opal_hwloc_base_get_topology ();
-        core_count = hwloc_get_nbobjs_by_type (opal_hwloc_topology, HWLOC_OBJ_CORE);
+        if (0 > (core_count = hwloc_get_nbobjs_by_type(opal_hwloc_topology, HWLOC_OBJ_CORE))) {
+            return OPAL_ERROR;
+        }
 
-        if (core_count <= opal_process_info.num_local_peers || !opal_using_threads()) {
+        if ((uint32_t)core_count <= opal_process_info.num_local_peers || !opal_using_threads()) {
             /* there is probably no benefit to using multiple device contexts when not
              * using threads or oversubscribing the node with mpi processes. */
             mca_btl_uct_component.num_contexts_per_module = 1;
@@ -437,9 +439,9 @@ static int mca_btl_uct_component_process_uct_component (uct_component_h componen
         return OPAL_ERROR;
     }
 
-    for (int i = 0 ; i < attr.md_resource_count ; ++i) {
-        rc = mca_btl_uct_component_process_uct_md (component, attr.md_resources + i,
-                                                   allowed_ifaces);
+    for (unsigned i = 0; i < attr.md_resource_count; ++i) {
+        rc = mca_btl_uct_component_process_uct_md(component, attr.md_resources + i,
+                                                  allowed_ifaces);
         if (OPAL_SUCCESS != rc) {
             break;
         }
@@ -464,8 +466,6 @@ static mca_btl_base_module_t **mca_btl_uct_component_init (int *num_btl_modules,
 {
     /* for this BTL to be useful the interface needs to support RDMA and certain atomic operations */
     struct mca_btl_base_module_t **base_modules;
-    uct_md_resource_desc_t *resources;
-    unsigned resource_count;
     ucs_status_t ucs_status;
     char **allowed_ifaces;
     int rc;
@@ -506,6 +506,8 @@ static mca_btl_base_module_t **mca_btl_uct_component_init (int *num_btl_modules,
     uct_release_component_list (components);
 
 #else /* UCT 1.6 and older */
+    uct_md_resource_desc_t *resources;
+    unsigned resource_count;
 
     uct_query_md_resources (&resources, &resource_count);
 

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -235,8 +235,7 @@ opal_common_ucx_support_level(ucp_context_h context)
 
     /* Check for special value "any" */
     if (is_any_tl && is_any_device) {
-        MCA_COMMON_UCX_VERBOSE(1, "ucx is enabled on any transport or device",
-                               *opal_common_ucx.tls);
+        MCA_COMMON_UCX_VERBOSE(1, "ucx is enabled on any transport or device");
         support_level = OPAL_COMMON_UCX_SUPPORT_DEVICE;
         goto out;
     }

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -15,6 +15,7 @@
 #include "opal/mca/pmix/pmix.h"
 #include "opal/memoryhooks/memory.h"
 #include "opal/util/argv.h"
+#include "opal/util/printf.h"
 
 #include <ucm/api/ucm.h>
 #include <fnmatch.h>
@@ -168,13 +169,16 @@ static bool opal_common_ucx_check_device(const char *device_name, char **device_
 {
     char sysfs_driver_link[PATH_MAX];
     char driver_path[PATH_MAX];
-    char *ib_device_name;
+    char ib_device_name[NAME_MAX];
     char *driver_name;
     char **list_item;
     ssize_t ret;
+    char ib_device_name_fmt[NAME_MAX];
 
     /* mlx5_0:1 */
-    ret = sscanf(device_name, "%m[^:]%*d", &ib_device_name);
+    opal_snprintf(ib_device_name_fmt, sizeof(ib_device_name_fmt),
+                  "%%%u[^:]%%*d", NAME_MAX - 1);
+    ret = sscanf(device_name, ib_device_name_fmt, &ib_device_name);
     if (ret != 1) {
         return false;
     }
@@ -182,7 +186,6 @@ static bool opal_common_ucx_check_device(const char *device_name, char **device_
     sysfs_driver_link[sizeof(sysfs_driver_link) - 1] = '\0';
     snprintf(sysfs_driver_link, sizeof(sysfs_driver_link) - 1,
              "/sys/class/infiniband/%s/device/driver", ib_device_name);
-    free(ib_device_name);
 
     ret = readlink(sysfs_driver_link, driver_path, sizeof(driver_path) - 1);
     if (ret < 0) {
@@ -215,7 +218,8 @@ opal_common_ucx_support_level(ucp_context_h context)
         [OPAL_COMMON_UCX_SUPPORT_DEVICE]    = "transports and devices"
     };
 #if HAVE_DECL_OPEN_MEMSTREAM
-    char *rsc_tl_name, *rsc_device_name;
+    char rsc_tl_name[NAME_MAX], rsc_device_name[NAME_MAX];
+    char rsc_name_fmt[NAME_MAX];
     char **tl_list, **device_list, **list_item;
     bool is_any_tl, is_any_device;
     bool found_tl, negate;
@@ -266,17 +270,17 @@ opal_common_ucx_support_level(ucp_context_h context)
     /* Print ucx transports information to the memory stream */
     ucp_context_print_info(context, stream);
 
+    /* "# resource 6  :  md 5  dev 4  flags -- rc_verbs/mlx5_0:1" */
+    opal_snprintf(rsc_name_fmt, sizeof(rsc_name_fmt),
+        "# resource %%*d : md %%*d dev %%*d flags -- %%%u[^/ \n\r]/%%%u[^/ \n\r]",
+        NAME_MAX - 1, NAME_MAX - 1);
+
     /* Rewind and read transports/devices list from the stream */
     fseek(stream, 0, SEEK_SET);
     while ((support_level != OPAL_COMMON_UCX_SUPPORT_DEVICE) &&
            (fgets(line, sizeof(line), stream) != NULL)) {
-        rsc_tl_name = NULL;
-        ret = sscanf(line,
-                     /* "# resource 6  :  md 5  dev 4  flags -- rc_verbs/mlx5_0:1" */
-                     "# resource %*d : md %*d dev %*d flags -- %m[^/ \n\r]/%m[^/ \n\r]",
-                     &rsc_tl_name, &rsc_device_name);
+        ret = sscanf(line, rsc_name_fmt, rsc_tl_name, rsc_device_name);
         if (ret != 2) {
-            free(rsc_tl_name);
             continue;
         }
 
@@ -303,9 +307,6 @@ opal_common_ucx_support_level(ucp_context_h context)
             MCA_COMMON_UCX_VERBOSE(2, "%s/%s: did not match transport list",
                                    rsc_tl_name, rsc_device_name);
         }
-
-        free(rsc_device_name);
-        free(rsc_tl_name);
     }
 
     MCA_COMMON_UCX_VERBOSE(2, "support level is %s", support_level_names[support_level]);

--- a/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
@@ -29,7 +29,7 @@ int mca_atomic_ucx_cswap(shmem_ctx_t ctx,
 {
     ucs_status_ptr_t status_ptr;
     spml_ucx_mkey_t *ucx_mkey;
-    uint64_t rva;
+    void *rva = NULL;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     ucp_request_param_t param = {
@@ -48,16 +48,16 @@ int mca_atomic_ucx_cswap(shmem_ctx_t ctx,
     assert(NULL != prev);
 
     *prev      = value;
-    ucx_mkey   = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey   = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, &rva, mca_spml_self);
     assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn,
-                                   UCP_ATOMIC_OP_CSWAP, &cond, 1, rva,
+                                   UCP_ATOMIC_OP_CSWAP, &cond, 1, (uint64_t)rva,
                                    ucx_mkey->rkey, &param);
 #else
     status_ptr = ucp_atomic_fetch_nb(ucx_ctx->ucp_peers[pe].ucp_conn,
                                      UCP_ATOMIC_FETCH_OP_CSWAP, cond, prev, size,
-                                     rva, ucx_mkey->rkey,
+                                     (uint64_t)rva, ucx_mkey->rkey,
                                      opal_common_ucx_empty_complete_cb);
 #endif
 

--- a/oshmem/mca/atomic/ucx/atomic_ucx_module.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_module.c
@@ -56,7 +56,7 @@ int mca_atomic_ucx_op(shmem_ctx_t ctx,
 #endif
 {
     spml_ucx_mkey_t *ucx_mkey;
-    uint64_t rva;
+    void *rva = NULL;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     ucs_status_ptr_t status_ptr;
@@ -67,17 +67,17 @@ int mca_atomic_ucx_op(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, &rva, mca_spml_self);
     assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn,
-                                   op, &value, 1, rva, ucx_mkey->rkey,
+                                   op, &value, 1, (uint64_t)rva, ucx_mkey->rkey,
                                    &mca_spml_ucp_request_params[size >> 3]);
     res = opal_common_ucx_wait_request(status_ptr, ucx_ctx->ucp_worker[0],
                                        "ucp_atomic_op_nbx post");
 #else
     status = ucp_atomic_post(ucx_ctx->ucp_peers[pe].ucp_conn,
-                             op, value, size, rva,
+                             op, value, size, (uint64_t)rva,
                              ucx_mkey->rkey);
     res = ucx_status_to_oshmem(status);
 #endif
@@ -104,7 +104,7 @@ int mca_atomic_ucx_fop(shmem_ctx_t ctx,
 {
     ucs_status_ptr_t status_ptr;
     spml_ucx_mkey_t *ucx_mkey;
-    uint64_t rva;
+    void *rva = NULL;
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     ucp_request_param_t param = {
@@ -117,17 +117,17 @@ int mca_atomic_ucx_fop(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, pe, target, &rva, mca_spml_self);
     assert(NULL != ucx_mkey);
 #if HAVE_DECL_UCP_ATOMIC_OP_NBX
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn, op, &value, 1,
-                                   rva, ucx_mkey->rkey, &param);
+                                   (uint64_t)rva, ucx_mkey->rkey, &param);
     return opal_common_ucx_wait_request(status_ptr, ucx_ctx->ucp_worker[0],
                                         "ucp_atomic_op_nbx");
 #else
     status_ptr = ucp_atomic_fetch_nb(ucx_ctx->ucp_peers[pe].ucp_conn,
                                      op, value, prev, size,
-                                     rva, ucx_mkey->rkey,
+                                     (uint64_t)rva, ucx_mkey->rkey,
                                      opal_common_ucx_empty_complete_cb);
     return opal_common_ucx_wait_request(status_ptr, ucx_ctx->ucp_worker[0],
                                         "ucp_atomic_fetch_nb");

--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -199,7 +199,7 @@ static inline int memheap_find_segnum(void *va, int pe)
                 if (mkeys_cache) {
                     if (mkeys_cache[pe]) {
                         if ((va >= mkeys_cache[pe]->va_base) &&
-                            (va < mkeys_cache[pe]->va_base + mkeys_cache[pe]->len)) {
+                            ((char*)va < (char*)mkeys_cache[pe]->va_base + mkeys_cache[pe]->len)) {
                             return i;
                         }
                     }

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -121,7 +121,7 @@ void mca_spml_ucx_peer_mkey_cache_init(mca_spml_ucx_ctx_t *ucx_ctx, int pe)
 int mca_spml_ucx_peer_mkey_cache_add(ucp_peer_t *ucp_peer, int index)
 {
     /* Allocate an array to hold the pointers to the ucx_cached_mkey */
-    if (index >= ucp_peer->mkeys_cnt){
+    if (index >= (int)ucp_peer->mkeys_cnt) {
         int old_size = ucp_peer->mkeys_cnt;
         if (MCA_MEMHEAP_MAX_SEGMENTS <= (index + 1)) {
             SPML_UCX_ERROR("Failed to get new mkey for segment: max number (%d) of segment descriptor is exhausted",
@@ -156,7 +156,7 @@ int mca_spml_ucx_peer_mkey_cache_add(ucp_peer_t *ucp_peer, int index)
 /* Release individual mkeys */
 int mca_spml_ucx_peer_mkey_cache_del(ucp_peer_t *ucp_peer, int segno)
 {
-    if ((ucp_peer->mkeys_cnt <= segno) || (segno < 0)) {
+    if (((int)ucp_peer->mkeys_cnt <= segno) || (segno < 0)) {
         return OSHMEM_ERR_NOT_AVAILABLE;
     }
     if (NULL != ucp_peer->mkeys[segno]) {
@@ -169,7 +169,7 @@ int mca_spml_ucx_peer_mkey_cache_del(ucp_peer_t *ucp_peer, int segno)
 /* Release the memkey map from a ucp_peer if it has any element in memkey */
 void mca_spml_ucx_peer_mkey_cache_release(ucp_peer_t *ucp_peer)
 {
-    int i;
+    size_t i;
     if (ucp_peer->mkeys_cnt) {
         for(i = 0; i < ucp_peer->mkeys_cnt; i++) {
             assert(NULL == ucp_peer->mkeys[i]);
@@ -242,7 +242,6 @@ int mca_spml_ucx_ctx_mkey_add(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segn
 int mca_spml_ucx_ctx_mkey_del(mca_spml_ucx_ctx_t *ucx_ctx, int pe, uint32_t segno, spml_ucx_mkey_t *ucx_mkey)
 {
     ucp_peer_t *ucp_peer;
-    spml_ucx_cached_mkey_t *ucx_cached_mkey;
     int rc;
     ucp_peer = &(ucx_ctx->ucp_peers[pe]);
     ucp_rkey_destroy(ucx_mkey->rkey);
@@ -401,8 +400,6 @@ err:
 }
 
 
-static char spml_ucx_transport_ids[1] = { 0 };
-
 int mca_spml_ucx_init_put_op_mask(mca_spml_ucx_ctx_t *ctx, size_t nprocs)
 {
     int res;
@@ -439,7 +436,7 @@ int mca_spml_ucx_clear_put_op_mask(mca_spml_ucx_ctx_t *ctx)
 
 int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
 {
-    size_t i, j, k, w, n;
+    size_t i, w, n;
     int rc = OSHMEM_ERROR;
     int my_rank = oshmem_my_proc_id();
     int ucp_workers = mca_spml_ucx.ucp_workers;
@@ -983,7 +980,7 @@ void mca_spml_ucx_ctx_destroy(shmem_ctx_t ctx)
 
 int mca_spml_ucx_get(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_addr, int src)
 {
-    void *rva;
+    void *rva = NULL;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
@@ -1010,7 +1007,7 @@ int mca_spml_ucx_get(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_add
 
 int mca_spml_ucx_get_nb(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_addr, int src, void **handle)
 {
-    void *rva;
+    void *rva = NULL;
     ucs_status_t status;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);
@@ -1038,7 +1035,7 @@ int mca_spml_ucx_get_nb(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_
 int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_addr, int src, void **handle)
 {
     unsigned int i;
-    void *rva;
+    void *rva = NULL;
     ucs_status_t status;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, src, src_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);
@@ -1076,7 +1073,7 @@ int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx, void *src_addr, size_t size, 
 
 int mca_spml_ucx_put(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst)
 {
-    void *rva;
+    void *rva = NULL;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
@@ -1110,7 +1107,7 @@ int mca_spml_ucx_put(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_add
 
 int mca_spml_ucx_put_nb(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst, void **handle)
 {
-    void *rva;
+    void *rva = NULL;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);
     mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
@@ -1143,7 +1140,7 @@ int mca_spml_ucx_put_nb(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_
 int mca_spml_ucx_put_nb_wprogress(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst, void **handle)
 {
     unsigned int i;
-    void *rva;
+    void *rva = NULL;
     ucs_status_t status;
     spml_ucx_mkey_t *ucx_mkey = mca_spml_ucx_ctx_mkey_by_va(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
     assert(NULL != ucx_mkey);

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -259,7 +259,7 @@ int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs)
     opal_common_ucx_del_proc_t *del_procs;
     size_t i, w, n;
     int ret;
-    int ucp_workers = mca_spml_ucx.ucp_workers;
+    size_t ucp_workers = mca_spml_ucx.ucp_workers;
 
     oshmem_shmem_barrier();
 
@@ -439,7 +439,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
     size_t i, w, n;
     int rc = OSHMEM_ERROR;
     int my_rank = oshmem_my_proc_id();
-    int ucp_workers = mca_spml_ucx.ucp_workers;
+    size_t ucp_workers = mca_spml_ucx.ucp_workers;
     ucs_status_t err;
     ucp_address_t **wk_local_addr;
     unsigned int *wk_addr_len;
@@ -922,8 +922,7 @@ int mca_spml_ucx_ctx_create(long options, shmem_ctx_t *ctx)
 {
     mca_spml_ucx_ctx_t *ucx_ctx = NULL;
     mca_spml_ucx_ctx_array_t *idle_array = &mca_spml_ucx.idle_array;
-    mca_spml_ucx_ctx_array_t *active_array = &mca_spml_ucx.active_array;
-    int i, rc;
+    int i, rc = OSHMEM_SUCCESS;
 
     /* Take a lock controlling context creation. AUX context may set specific
      * UCX parameters affecting worker creation, which are not needed for

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -221,8 +221,9 @@ static inline int
 mca_spml_ucx_peer_mkey_get(ucp_peer_t *ucp_peer, int index, spml_ucx_cached_mkey_t **out_rmkey)
 {
     *out_rmkey = NULL;
-    if (OPAL_UNLIKELY((index >= ucp_peer->mkeys_cnt) || (MCA_MEMHEAP_MAX_SEGMENTS <= index) || (0 > index))) {
-        SPML_UCX_ERROR("Failed to get mkey for segment: bad index = %d, MAX = %d, cached mkeys count: %d",
+    if (OPAL_UNLIKELY((index >= (int)ucp_peer->mkeys_cnt) ||
+                      (MCA_MEMHEAP_MAX_SEGMENTS <= index) || (0 > index))) {
+        SPML_UCX_ERROR("Failed to get mkey for segment: bad index = %d, MAX = %d, cached mkeys count: %zu",
                         index, MCA_MEMHEAP_MAX_SEGMENTS, ucp_peer->mkeys_cnt);
         return OSHMEM_ERR_BAD_PARAM;
     }

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
@@ -223,7 +223,6 @@ segment_create(map_segment_t *ds_buf,
 {
     mca_spml_ucx_t *spml = (mca_spml_ucx_t*)mca_spml.self;
     unsigned flags;
-    int ret;
 
 #if HAVE_UCX_DEVICE_MEM
     int ret = OSHMEM_ERROR;


### PR DESCRIPTION
Fixes compiler warnings for v4.1.x and cherry-picked https://github.com/open-mpi/ompi/pull/9997, https://github.com/open-mpi/ompi/pull/9438

bot:notacherrypick