### PR TITLE
wrapper: Fix mis-application of flags filter

### DIFF
--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -402,7 +402,7 @@ static void data_callback(const char *key, const char *value)
         opal_argv_insert(&options_data[parse_options_idx].comp_flags,
                          opal_argv_count(options_data[parse_options_idx].comp_flags), values);
         expand_flags(options_data[parse_options_idx].comp_flags);
-        filter_flags(&options_data[parse_options_idx].preproc_flags);
+        filter_flags(&options_data[parse_options_idx].comp_flags);
         opal_argv_free(values);
     } else if (0 == strcmp(key, "compiler_flags_prefix")) {
         char **values = opal_argv_split(value, ' ');


### PR DESCRIPTION
Fix a bug introduced with 5d23e0, where we were filtering out standard
paths from preprocessor flags instead of compiler flags.  In practice,
this didn't change any behaviors because we wanted to filter
preprocessor flags (and already had, so this call was a no-op) and
we never put -Is in compiler flags.  But it's a mistake and Coverity
found it, so fix it.

Fixes CID 1503336.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>