### PR TITLE
news-main and news-v5.0.x updates/sync with v5.0.x.

### DIFF
--- a/docs/news/news-main.rst
+++ b/docs/news/news-main.rst
@@ -8,7 +8,6 @@ considered definitive.
 
 Open MPI version main
 ---------------------
-:Date: 30 March 2022
 
 .. admonition:: MPIR API has been removed
    :class: warning

--- a/docs/news/news-v5.0.x.rst
+++ b/docs/news/news-v5.0.x.rst
@@ -6,7 +6,7 @@ series, in reverse chronological order.
 
 Open MPI version 5.0.0rc4
 -------------------------
-:Date: 30 March 2022
+:Date: 31 March 2022
 
 .. admonition:: MPIR API has been removed
    :class: warning
@@ -30,8 +30,8 @@ Open MPI version 5.0.0rc4
    regardless of whether you are using an externally-installed PMIx or
    the PMIx that is installed with Open MPI.
 
-- Updated to use PMIx ``v4.2`` branch - current hash: ``1b86a35``.
-- Updated to use PRRTE ``v2.1`` branch - current hash: ``91f791e``.
+- Updated to use PMIx ``v4.2`` branch - current hash: ``d3445c8``.
+- Updated to use PRRTE ``v2.1`` branch - current hash: ``5378b09``.
 
 .. caution::
    Open MPI no longer builds 3rd-party packages


### PR DESCRIPTION
- news-main: Remove the date.
- news-v5.0.x:
  - Correct the date.
  - Update the PMIx/PRRTE hashes for v5.0.0rc4.

These fixes were mistakenly put on the v5.0.x branch
before the went to main. Syncing these here, and therefore
this does NOT need a cherry-pick back to the v5.0.x branch.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>