### PR TITLE
Make OPAL_SUMMARY_ADD uniqify calls

### DIFF
--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -19,7 +19,7 @@
 #                         reserved.
 #  Copyright (c) 2021     Triad National Security, LLC. All rights
 #                         reserved.
-#
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -96,7 +96,7 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
 	LDFLAGS="$ompi_check_psm2_$1_save_LDFLAGS"
 	LIBS="$ompi_check_psm2_$1_save_LIBS"
 
-        OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
+        OPAL_SUMMARY_ADD([Transports], [Intel Omnipath (PSM2)], [], [$ompi_check_psm2_happy])
     fi
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -161,7 +162,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                         ])
                   CPPFLAGS=$old_CPPFLAGS
 
-                  OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])])])
+                  OPAL_SUMMARY_ADD([Transports], [Open UCX], [], [$ompi_check_ucx_happy])])])
 
     AS_IF([test "$ompi_check_ucx_happy" = "yes"],
           [$1_CPPFLAGS="[$]$1_CPPFLAGS $ompi_check_ucx_CPPFLAGS"

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -16,8 +16,7 @@ dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.
-dnl                         All Rights reserved.
+dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
@@ -108,7 +107,7 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
                        [$OMPI_USING_INTERNAL_PRRTE],
                        [Whether or not we are using the internal PRRTE])
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]], [[prrte]], [prrte], [$opal_prrte_mode])
+    OPAL_SUMMARY_ADD([Miscellaneous], [prrte], [], [$opal_prrte_mode])
 
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_check_cma.m4
+++ b/config/opal_check_cma.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
 # Copyright (c) 2013-2016 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -132,5 +133,5 @@ static void do_check (pid_t pid, int *in, int *out)
     AS_IF([test $opal_check_cma_happy -eq 1],
           [opal_check_cma_msg=yes],
           [opal_check_cma_msg=no])
-    OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/Linux CMA]],[$1],[$opal_check_cma_msg])
+    OPAL_SUMMARY_ADD([Transports], [Shared memory/Linux CMA], [], [$opal_check_cma_msg])
 ])

--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -1,4 +1,4 @@
-dnl -*- shell-script -*-
+dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
 dnl                         University Research and Technology
@@ -19,7 +19,7 @@ dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2015 NVIDIA Corporation.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -124,7 +124,7 @@ else
     CUDA_SUPPORT=0
 fi
 
-OPAL_SUMMARY_ADD([[Miscellaneous]],[[CUDA support]],[opal_cuda], [$opal_check_cuda_happy])
+OPAL_SUMMARY_ADD([Miscellaneous], [CUDA support], [], [$opal_check_cuda_happy])
 
 AM_CONDITIONAL([OPAL_cuda_support], [test "x$CUDA_SUPPORT" = "x1"])
 AC_DEFINE_UNQUOTED([OPAL_CUDA_SUPPORT],$CUDA_SUPPORT,

--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -9,6 +9,7 @@ dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -61,7 +62,7 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
 
 	CPPFLAGS="$opal_check_knem_$1_save_CPPFLAGS"
 
-        OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/Linux KNEM]],[$1],[$opal_check_knem_happy])
+        OPAL_SUMMARY_ADD([Transports], [Shared memory/Linux KNEM], [], [$opal_check_knem_happy])
 	OPAL_VAR_SCOPE_POP
     fi
 

--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -3,8 +3,7 @@ dnl
 dnl Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
-dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates. All rights
-dnl                         reserved.
+dnl Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -159,7 +158,7 @@ AC_DEFUN([_OPAL_CHECK_OFI],[
     AC_SUBST([opal_ofi_LDFLAGS])
     AC_SUBST([opal_ofi_LIBS])
 
-    OPAL_SUMMARY_ADD([[Transports]],[[OpenFabrics OFI Libfabric]],[],[$opal_ofi_happy])
+    OPAL_SUMMARY_ADD([Transports], [OpenFabrics OFI Libfabric], [], [$opal_ofi_happy])
 
     OPAL_VAR_SCOPE_POP
 

--- a/config/opal_check_portals4.m4
+++ b/config/opal_check_portals4.m4
@@ -16,6 +16,7 @@ dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -94,7 +95,7 @@ AC_DEFUN([OPAL_CHECK_PORTALS4],[
 	AS_IF([test $max_md_size -ne 0 && test $max_va_size -ne 0],
               [AC_MSG_NOTICE([Portals 4 address space size: $max_md_size, $max_va_size])])
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Portals4]],[$1],[$ompi_check_portals4_happy])
+	OPAL_SUMMARY_ADD([Transports], [Portals4], [], [$ompi_check_portals4_happy])
     fi
 
     AS_IF([test "$ompi_check_portals4_happy" = "yes"],

--- a/config/opal_check_ugni.m4
+++ b/config/opal_check_ugni.m4
@@ -17,6 +17,7 @@ dnl                         reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -68,7 +69,7 @@ AC_DEFUN([OPAL_CHECK_UGNI], [
               [AC_MSG_WARN([GNI driver does not currently support progress threads.  Disabling.])
                opal_check_ugni_happy="no"])
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Cray uGNI (Gemini/Aries)]],[$1],[$opal_check_ugni_happy])
+	OPAL_SUMMARY_ADD([Transports], [Cray uGNI (Gemini/Aries)], [], [$opal_check_ugni_happy])
     fi
 
     AS_IF([test "$opal_check_ugni_happy" = "yes"],

--- a/config/opal_check_xpmem.m4
+++ b/config/opal_check_xpmem.m4
@@ -16,6 +16,7 @@
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
 # Copyright (c) 2014-2015 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -101,7 +102,7 @@ AC_DEFUN([OPAL_CHECK_XPMEM], [
 	    fi
 	fi
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_xpmem_happy])
+	OPAL_SUMMARY_ADD([Transports], [Shared memory/XPMEM], [], [$opal_check_xpmem_happy])
     fi
 
     AS_IF([test "$opal_check_xpmem_happy" = "yes"], [

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -15,13 +15,10 @@ dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
-dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
-dnl                         reserved.
+dnl Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2020      Google, LLC. All rights reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
-dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
-dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -703,7 +700,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
         [$want_asm_atomics],
         [Whether to use assembly-coded atomics for atomics implementation])
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]],[[Atomics]],[],[$atomics_found])
+    OPAL_SUMMARY_ADD([Miscellaneous], [Atomics], [], [$atomics_found])
 
     OPAL_VAR_SCOPE_POP
 ])dnl

--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -3,8 +3,7 @@ dnl
 dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2014-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
-dnl                         reserved.
+dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -110,7 +109,7 @@ AC_DEFUN([OPAL_CONFIG_HWLOC], [
     AC_SUBST(opal_hwloc_LIBS)
     AC_SUBST(opal_hwloc_LDFLAGS)
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]], [[hwloc]], [hwloc], [$opal_hwloc_mode])
+    OPAL_SUMMARY_ADD([Miscellaneous], [hwloc], [], [$opal_hwloc_mode])
 
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -4,8 +4,7 @@ dnl Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
-dnl                         reserved.
+dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -122,7 +121,7 @@ AC_DEFUN([OPAL_CONFIG_LIBEVENT], [
     AC_SUBST(opal_libevent_LIBS)
     AC_SUBST(opal_libevent_LDFLAGS)
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]],[[libevent]],[libevent], [$opal_libevent_mode])
+    OPAL_SUMMARY_ADD([Miscellaneous], [libevent], [], [$opal_libevent_mode])
 
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -19,8 +19,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
-dnl Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
-dnl                         reserved.
+dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -181,7 +180,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
     AC_SUBST(opal_pmix_LDFLAGS)
     AC_SUBST(opal_pmix_LIBS)
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]], [[pmix]], [pmix], [$opal_pmix_mode])
+    OPAL_SUMMARY_ADD([Miscellaneous], [pmix], [], [$opal_pmix_mode])
 
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_setup_ft.m4
+++ b/config/opal_setup_ft.m4
@@ -6,6 +6,7 @@ dnl Copyright (c) 2009-2012 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -138,5 +139,5 @@ AC_DEFUN([OPAL_SETUP_FT],[
         fi
     fi
 
-    OPAL_SUMMARY_ADD([[Miscellaneous]],[[Fault Tolerance support]],[unnecessary], [$opal_want_ft_type])
+    OPAL_SUMMARY_ADD([Miscellaneous], [Fault Tolerance support], [], [$opal_want_ft_type])
 ])

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -1,41 +1,92 @@
-dnl -*- shell-script -*-
+dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
 dnl
 dnl $HEADER$
 dnl
