### PR TITLE
No segmenting for datatype copy on CUDA devices.

### DIFF
--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -48,6 +48,8 @@ static size_t opal_datatype_memop_block_size = 128 * 1024;
 /**
  * Non overlapping memory regions
  */
+#undef MEM_OP_BLOCK_SIZE
+#define MEM_OP_BLOCK_SIZE opal_datatype_memop_block_size
 #undef MEM_OP_NAME
 #define MEM_OP_NAME non_overlap
 #undef MEM_OP
@@ -75,6 +77,8 @@ static size_t opal_datatype_memop_block_size = 128 * 1024;
 #if OPAL_CUDA_SUPPORT
 #    include "opal/mca/common/cuda/common_cuda.h"
 
+#    undef MEM_OP_BLOCK_SIZE
+#    define MEM_OP_BLOCK_SIZE total_length
 #    undef MEM_OP_NAME
 #    define MEM_OP_NAME non_overlap_cuda
 #    undef MEM_OP

--- a/opal/datatype/opal_datatype_copy.h
+++ b/opal/datatype/opal_datatype_copy.h
@@ -23,6 +23,9 @@
 #if !defined(MEM_OP)
 #    error
 #endif /* !defined(MEM_OP) */
+#if !defined(MEM_OP_BLOCK_SIZE)
+#    error
+#endif  /* !defined(MEM_OP_BLOCK_SIZE) */
 
 #ifndef STRINGIFY
 #    define STRINGIFY_(arg) #    arg
@@ -136,7 +139,7 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
         source += datatype->true_lb;
         if ((ptrdiff_t) datatype->size == extent) { /* all contiguous == no gaps around */
             size_t total_length = iov_len_local;
-            size_t memop_chunk = opal_datatype_memop_block_size;
+            size_t memop_chunk = MEM_OP_BLOCK_SIZE;
             OPAL_DATATYPE_SAFEGUARD_POINTER(source, iov_len_local, (unsigned char *) source_base,
                                             datatype, count);
             while (total_length > 0) {


### PR DESCRIPTION
Generate the code to avoid asegmenting for CUDA but maintain it for all
other cases.

This PR provides a different approach to #10062.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>