### PR TITLE
Release the temporary arrays for nonblocking collectives.

### DIFF
--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -308,7 +308,7 @@ static inline int memchecker_request(MPI_Request *request)
     opal_memchecker_base_isdefined (&(*request)->req_status._ucount, sizeof(size_t));
 #endif
 
-    opal_memchecker_base_isdefined ((void*)&(*request)->req_complete, sizeof(volatile _Bool));
+    opal_memchecker_base_isdefined ((void*)&(*request)->req_complete, sizeof(volatile void*));
     opal_memchecker_base_isdefined ((void*)&(*request)->req_state, sizeof(volatile ompi_request_state_t));
     opal_memchecker_base_isdefined (&(*request)->req_persistent, sizeof(_Bool));
     opal_memchecker_base_isdefined (&(*request)->req_f_to_c_index, sizeof(int));

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -127,14 +127,29 @@ int ompi_rounddown(int num, int factor)
     return num * factor;    /* floor(num / factor) * factor */
 }
 
-static void release_objs_callback(struct ompi_coll_base_nbc_request_t *request) {
-    if (NULL != request->data.objs.objs[0]) {
-        OBJ_RELEASE(request->data.objs.objs[0]);
-        request->data.objs.objs[0] = NULL;
+/**
+ * Release all objects and arrays stored into the nbc_request.
+ * The release_arrays are temporary memory to stored the values
+ * converted from Fortran, and should dissapear in same time as the
+ * request itself.
+ */
+static void
+release_objs_callback(struct ompi_coll_base_nbc_request_t *request)
+{
+    if (NULL != request->data.refcounted.objs.objs[0]) {
+        OBJ_RELEASE(request->data.refcounted.objs.objs[0]);
+        request->data.refcounted.objs.objs[0] = NULL;
     }
-    if (NULL != request->data.objs.objs[1]) {
-        OBJ_RELEASE(request->data.objs.objs[1]);
-        request->data.objs.objs[1] = NULL;
+    if (NULL != request->data.refcounted.objs.objs[1]) {
+        OBJ_RELEASE(request->data.refcounted.objs.objs[1]);
+        request->data.refcounted.objs.objs[1] = NULL;
+    }
+    for(int i = 0; i < OMPI_REQ_NB_RELEASE_ARRAYS; i++ ) {
+        if (NULL == request->data.release_arrays[i]) {
+            break;
+        }
+        free(request->data.release_arrays[i]);
+        request->data.release_arrays[i] = NULL;
     }
 }
 
@@ -168,12 +183,12 @@ int ompi_coll_base_retain_op( ompi_request_t *req, ompi_op_t *op,
     }
     if (!ompi_op_is_intrinsic(op)) {
         OBJ_RETAIN(op);
-        request->data.op.op = op;
+        request->data.refcounted.op.op = op;
         retain = true;
     }
     if (!ompi_datatype_is_predefined(type)) {
         OBJ_RETAIN(type);
-        request->data.op.datatype = type;
+        request->data.refcounted.op.datatype = type;
         retain = true;
     }
     if (OPAL_UNLIKELY(retain)) {
@@ -207,12 +222,12 @@ int ompi_coll_base_retain_datatypes( ompi_request_t *req, ompi_datatype_t *stype
     }
     if (NULL != stype && !ompi_datatype_is_predefined(stype)) {
         OBJ_RETAIN(stype);
-        request->data.types.stype = stype;
+        request->data.refcounted.types.stype = stype;
         retain = true;
     }
     if (NULL != rtype && !ompi_datatype_is_predefined(rtype)) {
         OBJ_RETAIN(rtype);
-        request->data.types.rtype = rtype;
+        request->data.refcounted.types.rtype = rtype;
         retain = true;
     }
     if (OPAL_UNLIKELY(retain)) {
@@ -237,21 +252,21 @@ static void release_vecs_callback(ompi_coll_base_nbc_request_t *request) {
     } else {
         scount = rcount = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
     }
-    if (NULL != request->data.vecs.stypes) {
+    if (NULL != request->data.refcounted.vecs.stypes) {
         for (int i=0; i<scount; i++) {
-            if (NULL != request->data.vecs.stypes[i]) {
-                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.vecs.stypes[i]);
+            if (NULL != request->data.refcounted.vecs.stypes[i]) {
+                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.refcounted.vecs.stypes[i]);
             }
         }
-        request->data.vecs.stypes = NULL;
+        request->data.refcounted.vecs.stypes = NULL;
     }
-    if (NULL != request->data.vecs.rtypes) {
+    if (NULL != request->data.refcounted.vecs.rtypes) {
         for (int i=0; i<rcount; i++) {
-            if (NULL != request->data.vecs.rtypes[i]) {
-                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.vecs.rtypes[i]);
+            if (NULL != request->data.refcounted.vecs.rtypes[i]) {
+                OMPI_DATATYPE_RELEASE_NO_NULLIFY(request->data.refcounted.vecs.rtypes[i]);
             }
         }
-        request->data.vecs.rtypes = NULL;
+        request->data.refcounted.vecs.rtypes = NULL;
     }
 }
 
@@ -304,8 +319,8 @@ int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
         }
     }
     if (OPAL_UNLIKELY(retain)) {
-        request->data.vecs.stypes = (ompi_datatype_t **) stypes;
-        request->data.vecs.rtypes = (ompi_datatype_t **) rtypes;
+        request->data.refcounted.vecs.stypes = (ompi_datatype_t **) stypes;
+        request->data.refcounted.vecs.rtypes = (ompi_datatype_t **) rtypes;
         if (req->req_persistent) {
             request->cb.req_free = req->req_free;
             req->req_free = free_vecs_callback;
@@ -319,15 +334,16 @@ int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
     return OMPI_SUCCESS;
 }
 
-static void nbc_req_cons(ompi_coll_base_nbc_request_t *req)
+static void nbc_req_constructor(ompi_coll_base_nbc_request_t *req)
 {
     req->cb.req_complete_cb = NULL;
     req->req_complete_cb_data = NULL;
-    req->data.objs.objs[0] = NULL;
-    req->data.objs.objs[1] = NULL;
+    req->data.refcounted.objs.objs[0] = NULL;
+    req->data.refcounted.objs.objs[1] = NULL;
+    req->data.release_arrays[0] = NULL;
 }
 
-OBJ_CLASS_INSTANCE(ompi_coll_base_nbc_request_t, ompi_request_t, nbc_req_cons, NULL);
+OBJ_CLASS_INSTANCE(ompi_coll_base_nbc_request_t, ompi_request_t, nbc_req_constructor, NULL);
 
 /* File reading functions */
 static void skiptonewline (FILE *fptr, int *fileline)

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -35,6 +35,13 @@
 BEGIN_C_DECLS
 
 /**
+ * The largest array we need to track collective temporary memory. Right now
+ * the record is for ialltoallw, for the array of send and receive types,
+ * count and displacements.
+ */
+#define OMPI_REQ_NB_RELEASE_ARRAYS 7
+
+/**
  * Request structure to be returned by non-blocking
  * collective operations.
  */
@@ -45,22 +52,25 @@ struct ompi_coll_base_nbc_request_t {
         ompi_request_free_fn_t req_free;
     } cb;
     void *req_complete_cb_data;
-    union {
-        struct {
-            ompi_op_t *op;
-            ompi_datatype_t *datatype;
-        } op;
-        struct {
-            ompi_datatype_t *stype;
-            ompi_datatype_t *rtype;
-        } types;
-        struct {
-            opal_object_t *objs[2];
-        } objs;
-        struct {
-            ompi_datatype_t * const *stypes;
-            ompi_datatype_t * const *rtypes;
-        } vecs;
+    struct {
+        union {
+            struct {
+                ompi_op_t *op;
+                ompi_datatype_t *datatype;
+            } op;
+            struct {
+                ompi_datatype_t *stype;
+                ompi_datatype_t *rtype;
+            } types;
+            struct {
+                opal_object_t *objs[2];
+            } objs;
+            struct {
+                ompi_datatype_t * const *stypes;
+                ompi_datatype_t * const *rtypes;
+            } vecs;
+        } refcounted;
+        void* release_arrays[OMPI_REQ_NB_RELEASE_ARRAYS];
     } data;
 };
 

--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -352,8 +352,8 @@ static void* get_coll_handle(void)
     ompi_req->super.req_state            = OMPI_REQUEST_ACTIVE;
     ompi_req->super.req_free             = request_free;
     ompi_req->super.req_type             = OMPI_REQUEST_COLL;
-    ompi_req->data.objs.objs[0]          = NULL;
-    ompi_req->data.objs.objs[1]          = NULL;
+    ompi_req->data.refcounted.objs.objs[0]          = NULL;
+    ompi_req->data.refcounted.objs.objs[1]          = NULL;
     return (void *)ompi_req;
 }
 

--- a/ompi/mpi/fortran/mpif-h/allgatherv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/allgatherv_init_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -76,7 +77,7 @@ void ompi_allgatherv_init_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendty
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
     MPI_Info c_info;
-    int size, ierr_c;
+    int size, idx = 0, ierr_c;
     OMPI_ARRAY_NAME_DECL(recvcounts);
     OMPI_ARRAY_NAME_DECL(displs);
 
@@ -102,8 +103,16 @@ void ompi_allgatherv_init_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendty
                                   c_recvtype, c_comm, c_info, &c_request);
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
-    if (MPI_SUCCESS == ierr_c) *request = PMPI_Request_c2f(c_request);
-
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    if (MPI_SUCCESS == ierr_c) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(displs);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+     } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/alltoallv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/alltoallv_init_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -76,7 +77,7 @@ void ompi_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispl
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -106,10 +107,20 @@ void ompi_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispl
                                  OMPI_ARRAY_NAME_CONVERT(rdispls),
                                  c_recvtype, c_comm, c_info, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
-
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    if (MPI_SUCCESS == c_ierr) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (sendcounts != OMPI_ARRAY_NAME_CONVERT(sendcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sdispls);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(rdispls);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/alltoallw_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/alltoallw_init_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,7 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
-#include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -78,7 +78,7 @@ void ompi_alltoallw_init_f(char *sendbuf, MPI_Fint *sendcounts,
     MPI_Datatype *c_sendtypes = NULL, *c_recvtypes;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -117,14 +117,30 @@ void ompi_alltoallw_init_f(char *sendbuf, MPI_Fint *sendcounts,
                                  OMPI_ARRAY_NAME_CONVERT(rdispls),
                                  c_recvtypes, c_comm, c_info, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
-
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
-    if (NULL != c_sendtypes) {
-        free(c_sendtypes);
+    if (MPI_SUCCESS == c_ierr) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        nb_request->data.release_arrays[idx++] = c_recvtypes;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(rdispls);
+        }
+        if (NULL != c_sendtypes) {
+            nb_request->data.release_arrays[idx++] = c_sendtypes;
+            if (sendcounts != OMPI_ARRAY_NAME_CONVERT(sendcounts)) {
+                nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+                nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sdispls);
+            }
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+        if (NULL != c_sendtypes) {
+            free(c_sendtypes);
+        }
+        free(c_recvtypes);
     }
-    free(c_recvtypes);
 }

--- a/ompi/mpi/fortran/mpif-h/gatherv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/gatherv_init_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -76,7 +77,7 @@ void ompi_gatherv_init_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(recvcounts);
     OMPI_ARRAY_NAME_DECL(displs);
 
@@ -101,5 +102,16 @@ void ompi_gatherv_init_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
                                OMPI_FINT_2_INT(*root),
                                 c_comm, c_info, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
+    if (MPI_SUCCESS == c_ierr) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(displs);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+     } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+     }
 }

