### PR TITLE
v4.0.x: Accept a NULL pointer to descriptor in sendi.

### DIFF
--- a/opal/mca/btl/self/btl_self.c
+++ b/opal/mca/btl/self/btl_self.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -246,7 +246,9 @@ static int mca_btl_self_sendi (struct mca_btl_base_module_t *btl, struct mca_btl
     frag = mca_btl_self_prepare_src (btl, endpoint, convertor, order, header_size, &payload_size,
                                      flags | MCA_BTL_DES_FLAGS_BTL_OWNERSHIP);
     if (NULL == frag) {
-        *descriptor = NULL;
+        if( NULL != descriptor ) {
+            *descriptor = NULL;
+        }
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2011 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -925,10 +925,7 @@ int mca_btl_smcuda_sendi( struct mca_btl_base_module_t* btl,
     }
     /* We do not want to use this path when we have CUDA IPC support */
     if ((convertor->flags & CONVERTOR_CUDA) && (IPC_ACKED == endpoint->ipcstate)) {
-        if (NULL != descriptor) {
-            *descriptor = mca_btl_smcuda_alloc(btl, endpoint, order, payload_size+header_size, flags);
-        }
-        return OPAL_ERR_RESOURCE_BUSY;
+        goto return_resource_busy;
     }
 #endif /* OPAL_CUDA_SUPPORT */
 
@@ -987,9 +984,10 @@ int mca_btl_smcuda_sendi( struct mca_btl_base_module_t* btl,
         return OPAL_SUCCESS;
     }
 
-    /* presumably, this code path will never get executed */
-    *descriptor = mca_btl_smcuda_alloc( btl, endpoint, order,
-                                    payload_size + header_size, flags);
+  return_resource_busy:
+    if (NULL != descriptor) {
+        *descriptor = mca_btl_smcuda_alloc(btl, endpoint, order, payload_size + header_size, flags);
+    }
     return OPAL_ERR_RESOURCE_BUSY;
 }
 


### PR DESCRIPTION
In the initial design _sendi would either send a immediate (aka very
short) message or, in case of resource exhaustion, return a descriptor
on the current BTL to host the message. It seems this logic was changed
sometimes recently, and now _sendi should not return a descriptor if the
immediate communication failed and the upper level does not want a
descriptor.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 1ee52d082ebed09ab5bf41d88fbb994523a5fa66)