### PR TITLE
README.md: fix doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Open MPI
 
-`The Open MPI Project <https://www.open-mpi.org/>`_ is an open source
-implementation of the `Message Passing Interface (MPI) specification
-<https://www.mpi-forum.org/docs/>`_ that is developed and maintained
-by a consortium of academic, research, and industry partners.  Open
-MPI is therefore able to combine the expertise, technologies, and
-resources from all across the High Performance Computing community in
-order to build the best MPI library available.  Open MPI offers
-advantages for system and software vendors, application developers and
-computer science researchers.
+[The Open MPI Project](https://www.open-mpi.org/) is an open source
+implementation of the [Message Passing Interface (MPI)
+specification](https://www.mpi-forum.org/docs/) that is developed and
+maintained by a consortium of academic, research, and industry
+partners.  Open MPI is therefore able to combine the expertise,
+technologies, and resources from all across the High Performance
+Computing community in order to build the best MPI library available.
+Open MPI offers advantages for system and software vendors,
+application developers and computer science researchers.
 
 ## Official documentation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ computer science researchers.
 
 The Open MPI documentation can be viewed in the following ways:
 
-1. Online at https://ompi.readthedocs.io/en/latest/
+1. Online at https://docs.open-mpi.org/
 1. In self-contained (i.e., suitable for local viewing, without an
    internet connection) in official distribution tarballs under
    `docs/_build/html/index.html`.
@@ -28,4 +28,4 @@ Developers who clone the Open MPI Git repository will not have the
 HTML documentation and man pages by default; it must be built.
 Instructions for how to build the Open MPI documentation can be found
 here:
-https://ompi.readthedocs.io/en/latest/developers/prerequisites.html#sphinx.
+https://docs.open-mpi.org/en/master/developers/prerequisites.html#sphinx.


### PR DESCRIPTION
The current URL <https://ompi.readthedocs.io/en/latest/>  does not exist.