### PR TITLE
common/ompio: fix a division by zero problem in cost_calc

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -1459,8 +1459,8 @@ exit:
 */
 static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
 {
-    float  n_as=1.0, m_s=1.0, n_s=1.0;
-    float  n_ar=1.0;
+    double  n_as=1.0, m_s=1.0, n_s=1.0;
+    double  n_ar=1.0;
     double t_send, t_recv, t_tot;
 
     /* LogGP parameters based on DDR InfiniBand values */
@@ -1470,7 +1470,7 @@ static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
     double G=.00000000067;
     
     long file_domain = (P * d_p) / P_a;
-    float n_r = (float)file_domain/(float) b_c;
+    double n_r = (double)file_domain/(double) b_c;
     
     switch (dim) {
 	case DIM1:
@@ -1480,10 +1480,10 @@ static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
 		n_ar = 1;
 		n_as = 1;
 		m_s = b_c;
-		n_s = (float)d_p/(float)b_c;
+		n_s = (double)d_p/(double)b_c;
 	    }
 	    else {
-		n_ar = (float)b_c/(float)d_p;
+		n_ar = (double)b_c/(double)d_p;
 		n_as = 1;
 		m_s = d_p;
 		n_s = 1;
@@ -1495,14 +1495,14 @@ static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
 	    int P_x, P_y;
 	    
 	    P_x = P_y = (int) sqrt(P);
-	    n_as = (float) P_a / (float)P_x;
+	    n_as = (double) P_a / (double)P_x;
 	    
-	    n_ar = (float) P_y;
+	    n_ar = (double) P_y;
 	    if ( d_p > (P_a*b_c/P )) {
-		m_s = fmin(b_c / P_y, d_p);
+		m_s = fmin((double) b_c / (double)P_y, (double)d_p);
 	    }
 	    else {
-		m_s = fmin(d_p * P_x / P_a, d_p);
+		m_s = fmin((double) (d_p * P_x) / (double)P_a, (double)d_p);
 	    }
 	    break;	  
 	}
@@ -1511,7 +1511,7 @@ static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
 	    break;
     } 
     
-    n_s = (float) d_p / (float)(n_as * m_s);
+    n_s = (double) d_p / (double)(n_as * m_s);
     
     if( m_s < 33554432) {
 	g = .00000108;


### PR DESCRIPTION
the cost_calc function is used to tune the number of aggregators used for collective I/O. A division by zero could occur at one location where two integeres are divided before being converted to a float. Reverting the sequence to explicitely convert the values first to floats before performing the division (as done at a number of other places in the same function) fixes the issue.

Fixes Issue #10115
main PR: #10133

Signed-off-by: Edgar Gabriel <edgar.gabriel1@outlook.com>
(cherry picked from commit 45b9493e180a246f1d683bb4d5d3d57d3fa097c0)
Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>