### PR TITLE
sessions: support MPI_TAG_UB

### DIFF
--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -515,11 +515,22 @@ int ompi_attr_delete_all(ompi_attribute_type_t type, void *object,
 /**
  * \internal
  *
- * Create all the predefined attributes
+ * Create all the predefined attribute keys
+ * @note This routine is invoked when creating a session 
+ *       so must be thread safe.
  *
  * @returns OMPI_SUCCESS
  */
-int ompi_attr_create_predefined(void);
+int ompi_attr_create_predefined_keyvals(void);
+
+/**
+ * \internal
+ *
+ * Cache predefined attribute keys used in the World Model
+ *
+ * @returns OMPI_SUCCESS
+ */
+int ompi_attr_set_predefined_keyvals_for_wm(void);
 
 /**
  * \internal

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1331,6 +1331,17 @@ int ompi_comm_create_from_group (ompi_group_t *group, const char *tag, opal_info
 
     newcomp->instance = group->grp_instance;
 
+    /*
+     * setup predefined keyvals - see MPI Standard for predefined keyvals cached on 
+     * communicators created via MPI_Comm_from_group or MPI_Intercomm_create_from_groups
+     */
+    ompi_attr_hash_init(&newcomp->c_keyhash);
+    ompi_attr_set_int(COMM_ATTR,
+                      newcomp,
+                      &newcomp->c_keyhash,
+                      MPI_TAG_UB, mca_pml.pml_max_tag,
+                      true);
+
     *newcomm = newcomp;
     return MPI_SUCCESS;
 }

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -292,7 +292,7 @@ int ompi_comm_init_mpi3 (void)
     /*
      * finally here we set the predefined attribute keyvals
      */
-    ompi_attr_create_predefined();
+    ompi_attr_set_predefined_keyvals_for_wm();
 
     OBJ_RETAIN(&ompi_mpi_errors_are_fatal.eh);
     /* During dyn_init, the comm_parent error handler will be set to the same

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -595,6 +595,13 @@ static int ompi_mpi_instance_init_common (void)
         return ompi_instance_print_error ("ompi_comm_init() failed", ret);
     }
 
+    /* Construct predefined keyvals */
+
+    if (OMPI_SUCCESS != (ret = ompi_attr_create_predefined_keyvals())) {
+        opal_mutex_unlock (&instance_lock);
+        return ompi_instance_print_error ("ompi_attr_create_predefined_keyvals() failed", ret);
+    }
+
     if (mca_pml_base_requires_world ()) {
         /* need to set up comm world for this instance -- XXX -- FIXME -- probably won't always
          * be the case. */


### PR DESCRIPTION
related to #9097

test https://github.com/open-mpi/ompi-tests-public/blob/master/sessions/sessions_test16.c
now passes.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>