### PR TITLE
openmpi.spec: updates for v5.0.0

### DIFF
--- a/contrib/dist/linux/README.md
+++ b/contrib/dist/linux/README.md
@@ -61,6 +61,13 @@ Please, do NOT set the same settings with parameters and config vars.
 * `-c parameter`:
    Add custom configure parameter.
 
+   **NOTE:** As of Open MPI v5.0.x, there are default configure
+   options for `--with-FOO=external` for all the 3rd party packages
+   (libevent, hwloc, pmix, prrte).  This makes a pure Open MPI RPM,
+   not an RPM that includes those 3rd party packages.  If you specify
+   `-c`, if you want to preserve the default options, you will need to
+   include those in the parameter value.
+
 * `-r parameter`:
    Add custom RPM build parameter.
 

--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -85,7 +85,6 @@ unpack_spec=0
 # "normal" names.
 #export CC=gcc
 #export CXX=g++
-#export F77=f77
 #export FC=
 
 # Note that this script can build one or all of the following RPMs:
@@ -353,7 +352,6 @@ cat <<EOF
 --> Hard-wired for compilers:
     CC = $CC
     CXX = $CXX
-    F77 = $F77
     FC = $FC
 EOF
 
@@ -390,9 +388,6 @@ if test "$CC" != ""; then
 fi
 if test "$CXX" != ""; then
     configure_options="$configure_options CXX=$CXX"
-fi
-if test "$F77" != ""; then
-    configure_options="$configure_options F77=$F77"
 fi
 if test "$FC" != ""; then
     configure_options="$configure_options FC=$FC"
@@ -446,6 +441,8 @@ fi
 if test "$build_multiple" = "yes"; then
     echo "--> Building the multiple Open MPI RPM"
     cmd="$rpm_cmd -bb $rpmbuild_options --define 'build_all_in_one_rpm 0'"
+    # JMS
+    cmd="$cmd --define 'mflags -j12'"
     if test "$configure_options" != ""; then
         cmd="$cmd --define 'configure_options $configure_options'"
     fi
@@ -471,7 +468,7 @@ cat <<EOF
 ====                FINISHED BUILDING Open MPI RPM                        ====
 ------------------------------------------------------------------------------
 A copy of the tarball is located in: $rpmtopdir/SOURCES/
-The completed rpms are located in:   $rpmtopdir/RPMS/i<something>86/
+The completed rpms are located in:   $rpmtopdir/RPMS/
 The sources rpms are located in:     $rpmtopdir/SRPMS/
 The spec files are located in:       $rpmtopdir/SPECS/
 ------------------------------------------------------------------------------


### PR DESCRIPTION
- Default all 3rd-party packages to be "external".  It is strognly
  recomended that the RPM only contain Open MPI, not the embedded
  3rd-party packages.  This behavior can be overridden via the
  configure_options rpmbuild macros.
- Copy all the Sphinx-generated HTML files to pkgdocdir/html.  These
  are not normally installed, but it's probably worth it for the RPM.
- Remove no-longer-existing INSTALL file.  This file was removed as
  part of the conversion to RST-based documentation.
- Tighten up files listings for the individual RPMs.
- Convert -docs sub-package to exclusively use mandir and pkgdocdir
  (instead of docs.files).  We already excluded mandir because
  rpmbuild may have renamed all the man pages after compressing them
  (so we didn't necessarily know the correct filenames).  We also
  explicitly list pkgdocdir so that it picks up the entire tree of
  files and also removes the entire tree (including directories) when
  the RPM is removed.
- Remove some stale F77 and VT references.
- Fix some minor typos.
- Fix a few "file listed twice" warnings (but leave at least one set
  of these because in some cases it will appear, but in other cases it
  will not -- depending on the prefix).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>