### PR TITLE
v4.0.x: Rename relevant "master" references

### DIFF
--- a/.ci/mellanox/azure-pipelines.yml
+++ b/.ci/mellanox/azure-pipelines.yml
@@ -1,6 +1,6 @@
 trigger: none
 pr:
-  - master
+  - main
   - v*.*.x
 
 pool:

--- a/HACKING
+++ b/HACKING
@@ -8,7 +8,7 @@ Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2005 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2008-2016 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved
 Copyright (c) 2013      Intel, Inc.  All rights reserved.
 $COPYRIGHT$
 
@@ -67,7 +67,7 @@ If you are building Open MPI from a developer's tree, you must first
 install fairly recent versions of the GNU tools Autoconf, Automake,
 and Libtool (and possibly GNU m4, because recent versions of Autoconf
 have specific GNU m4 version requirements).  The specific versions
-required depend on if you are using the Git master branch or a release
+required depend on if you are using the Git main branch or a release
 branch (and which release branch you are using).  The specific
 versions can be found here:
 

--- a/VERSION
+++ b/VERSION
@@ -100,7 +100,7 @@ date="Unreleased developer copy"
 # release managers (not individual developers).  Notes:
 
 # 1. Since these version numbers are associated with *releases*, the
-# version numbers maintained on the Open MPI GIT master (and developer
+# version numbers maintained on the Open MPI GIT main (and developer
 # branches) is always 0:0:0 for all libraries.
 
 # 2. The version number of libmpi refers to the public MPI interfaces.

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
@@ -375,7 +375,7 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
 
     # The mpi_f08 module in this version of Open MPI does not properly
     # handle if sizeof(INTEGER) != sizeof(int) with the mpi_f08
-    # bindings.  As of July 2020, this issue is fixed on master / what
+    # bindings.  As of July 2020, this issue is fixed on main / what
     # will eventually become Open MPI v5.0.x, but the fix causes an
     # ABI break.  Hence, we're not going to fix it here on this
     # release branch.

--- a/contrib/annual-maintenance/convert-to-git.txt
+++ b/contrib/annual-maintenance/convert-to-git.txt
@@ -3,7 +3,7 @@ From Dave:
 For fun, here's the Git version of the "AUTHORS with commits in the past year" part of your script:
 
 ----8<----
-savbu-usnic-a ~/g/ompi-svn-mirror git:master ❮❮❮ git log --all --since='1 year ago' --pretty=tformat:'%ae' | sort | uniq -c
+savbu-usnic-a ~/g/ompi-svn-mirror git:main ❮❮❮ git log --all --since='1 year ago' --pretty=tformat:'%ae' | sort | uniq -c
     39 adrian@open-mpi-git-mirror.example.com
      3 alex@open-mpi-git-mirror.example.com
      5 alinas@open-mpi-git-mirror.example.com
@@ -40,7 +40,7 @@ savbu-usnic-a ~/g/ompi-svn-mirror git:master ❮❮❮ git log --all --since='1 
 
 And the "NO commits":
 ----8<----
-savbu-usnic-a ~/g/ompi-svn-mirror git:master ❯❯❯ git log --all --since='1 year ago' --pretty=tformat:'%ae' | sort | uniq > /tmp/active ; git log --pretty=tformat:'%ae' --all | sort | uniq > /tmp/all ; diff -u
+savbu-usnic-a ~/g/ompi-svn-mirror git:main ❯❯❯ git log --all --since='1 year ago' --pretty=tformat:'%ae' | sort | uniq > /tmp/active ; git log --pretty=tformat:'%ae' --all | sort | uniq > /tmp/all ; diff -u
 /tmp/all /tmp/active | grep '^-[^-]'
 -abbyz@open-mpi-git-mirror.example.com
 -adi@open-mpi-git-mirror.example.com

