### PR TITLE
v5.0.x: OSC backports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -633,6 +633,7 @@ test/class/ompi_rb_tree
 test/class/ompi_bitmap
 test/class/opal_bitmap
 test/class/opal_fifo
+test/class/opal_cstring
 test/class/opal_hash_table
 test/class/opal_lifo
 test/class/opal_list

--- a/ompi/mca/osc/base/osc_base_init.c
+++ b/ompi/mca/osc/base/osc_base_init.c
@@ -57,10 +57,6 @@ ompi_osc_base_select(ompi_win_t *win,
         priority = component->osc_query(win, base, size, disp_unit, comm,
                                         win->super.s_info, flavor);
         if (priority < 0) {
-            if (MPI_WIN_FLAVOR_SHARED == flavor && OMPI_ERR_RMA_SHARED == priority) {
-                /* NTH: quick fix to return OMPI_ERR_RMA_SHARED */
-                return OMPI_ERR_RMA_SHARED;
-            }
             continue;
         }
 

--- a/ompi/mca/osc/monitoring/osc_monitoring_component.c
+++ b/ompi/mca/osc/monitoring/osc_monitoring_component.c
@@ -90,10 +90,6 @@ static int mca_osc_monitoring_component_select(struct ompi_win_t *win, void **ba
         
         priority = component->osc_query(win, base, size, disp_unit, comm, info, flavor);
         if (priority < 0) {
-            if (MPI_WIN_FLAVOR_SHARED == flavor && OMPI_ERR_RMA_SHARED == priority) {
-                /* NTH: quick fix to return OMPI_ERR_RMA_SHARED */
-                return OMPI_ERR_RMA_SHARED;
-            }
             continue;
         }
 

--- a/ompi/mca/osc/rdma/Makefile.am
+++ b/ompi/mca/osc/rdma/Makefile.am
@@ -11,6 +11,8 @@
 # Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,6 +23,8 @@
 rdma_sources = \
 	osc_rdma.h \
 	osc_rdma_module.c \
+	osc_rdma_btl_comm.h \
+	osc_rdma_btl_comm.c \
 	osc_rdma_comm.h \
 	osc_rdma_comm.c \
 	osc_rdma_accumulate.c \

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -148,9 +148,6 @@ struct ompi_osc_rdma_module_t {
     /** value of same_size info key for this window */
     bool same_size;
 
-    /** CPU atomics can be used */
-    bool use_cpu_atomics;
-
     /** passive-target synchronization will not be used in this window */
     bool no_locks;
 

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -762,9 +762,10 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "RDMA compare-and-swap initiating blocking btl put...");
 
     do {
-        ret = btl->btl_put (btl, peer->data_endpoint, ptr, target_address,
-                            local_handle, target_handle, len, 0, MCA_BTL_NO_ORDER,
-                            ompi_osc_rdma_cas_put_complete, (void *) &complete, NULL);
+        ret = ompi_osc_rdma_btl_put(module, peer->data_btl_index, peer->data_endpoint,
+                                    ptr, target_address, local_handle, target_handle,
+                                    len, 0, MCA_BTL_NO_ORDER,
+                                    ompi_osc_rdma_cas_put_complete, (void *) &complete, NULL);
         if (OPAL_SUCCESS == ret || (OPAL_ERR_OUT_OF_RESOURCE != ret && OPAL_ERR_TEMP_OUT_OF_RESOURCE != ret)) {
             break;
         }

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -164,13 +164,11 @@ static int ompi_osc_rdma_fetch_and_op_atomic (ompi_osc_rdma_sync_t *sync, const 
                                               mca_btl_base_registration_handle_t *target_handle, ompi_op_t *op, ompi_osc_rdma_request_t *req)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = selected_btl->btl_atomic_flags;
     int btl_op, flags;
     int64_t origin;
 
-    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
-        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
+    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags) && 4 == extent)) ||
+        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & module->atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -242,13 +240,11 @@ static int ompi_osc_rdma_acc_single_atomic (ompi_osc_rdma_sync_t *sync, const vo
                                             ompi_op_t *op, ompi_osc_rdma_request_t *req)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = selected_btl->btl_atomic_flags;
     int btl_op, flags;
     int64_t origin;
 
-    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
-        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
+    if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags) && 4 == extent)) ||
+        (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & module->atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -663,13 +659,11 @@ static inline int ompi_osc_rdma_cas_atomic (ompi_osc_rdma_sync_t *sync, const vo
                                             bool lock_acquired)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    int32_t atomic_flags = btl->btl_atomic_flags;
     const size_t size = datatype->super.size;
     int64_t compare, source;
     int flags, ret;
 
-    if (8 != size && !(4 == size && (MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags))) {
+    if (8 != size && !(4 == size && (MCA_BTL_ATOMIC_SUPPORTS_32BIT & module->atomic_flags))) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
@@ -717,7 +711,6 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
                             mca_btl_base_registration_handle_t *target_handle, bool lock_acquired)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     unsigned long len = datatype->super.size;
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
@@ -742,18 +735,21 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_addr,
         return OMPI_SUCCESS;
     }
 
