### PR TITLE
opal_atomic_rmb: GCC has fixed its acquire fence barrier in its 8 release [v5.0.x]

### DIFF
--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -50,10 +50,13 @@ static inline void opal_atomic_wmb(void)
 
 static inline void opal_atomic_rmb(void)
 {
-#    if defined(PLATFORM_ARCH_X86_64)
+#    if defined(PLATFORM_ARCH_X86_64) && PLATFORM_COMPILER_GNU && __GNUC__ < 8
     /* work around a bug in older gcc versions (observed in gcc 6.x)
      * where acquire seems to get treated as a no-op instead of being
-     * equivalent to __asm__ __volatile__("": : :"memory") on x86_64 */
+     * equivalent to __asm__ __volatile__("": : :"memory") on x86_64.
+     * The issue has been fixed in the GCC 8 release series:
+     * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80640
+     */
     opal_atomic_mb();
 #    else
     atomic_thread_fence(memory_order_acquire);


### PR DESCRIPTION
Only force a full memory barrier for GCC releases prior to 8.1.0.

Backport of #10118 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu> 