### PR TITLE
v5.0.x: news-main and news-v5.0.x updates.

### DIFF
--- a/docs/news/news-main.rst
+++ b/docs/news/news-main.rst
@@ -1,5 +1,5 @@
-Master updates (not on release branches yet)
-============================================
+Main updates (not on release branches yet)
+==========================================
 
 This file generally contains all the updates for Open MPI that have
 not yet appeared on a release branch.  It reflects active development,

--- a/docs/news/news-v5.0.x.rst
+++ b/docs/news/news-v5.0.x.rst
@@ -30,8 +30,8 @@ Open MPI version 5.0.0rc4
    regardless of whether you are using an externally-installed PMIx or
    the PMIx that is installed with Open MPI.
 
-- Updated to use PMIx ``v4.2`` branch - current hash: ``1b86a35``.
-- Updated to use PRRTE ``v2.1`` branch - current hash: ``91f791e``.
+- Updated to use PMIx ``v4.2`` branch - current hash: ``d3445c8``.
+- Updated to use PRRTE ``v2.1`` branch - current hash: ``5378b09``.
 
 .. caution::
    Open MPI no longer builds 3rd-party packages


### PR DESCRIPTION
Replace with 'Main'.

[skip ci]
bot:notest
bot:notacherrypick

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 20b22da97391f3ee0b36d1b1879035a1d314a6e5)