-    if (btl->btl_register_mem && len > btl->btl_put_local_registration_threshold) {
-        do {
-            ret = ompi_osc_rdma_frag_alloc (module, len, &frag, &ptr);
-            if (OPAL_UNLIKELY(OMPI_SUCCESS == ret)) {
-                break;
-            }
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
+        if (len > btl->btl_put_local_registration_threshold) {
+            do {
+                ret = ompi_osc_rdma_frag_alloc(module, len, &frag, &ptr);
+                if (OPAL_UNLIKELY(OMPI_SUCCESS == ret)) {
+                    break;
+                }
 
-            ompi_osc_rdma_progress (module);
-        } while (1);
+                ompi_osc_rdma_progress (module);
+            } while (1);
 
-        memcpy (ptr, source_addr, len);
-        local_handle = frag->handle;
+            memcpy(ptr, source_addr, len);
+            local_handle = frag->handle;
+        }
     }
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "RDMA compare-and-swap initiating blocking btl put...");

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -244,12 +244,6 @@ static int ompi_osc_rdma_acc_single_atomic (ompi_osc_rdma_sync_t *sync, const vo
     int btl_op, flags;
     int64_t origin;
 
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
-        /* btl put atomics not supported or disabled. fall back on fetch-and-op */
-        return ompi_osc_rdma_fetch_and_op_atomic (sync, origin_addr, NULL, dt, extent, peer, target_address, target_handle,
-                                                  op, req);
-    }
-
     if ((8 != extent && !((MCA_BTL_ATOMIC_SUPPORTS_32BIT & atomic_flags) && 4 == extent)) ||
         (!(OMPI_DATATYPE_FLAG_DATA_INT & dt->super.flags) && !(MCA_BTL_ATOMIC_SUPPORTS_FLOAT & atomic_flags)) ||
         !ompi_op_is_intrinsic (op) || (0 == ompi_osc_rdma_op_mapping[op->op_type])) {

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -19,12 +19,15 @@
  * $HEADER$
  */
 
+#include "ompi_config.h"
+
 #include "osc_rdma_accumulate.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_comm.h"
 #include "osc_rdma_lock.h"
 #include "osc_rdma_btl_comm.h"
 
+#include "opal/util/minmax.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 
@@ -583,9 +586,9 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
 
             /* determine how much to put in this operation */
             if (source_count) {
-                acc_len = min(min(target_iovec[target_iov_index].iov_len, source_iovec[source_iov_index].iov_len), acc_limit);
+                acc_len = opal_min(opal_min(target_iovec[target_iov_index].iov_len, source_iovec[source_iov_index].iov_len), acc_limit);
             } else {
-                acc_len = min(target_iovec[target_iov_index].iov_len, acc_limit);
+                acc_len = opal_min(target_iovec[target_iov_index].iov_len, acc_limit);
             }
 
             if (0 != acc_len) {

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +22,8 @@
 #include "osc_rdma_accumulate.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_comm.h"
+#include "osc_rdma_lock.h"
+#include "osc_rdma_btl_comm.h"
 
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -77,33 +77,6 @@ OBJ_CLASS_INSTANCE(ompi_osc_rdma_pending_op_t, opal_list_item_t,
                    ompi_osc_rdma_pending_op_construct,
                    ompi_osc_rdma_pending_op_destruct);
 
-/**
- * Dummy completion function for atomic operations
- */
-void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
-                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
-                                    void *context, void *data, int status)
-{
-    ompi_osc_rdma_pending_op_t *pending_op = (ompi_osc_rdma_pending_op_t *) context;
-
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "pending atomic %p complete with status %d", (void*)pending_op, status);
-
-    if (pending_op->op_result) {
-        memmove (pending_op->op_result, pending_op->op_buffer, pending_op->op_size);
-    }
-
-    if (NULL != pending_op->cbfunc) {
-        pending_op->cbfunc (pending_op->cbdata, pending_op->cbcontext, status);
-    }
-
-    if (NULL != pending_op->op_frag) {
-        ompi_osc_rdma_frag_complete (pending_op->op_frag);
-        pending_op->op_frag = NULL;
-    }
-
-    pending_op->op_complete = true;
-    OBJ_RELEASE(pending_op);
-}
 
 /**
  * compare_ranks:

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2004-2005 The Trustees of the University of Tennessee.
+ *                         All rights reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "osc_rdma.h"
+#include "osc_rdma_frag.h"
+#include "osc_rdma_btl_comm.h"
+
+#include "opal/mca/btl/base/base.h"
+
+void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
+                                    void *context, void *data, int status)
+{
+    ompi_osc_rdma_pending_op_t *pending_op = (ompi_osc_rdma_pending_op_t *) context;
+
+    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "pending atomic %p complete with status %d", (void*)pending_op, status);
+
+    if (pending_op->op_result) {
+        memmove (pending_op->op_result, pending_op->op_buffer, pending_op->op_size);
+    }
+
+    if (NULL != pending_op->cbfunc) {
+        pending_op->cbfunc (pending_op->cbdata, pending_op->cbcontext, status);
+    }
+
+    if (NULL != pending_op->op_frag) {
+        ompi_osc_rdma_frag_complete (pending_op->op_frag);
+        pending_op->op_frag = NULL;
+    }
+
+    pending_op->op_complete = true;
+    OBJ_RELEASE(pending_op);
+}

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
@@ -36,11 +36,17 @@ ompi_osc_rdma_btl_put(ompi_osc_rdma_module_t *module, uint8_t btl_index,
 		      mca_btl_base_rdma_completion_fn_t cbfunc,
 		      void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_put(btl, endpoint, local_address, remote_address,
-                        local_handle, remote_handle, size, flags, order,
-                        cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_put(btl, endpoint, local_address, remote_address,
+                            local_handle, remote_handle, size, flags, order,
+                            cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_put(am_rdma, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle, size, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -54,11 +60,18 @@ ompi_osc_rdma_btl_get(ompi_osc_rdma_module_t *module, uint8_t btl_index,
 		      mca_btl_base_rdma_completion_fn_t cbfunc,
 		      void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
 
-    return btl->btl_get(btl, endpoint, local_address, remote_address,
-                        local_handle, remote_handle, size, flags, order,
-                        cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_get(btl, endpoint, local_address, remote_address,
+                            local_handle, remote_handle, size, flags, order,
+                            cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_get(am_rdma, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle, size, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -70,6 +83,9 @@ ompi_osc_rdma_btl_atomic_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
                             mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 {
     mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+
+    /* the AM BTL interface does not currently support op calls */
+    assert(module->use_accelerated_btl);
 
     return btl->btl_atomic_op(btl, endpoint, remote_address, remote_handle,
                               op, operand, flags, order,
@@ -87,12 +103,19 @@ ompi_osc_rdma_btl_atomic_fop(ompi_osc_rdma_module_t *module, uint8_t btl_index,
                              mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_atomic_fop(btl, endpoint, local_address, remote_address,
-                               local_handle, remote_handle,
-                               op, operand, flags, order,
-                               cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_atomic_fop(btl, endpoint, local_address, remote_address,
+                                   local_handle, remote_handle,
+                                   op, operand, flags, order,
+                                   cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_atomic_fop(am_rdma, endpoint, local_address, remote_address,
+                                          local_handle, remote_handle,
+                                          op, operand, flags, order,
+                                          cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -105,12 +128,19 @@ ompi_osc_rdma_btl_atomic_cswap(ompi_osc_rdma_module_t *module, uint8_t btl_index
                                uint64_t compare, uint64_t value, int flags, int order,
                                mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
-
-    return btl->btl_atomic_cswap(btl, endpoint, local_address, remote_address,
-                                 local_handle, remote_handle,
-                                 compare, value, flags, order,
-                                 cbfunc, cbcontext, cbdata);
+    if (module->use_accelerated_btl) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        return btl->btl_atomic_cswap(btl, endpoint, local_address, remote_address,
+                                     local_handle, remote_handle,
+                                     compare, value, flags, order,
+                                     cbfunc, cbcontext, cbdata);
+    } else {
+        mca_btl_base_am_rdma_module_t *am_rdma = ompi_osc_rdma_selected_am_rdma(module, btl_index);
+        return am_rdma->am_btl_atomic_cswap(am_rdma, endpoint, local_address, remote_address,
+                                            local_handle, remote_handle,
+                                            compare, value, flags, order,
+                                            cbfunc, cbcontext, cbdata);
+    }
 }
 
 
@@ -195,7 +225,10 @@ ompi_osc_rdma_btl_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
     mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
     int ret;
 
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
+    /* if using the AM RDMA interface with alternate BTLs or if the
+       accelerated BTL does not support atomic ops, emulate the atomic
+       op over a fetch and atomic op */
+    if (!module->use_accelerated_btl || !(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
         return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
                                       NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
     }

--- a/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_btl_comm.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OSC_RDMA_BTL_COMM_H
+#define OSC_RDMA_BTL_COMM_H
+
+#include "osc_rdma_frag.h"
+
+#include "opal/mca/btl/btl.h"
+
+
+void ompi_osc_rdma_atomic_complete(mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
+                                    void *context, void *data, int status);
+
+
+static inline int
+ompi_osc_rdma_btl_fop(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+		      struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+		      mca_btl_base_registration_handle_t *address_handle, int op,
+		      int64_t operand, int flags, int64_t *result, const bool wait_for_completion,
+		      ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret = OPAL_ERROR;
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+
+    if (!wait_for_completion) {
+        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
+        pending_op->module = module;
+        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
+    }
+
+    pending_op->op_result = (void *) result;
+    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
+    OBJ_RETAIN(pending_op);
+    if (cbfunc) {
+        pending_op->cbfunc = cbfunc;
+        pending_op->cbdata = cbdata;
+        pending_op->cbcontext = cbcontext;
+    }
+
+    /* spin until the btl has accepted the operation */
+    do {
+        if (NULL == pending_op->op_frag) {
+            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
+        }
+
+        if (NULL != pending_op->op_frag) {
+            ret = selected_btl->btl_atomic_fop (selected_btl, endpoint, pending_op->op_buffer,
+                                                (intptr_t) address, pending_op->op_frag->handle, address_handle,
+                                                op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
+                                                (void *) pending_op, NULL);
+        }
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        if (OPAL_LIKELY(1 == ret)) {
+            *result = ((int64_t *) pending_op->op_buffer)[0];
+            ret = OMPI_SUCCESS;
+            ompi_osc_rdma_atomic_complete (selected_btl, endpoint, pending_op->op_buffer,
+                                           pending_op->op_frag->handle, (void *) pending_op, NULL, OPAL_SUCCESS);
+        } else {
+            /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+            OBJ_RELEASE(pending_op);
+        }
+    } else if (wait_for_completion) {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+
+static inline int
+ompi_osc_rdma_btl_op(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+		     struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+		     mca_btl_base_registration_handle_t *address_handle,
+		     int op, int64_t operand, int flags, const bool wait_for_completion,
+		     ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret;
+
+    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
+        return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
+                                      NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
+    }
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+    OBJ_RETAIN(pending_op);
+    if (cbfunc) {
+        pending_op->cbfunc = cbfunc;
+        pending_op->cbdata = cbdata;
+        pending_op->cbcontext = cbcontext;
+    }
+
+    if (!wait_for_completion) {
+        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
+        pending_op->module = module;
+        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
+    }
+
+    /* spin until the btl has accepted the operation */
+    do {
+        ret = selected_btl->btl_atomic_op (selected_btl, endpoint, (intptr_t) address, address_handle,
+                                           op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
+                                           (void *) pending_op, NULL);
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+        OBJ_RELEASE(pending_op);
+        if (OPAL_LIKELY(1 == ret)) {
+            if (cbfunc) {
+                cbfunc (cbdata, cbcontext, OMPI_SUCCESS);
+            }
+            ret = OMPI_SUCCESS;
+        }
+    } else if (wait_for_completion) {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+
+static inline int
+ompi_osc_rdma_btl_cswap(ompi_osc_rdma_module_t *module, uint8_t btl_index,
+			struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
+			mca_btl_base_registration_handle_t *address_handle,
+			int64_t compare, int64_t value, int flags, int64_t *result)
+{
+    ompi_osc_rdma_pending_op_t *pending_op;
+    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
+    int ret;
+
+    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
+    assert (NULL != pending_op);
+
+    OBJ_RETAIN(pending_op);
+
+    pending_op->op_result = (void *) result;
+    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
+
+    /* spin until the btl has accepted the operation */
+    do {
+        if (NULL == pending_op->op_frag) {
+            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
+        }
+        if (NULL != pending_op->op_frag) {
+            ret = selected_btl->btl_atomic_cswap (selected_btl, endpoint, pending_op->op_buffer,
+                                                  address, pending_op->op_frag->handle, address_handle, compare,
+                                                  value, flags, 0, ompi_osc_rdma_atomic_complete, (void *) pending_op,
+                                                  NULL);
+        }
+
+        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
+            break;
+        }
+        ompi_osc_rdma_progress (module);
+    } while (1);
+
+    if (OPAL_SUCCESS != ret) {
+        if (OPAL_LIKELY(1 == ret)) {
+            *result = ((int64_t *) pending_op->op_buffer)[0];
+            ret = OMPI_SUCCESS;
+        }
+
+        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
+        OBJ_RELEASE(pending_op);
+    } else {
+        while (!pending_op->op_complete) {
+            ompi_osc_rdma_progress (module);
+        }
+    }
+
+    OBJ_RELEASE(pending_op);
+
+    return ret;
+}
+
+#endif /* OSC_RDMA_BTL_COMM_H */

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,6 +16,7 @@
  */
 
 #include "osc_rdma_comm.h"
+#include "osc_rdma_frag.h"
 #include "osc_rdma_sync.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_dynamic.h"

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -65,8 +65,7 @@ int ompi_osc_get_data_blocking (ompi_osc_rdma_module_t *module, uint8_t btl_inde
                                 struct mca_btl_base_endpoint_t *endpoint, uint64_t source_address,
                                 mca_btl_base_registration_handle_t *source_handle, void *data, size_t len)
 {
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    const size_t btl_alignment_mask = ALIGNMENT_MASK(btl->btl_get_alignment);
+    const size_t btl_alignment_mask = ALIGNMENT_MASK(module->get_alignment);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
     volatile bool read_complete = false;
@@ -82,25 +81,28 @@ int ompi_osc_get_data_blocking (ompi_osc_rdma_module_t *module, uint8_t btl_inde
                      "), len: %lu (aligned: %lu)", (void *) endpoint, source_address, aligned_addr, (unsigned long) len,
                      (unsigned long) aligned_len);
 
-    if (btl->btl_register_mem && len >= btl->btl_get_local_registration_threshold) {
-        do {
-            ret = ompi_osc_rdma_frag_alloc (module, aligned_len, &frag, &ptr);
-            if (OPAL_UNLIKELY(OMPI_ERR_OUT_OF_RESOURCE == ret)) {
-                ompi_osc_rdma_progress (module);
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, btl_index);
+        if (len >= btl->btl_get_local_registration_threshold) {
+            do {
+                ret = ompi_osc_rdma_frag_alloc(module, aligned_len, &frag, &ptr);
+                if (OPAL_UNLIKELY(OMPI_ERR_OUT_OF_RESOURCE == ret)) {
+                    ompi_osc_rdma_progress(module);
+                }
+            } while (OMPI_ERR_OUT_OF_RESOURCE == ret);
+
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "error allocating temporary buffer");
+                return ret;
             }
-        } while (OMPI_ERR_OUT_OF_RESOURCE == ret);
 
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "error allocating temporary buffer");
-            return ret;
+            local_handle = frag->handle;
+            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocated temporary buffer %p in fragment %p", (void*)ptr,
+                             (void *) frag);
         }
-
-        local_handle = frag->handle;
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocated temporary buffer %p in fragment %p", (void*)ptr,
-                         (void *) frag);
     }
 
-    assert (!(source_address & ALIGNMENT_MASK(btl->btl_get_alignment)));
+    assert (!(source_address & ALIGNMENT_MASK(module->get_alignment)));
 
     do {
         ret = ompi_osc_rdma_btl_get(module, btl_index, endpoint, ptr, aligned_addr,
@@ -487,7 +489,6 @@ int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *
                               ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     mca_btl_base_rdma_completion_fn_t cbfunc = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
@@ -495,16 +496,19 @@ int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *
     void *cbcontext;
     int ret;
 
-    if (btl->btl_register_mem && size > btl->btl_put_local_registration_threshold) {
-        ret = ompi_osc_rdma_frag_alloc (module, size, &frag, &ptr);
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            ret = ompi_osc_rdma_register (module, peer->data_endpoint, source_buffer, size, 0, &local_handle);
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, peer->data_btl_index);
+        if (size > btl->btl_put_local_registration_threshold) {
+            ret = ompi_osc_rdma_frag_alloc(module, size, &frag, &ptr);
             if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                return ret;
+                ret = ompi_osc_rdma_register(module, peer->data_endpoint, source_buffer, size, 0, &local_handle);
+                if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                    return ret;
+                }
+            } else {
+                memcpy(ptr, source_buffer, size);
+                local_handle = frag->handle;
             }
-        } else {
-            memcpy (ptr, source_buffer, size);
-            local_handle = frag->handle;
         }
     }
 
@@ -606,8 +610,7 @@ static int ompi_osc_rdma_get_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_p
                                      ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
-    const size_t btl_alignment_mask = ALIGNMENT_MASK(btl->btl_get_alignment);
+    const size_t btl_alignment_mask = ALIGNMENT_MASK(module->get_alignment);
     mca_btl_base_registration_handle_t *local_handle = NULL;
     ompi_osc_rdma_frag_t *frag = NULL;
     osc_rdma_size_t aligned_len;
@@ -623,70 +626,73 @@ static int ompi_osc_rdma_get_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_p
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "initiating get of %lu bytes from remote ptr %" PRIx64 " to local ptr %p",
                      size, source_address, target_buffer);
 
-    if ((btl->btl_register_mem && size > btl->btl_get_local_registration_threshold) ||
-        (((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
+    if (module->use_memory_registration) {
+        mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl(module, peer->data_btl_index);
+        if (size > btl->btl_get_local_registration_threshold ||
+            (((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
 
-        ret = ompi_osc_rdma_frag_alloc (module, aligned_len, &frag, &ptr);
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            if (OMPI_ERR_VALUE_OUT_OF_BOUNDS == ret) {
-                /* region is too large for a buffered read */
-                size_t subsize;
+            ret = ompi_osc_rdma_frag_alloc(module, aligned_len, &frag, &ptr);
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                if (OMPI_ERR_VALUE_OUT_OF_BOUNDS == ret) {
+                    /* region is too large for a buffered read */
+                    size_t subsize;
 
-                if ((source_address & btl_alignment_mask) && (source_address & btl_alignment_mask) == ((intptr_t) target_buffer & btl_alignment_mask)) {
-                    /* remote region has the same alignment but the base is not aligned. perform a small
-                     * buffered get of the beginning of the remote region */
-                    aligned_source_base = OPAL_ALIGN(source_address, btl->btl_get_alignment, osc_rdma_base_t);
-                    subsize = (size_t) (aligned_source_base - source_address);
+                    if ((source_address & btl_alignment_mask) && (source_address & btl_alignment_mask) == ((intptr_t) target_buffer & btl_alignment_mask)) {
+                        /* remote region has the same alignment but the base is not aligned. perform a small
+                         * buffered get of the beginning of the remote region */
+                        aligned_source_base = OPAL_ALIGN(source_address, btl->btl_get_alignment, osc_rdma_base_t);
+                        subsize = (size_t) (aligned_source_base - source_address);
 
-                    ret = ompi_osc_rdma_get_partial (sync, peer, source_address, source_handle, target_buffer, subsize, request);
-                    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                        return ret;
+                        ret = ompi_osc_rdma_get_partial(sync, peer, source_address, source_handle, target_buffer, subsize, request);
+                        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                            return ret;
+                        }
+
+                        source_address += subsize;
+                        target_buffer = (void *) ((intptr_t) target_buffer + subsize);
+                        size -= subsize;
+
+                        aligned_len = aligned_source_bound - aligned_source_base;
                     }
 
-                    source_address += subsize;
-                    target_buffer = (void *) ((intptr_t) target_buffer + subsize);
-                    size -= subsize;
-
-                    aligned_len = aligned_source_bound - aligned_source_base;
-                }
-
-                if (!(((uint64_t) target_buffer | source_address) & btl_alignment_mask) &&
-                    (size & btl_alignment_mask)) {
-                    /* remote region bases are aligned but the bounds are not. perform a
-                     * small buffered get of the end of the remote region */
-                    aligned_len = size & ~btl_alignment_mask;
-                    subsize = size - aligned_len;
-                    size = aligned_len;
-                    ret = ompi_osc_rdma_get_partial (sync, peer, source_address + aligned_len, source_handle,
-                                                     (void *) ((intptr_t) target_buffer + aligned_len), subsize, request);
-                    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                        return ret;
+                    if (!(((uint64_t) target_buffer | source_address) & btl_alignment_mask) &&
+                        (size & btl_alignment_mask)) {
+                        /* remote region bases are aligned but the bounds are not. perform a
+                         * small buffered get of the end of the remote region */
+                        aligned_len = size & ~btl_alignment_mask;
+                        subsize = size - aligned_len;
+                        size = aligned_len;
+                        ret = ompi_osc_rdma_get_partial(sync, peer, source_address + aligned_len, source_handle,
+                                                        (void *) ((intptr_t) target_buffer + aligned_len), subsize, request);
+                        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                            return ret;
+                        }
                     }
+                    /* (remaining) user request is now correctly aligned */
                 }
-                /* (remaining) user request is now correctly aligned */
-            }
 
-            if ((((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
-                /* local and remote alignments differ */
-                request->buffer = ptr = malloc (aligned_len);
+                if ((((uint64_t) target_buffer | size | source_address) & btl_alignment_mask)) {
+                    /* local and remote alignments differ */
+                    request->buffer = ptr = malloc(aligned_len);
+                } else {
+                    ptr = target_buffer;
+                }
+
+                if (NULL != ptr) {
+                    (void)ompi_osc_rdma_register(module, peer->data_endpoint, ptr, aligned_len, MCA_BTL_REG_FLAG_LOCAL_WRITE,
+                                                 &local_handle);
+                }
+
+                if (OPAL_UNLIKELY(NULL == local_handle)) {
+                    free(request->buffer);
+                    request->buffer = NULL;
+                    return ret;
+                }
             } else {
-                ptr = target_buffer;
+                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "using internal buffer %p in fragment %p for get of size %lu bytes, source address 0x%lx",
+                                 (void*)ptr, (void *) frag, (unsigned long) aligned_len, (unsigned long) aligned_source_base);
+                local_handle = frag->handle;
             }
-
-            if (NULL != ptr) {
-                (void) ompi_osc_rdma_register (module, peer->data_endpoint, ptr, aligned_len, MCA_BTL_REG_FLAG_LOCAL_WRITE,
-                                               &local_handle);
-            }
-
-            if (OPAL_UNLIKELY(NULL == local_handle)) {
-                free (request->buffer);
-                request->buffer = NULL;
-                return ret;
-            }
-        } else {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "using internal buffer %p in fragment %p for get of size %lu bytes, source address 0x%lx",
-                             (void*)ptr, (void *) frag, (unsigned long) aligned_len, (unsigned long) aligned_source_base);
-            local_handle = frag->handle;
         }
     }
 
@@ -742,7 +748,6 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
                                            ompi_datatype_t *target_datatype, ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *target_handle;
     uint64_t target_address;
     int ret;
@@ -777,7 +782,7 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
 
     return ompi_osc_rdma_master (sync, (void *) origin_addr, origin_count, origin_datatype, peer,
                                  target_address, target_handle, target_count, target_datatype, request,
-                                 btl->btl_put_limit, ompi_osc_rdma_put_contig, false);
+                                 module->put_limit, ompi_osc_rdma_put_contig, false);
 }
 
 static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *origin_addr, int origin_count, ompi_datatype_t *origin_datatype,
@@ -785,7 +790,6 @@ static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *ori
                                            ompi_datatype_t *source_datatype, ompi_osc_rdma_request_t *request)
 {
     ompi_osc_rdma_module_t *module = sync->module;
-    mca_btl_base_module_t *btl = ompi_osc_rdma_selected_btl (module, peer->data_btl_index);
     mca_btl_base_registration_handle_t *source_handle;
     uint64_t source_address;
     ptrdiff_t source_span, source_lb;
@@ -818,7 +822,7 @@ static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *ori
 
     return ompi_osc_rdma_master (sync, origin_addr, origin_count, origin_datatype, peer, source_address,
                                  source_handle, source_count, source_datatype, request,
-                                 btl->btl_get_limit, ompi_osc_rdma_get_contig, true);
+                                 module->get_limit, ompi_osc_rdma_get_contig, true);
 }
 int ompi_osc_rdma_put (const void *origin_addr, int origin_count, ompi_datatype_t *origin_datatype,
                        int target_rank, ptrdiff_t target_disp, int target_count,

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -15,6 +15,8 @@
  * $HEADER$
  */
 
+#include "ompi_config.h"
+
 #include "osc_rdma_comm.h"
 #include "osc_rdma_frag.h"
 #include "osc_rdma_sync.h"
@@ -22,8 +24,9 @@
 #include "osc_rdma_dynamic.h"
 #include "osc_rdma_btl_comm.h"
 
-#include "ompi/mca/osc/base/osc_base_obj_convert.h"
 #include "opal/align.h"
+#include "opal/util/minmax.h"
+#include "ompi/mca/osc/base/osc_base_obj_convert.h"
 
 /* helper functions */
 static inline void ompi_osc_rdma_cleanup_rdma (ompi_osc_rdma_sync_t *sync, bool dec_always, ompi_osc_rdma_frag_t *frag,
@@ -246,7 +249,7 @@ static int ompi_osc_rdma_master_noncontig (ompi_osc_rdma_sync_t *sync, void *loc
             assert (0 != local_iov_count);
 
             /* determine how much to transfer in this operation */
-            rdma_len = min(min(local_iovec[local_iov_index].iov_len, remote_iovec[remote_iov_index].iov_len), max_rdma_len);
+            rdma_len = opal_min(opal_min(local_iovec[local_iov_index].iov_len, remote_iovec[remote_iov_index].iov_len), max_rdma_len);
 
             /* execute the get */
             if (!subreq && alloc_reqs) {

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -398,7 +398,7 @@ static void ompi_osc_rdma_put_complete (struct mca_btl_base_module_t *btl, struc
 
     /* the lowest bit is used as a flag indicating this put operation has a request */
     if ((intptr_t) context & 0x1) {
-        ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
+        ompi_osc_rdma_request_t *request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         sync = request->sync;
 
         if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {
@@ -429,7 +429,7 @@ static void ompi_osc_rdma_put_complete_flush (struct mca_btl_base_module_t *btl,
 
     /* the lowest bit is used as a flag indicating this put operation has a request */
     if ((intptr_t) context & 0x1) {
-        ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
+        ompi_osc_rdma_request_t *request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         module = request->module;
 
         if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {

--- a/ompi/mca/osc/rdma/osc_rdma_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.h
@@ -22,7 +22,6 @@
 
 #define OMPI_OSC_RDMA_DECODE_MAX 64
 
-#define min(a,b) ((a) < (b) ? (a) : (b))
 #define ALIGNMENT_MASK(x) ((x) ? (x) - 1 : 0)
 
 /**

--- a/ompi/mca/osc/rdma/osc_rdma_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.h
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +19,6 @@
 #include "osc_rdma_dynamic.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_sync.h"
-#include "osc_rdma_lock.h"
 
 #define OMPI_OSC_RDMA_DECODE_MAX 64
 

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -376,7 +376,7 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
 {
 
     if (MPI_WIN_FLAVOR_SHARED == flavor) {
-        return OMPI_ERR_RMA_SHARED;
+        return -1;
     }
 
 #if OPAL_CUDA_SUPPORT

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -374,7 +374,6 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
                                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                                           int flavor)
 {
-
     if (MPI_WIN_FLAVOR_SHARED == flavor) {
         return -1;
     }
@@ -395,7 +394,7 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
         return -1;
     }
 
-    return OMPI_SUCCESS;;
+    return mca_osc_rdma_component.priority;
 }
 
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -231,7 +231,7 @@ static int ompi_osc_rdma_component_register (void)
                                            MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.max_attach);
     free(description_str);
 
-    mca_osc_rdma_component.priority = 101;
+    mca_osc_rdma_component.priority = 20;
     opal_asprintf(&description_str, "Priority of the osc/rdma component (default: %d)",
              mca_osc_rdma_component.priority);
     (void) mca_base_component_var_register (&mca_osc_rdma_component.super.osc_version, "priority", description_str,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -442,7 +442,8 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
     int ret, my_rank;
     size_t memory_alignment = module->memory_alignment;
 
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocating private internal state");
+    opal_output_verbose(MCA_BASE_VERBOSE_TRACE, ompi_osc_base_framework.framework_output,
+                        "allocating private internal state");
 
     my_rank = ompi_comm_rank (module->comm);
 
@@ -598,7 +599,8 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
         return allocate_state_single (module, base, size);
     }
 
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "allocating shared internal state");
+    opal_output_verbose(MCA_BASE_VERBOSE_TRACE, ompi_osc_base_framework.framework_output,
+                        "allocating shared internal state");
 
     local_rank_array_size = sizeof (ompi_osc_rdma_rank_data_t) * RANK_ARRAY_COUNT (module);
     leader_peer_data_size = module->region_size * module->node_count;
@@ -654,7 +656,8 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
                 ret = opal_shmem_segment_create (&module->seg_ds, data_file, total_size);
                 free (data_file);
                 if (OPAL_SUCCESS != ret) {
-                    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to create shared memory segment");
+                    opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                                        "failed to create shared memory segment");
                 }
             }
         }
@@ -672,7 +675,8 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
         module->segment_base = opal_shmem_segment_attach (&module->seg_ds);
         if (NULL == module->segment_base) {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to attach to the shared memory segment");
+            opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                                "failed to attach to the shared memory segment");
             ret = OPAL_ERROR;
         }
 
@@ -898,7 +902,8 @@ static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_o
 
     btls_to_use = opal_argv_split (ompi_osc_rdma_btl_alternate_names, ',');
     if (NULL == btls_to_use) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "no alternate BTLs requested: %s", ompi_osc_rdma_btl_alternate_names);
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                            "no alternate BTLs requested: %s", ompi_osc_rdma_btl_alternate_names);
         return OMPI_ERR_UNREACH;
     }
 
@@ -908,20 +913,24 @@ static int ompi_osc_rdma_query_alternate_btls (ompi_communicator_t *comm, ompi_o
 
     /* rdma and atomics are only supported with BTLs at the moment */
     for (int i = 0 ; btls_to_use[i] ; ++i) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "checking for btl %s", btls_to_use[i]);
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                            "checking for btl %s", btls_to_use[i]);
         OPAL_LIST_FOREACH(item, &mca_btl_base_modules_initialized, mca_btl_base_selected_module_t) {
             if (NULL != item->btl_module->btl_register_mem) { 
-                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "skipping RDMA btl when searching for alternate BTL");
+                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                                    "skipping RDMA btl when searching for alternate BTL");
                 continue;
             }
 
             if (0 != strcmp (btls_to_use[i], item->btl_module->btl_component->btl_version.mca_component_name)) {
-                OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "skipping btl %s",
-                                 item->btl_module->btl_component->btl_version.mca_component_name);
+                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                                    "skipping btl %s",
+                                    item->btl_module->btl_component->btl_version.mca_component_name);
                 continue;
             }
 
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "found alternate btl %s", btls_to_use[i]);
+            opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                                "found alternate btl %s", btls_to_use[i]);
 
             ++btls_found;
             if (module) {
@@ -1089,7 +1098,8 @@ static int ompi_osc_rdma_query_accelerated_btls (ompi_communicator_t *comm, ompi
     }
 
     if (NULL == selected_btl) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "no suitable btls found");
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                            "accelerated_query: no suitable btls found");
         return OMPI_ERR_NOT_AVAILABLE;
     }
 
@@ -1100,8 +1110,9 @@ btl_selection_complete:
         module->use_memory_registration = selected_btl->btl_register_mem != NULL;
     }
 
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "selected btl: %s",
-                     selected_btl->btl_component->btl_version.mca_component_name);
+    opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                        "accelerated_query: selected btl: %s",
+                        selected_btl->btl_component->btl_version.mca_component_name);
 
     return OMPI_SUCCESS;
 }
@@ -1150,7 +1161,8 @@ static int ompi_osc_rdma_share_data (ompi_osc_rdma_module_t *module)
                                                                     module->region_size, MPI_BYTE, module->local_leaders,
                                                                     module->local_leaders->c_coll->coll_allgather_module);
                 if (OMPI_SUCCESS != ret) {
-                    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "leader allgather failed with ompi error code %d", ret);
+                    opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                                        "leader allgather failed with ompi error code %d", ret);
                     break;
                 }
             }
