### PR TITLE
fortran bindings: use assumed rank syntax if supported

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -14,6 +14,9 @@ dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2022      Triad National Security, LLC. All rights
+dnl                         reserved.
+dnl
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -70,12 +73,18 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
     ompi_fortran_ignore_tkr_predecl=!
     ompi_fortran_ignore_tkr_type=real
 
+    # Vendor-neutral, TYPE(*),DIMENSION(..) assumed rank syntax
+    OMPI_FORTRAN_CHECK_F08_ASSUMED_RANK(
+        [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
+               [!], [type(*), dimension(..)],
+               [TYPE(*), DIMENSION(..)], 
+               [happy=1], [happy=0])])
     # Vendor-neutral, TYPE(*) syntax
-    OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
-         [!], [type(*)],
-         [TYPE(*), DIMENSION(*)],
-         [happy=1], [happy=0])
-
+    AS_IF([test $happy -eq 0],
+          [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
+               [!], [type(*)],
+               [TYPE(*), DIMENSION(*)],
+               [happy=1], [happy=0])])
     # GCC compilers
     AS_IF([test $happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
@@ -10,7 +10,7 @@
 ! Copyright (c) 2015-2020 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
-! Copyright (c) 2021      Triad National Security, LLC. All rights
+! Copyright (c) 2021-2022 Triad National Security, LLC. All rights
 !                         reserved.
 ! $COPYRIGHT$
 !
@@ -203,12 +203,8 @@ interface  MPI_Precv_init
 subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    implicit none
-   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
-   !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
-   !$PRAGMA IGNORE_TKR buf
-   !DIR$ IGNORE_TKR buf
-   !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions, count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -221,12 +217,8 @@ interface  MPI_Psend_init
 subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    implicit none
-   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
-   !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
-   !$PRAGMA IGNORE_TKR buf
-   !DIR$ IGNORE_TKR buf
-   !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
+   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: partitions, count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm


### PR DESCRIPTION
If the fortran compiler being used to build the fortran bindings
supports it, use assumed rank rather than assumed size argument types.

This brings Open MPI into compliance with the MPI standard wrt the fortran bindings.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>