### PR TITLE
v4.0.x: Correctly handle MPI_UNSIGNED_LONG.

### DIFF
--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -361,7 +361,7 @@ const ompi_datatype_t* ompi_datatype_basicDatatypes[OMPI_DATATYPE_MPI_MAX_PREDEF
     [OMPI_DATATYPE_MPI_UB] = &ompi_mpi_ub.dt,
 
     [OMPI_DATATYPE_MPI_LONG] = &ompi_mpi_long.dt,
-    [OMPI_DATATYPE_MPI_UNSIGNED_LONG] = &ompi_mpi_long.dt,
+    [OMPI_DATATYPE_MPI_UNSIGNED_LONG] = &ompi_mpi_unsigned_long.dt,
     /* MPI 3.0 types */
     [OMPI_DATATYPE_MPI_COUNT] = &ompi_mpi_count.dt,
 


### PR DESCRIPTION
We incorrectly reference the internal long datatype with the
MPI_UNSIGNED_LONG datatype. Thanks to Kendra Long for finding
and analyzing the issue, as well as for the proposed fix.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 8912ef9c5a8c2f57b2f2685049c0caf52641003a)