@@ -1193,7 +1205,8 @@ static int ompi_osc_rdma_create_groups (ompi_osc_rdma_module_t *module)
     /* create a shared communicator to handle communication about the local segment */
     ret = ompi_comm_split_type (module->comm, MPI_COMM_TYPE_SHARED, 0, NULL, &module->shared_comm);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to create a shared memory communicator. error code %d", ret);
+        opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                            "failed to create a shared memory communicator. error code %d", ret);
         return ret;
     }
 
@@ -1204,7 +1217,8 @@ static int ompi_osc_rdma_create_groups (ompi_osc_rdma_module_t *module)
     ret = ompi_comm_split (module->comm, (0 == local_rank) ? 0 : MPI_UNDEFINED, comm_rank, &module->local_leaders,
                            false);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to create local leaders communicator. error code %d", ret);
+        opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                            "failed to create local leaders communicator. error code %d", ret);
         return ret;
     }
 
@@ -1217,7 +1231,8 @@ static int ompi_osc_rdma_create_groups (ompi_osc_rdma_module_t *module)
         ret = module->shared_comm->c_coll->coll_bcast (values, 2, MPI_INT, 0, module->shared_comm,
                                                       module->shared_comm->c_coll->coll_bcast_module);
         if (OMPI_SUCCESS != ret) {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to broadcast local data. error code %d", ret);
+            opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                                "failed to broadcast local data. error code %d", ret);
             return ret;
         }
     }
