### PR TITLE
OPAL/COMMON/UCX: enable OPAL memory hooks  by default - v5.0

### DIFF
--- a/contrib/platform/mellanox/optimized.conf
+++ b/contrib/platform/mellanox/optimized.conf
@@ -63,6 +63,7 @@ hwloc_base_binding_policy = core
 btl = self
 pml_ucx_tls = any
 pml_ucx_devices = any
+opal_common_ucx_opal_mem_hooks = 0
 # Basic behavior to smooth startup
 mca_base_component_show_load_errors = 0
 orte_abort_timeout = 10

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -34,7 +34,7 @@ extern mca_base_framework_t opal_memory_base_framework;
 opal_common_ucx_module_t opal_common_ucx = {.verbose = 0,
                                             .progress_iterations = 100,
                                             .registered = 0,
-                                            .opal_mem_hooks = 0,
+                                            .opal_mem_hooks = 1,
                                             .tls = NULL};
 
 static opal_mutex_t opal_common_ucx_mutex = OPAL_MUTEX_STATIC_INIT;


### PR DESCRIPTION
- enable OPAL memory hooks by default to provide compatibility
  with other transports

back port from https://github.com/open-mpi/ompi/pull/9946

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
(cherry picked from commit 62f6be4afab1b8996f738226e1d96c0c3fe5957f)