### PR TITLE
Introduce support for AMD ROCm GPU devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,8 @@ ompi/mpiext/cuda/c/MPIX_Query_cuda_support.3
 ompi/mpiext/cuda/c/mpiext_cuda_c.h
 ompi/mpiext/cuda/c/cuda_c.h
 
+ompi/mpiext/rocm/c/mpiext_rocm_c.h
+
 ompi/mpiext/pcollreq/c/MPIX_*.3
 ompi/mpiext/pcollreq/c/profile/pallgather_init.c
 ompi/mpiext/pcollreq/c/profile/pallgatherv_init.c

--- a/config/opal_check_rocm.m4
+++ b/config/opal_check_rocm.m4
@@ -1,0 +1,86 @@
+#
+# 2022     Copyright (C) Advanced Micro Devices, Inc. All rights reserved.
+#
+
+
+# OMPI_CHECK_ROCM(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if ROCM support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+
+
+# ROCM_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
+# ----------------------------------------------------------
+# Parse value of ARG into appropriate LIBS, LDFLAGS, and
+# CPPFLAGS variables.
+AC_DEFUN([ROCM_BUILD_FLAGS],
+    $4="-D__HIP_PLATFORM_AMD__ -I$1/include/hip -I$1/include"
+    $3="-L$1/hip/lib -L$1/lib"
+    $2="-lamdhip64"
+)
+
+#
+# Check for ROCm  support
+#
+AC_DEFUN([OPAL_CHECK_ROCM],[
+
+     OPAL_VAR_SCOPE_PUSH([opal_check_rocm_happy])
+
+    # Get some configuration information
+     AC_ARG_WITH([rocm],
+        [AS_HELP_STRING([--with-rocm(=DIR)],
+        [Build ROCm support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+     OPAL_CHECK_WITHDIR([rocm], [$with_rocm], [include/hip/hip_runtime.h])
+
+     AS_IF([test "$with_rocm" = "no"],
+           [opal_check_rocm_happy="no"],
+           [AS_IF([test -n "$with_rocm" && test "$with_rocm" != "yes"],
+                  [opal_check_rocm_dir=$with_rocm])
+
+          SAVE_CPPFLAGS="$CPPFLAGS"
+          SAVE_LDFLAGS="$LDFLAGS"
+          SAVE_LIBS="$LIBS"
+
+          ROCM_BUILD_FLAGS([$with_rocm],
+                           [common_rocm_LIBS], [common_rocm_LDFLAGS], [common_rocm_CPPFLAGS])
+
+
+          save_common_rocm_CPPFLAGS=$common_rocm_CPPFLAGS
+          save_common_rocm_LFFLAGS=$common_rocm_LDFLAGS
+          save_common_rocm_LIBS=$common_rocm_LIBS
+
+          CPPFLAGS="$common_rocm_CPPFLAGS $CPPFLAGS"
+          LDFLAGS="$common_rocm_LDFLAGS $LDFLAGS"
+          LIBS="$common_rocm_LIBS $LIBS"
+
+          OAC_CHECK_PACKAGE([rocm], [$1], [hip/hip_runtime.h],
+	                    [amdhip64], [hipFree],
+                            [opal_check_rocm_happy="yes"],
+                            [opal_check_rocm_happy="no"])
+          CPPFLAGS="$SAVE_CPPFLAGS"
+          LDFLAGS="$SAVE_LDFLAGS"
+          LIBS="$SAVE_LIBS"
+
+          common_rocm_CPPFLAGS=$save_common_rocm_CPPFLAGS
+          common_rocm_LFFLAGS=$save_common_rocm_LDFLAGS
+          common_rocm_LIBS=$save_common_rocm_LIBS
+     ])
+
+     AS_IF([test "$opal_check_rocm_happy" = "yes"],
+           AC_DEFINE([OPAL_ROCM_SUPPORT], 1, [Enable ROCM support]),
+	   [AC_DEFINE([OPAL_ROCM_SUPPORT], 0, [Enable ROCM support])
+	    ROCM_CPPFLAGS=
+	    ROCM_LDFLAGS=
+	    ROCM_LIBS=
+	    ])
+
+     AS_IF([test "$opal_check_rocm_happy" = "yes"],
+            [$2],
+            [AS_IF([test -n "$with_rocm" && test "$with_rocm" != "no"],
+                   [AC_MSG_ERROR([ROCm support requested but not found.  Aborting])])
+            $3])
+
+     AM_CONDITIONAL([OPAL_rocm_support], [test "$opal_check_rocm_happy" = "yes"])
+     OPAL_VAR_SCOPE_POP
+])

--- a/config/opal_config_files.m4
+++ b/config/opal_config_files.m4
@@ -18,6 +18,7 @@ AC_DEFUN([OPAL_CONFIG_FILES],[
     AC_CONFIG_FILES([
         opal/Makefile
         opal/cuda/Makefile
+        opal/rocm/Makefile
         opal/etc/Makefile
         opal/include/Makefile
         opal/datatype/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ m4_include([config/autogen_found_items.m4])
 m4_include([config/opal_get_version.m4])
 AC_LANG([C])
 
+
 # Init autoconf
 
 # We don't have the version number to put in here yet, and we can't
@@ -189,6 +190,7 @@ AC_SUBST(libopen_pal_so_version)
 # right now.
 AC_SUBST(libmca_opal_common_ofi_so_version)
 AC_SUBST(libmca_opal_common_cuda_so_version)
+AC_SUBST(libmca_opal_common_rocm_so_version)
 AC_SUBST(libmca_opal_common_sm_so_version)
 AC_SUBST(libmca_opal_common_ugni_so_version)
 AC_SUBST(libmca_ompi_common_ompio_so_version)
@@ -1246,6 +1248,19 @@ AC_CACHE_SAVE
 # all other MCA checks" hook...?
 
 OPAL_CHECK_CUDA_AFTER_OPAL_DL
+
+##################################
+# ROCm support
+##################################
+OPAL_CHECK_ROCM([common_rocm],
+                [common_rocm_happy="yes"],
+                [common_rocm_happy="no"])
+
+AC_SUBST([common_rocm_CPPFLAGS])
+AC_SUBST([common_rocm_LDFLAGS])
+AC_SUBST([common_rocm_LIBS])
+
+OPAL_SUMMARY_ADD([[Miscellaneous]],[[ROCm suport]],[$1], [$common_rocm_happy])
 
 ##################################
 # MPI Extended Interfaces

--- a/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
@@ -1,0 +1,72 @@
+.. _mpix_query_rocm_support:
+
+
+MPIX_Query_rocm_support
+=======================
+
+.. include_body
+
+**MPIX_Query_rocm_support** - Returns 1 if there is AMD ROCm aware support
+and 0 if there is not.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Query_rocm_support(void)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+There is no Fortran binding for this function.
+
+
+C++ Syntax
+^^^^^^^^^^
+
+There is no C++ binding for this function.
+
+
+DESCRIPTION
+-----------
+
+This routine return 1 if MPI library is build with ROCm and runtime
+supports ROCm buffers. This routine must be called after MPI is
+initialized by a call to :ref:`MPI_Init` or :ref:`MPI_Init_thread`.
+
+
+Examples
+^^^^^^^^
+
+::
+
+
+   #include <stdio.h>
+   #include "mpi.h"
+
+   #include "mpi-ext.h" /* Needed for ROCm-aware check */
+
+   int main(int argc, char *argv[])
+   {
+
+       MPI_Init(&argc, &argv);
+
+       if (MPIX_Query_rocm_support()) {
+           printf("This MPI library has ROCm-aware support.);
+       } else {
+           printf("This MPI library does not have ROCm-aware support.);
+       }
+       MPI_Finalize();
+
+       return 0;
+   }

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -466,4 +466,5 @@ MPI API manual pages (section 3)
    MPI_Wtick.3.rst
    MPI_Wtime.3.rst
    MPIX_Query_cuda_support.3.rst
+   MPIX_Query_rocm_support.3.rst
    OMPI_Affinity_str.3.rst

--- a/ompi/mpiext/rocm/Makefile.am
+++ b/ompi/mpiext/rocm/Makefile.am
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This Makefile is not traversed during a normal "make all" in an OMPI
+# build.  It *is* traversed during "make dist", however.  So you can
+# put EXTRA_DIST targets in here.
+#
+# You can also use this as a convenience for building this MPI
+# extension (i.e., "make all" in this directory to invoke "make all"
+# in all the subdirectories).
+
+SUBDIRS = c

--- a/ompi/mpiext/rocm/c/Makefile.am
+++ b/ompi/mpiext/rocm/c/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+# Copyright (c) 2018      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This file builds the C bindings for MPI extensions.  It must be
+# present in all MPI extensions.
+
+# We must set these #defines so that the inner OMPI MPI prototype
+# header files do the Right Thing.
+AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
+
+# Convenience libtool library that will be slurped up into libmpi.la.
+noinst_LTLIBRARIES = libmpiext_rocm_c.la
+
+# This is where the top-level header file (that is included in
+# <mpi-ext.h>) must be installed.
+ompidir = $(ompiincludedir)/mpiext
+
+# This is the header file that is installed.
+nodist_ompi_HEADERS = mpiext_rocm_c.h
+
+# Sources for the convenience libtool library.  Other than the one
+# header file, all source files in the extension have no file naming
+# conventions.
+libmpiext_rocm_c_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_rocm.c
+libmpiext_rocm_c_la_LDFLAGS = -module -avoid-version
+

--- a/ompi/mpiext/rocm/c/mpiext_rocm.c
+++ b/ompi/mpiext/rocm/c/mpiext_rocm.c
@@ -1,0 +1,54 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "ompi_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "opal/constants.h"
+#include "opal/runtime/opal_params.h"
+#include "ompi/mpiext/rocm/c/mpiext_rocm_c.h"
+
+#if OPAL_ROCM_SUPPORT
+#include "opal/rocm/common_rocm_prototypes.h"
+#endif
+
+int MPIX_Query_rocm_support(void)
+{
+
+    if (!opal_built_with_rocm_support) {
+        return 0;
+    } else {
+        if ( opal_rocm_runtime_initialized ) {
+            return 1;
+        }
+#if OPAL_ROCM_SUPPORT
+        // There is a chance that the rocm runtime has simply not
+        // been initialized yet, since that is done during the first convertor creation
+        // Invoke a function that will trigger the rocm runtime initialized and
+        // check the value again after that.
+
+        int val1, val2;
+        mca_common_rocm_check_bufs((char *)&val1, (char *)&val2);
+#endif
+    }
+
+    return opal_rocm_runtime_initialized;
+}

--- a/ompi/mpiext/rocm/c/mpiext_rocm_c.h.in
+++ b/ompi/mpiext/rocm/c/mpiext_rocm_c.h.in
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define MPIX_ROCM_AWARE_SUPPORT @MPIX_ROCM_AWARE_SUPPORT@
+OMPI_DECLSPEC int MPIX_Query_rocm_support(void);

--- a/ompi/mpiext/rocm/configure.m4
+++ b/ompi/mpiext/rocm/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2010 The Trustees of Indiana University.
+#                         All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_MPIEXT_rocm_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([OMPI_MPIEXT_rocm_CONFIG],[
+    AC_CONFIG_FILES([ompi/mpiext/rocm/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/rocm/c/Makefile])
+    AC_CONFIG_HEADERS([ompi/mpiext/rocm/c/mpiext_rocm_c.h])
+
+    AC_DEFINE_UNQUOTED([MPIX_ROCM_AWARE_SUPPORT],[$ROCM_SUPPORT],
+                       [Macro that is set to 1 when ROCM-aware support is configured in and 0 when it is not])
+
+    # We compile this whether ROCM support was requested or not. It allows
+    # us to to detect if we have ROCM support.
+    AS_IF([test "$ENABLE_rocm" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [$1],
+          [$2])
+])

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,17 +23,23 @@
 #
 
 if OPAL_cuda_support
-LIBOPAL_CUDA_SUBDIR = cuda
-LIBOPAL_CUDA_LA = cuda/libopalcuda.la
+LIBOPAL_GPU_SUBDIR = cuda
+LIBOPAL_GPU_LA = cuda/libopalcuda.la
+else
+if OPAL_rocm_support
+LIBOPAL_GPU_SUBDIR = rocm
+LIBOPAL_GPU_LA = rocm/libopalrocm.la
 endif
+endif
+
 
 SUBDIRS = \
 	include \
         datatype \
+	$(LIBOPAL_GPU_SUBDIR) \
         etc \
         util \
 	mca/base \
-	$(LIBOPAL_CUDA_SUBDIR) \
 	$(MCA_opal_FRAMEWORKS_SUBDIRS) \
 	$(MCA_opal_FRAMEWORK_COMPONENT_STATIC_SUBDIRS) \
         . \
@@ -40,6 +47,7 @@ SUBDIRS = \
 DIST_SUBDIRS = \
 	include \
 	cuda \
+	rocm \
         datatype \
         etc \
 	util \
@@ -54,14 +62,14 @@ lib@OPAL_LIB_NAME@_la_LIBADD = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
-	$(LIBOPAL_CUDA_LA) \
+	$(LIBOPAL_GPU_LA) \
 	$(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_NAME@_la_DEPENDENCIES = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
-        $(MCA_opal_FRAMEWORK_LIBS) \
-        $(LIBOPAL_CUDA_LA)
+        $(LIBOPAL_GPU_LA)  \
+        $(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_NAME@_la_LDFLAGS = -version-info @libopen_pal_so_version@
 
 # included subdirectory Makefile.am's and appended-to variables

--- a/opal/datatype/opal_convertor.h
+++ b/opal/datatype/opal_convertor.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +49,7 @@ BEGIN_C_DECLS
 #define CONVERTOR_NO_OP           0x00100000
 #define CONVERTOR_WITH_CHECKSUM   0x00200000
 #define CONVERTOR_CUDA            0x00400000
+#define CONVERTOR_ROCM            0x00400000 //same as CUDA on purpose
 #define CONVERTOR_CUDA_ASYNC      0x00800000
 #define CONVERTOR_TYPE_MASK       0x10FF0000
 #define CONVERTOR_STATE_START     0x01000000
@@ -57,6 +59,7 @@ BEGIN_C_DECLS
 #define CONVERTOR_CUDA_UNIFIED    0x10000000
 #define CONVERTOR_HAS_REMOTE_SIZE 0x20000000
 #define CONVERTOR_SKIP_CUDA_INIT  0x40000000
+#define CONVERTOR_SKIP_GPU_INIT   0x40000000 // same as CUDA on purpose
 
 union dt_elem_desc;
 typedef struct opal_convertor_t opal_convertor_t;
@@ -115,9 +118,9 @@ struct opal_convertor_t {
     /* --- fields are no more aligned on cacheline --- */
     dt_stack_t static_stack[DT_STATIC_STACK_SIZE]; /**< local stack for small datatypes */
 
-#if OPAL_CUDA_SUPPORT
-    memcpy_fct_t cbmemcpy; /**< memcpy or cuMemcpy */
-    void *stream;          /**< CUstream for async copy */
+#if defined (OPAL_CUDA_SUPPORT) || defined (OPAL_ROCM_SUPPORT)
+    memcpy_fct_t cbmemcpy; /**< memcpy, cuMemcpy, or hipMemcpy */
+    void *stream;          /**< CUstream/hipStream for async copy */
 #endif
 };
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_convertor_t);
@@ -180,8 +183,8 @@ static inline int32_t opal_convertor_need_buffers(const opal_convertor_t *pConve
 {
     if (OPAL_UNLIKELY(0 == (pConvertor->flags & CONVERTOR_HOMOGENEOUS)))
         return 1;
-#if OPAL_CUDA_SUPPORT
-    if (pConvertor->flags & (CONVERTOR_CUDA | CONVERTOR_CUDA_UNIFIED))
+#if defined (OPAL_CUDA_SUPPORT) || defined (OPAL_ROCM_SUPPORT)
+    if (pConvertor->flags & (CONVERTOR_CUDA | CONVERTOR_CUDA_UNIFIED | CONVERTOR_ROCM))
         return 1;
 #endif
     if (pConvertor->flags & OPAL_DATATYPE_FLAG_NO_GAPS)

--- a/opal/datatype/opal_datatype_pack.h
+++ b/opal/datatype/opal_datatype_pack.h
@@ -9,6 +9,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +23,7 @@
 #include "opal_config.h"
 #include "opal/datatype/opal_datatype_pack_unpack_predefined.h"
 
-#if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
+#if !defined(CHECKSUM) && (defined (OPAL_CUDA_SUPPORT) || defined (OPAL_ROCM_SUPPORT))
 /* Make use of existing macro to do CUDA style memcpy */
 #    undef MEMCPY_CSUM
 #    define MEMCPY_CSUM(DST, SRC, BLENGTH, CONVERTOR) \
@@ -105,7 +106,8 @@ static inline void pack_predefined_data(opal_convertor_t *CONVERTOR, const dt_el
     *(COUNT) -= cando_count;
 
     if (_elem->blocklen < 9) {
-        if ((!(CONVERTOR->flags & CONVERTOR_CUDA))
+        if ( !(CONVERTOR->flags & CONVERTOR_CUDA) &&
+             !(CONVERTOR->flags & CONVERTOR_ROCM)
             && OPAL_LIKELY(
                 OPAL_SUCCESS
                 == opal_datatype_pack_predefined_element(&_memory, &_packed, cando_count, _elem))) {

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -217,7 +217,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
     MEMCPY( temporary + start_position, partial_data, length );
 
     /* Save the original content of the user memory */
-#if OPAL_CUDA_SUPPORT
+#if defined (OPAL_CUDA_SUPPORT) || defined (OPAL_ROCM_SUPPORT)
     /* In the case where the data is being unpacked from device memory, need to
      * use the special host to device memory copy. */
     pConvertor->cbmemcpy(saved_data, user_data, data_length, pConvertor );
@@ -235,7 +235,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
 
     /* Rebuild the data by pulling back the unmodified bytes from the original
      * content in the user memory. */
-#if OPAL_CUDA_SUPPORT
+#if defined (OPAL_CUDA_SUPPORT) || defined (OPAL_ROCM_SUPPORT)
     /* Need to copy the modified user_data again so we can see which
      * bytes need to be converted back to their original values. */
     {

--- a/opal/datatype/opal_datatype_unpack.h
+++ b/opal/datatype/opal_datatype_unpack.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
 #include "opal_config.h"
 #include "opal/datatype/opal_datatype_pack_unpack_predefined.h"
 
-#if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
+#if !defined(CHECKSUM) && (defined(OPAL_CUDA_SUPPORT) || defined(OPAL_ROCM_SUPPORT))
 /* Make use of existing macro to do CUDA style memcpy */
 #    undef MEMCPY_CSUM
 #    define MEMCPY_CSUM(DST, SRC, BLENGTH, CONVERTOR) \
@@ -102,7 +103,8 @@ static inline void unpack_predefined_data(opal_convertor_t *CONVERTOR, const dt_
     *(COUNT) -= cando_count;
 
     if (_elem->blocklen < 9) {
-        if ((!(CONVERTOR->flags & CONVERTOR_CUDA))
+        if ( !(CONVERTOR->flags & CONVERTOR_CUDA) &&
+             !(CONVERTOR->flags & CONVERTOR_ROCM)
             && OPAL_LIKELY(OPAL_SUCCESS
                            == opal_datatype_unpack_predefined_element(&_packed, &_memory,
                                                                       cando_count, _elem))) {

--- a/opal/rocm/Makefile.am
+++ b/opal/rocm/Makefile.am
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2013 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(common_rocm_CPPFLAGS)
+
+# Header files
+headers = \
+        common_rocm.h \
+	common_rocm_prototypes.h
+
+# Source files
+sources = \
+        common_rocm.c
+
+
+noinst_LTLIBRARIES = libopalrocm.la
+
+libopalrocm_la_SOURCES  = $(headers) $(sources)
+libopalrocm_la_CPPFLAGS = $(common_rocm_CPPFLAGS)
+libopalrocm_la_LDFLAGS  = $(common_rocm_LDFLAGS)
+libopalrocm_la_LIBADD   =
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+opaldir = $(opalincludedir)/$(subdir)
+opal_HEADERS = $(headers)
+endif

--- a/opal/rocm/common_rocm.c
+++ b/opal/rocm/common_rocm.c
@@ -1,0 +1,322 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include "opal_config.h"
+#include "common_rocm.h"
+#include "opal/mca/dl/base/base.h"
+#include "opal/runtime/opal_params.h"
+
+static void* hip_handle = NULL;
+static hipFunctionTable_t hip_funcs;
+
+int mca_common_rocm_memcpy_async = 1;
+int mca_common_rocm_verbose = 0;
+size_t mca_common_rocm_memcpy_limit=1024;
+
+static bool rocm_initialized = false;
+static hipStream_t common_rocm_MemcpyStream;
+static opal_mutex_t common_rocm_init_lock;
+
+#define HIP_CHECK(condition)                                                 \
+{                                                                            \
+    hipError_t error = condition;                                            \
+    if(hipSuccess != error){                                                 \
+        const char* msg = hip_funcs.hipGetErrorString(error);                \
+        opal_output(10, "HIP error: %d %s file: %s line: %d\n", error, msg, __FILE__, __LINE__); \
+        return error;                                                        \
+    }                                                                        \
+}
+
+#define HIP_CHECK_RETNULL(condition)                                         \
+{                                                                            \
+    hipError_t error = condition;                                            \
+    if(hipSuccess != error){                                                 \
+        const char* msg = hip_funcs.hipGetErrorString(error);                \
+        opal_output(10, "HIP error: %d %s file: %s line: %d\n", error, msg, __FILE__, __LINE__); \
+        return NULL;                                                         \
+    }                                                                        \
+}
+
+static int hip_dl_init(void)
+{
+    char *str;
+    void *ptr;
+    int ret  = opal_dl_open("libamdhip64.so", false, false, &hip_handle, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Unable to open libamdhip64.so\n");
+        return OPAL_ERROR;
+    }
+
+    ret = opal_dl_lookup(hip_handle, "hipMalloc", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipMalloc\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **)(&hip_funcs.hipMalloc) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipFree", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipFree\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipFree) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipMemcpy", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipMemcpy\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipMemcpy) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipMemcpyAsync", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipMemcpyAsync\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipMemcpyAsync) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipStreamCreate", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipStreamCreate\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipStreamCreate) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipStreamDestroy", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipStreamDestroy\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipStreamDestroy) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipStreamSynchronize", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipStreamSynchronize\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipStreamSynchronize) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipGetErrorString", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipGetErrorString\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipGetErrorString) = ptr;
+
+    ret = opal_dl_lookup (hip_handle, "hipPointerGetAttributes", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(10, "Failed to find hipPointerGetAttributes\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    *(void **) (&hip_funcs.hipPointerGetAttributes) = ptr;
+
+    return OPAL_SUCCESS;
+}
+
+static void hip_dl_finalize(void)
+{
+    hipError_t err = hip_funcs.hipStreamDestroy(&common_rocm_MemcpyStream);
+    if (hipSuccess != err) {
+        opal_output(10, "hip_dl_finalize: error while destroying the hipStream\n");
+    }
+    dlclose(hip_handle);
+}
+
+
+static void mca_common_rocm_support_init(void)
+{
+    if (rocm_initialized) {
+        return;
+    }
+
+    OBJ_CONSTRUCT(&common_rocm_init_lock, opal_mutex_t);
+    OPAL_THREAD_LOCK(&common_rocm_init_lock);
+
+    if (rocm_initialized) {
+        return;
+    }
+
+    if (!OPAL_HAVE_DL_SUPPORT) {
+        opal_output(1, "Can not open libamdhip64.so without dlopen support\n");
+        OPAL_THREAD_UNLOCK(&common_rocm_init_lock);
+        return;
+    }
+    if (OPAL_SUCCESS != hip_dl_init()) {
+        opal_output(10, "Could not open libamdhip64.so. Please check your LD_LIBRARY_PATH\n");
+        OPAL_THREAD_UNLOCK(&common_rocm_init_lock);
+        return;
+    }
+    rocm_initialized = true;
+    opal_rocm_runtime_initialized = true;
+
+    mca_common_rocm_register_mca_variables();
+
+    hipError_t err = hip_funcs.hipStreamCreate(&common_rocm_MemcpyStream);
+    if (hipSuccess != err) {
+        opal_output(10, "Could not create hipStream, err=%d %s\n",
+                err, hip_funcs.hipGetErrorString(err));
+    }
+    OPAL_THREAD_UNLOCK(&common_rocm_init_lock);
+}
+
+void mca_common_rocm_convertor_init(opal_convertor_t *convertor, const void *pUserBuf)
+{
+    /* Only do the initialization on the first GPU access */
+    if (!rocm_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    convertor->cbmemcpy = (memcpy_fct_t) &mca_common_rocm_memcpy;
+    // set convertor->stream as well ? Not right now.
+
+    hipPointerAttribute_t attr;
+    hipError_t err =  hip_funcs.hipPointerGetAttributes(&attr, pUserBuf);
+    if (hipSuccess != err) {
+        return;
+    }
+    if (hipMemoryTypeDevice == attr.memoryType || hipMemoryTypeUnified == attr.memoryType) {
+        convertor->flags |= CONVERTOR_ROCM;
+    }
+}
+
+bool mca_common_rocm_check_bufs(char *dst, char *src)
+{
+    /* Only do the initialization on the first GPU access */
+    if (!rocm_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    hipPointerAttribute_t srcAttr, dstAttr;
+    hipError_t err = hip_funcs.hipPointerGetAttributes(&srcAttr, src);
+    if (true != err) {
+        //an error here only means its most likely an address in host memory
+        //ignore for now.
+    }
+    err = hip_funcs.hipPointerGetAttributes(&dstAttr, dst);
+    if (true != err) {
+        //an error here only means its most likely an address in host memory
+        //ignore for now.
+    }
+
+    if ( hipMemoryTypeDevice == srcAttr.memoryType || hipMemoryTypeUnified == srcAttr.memoryType ||
+         hipMemoryTypeDevice == dstAttr.memoryType || hipMemoryTypeUnified == dstAttr.memoryType ) {
+        return true;
+    }
+
+    return false;
+}
+
+int mca_common_rocm_memcpy_sync(void *dst, void *src, size_t nBytes)
+{
+
+    if (!rocm_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    if (nBytes < mca_common_rocm_memcpy_limit) {
+        memcpy(dst, src, nBytes);
+        return OPAL_SUCCESS;
+    }
+
+    if (mca_common_rocm_memcpy_async) {
+        HIP_CHECK(hip_funcs.hipMemcpyAsync (dst, src, nBytes, hipMemcpyDefault,
+                                            common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipStreamSynchronize(common_rocm_MemcpyStream));
+    }
+    else {
+        HIP_CHECK(hip_funcs.hipMemcpy (dst, src, nBytes, hipMemcpyDefault));
+    }
+
+    return OPAL_SUCCESS;
+}
+
+void *mca_common_rocm_memcpy(void *dst, const void *src, size_t nBytes, opal_convertor_t *pConvertor)
+{
+
+    if (!(pConvertor->flags & CONVERTOR_ROCM) || nBytes < mca_common_rocm_memcpy_limit) {
+        //For short messages a regular memcpy is faster than hipMemcpy or hipMemcpyAsync
+        //printf("In common_rocm_memcpy fallback path\n");
+        return memcpy(dst, src, nBytes);
+    }
+
+    if (mca_common_rocm_memcpy_async) {
+        //printf("In common_rocm_memcpy async path\n");
+        HIP_CHECK_RETNULL(hip_funcs.hipMemcpyAsync (dst, src, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK_RETNULL(hip_funcs.hipStreamSynchronize(common_rocm_MemcpyStream));
+    }
+    else {
+        //printf("In common_rocm_memcpy sync path\n");
+        HIP_CHECK_RETNULL(hip_funcs.hipMemcpy (dst, src, nBytes, hipMemcpyDefault));
+    }
+
+  return dst;
+}
+
+int mca_common_rocm_memmove(void *dst, void *src, size_t nBytes)
+{
+    if (!rocm_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    // Do we need to make sure that we use either src or dst device before hipMalloc
+    char *tmp=NULL;
+    HIP_CHECK(hip_funcs.hipMalloc((void **)&tmp, nBytes));
+    if (mca_common_rocm_memcpy_async) {
+        HIP_CHECK(hip_funcs.hipMemcpyAsync (tmp, src, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipMemcpyAsync (dst, tmp, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipStreamSynchronize (common_rocm_MemcpyStream));
+    } else {
+        HIP_CHECK(hip_funcs.hipMemcpy (tmp, src, nBytes, hipMemcpyDefault));
+        HIP_CHECK(hip_funcs.hipMemcpy (dst, tmp, nBytes, hipMemcpyDefault));
+    }
+
+    HIP_CHECK(hip_funcs.hipFree(tmp));
+    return OPAL_SUCCESS;
+}
+
+void mca_common_rocm_register_mca_variables(void)
+{
+
+    /* Set verbosity in the crocm related code. */
+    mca_common_rocm_verbose = 0;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "verbose",
+                                 "Set level of common rocm verbosity", MCA_BASE_VAR_TYPE_INT, NULL,
+                                 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                 &mca_common_rocm_verbose);
+
+    /* Set verbosity in the crocm related code. */
+    mca_common_rocm_memcpy_limit = 1024;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "memcpy_limit",
+                                 "Max. no. of bytes to use memcpy instead of hip copy functions",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                 &mca_common_rocm_memcpy_limit);
+
+    /* Use this flag to test async vs sync copies */
+    mca_common_rocm_memcpy_async = 1;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "memcpy_async",
+                                 "Set to 0 to force hipMemcpy copy instead of hipMemcpyAsync",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &mca_common_rocm_memcpy_async);
+
+    return;
+}

--- a/opal/rocm/common_rocm.h
+++ b/opal/rocm/common_rocm.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_MCA_COMMON_ROCM_H
+#define OPAL_MCA_COMMON_ROCM_H
+
+#include <stdio.h>
+#include <hip/hip_runtime_api.h>
+
+#include "opal_config.h"
+
+#include "common_rocm_prototypes.h"
+#include "opal/mca/btl/base/base.h"
+
+struct hipFunctionTable_s {
+    hipError_t (*hipMalloc)(void** pts, size_t size);
+    hipError_t (*hipFree)(void* ptr);
+    hipError_t (*hipMemcpy)(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
+    hipError_t (*hipMemcpyAsync)(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind, hipStream_t stream);
+    hipError_t (*hipStreamCreate)(hipStream_t* stream);
+    hipError_t (*hipStreamDestroy)(hipStream_t stream);
+    hipError_t (*hipStreamSynchronize)(hipStream_t stream);
+    const char* (*hipGetErrorString)(hipError_t hipError);
+    hipError_t (*hipPointerGetAttributes)(hipPointerAttribute_t *attributes, const void *ptr);
+};
+typedef struct hipFunctionTable_s hipFunctionTable_t;
+
+OPAL_DECLSPEC void mca_common_rocm_register_mca_variables(void);
+
+#endif

--- a/opal/rocm/common_rocm_prototypes.h
+++ b/opal/rocm/common_rocm_prototypes.h
@@ -1,0 +1,23 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_MCA_COMMON_ROCM_PROTOTYPES_H
+#define OPAL_MCA_COMMON_ROCM_PROTOTYPES_H
+
+#include "opal/datatype/opal_convertor.h"
+
+OPAL_DECLSPEC void mca_common_rocm_convertor_init(opal_convertor_t *convertor, const void *pUserBuf);
+OPAL_DECLSPEC bool mca_common_rocm_check_bufs(char *destination_base, char *source_base);
+OPAL_DECLSPEC int mca_common_rocm_memcpy_sync(void *dst, void *src, size_t nBytes);
+OPAL_DECLSPEC int mca_common_rocm_memmove(void *dst, void *src, size_t nBytes);
+OPAL_DECLSPEC void *mca_common_rocm_memcpy(void *dest, const void *src, size_t n, opal_convertor_t *pConvertor);
+
+#endif

--- a/opal/rocm/owner.txt
+++ b/opal/rocm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: AMD
+status:active

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,6 +65,10 @@ bool opal_built_with_cuda_support = OPAL_INT_TO_BOOL(OPAL_CUDA_SUPPORT);
 bool opal_cuda_runtime_initialized = false;
 bool opal_cuda_support = false;
 bool opal_warn_on_missing_libcuda = true;
+
+bool opal_built_with_rocm_support = OPAL_INT_TO_BOOL(OPAL_ROCM_SUPPORT);
+bool opal_rocm_runtime_initialized = false;
+
 
 /**
  * Globals imported from the OMPI layer.

--- a/opal/runtime/opal_params.h
+++ b/opal/runtime/opal_params.h
@@ -19,6 +19,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +43,7 @@ extern bool opal_timing_overhead;
 
 OPAL_DECLSPEC extern int opal_initialized;
 OPAL_DECLSPEC extern bool opal_built_with_cuda_support;
+OPAL_DECLSPEC extern bool opal_built_with_rocm_support;
 
 /**
  *  * Whether we want to enable CUDA GPU buffer send and receive support.
@@ -52,6 +54,11 @@ OPAL_DECLSPEC extern bool opal_cuda_support;
  * Whether cuda runtime support is initialized or not.
  */
 OPAL_DECLSPEC extern bool opal_cuda_runtime_initialized;
+
+/**
+ * Whether rocm runtime support is initialized or not.
+ */
+OPAL_DECLSPEC extern bool opal_rocm_runtime_initialized;
 
 /**
  *  * Whether we want to warn the user when libcuda is missing.


### PR DESCRIPTION
This commit introduces support for AMD ROCm devices. The core aspect of this commit is to enable
using hipMemcpy* based operations for packing/unpacking derived datatyes.

At the moment, support for AMD GPUs is *only* available through ROCm enabled UCX. There are furthermore a couple of known issues that will be addressed in later commits, but might not be required if the device code is moved to an accelerator framework.

The most notable limitations:
 - rocm mca variables are not listed with ompi_info, since there is no component (at the moment) that is using rocm.
 - the 'compiled but not enabled' feature has received very limited testing.

Compiling a hip/MPI code will require a few additional flags. A typical compile line is:
mpiCC -D__HIP_PLATFORM_AMD__ -I/opt/rocm/include/hip -I/opt/rocm/include hipMPItest.cc -L/opt/rocm/lib -lamdhip64

Signed-off-by: Edgar <edgar.gabriel@amd.com>