### PR TITLE
Use '-n' instead of '-np' option in documentation, examples, and tests

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -28,6 +28,6 @@ Please describe, in detail, the problem that you are having, including the behav
 
 **Note**: If you include verbatim output (or a code block), please use a [GitHub Markdown](https://help.github.com/articles/creating-and-highlighting-code-blocks/) code block like below:
 ```shell
-shell$ mpirun -np 2 ./hello_world
+shell$ mpirun -n 2 ./hello_world
 ```
 

--- a/docs/developers/frameworks.rst
+++ b/docs/developers/frameworks.rst
@@ -166,7 +166,7 @@ values of parameters:
 
    .. code-block:: sh
 
-      shell$ mpirun --mca btl_tcp_frag_size 65536 -np 2 hello_world_mpi
+      shell$ mpirun --mca btl_tcp_frag_size 65536 -n 2 hello_world_mpi
 
    .. error:: TODO Do we need content here about PMIx and PRTE MCA vars
               and corresponding command line switches?

--- a/docs/faq/debugging.rst
+++ b/docs/faq/debugging.rst
@@ -209,7 +209,7 @@ be to assume that the following would immediately work:
 
 .. code-block:: sh
 
-    shell$ mpirun -np 4 xterm -e gdb my_mpi_application
+    shell$ mpirun -n 4 xterm -e gdb my_mpi_application
 
 If running on a personal computer, this will probably work.  You can
 also use `tmpi <https://github.com/Azrael3000/tmpi>`_ to launch the
@@ -281,7 +281,7 @@ following:
 
       shell$ hostname
       arcade.example.come
-      shell$ mpirun -np 4 --hostfile my_hostfile \
+      shell$ mpirun -n 4 --hostfile my_hostfile \
           -x DISPLAY=arcade.example.com:0 xterm -e gdb my_mpi_application
 
    .. warning:: X traffic is fairly "heavy" |mdash| if you are
@@ -466,7 +466,7 @@ enabled. Then simply run your application with Valgrind, e.g.:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 valgrind ./my_app
+   shell$ mpirun -n 2 valgrind ./my_app
 
 Or if you enabled Memchecker, but you don't want to check the
 application at this time, then just run your application as
@@ -474,7 +474,7 @@ usual. E.g.:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 ./my_app
+   shell$ mpirun -n 2 ./my_app
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -572,7 +572,7 @@ line:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 valgrind --suppressions=$PREFIX/share/openmpi/openmpi-valgrind.supp
+   shell$ mpirun -n 2 valgrind --suppressions=$PREFIX/share/openmpi/openmpi-valgrind.supp
 
 More information on suppression-files and how to generate them can be
 found in `Valgrind's documentation

--- a/docs/faq/general-tuning.rst
+++ b/docs/faq/general-tuning.rst
@@ -222,7 +222,7 @@ listed below, and are resolved in the following priority order:
 
    .. code-block:: sh
 
-      shell$ mpirun --mca mpi_show_handle_leaks 1 -np 4 a.out
+      shell$ mpirun --mca mpi_show_handle_leaks 1 -n 4 a.out
 
    This sets the MCA parameter ``mpi_show_handle_leaks`` to the value
    of 1 before running ``a.out`` with four processes.  In general, the
@@ -245,7 +245,7 @@ listed below, and are resolved in the following priority order:
 
       shell$ OMPI_MCA_mpi_show_handle_leaks=1
       shell$ export OMPI_MCA_mpi_show_handle_leaks
-      shell$ mpirun -np 4 a.out
+      shell$ mpirun -n 4 a.out
 
    Note that setting environment variables to values with multiple words
    requires quoting, such as:
@@ -347,21 +347,21 @@ will typically run the application as:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 a.out
+   shell$ mpirun -n 2 a.out
 
 To use the ``foo.conf`` AMCA parameter file, this command line
 changes to:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 --am foo.conf a.out
+   shell$ mpirun -n 2 --am foo.conf a.out
 
 If the user wants to override a parameter set in ``foo.conf`` they
 can add it to the command line:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 --am foo.conf --mca btl tcp,self a.out
+   shell$ mpirun -n 2 --am foo.conf --mca btl tcp,self a.out
 
 AMCA parameter files can be coupled if more than one file is to be
 used. If we have another AMCA parameter file called ``bar.conf``
@@ -369,7 +369,7 @@ that we want to use, we add it to the command line as follows:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 --am foo.conf:bar.conf a.out
+   shell$ mpirun -n 2 --am foo.conf:bar.conf a.out
 
 AMCA parameter files are loaded in priority order. This means that
 ``foo.conf`` AMCA file has priority over the ``bar.conf`` file. So
@@ -423,14 +423,14 @@ will typically run the application as:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 a.out
+   shell$ mpirun -n 2 a.out
 
 To use the ``foo.conf`` tuned parameter file, this command line
 changes to:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 --tune foo.conf a.out
+   shell$ mpirun -n 2 --tune foo.conf a.out
 
 Tuned parameter files can be coupled if more than one file is to be
 used. If we have another tuuned parameter file called ``bar.conf``
@@ -438,7 +438,7 @@ that we want to use, we add it to the command line as follows:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 --tune foo.conf,bar.conf a.out
+   shell$ mpirun -n 2 --tune foo.conf,bar.conf a.out
 
 
 The contents of tuned files consist of one or more lines, each of

--- a/docs/faq/ompio.rst
+++ b/docs/faq/ompio.rst
@@ -82,7 +82,7 @@ mechanism available in Open MPI to influence a parameter value, e.g.:
 
 .. code-block:: sh
 
-   shell$ mpirun --mca fcoll dynamic -np 64 ./a.out
+   shell$ mpirun --mca fcoll dynamic -n 64 ./a.out
 
 ``fs`` and ``fbtl`` components are typically chosen based on the file
 system type utilized (e.g. the ``pvfs2`` component is chosen when the
@@ -222,7 +222,7 @@ IMB:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 1 ./IMB-IO S_write_indv
+   shell$ mpirun -n 1 ./IMB-IO S_write_indv
 
 For IMB, use the values obtained for AGGREGATE test cases. Plot the
 bandwidth over the message length. The recommended value for

--- a/docs/faq/running-mpi-apps.rst
+++ b/docs/faq/running-mpi-apps.rst
@@ -255,7 +255,7 @@ thusly:
 
 .. code-block::
 
-   shell$ mpirun --prefix /opt/openmpi-$ver_current -np 4 a.out
+   shell$ mpirun --prefix /opt/openmpi-$ver_current -n 4 a.out
 
 This will prefix the ``PATH`` and ``LD_LIBRARY_PATH`` on both the
 local and remote hosts with ``/opt/openmpi-$ver_current/bin`` and
@@ -282,7 +282,7 @@ following is equivalent to the above command line that uses
 
 .. code-block::
 
-   shell$ /opt/openmpi-$ver_current/bin/mpirun -np 4 a.out
+   shell$ /opt/openmpi-$ver_current/bin/mpirun -n 4 a.out
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -318,7 +318,7 @@ parallel is:
 
 .. code-block::
 
-   shell$ mpirun -np 4 my_parallel_application
+   shell$ mpirun -n 4 my_parallel_application
 
 This starts a four-process parallel application, running four copies
 of the executable named ``my_parallel_application``.
@@ -332,7 +332,7 @@ to start the processes:
    shell$ cat my_hostfile
    host01.example.com
    host02.example.com
-   shell$ mpirun --hostfile my_hostfile -np 4 my_parallel_application
+   shell$ mpirun --hostfile my_hostfile -n 4 my_parallel_application
 
 This command will launch one copy of ``my_parallel_application`` on
 each of ``host01.example.com`` and ``host02.example.com``.
@@ -360,7 +360,7 @@ from a file.  For example:
 
 .. code-block::
 
-   shell$ mpirun -np 2 a.out : -np 2 b.out
+   shell$ mpirun -n 2 a.out : -n 2 b.out
 
 This will launch a single parallel application, but the first two
 processes will be instances of the ``a.out`` executable, and the
@@ -384,9 +384,9 @@ where the file ``my_appfile`` contains the following:
    # Application context files specify each sub-application in the
    # parallel job, one per line.  The first sub-application is the 2
    # a.out processes:
-   -np 2 a.out
+   -n 2 a.out
    # The second sub-application is the 2 b.out processes:
-   -np 2 b.out
+   -n 2 b.out
 
 This will result in the same behavior as running ``a.out`` and ``b.out``
 from the command line.
@@ -581,7 +581,7 @@ For example, you may see warnings similar to the following:
 .. code-block:: sh
 
    # With the Intel compiler suite
-   shell$ mpirun -np 1 --host node1.example.com mpi_hello
+   shell$ mpirun -n 1 --host node1.example.com mpi_hello
    prted: error while loading shared libraries: libimf.so: cannot open shared object file: No such file or directory
    --------------------------------------------------------------------------
    A daemon (pid 11893) died unexpectedly with status 127 while
@@ -589,12 +589,12 @@ For example, you may see warnings similar to the following:
    ...more error messages...
 
    # With the PGI compiler suite
-   shell$ mpirun -np 1 --host node1.example.com mpi_hello
+   shell$ mpirun -n 1 --host node1.example.com mpi_hello
    prted: error while loading shared libraries: libpgcc.so: cannot open shared object file: No such file or directory
    ...more error messages...
 
    # With the PathScale compiler suite
-   shell$ mpirun -np 1 --host node1.example.com mpi_hello
+   shell$ mpirun -n 1 --host node1.example.com mpi_hello
    prted: error while loading shared libraries: libmv.so: cannot open shared object file: No such file or directory
    ...more error messages...
 
@@ -653,7 +653,7 @@ For example:
 
 .. code-block::
 
-   shell$ mpirun -np 2 --host a,b uptime
+   shell$ mpirun -n 2 --host a,b uptime
 
 This will launch a copy of the Unix command ``uptime`` on the hosts ``a``
 and ``b``.
@@ -682,7 +682,7 @@ the target display, perhaps something like this:
    shell$ hostname
    my_desktop.secure-cluster.example.com
    shell$ xhost +
-   shell$ mpirun -np 4 -x DISPLAY=my_desktop.secure-cluster.example.com a.out
+   shell$ mpirun -n 4 -x DISPLAY=my_desktop.secure-cluster.example.com a.out
 
 However, this technique is not generally suitable for unsecure
 environments (because it allows anyone to read and write to your
@@ -698,7 +698,7 @@ from the nodes where your application will be running:
    compute2 being added to access control list
    compute3 being added to access control list
    compute4 being added to access control list
-   shell$ mpirun -np 4 -x DISPLAY=my_desktop.secure-cluster.example.com a.out
+   shell$ mpirun -n 4 -x DISPLAY=my_desktop.secure-cluster.example.com a.out
 
 (assuming that the four nodes you are running on are ``compute1``
 through ``compute4``).
@@ -742,8 +742,7 @@ Several notable options are:
 * ``--host``: Specify a host or list of hosts to run on (see
   :ref:`this FAQ entry for more details
   <faq-running-mpi-apps-mpirun-host-label>`).
-* ``--np`` (or ``-np``): Indicate the number of processes to
-  start.
+* ``-n``: Indicate the number of processes to start.
 * ``--mca``: Set MCA parameters (see the :doc:`Run-Time Tuning FAQ
   category </faq/tuning/>` for more details).
 * ``--wdir DIRECTORY``: Set the working directory of the started
@@ -818,7 +817,7 @@ Hostfiles works in two different ways:
 
       shell$ cat my_hosts
       node03
-      shell$ mpirun -np 1 --hostfile my_hosts hostname
+      shell$ mpirun -n 1 --hostfile my_hosts hostname
 
    This will run a single copy of ``hostname`` on the host ``node03``.
 
@@ -829,7 +828,7 @@ Hostfiles works in two different ways:
 
       shell$ cat my_hosts
       node17
-      shell$ mpirun -np 1 --hostfile my_hosts hostname
+      shell$ mpirun -n 1 --hostfile my_hosts hostname
 
    This is an error (because ``node17`` is not allocated to your job),
    and ``mpirun`` will abort.
@@ -853,7 +852,7 @@ Hostfiles works in two different ways:
       node01.example.com slots=1
       node02.example.com slots=1
       node03.example.com slots=1
-      shell$ mpirun -np 3 --hostfile my_hosts hostname
+      shell$ mpirun -n 3 --hostfile my_hosts hostname
 
    This will launch a single copy of ``hostname`` on the hosts
    ``node01.example.com``, ``node02.example.com``, and
@@ -869,7 +868,7 @@ Hence, if you specify multiple applications (as in an MPMD job),
    node01.example.com
    shell$ cat hostfile_2
    node02.example.com
-   shell$ mpirun -np 1 --hostfile hostfile_1 hostname : -np 1 --hostfile hostfile_2 uptime
+   shell$ mpirun -n 1 --hostfile hostfile_1 hostname : -n 1 --hostfile hostfile_2 uptime
    node01.example.com
     06:11:45 up 1 day,  2:32,  0 users,  load average: 21.65, 20.85, 19.84
 
@@ -888,7 +887,7 @@ hosts on which to run.  For example:
 
 .. code-block::
 
-   shell$ mpirun -np 3 --host a,b,c hostname
+   shell$ mpirun -n 3 --host a,b,c hostname
 
 Will launch *one* copy of ``hostname`` on each of hosts ``a``, ``b``,
 and ``c``.  Specifically: each host defaults to 1 slot, unless
@@ -928,14 +927,14 @@ Slots are discussed in much more detail :ref:`in this FAQ entry
 
    .. code-block::
 
-      shell$ mpirun -np 1 --hostfile my_hosts --host node3 hostname
+      shell$ mpirun -n 1 --hostfile my_hosts --host node3 hostname
 
    This will run a single copy of ``hostname`` on the host ``node3``.
    However, if you run:
 
    .. code-block::
 
-      shell$ mpirun -np 1 --hostfile my_hosts --host node17 hostname
+      shell$ mpirun -n 1 --hostfile my_hosts --host node17 hostname
 
    This is an error (because ``node17`` is not listed in
    ``my_hosts``); ``mpirun`` will abort.
@@ -956,7 +955,7 @@ Slots are discussed in much more detail :ref:`in this FAQ entry
 
    .. code-block::
 
-      shell$ mpirun -np 3 --host a,b,c hostname
+      shell$ mpirun -n 3 --host a,b,c hostname
 
    This will launch a single copy of ``hostname`` on the hosts ``a``,
    ``b``, and ``c``.
@@ -967,7 +966,7 @@ Hence, if you specify multiple applications (as in an MPMD job),
 
 .. code-block::
 
-   shell$ mpirun -np 1 --host a hostname : -np 1 --host b uptime
+   shell$ mpirun -n 1 --host a hostname : -n 1 --host b uptime
 
 This will launch ``hostname`` on host ``a`` and ``uptime`` on host ``b``.
 
@@ -1134,8 +1133,8 @@ line:
 #. *How many* processes should be launched?
 #. *Where* should those processes be launched?
 
-The "how many" question is directly answered with the ``-np`` switch
-to ``mpirun``.  If ``-np`` is not specified on the ``mpirun`` command
+The "how many" question is directly answered with the ``-n`` switch
+to ``mpirun``.  If ``-n`` is not specified on the ``mpirun`` command
 line, its value is the sum of the slots on all the nodes.
 
 The "where" question is a little more complicated, and depends on
@@ -1172,7 +1171,7 @@ node:
       shell$ cat my-hosts
       node0 slots=2 max_slots=20
       node1 slots=2 max_slots=20
-      shell$ mpirun --hostfile my-hosts -np 8 --map-by slot hello | sort
+      shell$ mpirun --hostfile my-hosts -n 8 --map-by slot hello | sort
       Hello World I am rank 0 of 8 running on node0
       Hello World I am rank 1 of 8 running on node0
       Hello World I am rank 2 of 8 running on node1
@@ -1198,7 +1197,7 @@ node:
       shell$ cat my-hosts
       node0 slots=2 max_slots=20
       node1 slots=2 max_slots=20
-      shell$ mpirun --hostname my-hosts -np 8 --map-by node hello | sort
+      shell$ mpirun --hostname my-hosts -n 8 --map-by node hello | sort
       Hello World I am rank 0 of 8 running on node0
       Hello World I am rank 1 of 8 running on node1
       Hello World I am rank 2 of 8 running on node0
@@ -1252,7 +1251,7 @@ processes.  For example:
    # processor cores on the host
    shell$ cat my-hostfile
    localhost
-   shell$ mpirun -np 4 --hostfile my-hostfile a.out
+   shell$ mpirun -n 4 --hostfile my-hostfile a.out
 
 Specifically: we strongly suggest that you do **NOT** have a hostfile
 that contains ``slots=4`` (because there are only two available
@@ -1269,7 +1268,7 @@ specifically tell Open MPI that it is ok to oversubscribe via
    # For the purposes of this example, explicitly tell Open MPI
    # that we have 2 slots on the host.
    localhost slots=2
-   shell$ mpirun -np 4 --hostfile my-hostfile --map-by :OVERSUBSCRIBE a.out
+   shell$ mpirun -n 4 --hostfile my-hostfile --map-by :OVERSUBSCRIBE a.out
 
 The reason you should tell Open MPI whether you're oversubscribing or
 not (i.e., never specify a ``slots`` value more than the number of
@@ -1304,7 +1303,7 @@ For example, on a node with a two processor cores:
 
    shell$ cat my-hostfile
    localhost slots=4
-   shell$ mpirun -np 4 --hostfile my-hostfile a.out
+   shell$ mpirun -n 4 --hostfile my-hostfile a.out
 
 This would cause all 4 MPI processes to run in *aggressive* mode
 because Open MPI thinks that there are 4 available processor cores to

--- a/docs/man-openmpi/man1/mpirun.1.rst
+++ b/docs/man-openmpi/man1/mpirun.1.rst
@@ -54,7 +54,7 @@ probably want to use a command line of the following form:
 
 .. code:: sh
 
-   shell$ mpirun [ -np X ] [ --hostfile <filename> ]  <program>
+   shell$ mpirun [ -n X ] [ --hostfile <filename> ]  <program>
 
 This will run X copies of <program> in your current run-time
 environment (if running under a supported resource manager, Open MPI's
@@ -250,16 +250,21 @@ that none of the options imply a particular binding policy |mdash| e.g.,
 requesting N processes for each socket does not imply that the
 processes will be bound to the socket.
 
-* ``-c``, ``-n``, ``--n``, ``-np <#>``: Run this many copies of the
+* ``-n``, ``--n``, ``-c``, ``-np <#>``: Run this many copies of the
   program on the given nodes.  This option indicates that the
   specified file is an executable program and not an application
   context. If no value is provided for the number of copies to execute
-  (i.e., neither the ``-np`` nor its synonyms are provided on the
+  (i.e., neither the ``-n`` nor its synonyms are provided on the
   command line), Open MPI will automatically execute a copy of the
   program on each process slot (see below for description of a
   "process slot"). This feature, however, can only be used in the SPMD
   model and will return an error (without beginning execution of the
   application) otherwise.
+
+  .. note:: The ``-n`` option is the preferred option to be used to specify the
+            number of copies of the program to be executed, but the alternate
+            options are also accepted.
+
 
 * ``--map-by ppr:N:<object>``: Launch N times the number of objects of
   the specified type on each node.
@@ -653,7 +658,7 @@ Extended command line arguments allow for the description of the
 application layout on the command line using colons (``:``) to
 separate the specification of programs and arguments. Some options are
 globally set across all specified programs (e.g., ``--hostfile``),
-while others are specific to a single program (e.g., ``-np``).
+while others are specific to a single program (e.g., ``-n``).
 
 Specifying Host Nodes
 ^^^^^^^^^^^^^^^^^^^^^
@@ -740,7 +745,7 @@ launches one process per host node.
 
 is the same as ``--npernode 1``.
 
-Another alternative is to specify the number of processes with the ``-np``
+Another alternative is to specify the number of processes with the ``-n``
 option.  Consider now the hostfile:
 
 .. code:: sh
@@ -754,11 +759,11 @@ Now run with ``myhostfile``:
 
 .. code:: sh
 
-   shell$ mpirun --hostfile myhostfile -np 6 ./a.out
+   shell$ mpirun --hostfile myhostfile -n 6 ./a.out
 
 will launch processes 0-3 on node ``aa`` and processes 4-5 on node
 ``bb``.  The remaining slots in the hostfile will not be used since
-the ``-np`` option indicated that only 6 processes should be launched.
+the ``-n`` option indicated that only 6 processes should be launched.
 
 Mapping Processes to Nodes: Using Policies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -767,7 +772,7 @@ The examples above illustrate the default mapping of process processes
 to nodes.  This mapping can also be controlled with various ``mpirun``
 options that describe mapping policies.
 
-Consider the same hostfile as above, again with ``-np 6``.  The table
+Consider the same hostfile as above, again with ``-n 6``.  The table
 below lists a few ``mpirun`` variations, and shows which
 MPI_COMM_WORLD ranks end up on which node:
 
@@ -803,13 +808,13 @@ consumes few system resources, ``--nolocal`` can be helpful for
 launching very large jobs where mpirun may actually need to use
 noticeable amounts of memory and/or processing time.
 
-Just as ``-np`` can specify fewer processes than there are slots, it
+Just as ``-n`` can specify fewer processes than there are slots, it
 can also oversubscribe the slots.  For example, with the same
 hostfile:
 
 .. code:: sh
 
-   shell$ mpirun --hostfile myhostfile -np 14 ./a.out
+   shell$ mpirun --hostfile myhostfile -n 14 ./a.out
 
 will launch processes 0-3 on node ``aa``, 4-7 on ``bb``, and 8-11 on
 ``cc``.  It will then add the remaining two processes to whichever
@@ -820,7 +825,7 @@ same hostfile:
 
 .. code:: sh
 
-   shell$ mpirun --hostfile myhostfile -np 14 --nooversubscribe ./a.out
+   shell$ mpirun --hostfile myhostfile -n 14 --nooversubscribe ./a.out
 
 will produce an error since ``--nooversubscribe`` prevents
 oversubscription.
@@ -840,7 +845,7 @@ value defaults to the limit.  Now:
 
 .. code:: sh
 
-   shell$ mpirun --hostfile myhostfile -np 14 ./a.out
+   shell$ mpirun --hostfile myhostfile -n 14 ./a.out
 
 causes the first 12 processes to be launched as before, but the
 remaining two processes will be forced onto node ``cc``.  The other
@@ -850,12 +855,12 @@ this job.
 Using the ``--nooversubscribe`` option can be helpful since Open MPI
 currently does not get ``max_slots`` values from the resource manager.
 
-Of course, ``-np`` can also be used with the ``-H`` or ``-host``
+Of course, ``-n`` can also be used with the ``-H`` or ``-host``
 option.  For example:
 
 .. code:: sh
 
-   shell$ mpirun -H aa,bb -np 8 ./a.out
+   shell$ mpirun -H aa,bb -n 8 ./a.out
 
 launches 8 processes.  Since only two hosts are specified, after the
 first two processes are mapped, one to ``aa`` and one to ``bb``, the
@@ -865,7 +870,7 @@ And here is a MIMD example:
 
 .. code:: sh
 
-   shell$ mpirun -H aa -np 1 hostname : -H bb,cc -np 2 uptime
+   shell$ mpirun -H aa -n 1 hostname : -H bb,cc -n 2 uptime
 
 will launch process 0 running hostname on node ``aa`` and processes 1
 and 2 each running uptime on nodes ``bb`` and ``cc``, respectively.
@@ -990,7 +995,7 @@ Finally, ``--report-bindings`` can be used to report bindings.
 
 As an example, consider a node with two processor sockets, each
 comprised of four cores, and each of those cores contains one hardware
-thread.  We run mpirun with ``-np 4 --report-bindings`` and the
+thread.  We run mpirun with ``-n 4 --report-bindings`` and the
 following additional options:
 
 .. code::
@@ -1236,7 +1241,7 @@ example:
 
 .. code:: sh
 
-   shell$ mpirun -np 2 my_app < my_input > my_output
+   shell$ mpirun -n 2 my_app < my_input > my_output
 
 Note that in this example only the MPI_COMM_WORLD rank 0 process will
 receive the stream from ``my_input`` on stdin.  The stdin on all the other
@@ -1399,14 +1404,14 @@ select which BTL to be used for transporting MPI messages.  The
 
 .. code:: sh
 
-   shell$ mpirun --mca btl tcp,self -np 1 my_mpi_app
+   shell$ mpirun --mca btl tcp,self -n 1 my_mpi_app
 
 This tells Open MPI to use the ``tcp`` and ``self`` BTLs, and to run a
 single copy of ``my_mpi_app`` an allocated node.
 
 .. code:: sh
 
-   shell$ mpirun --mca btl self -np 1 my_mpi_app
+   shell$ mpirun --mca btl self -n 1 my_mpi_app
 
 Tells Open MPI to use the ``self`` BTL, and to run a single copy of
 ``my_mpi_app`` an allocated node.
@@ -1543,7 +1548,7 @@ Be sure also to see the examples throughout the sections above.
 
 .. code:: sh
 
-   shell$ mpirun -np 4 --mca btl tcp,sm,self prog1
+   shell$ mpirun -n 4 --mca btl tcp,sm,self prog1
 
 Run 4 copies of ``prog1`` using the ``tcp``, ``sm`` (shared memory),
 and ``self`` (process loopback) BTL's for the transport of MPI

--- a/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
+++ b/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
@@ -111,7 +111,7 @@ Examples
               rank, ompi_bound, current_binding, exists);
        ...
 
-Output of mpirun -np 2 -bind-to-core a.out:
+Output of mpirun -n 2 -bind-to-core a.out:
 
 ::
 
@@ -124,7 +124,7 @@ Output of mpirun -np 2 -bind-to-core a.out:
      current_binding: socket 0[core 1]
               exists: socket 0 has 4 cores
 
-Output of mpirun -np 2 -bind-to-socket a.out:
+Output of mpirun -n 2 -bind-to-socket a.out:
 
 ::
 
@@ -159,7 +159,7 @@ Output of mpirun -np 2 -bind-to-socket a.out:
               rank, ompi_bound, current_binding, exists);
        ...
 
-Output of mpirun -np 2 -bind-to-core a.out:
+Output of mpirun -n 2 -bind-to-core a.out:
 
 ::
 
@@ -172,7 +172,7 @@ Output of mpirun -np 2 -bind-to-core a.out:
      current_binding: [. B . .]
               exists: [. . . .]
 
-Output of mpirun -np 2 -bind-to-socket a.out:
+Output of mpirun -n 2 -bind-to-socket a.out:
 
 ::
 

--- a/docs/man-openshmem/man3/intro_shmem.3.rst
+++ b/docs/man-openshmem/man3/intro_shmem.3.rst
@@ -671,7 +671,7 @@ purpose (named **oshrun** for this example):
 
 ::
 
-   oshrun -np 32 ./a.out
+   oshrun -n 32 ./a.out
 
 
 EXAMPLES

--- a/docs/networking/cuda.rst
+++ b/docs/networking/cuda.rst
@@ -447,7 +447,7 @@ using Open MPI and UCX CUDA support:
 
 .. code-block::
 
-   shell$ mpirun -np 2 --mca pml ucx \
+   shell$ mpirun -n 2 --mca pml ucx \
        -x UCX_TLS=rc,sm,cuda_copy,gdr_copy,cuda_ipc ./osu_latency D D
 
 /////////////////////////////////////////////////////////////////////////

--- a/docs/networking/ofi.rst
+++ b/docs/networking/ofi.rst
@@ -95,7 +95,7 @@ the environment. For example:
 
 .. code-block::
 
-   shell$ mpirun -mca mtl [psm2|ofi] -x PSM2_MULTIRAIL=1 -np 2 -H host1,host2 ./a.out
+   shell$ mpirun -mca mtl [psm2|ofi] -x PSM2_MULTIRAIL=1 -n 2 -H host1,host2 ./a.out
 
 .. note:: When using the OFI MTL, please ensure that the PSM2 OFI
           provider is used for communication with OPA devices.

--- a/docs/networking/opa.rst
+++ b/docs/networking/opa.rst
@@ -18,7 +18,7 @@ in the environment. For example:
 
 .. code-block::
 
-   shell$ mpirun -mca mtl [psm2|ofi] -x PSM2_MULTIRAIL=1 -np 2 -H host1,host2 ./a.out
+   shell$ mpirun -mca mtl [psm2|ofi] -x PSM2_MULTIRAIL=1 -n 2 -H host1,host2 ./a.out
 
 .. note:: When using the OFI MTL, please ensure that the PSM2 OFI provider is used for
           communication with OPA devices.

--- a/docs/networking/shared-memory.rst
+++ b/docs/networking/shared-memory.rst
@@ -37,7 +37,7 @@ communications.  For example:
 
 .. code-block:: sh
 
-   shell$ mpirun --mca btl self,sm,tcp -np 16 ./a.out
+   shell$ mpirun --mca btl self,sm,tcp -n 16 ./a.out
 
 /////////////////////////////////////////////////////////////////////////
 

--- a/docs/networking/tcp.rst
+++ b/docs/networking/tcp.rst
@@ -435,7 +435,7 @@ be the library trying to make connections to unreachable hosts.
 
    # Here is an example with some of the output deleted for clarity.
    # One can see the connections that are attempted.
-   shell$ mpirun --mca btl self,sm,tcp --mca btl_base_verbose 30 -np 2 -host NodeA,NodeB a.out
+   shell$ mpirun --mca btl self,sm,tcp --mca btl_base_verbose 30 -n 2 -host NodeA,NodeB a.out
    [...snip...]
    [NodeA:18003] btl: tcp: attempting to connect() to address 10.8.47.2 on port 59822
    [NodeA:18003] btl: tcp: attempting to connect() to address 192.168.1.2 on port 59822

--- a/docs/release-notes/mpi.rst
+++ b/docs/release-notes/mpi.rst
@@ -145,7 +145,7 @@ Other MPI features
 
      shell$ cd examples/
      shell$ mpicc hello_c.c -o hello_c -lompitrace
-     shell$ mpirun -np 1 hello_c
+     shell$ mpirun -n 1 hello_c
      MPI_INIT: argc 1
      Hello, world, I am 0 of 1
      MPI_BARRIER[0]: comm MPI_COMM_WORLD

--- a/docs/running-apps/gridengine.rst
+++ b/docs/running-apps/gridengine.rst
@@ -59,7 +59,7 @@ that were allocated by Grid Engine:
    # Allocate an Grid Engine interactive job with 4 slots from a
    # parallel environment (PE) named 'ompi' and run a 4-process Open
    # MPI job
-   shell$ qrsh -pe ompi 4 -b y mpirun -np 4 mpi-hello-world
+   shell$ qrsh -pe ompi 4 -b y mpirun -n 4 mpi-hello-world
 
 There are also other ways to submit jobs under Grid Engine:
 
@@ -106,7 +106,7 @@ You may want to alter other parameters, but the important one is
 ``control_slaves``, specifying that the environment has "tight
 integration".  Note also the lack of a start or stop procedure.  The
 tight integration means that mpirun automatically picks up the slot
-count to use as a default in place of the ``-np`` argument, picks up a
+count to use as a default in place of the ``-n`` argument, picks up a
 host file, spawns remote processes via ``qrsh`` so that Grid Engine
 can control and monitor them, and creates and destroys a per-job
 temporary directory (``$TMPDIR``), in which Open MPI's directory will
@@ -177,7 +177,7 @@ like this batch script can be used:
    #$ -pe ompi 16
    #$ -j y
    #$ -l h_rt=00:20:00
-   mpirun -np 16 -mca orte_forward_job_control 1 mpi-hello-world
+   mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
 
 .. error:: Ralph: Does ``orte_forward_job_control`` still exist?
 
@@ -196,7 +196,7 @@ to handle it:
    #$ -pe ompi 16
    #$ -j y
    #$ -l h_rt=00:20:00
-   exec mpirun -np 16 -mca orte_forward_job_control 1 mpi-hello-world
+   exec mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
 
 Alternatively, one can catch the signals in the script instead of doing
 an exec on the mpirun:
@@ -225,7 +225,7 @@ an exec on the mpirun:
    trap sigusr1handler SIGUSR1
    trap sigusr2handler SIGUSR2
 
-   mpirun -np 16 -mca orte_forward_job_control 1 mpi-hello-world
+   mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
 
 Grid Engine job suspend / resume support
 ----------------------------------------
@@ -245,7 +245,7 @@ orte_forward_job_control 1``.  Here is an example on Solaris:
 
 .. code-block:: sh
 
-   shell$ mpirun -mca orte_forward_job_control 1 -np 2 mpi-hello-world
+   shell$ mpirun -mca orte_forward_job_control 1 -n 2 mpi-hello-world
 
 In another window, we suspend and continue the job:
 

--- a/docs/running-apps/localhost.rst
+++ b/docs/running-apps/localhost.rst
@@ -12,13 +12,13 @@ example:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 6 mpi-hello-world
+   shell$ mpirun -n 6 mpi-hello-world
    Hello world, I am 0 of 6 (running on my-laptop))
    Hello world, I am 1 of 6 (running on my-laptop)
    ...
    Hello world, I am 5 of 6 (running on my-laptop)
 
-If you do not specify the ``-np`` option, ``mpirun`` will default to
+If you do not specify the ``-n`` option, ``mpirun`` will default to
 launching as many MPI processes as there are processor cores (not
 hyperthreads) on the machine.
 

--- a/docs/running-apps/lsf.rst
+++ b/docs/running-apps/lsf.rst
@@ -35,7 +35,7 @@ Launching
 
 When properly configured, Open MPI obtains both the list of hosts and
 how many processes to start on each host from LSF directly.  Hence, it
-is unnecessary to specify the ``--hostfile``, ``--host``, or ``-np``
+is unnecessary to specify the ``--hostfile``, ``--host``, or ``-n``
 options to ``mpirun``.  Open MPI will use PBS/Torque-native mechanisms
 to launch and kill processes (``ssh`` is not required).
 

--- a/docs/running-apps/quickstart.rst
+++ b/docs/running-apps/quickstart.rst
@@ -19,11 +19,11 @@ equivalent) to launch MPI applications.  For example:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 2 mpi-hello-world
+   shell$ mpirun -n 2 mpi-hello-world
    # or
-   shell$ mpiexec -np 2 mpi-hello-world
+   shell$ mpiexec -n 2 mpi-hello-world
    # or
-   shell$ mpiexec -np 1 mpi-hello-world : -np 1 mpi-hello-world
+   shell$ mpiexec -n 1 mpi-hello-world : -n 1 mpi-hello-world
 
 are all equivalent.  For simplicity, the rest of this documentation
 will simply refer to ``mpirun``.
@@ -38,17 +38,17 @@ Launching on a single host
 
 It is common to develop MPI applications on a single laptop or
 workstation.  In such cases, use ``mpirun`` and specify how many MPI
-processes you want to launch via the ``-np`` option:
+processes you want to launch via the ``-n`` option:
 
 .. code-block:: sh
 
-   shell$ mpirun -np 6 mpi-hello-world
+   shell$ mpirun -n 6 mpi-hello-world
    Hello world, I am 0 of 6 (running on my-laptop))
    Hello world, I am 1 of 6 (running on my-laptop)
    ...
    Hello world, I am 5 of 6 (running on my-laptop)
 
-If you do not specify the ``-np`` option, ``mpirun`` will default to
+If you do not specify the ``-n`` option, ``mpirun`` will default to
 launching as many MPI processes as there are processor cores (not
 hyperthreads) on the machine.
 
@@ -144,7 +144,7 @@ in the scheduled allocation), you can simply:
    # Write a script that runs your MPI application
    shell$ cat my-slurm-script.sh
    #!/bin/sh
-   # There is no need to specify -np or --hostfile because that
+   # There is no need to specify -n or --hostfile because that
    # information will automatically be provided by Slurm.
    mpirun mpi-hello-world
 
@@ -182,7 +182,7 @@ the number of processes to run and hosts to use from the scheduler.
 
 ``mpirun`` has many more features not described in this Quick Start
 section.  For example, while uncommon in scheduled environments, you
-can use ``-np`` and/or ``--hostfile`` to launch in subsets of the
+can use ``-n`` and/or ``--hostfile`` to launch in subsets of the
 overall scheduler allocation.  See the mpirun man page for more
 details.
 

--- a/docs/running-apps/slurm.rst
+++ b/docs/running-apps/slurm.rst
@@ -21,7 +21,7 @@ When ``mpirun`` is launched in a Slurm job, ``mpirun`` will
 automatically utilize the Slurm infrastructure for launching and
 controlling the individual MPI processes.
 Hence, it is unnecessary to specify the ``--hostfile``,
-``--host``, or ``-np`` options to ``mpirun``.
+``--host``, or ``-n`` options to ``mpirun``.
 
 .. note:: Using ``mpirun`` is the recomended method for launching Open
    MPI jobs in Slurm jobs.

--- a/docs/running-apps/tm.rst
+++ b/docs/running-apps/tm.rst
@@ -37,7 +37,7 @@ Launching
 When properly configured, Open MPI obtains both the list of hosts and
 how many processes to start on each host from Torque / PBS Pro
 directly.  Hence, it is unnecessary to specify the ``--hostfile``,
-``--host``, or ``-np`` options to ``mpirun``.  Open MPI will use
+``--host``, or ``-n`` options to ``mpirun``.  Open MPI will use
 PBS/Torque-native mechanisms to launch and kill processes (``ssh`` is
 not required).
 

--- a/examples/dtrace/README
+++ b/examples/dtrace/README
@@ -61,7 +61,7 @@ perform the following steps:
   2.  Type the following command but replace the hostnames in the example with the
       names of the hosts in your cluster.
 
-	% mpirun -np 2 --host burl-ct-v440-4,burl-ct-v440-5 myppriv.sh
+	% mpirun -n 2 --host burl-ct-v440-4,burl-ct-v440-5 myppriv.sh
 
 
 If the output of ppriv shows that the E privilege set has the dtrace
@@ -109,7 +109,7 @@ There are two ways to use Dynamic Tracing with MPI programs:
 For illustration purposes, assume you have a program named mpiapp. To trace
 the program mpiapp using the mpitrace.d script, type the following command:
 
-% mpirun -np 4 dtrace -s mpitrace.d -c mpiapp
+% mpirun -n 4 dtrace -s mpitrace.d -c mpiapp
 
 The advantage of tracing an MPI program in this way is that all the processes
 in the job will be traced from the beginning.  This method is probably most
@@ -131,7 +131,7 @@ dtrace -s $1 -c $2 -o $2.$OMPI_COMM_WORLD_RANK.trace
 
 Type the following command to run the partrace.sh shell script:
 
-% mpirun -np 4 partrace.sh mpitrace.d mpiapp
+% mpirun -n 4 partrace.sh mpitrace.d mpiapp
 
 This will run mpiapp under dtrace using the mpitrace.d script.  The script
 saves the trace output for each process in a job under a separate file name,

--- a/examples/spc_example.c
+++ b/examples/spc_example.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     int num_messages, message_size, rc;
 
     if (argc < 3) {
-        printf("Usage: mpirun -np 2 --mca mpi_spc_attach all --mca mpi_spc_dump_enabled true "
+        printf("Usage: mpirun -n 2 --mca mpi_spc_attach all --mca mpi_spc_dump_enabled true "
                "./spc_example [num_messages] [message_size]\n");
         return -1;
     } else {

--- a/ompi/mca/common/monitoring/README.md
+++ b/ompi/mca/common/monitoring/README.md
@@ -144,7 +144,7 @@ Two perl scripts are provided in test/monitoring:
 For instance, the provided examples store phases output in `./prof`:
 
 ```
-shell$ mpirun -np 4 --mca pml_monitoring_enable 2 ./monitoring_test
+shell$ mpirun -n 4 --mca pml_monitoring_enable 2 ./monitoring_test
 ```
 
 Should provide the following output:

--- a/ompi/mca/common/monitoring/monitoring_prof.c
+++ b/ompi/mca/common/monitoring/monitoring_prof.c
@@ -27,7 +27,7 @@ Contact the authors for questions.
 
 To be run as:
 
-mpirun -np 4 \
+mpirun -n 4 \
     --mca pml_monitoring_enable 1 \
     -x LD_PRELOAD=ompi_install_dir/lib/ompi_monitoring_prof.so \
     ./my_app

--- a/opal/test/reachable/tests
+++ b/opal/test/reachable/tests
@@ -8,5 +8,5 @@
 # $HEADER$
 #
 
-mpirun -np 1 --mca reachable netlink reachable_netlink 
-mpirun -np 1 --mca reachable weighted reachable_weighted 
+mpirun -n 1 --mca reachable netlink reachable_netlink
+mpirun -n 1 --mca reachable weighted reachable_weighted

--- a/test/datatype/check_op.sh
+++ b/test/datatype/check_op.sh
@@ -5,10 +5,10 @@ set -u
 echo "ompi version with AVX512 -- Usage: arg1: count of elements, args2: 'i'|'u'|'f'|'d' : datatype: signed, unsigned, float, double. args3 size of type. args4 operation"
 mpirun="mpirun --mca pml ob1 --mca btl vader,self"
 # For SVE-architecture
-# echo "$mpirun -mca op_sve_hardware_available 0 -mca op_avx_hardware_available 0 -np 1 Reduce_local_float 1048576  i 8 max"
+# echo "$mpirun -mca op_sve_hardware_available 0 -mca op_avx_hardware_available 0 -n 1 Reduce_local_float 1048576  i 8 max"
 
 # For X86_64 architectures
-# echo "$mpirun -mca op_avx_support 0 -np 1 Reduce_local_float 1048576 i 8 max"
+# echo "$mpirun -mca op_avx_support 0 -n 1 Reduce_local_float 1048576 i 8 max"
 
 Orange="\033[0;33m"
 Blue="\033[0;34m"
@@ -27,7 +27,7 @@ for op in max min sum prod band bor bxor; do
         for size in 0 1 7 15 31 63 127 130; do
             foo=$((1024 * 1024 + $size))
             echo -e "Test $Yellow __mm512 instruction for loop $NC Total_num_bits = $foo * $type_size "
-            cmd="$mpirun -np 1 reduce_local -l $foo -u $foo -t i -s $type_size -o $op"
+            cmd="$mpirun -n 1 reduce_local -l $foo -u $foo -t i -s $type_size -o $op"
             if test $verbose -eq 1 ; then echo $cmd; fi
             eval $cmd
         done
@@ -46,7 +46,7 @@ for op in max min sum prod band bor bxor; do
         for size in 0 1 7 15 31 63 127 130; do
             foo=$((1024 * 1024 + $size))
             echo -e "Test $Yellow __mm512 instruction for loop $NC Total_num_bits = $foo * $type_size"
-            cmd="$mpirun -np 1 reduce_local -l $foo -u $foo -t u -s $type_size -o $op"
+            cmd="$mpirun -n 1 reduce_local -l $foo -u $foo -t u -s $type_size -o $op"
             if test $verbose -eq 1 ; then echo $cmd; fi
             eval $cmd
         done
@@ -61,7 +61,7 @@ for op in max min sum prod; do
     for size in 1024 127 130; do
         foo=$((1024 * 1024 + $size))
         echo -e "Test $Yellow __mm512 instruction for loop $NC Total_num_bits = $foo * 32"
-        cmd="$mpirun -np 1 reduce_local -l $foo -u $foo -t f -s 32 -o $op"
+        cmd="$mpirun -n 1 reduce_local -l $foo -u $foo -t f -s 32 -o $op"
         if test $verbose -eq 1 ; then echo $cmd; fi
         eval $cmd
     done
@@ -73,7 +73,7 @@ for op in max min sum prod; do
     for size in 1024 127 130; do
         foo=$((1024 * 1024 + $size))
         echo -e "Test $Yellow __mm512 instruction for loop $NC Total_num_bits = $foo * 64"
-        cmd="$mpirun -np 1 reduce_local -l $foo -u $foo -t d -s 64 -o $op"
+        cmd="$mpirun -n 1 reduce_local -l $foo -u $foo -t d -s 64 -o $op"
         if test $verbose -eq 1 ; then echo $cmd; fi
         eval $cmd
     done

--- a/test/monitoring/check_monitoring.c
+++ b/test/monitoring/check_monitoring.c
@@ -15,7 +15,7 @@
 
   To be run as:
 
-  mpirun -np 4 --mca pml_monitoring_enable 2 ./check_monitoring
+  mpirun -n 4 --mca pml_monitoring_enable 2 ./check_monitoring
 */
 
 #include <mpi.h>

--- a/test/monitoring/monitoring_test.c
+++ b/test/monitoring/monitoring_test.c
@@ -24,7 +24,7 @@ To disable the RMA operations testing, add "--without-rma" as an application par
 
 To be run as (without using MPI_Tool):
 
-mpirun -np 4 --mca pml_monitoring_enable 2 --mca pml_monitoring_enable_output 3 --mca pml_monitoring_filename prof/output ./monitoring_test
+mpirun -n 4 --mca pml_monitoring_enable 2 --mca pml_monitoring_enable_output 3 --mca pml_monitoring_filename prof/output ./monitoring_test
 
 with the results being, as an example:
 output.1.prof

--- a/test/monitoring/test_pvar_access.c
+++ b/test/monitoring/test_pvar_access.c
@@ -20,7 +20,7 @@ Contact the authors for questions.
 
 To be run as:
 
-mpirun -np 4 --mca pml_monitoring_enable 2 ./test_pvar_access
+mpirun -n 4 --mca pml_monitoring_enable 2 ./test_pvar_access
 
 Then, the output should be:
 Flushing phase 1:

--- a/test/simple/pmix.c
+++ b/test/simple/pmix.c
@@ -11,7 +11,7 @@
 /*
  * To compile test:
  * mpicc -I$src_dir -I$src_dir/opal/include -I$src_dir/orte/include -I$src_dir/ompi/include
- * -DOMPI_BUILDING=1 pmix.c -o pmix To run test: mpirun -np 2 <any mca params> ./pmix Test should
+ * -DOMPI_BUILDING=1 pmix.c -o pmix To run test: mpirun -n 2 <any mca params> ./pmix Test should
  * print "Passed" in case of success and print pmix time intervals at process with rank 0.
  * */
 #include <mpi.h>


### PR DESCRIPTION
Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>