### PR TITLE
v5.0.x: btl/usnic: Fix broken build

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -31,7 +31,7 @@ AC_DEFUN([OPAL_CHECK_OFI_VERSION_GE],[
     AC_CACHE_CHECK([if OFI API version number is >= version_pretty_print],
         [version_cache_var],
         [opal_ofi_ver_ge_save_CPPFLAGS=$CPPFLAGS
-         CPPFLAGS=$opal_ofi_CPPFLAGS
+         CPPFLAGS=$opal_ofi_internal_CPPFLAGS
 
          AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                 [[#include <rdma/fabric.h>
@@ -143,10 +143,8 @@ AC_DEFUN([OPAL_CHECK_OFI],[
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}
     LIBS=${opal_check_ofi_save_LIBS}
 
-    dnl for backwards compatibility reasons
-    opal_ofi_CPPFLAGS="${$1_CPPFLAGS}"
-    opal_ofi_LDFLAGS="${$1_LDFLAGS}"
-    opal_ofi_LIBS="${$1_LIBS}"
+    dnl for version compare tests
+    opal_ofi_internal_CPPFLAGS="${$1_CPPFLAGS}"
 
     OPAL_SUMMARY_ADD([Transports], [OpenFabrics OFI Libfabric], [], [${$1_SUMMARY}])
 

--- a/opal/mca/btl/usnic/Makefile.am
+++ b/opal/mca/btl/usnic/Makefile.am
@@ -18,6 +18,7 @@
 #                         reserved.
 # Copyright (c) 2019      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,7 +26,7 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = $(opal_ofi_CPPFLAGS) -DOMPI_LIBMPI_NAME=\"$(OMPI_LIBMPI_NAME)\"
+AM_CPPFLAGS = $(btl_usnic_CPPFLAGS) -DOMPI_LIBMPI_NAME=\"$(OMPI_LIBMPI_NAME)\"
 
 EXTRA_DIST = README.md README.test
 
@@ -90,18 +91,18 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_btl_usnic_la_SOURCES = $(component_sources)
 mca_btl_usnic_la_LDFLAGS = \
         $(opal_btl_usnic_LDFLAGS) \
-        $(opal_ofi_LDFLAGS) \
+        $(btl_usnic_LDFLAGS) \
         -module -avoid-version
 mca_btl_usnic_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(opal_ofi_LIBS)
+        $(btl_usnic_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_btl_usnic_la_SOURCES = $(lib_sources)
 libmca_btl_usnic_la_LDFLAGS = \
         $(opal_btl_usnic_LDFLAGS) \
-        $(opal_ofi_LDFLAGS) \
+        $(btl_usnic_LDFLAGS) \
         -module -avoid-version
-libmca_btl_usnic_la_LIBADD = $(opal_ofi_LIBS)
+libmca_btl_usnic_la_LIBADD = $(btl_usnic_LIBS)
 
 if OPAL_BTL_USNIC_BUILD_UNIT_TESTS
 usnic_btl_run_tests_CPPFLAGS = $(AM_CPPFLAGS) \

--- a/opal/mca/btl/usnic/configure.m4
+++ b/opal/mca/btl/usnic/configure.m4
@@ -110,12 +110,16 @@ AC_DEFUN([_OPAL_BTL_USNIC_DO_CONFIG],[
     # Make sure we can find the OFI libfabric usnic extensions header
     AS_IF([test "$opal_btl_usnic_happy" = "yes" ],
           [opal_btl_usnic_CPPFLAGS_save=$CPPFLAGS
-           CPPFLAGS="$opal_ofi_CPPFLAGS $CPPFLAGS"
+           CPPFLAGS="$btl_usnic_CPPFLAGS $CPPFLAGS"
            AC_CHECK_HEADER([rdma/fi_ext_usnic.h],
                             [],
                             [opal_btl_usnic_happy=no])
            CPPFLAGS=$opal_btl_usnic_CPPFLAGS_save
           ])
+
+    AC_SUBST([btl_usnic_CPPFLAGS])
+    AC_SUBST([btl_usnic_LDFLAGS])
+    AC_SUBST([btl_usnic_LIBS])
 
     # All done
     AS_IF([test "$opal_btl_usnic_happy" = "yes"],


### PR DESCRIPTION
b542a9c broke building usnic (at least when Libfabric isn't in default
search paths), because I removed the AC_SUBST of the legacy opal_ofi_*
flags.  I should have just deleted them and fixed up the last remaining
user, the usnic btl, so do that here.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 7d8d130f5ef7b839824dbb24ef3dbbc1220022e8)

This is the v5.0.x cherry pick of #10260 