### PR TITLE
v4.1.x: FORTRAN:add elemental attribute to handle compars

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,7 +61,10 @@ included in the vX.Y.Z section and be denoted as:
 4.1.3 -- March, 2022
 --------------------
 
-- Minor datatype performance improvements in the CUDA-based code paths.q
+- Added support for ELEMENTAL to the MPI handle comparison functions
+  in the mpi_f08 module.  Thanks to Salvatore Filippone for raising
+  the issue.
+- Minor datatype performance improvements in the CUDA-based code paths.
 - Fix MPI_ALLTOALLV when used with MPI_IN_PLACE.
 - Fix MPI_BOTTOM handling for non-blocking collectives.  Thanks to
   Lisandro Dalcin for reporting the problem.

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -240,104 +240,104 @@ contains
 
 !... .EQ. operator
 !-----------------
-  logical function ompi_comm_op_eq(a, b)
+  elemental logical function ompi_comm_op_eq(a, b)
     type(MPI_Comm), intent(in) :: a, b
     ompi_comm_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_comm_op_eq
 
-  logical function ompi_datatype_op_eq(a, b)
+  elemental logical function ompi_datatype_op_eq(a, b)
     type(MPI_Datatype), intent(in) :: a, b
     ompi_datatype_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_datatype_op_eq
 
-  logical function ompi_errhandler_op_eq(a, b)
+  elemental logical function ompi_errhandler_op_eq(a, b)
     type(MPI_Errhandler), intent(in) :: a, b
     ompi_errhandler_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_errhandler_op_eq
 
-  logical function ompi_file_op_eq(a, b)
+  elemental logical function ompi_file_op_eq(a, b)
     type(MPI_File), intent(in) :: a, b
     ompi_file_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_file_op_eq
 
-  logical function ompi_group_op_eq(a, b)
+  elemental logical function ompi_group_op_eq(a, b)
     type(MPI_Group), intent(in) :: a, b
     ompi_group_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_group_op_eq
 
-  logical function ompi_info_op_eq(a, b)
+  elemental logical function ompi_info_op_eq(a, b)
     type(MPI_Info), intent(in) :: a, b
     ompi_info_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_info_op_eq
 
-  logical function ompi_message_op_eq(a, b)
+  elemental logical function ompi_message_op_eq(a, b)
     type(MPI_Message), intent(in) :: a, b
     ompi_message_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_message_op_eq
 
-  logical function ompi_op_op_eq(a, b)
+  elemental logical function ompi_op_op_eq(a, b)
     type(MPI_Op), intent(in) :: a, b
     ompi_op_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_op_op_eq
 
-  logical function ompi_request_op_eq(a, b)
+  elemental logical function ompi_request_op_eq(a, b)
     type(MPI_Request), intent(in) :: a, b
     ompi_request_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_request_op_eq
 
-  logical function ompi_win_op_eq(a, b)
+  elemental logical function ompi_win_op_eq(a, b)
     type(MPI_Win), intent(in) :: a, b
     ompi_win_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_win_op_eq
 
 !... .NE. operator
 !-----------------
-  logical function ompi_comm_op_ne(a, b)
+  elemental logical function ompi_comm_op_ne(a, b)
     type(MPI_Comm), intent(in) :: a, b
     ompi_comm_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_comm_op_ne
 
-  logical function ompi_datatype_op_ne(a, b)
+  elemental logical function ompi_datatype_op_ne(a, b)
     type(MPI_Datatype), intent(in) :: a, b
     ompi_datatype_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_datatype_op_ne
 
-  logical function ompi_errhandler_op_ne(a, b)
+  elemental logical function ompi_errhandler_op_ne(a, b)
     type(MPI_Errhandler), intent(in) :: a, b
     ompi_errhandler_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_errhandler_op_ne
 
-  logical function ompi_file_op_ne(a, b)
+  elemental logical function ompi_file_op_ne(a, b)
     type(MPI_File), intent(in) :: a, b
     ompi_file_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_file_op_ne
 
-  logical function ompi_group_op_ne(a, b)
+  elemental logical function ompi_group_op_ne(a, b)
     type(MPI_Group), intent(in) :: a, b
     ompi_group_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_group_op_ne
 
-  logical function ompi_info_op_ne(a, b)
+  elemental logical function ompi_info_op_ne(a, b)
     type(MPI_Info), intent(in) :: a, b
     ompi_info_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_info_op_ne
 
-  logical function ompi_message_op_ne(a, b)
+  elemental logical function ompi_message_op_ne(a, b)
     type(MPI_Message), intent(in) :: a, b
     ompi_message_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_message_op_ne
 
-  logical function ompi_op_op_ne(a, b)
+  elemental logical function ompi_op_op_ne(a, b)
     type(MPI_Op), intent(in) :: a, b
     ompi_op_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_op_op_ne
 
-  logical function ompi_request_op_ne(a, b)
+  elemental logical function ompi_request_op_ne(a, b)
     type(MPI_Request), intent(in) :: a, b
     ompi_request_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_request_op_ne
 
-  logical function ompi_win_op_ne(a, b)
+  elemental logical function ompi_win_op_ne(a, b)
     type(MPI_Win), intent(in) :: a, b
     ompi_win_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_win_op_ne


### PR DESCRIPTION
hand crafted variant of commit f722edc8edc58ef3f9c7943b8c09922d8f963b59 on master.

    FORTRAN:  add elemental attribute to comp ops

    See discussion in issue https://github.com/open-mpi/ompi/issues/10057

    Note the elemental attribute has been supported for user defined methods since
    F95.

bot:notacherrypick

Signed-off-by: Howard Pritchard <howardp@lanl.gov>