+
+# OPAL_SUMMARY_ADD(section, topic, unused, result)
+#
+# queue a summary line in the given section of the form:
+#   topic: result
+#
+# section:topic lines are only added once; first to add wins.
+# The key for uniqification is a shell-variable-ified representation
+# of section followed by an underscore followed by a
+# shell-variable-ified representation of line.
+#
+# There are no restrictions on the contents of section and topic; they
+# can be variable references (although the use case for this is
+# dubious) and they can contain most ASCII characters (escape
+# characters excluded).  Note that some care must be taken with the
+# unique check and this liberal rule, as the unique check is after the
+# string has been run through AS_TR_SH.  Basically, any character that
+# is not legal in a shell variable name will be turned into an
+# underscore.  So the strings "Section_foo" and "Section-foo" would be
+# the same as far as the unique check is concerned.
+#
+# The input strings are evaluated during OPAL_SUMMARY_ADD, not during
+# OPAL_SUMMARY_PRINT.  This seems to meet the principle of least
+# astonishment.  A common pattern is to call
+# OPAL_SUMMARY_ADD([Resource Type], [Component Name], [], [$results])
+# and then unset $results to avoid namespace pollution.  This will
+# work properly with the current behavior, but would result in odd
+# errors if we delayed evaulation.
+#
+# As a historical note, the third argument has never been used in
+# OPAL_SUMMARY_ADD and its meaning is unclear.  Preferred behavior is
+# to leave it empty.
+#
+# As a final historical note, the initial version of SUMMARY_ADD was
+# added with implementation of the callers having all of the section
+# and topic headers double quoted.  This was never necessary, and
+# certainly is not with the current implementation.  While harmless,
+# it is not great practice to over-quote, so we recommend against
+# doing so.
+# -----------------------------------------------------------
 AC_DEFUN([OPAL_SUMMARY_ADD],[
-    OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_line ompi_summary_section_current])
+    OPAL_VAR_SCOPE_PUSH([opal_summary_line opal_summary_newline opal_summary_key])
 
-    dnl need to replace spaces in the section name with somethis else. _ seems like a reasonable
-    dnl choice. if this changes remember to change OMPI_PRINT_SUMMARY as well.
-    ompi_summary_section=$(echo $1 | tr ' ' '_')
-    ompi_summary_line="$2: $4"
-    ompi_summary_section_current=$(eval echo \$ompi_summary_values_$ompi_summary_section)
+    # The end quote on the next line is intentional!
+    opal_summary_newline="
+"
+    opal_summary_line="$2: $4"
+    opal_summary_key="AS_TR_SH([$1])_AS_TR_SH([$2])"
 
-    if test -z "$ompi_summary_section_current" ; then
-        if test -z "$ompi_summary_sections" ; then
-            ompi_summary_sections=$ompi_summary_section
-        else
-            ompi_summary_sections="$ompi_summary_sections $ompi_summary_section"
-        fi
-        eval ompi_summary_values_$ompi_summary_section=\"$ompi_summary_line\"
-    else
-        eval ompi_summary_values_$ompi_summary_section=\"$ompi_summary_section_current,$ompi_summary_line\"
-    fi
+    # Use the section name variable as an indicator for whether or not
+    # the section has already been created.
+    AS_IF([AS_VAR_TEST_SET([opal_summary_section_]AS_TR_SH([$1])[_name])],
+          [],
+          [AS_VAR_SET([opal_summary_section_]AS_TR_SH([$1])[_name], ["$1"])
+           OPAL_APPEND([opal_summary_sections], [AS_TR_SH([$1])])])
+
+    # Use the summary key as indicator if the section:topic has already
+    # been added to the results for the given section.
+    AS_IF([AS_VAR_TEST_SET([${opal_summary_key}])],
+          [],
+          [AS_VAR_SET([${opal_summary_key}], [1])
+           dnl this is a bit overcomplicated, but we are basically implementing
+           dnl a poor mans AS_VAR_APPEND with the ability to specify a separator,
+           dnl because we have a newline separator in the string.
+           AS_IF([AS_VAR_TEST_SET([opal_summary_section_]AS_TR_SH([$1])[_value])],
+                 [AS_VAR_APPEND([opal_summary_section_]AS_TR_SH([$1])[_value],
+                                ["${opal_summary_newline}${opal_summary_line}"])],
+                 [AS_VAR_SET([opal_summary_section_]AS_TR_SH([$1])[_value],
+                             ["${opal_summary_line}"])])])
 
     OPAL_VAR_SCOPE_POP
 ])
 
 AC_DEFUN([OPAL_SUMMARY_PRINT],[
-    OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_section_name])
+    OPAL_VAR_SCOPE_PUSH([opal_summary_section opal_summary_section_name])
     cat <<EOF
 
 Open MPI configuration:
