### PR TITLE
v5.0.x: Don't overwrite NULL descriptors.

### DIFF
--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -887,8 +887,7 @@ int mca_btl_smcuda_sendi(struct mca_btl_base_module_t *btl,
         /* note that frag==NULL is equivalent to rc returning an error code */
         MCA_BTL_SMCUDA_FRAG_ALLOC_EAGER(frag);
         if (OPAL_UNLIKELY(NULL == frag)) {
-            *descriptor = NULL;
-            return OPAL_ERR_OUT_OF_RESOURCE;
+            goto return_resource_busy;
         }
 
         /* fill in fragment fields */
@@ -940,7 +939,7 @@ int mca_btl_smcuda_sendi(struct mca_btl_base_module_t *btl,
 
   return_resource_busy:
     if (NULL != descriptor) {
-        *descriptor = mca_btl_smcuda_alloc(btl, endpoint, order, payload_size + header_size, flags);
+        *descriptor = mca_btl_smcuda_alloc(btl, endpoint, order, length, flags);
     }
     return OPAL_ERR_RESOURCE_BUSY;
 }


### PR DESCRIPTION
If the descriptor is NULL in sendi don't try to provide back a fragment.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit d94da201dad395e6f0d4f98d8ae4f0909d77e52e)