### PR TITLE
reachable/netlink: Fix flags exporting

### DIFF
--- a/opal/mca/reachable/netlink/Makefile.am
+++ b/opal/mca/reachable/netlink/Makefile.am
@@ -31,7 +31,7 @@ component_install =
 endif
 
 AM_CPPFLAGS = \
-        $(opal_reachable_netlink_CPPFLAGS) \
+        $(reachable_netlink_CPPFLAGS) \
         -DOPAL_HAVE_LIBNL3=$(OPAL_HAVE_LIBNL3)
 
 mcacomponentdir = $(opallibdir)
@@ -39,9 +39,9 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_netlink_la_SOURCES = $(sources)
 mca_reachable_netlink_la_LDFLAGS = -module -avoid-version
 mca_reachable_netlink_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-	$(opal_reachable_netlink_LIBS)
+	$(reachable_netlink_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_netlink_la_SOURCES =$(sources)
 libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version
-libmca_reachable_netlink_la_LIBADD = $(opal_reachable_netlink_LIBS)
+libmca_reachable_netlink_la_LIBADD = $(reachable_netlink_LIBS)

--- a/opal/mca/reachable/netlink/configure.m4
+++ b/opal/mca/reachable/netlink/configure.m4
@@ -36,7 +36,7 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
     AS_IF([test $opal_libnl_version -eq 1],
 	  [opal_reachable_netlink_happy=0],
           [OPAL_CHECK_LIBNL_V3([$opal_libnl_location],
-			       [opal_reachable_netlink])
+			       [reachable_netlink])
 	   AS_IF([test "$OPAL_HAVE_LIBNL3" != "1"],
 		 [opal_reachable_netlink_happy=0])])
 
@@ -44,9 +44,9 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
           [$1],
           [$2])
 
-    AC_SUBST([opal_reachable_netlink_CPPFLAGS])
-    AC_SUBST([opal_reachable_netlink_LDFLAGS])
-    AC_SUBST([opal_reachable_netlink_LIBS])
+    AC_SUBST([reachable_netlink_CPPFLAGS])
+    AC_SUBST([reachable_netlink_LDFLAGS])
+    AC_SUBST([reachable_netlink_LIBS])
 
     OPAL_VAR_SCOPE_POP()
 ])


### PR DESCRIPTION
The MCA infrastructure assumes that the CPPFLAGS, LDFLAGS, and
LIBS set by the component will be named framework_component_flag,
without the project prefix.  Rename the reachable/netlink flags
to match this format so that the MCA system can pull in the
right WRAPPER flags.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>