@@ -90,11 +141,12 @@ EOF
 
     echo
 
-    for ompi_summary_section in $(echo $ompi_summary_sections) ; do
-        ompi_summary_section_name=$(echo $ompi_summary_section | tr '_' ' ')
-        echo "$ompi_summary_section_name"
+    for opal_summary_section in ${opal_summary_sections} ; do
+        AS_VAR_COPY([opal_summary_section_name], [opal_summary_section_${opal_summary_section}_name])
+        AS_VAR_COPY([opal_summary_section_value], [opal_summary_section_${opal_summary_section}_value])
+        echo "${opal_summary_section_name}"
         echo "-----------------------"
-        echo "$(eval echo \$ompi_summary_values_$ompi_summary_section)" | tr ',' $'\n' | sort -f
+        echo "${opal_summary_section_value}" | sort -f
         echo " "
     done
 

--- a/ompi/mca/coll/ucc/configure.m4
+++ b/ompi/mca/coll/ucc/configure.m4
@@ -4,6 +4,7 @@
 # Copyright (c) 2021      Mellanox Technologies. All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +30,7 @@ AC_DEFUN([MCA_ompi_coll_ucc_CONFIG],[
            $1],
           [$2])
     
-    OPAL_SUMMARY_ADD([[Miscellaneous]],[[Open UCC]],[$1],[$coll_ucc_happy])])])
+    OPAL_SUMMARY_ADD([Miscellaneous], [Open UCC], [], [$coll_ucc_happy])
 
     # substitute in the things needed to build ucc
     AC_SUBST([coll_ucc_CFLAGS])

--- a/ompi/mca/fs/gpfs/configure.m4
+++ b/ompi/mca/fs/gpfs/configure.m4
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -36,7 +37,7 @@ AC_DEFUN([MCA_ompi_fs_gpfs_CONFIG],[
            $1],
           [$2])
 
-    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[IBM Spectrum Scale/GPFS]],[$1],[$fs_gpfs_happy])
+    OPAL_SUMMARY_ADD([OMPIO File Systems], [IBM Spectrum Scale/GPFS], [], [$fs_gpfs_happy])
 
     # substitute in the things needed to build gpfs
     AC_SUBST([fs_gpfs_CPPFLAGS])

--- a/ompi/mca/fs/ime/configure.m4
+++ b/ompi/mca/fs/ime/configure.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2018      DataDirect Networks. All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,7 +19,7 @@ AC_DEFUN([MCA_ompi_fs_ime_CONFIG],[
                     [fs_ime_happy="yes"],
                     [fs_ime_happy="no"])
 
-    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[DDN Infinite Memory Engine]],[$1],[$fs_ime_happy])
+    OPAL_SUMMARY_ADD([OMPIO File Systems], [DDN Infinite Memory Engine], [], [$fs_ime_happy])
     AS_IF([test "$fs_ime_happy" = "yes"],
           [$1],
           [$2])

--- a/ompi/mca/fs/lustre/configure.m4
+++ b/ompi/mca/fs/lustre/configure.m4
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +35,7 @@ AC_DEFUN([MCA_ompi_fs_lustre_CONFIG],[
           [$1],
           [$2])
 
-    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[Lustre]],[$1],[$fs_lustre_happy])
+    OPAL_SUMMARY_ADD([OMPIO File Systems], [Lustre], [], [$fs_lustre_happy])
 
     # substitute in the things needed to build lustre
     AC_SUBST([fs_lustre_CPPFLAGS])

