### PR TITLE
scoll/ucc: proper fallback

### DIFF
--- a/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
@@ -70,6 +70,7 @@ int mca_scoll_ucc_alltoall(struct oshmem_group_t *group,
     mca_scoll_ucc_module_t *ucc_module;
     size_t count;
     ucc_coll_req_h req;
+    int rc;
 
     UCC_VERBOSE(3, "running ucc alltoall");
     ucc_module = (mca_scoll_ucc_module_t *) group->g_scoll.scoll_alltoall_module;
@@ -87,7 +88,7 @@ int mca_scoll_ucc_alltoall(struct oshmem_group_t *group,
     return OSHMEM_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback alltoall");
-    return ucc_module->previous_alltoall(group, target, source, dst, sst, nelems, 
-                                         element_size, pSync, alg);
+    PREVIOUS_SCOLL_FN(ucc_module, alltoall, group, target, source,
+                      dst, sst, nelems, element_size, pSync, alg);
+    return rc;
 }
-

--- a/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
@@ -34,6 +34,7 @@ int mca_scoll_ucc_barrier(struct oshmem_group_t *group, long *pSync, int alg)
 {
     mca_scoll_ucc_module_t *ucc_module;
     ucc_coll_req_h req;
+    int            rc;
 
     UCC_VERBOSE(3, "running ucc barrier");
     ucc_module = (mca_scoll_ucc_module_t *) group->g_scoll.scoll_barrier_module;
@@ -44,6 +45,8 @@ int mca_scoll_ucc_barrier(struct oshmem_group_t *group, long *pSync, int alg)
     return OSHMEM_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback barrier");
-    return ucc_module->previous_barrier(group, pSync, alg);
+    PREVIOUS_SCOLL_FN(ucc_module, barrier, group,
+                      pSync, alg);
+    return rc;
 }
 

--- a/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
@@ -52,6 +52,7 @@ int mca_scoll_ucc_broadcast(struct oshmem_group_t *group,
     mca_scoll_ucc_module_t * ucc_module;
     void * buf;
     ucc_coll_req_h req;
+    int rc;
 
     UCC_VERBOSE(3, "running ucc bcast");
     ucc_module = (mca_scoll_ucc_module_t *) group->g_scoll.scoll_broadcast_module;
@@ -72,6 +73,7 @@ int mca_scoll_ucc_broadcast(struct oshmem_group_t *group,
     return OSHMEM_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback bcast");
-    return ucc_module->previous_broadcast(group, PE_root, target, source, 
-                                          nlong, pSync, nlong_type, alg);
+    PREVIOUS_SCOLL_FN(ucc_module, broadcast, group, PE_root, target, source,
+                      nlong, pSync, nlong_type, alg);
+    return rc;
 }

--- a/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
@@ -55,6 +55,7 @@ int mca_scoll_ucc_collect(struct oshmem_group_t *group,
 {
     mca_scoll_ucc_module_t *ucc_module;
     ucc_coll_req_h req;
+    int rc;
 
     UCC_VERBOSE(3, "running ucc collect");
     ucc_module = (mca_scoll_ucc_module_t *) group->g_scoll.scoll_collect_module;
@@ -69,6 +70,7 @@ int mca_scoll_ucc_collect(struct oshmem_group_t *group,
     return OSHMEM_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback collect");
-    return ucc_module->previous_collect(group, target, source, nlong,
-                                        pSync, nlong_type, alg);
+    PREVIOUS_SCOLL_FN(ucc_module, collect, group, target, source,
+                      nlong, pSync, nlong_type, alg);
+    return rc;
 }

--- a/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
@@ -77,6 +77,7 @@ int mca_scoll_ucc_reduce(struct oshmem_group_t *group,
     mca_scoll_ucc_module_t *ucc_module;
     size_t count;
     ucc_coll_req_h req;
+    int rc;
 
     UCC_VERBOSE(3, "running ucc reduce");
     ucc_module = (mca_scoll_ucc_module_t *) group->g_scoll.scoll_reduce_module;
@@ -93,6 +94,7 @@ int mca_scoll_ucc_reduce(struct oshmem_group_t *group,
     return OSHMEM_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduction");
-    return ucc_module->previous_reduce(group, op, target, source, nlong, pSync,
-                                       pWrk, alg);
+    PREVIOUS_SCOLL_FN(ucc_module, reduce, group, op, target,
+                      source, nlong, pSync, pWrk, alg);
+    return rc;
 }


### PR DESCRIPTION
Need to use PREVIOUS_SCOLL_FN macro for fallback in scoll/ucc. Otherwise group->g_scoll.scoll_<collname>_module always points to ucc_module even when running fallback from scoll/mpi. That leads to a crash.