--- a/ompi/mpi/fortran/mpif-h/iallgatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/iallgatherv_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -75,7 +76,7 @@ void ompi_iallgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, ierr_c;
+    int size, idx = 0, ierr_c;
     OMPI_ARRAY_NAME_DECL(recvcounts);
     OMPI_ARRAY_NAME_DECL(displs);
 
@@ -102,6 +103,15 @@ void ompi_iallgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
     if (MPI_SUCCESS == ierr_c) *request = PMPI_Request_c2f(c_request);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    if ( REQUEST_COMPLETE(c_request)) {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    } else {
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(displs);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/ialltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/ialltoallv_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -75,7 +76,7 @@ void ompi_ialltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispls,
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -106,8 +107,19 @@ void ompi_ialltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispls,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    if ( REQUEST_COMPLETE(c_request)) {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    } else {
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (sendcounts != OMPI_ARRAY_NAME_CONVERT(sendcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sdispls);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(rdispls);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/igatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/igatherv_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -75,7 +76,7 @@ void ompi_igatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(recvcounts);
     OMPI_ARRAY_NAME_DECL(displs);
 
@@ -100,4 +101,16 @@ void ompi_igatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
                           c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
+
+    if ( REQUEST_COMPLETE(c_request)) {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    } else {
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(displs);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -26,6 +26,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -79,7 +80,7 @@ void ompi_ineighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     MPI_Comm c_comm;
     MPI_Datatype *c_sendtypes, *c_recvtypes;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(recvcounts);
 
@@ -113,8 +114,17 @@ void ompi_ineighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    free(c_sendtypes);
-    free(c_recvtypes);
+    if ( REQUEST_COMPLETE(c_request)) {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        free(c_sendtypes);
+        free(c_recvtypes);
+    } else {
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+        nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+        nb_request->data.release_arrays[idx++] = c_sendtypes;
+        nb_request->data.release_arrays[idx++] = c_recvtypes;
+        nb_request->data.release_arrays[idx]   = NULL;
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/iscatterv_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscatterv_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -24,6 +24,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -77,7 +78,7 @@ void ompi_iscatterv_f(char *sendbuf, MPI_Fint *sendcounts,
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(displs);
 
@@ -103,6 +104,15 @@ void ompi_iscatterv_f(char *sendbuf, MPI_Fint *sendcounts,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    if ( REQUEST_COMPLETE(c_request)) {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    } else {
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (sendcounts != OMPI_ARRAY_NAME_CONVERT(sendcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(displs);
+        }
+        nb_request->data.release_arrays[idx]   = NULL;
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/neighbor_allgatherv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_allgatherv_init_f.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -26,6 +26,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -105,8 +106,16 @@ void ompi_neighbor_allgatherv_init_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fin
                                            c_recvtype, c_comm, c_info, &c_request);
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
-    if (MPI_SUCCESS == ierr_c) *request = PMPI_Request_c2f(c_request);
-
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    if (MPI_SUCCESS == ierr_c) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (recvcounts != OMPI_ARRAY_NAME_CONVERT(recvcounts)) {
+            nb_request->data.release_arrays[0] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[1] = OMPI_ARRAY_NAME_CONVERT(displs);
+            nb_request->data.release_arrays[2] = NULL;
+        }
+    } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_init_f.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -26,6 +26,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -79,7 +80,7 @@ void ompi_neighbor_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fin
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, c_ierr;
+    int size, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -109,10 +110,20 @@ void ompi_neighbor_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fin
                                           OMPI_ARRAY_NAME_CONVERT(rdispls),
                                           c_recvtype, c_comm, c_info, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
-
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    if (MPI_SUCCESS == c_ierr) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        if (sendcounts != OMPI_ARRAY_NAME_CONVERT(sendcounts)) {
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sendcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(sdispls);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+            nb_request->data.release_arrays[idx++] = OMPI_ARRAY_NAME_CONVERT(rdispls);
+        }
+        nb_request->data.release_arrays[idx] = NULL;
+    } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    }
 }

--- a/ompi/mpi/fortran/mpif-h/reduce_scatter_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/reduce_scatter_init_f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -23,6 +23,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -97,5 +98,12 @@ void ompi_reduce_scatter_init_f(char *sendbuf, char *recvbuf,
                                       OMPI_ARRAY_NAME_CONVERT(recvcounts),
                                       c_type, c_op, c_comm, c_info, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
+    if (MPI_SUCCESS == c_ierr) {
+        *request = PMPI_Request_c2f(c_request);
+        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
+        nb_request->data.release_arrays[0] = OMPI_ARRAY_NAME_CONVERT(recvcounts);
+        nb_request->data.release_arrays[1] = NULL;
+    } else {
+        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
+    }
 }


### PR DESCRIPTION
If Fortran and C integers have different sizes we allocate the storage
for the C objects in the MPI API. For nonblocking functions we need to
release these temporary arrays upon completion of the request in order
to avoid memory leaks.

Replaces: https://github.com/open-mpi/ompi/pull/8926

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>