### PR TITLE
fs/lustre and fs/pvfs2: fix info names

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -76,18 +76,34 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "stripe_size", &stripe_str, &flag);
+    opal_info_get (info, "striping_factor", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
         OBJ_RELEASE(stripe_str);
     }
-
-    opal_info_get (info, "stripe_width", &stripe_str, &flag);
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_size", &stripe_str, &flag);
+        if ( flag ) {
+            sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
+            OBJ_RELEASE(stripe_str);
+        }
+    }
+    
+    opal_info_get (info, "striping_unit", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
         OBJ_RELEASE(stripe_str);
     }
-
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.        
+        opal_info_get (info, "stripe_width", &stripe_str, &flag);
+        if ( flag ) {
+            sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
+            OBJ_RELEASE(stripe_str);
+        }
+    }
+    
     if (fs_lustre_stripe_size < 0) {
         fs_lustre_stripe_size = mca_fs_lustre_stripe_size;
     }   

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -109,18 +109,35 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
        update mca_fs_pvfs2_stripe_width and mca_fs_pvfs2_stripe_size
        before calling fake_an_open() */
 
-    opal_info_get (info, "stripe_size", &stripe_str, &flag);
+    opal_info_get (info, "striping_factor", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_size );
         OBJ_RELEASE(stripe_str);
     }
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_size", &stripe_str, &flag);
+        if ( flag ) {
+            sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_size );
+            OBJ_RELEASE(stripe_str);
+        }
+    }
 
-    opal_info_get (info, "stripe_width", &stripe_str, &flag);
+    opal_info_get (info, "striping_unit", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_width );
         OBJ_RELEASE(stripe_str);
     }
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_width", &stripe_str, &flag);
+        if ( flag ) {
+            sscanf ( stripe_str->string, "%d", &fs_pvfs2_stripe_width );
+            OBJ_RELEASE(stripe_str);
+        }
+    }
 
+    
     if (fs_pvfs2_stripe_size < 0) {
         fs_pvfs2_stripe_size = mca_fs_pvfs2_stripe_size;
     }


### PR DESCRIPTION
use the names defined in the MPI specification for setting striping information.
We keep the old ones as well for backwards compatibility.

Signed-off-by: Edgar Gabriel <edgar.gabriel1@outlook.com>
(cherry picked from commit 1631f387704641dd7939cbce156a47ea8eda39eb)