### PR TITLE
reachable/netlink: Fix missing LDFLAGS

### DIFF
--- a/opal/mca/reachable/netlink/Makefile.am
+++ b/opal/mca/reachable/netlink/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,11 +38,11 @@ AM_CPPFLAGS = \
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_netlink_la_SOURCES = $(sources)
-mca_reachable_netlink_la_LDFLAGS = -module -avoid-version
+mca_reachable_netlink_la_LDFLAGS = -module -avoid-version $(reachable_netlink_LDFLAGS)
 mca_reachable_netlink_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(reachable_netlink_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_netlink_la_SOURCES =$(sources)
-libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version
+libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version $(reachable_netlink_LDFLAGS)
 libmca_reachable_netlink_la_LIBADD = $(reachable_netlink_LIBS)


### PR DESCRIPTION
Fix missing LDFLAGS for the reachable netlink component, which could
cause link failures when building with a netlink library not in the
standard location.  Thanks to Howard Pritchard for finding this issue
in PRRTE.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 27f98b0d8b33aa55e84854308da9e016a2bd6d4c)