### PR TITLE
libompitrace: handle MPI_DATATYPE_NULL

### DIFF
--- a/ompi/contrib/libompitrace/allgather.c
+++ b/ompi/contrib/libompitrace/allgather.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -38,8 +38,18 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(sendtype, sendtypename, &len);
-    PMPI_Type_get_name(recvtype, recvtypename, &len);
+    if (sendtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(sendtype, sendtypename, &len);
+    } else {
+        strncpy(sendtypename, "MPI_DATATYPE_NULL",
+                sizeof(sendtypename));
+    }
+    if (recvtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(recvtype, recvtypename, &len);
+    } else {
+        strncpy(recvtypename, "MPI_DATATYPE_NULL",
+                sizeof(recvtypename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_ALLGATHER[%d]: sendbuf %0" PRIxPTR " sendcount %d sendtype %s\n\trecvbuf %0" PRIxPTR " recvcount %d recvtype %s comm %s\n",

--- a/ompi/contrib/libompitrace/allgatherv.c
+++ b/ompi/contrib/libompitrace/allgatherv.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -38,8 +38,18 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(sendtype, sendtypename, &len);
-    PMPI_Type_get_name(recvtype, recvtypename, &len);
+    if (sendtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(sendtype, sendtypename, &len);
+    } else {
+        strncpy(sendtypename, "MPI_DATATYPE_NULL",
+                sizeof(sendtypename));
+    }
+    if (recvtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(recvtype, recvtypename, &len);
+    } else {
+        strncpy(recvtypename, "MPI_DATATYPE_NULL",
+                sizeof(recvtypename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_ALLGATHERV[%d]: sendbuf %0" PRIxPTR " sendcount %d sendtype %s\n\trecvbuf %0" PRIxPTR " recvtype %s comm %s\n",

--- a/ompi/contrib/libompitrace/allreduce.c
+++ b/ompi/contrib/libompitrace/allreduce.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -36,7 +36,11 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(datatype, typename, &len);
+    if (datatype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(datatype, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_ALLREDUCE[%d]: sendbuf %0" PRIxPTR " recvbuf %0" PRIxPTR " count %d datatype %s op %s comm %s\n",

--- a/ompi/contrib/libompitrace/bcast.c
+++ b/ompi/contrib/libompitrace/bcast.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +34,11 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(datatype, typename, &len);
+    if (datatype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(datatype, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_BCAST[%d]: buffer %0" PRIxPTR " count %d datatype %s root %d comm %s\n",

--- a/ompi/contrib/libompitrace/isend.c
+++ b/ompi/contrib/libompitrace/isend.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -36,7 +36,11 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype type, int dest,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(type, typename, &len);
+    if (type != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(type, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_ISEND[%d]: buf %0" PRIxPTR " count %d datatype %s dest %d tag %d comm %s\n",

--- a/ompi/contrib/libompitrace/recv.c
+++ b/ompi/contrib/libompitrace/recv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +33,11 @@ int MPI_Recv(void *buf, int count, MPI_Datatype type, int source,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(type, typename, &len);
+    if (type != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(type, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_RECV[%d]: buf %0" PRIxPTR " count %d datatype %s source %d tag %d comm %s\n",

--- a/ompi/contrib/libompitrace/reduce.c
+++ b/ompi/contrib/libompitrace/reduce.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -37,7 +37,11 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(datatype, typename, &len);
+    if (datatype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(datatype, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr,"MPI_REDUCE[%d]: sendbuf %0" PRIxPTR " recvbuf %0" PRIxPTR " count %d datatype %s op %s root %d comm %s\n",

--- a/ompi/contrib/libompitrace/send.c
+++ b/ompi/contrib/libompitrace/send.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -36,7 +36,11 @@ int MPI_Send(const void *buf, int count, MPI_Datatype type, int dest,
     int rank;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(type, typename, &len);
+    if (type != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(type, typename, &len);
+    } else {
+        strncpy(typename, "MPI_DATATYPE_NULL", sizeof(typename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
 
     fprintf(stderr, "MPI_SEND[%d]: : buf %0" PRIxPTR " count %d datatype %s dest %d tag %d comm %s\n",

--- a/ompi/contrib/libompitrace/sendrecv.c
+++ b/ompi/contrib/libompitrace/sendrecv.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -41,8 +41,18 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     int size;
 
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    PMPI_Type_get_name(sendtype, sendtypename, &len);
-    PMPI_Type_get_name(sendtype, recvtypename, &len);
+    if (sendtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(sendtype, sendtypename, &len);
+    } else {
+        strncpy(sendtypename, "MPI_DATATYPE_NULL",
+                sizeof(sendtypename));
+    }
+    if (recvtype != MPI_DATATYPE_NULL) {
+        PMPI_Type_get_name(recvtype, recvtypename, &len);
+    } else {
+        strncpy(recvtypename, "MPI_DATATYPE_NULL",
+                sizeof(recvtypename));
+    }
     PMPI_Comm_get_name(comm, commname, &len);
     PMPI_Type_size(recvtype, &size);
 


### PR DESCRIPTION
Ensure to check for MPI_DATATYPE_NULL before calling
PMPI_Type_get_name().  As of MPI-4.0, there's still at least some
disagreement as to whether MPI_DATATYPE_NULL is a valid input
parameter for MPI_TYPE_GET_NAME.  While that discussion is ongoing,
fix up libompitrace to do what is guaranteed to work.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #10028, #10029, https://github.com/mpi-forum/mpi-issues/issues/544, https://github.com/mpi-forum/mpi-standard/pull/652