### PR TITLE
Fix undefined PLATFORM_COMPILER_GNU build warning 

### DIFF
--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -29,6 +29,7 @@
 #    define OPAL_ATOMIC_STDC_H
 
 #    include "opal_stdint.h"
+#    include "opal/opal_portable_platform.h"
 #    include <stdatomic.h>
 #    include <stdint.h>
 
@@ -50,7 +51,7 @@ static inline void opal_atomic_wmb(void)
 
 static inline void opal_atomic_rmb(void)
 {
-#    if defined(PLATFORM_ARCH_X86_64) && PLATFORM_COMPILER_GNU && __GNUC__ < 8
+#    if defined(PLATFORM_ARCH_X86_64) && defined(PLATFORM_COMPILER_GNU) && __GNUC__ < 8
     /* work around a bug in older gcc versions (observed in gcc 6.x)
      * where acquire seems to get treated as a no-op instead of being
      * equivalent to __asm__ __volatile__("": : :"memory") on x86_64.


### PR DESCRIPTION
On Mac build I observed streams of:

```
In file included from ../../opal/include/opal/sys/atomic.h:420:
../../opal/include/opal/sys/atomic_stdc.h:53:42: warning: 'PLATFORM_COMPILER_GNU' is not defined, evaluates to 0 [-Wundef]
                                         ^
                                         1 warning generated.
```

Fixes #10233 

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>
(cherry picked from commit 977737616460694663f60408730755ec0eb66e64)