@@ -1350,8 +1365,9 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
         return ret;
     }
 
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "creating osc/rdma window of flavor %d with id %d",
-                     flavor, ompi_comm_get_cid(module->comm));
+    opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                        "creating osc/rdma window of flavor %d with id %d",
+                        flavor, ompi_comm_get_cid(module->comm));
 
     /* peer data */
     if (world_size > init_limit) {
@@ -1372,11 +1388,13 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     /* find rdma capable endpoints */
     ret = ompi_osc_rdma_query_accelerated_btls (module->comm, module);
     if (OMPI_SUCCESS != ret) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_WARN, "could not find a suitable btl. falling back on "
-                         "active-message BTLs");
+        opal_output_verbose(MCA_BASE_VERBOSE_WARN, ompi_osc_base_framework.framework_output,
+                            "could not find an accelerated btl. falling back on "
+                            "active-message BTLs");
         ret = ompi_osc_rdma_query_alternate_btls (module->comm, module);
         if (OMPI_SUCCESS != ret) {
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_WARN, "no BTL available for RMA window");
+            opal_output_verbose(MCA_BASE_VERBOSE_WARN, ompi_osc_base_framework.framework_output,
+                                "no BTL available for RMA window");
             ompi_osc_rdma_free (win);
             return ret;
         }
