### PR TITLE
buildrpm.sh: remove debug statement

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -441,8 +441,6 @@ fi
 if test "$build_multiple" = "yes"; then
     echo "--> Building the multiple Open MPI RPM"
     cmd="$rpm_cmd -bb $rpmbuild_options --define 'build_all_in_one_rpm 0'"
-    # JMS
-    cmd="$cmd --define 'mflags -j12'"
     if test "$configure_options" != ""; then
         cmd="$cmd --define 'configure_options $configure_options'"
     fi


### PR DESCRIPTION
Arrgh -- this accidentally made it through #10224; I didn't notice it until I was making the corresponding v5.0.x cherry-pick PR (#10270).

-----

Adding "-j12" to the mflags was intended as a debuggin aid; it
accidentally slipped through and was merged as part of
https://github.com/open-mpi/ompi/pull/10224.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

