### PR TITLE
FORTRAN:  add elemental attribute to comp ops

### DIFF
--- a/config/ompi_fortran_check_elemental.m4
+++ b/config/ompi_fortran_check_elemental.m4
@@ -1,0 +1,47 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2022      Triad National Security, LLC. All rights
+dnl                         reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# Check whether or not the Fortran compiler supports the "elemental"
+# keyword in derived types or not.
+
+# OMPI_FORTRAN_CHECK_ELEMENTAL([action if found],
+#                            [action if not found])
+# ----------------------------------------------------
+AC_DEFUN([OMPI_FORTRAN_CHECK_ELEMENTAL],[
+    AS_VAR_PUSHDEF([elemental_var], [ompi_cv_fortran_elemental])
+
+    AC_CACHE_CHECK([if Fortran compiler supports ELEMENTAL], elemental_var,
+       [AC_LANG_PUSH([Fortran])
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([[ELEMENTAL SUBROUTINE binky(buf)
+ REAL,INTENT(INOUT) :: buf
+ BUF = BUF + 1
+END SUBROUTINE binky]])],
+             [AS_VAR_SET(elemental_var, yes)],
+             [AS_VAR_SET(elemental_var, no)])
+        touch conftest_foo.mod
+        rm -rf *.mod 2>/dev/null
+        AC_LANG_POP([Fortran])
+       ])
+
+    AS_VAR_IF(elemental_var, [yes], [$1], [$2])
+    AS_VAR_POPDEF([elemental_var])dnl
+])

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -19,6 +19,8 @@ dnl Copyright (c) 2014-2021 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+dnl Copyright (c) 2022      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -586,6 +588,15 @@ end type test_mpi_handle],
                          AC_MSG_RESULT(["bad" compiler, no array subsections])
                      ])
           ])
+
+    OMPI_FORTRAN_HAVE_ELEMENTAL=0
+    AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS && \
+           test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS],
+          [ # Does the compiler support "elemental"
+           OMPI_FORTRAN_CHECK_ELEMENTAL(
+               [OMPI_FORTRAN_ELEMENTAL_TYPE="ELEMENTAL"],
+               [OMPI_FORTRAN_ELEMENTAL_TYPE=])])
+    AC_SUBST(OMPI_FORTRAN_ELEMENTAL_TYPE)
 
     # Note: the current implementation *only* has wrappers;
     # there is no optimized implementation for a "good"

--- a/ompi/mpi/fortran/use-mpi/mpi-types.F90.in
+++ b/ompi/mpi/fortran/use-mpi/mpi-types.F90.in
@@ -114,104 +114,104 @@ contains
 
   ! .EQ. operator
   !-----------------
-  logical function ompi_comm_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_comm_op_eq(a, b)
     type(MPI_Comm), intent(in) :: a, b
     ompi_comm_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_comm_op_eq
 
-  logical function ompi_datatype_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_datatype_op_eq(a, b)
     type(MPI_Datatype), intent(in) :: a, b
     ompi_datatype_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_datatype_op_eq
 
-  logical function ompi_errhandler_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_errhandler_op_eq(a, b)
     type(MPI_Errhandler), intent(in) :: a, b
     ompi_errhandler_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_errhandler_op_eq
 
-  logical function ompi_file_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_file_op_eq(a, b)
     type(MPI_File), intent(in) :: a, b
     ompi_file_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_file_op_eq
 
-  logical function ompi_group_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_group_op_eq(a, b)
     type(MPI_Group), intent(in) :: a, b
     ompi_group_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_group_op_eq
 
-  logical function ompi_info_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_info_op_eq(a, b)
     type(MPI_Info), intent(in) :: a, b
     ompi_info_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_info_op_eq
 
-  logical function ompi_message_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_message_op_eq(a, b)
     type(MPI_Message), intent(in) :: a, b
     ompi_message_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_message_op_eq
 
-  logical function ompi_op_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_op_op_eq(a, b)
     type(MPI_Op), intent(in) :: a, b
     ompi_op_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_op_op_eq
 
-  logical function ompi_request_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_request_op_eq(a, b)
     type(MPI_Request), intent(in) :: a, b
     ompi_request_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_request_op_eq
 
-  logical function ompi_win_op_eq(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_win_op_eq(a, b)
     type(MPI_Win), intent(in) :: a, b
     ompi_win_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
   end function ompi_win_op_eq
 
   ! .NE. operator
   !-----------------
-  logical function ompi_comm_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_comm_op_ne(a, b)
     type(MPI_Comm), intent(in) :: a, b
     ompi_comm_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_comm_op_ne
 
-  logical function ompi_datatype_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_datatype_op_ne(a, b)
     type(MPI_Datatype), intent(in) :: a, b
     ompi_datatype_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_datatype_op_ne
 
-  logical function ompi_errhandler_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_errhandler_op_ne(a, b)
     type(MPI_Errhandler), intent(in) :: a, b
     ompi_errhandler_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_errhandler_op_ne
 
-  logical function ompi_file_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_file_op_ne(a, b)
     type(MPI_File), intent(in) :: a, b
     ompi_file_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_file_op_ne
 
-  logical function ompi_group_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_group_op_ne(a, b)
     type(MPI_Group), intent(in) :: a, b
     ompi_group_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_group_op_ne
 
-  logical function ompi_info_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_info_op_ne(a, b)
     type(MPI_Info), intent(in) :: a, b
     ompi_info_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_info_op_ne
 
-  logical function ompi_message_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_message_op_ne(a, b)
     type(MPI_Message), intent(in) :: a, b
     ompi_message_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_message_op_ne
 
-  logical function ompi_op_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_op_op_ne(a, b)
     type(MPI_Op), intent(in) :: a, b
     ompi_op_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_op_op_ne
 
-  logical function ompi_request_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_request_op_ne(a, b)
     type(MPI_Request), intent(in) :: a, b
-    ompi_request_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+    ompi_request_op_ne  = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_request_op_ne
 
-  logical function ompi_win_op_ne(a, b)
+  @OMPI_FORTRAN_ELEMENTAL_TYPE@ logical function ompi_win_op_ne(a, b)
     type(MPI_Win), intent(in) :: a, b
     ompi_win_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
   end function ompi_win_op_ne


### PR DESCRIPTION
See discussion in issue https://github.com/open-mpi/ompi/issues/10057

Added configury boiler plate in case someone is using an ancient fortran compiler.
Note the elemental attribute has been supported for user defined methods since
F95.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit f722edc8edc58ef3f9c7943b8c09922d8f963b59)