@@ -1428,7 +1446,8 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     /* notify all others if something went wrong */
     ret = synchronize_errorcode(ret, module->comm);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to allocate internal state");
+        opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                            "failed to allocate internal state");
         ompi_osc_rdma_free (win);
         return ret;
     }
@@ -1479,14 +1498,16 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
 
     ret = ompi_osc_rdma_share_data (module);
     if (OMPI_SUCCESS != ret) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_ERROR, "failed to share window data with peers");
+        opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_osc_base_framework.framework_output,
+                            "failed to share window data with peers");
         ompi_osc_rdma_free (win);
     } else {
         /* for now the leader is always rank 0 in the communicator */
         module->leader = ompi_osc_rdma_module_peer (module, 0);
 
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "finished creating osc/rdma window with id %d",
-                         ompi_comm_get_cid(module->comm));
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_osc_base_framework.framework_output,
+                            "finished creating osc/rdma window with id %d",
+                            ompi_comm_get_cid(module->comm));
     }
 
     return ret;

--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -252,7 +252,8 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
             return OMPI_ERR_RMA_ATTACH;
         }
 
-        memcpy (region->btl_handle_data, handle, module->selected_btls[0]->btl_registration_handle_size);
+        assert(module->use_accelerated_btl);
+        memcpy(region->btl_handle_data, handle, module->accelerated_btl->btl_registration_handle_size);
         rdma_region_handle->btl_handle = handle;
     } else {
         rdma_region_handle->btl_handle = NULL;

--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -5,6 +5,8 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +19,7 @@
 
 #include "osc_rdma_types.h"
 #include "osc_rdma_frag.h"
+#include "osc_rdma_btl_comm.h"
 
 static inline int ompi_osc_rdma_trylock_local (ompi_osc_rdma_atomic_lock_t *lock)
 {
@@ -29,82 +32,6 @@ static inline void ompi_osc_rdma_unlock_local (ompi_osc_rdma_atomic_lock_t *lock
     (void) ompi_osc_rdma_lock_add (lock, -OMPI_OSC_RDMA_LOCK_EXCLUSIVE);
 }
 
-/**
- * Dummy completion function for atomic operations
- */
-void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
-                                    void *local_address, mca_btl_base_registration_handle_t *local_handle,
-                                    void *context, void *data, int status);
-
-__opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_fop (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                         struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                         mca_btl_base_registration_handle_t *address_handle, int op,
-                                         int64_t operand, int flags, int64_t *result, const bool wait_for_completion,
-                                         ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret = OPAL_ERROR;
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-
-    if (!wait_for_completion) {
-        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
-        pending_op->module = module;
-        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
-    }
-
-    pending_op->op_result = (void *) result;
-    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
-    OBJ_RETAIN(pending_op);
-    if (cbfunc) {
-        pending_op->cbfunc = cbfunc;
-        pending_op->cbdata = cbdata;
-        pending_op->cbcontext = cbcontext;
-    }
-
-    /* spin until the btl has accepted the operation */
-    do {
-        if (NULL == pending_op->op_frag) {
-            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
-        }
-
-        if (NULL != pending_op->op_frag) {
-            ret = selected_btl->btl_atomic_fop (selected_btl, endpoint, pending_op->op_buffer,
-                                                (intptr_t) address, pending_op->op_frag->handle, address_handle,
-                                                op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
-                                                (void *) pending_op, NULL);
-        }
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        if (OPAL_LIKELY(1 == ret)) {
-            *result = ((int64_t *) pending_op->op_buffer)[0];
-            ret = OMPI_SUCCESS;
-            ompi_osc_rdma_atomic_complete (selected_btl, endpoint, pending_op->op_buffer,
-                                           pending_op->op_frag->handle, (void *) pending_op, NULL, OPAL_SUCCESS);
-        } else {
-            /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-            OBJ_RELEASE(pending_op);
-        }
-    } else if (wait_for_completion) {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
-}
-
 __opal_attribute_always_inline__
 static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer, uint64_t address,
                                               int op, ompi_osc_rdma_lock_t operand, ompi_osc_rdma_lock_t *result,
@@ -115,129 +42,11 @@ static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, om
 }
 
 __opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_op (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                        struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                        mca_btl_base_registration_handle_t *address_handle,
-                                        int op, int64_t operand, int flags, const bool wait_for_completion,
-                                        ompi_osc_rdma_pending_op_cb_fn_t cbfunc, void *cbdata, void *cbcontext)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret;
-
-    if (!(selected_btl->btl_flags & MCA_BTL_FLAGS_ATOMIC_OPS)) {
-        return ompi_osc_rdma_btl_fop (module, btl_index, endpoint, address, address_handle, op, operand, flags,
-                                      NULL, wait_for_completion, cbfunc, cbdata, cbcontext);
-    }
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-    OBJ_RETAIN(pending_op);
-    if (cbfunc) {
-        pending_op->cbfunc = cbfunc;
-        pending_op->cbdata = cbdata;
-        pending_op->cbcontext = cbcontext;
-    }
-
-    if (!wait_for_completion) {
-        /* NTH: need to keep track of pending ops to avoid a potential teardown problem */
-        pending_op->module = module;
-        (void) opal_atomic_fetch_add_32 (&module->pending_ops, 1);
-    }
-
-    /* spin until the btl has accepted the operation */
-    do {
-        ret = selected_btl->btl_atomic_op (selected_btl, endpoint, (intptr_t) address, address_handle,
-                                           op, operand, flags, MCA_BTL_NO_ORDER, ompi_osc_rdma_atomic_complete,
-                                           (void *) pending_op, NULL);
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-        OBJ_RELEASE(pending_op);
-        if (OPAL_LIKELY(1 == ret)) {
-            if (cbfunc) {
-                cbfunc (cbdata, cbcontext, OMPI_SUCCESS);
-            }
-            ret = OMPI_SUCCESS;
-        }
-    } else if (wait_for_completion) {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
-}
-
-__opal_attribute_always_inline__
 static inline int ompi_osc_rdma_lock_btl_op (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer, uint64_t address,
                                              int op, ompi_osc_rdma_lock_t operand, const bool wait_for_completion)
 {
     return ompi_osc_rdma_btl_op (module, peer->state_btl_index, peer->state_endpoint, address, peer->state_handle, op,
                                  operand, 0, wait_for_completion, NULL, NULL, NULL);
-}
-
-__opal_attribute_always_inline__
-static inline int ompi_osc_rdma_btl_cswap (ompi_osc_rdma_module_t *module, uint8_t btl_index,
-                                           struct mca_btl_base_endpoint_t *endpoint, uint64_t address,
-                                           mca_btl_base_registration_handle_t *address_handle,
-                                           int64_t compare, int64_t value, int flags, int64_t *result)
-{
-    ompi_osc_rdma_pending_op_t *pending_op;
-    mca_btl_base_module_t *selected_btl = ompi_osc_rdma_selected_btl (module, btl_index);
-    int ret;
-
-    pending_op = OBJ_NEW(ompi_osc_rdma_pending_op_t);
-    assert (NULL != pending_op);
-
-    OBJ_RETAIN(pending_op);
-
-    pending_op->op_result = (void *) result;
-    pending_op->op_size = (MCA_BTL_ATOMIC_FLAG_32BIT & flags) ? 4 : 8;
-
-    /* spin until the btl has accepted the operation */
-    do {
-        if (NULL == pending_op->op_frag) {
-            ret = ompi_osc_rdma_frag_alloc (module, 8, &pending_op->op_frag, (char **) &pending_op->op_buffer);
-        }
-        if (NULL != pending_op->op_frag) {
-            ret = selected_btl->btl_atomic_cswap (selected_btl, endpoint, pending_op->op_buffer,
-                                                  address, pending_op->op_frag->handle, address_handle, compare,
-                                                  value, flags, 0, ompi_osc_rdma_atomic_complete, (void *) pending_op,
-                                                  NULL);
-        }
-
-        if (OPAL_LIKELY(!ompi_osc_rdma_oor(ret))) {
-            break;
-        }
-        ompi_osc_rdma_progress (module);
-    } while (1);
-
-    if (OPAL_SUCCESS != ret) {
-        if (OPAL_LIKELY(1 == ret)) {
-            *result = ((int64_t *) pending_op->op_buffer)[0];
-            ret = OMPI_SUCCESS;
-        }
-
-        /* need to release here because ompi_osc_rdma_atomic_complete was not called */
-        OBJ_RELEASE(pending_op);
-    } else {
-        while (!pending_op->op_complete) {
-            ompi_osc_rdma_progress (module);
-        }
-    }
-
-    OBJ_RELEASE(pending_op);
-
-    return ret;
 }
 
 __opal_attribute_always_inline__

--- a/ompi/mca/osc/rdma/osc_rdma_module.c
+++ b/ompi/mca/osc/rdma/osc_rdma_module.c
@@ -145,7 +145,10 @@ int ompi_osc_rdma_free(ompi_win_t *win)
     mca_mpool_base_default_module->mpool_free(mca_mpool_base_default_module,
                                               module->free_after);
     if (!module->use_accelerated_btl) {
-        free(module->alternate_btls);
+        for (int i = 0 ; i < module->alternate_btl_count ; ++i) {
+            OBJ_RELEASE(module->alternate_am_rdmas[i]);
+        }
+        free(module->alternate_am_rdmas);
     }
     free (module);
 

--- a/ompi/mca/osc/rdma/osc_rdma_module.c
+++ b/ompi/mca/osc/rdma/osc_rdma_module.c
@@ -144,7 +144,9 @@ int ompi_osc_rdma_free(ompi_win_t *win)
     free (module->outstanding_lock_array);
     mca_mpool_base_default_module->mpool_free(mca_mpool_base_default_module,
                                               module->free_after);
-    free (module->selected_btls);
+    if (!module->use_accelerated_btl) {
+        free(module->alternate_btls);
+    }
     free (module);
 
     return OMPI_SUCCESS;

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -53,6 +53,9 @@ typedef struct ompi_osc_sm_node_state_t ompi_osc_sm_node_state_t;
 struct ompi_osc_sm_component_t {
     ompi_osc_base_component_t super;
 
+    /** Priority of the osc/sm component */
+    unsigned int priority;
+
     char *backing_directory;
 };
 typedef struct ompi_osc_sm_component_t ompi_osc_sm_component_t;

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -115,6 +115,8 @@ ompi_osc_sm_module_t ompi_osc_sm_module_template = {
 
 static int component_register (void)
 {
+    char *description_str;
+
     if (0 == access ("/dev/shm", W_OK)) {
         mca_osc_sm_component.backing_directory = "/dev/shm";
     } else {
@@ -127,6 +129,16 @@ static int component_register (void)
                                             "/dev/shm (default: (linux) /dev/shm, (others) session directory)",
                                             MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
                                             MCA_BASE_VAR_SCOPE_READONLY, &mca_osc_sm_component.backing_directory);
+
+    mca_osc_sm_component.priority = 100;
+    opal_asprintf(&description_str, "Priority of the osc/sm component (default: %d)",
+                  mca_osc_sm_component.priority);
+    (void)mca_base_component_var_register(&mca_osc_sm_component.super.osc_version,
+                                          "priority", description_str,
+                                          MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
+                                          OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_GROUP,
+                                          &mca_osc_sm_component.priority);
+    free(description_str);
 
     return OPAL_SUCCESS;
 }
@@ -183,7 +195,7 @@ component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
         return ret;
     }
 
-    return 100;
+    return mca_osc_sm_component.priority;
 }
 
 

