### PR TITLE
build: Fix missing CUDA helper dependency

### DIFF
--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -66,7 +66,8 @@ lib@OPAL_LIB_NAME@_la_DEPENDENCIES = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
-        $(MCA_opal_FRAMEWORK_LIBS)
+        $(MCA_opal_FRAMEWORK_LIBS) \
+        $(LIBOPAL_CUDA_LA)
 lib@OPAL_LIB_NAME@_la_LDFLAGS = -version-info @libopen_pal_so_version@ \
 	$(opal_libevent_LDFLAGS) \
 	$(opal_hwloc_LDFLAGS) \


### PR DESCRIPTION
In 58cdac, I missed adding the libopal_cuda.la file in the libopen-pal
dependency list (since we have an explicit dependency list for
libopen-pal.  This patch adds the dependency for the relink case.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>