### PR TITLE
osc/rdma: Fix priority setting bug

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -374,7 +374,6 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
                                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                                           int flavor)
 {
-
     if (MPI_WIN_FLAVOR_SHARED == flavor) {
         return -1;
     }
@@ -395,7 +394,7 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
         return -1;
     }
 
-    return OMPI_SUCCESS;;
+    return mca_osc_rdma_component.priority;
 }
 
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {


### PR DESCRIPTION
In a previous commit, I accidently set the priority to always
be 0.  Which is wrong, but had no practical impact, given
the priorities and availabilities of other OSC components.
However, it was wrong and this patch fixes the issue.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>