### PR TITLE
Netlink/reachable link fixes

### DIFF
--- a/opal/mca/reachable/netlink/Makefile.am
+++ b/opal/mca/reachable/netlink/Makefile.am
@@ -31,7 +31,7 @@ component_install =
 endif
 
 AM_CPPFLAGS = \
-        $(opal_reachable_netlink_CPPFLAGS) \
+        $(reachable_netlink_CPPFLAGS) \
         -DOPAL_HAVE_LIBNL3=$(OPAL_HAVE_LIBNL3)
 
 mcacomponentdir = $(opallibdir)
@@ -39,9 +39,9 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_netlink_la_SOURCES = $(sources)
 mca_reachable_netlink_la_LDFLAGS = -module -avoid-version
 mca_reachable_netlink_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
-	$(opal_reachable_netlink_LIBS)
+	$(reachable_netlink_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_netlink_la_SOURCES =$(sources)
 libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version
-libmca_reachable_netlink_la_LIBADD = $(opal_reachable_netlink_LIBS)
+libmca_reachable_netlink_la_LIBADD = $(reachable_netlink_LIBS)

--- a/opal/mca/reachable/netlink/Makefile.am
+++ b/opal/mca/reachable/netlink/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,11 +38,11 @@ AM_CPPFLAGS = \
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_netlink_la_SOURCES = $(sources)
-mca_reachable_netlink_la_LDFLAGS = -module -avoid-version
+mca_reachable_netlink_la_LDFLAGS = -module -avoid-version $(reachable_netlink_LDFLAGS)
 mca_reachable_netlink_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(reachable_netlink_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_netlink_la_SOURCES =$(sources)
-libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version
+libmca_reachable_netlink_la_LDFLAGS = -module -avoid-version $(reachable_netlink_LDFLAGS)
 libmca_reachable_netlink_la_LIBADD = $(reachable_netlink_LIBS)

--- a/opal/mca/reachable/netlink/configure.m4
+++ b/opal/mca/reachable/netlink/configure.m4
@@ -36,7 +36,7 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
     AS_IF([test $opal_libnl_version -eq 1],
 	  [opal_reachable_netlink_happy=0],
           [OPAL_CHECK_LIBNL_V3([$opal_libnl_location],
-			       [opal_reachable_netlink])
+			       [reachable_netlink])
 	   AS_IF([test "$OPAL_HAVE_LIBNL3" != "1"],
 		 [opal_reachable_netlink_happy=0])])
 
@@ -44,9 +44,9 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
           [$1],
           [$2])
 
-    AC_SUBST([opal_reachable_netlink_CPPFLAGS])
-    AC_SUBST([opal_reachable_netlink_LDFLAGS])
-    AC_SUBST([opal_reachable_netlink_LIBS])
+    AC_SUBST([reachable_netlink_CPPFLAGS])
+    AC_SUBST([reachable_netlink_LDFLAGS])
+    AC_SUBST([reachable_netlink_LIBS])
 
     OPAL_VAR_SCOPE_POP()
 ])


### PR DESCRIPTION
Backport of two different PRs, https://github.com/open-mpi/ompi/pull/10107 and https://github.com/open-mpi/ompi/pull/10192, to fix linking issues with the reachable/netlink framework.