### PR TITLE
attributes: Remove internal copy arg

### DIFF
--- a/contrib/check_unnecessary_headers.sh
+++ b/contrib/check_unnecessary_headers.sh
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 #
 #
 # Some grep/sed mojo may be of interest to others...
@@ -175,7 +177,7 @@ SEARCH_HEADER[29]=""
 delete_unnessary_header .
 
 ####################################
-SEARCH_HEADER[0]="ompi/attribute/attribute.h ATTR_HASH_SIZE OMPI_KEYVAL_PREDEFINED OMPI_KEYVAL_F77 ompi_attribute_type_t ompi_mpi1_fortran_copy_attr_function ompi_mpi1_fortran_delete_attr_function ompi_mpi2_fortran_copy_attr_function ompi_mpi2_fortran_delete_attr_function MPI_Comm_internal_copy_attr_function MPI_Type_internal_copy_attr_function MPI_Win_internal_copy_attr_function ompi_attribute_keyval_destructor_fn_t ompi_attribute_fn_ptr_union_t ompi_attribute_fortran_ptr_t ompi_attribute_keyval_t ompi_attr_hash_init ompi_attr_init ompi_attr_finalize ompi_attr_create_keyval ompi_attr_free_keyval ompi_attr_set_c ompi_attr_set_fortran_mpi1 ompi_attr_set_fortran_mpi2 ompi_attr_get_c ompi_attr_get_fortran_mpi1 ompi_attr_get_fortran_mpi2 ompi_attr_delete ompi_attr_copy_all ompi_attr_delete_all ompi_attr_create_predefined ompi_attr_free_predefined"
+SEARCH_HEADER[0]="ompi/attribute/attribute.h ATTR_HASH_SIZE OMPI_KEYVAL_PREDEFINED OMPI_KEYVAL_F77 ompi_attribute_type_t ompi_mpi1_fortran_copy_attr_function ompi_mpi1_fortran_delete_attr_function ompi_mpi2_fortran_copy_attr_function ompi_mpi2_fortran_delete_attr_function  ompi_attribute_keyval_destructor_fn_t ompi_attribute_fn_ptr_union_t ompi_attribute_fortran_ptr_t ompi_attribute_keyval_t ompi_attr_hash_init ompi_attr_init ompi_attr_finalize ompi_attr_create_keyval ompi_attr_free_keyval ompi_attr_set_c ompi_attr_set_fortran_mpi1 ompi_attr_set_fortran_mpi2 ompi_attr_get_c ompi_attr_get_fortran_mpi1 ompi_attr_get_fortran_mpi2 ompi_attr_delete ompi_attr_copy_all ompi_attr_delete_all ompi_attr_create_predefined ompi_attr_free_predefined"
 SEARCH_HEADER[1]="ompi/class/ompi_free_list.h ompi_free_list_item_init_fn_t ompi_free_list_t ompi_free_list_item_t ompi_free_list_init_ex ompi_free_list_init ompi_free_list_init_ex_new ompi_free_list_init_new ompi_free_list_grow ompi_free_list_resize ompi_free_list_pos_t OMPI_FREE_LIST_POS_BEGINNING ompi_free_list_parse OMPI_FREE_LIST_GET OMPI_FREE_LIST_WAIT __ompi_free_list_wait OMPI_FREE_LIST_RETURN"
 SEARCH_HEADER[2]="ompi/class/ompi_rb_tree.h ompi_rb_tree_nodecolor_t ompi_rb_tree_node_t ompi_rb_tree_comp_fn_t ompi_rb_tree_t ompi_rb_tree_condition_fn_t ompi_rb_tree_action_fn_t ompi_rb_tree_construct ompi_rb_tree_destruct ompi_rb_tree_init ompi_rb_tree_insert ompi_rb_tree_find_with ompi_rb_tree_find ompi_rb_tree_delete ompi_rb_tree_destroy ompi_rb_tree_traverse ompi_rb_tree_size"
 SEARCH_HEADER[3]="ompi/class/ompi_seq_tracker.h ompi_seq_tracker_range_t ompi_seq_tracker_t ompi_seq_tracker_check_duplicate ompi_seq_tracker_insert ompi_seq_tracker_copy"

