### PR TITLE
Check HWLOC compatibility with TreeMatch

### DIFF
--- a/3rd-party/treematch/tm_topology.c
+++ b/3rd-party/treematch/tm_topology.c
@@ -165,10 +165,10 @@ double ** topology_to_arch(hwloc_topology_t topology)
   double **arch = NULL;
 
   nb_proc = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-  if (nb_proc < 0) {
+  if( nb_proc < 1 ) {
     return NULL;
   }
-  arch = (double**)malloc(sizeof(double*)*nb_proc);
+  arch = (double**)MALLOC(sizeof(double*)*nb_proc);
   if (NULL == arch) {
     return NULL;
   }

--- a/config/opal_config_treematch.m4
+++ b/config/opal_config_treematch.m4
@@ -80,6 +80,11 @@ AC_DEFUN([OPAL_CONFIG_TREEMATCH], [
 	    else
 		opal_config_treematch_happy=1
 	    fi
+            if test $opal_config_treematch_happy -eq 1 ; then
+                AC_CHECK_FUNC([hwloc_topology_ignore_all_keep_structure],
+                              [opal_config_treematch_happy=1],
+                              [opal_config_treematch_happy=0])
+            fi
 	fi
 
 	if test $opal_config_treematch_happy -eq 1 && test $treematch_files_local = yes ; then
@@ -112,9 +117,8 @@ EOF
 
     OPAL_3RDPARTY_SUBDIRS="$OPAL_3RDPARTY_SUBDIRS treematch"
     OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS treematch"
-    
-    AS_IF([test $opal_config_treematch_happy -eq 1], [$2], [$3])
+
+    AS_IF([test $opal_config_treematch_happy -eq 1], [$1], [$2])
     OPAL_VAR_SCOPE_POP
 ])
 
-    

--- a/ompi/mca/topo/treematch/configure.m4
+++ b/ompi/mca/topo/treematch/configure.m4
@@ -22,7 +22,7 @@
 #                                [action-if-cant-compile])
 # -------------------------------------------
 AC_DEFUN([MCA_ompi_topo_treematch_CONFIG], [
-    OPAL_CONFIG_TREEMATCH([topo_treematch], [$1], [$2])
+    OPAL_CONFIG_TREEMATCH([$1], [$2])
     AC_CONFIG_FILES([ompi/mca/topo/treematch/Makefile])
 
     AC_SUBST([topo_treematch_CFLAGS])


### PR DESCRIPTION
TreeMatch requires hwloc_topology_ignore_all_keep_structure which does not
exists in all HWLOC versions (including the one we use for internal HWLOC).

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>