### PR TITLE
v5.0.x: Upgrade internal HWLOC to v2.7.1.

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -76,7 +76,7 @@ my $ompi_libtoolize_search = "libtoolize;glibtoolize";
 
 # version of packages we ship as tarballs
 my $libevent_version="2.1.12-stable";
-my $hwloc_version="2.7.0";
+my $hwloc_version="2.7.1";
 
 # One-time setup
 my $username;


### PR DESCRIPTION
This pulls in a fix for a segv when doing a sequence of dlopen(libmpi) +
dlocose() + getenv().

See https://github.com/open-mpi/ompi/issues/10142 for more details.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/open-mpi/ompi/commit/1b4379e36284bd73d3e27cbb228c54288093754a) 