--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -17,6 +17,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -331,7 +333,7 @@ do { \
 /* See the big, long comment above from DELETE_ATTR_CALLBACKS -- most of
    that text applies here, too. */
 
-#define COPY_ATTR_CALLBACKS(type, old_object, keyval_obj, in_attr, new_object, out_attr, err) \
+#define COPY_ATTR_CALLBACKS(type, old_object, keyval_obj, in_attr, out_attr, err) \
 do { \
     OPAL_THREAD_UNLOCK(&attribute_lock); \
     if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77)) { \
@@ -380,7 +382,7 @@ do { \
         in = translate_to_c(in_attr); \
         if ((err = (*((keyval_obj->copy_attr_fn).attr_##type##_copy_fn)) \
               ((ompi_##type##_t *)old_object, key, keyval_obj->extra_state.c_ptr, \
-               in, &out, &flag, (ompi_##type##_t *)(new_object))) == MPI_SUCCESS) { \
+               in, &out, &flag)) == MPI_SUCCESS) { \
             out_attr->av_value = out;                                   \
         }                                                               \
     } \
@@ -1036,19 +1038,19 @@ int ompi_attr_copy_all(ompi_attribute_type_t type, void *old_object,
         case COMM_ATTR:
             /* Now call the copy_attr_fn */
             COPY_ATTR_CALLBACKS(communicator, old_object, hash_value,
-                                old_attr, new_object, new_attr, err);
+                                old_attr, new_attr, err);
             break;
 
         case TYPE_ATTR:
             /* Now call the copy_attr_fn */
             COPY_ATTR_CALLBACKS(datatype, old_object, hash_value,
-                                old_attr, new_object, new_attr, err);
+                                old_attr, new_attr, err);
             break;
 
         case WIN_ATTR:
             /* Now call the copy_attr_fn */
             COPY_ATTR_CALLBACKS(win, old_object, hash_value,
-                                old_attr, new_object, new_attr, err);
+                                old_attr, new_attr, err);
             break;
 
         default:

--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -15,6 +15,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,18 +85,6 @@ typedef void (*ompi_aint_copy_attr_function)(MPI_Fint *oldobj, MPI_Fint *keyval,
                                              ompi_fortran_logical_t *flag, MPI_Fint *ierr);
 typedef void (*ompi_aint_delete_attr_function)(MPI_Fint *obj, MPI_Fint *keyval, void *attr_in,
                                                void *extra_state, MPI_Fint *ierr);
-/*
- * Internally the copy function for all kinds of MPI objects has one more
- * argument, the pointer to the new object. Therefore, we can do on the
- * flight modifications of the new communicator based on attributes stored
- * on the main communicator.
- */
-typedef int (*MPI_Comm_internal_copy_attr_function)(MPI_Comm, int, void *, void *, void *, int *,
-                                                    MPI_Comm);
-typedef int (*MPI_Type_internal_copy_attr_function)(MPI_Datatype, int, void *, void *, void *,
-                                                    int *, MPI_Datatype);
-typedef int (*MPI_Win_internal_copy_attr_function)(MPI_Win, int, void *, void *, void *, int *,
-                                                   MPI_Win);
 
 typedef void (ompi_attribute_keyval_destructor_fn_t)(int);
 
@@ -107,19 +97,17 @@ union ompi_attribute_fn_ptr_union_t {
     MPI_Type_delete_attr_function          *attr_datatype_delete_fn;
     MPI_Win_delete_attr_function           *attr_win_delete_fn;
 
-    MPI_Comm_internal_copy_attr_function attr_communicator_copy_fn;
-    MPI_Type_internal_copy_attr_function attr_datatype_copy_fn;
-    MPI_Win_internal_copy_attr_function attr_win_copy_fn;
+    MPI_Comm_copy_attr_function            *attr_communicator_copy_fn;
+    MPI_Type_copy_attr_function            *attr_datatype_copy_fn;
+    MPI_Win_copy_attr_function             *attr_win_copy_fn;
 
     /* For Fortran old MPI-1 callback functions */
-
-    ompi_fint_delete_attr_function attr_fint_delete_fn;
-    ompi_fint_copy_attr_function attr_fint_copy_fn;
+    ompi_fint_delete_attr_function          attr_fint_delete_fn;
+    ompi_fint_copy_attr_function            attr_fint_copy_fn;
 
     /* For Fortran new MPI-2 callback functions */
-
-    ompi_aint_delete_attr_function attr_aint_delete_fn;
-    ompi_aint_copy_attr_function attr_aint_copy_fn;
+    ompi_aint_delete_attr_function          attr_aint_delete_fn;
+    ompi_aint_copy_attr_function            attr_aint_copy_fn;
 };
 
 typedef union ompi_attribute_fn_ptr_union_t ompi_attribute_fn_ptr_union_t;

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -194,8 +196,8 @@ static int create_comm(int target_keyval, bool want_inherit)
     ompi_attribute_fn_ptr_union_t del;
 
     keyval = -1;
-    copy.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function)(
-        want_inherit ? MPI_COMM_DUP_FN : MPI_COMM_NULL_COPY_FN);
+    copy.attr_communicator_copy_fn =
+        want_inherit ? MPI_COMM_DUP_FN : MPI_COMM_NULL_COPY_FN;
     del.attr_communicator_delete_fn = MPI_COMM_NULL_DELETE_FN;
     keyval = target_keyval;
     err = ompi_attr_create_keyval(COMM_ATTR, copy, del,
@@ -225,7 +227,7 @@ static int create_win(int target_keyval)
     ompi_attribute_fn_ptr_union_t del;
 
     keyval = -1;
-    copy.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function) MPI_WIN_NULL_COPY_FN;
+    copy.attr_win_copy_fn = MPI_WIN_NULL_COPY_FN;
     del.attr_win_delete_fn = MPI_WIN_NULL_DELETE_FN;
     keyval = target_keyval;
     err = ompi_attr_create_keyval(WIN_ATTR, copy, del,

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -5,6 +5,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -335,7 +337,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         } else {
             cm->using_mem_hooks = 0;
         }
-        copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*) MPI_COMM_NULL_COPY_FN;
+        copy_fn.attr_communicator_copy_fn = MPI_COMM_NULL_COPY_FN;
         del_fn.attr_communicator_delete_fn = hcoll_comm_attr_del_fn;
         err = ompi_attr_create_keyval(COMM_ATTR, copy_fn, del_fn, &hcoll_comm_attr_keyval, NULL ,0, NULL);
         if (OMPI_SUCCESS != err) {
@@ -348,7 +350,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
 
         if (mca_coll_hcoll_component.derived_types_support_enabled) {
             zero_dte_mapping.type = DTE_ZERO;
-            copy_fn.attr_datatype_copy_fn = (MPI_Type_internal_copy_attr_function *) MPI_TYPE_NULL_COPY_FN;
+            copy_fn.attr_datatype_copy_fn = MPI_TYPE_NULL_COPY_FN;
             del_fn.attr_datatype_delete_fn = hcoll_type_attr_del_fn;
             err = ompi_attr_create_keyval(TYPE_ATTR, copy_fn, del_fn, &hcoll_type_attr_keyval, NULL ,0, NULL);
             if (OMPI_SUCCESS != err) {

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -1,5 +1,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -291,8 +293,7 @@ static int mca_coll_ucc_init_ctx() {
     }
     ucc_context_config_release(ctx_config);
 
-    copy_fn.attr_communicator_copy_fn  = (MPI_Comm_internal_copy_attr_function)
-        MPI_COMM_NULL_COPY_FN;
+    copy_fn.attr_communicator_copy_fn  = MPI_COMM_NULL_COPY_FN;
     del_fn.attr_communicator_delete_fn = ucc_comm_attr_del_fn;
     if (OMPI_SUCCESS != ompi_attr_create_keyval(COMM_ATTR, copy_fn, del_fn,
                                                 &ucc_comm_attr_keyval, NULL ,0, NULL)) {

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -7,6 +7,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018 IBM Corporation. All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -496,8 +498,7 @@ int mca_pml_ucx_enable(bool enable)
     int ret;
 
     /* Create a key for adding custom attributes to datatypes */
-    copy_fn.attr_datatype_copy_fn  =
-                    (MPI_Type_internal_copy_attr_function)MPI_TYPE_NULL_COPY_FN;
+    copy_fn.attr_datatype_copy_fn  = MPI_TYPE_NULL_COPY_FN;
     del_fn.attr_datatype_delete_fn = mca_pml_ucx_datatype_attr_del_fn;
     ret = ompi_attr_create_keyval(TYPE_ATTR, copy_fn, del_fn,
                                   &ompi_pml_ucx.datatype_attr_keyval, NULL, 0,

--- a/ompi/mpi/c/comm_create_keyval.c
+++ b/ompi/mpi/c/comm_create_keyval.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +56,7 @@ int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function) comm_copy_attr_fn;
+    copy_fn.attr_communicator_copy_fn = comm_copy_attr_fn;
     del_fn.attr_communicator_delete_fn = comm_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn,

--- a/ompi/mpi/c/keyval_create.c
+++ b/ompi/mpi/c/keyval_create.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,7 +58,7 @@ int MPI_Keyval_create(MPI_Copy_function *copy_attr_fn,
         }
     }
 
-    copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function) copy_attr_fn;
+    copy_fn.attr_communicator_copy_fn = copy_attr_fn;
     del_fn.attr_communicator_delete_fn = delete_attr_fn;
 
     ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn,

--- a/ompi/mpi/c/type_create_keyval.c
+++ b/ompi/mpi/c/type_create_keyval.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,7 +58,7 @@ int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_datatype_copy_fn = (MPI_Type_internal_copy_attr_function) type_copy_attr_fn;
+    copy_fn.attr_datatype_copy_fn = type_copy_attr_fn;
     del_fn.attr_datatype_delete_fn = type_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(TYPE_ATTR, copy_fn, del_fn,

--- a/ompi/mpi/c/win_create_keyval.c
+++ b/ompi/mpi/c/win_create_keyval.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +56,7 @@ int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn,
         }
     }
 
-    copy_fn.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function) win_copy_attr_fn;
+    copy_fn.attr_win_copy_fn = win_copy_attr_fn;
     del_fn.attr_win_delete_fn = win_delete_attr_fn;
 
     ret = ompi_attr_create_keyval(WIN_ATTR, copy_fn, del_fn,


### PR DESCRIPTION
In commit 85bb1a9c9 (from 2006), we added an internal argument of
the new object for the attribute copy functions.  We don't use
that argument anywhere in the code base, so simplify things and
remove the internal types and the extra argument.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>