--- a/opal/class/opal_cstring.h
+++ b/opal/class/opal_cstring.h
@@ -43,7 +43,6 @@
 #ifndef OPAL_STRING_H
 #define OPAL_STRING_H
 
-#include "opal_config.h"
 #include "opal/class/opal_object.h"
 #include "opal/mca/base/mca_base_var_enum.h"
 

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -701,7 +701,7 @@ static int am_rdma_target_put(mca_btl_base_module_t *btl,
             (struct mca_btl_base_registration_handle_t *) (*operation)->local_handle_data,
             (struct mca_btl_base_registration_handle_t *) (*operation)->remote_handle_data,
             hdr->data.rdma.size, /*flags=*/0, MCA_BTL_NO_ORDER, am_rdma_rdma_complete,
-            operation, NULL);
+            *operation, NULL);
         if (OPAL_SUCCESS != ret) {
             OBJ_RELEASE(*operation);
         }

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -35,7 +35,8 @@ check_PROGRAMS = \
 	opal_value_array \
 	opal_pointer_array \
 	opal_lifo \
-	opal_fifo
+	opal_fifo \
+	opal_cstring
 
 TESTS = $(check_PROGRAMS)
 
@@ -93,6 +94,12 @@ opal_fifo_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
 	$(top_builddir)/test/support/libsupport.a
 opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