--- a/contrib/check-owner.pl
+++ b/contrib/check-owner.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015-2022 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015 Los Alamos National Security, LLC.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -55,7 +55,7 @@ sub DebugDump {
 sub isTopDir {
     my ($d) = @_;
 
-    # master
+    # main
     if (-f "$d/Makefile.ompi-rules") {
         return 1;
     }

--- a/contrib/ompi-time.sh
+++ b/contrib/ompi-time.sh
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -201,11 +202,11 @@ function do_checksync_mpisync() {
   if [ ! -e ${tooldir} ]; then
     mkdir -p ${tooldir}
     cd ${tooldir}
-    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/master/ompi/tools/mpisync/mpigclock.c >> $logfile 2>&1
-    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/master/ompi/tools/mpisync/mpigclock.h >> $logfile 2>&1
-    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/master/ompi/tools/mpisync/hpctimer.c >> $logfile 2>&1
-    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/master/ompi/tools/mpisync/hpctimer.h >> $logfile 2>&1
-    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/master/ompi/tools/mpisync/sync.c >> $logfile 2>&1
+    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/main/ompi/tools/mpisync/mpigclock.c >> $logfile 2>&1
+    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/main/ompi/tools/mpisync/mpigclock.h >> $logfile 2>&1
+    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/main/ompi/tools/mpisync/hpctimer.c >> $logfile 2>&1
+    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/main/ompi/tools/mpisync/hpctimer.h >> $logfile 2>&1
+    wget --no-check-certificate https://github.com/open-mpi/ompi/raw/main/ompi/tools/mpisync/sync.c >> $logfile 2>&1
     mpicc hpctimer.c mpigclock.c sync.c -o mpisync >> $logfile 2>&1
   fi
   if [ ! -e "$tooldir" ] || [ ! -f "$tooldir/mpisync" ]; then

--- a/examples/Ring.java
+++ b/examples/Ring.java
@@ -29,7 +29,7 @@ class Ring {
 	next = (myrank + 1) % size;
 	prev = (myrank + size - 1) % size;
 
-	/* If we are the "master" process (i.e., MPI_COMM_WORLD rank 0),
+	/* If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0),
 	   put the number of times to go around the ring in the
 	   message. */
 

--- a/examples/ring_c.c
+++ b/examples/ring_c.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     next = (rank + 1) % size;
     prev = (rank + size - 1) % size;
 
-    /* If we are the "master" process (i.e., MPI_COMM_WORLD rank 0),
+    /* If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0),
        put the number of times to go around the ring in the
        message. */
 

--- a/examples/ring_cxx.cc
+++ b/examples/ring_cxx.cc
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     next = (rank + 1) % size;
     prev = (rank + size - 1) % size;
 
-    // If we are the "master" process (i.e., MPI_COMM_WORLD rank 0),
+    // If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0),
     // put the number of times to go around the ring in the message.
 
     if (0 == rank) {

--- a/examples/ring_mpifh.f
+++ b/examples/ring_mpifh.f
@@ -2,7 +2,7 @@ C
 C Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
 C                         University Research and Technology
 C                         Corporation.  All rights reserved.
-C Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+C Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 C $COPYRIGHT$
 C
 C Simple ring test program using the mpif.h Fortran bindings.
@@ -26,7 +26,7 @@ C     zero.
       next = mod((rank + 1), size)
       from = mod((rank + size - 1), size)
 
-C     If we are the "master" process (i.e., MPI_COMM_WORLD rank 0), put
+C     If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0), put
 C     the number of times to go around the ring in the message.
 
       if (rank .eq. 0) then

--- a/examples/ring_usempi.f90
+++ b/examples/ring_usempi.f90
@@ -2,7 +2,7 @@
 ! Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
 !                         University Research and Technology
 !                         Corporation.  All rights reserved.
-! Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 ! $COPYRIGHT$
 !
 ! Simple ring test program using the Fortran mpi module bindings.
@@ -25,7 +25,7 @@ program ring
   next = mod((rank + 1), size)
   from = mod((rank + size - 1), size)
 
-! If we are the "master" process (i.e., MPI_COMM_WORLD rank 0), put
+! If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0), put
 ! the number of times to go around the ring in the message.
 
   if (rank .eq. 0) then

--- a/examples/ring_usempif08.f90
+++ b/examples/ring_usempif08.f90
@@ -3,7 +3,7 @@
 ! Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
 !                         University Research and Technology
 !                         Corporation.  All rights reserved.
-! Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! $COPYRIGHT$
@@ -29,7 +29,7 @@ program ring
   next = mod((rank + 1), size)
   from = mod((rank + size - 1), size)
 
-! If we are the "master" process (i.e., MPI_COMM_WORLD rank 0), put
+! If we are the "manager" process (i.e., MPI_COMM_WORLD rank 0), put
 ! the number of times to go around the ring in the message.
 
   if (rank .eq. 0) then

--- a/ompi/mpi/man/man3/MPI_Comm_rank.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_rank.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2022 Cisco Systems, Inc.  All rights reserved
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -60,7 +60,7 @@ This function gives the rank of the process in the
 particular communicator's group. It is equivalent to accessing the
 communicator's group with MPI_Comm_group, computing the rank using MPI_Group_rank, and then freeing the temporary group via MPI_Group_free.
 .sp
-Many programs will be written with the master-slave model, where one process (such as the rank-zero process) will play a supervisory role, and the other processes will serve as compute nodes. In this framework, MPI_Comm_size and MPI_Comm_rank are useful for determining the roles of the various processes of a communicator.
+Many programs will be written with the manager-worker model, where one process (such as the rank-zero process) will play a supervisory role, and the other processes will serve as compute nodes. In this framework, MPI_Comm_size and MPI_Comm_rank are useful for determining the roles of the various processes of a communicator.
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.

--- a/opal/mca/btl/usnic/README.txt
+++ b/opal/mca/btl/usnic/README.txt
@@ -289,10 +289,10 @@ that would be.
 November 2014 / SC 2014
 Update February 2015
 
-The usnic BTL code has been unified across master and the v1.8
+The usnic BTL code has been unified across main and the v1.8
 branches.  That is, you can copy the code from
-v1.8:ompi/mca/btl/usnic/* to master:opal/mca/btl/usnic*, and then only
-have to make 3 changes in the resulting code in master:
+v1.8:ompi/mca/btl/usnic/* to main:opal/mca/btl/usnic*, and then only
+have to make 3 changes in the resulting code in main:
 
 1. Edit Makefile.am: s/ompi/opal/gi
 2. Edit configure.m4: s/ompi/opal/gi

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2013-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Intel, Inc. All rights reserved.
@@ -234,7 +234,7 @@ usnic_compat_opal_hotel_init(opal_hotel_t *hotel, int num_rooms,
 
 
 /*
- * Replicate functions that exist on master
+ * Replicate functions that exist on main
  */
 char* opal_get_proc_hostname(opal_proc_t *proc);
 

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
@@ -88,7 +88,7 @@ static inline bool opal_set_using_threads(bool have)
 }
 
 
-// Back-ported from master (2019-05-04) as part of
+// Back-ported from main (2019-05-04) as part of
 // a16cf0e4dd6df4dea820fecedd5920df632935b8
 typedef volatile size_t opal_atomic_size_t;
 


### PR DESCRIPTION
Change to "main" when referring to Open MPI git branch / URL things,
and "manager" when referring to a primary process (e.g., in a "manager
/ worker" scheme).

This is more-or-less the same as commit
6845ac0b2670231897831fe21e871037a8749d63 on main, but has been adapted
for this branch.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit af61e7bd4f9963c4885988d0f3b47d95cb699ce5)