### PR TITLE
Improve support for AMD ROCm GPU devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,8 @@ ompi/mpiext/cuda/c/MPIX_Query_cuda_support.3
 ompi/mpiext/cuda/c/mpiext_cuda_c.h
 ompi/mpiext/cuda/c/cuda_c.h
 
+ompi/mpiext/rocm/c/mpiext_rocm_c.h
+
 ompi/mpiext/pcollreq/c/MPIX_*.3
 ompi/mpiext/pcollreq/c/profile/pallgather_init.c
 ompi/mpiext/pcollreq/c/profile/pallgatherv_init.c

--- a/config/opal_check_rocm.m4
+++ b/config/opal_check_rocm.m4
@@ -1,0 +1,82 @@
+dnl
+dnl Copyright (C) 2022      Advanced Micro Devices, Inc. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+
+# OMPI_CHECK_ROCM(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if ROCM support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+
+
+#
+# Check for ROCm  support
+#
+AC_DEFUN([OPAL_CHECK_ROCM],[
+
+     OPAL_VAR_SCOPE_PUSH([opal_check_rocm_happy rocm_save_CPPFLAGS rocm_save_LDFLAGS rocm_CPPFLAGS rocm_LDFLAGS])
+
+     rocm_save_CPPFLAGS="$CPPFLAGS"
+     rocm_save_LDFLAGS="$LDFLAGS"
+     
+     # Get some configuration information
+     AC_ARG_WITH([rocm],
+        [AS_HELP_STRING([--with-rocm(=DIR)],
+        [Build ROCm support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+
+
+     AS_IF([ test -n "$with_rocm" && test "$with_rocm" = "yes" ],
+           [ with_rocm="/opt/rocm"] )
+
+     rocm_CPPFLAGS="-D__HIP_PLATFORM_AMD__"
+     rocm_LDFLAGS="-L${with_rocm}/lib/hip"
+
+     AS_IF([ test -n "$with_rocm" && test "$with_rocm" != "no" ],
+           [ OPAL_APPEND([CPPFLAGS], [$rocm_CPPFLAGS])
+	     OPAL_APPEND([LDFLAGS], [$rocm_LDFLAGS]) ])
+
+     OAC_CHECK_PACKAGE([rocm],
+                       [$1],
+                       [hip/hip_runtime.h],
+                       [amdhip64],
+		       [hipFree],
+                       [opal_check_rocm_happy="yes"],
+                       [opal_check_rocm_happy="no"])
+
+     LDFLAGS="$rocm_save_LDFLAGS"
+     OPAL_APPEND([CPPFLAGS], [${$1_CPPFLAGS}] )
+     
+     AS_IF([ test "$opal_check_rocm_happy" = "no" ],
+           [ CPPFLAGS="$rocm_save_CPPFLAGS"])
+
+     AS_IF([ test "$opal_check_rocm_happy" = "yes" ],
+           [ AC_DEFINE_UNQUOTED([OPAL_ROCM_SUPPORT], [1], [Enable ROCm support])
+             ROCM_SUPPORT=1 ],
+           [ AC_DEFINE_UNQUOTED([OPAL_ROCM_SUPPORT], [0], [Disable ROCm support])
+             ROCM_SUPPORT=0 ])
+
+     AS_IF([ test "$opal_check_rocm_happy" = "yes" ],
+            [$2],
+            [AS_IF([test -n "$with_rocm" && test "$with_rocm" != "no"],
+                   [AC_MSG_ERROR([ROCm support requested but not found.  Aborting])])
+            $3])
+
+     AM_CONDITIONAL([OPAL_rocm_support], [test "$opal_check_rocm_happy" = "yes"])
+     OPAL_VAR_SCOPE_POP
+])
+
+AC_DEFUN([OPAL_CHECK_ROCM_AFTER_OPAL_DL],[
+    # We cannot have ROCm support without OPAL DL support.  Error out
+    # if the user wants Rocm but we do not have OPAL DL support.
+     AS_IF([test $OPAL_HAVE_DL_SUPPORT -eq 0 && test "$opal_check_rocm_happy" = "yes"],
+          [AC_MSG_WARN([--with-rocm was specified, but dlopen support is disabled.])
+           AC_MSG_WARN([You must reconfigure Open MPI with dlopen ("dl") support.])
+           AC_MSG_ERROR([Cannot continue.])])
+
+])

--- a/config/opal_config_files.m4
+++ b/config/opal_config_files.m4
@@ -18,6 +18,7 @@ AC_DEFUN([OPAL_CONFIG_FILES],[
     AC_CONFIG_FILES([
         opal/Makefile
         opal/cuda/Makefile
+        opal/rocm/Makefile
         opal/etc/Makefile
         opal/include/Makefile
         opal/datatype/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1003,7 +1003,23 @@ AC_CACHE_SAVE
 opal_show_title "System-specific tests"
 
 OPAL_CHECK_CUDA
+##################################
+# ROCm support
+##################################
+OPAL_CHECK_ROCM([opal_rocm],
+	        [opal_rocm_happy="yes"],
+	        [opal_rocm_happy="no"])
+OPAL_SUMMARY_ADD([Miscellaneous], [ROCm suport], [], [$opal_rocm_happy])
+
+AS_IF([test "$OPAL_CUDA_SUPPORT" = "1" && test "$OPAL_ROCM_SUPPORT" = "1"],
+          [AC_MSG_WARN([Cannot support both CUDA and ROCm.])
+           AC_MSG_WARN([You must reconfigure Open MPI choosing either CUDA or ROCm .])
+           AC_MSG_ERROR([Cannot continue.])])
+
+##################################
 OPAL_CHECK_OS_FLAVORS
+
+
 
 # Do we have _SC_NPROCESSORS_ONLN? (only going to pass if we also have
 # <unistd.h> and sysconf(), which is ok) OS X 10.4 has <unistd.h> and
@@ -1246,6 +1262,8 @@ AC_CACHE_SAVE
 # all other MCA checks" hook...?
 
 OPAL_CHECK_CUDA_AFTER_OPAL_DL
+
+OPAL_CHECK_ROCM_AFTER_OPAL_DL
 
 ##################################
 # MPI Extended Interfaces

--- a/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
@@ -1,0 +1,72 @@
+.. _mpix_query_rocm_support:
+
+
+MPIX_Query_rocm_support
+=======================
+
+.. include_body
+
+**MPIX_Query_rocm_support** - Returns 1 if there is AMD ROCm aware support
+and 0 if there is not.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Query_rocm_support(void)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+There is no Fortran binding for this function.
+
+
+C++ Syntax
+^^^^^^^^^^
+
+There is no C++ binding for this function.
+
+
+DESCRIPTION
+-----------
+
+This routine return 1 if MPI library is build with ROCm and runtime
+supports ROCm buffers. This routine must be called after MPI is
+initialized by a call to :ref:`MPI_Init` or :ref:`MPI_Init_thread`.
+
+
+Examples
+^^^^^^^^
+
+::
+
+
+   #include <stdio.h>
+   #include "mpi.h"
+
+   #include "mpi-ext.h" /* Needed for ROCm-aware check */
+
+   int main(int argc, char *argv[])
+   {
+
+       MPI_Init(&argc, &argv);
+
+       if (MPIX_Query_rocm_support()) {
+           printf("This MPI library has ROCm-aware support.);
+       } else {
+           printf("This MPI library does not have ROCm-aware support.);
+       }
+       MPI_Finalize();
+
+       return 0;
+   }

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -466,4 +466,5 @@ MPI API manual pages (section 3)
    MPI_Wtick.3.rst
    MPI_Wtime.3.rst
    MPIX_Query_cuda_support.3.rst
+   MPIX_Query_rocm_support.3.rst
    OMPI_Affinity_str.3.rst

--- a/ompi/mpiext/rocm/Makefile.am
+++ b/ompi/mpiext/rocm/Makefile.am
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved
+# Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This Makefile is not traversed during a normal "make all" in an OMPI
+# build.  It *is* traversed during "make dist", however.  So you can
+# put EXTRA_DIST targets in here.
+#
+# You can also use this as a convenience for building this MPI
+# extension (i.e., "make all" in this directory to invoke "make all"
+# in all the subdirectories).
+
+SUBDIRS = c

--- a/ompi/mpiext/rocm/c/Makefile.am
+++ b/ompi/mpiext/rocm/c/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+# Copyright (c) 2018      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This file builds the C bindings for MPI extensions.  It must be
+# present in all MPI extensions.
+
+# We must set these #defines so that the inner OMPI MPI prototype
+# header files do the Right Thing.
+AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
+
+# Convenience libtool library that will be slurped up into libmpi.la.
+noinst_LTLIBRARIES = libmpiext_rocm_c.la
+
+# This is where the top-level header file (that is included in
+# <mpi-ext.h>) must be installed.
+ompidir = $(ompiincludedir)/mpiext
+
+# This is the header file that is installed.
+nodist_ompi_HEADERS = mpiext_rocm_c.h
+
+# Sources for the convenience libtool library.  Other than the one
+# header file, all source files in the extension have no file naming
+# conventions.
+libmpiext_rocm_c_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_rocm.c
+libmpiext_rocm_c_la_LDFLAGS = -module -avoid-version
+

--- a/ompi/mpiext/rocm/c/mpiext_rocm.c
+++ b/ompi/mpiext/rocm/c/mpiext_rocm.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "ompi_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "opal/constants.h"
+#include "opal/runtime/opal_params.h"
+#include "ompi/mpiext/rocm/c/mpiext_rocm_c.h"
+
+#if OPAL_ROCM_SUPPORT
+#include "opal/rocm/common_rocm_prototypes.h"
+#endif
+
+int MPIX_Query_rocm_support(void)
+{
+
+    if (!opal_built_with_rocm_support) {
+        return 0;
+    } else {
+        if ( opal_rocm_runtime_initialized ) {
+            return 1;
+        }
+#if OPAL_ROCM_SUPPORT
+        // There is a chance that the rocm runtime has simply not
+        // been initialized yet, since that is done during the first convertor creation
+        // Invoke a function that will trigger the rocm runtime initialized and
+        // check the value again after that.
+
+        int val1, val2;
+        mca_common_rocm_check_bufs((char *)&val1, (char *)&val2);
+#endif
+    }
+
+    return opal_rocm_runtime_initialized;
+}

--- a/ompi/mpiext/rocm/c/mpiext_rocm_c.h.in
+++ b/ompi/mpiext/rocm/c/mpiext_rocm_c.h.in
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define MPIX_ROCM_AWARE_SUPPORT @MPIX_ROCM_AWARE_SUPPORT@
+OMPI_DECLSPEC int MPIX_Query_rocm_support(void);

--- a/ompi/mpiext/rocm/configure.m4
+++ b/ompi/mpiext/rocm/configure.m4
@@ -1,0 +1,35 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2010 The Trustees of Indiana University.
+#                         All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc.  All rights reserved.
+# Copyright (c) 2022      Advanced Micro Devices, Inc.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_MPIEXT_rocm_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([OMPI_MPIEXT_rocm_CONFIG],[
+    AC_CONFIG_FILES([ompi/mpiext/rocm/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/rocm/c/Makefile])
+    AC_CONFIG_HEADERS([ompi/mpiext/rocm/c/mpiext_rocm_c.h])
+
+    AC_DEFINE_UNQUOTED([MPIX_ROCM_AWARE_SUPPORT], [$ROCM_SUPPORT],
+                       [Macro that is set to 1 when ROCM-aware support is configured in and 0 when it is not])
+
+    
+    # We compile this whether ROCm support was requested or not. It allows
+    # us to to detect if we have ROCm support.
+    AS_IF([test "$ENABLE_rocm" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [$1],
+          [$2])
+    
+])

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,9 +23,15 @@
 #
 
 if OPAL_cuda_support
-LIBOPAL_CUDA_SUBDIR = cuda
-LIBOPAL_CUDA_LA = cuda/libopalcuda.la
+LIBOPAL_GPU_SUBDIR = cuda
+LIBOPAL_GPU_LA = cuda/libopalcuda.la
+else
+if OPAL_rocm_support
+LIBOPAL_GPU_SUBDIR = rocm
+LIBOPAL_GPU_LA = rocm/libopalrocm.la
 endif
+endif
+
 
 SUBDIRS = \
 	include \
@@ -32,7 +39,7 @@ SUBDIRS = \
         etc \
         util \
 	mca/base \
-	$(LIBOPAL_CUDA_SUBDIR) \
+	$(LIBOPAL_GPU_SUBDIR) \
 	$(MCA_opal_FRAMEWORKS_SUBDIRS) \
 	$(MCA_opal_FRAMEWORK_COMPONENT_STATIC_SUBDIRS) \
         . \
@@ -40,6 +47,7 @@ SUBDIRS = \
 DIST_SUBDIRS = \
 	include \
 	cuda \
+	rocm \
         datatype \
         etc \
 	util \
@@ -54,14 +62,14 @@ lib@OPAL_LIB_NAME@_la_LIBADD = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
-	$(LIBOPAL_CUDA_LA) \
+	$(LIBOPAL_GPU_LA) \
 	$(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_NAME@_la_DEPENDENCIES = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
-        $(MCA_opal_FRAMEWORK_LIBS) \
-        $(LIBOPAL_CUDA_LA)
+        $(LIBOPAL_GPU_LA)  \
+        $(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_NAME@_la_LDFLAGS = -version-info @libopen_pal_so_version@
 
 # included subdirectory Makefile.am's and appended-to variables

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -16,6 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,9 +42,16 @@
 #include "opal/datatype/opal_datatype_prototypes.h"
 #if OPAL_CUDA_SUPPORT
 #    include "opal/cuda/common_cuda.h"
-#    define MEMCPY_CUDA(DST, SRC, BLENGTH, CONVERTOR) \
+#    define MEMCPY_GPU(DST, SRC, BLENGTH, CONVERTOR) \
         CONVERTOR->cbmemcpy((DST), (SRC), (BLENGTH), (CONVERTOR))
 #endif
+#if OPAL_ROCM_SUPPORT
+#    include "opal/rocm/common_rocm_prototypes.h"
+#    define MEMCPY_GPU(DST, SRC, BLENGTH, CONVERTOR) \
+        CONVERTOR->cbmemcpy((DST), (SRC), (BLENGTH), (CONVERTOR))
+#endif
+
+
 
 static void opal_convertor_construct(opal_convertor_t *convertor)
 {
@@ -54,6 +62,9 @@ static void opal_convertor_construct(opal_convertor_t *convertor)
     convertor->flags = OPAL_DATATYPE_FLAG_NO_GAPS | CONVERTOR_COMPLETED;
 #if OPAL_CUDA_SUPPORT
     convertor->cbmemcpy = &opal_cuda_memcpy;
+#endif
+#if OPAL_ROCM_SUPPORT
+    convertor->cbmemcpy = &mca_common_rocm_memcpy;
 #endif
 }
 
@@ -252,8 +263,8 @@ int32_t opal_convertor_pack(opal_convertor_t *pConv, struct iovec *iov, uint32_t
             if (OPAL_LIKELY(NULL == iov[i].iov_base)) {
                 iov[i].iov_base = (IOVBASE_TYPE *) base_pointer;
             } else {
-#if OPAL_CUDA_SUPPORT
-                MEMCPY_CUDA(iov[i].iov_base, base_pointer, iov[i].iov_len, pConv);
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+                MEMCPY_GPU(iov[i].iov_base, base_pointer, iov[i].iov_len, pConv);
 #else
                 MEMCPY(iov[i].iov_base, base_pointer, iov[i].iov_len);
 #endif
@@ -270,8 +281,8 @@ int32_t opal_convertor_pack(opal_convertor_t *pConv, struct iovec *iov, uint32_t
         if (OPAL_LIKELY(NULL == iov[i].iov_base)) {
             iov[i].iov_base = (IOVBASE_TYPE *) base_pointer;
         } else {
-#if OPAL_CUDA_SUPPORT
-            MEMCPY_CUDA(iov[i].iov_base, base_pointer, iov[i].iov_len, pConv);
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+            MEMCPY_GPU(iov[i].iov_base, base_pointer, iov[i].iov_len, pConv);
 #else
             MEMCPY(iov[i].iov_base, base_pointer, iov[i].iov_len);
 #endif
@@ -307,8 +318,8 @@ int32_t opal_convertor_unpack(opal_convertor_t *pConv, struct iovec *iov, uint32
             if (iov[i].iov_len >= pending_length) {
                 goto complete_contiguous_data_unpack;
             }
-#if OPAL_CUDA_SUPPORT
-            MEMCPY_CUDA(base_pointer, iov[i].iov_base, iov[i].iov_len, pConv);
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+            MEMCPY_GPU(base_pointer, iov[i].iov_base, iov[i].iov_len, pConv);
 #else
             MEMCPY(base_pointer, iov[i].iov_base, iov[i].iov_len);
 #endif
@@ -321,8 +332,8 @@ int32_t opal_convertor_unpack(opal_convertor_t *pConv, struct iovec *iov, uint32
 
     complete_contiguous_data_unpack:
         iov[i].iov_len = pending_length;
-#if OPAL_CUDA_SUPPORT
-        MEMCPY_CUDA(base_pointer, iov[i].iov_base, iov[i].iov_len, pConv);
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+        MEMCPY_GPU(base_pointer, iov[i].iov_base, iov[i].iov_len, pConv);
 #else
         MEMCPY(base_pointer, iov[i].iov_base, iov[i].iov_len);
 #endif
@@ -560,6 +571,10 @@ int32_t opal_convertor_prepare_for_recv(opal_convertor_t *convertor,
     if (!(convertor->flags & CONVERTOR_SKIP_CUDA_INIT)) {
         mca_cuda_convertor_init(convertor, pUserBuf);
     }
+#elif OPAL_ROCM_SUPPORT
+    if (!(convertor->flags & CONVERTOR_SKIP_GPU_INIT)) {
+        mca_common_rocm_convertor_init(convertor, pUserBuf);
+    }
 #endif
 
     assert(!(convertor->flags & CONVERTOR_SEND));
@@ -601,6 +616,10 @@ int32_t opal_convertor_prepare_for_send(opal_convertor_t *convertor,
 #if OPAL_CUDA_SUPPORT
     if (!(convertor->flags & CONVERTOR_SKIP_CUDA_INIT)) {
         mca_cuda_convertor_init(convertor, pUserBuf);
+    }
+#elif OPAL_ROCM_SUPPORT
+    if (!(convertor->flags & CONVERTOR_SKIP_GPU_INIT)) {
+        mca_common_rocm_convertor_init(convertor, pUserBuf);
     }
 #endif
 
@@ -686,7 +705,7 @@ int opal_convertor_clone(const opal_convertor_t *source, opal_convertor_t *desti
         destination->bConverted = source->bConverted;
         destination->stack_pos = source->stack_pos;
     }
-#if OPAL_CUDA_SUPPORT
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
     destination->cbmemcpy = source->cbmemcpy;
 #endif
     return OPAL_SUCCESS;

--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,14 +93,40 @@ static size_t opal_datatype_memop_block_size = 128 * 1024;
 #    define MEM_OP opal_cuda_memmove
 #    include "opal_datatype_copy.h"
 
-#    define SET_CUDA_COPY_FCT(cuda_device_bufs, fct, copy_function) \
+#    define non_overlap_gpu_copy_function non_overlap_cuda_copy_content_same_ddt
+#    define overlap_gpu_copy_function     overlap_cuda_copy_content_same_ddt
+#    define gpu_check_bufs                opal_cuda_check_bufs
+#elif OPAL_ROCM_SUPPORT
+#    include "opal/rocm/common_rocm_prototypes.h"
+
+#    undef MEM_OP_BLOCK_SIZE
+#    define MEM_OP_BLOCK_SIZE total_length
+#    undef MEM_OP_NAME
+#    define MEM_OP_NAME non_overlap_rocm
+#    undef MEM_OP
+#    define MEM_OP mca_common_rocm_memcpy_sync
+#    include "opal_datatype_copy.h"
+
+#    undef MEM_OP_NAME
+#    define MEM_OP_NAME overlap_rocm
+#    undef MEM_OP
+#    define MEM_OP mca_common_rocm_memmove
+#    include "opal_datatype_copy.h"
+
+#    define non_overlap_gpu_copy_function non_overlap_rocm_copy_content_same_ddt
+#    define overlap_gpu_copy_function     overlap_rocm_copy_content_same_ddt
+#    define gpu_check_bufs                mca_common_rocm_check_bufs
+#endif
+
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+#    define SET_GPU_COPY_FCT(device_bufs, fct, copy_function)       \
         do {                                                        \
-            if (true == cuda_device_bufs) {                         \
+            if (true == device_bufs) {                              \
                 fct = copy_function;                                \
             }                                                       \
         } while (0)
 #else
-#    define SET_CUDA_COPY_FCT(cuda_device_bufs, fct, copy_function)
+#    define SET_GPU_COPY_FCT(device_bufs, fct, copy_function)
 #endif
 
 int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, int32_t count,
@@ -108,8 +135,8 @@ int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, int
     ptrdiff_t extent;
     int32_t (*fct)(const opal_datatype_t *, int32_t, char *, char *);
 
-#if OPAL_CUDA_SUPPORT
-    bool cuda_device_bufs = opal_cuda_check_bufs(destination_base, source_base);
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
+    bool device_bufs = gpu_check_bufs(destination_base, source_base);
 #endif
 
     DO_DEBUG(opal_output(0, "opal_datatype_copy_content_same_ddt( %p, %d, dst %p, src %p )\n",
@@ -131,18 +158,18 @@ int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, int
     extent = (datatype->true_ub - datatype->true_lb) + (count - 1) * (datatype->ub - datatype->lb);
 
     fct = non_overlap_copy_content_same_ddt;
-    SET_CUDA_COPY_FCT(cuda_device_bufs, fct, non_overlap_cuda_copy_content_same_ddt);
+    SET_GPU_COPY_FCT(device_bufs, fct, non_overlap_gpu_copy_function);
     if (destination_base < source_base) {
         if ((destination_base + extent) > source_base) {
             /* memmove */
             fct = overlap_copy_content_same_ddt;
-            SET_CUDA_COPY_FCT(cuda_device_bufs, fct, overlap_cuda_copy_content_same_ddt);
+            SET_GPU_COPY_FCT(device_bufs, fct, overlap_gpu_copy_function);
         }
     } else {
         if ((source_base + extent) > destination_base) {
             /* memmove */
             fct = overlap_copy_content_same_ddt;
-            SET_CUDA_COPY_FCT(cuda_device_bufs, fct, overlap_cuda_copy_content_same_ddt);
+            SET_GPU_COPY_FCT(device_bufs, fct, overlap_gpu_copy_function);
         }
     }
     return fct(datatype, count, destination_base, source_base);

--- a/opal/datatype/opal_datatype_pack.h
+++ b/opal/datatype/opal_datatype_pack.h
@@ -9,6 +9,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +23,7 @@
 #include "opal_config.h"
 #include "opal/datatype/opal_datatype_pack_unpack_predefined.h"
 
-#if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
+#if !defined(CHECKSUM) && (OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT)
 /* Make use of existing macro to do CUDA style memcpy */
 #    undef MEMCPY_CSUM
 #    define MEMCPY_CSUM(DST, SRC, BLENGTH, CONVERTOR) \
@@ -105,7 +106,8 @@ static inline void pack_predefined_data(opal_convertor_t *CONVERTOR, const dt_el
     *(COUNT) -= cando_count;
 
     if (_elem->blocklen < 9) {
-        if ((!(CONVERTOR->flags & CONVERTOR_CUDA))
+        if ( !(CONVERTOR->flags & CONVERTOR_CUDA) &&
+             !(CONVERTOR->flags & CONVERTOR_ROCM)
             && OPAL_LIKELY(
                 OPAL_SUCCESS
                 == opal_datatype_pack_predefined_element(&_memory, &_packed, cando_count, _elem))) {

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -217,7 +217,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
     MEMCPY( temporary + start_position, partial_data, length );
 
     /* Save the original content of the user memory */
-#if OPAL_CUDA_SUPPORT
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
     /* In the case where the data is being unpacked from device memory, need to
      * use the special host to device memory copy. */
     pConvertor->cbmemcpy(saved_data, user_data, data_length, pConvertor );
@@ -235,7 +235,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
 
     /* Rebuild the data by pulling back the unmodified bytes from the original
      * content in the user memory. */
-#if OPAL_CUDA_SUPPORT
+#if OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT
     /* Need to copy the modified user_data again so we can see which
      * bytes need to be converted back to their original values. */
     {

--- a/opal/datatype/opal_datatype_unpack.h
+++ b/opal/datatype/opal_datatype_unpack.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation. All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
 #include "opal_config.h"
 #include "opal/datatype/opal_datatype_pack_unpack_predefined.h"
 
-#if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
+#if !defined(CHECKSUM) && (OPAL_CUDA_SUPPORT || OPAL_ROCM_SUPPORT)
 /* Make use of existing macro to do CUDA style memcpy */
 #    undef MEMCPY_CSUM
 #    define MEMCPY_CSUM(DST, SRC, BLENGTH, CONVERTOR) \
@@ -102,7 +103,8 @@ static inline void unpack_predefined_data(opal_convertor_t *CONVERTOR, const dt_
     *(COUNT) -= cando_count;
 
     if (_elem->blocklen < 9) {
-        if ((!(CONVERTOR->flags & CONVERTOR_CUDA))
+        if ( !(CONVERTOR->flags & CONVERTOR_CUDA) &&
+             !(CONVERTOR->flags & CONVERTOR_ROCM)
             && OPAL_LIKELY(OPAL_SUCCESS
                            == opal_datatype_unpack_predefined_element(&_packed, &_memory,
                                                                       cando_count, _elem))) {

--- a/opal/rocm/Makefile.am
+++ b/opal/rocm/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2013 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(common_rocm_CPPFLAGS)
+
+# Header files
+headers = \
+        common_rocm.h \
+	common_rocm_prototypes.h
+
+# Source files
+sources = \
+        common_rocm.c
+
+
+noinst_LTLIBRARIES = libopalrocm.la
+
+libopalrocm_la_SOURCES  = $(headers) $(sources)
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+opaldir = $(opalincludedir)/$(subdir)
+opal_HEADERS = $(headers)
+endif

--- a/opal/rocm/common_rocm.c
+++ b/opal/rocm/common_rocm.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include <stdio.h>
+#include <dlfcn.h>
+#include "common_rocm.h"
+#include "opal/mca/dl/base/base.h"
+#include "opal/runtime/opal_params.h"
+
+static struct opal_dl_handle_t* hip_handle = NULL;
+static hipFunctionTable_t hip_funcs;
+
+int mca_common_rocm_memcpy_async = 1;
+int mca_common_rocm_verbose = 0;
+size_t mca_common_rocm_memcpy_limit=1024;
+
+static hipStream_t common_rocm_MemcpyStream;
+static opal_mutex_t common_rocm_init_lock = OPAL_MUTEX_STATIC_INIT;
+
+#define HIP_CHECK(condition)                                                 \
+{                                                                            \
+    hipError_t error = condition;                                            \
+    if (hipSuccess != error){                                                \
+        const char* msg = hip_funcs.hipGetErrorString(error);                \
+        opal_output(0, "HIP error: %d %s file: %s line: %d\n", error, msg, __FILE__, __LINE__); \
+        return error;                                                        \
+    }                                                                        \
+}
+
+#define HIP_CHECK_RETNULL(condition)                                         \
+{                                                                            \
+    hipError_t error = condition;                                            \
+    if (hipSuccess != error){                                                \
+        const char* msg = hip_funcs.hipGetErrorString(error);                \
+        opal_output(0, "HIP error: %d %s file: %s line: %d\n", error, msg, __FILE__, __LINE__); \
+        return NULL;                                                         \
+    }                                                                        \
+}
+
+static int hip_dl_init(void)
+{
+    char *str;
+    void *ptr;
+    int ret  = opal_dl_open("libamdhip64.so", false, false, &hip_handle, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(0, "Unable to open libamdhip64.so\n");
+        return OPAL_ERROR;
+    }
+
+    ret = opal_dl_lookup(hip_handle, "hipMalloc", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+        opal_output(0, "Failed to find hipMalloc\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipMalloc = (hipMalloc_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipFree", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipFree\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipFree = (hipFree_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipMemcpy", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipMemcpy\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipMemcpy = (hipMemcpy_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipMemcpyAsync", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipMemcpyAsync\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipMemcpyAsync = (hipMemcpyAsync_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipStreamCreate", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipStreamCreate\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipStreamCreate = (hipStreamCreate_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipStreamDestroy", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipStreamDestroy\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipStreamDestroy = (hipStreamDestroy_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipStreamSynchronize", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipStreamSynchronize\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipStreamSynchronize = (hipStreamSynchronize_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipGetErrorString", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipGetErrorString\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipGetErrorString = (hipGetErrorString_t)ptr;
+
+    ret = opal_dl_lookup(hip_handle, "hipPointerGetAttributes", &ptr, &str);
+    if (OPAL_SUCCESS != ret) {
+      opal_output_verbose(10, 0, "Failed to find hipPointerGetAttributes\n");
+        dlclose(hip_handle);
+        return OPAL_ERROR;
+    }
+    hip_funcs.hipPointerGetAttributes = (hipPointerGetAttributes_t)ptr;
+
+    return OPAL_SUCCESS;
+}
+
+static void hip_dl_finalize(void)
+{
+    hipError_t err = hip_funcs.hipStreamDestroy(common_rocm_MemcpyStream);
+    if (hipSuccess != err) {
+      opal_output_verbose(10, 0, "hip_dl_finalize: error while destroying the hipStream\n");
+    }
+    dlclose(hip_handle);
+}
+
+
+static void mca_common_rocm_support_init(void)
+{
+    if (opal_rocm_runtime_initialized) {
+        return;
+    }
+
+    OPAL_THREAD_LOCK(&common_rocm_init_lock);
+
+    if (opal_rocm_runtime_initialized) {
+        return;
+    }
+
+    if (OPAL_SUCCESS != hip_dl_init()) {
+        opal_output(0, "Could not open libamdhip64.so. Please check your LD_LIBRARY_PATH\n");
+        OPAL_THREAD_UNLOCK(&common_rocm_init_lock);
+        return;
+    }
+
+    hipError_t err = hip_funcs.hipStreamCreate(&common_rocm_MemcpyStream);
+    if (hipSuccess != err) {
+        opal_output(0, "Could not create hipStream, err=%d %s\n",
+                err, hip_funcs.hipGetErrorString(err));
+    }
+
+    opal_atomic_mb();
+    opal_rocm_runtime_initialized = true;
+    OPAL_THREAD_UNLOCK(&common_rocm_init_lock);
+}
+
+void mca_common_rocm_convertor_init(opal_convertor_t *convertor, const void *pUserBuf)
+{
+    /* Only do the initialization on the first GPU access */
+    if (!opal_rocm_runtime_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    convertor->cbmemcpy = (memcpy_fct_t) &mca_common_rocm_memcpy;
+    // set convertor->stream as well ? Does not seem to be used at the moment in the datatype engine.
+
+    hipPointerAttribute_t attr;
+    hipError_t err =  hip_funcs.hipPointerGetAttributes(&attr, pUserBuf);
+    if (hipSuccess != err) {
+        return;
+    }
+    if (hipMemoryTypeDevice == attr.memoryType || hipMemoryTypeUnified == attr.memoryType) {
+        convertor->flags |= CONVERTOR_ROCM;
+    }
+}
+
+bool mca_common_rocm_check_bufs(char *dst, char *src)
+{
+    /* Only do the initialization on the first GPU access */
+    if (!opal_rocm_runtime_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    hipPointerAttribute_t srcAttr, dstAttr;
+    bool srcFlag=false, dstFlag=false;
+    hipError_t err = hip_funcs.hipPointerGetAttributes(&srcAttr, src);
+    if (hipSuccess == err) {
+        if (hipMemoryTypeDevice == srcAttr.memoryType || hipMemoryTypeUnified == srcAttr.memoryType) {
+            srcFlag = true;
+        }
+    }
+    err = hip_funcs.hipPointerGetAttributes(&dstAttr, dst);
+    if (hipSuccess == err) {
+        if (hipMemoryTypeDevice == dstAttr.memoryType || hipMemoryTypeUnified == dstAttr.memoryType ) {
+            dstFlag = true;
+        }
+    }
+    if (srcFlag || dstFlag) {
+        return true;
+    }
+    
+    return false;
+}
+
+int mca_common_rocm_memcpy_sync(void *dst, void *src, size_t nBytes)
+{
+
+    if (!opal_rocm_runtime_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    if (nBytes < mca_common_rocm_memcpy_limit) {
+        memcpy(dst, src, nBytes);
+        return OPAL_SUCCESS;
+    }
+
+    if (mca_common_rocm_memcpy_async) {
+        HIP_CHECK(hip_funcs.hipMemcpyAsync(dst, src, nBytes, hipMemcpyDefault,
+                                            common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipStreamSynchronize(common_rocm_MemcpyStream));
+    }
+    else {
+        HIP_CHECK(hip_funcs.hipMemcpy(dst, src, nBytes, hipMemcpyDefault));
+    }
+
+    return OPAL_SUCCESS;
+}
+
+void *mca_common_rocm_memcpy(void *dst, const void *src, size_t nBytes, opal_convertor_t *pConvertor)
+{
+
+    if (!(pConvertor->flags & CONVERTOR_ROCM) || nBytes < mca_common_rocm_memcpy_limit) {
+        //For short messages a regular memcpy is faster than hipMemcpy or hipMemcpyAsync
+        return memcpy(dst, src, nBytes);
+    }
+
+    if (mca_common_rocm_memcpy_async) {
+        HIP_CHECK_RETNULL(hip_funcs.hipMemcpyAsync(dst, src, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK_RETNULL(hip_funcs.hipStreamSynchronize(common_rocm_MemcpyStream));
+    }
+    else {
+        HIP_CHECK_RETNULL(hip_funcs.hipMemcpy(dst, src, nBytes, hipMemcpyDefault));
+    }
+
+  return dst;
+}
+
+int mca_common_rocm_memmove(void *dst, void *src, size_t nBytes)
+{
+    if (!opal_rocm_runtime_initialized) {
+        mca_common_rocm_support_init();
+    }
+
+    char *tmp=NULL;
+    HIP_CHECK(hip_funcs.hipMalloc((void **)&tmp, nBytes));
+    if (mca_common_rocm_memcpy_async) {
+        HIP_CHECK(hip_funcs.hipMemcpyAsync(tmp, src, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipMemcpyAsync(dst, tmp, nBytes, hipMemcpyDefault, common_rocm_MemcpyStream));
+        HIP_CHECK(hip_funcs.hipStreamSynchronize(common_rocm_MemcpyStream));
+    } else {
+        HIP_CHECK(hip_funcs.hipMemcpy(tmp, src, nBytes, hipMemcpyDefault));
+        HIP_CHECK(hip_funcs.hipMemcpy(dst, tmp, nBytes, hipMemcpyDefault));
+    }
+
+    HIP_CHECK(hip_funcs.hipFree(tmp));
+    return OPAL_SUCCESS;
+}
+
+void mca_common_rocm_register_mca_variables(void)
+{
+
+    /* Set verbosity in the rocm related code. */
+    mca_common_rocm_verbose = 0;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "verbose",
+                                 "Set level of common rocm verbosity", MCA_BASE_VAR_TYPE_INT, NULL,
+                                 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                 &mca_common_rocm_verbose);
+
+    /* Switching point between using memcpy and hipMemcpy* functions. */
+    mca_common_rocm_memcpy_limit = 1024;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "memcpy_limit",
+                                 "Max. msg. length to use memcpy instead of hip copy functions",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                 &mca_common_rocm_memcpy_limit);
+
+    /* Use this flag to test async vs sync copies */
+    mca_common_rocm_memcpy_async = 1;
+    (void) mca_base_var_register("ompi", "mpi", "common_rocm", "memcpy_async",
+                                 "Set to 0 to force using hipMemcpy instead of hipMemcpyAsync",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &mca_common_rocm_memcpy_async);
+
+    return;
+}

--- a/opal/rocm/common_rocm.h
+++ b/opal/rocm/common_rocm.h
@@ -1,0 +1,47 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_MCA_COMMON_ROCM_H
+#define OPAL_MCA_COMMON_ROCM_H
+
+#include <stdio.h>
+#include <hip/hip_runtime_api.h>
+
+#include "opal_config.h"
+#include "common_rocm_prototypes.h"
+#include "opal/mca/btl/base/base.h"
+
+typedef hipError_t(*hipMalloc_t)(void **, size_t);
+typedef hipError_t(*hipFree_t)(void*);
+typedef hipError_t(*hipMemcpy_t)(void*, const void*, size_t, hipMemcpyKind);
+typedef hipError_t(*hipMemcpyAsync_t)(void*, const void*, size_t, hipMemcpyKind, hipStream_t);
+typedef hipError_t(*hipStreamCreate_t)(hipStream_t*);
+typedef hipError_t(*hipStreamDestroy_t)(hipStream_t);
+typedef hipError_t(*hipStreamSynchronize_t)(hipStream_t);
+typedef const char*(*hipGetErrorString_t)(hipError_t);
+typedef hipError_t(*hipPointerGetAttributes_t)(hipPointerAttribute_t *, const void *);
+
+
+struct hipFunctionTable_s {
+    hipError_t (*hipMalloc)(void** pts, size_t size);
+    hipError_t (*hipFree)(void* ptr);
+    hipError_t (*hipMemcpy)(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
+    hipError_t (*hipMemcpyAsync)(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind, hipStream_t stream);
+    hipError_t (*hipStreamCreate)(hipStream_t* stream);
+    hipError_t (*hipStreamDestroy)(hipStream_t stream);
+    hipError_t (*hipStreamSynchronize)(hipStream_t stream);
+    const char* (*hipGetErrorString)(hipError_t hipError);
+    hipError_t (*hipPointerGetAttributes)(hipPointerAttribute_t *attributes, const void *ptr);
+};
+typedef struct hipFunctionTable_s hipFunctionTable_t;
+
+
+#endif

--- a/opal/rocm/common_rocm_prototypes.h
+++ b/opal/rocm/common_rocm_prototypes.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_MCA_COMMON_ROCM_PROTOTYPES_H
+#define OPAL_MCA_COMMON_ROCM_PROTOTYPES_H
+
+#include "opal/datatype/opal_convertor.h"
+
+/* These five routines represent at the moment the functionality required to support a device/GPU
+ * in the Open MPI datatype engine. The interface are kept on purpose independent of the library
+ * supporting the GPU/device, since it avoids compile problems in cases where the library is not 
+ * available.
+ */
+
+/* Function invoked by the datatype engine to initialize support for the GPU device. */
+OPAL_DECLSPEC void mca_common_rocm_convertor_init(opal_convertor_t *convertor, const void *pUserBuf);
+
+/* Function verifying the buffer types provided as input argument. Returns true if either 
+ * one of the two functions is located in the GPU device memory, indicating the necessity 
+ * to utilize GPU specific data movement functions.
+ */
+OPAL_DECLSPEC bool mca_common_rocm_check_bufs(char *destination_base, char *source_base);
+
+/* Function performing a copy from the src to the dst buffer if either one (or both)
+ * are GPU buffers. Buffers must be non-overlapping.
+ */
+OPAL_DECLSPEC int mca_common_rocm_memcpy_sync(void *dst, void *src, size_t nBytes);
+
+
+/* Function performing a copy from the src to the dst buffer if either one (or both)
+ * are GPU buffers. Used when src and dst buffer are overlapping.
+ */
+OPAL_DECLSPEC int mca_common_rocm_memmove(void *dst, void *src, size_t nBytes);
+
+
+/* Function performing a copy from the src to the dst buffer if either one 
+ * are GPU buffers. Buffers must be non-overlapping. The additional convertor argument
+ * is at the moment only used to verify that the appropriate flags for device buffers
+ * has been set.
+ */
+OPAL_DECLSPEC void *mca_common_rocm_memcpy(void *dest, const void *src, size_t n, opal_convertor_t *pConvertor);
+
+/* Registration function for rocm_mca_parameters. */
+OPAL_DECLSPEC void mca_common_rocm_register_mca_variables(void);
+
+#endif

--- a/opal/rocm/owner.txt
+++ b/opal/rocm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: AMD
+status:active

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -79,6 +79,9 @@
 #include "opal/util/stacktrace.h"
 #include "opal/util/sys_limits.h"
 #include "opal/util/timings.h"
+#if OPAL_ROCM_SUPPORT
+#include "opal/rocm/common_rocm_prototypes.h"
+#endif
 
 const char opal_version_string[] = OPAL_IDENT_STRING;
 
@@ -554,6 +557,11 @@ int opal_init_util(int *pargc, char ***pargv)
         return opal_init_error("opal_register_params", ret);
     }
 
+#if OPAL_ROCM_SUPPORT
+    /* register params for opal/rocm. This is temporarily done here. */
+    mca_common_rocm_register_mca_variables();
+#endif
+    
     if (OPAL_SUCCESS != (ret = opal_net_init())) {
         return opal_init_error("opal_net_init", ret);
     }

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,6 +65,10 @@ bool opal_built_with_cuda_support = OPAL_INT_TO_BOOL(OPAL_CUDA_SUPPORT);
 bool opal_cuda_runtime_initialized = false;
 bool opal_cuda_support = false;
 bool opal_warn_on_missing_libcuda = true;
+
+bool opal_built_with_rocm_support = OPAL_INT_TO_BOOL(OPAL_ROCM_SUPPORT);
+bool opal_rocm_runtime_initialized = false;
+
 
 /**
  * Globals imported from the OMPI layer.

--- a/opal/runtime/opal_params.h
+++ b/opal/runtime/opal_params.h
@@ -19,6 +19,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +43,7 @@ extern bool opal_timing_overhead;
 
 OPAL_DECLSPEC extern int opal_initialized;
 OPAL_DECLSPEC extern bool opal_built_with_cuda_support;
+OPAL_DECLSPEC extern bool opal_built_with_rocm_support;
 
 /**
  *  * Whether we want to enable CUDA GPU buffer send and receive support.
@@ -52,6 +54,11 @@ OPAL_DECLSPEC extern bool opal_cuda_support;
  * Whether cuda runtime support is initialized or not.
  */
 OPAL_DECLSPEC extern bool opal_cuda_runtime_initialized;
+
+/**
+ * Whether rocm runtime support is initialized or not.
+ */
+OPAL_DECLSPEC extern bool opal_rocm_runtime_initialized;
 
 /**
  *  * Whether we want to warn the user when libcuda is missing.


### PR DESCRIPTION
This commit enhances the support for AMD ROCm devices in Open MPI. The core aspect of this commit is to enable using hipMemcpy* based operations for packing/unpacking derived datatypes.

At the moment, support for AMD GPUs is *only* available through ROCm enabled UCX. Note that applications using basic datatypes and contiguous buffers with ROCm enabled UCX already work even without this commit, and even applications using derived datatypes worked in most instances due to the fact that AMD GPUs require enabling PCIe large bar support. This commit will lead however to a performance improvement for applications using derived datatypes.

There are a couple of known issues that will be addressed in later commits, but might not be required if the device code is moved to an accelerator framework.

The most notable limitations:
 - rocm mca variables are not listed with ompi_info, since there is no component (at the moment) that is using rocm.
 - the 'compiled but not enabled' feature has received very limited testing.

Compiling a hip/MPI code will require a few additional flags. A typical compile line is:
```
mpiCC -D__HIP_PLATFORM_AMD__ -I/opt/rocm/include/hip -I/opt/rocm/include hipMPItest.cc -L/opt/rocm/lib -lamdhip64
``` 
Signed-off-by: Edgar <edgar.gabriel@amd.com>