+
+opal_cstring_SOURCES = opal_cstring.c
+opal_cstring_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+	$(top_builddir)/test/support/libsupport.a
+opal_cstring_DEPENDENCIES = $(opal_cstring_LDADD)
 
 clean-local:
 	rm -f opal_bitmap_test_out.txt opal_hash_table_test_out.txt opal_proc_table_test_out.txt

--- a/test/class/opal_cstring.c
+++ b/test/class/opal_cstring.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include <assert.h>
+
+#include "opal/class/opal_cstring.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK_INT(actual, expected)                   \
+    if (expected != actual) {                         \
+        printf("%s:%d: expected %d, got %d\n",        \
+               __FILE__, __LINE__, expected, actual); \
+        exit(1);                                      \
+    }
+
+#define CHECK_BOOL(actual, expected)                  \
+    if (expected != actual) {                         \
+        printf("%s:%d: expected %s, got %s\n",        \
+               __FILE__, __LINE__,                    \
+               expected ? "true" : "false",           \
+               actual ? "true" : "false");            \
+        exit(1);                                      \
+    }
+
+int main(int argc, char *argv[])
+{
+    int ret, int_val;
+    bool bool_val;
+    opal_cstring_t *cstr;
+
+    /*
+     * bool tests
+     */
+    cstr = opal_cstring_create("true");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, true);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("yes");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, true);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("false");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, false);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("no");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, false);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("1");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, true);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("0");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, false);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("1.0");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, true);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("0.0");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_BOOL(bool_val, false);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("foobar");
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create(NULL);
+    ret = opal_cstring_to_bool(cstr, &bool_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+
+    /*
+     * bool string tests
+     */
+    bool_val = opal_str_to_bool("true");
+    CHECK_BOOL(bool_val, true);
+
+    bool_val = opal_str_to_bool("yes");
+    CHECK_BOOL(bool_val, true);
+
+    bool_val = opal_str_to_bool("false");
+    CHECK_BOOL(bool_val, false);
+
+    bool_val = opal_str_to_bool("no");
+    CHECK_BOOL(bool_val, false);
+
+    bool_val = opal_str_to_bool("1");
+    CHECK_BOOL(bool_val, true);
+
+    bool_val = opal_str_to_bool("0");
+    CHECK_BOOL(bool_val, false);
+
+    bool_val = opal_str_to_bool("1.0");
+    CHECK_BOOL(bool_val, true);
+
+    bool_val = opal_str_to_bool("0.0");
+    CHECK_BOOL(bool_val, false);
+
+    bool_val = opal_str_to_bool("foobar");
+    CHECK_BOOL(bool_val, false);
+
+    bool_val = opal_str_to_bool(NULL);
+    CHECK_BOOL(bool_val, false);
+
+    /*
+     * integer tests
+     */
+    cstr = opal_cstring_create("1");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_INT(int_val, 1);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("0");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_SUCCESS);
+    CHECK_INT(int_val, 0);
+    OBJ_RELEASE(cstr);
+
+    /* test intentional overflow cases */
+    if (sizeof(long) > sizeof(int)) {
+        long input = (long)INT_MAX + 1L;
+        char *input_str;
+
+        ret = asprintf(&input_str, "%ld", input);
+        if (ret < 0) {
+            printf("%s:%d: asprintf()", __FILE__, __LINE__);
+            exit(1);
+        }
+
+        cstr = opal_cstring_create(input_str);
+        ret = opal_cstring_to_int(cstr, &int_val);
+        CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+        OBJ_RELEASE(cstr);
+        free(input_str);
+    }
+
+    /* yes, this may be redundant from above, but always try both
+       cases for simplicity */
+    if (sizeof(long long) > sizeof(int)) {
+        long long input = (long long)INT_MAX + 1L;
+        char *input_str;
+
+        ret = asprintf(&input_str, "%lld", input);
+        if (ret < 0) {
+            printf("%s:%d: asprintf()", __FILE__, __LINE__);
+            exit(1);
+        }
+
+        cstr = opal_cstring_create(input_str);
+        ret = opal_cstring_to_int(cstr, &int_val);
+        CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+        OBJ_RELEASE(cstr);
+        free(input_str);
+    }
+
+    {
+        long input = (long)LONG_MAX;
+        char *input_str;
+
+        ret = asprintf(&input_str, "%ld0", input);
+        if (ret < 0) {
+            printf("%s:%d: asprintf()", __FILE__, __LINE__);
+            exit(1);
+        }
+
+        cstr = opal_cstring_create(input_str);
+        ret = opal_cstring_to_int(cstr, &int_val);
+        CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+        OBJ_RELEASE(cstr);
+        free(input_str);
+    }
+
+
+    cstr = opal_cstring_create("1.0");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("0.0");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("foobar");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create(NULL);
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("true");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("yes");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("false");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    cstr = opal_cstring_create("no");
+    ret = opal_cstring_to_int(cstr, &int_val);
+    CHECK_INT(ret, OPAL_ERR_BAD_PARAM);
+    OBJ_RELEASE(cstr);
+
+    return 0;
+}


### PR DESCRIPTION
Backports of https://github.com/open-mpi/ompi/pull/9975 and https://github.com/open-mpi/ompi/pull/9991.