### PR TITLE
v5.0.x: Fix leak of sm_segment files in /dev/shm.

### DIFF
--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -492,8 +492,13 @@ int opal_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
         rc = PMIx_Job_control_nb(NULL, 0, pinfo, ninfo, cleanup_cbfunc, (void *) &lk);
     } else {
         /* only applies to us */
-        (void) snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s",
-                        OPAL_JOBID_PRINT(OPAL_PROC_MY_NAME.jobid));
+        pmix_nspace_t nspace;
+        if(OPAL_SUCCESS == opal_pmix_convert_jobid(nspace, OPAL_PROC_MY_NAME.jobid)) {
+          (void) snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s", nspace);
+        }
+        else {
+          (void) snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s", OPAL_JOBID_PRINT(OPAL_PROC_MY_NAME.jobid));
+        }
         proc.rank = OPAL_PROC_MY_NAME.vpid;
         rc = PMIx_Job_control_nb(&proc, 1, pinfo, ninfo, cleanup_cbfunc, (void *) &lk);
     }


### PR DESCRIPTION
I noticed that there were dozens of 'sm_segment.$HOSTNAME.$UID..'
files leftover in /dev/shm. This seems to clean it up - the
correct namespace wasn't being added so the cleanup callback
was doing nothing.

This may also cleanup some other leaks, as opal_pmix_register_cleanup()
is used in open_file() in opal/util.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 7412e27a6629ad08254afd13b116a894f6faba99)