### PR TITLE
smsc/xpmem: header detection fix

### DIFF
--- a/config/opal_check_xpmem.m4
+++ b/config/opal_check_xpmem.m4
@@ -59,7 +59,7 @@ AC_DEFUN([OPAL_CHECK_CRAY_XPMEM],[
           [$1_LDFLAGS="[$]$1_LDFLAGS $CRAY_XPMEM_LIBS"
            $1_CPPFLAGS="[$]$1_CPPFLAGS $CRAY_XPMEM_CFLAGS"
            $1_LIBS="[$]$1_LIBS $CRAY_XPMEM_LIBS"
-           AC_DEFINE_UNQUOTED([HAVE_XPMEM_H], [1],[is xpmem.h available])
+           AC_DEFINE_UNQUOTED([HAVE_XPMEM_H], [1], [is xpmem.h available])
            $2], [$3])
 ])
 
@@ -103,7 +103,8 @@ AC_DEFUN([OPAL_CHECK_BASE_XPMEM], [
                       [opal_check_xpmem_base_happy="no"])
 
      AS_IF([test "${opal_check_xpmem_base_happy}" = "yes"],
-           [$2],
+           [AC_DEFINE_UNQUOTED([HAVE_XPMEM_H], [1], [is xpmem.h available])
+            $2],
            [AS_IF([test -n "${with_xpmem}" -a "${with_xpmem}" != "no"],
                   [AC_MSG_ERROR([XPMEM support requested but not found.  Aborting])])
             $3])


### PR DESCRIPTION
Fixes the issue I've noticed where `xpmem.h` is present but not used:
```
make[2]: Entering directory '/home/alexm/workspace/ompi/opal/mca/smsc/xpmem'
  CC       smsc_xpmem_component.lo
In file included from smsc_xpmem_component.c:13:
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:32:5: error: unknown type name 'xpmem_segid_t'
    xpmem_segid_t seg_id;
    ^
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:42:5: error: unknown type name 'xpmem_apid_t'; did you mean 'xpmem_addr_t'?
    xpmem_apid_t apid;
    ^~~~~~~~~~~~
    xpmem_addr_t
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:28:27: note: 'xpmem_addr_t' declared here
typedef struct xpmem_addr xpmem_addr_t;
                          ^
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:42:18: error: field has incomplete type 'xpmem_addr_t' (aka 'struct xpmem_addr')
    xpmem_apid_t apid;
                 ^
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:28:16: note: forward declaration of 'struct xpmem_addr'
typedef struct xpmem_addr xpmem_addr_t;
               ^
../../../../opal/mca/smsc/xpmem/smsc_xpmem_internal.h:57:5: error: unknown type name 'xpmem_segid_t'
    xpmem_segid_t my_seg_id;
    ^
smsc_xpmem_component.c:120:19: warning: variable 'low' set but not used [-Wunused-but-set-variable]
        uintptr_t low, high;
                  ^
smsc_xpmem_component.c:143:42: error: implicit declaration of function 'xpmem_make' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    mca_smsc_xpmem_component.my_seg_id = xpmem_make(0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE,
                                         ^
smsc_xpmem_component.c:143:56: error: use of undeclared identifier 'XPMEM_MAXADDR_SIZE'
    mca_smsc_xpmem_component.my_seg_id = xpmem_make(0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE,
                                                       ^
smsc_xpmem_component.c:143:76: error: use of undeclared identifier 'XPMEM_PERMIT_MODE'
    mca_smsc_xpmem_component.my_seg_id = xpmem_make(0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE,
                                                                           ^
1 warning and 7 errors generated.
make[2]: *** [Makefile:1511: smsc_xpmem_component.lo] Error 1

```