--- a/ompi/mca/fs/pvfs2/configure.m4
+++ b/ompi/mca/fs/pvfs2/configure.m4
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +31,7 @@ AC_DEFUN([MCA_ompi_fs_pvfs2_CONFIG],[
                      [fs_pvfs2_happy="yes"],
                      [fs_pvfs2_happy="no"])
 
-    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[PVFS2/OrangeFS]],[$1],[$fs_pvfs2_happy])
+    OPAL_SUMMARY_ADD([OMPIO File Systems], [PVFS2/OrangeFS], [], [$fs_pvfs2_happy])
     AS_IF([test "$fs_pvfs2_happy" = "yes"],
           [$1],
           [$2])

--- a/ompi/mca/fs/ufs/configure.m4
+++ b/ompi/mca/fs/ufs/configure.m4
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008-2018 University of Houston. All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,5 +26,5 @@
 AC_DEFUN([MCA_ompi_fs_ufs_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/fs/ufs/Makefile])
 
-    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[Generic Unix FS]],[$1],[yes])
+    OPAL_SUMMARY_ADD([OMPIO File Systems], [Generic Unix FS], [], [yes])
 ])dnl

--- a/opal/mca/btl/sm/configure.m4
+++ b/opal/mca/btl/sm/configure.m4
@@ -8,6 +8,7 @@
 #                         reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,7 +25,7 @@ AC_DEFUN([MCA_opal_btl_sm_CONFIG],[
     # always happy
     [$1]
 
-    OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/copy in+copy out]],[$1],[yes])
+    OPAL_SUMMARY_ADD([Transports], [Shared memory/copy in+copy out], [], [yes])
 
     # substitute in the things needed to build with XPMEM support
     AC_SUBST([btl_sm_CFLAGS])

--- a/opal/mca/btl/tcp/configure.m4
+++ b/opal/mca/btl/tcp/configure.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,5 +37,5 @@ AC_DEFUN([MCA_opal_btl_tcp_CONFIG],[
 #include <netinet/in.h>
 #endif
 		   ])
-    OPAL_SUMMARY_ADD([[Transports]],[[TCP]],[[btl_tcp]],[$opal_btl_tcp_happy])
+    OPAL_SUMMARY_ADD([Transports], [TCP], [], [$opal_btl_tcp_happy])
 ])dnl

--- a/opal/mca/btl/usnic/configure.m4
+++ b/opal/mca/btl/usnic/configure.m4
@@ -15,6 +15,7 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -125,6 +126,6 @@ AC_DEFUN([_OPAL_BTL_USNIC_DO_CONFIG],[
                  [$2])
           ])
 
-    OPAL_SUMMARY_ADD([[Transports]],[[Cisco usNIC]],[[btl_usnic]],[$opal_btl_usnic_happy])
+    OPAL_SUMMARY_ADD([Transports], [Cisco usNIC], [], [$opal_btl_usnic_happy])
     OPAL_VAR_SCOPE_POP
 ])dnl

--- a/opal/mca/threads/configure.m4
+++ b/opal/mca/threads/configure.m4
@@ -14,7 +14,7 @@ dnl Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
 dnl Copyright (c) 2019      Triad National Security, LLC. All rights
 dnl                         reserved.
-dnl
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -63,5 +63,5 @@ AC_SUBST(THREAD_CPPFLAGS)
 AC_SUBST(THREAD_LDFLAGS)
 AC_SUBST(THREAD_LIBS)
 
-OPAL_SUMMARY_ADD([[Miscellaneous]],[[Threading Package]],[], [$opal_thread_type_found])
+OPAL_SUMMARY_ADD([Miscellaneous], [Threading Package], [], [$opal_thread_type_found])
 ])dnl


### PR DESCRIPTION
A bunch of the macros in the OMPI repository seem to go through lots of work to avoid calling OPAL_SUMMARY_ADD twice.  We'll remove that eventually, but step one, let's uniqify in OPAL_SUMMARY_ADD itself.

And since we're messing around with OPAL_SUMMARY_ADD, make it much more flexible (at the cost of slightly more strings in the shell environment) around section/topic names, so that they can contain basically any valid shell string character (or even shell variables, but that's probably crazy talk).

Finally, clean up the style issues around all the calls to OPAL_SUMMARY_ADD.