### PR TITLE
build: Run missing package dist-hook earlier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2017-2021 Amazon.com, Inc. or its affiliates.
+# Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 #                         All Rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
@@ -22,6 +22,9 @@
 # $HEADER$
 #
 
+# There is an assumption in config/Makefile.am that config is the first
+# subdirectory in the DIST_SUBDIRS list.  If that changes, work may
+# be required.
 SUBDIRS = config contrib 3rd-party $(MCA_PROJECT_SUBDIRS) test docs
 DIST_SUBDIRS = config contrib 3rd-party $(MCA_PROJECT_DIST_SUBDIRS) test docs
 EXTRA_DIST = README.md VERSION Doxyfile LICENSE autogen.pl AUTHORS
@@ -32,14 +35,6 @@ dist-hook:
 	env LS_COLORS= sh "$(top_srcdir)/config/distscript.sh" "$(top_srcdir)" "$(distdir)" "$(OMPI_REPO_REV)"
 	@if test ! -s $(distdir)/AUTHORS ; then \
 		echo "AUTHORS file is empty; aborting distribution"; \
-		exit 1; \
-	fi
-	@if test -n "$(OPAL_MAKEDIST_DISABLE)" ; then \
-		echo "#########################################################################"; \
-		echo "#"; \
-		echo "# make dist is disabled due to the following packages: $(OPAL_MAKEDIST_DISABLE)"; \
-		echo "#"; \
-		echo "#########################################################################"; \
 		exit 1; \
 	fi
 

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -15,12 +15,26 @@
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+# This is a weird place for this, but config/ is the first directory that
+# is entered, and the dist-hook runs at the end of the current directory,
+# so this is the earliest we can run this test.
+dist-hook:
+	@if test -n "$(OPAL_MAKEDIST_DISABLE)" ; then \
+		echo "#########################################################################"; \
+		echo "#"; \
+		echo "# make dist is disabled due to the following packages: $(OPAL_MAKEDIST_DISABLE)"; \
+		echo "#"; \
+		echo "#########################################################################"; \
+		exit 1; \
+	fi
 
 EXTRA_DIST = \
         distscript.sh \


### PR DESCRIPTION
The hook that would fail "make dist" if packages weren't configured to
be included in the tarball ran at the end of "make dist".  This was
fine when the packages missing didn't break running make dist.  However,
Sphinx not being available means that "make dist" won't work because
of missing files, but the error was really not intuitive.

Move the dist-hook for missing packages from the top level to the
config directory Makefile, which has the practical outcome of running
the missing package check right after generation of the AUTHORS file,
well before any likely missing package make breakage, returning us to
clear error messages.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>