### PR TITLE
v5.0.x: Docs: datarep argument to MPI_Pack_external_size is const

### DIFF
--- a/docs/man-openmpi/man3/MPI_Info_set.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_set.3.rst
@@ -20,7 +20,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Info_set(MPI_Info info, char *key, char *value)
+   int MPI_Info_set(MPI_Info info, const char *key, const char *value)
 
 
 Fortran Syntax

--- a/docs/man-openmpi/man3/MPI_Pack_external_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pack_external_size.3.rst
@@ -21,7 +21,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Pack_external_size(char *datarep, int incount,
+   int MPI_Pack_external_size(const char *datarep, int incount,
    	MPI_Datatype datatype, MPI_Aint *size)
 
 


### PR DESCRIPTION
bot:notest
[skip ci]

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 601c58505a5633c6cd97eb2a032e6867692ca14e)