### PR TITLE
release: Bump version to 4.1.3rc3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -70,7 +70,7 @@ release=3
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc3
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
4.1.3rc2 is out; on to rc3

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

bot:notacherrypick