### PR TITLE
v5.0.x: ompi_check_libhcoll: Fix bug where --with-hcoll will fail to configure. 

### DIFF
--- a/config/ompi_check_libhcoll.m4
+++ b/config/ompi_check_libhcoll.m4
@@ -24,7 +24,7 @@ AC_DEFUN([OMPI_CHECK_HCOLL],[
              [Build hcoll (Mellanox Hierarchical Collectives) support, optionally adding
               DIR/include and DIR/lib or DIR/lib64 to the search path for headers and libraries])])
 
-    OAC_CHECK_PACKAGE([libhcoll],
+    OAC_CHECK_PACKAGE([hcoll],
                       [$1],
                       [hcoll/api/hcoll_api.h],
                       [hcoll],


### PR DESCRIPTION
I have HCOLL installed on my local machine via rpm in '/opt/mellanox/hcoll',
and using this configure option would fail to find the pkgconfig 'hcoll.pc',
resulting in a configure failure.

I think this should be 'hcoll' not 'libhcoll', and this makes it consistent
with other OAC_CHECK_PACKAGE calls.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 7c4a40872d33eb37a4cc2e773e09faa99587e1ee)