### PR TITLE
Populate some additional MPI_INFO_ENV keys with singleton launch.

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -330,7 +330,7 @@ static void evhandler_dereg_callbk(pmix_status_t status,
 /**
  * @brief Function that starts up the common components needed by all instances
  */
-static int ompi_mpi_instance_init_common (void)
+static int ompi_mpi_instance_init_common (int argc, char **argv)
 {
     int ret;
     ompi_proc_t **procs;
@@ -384,7 +384,7 @@ static int ompi_mpi_instance_init_common (void)
     OMPI_TIMING_NEXT("initialization");
 
     /* Setup RTE */
-    if (OMPI_SUCCESS != (ret = ompi_rte_init (NULL, NULL))) {
+    if (OMPI_SUCCESS != (ret = ompi_rte_init (&argc, &argv))) {
         return ompi_instance_print_error ("ompi_mpi_init: ompi_rte_init failed", ret);
     }
 
@@ -784,7 +784,7 @@ static int ompi_mpi_instance_init_common (void)
     return OMPI_SUCCESS;
 }
 
-int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t *errhandler, ompi_instance_t **instance)
+int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t *errhandler, ompi_instance_t **instance, int argc, char **argv)
 {
     ompi_instance_t *new_instance;
     int ret;
@@ -799,7 +799,7 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
 
     opal_mutex_lock (&instance_lock);
     if (0 == opal_atomic_fetch_add_32 (&ompi_instance_count, 1)) {
-        ret = ompi_mpi_instance_init_common ();
+        ret = ompi_mpi_instance_init_common (argc, argv);
         if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
             opal_mutex_unlock (&instance_lock);
             return ret;

--- a/ompi/instance/instance.h
+++ b/ompi/instance/instance.h
@@ -123,7 +123,8 @@ void ompi_mpi_instance_release (void);
  * @param[in]    info      info object
  * @param[in]    errhander errhandler to set on the instance
  */
-OMPI_DECLSPEC int ompi_mpi_instance_init (int ts_level, opal_info_t *info, ompi_errhandler_t *errhandler, ompi_instance_t **instance);
+OMPI_DECLSPEC int ompi_mpi_instance_init (int ts_level, opal_info_t *info, ompi_errhandler_t *errhandler,
+                                          ompi_instance_t **instance, int argc, char **argv);
 
 /**
  * @brief Destroy an MPI instance and set it to MPI_SESSION_NULL

--- a/ompi/mpi/c/session_init.c
+++ b/ompi/mpi/c/session_init.c
@@ -54,7 +54,7 @@ int MPI_Session_init (MPI_Info info, MPI_Errhandler errhandler, MPI_Session *ses
         }
     }
 
-    rc = ompi_mpi_instance_init (ts_level, &info->super, errhandler, session);
+    rc = ompi_mpi_instance_init (ts_level, &info->super, errhandler, session, 0, NULL);
     /* if an error occurred raise it on the null session */
     OMPI_ERRHANDLER_RETURN (rc, MPI_SESSION_NULL, rc, FUNC_NAME);
 }

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -356,7 +356,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
 
     ompi_mpi_thread_level(requested, provided);
 
-    ret = ompi_mpi_instance_init (*provided, &ompi_mpi_info_null.info.super, MPI_ERRORS_ARE_FATAL, &ompi_mpi_instance_default);
+    ret = ompi_mpi_instance_init (*provided, &ompi_mpi_info_null.info.super, MPI_ERRORS_ARE_FATAL, &ompi_mpi_instance_default, argc, argv);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
         error = "ompi_mpi_init: ompi_mpi_instance_init failed";
         goto error;

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -818,6 +818,11 @@ int ompi_rte_init(int *pargc, char ***pargv)
         opal_process_info.initial_wdir = val;
         val = NULL;  // protect the string
     }
+    else {
+        // Probably singleton case. Just assume cwd.
+        opal_process_info.initial_wdir = calloc(1, OPAL_PATH_MAX + 1);
+        opal_getcwd(opal_process_info.initial_wdir, OPAL_PATH_MAX);
+    }
 
     /* identify our location */
     val = NULL;


### PR DESCRIPTION
Specifically, 'command', 'wdir' and 'argv'.

Pass down the argv and argc commands to the lower levels from MPI_Init().
In the singleton case, the PMIx calls to get these data will fail, so populate
them when they do if provided. Nothing to do for the MPI_Sessions model,
as it is not supported.

'wdir' can be populated with a good enough guess of getcwd().

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>