### PR TITLE
v5.0.x: osc/ucx: one sided fixes

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -656,6 +656,7 @@ int accumulate_req(const void *origin_addr, int origin_count,
             if (ret != OMPI_SUCCESS) {
                 return ret;
             }
+            temp_count *= target_count;
         }
         ompi_datatype_get_true_extent(temp_dt, &temp_lb, &temp_extent);
         temp_addr = free_ptr = malloc(temp_extent * temp_count);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -581,7 +581,7 @@ int ompi_osc_find_attached_region_position(ompi_osc_dynamic_win_info_t *dynamic_
     if (dynamic_wins[mid_index].base > base) {
         return ompi_osc_find_attached_region_position(dynamic_wins, min_index, mid_index-1,
                                                       base, len, insert);
-    } else if (base + len < dynamic_wins[mid_index].base + dynamic_wins[mid_index].size) {
+    } else if (base + len <= dynamic_wins[mid_index].base + dynamic_wins[mid_index].size) {
         return mid_index;
     } else {
         return ompi_osc_find_attached_region_position(dynamic_wins, mid_index+1, max_index,


### PR DESCRIPTION
 - Failure in window Post and Complete routines
 - Failure in Put with 1 byte for Dynamic windows
 - Failure in Accumulate with noncontig dt
 - Hang in PSCW
 - Flush every attached win in fence for dynamic win

Signed-off-by:  Mamzi Bayatpour                 <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic               <tomislavj@nvidia.com>
(cherry picked from commit 3366ba39ddeeada5ff2cdad06348faafcf559fc9)