### PR TITLE
runtime: warn before using singleton mode

### DIFF
--- a/ompi/runtime/help-mpi-runtime.txt
+++ b/ompi/runtime/help-mpi-runtime.txt
@@ -118,3 +118,7 @@ PMIx_Init failed for the following reason:
 Open MPI requires access to a local PMIx server to execute. Please ensure
 that either you are operating in a PMIx-enabled environment, or use "mpirun"
 to execute the job.
+#
+[no-pmix-but]
+No PMIx server was reachable, but a PMI1/2 or SLURM environment was detected.
+Open MPI will start %d singletons


### PR DESCRIPTION
If PMIx is unreachable, but a PMI1/2 or SLURM environment is detected,
issue a warning before "falling back" to singleton mode.

Refs. open-mpi/ompi#10286

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>