### PR TITLE
v5.0.x: open-mpi side mpirun/mpiexec --version fix

### DIFF
--- a/config/opal_save_version.m4
+++ b/config/opal_save_version.m4
@@ -55,7 +55,7 @@ AC_DEFUN([OPAL_SAVE_VERSION], [
         [The repository version ]$2)
     AC_DEFINE_UNQUOTED($1[_TARBALL_VERSION], ["$]$1[_TARBALL_VERSION"],
         [Tarball filename version string of ]$2)
-    AC_DEFINE_UNQUOTED($1[_VERSION], ["$]$1[_RELEASE_VERSION"],
+    AC_DEFINE_UNQUOTED($1[_VERSION], ["$]$1[_VERSION"],
         [Complete release number of ]$2)
     AC_DEFINE_UNQUOTED($1[_RELEASE_DATE], ["$]$1[_RELEASE_DATE"],
         [Release date of ]$2)

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -28,9 +28,6 @@
 int main(int argc, char *argv[])
 {
     char *evar;
-#if OPAL_USING_INTERNAL_PMIX || OMPI_USING_INTERNAL_PRRTE
-    char *pvar;
-#endif
     char **pargs = NULL;
     char *pfx = NULL;
     int m, param_len;
@@ -39,16 +36,14 @@ int main(int argc, char *argv[])
     if (NULL != (evar = getenv("OPAL_PREFIX"))) {
 
 #if OMPI_USING_INTERNAL_PRRTE
-        opal_asprintf(&pvar, "PRTE_PREFIX=%s", evar);
-        putenv(pvar);
+        setenv("PRTE_PREFIX", evar, 1);
 #endif
 
 #if OPAL_USING_INTERNAL_PMIX
-        opal_asprintf(&pvar, "PMIX_PREFIX=%s", evar);
-        putenv(pvar);
+        setenv("PMIX_PREFIX", evar, 1);
 #endif
     }
-    putenv("PRTE_MCA_schizo_proxy=ompi");
+    setenv("PRTE_MCA_schizo_proxy", "ompi", 1);
 
     opal_argv_append_nosize(&pargs, "prterun");
     for (m=1; NULL != argv[m]; m++) {

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 #endif
     }
     setenv("PRTE_MCA_schizo_proxy", "ompi", 1);
+    setenv("OMPI_VERSION", OMPI_VERSION, 1);
 
     opal_argv_append_nosize(&pargs, "prterun");
     for (m=1; NULL != argv[m]; m++) {

--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -45,6 +45,10 @@ int main(int argc, char *argv[])
     }
     setenv("PRTE_MCA_schizo_proxy", "ompi", 1);
     setenv("OMPI_VERSION", OMPI_VERSION, 1);
+    char *base_tool_name = opal_basename(argv[0]);
+    setenv("OMPI_TOOL_NAME", base_tool_name, 1);
+    free(base_tool_name);
+
 
     opal_argv_append_nosize(&pargs, "prterun");
     for (m=1; NULL != argv[m]; m++) {


### PR DESCRIPTION
Port of https://github.com/open-mpi/ompi/pull/10120

Will require submodule pointer update for openpmix/prrte when those fixes go into the release branches. But there's no harm in porting this now.

Refs: https://github.com/open-mpi/ompi/issues/10096