### PR TITLE
libnbc fix for iallreduce count*extent overflowing int

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_iallreduce.c
+++ b/ompi/mca/coll/libnbc/nbc_iallreduce.c
@@ -9,7 +9,7 @@
  *                         reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -584,9 +584,9 @@ static inline int allred_sched_ring (int r, int p, int count, MPI_Datatype datat
   /* first p-1 rounds are reductions */
   for (int round = 0 ; round < p - 1 ; ++round) {
     int selement = (r+1-round + 2*p /*2*p avoids negative mod*/)%p; /* the element I am sending */
-    int soffset = segoffsets[selement]*ext;
+    size_t soffset = segoffsets[selement]*(size_t)ext;
     int relement = (r-round + 2*p /*2*p avoids negative mod*/)%p; /* the element that I receive from my neighbor */
-    int roffset = segoffsets[relement]*ext;
+    size_t roffset = segoffsets[relement]*(size_t)ext;
 
     /* first message come out of sendbuf */
     if (round == 0) {
@@ -623,9 +623,9 @@ static inline int allred_sched_ring (int r, int p, int count, MPI_Datatype datat
   }
   for (int round = p - 1 ; round < 2 * p - 2 ; ++round) {
     int selement = (r+1-round + 2*p /*2*p avoids negative mod*/)%p; /* the element I am sending */
-    int soffset = segoffsets[selement]*ext;
+    size_t soffset = segoffsets[selement]*(size_t)ext;
     int relement = (r-round + 2*p /*2*p avoids negative mod*/)%p; /* the element that I receive from my neighbor */
-    int roffset = segoffsets[relement]*ext;
+    size_t roffset = segoffsets[relement]*(size_t)ext;
 
     res = NBC_Sched_send ((char *) recvbuf + soffset, false, segsizes[selement], datatype, speer,
                           schedule, false);


### PR DESCRIPTION
In the libnbc iallreduce ring algorithm at -np 4, if the datatype is
MPI_LONG_LONG of 8bytes and a count is used like 1.5 billion so the
total bytes is 12Gb, the offsets for some of the iterations were going
negative.

gist for testcase:
    https://gist.github.com/markalle/61e05fed6de4cd201d5e7d22b0c175a1
% mpicc -o x iallreduce_overflow.c
% mpirun -np 4 --mca coll_libnbc_iallreduce_algorithm 1 ./x 12000000000

The testcase picks a random number of bytes for the allreduce buffer if one
isn't specified on the command line.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit b8d6b6bd889696714a93f564bb8cb230100a5991)
