### PR TITLE
scoll/ucc: split UCC initialization and context creation

### DIFF
--- a/oshmem/mca/scoll/ucc/scoll_ucc.h
+++ b/oshmem/mca/scoll/ucc/scoll_ucc.h
@@ -44,10 +44,10 @@ struct mca_scoll_ucc_component_t {
     char * cts;
     int nr_modules;
     bool libucc_initialized;
+    ucc_context_h ucc_context;
     ucc_lib_h ucc_lib;
     ucc_lib_attr_t ucc_lib_attr;
     ucc_coll_type_t cts_requested;
-    ucc_context_h ucc_context;
 };
 typedef struct mca_scoll_ucc_component_t mca_scoll_ucc_component_t;
 
@@ -84,6 +84,8 @@ int mca_scoll_ucc_init_query(bool enable_progress_threads, bool enable_mpi_threa
 
 int mca_scoll_ucc_team_create(mca_scoll_ucc_module_t *ucc_module, 
                               oshmem_group_t *osh_group);
+
+int mca_scoll_ucc_init_ctx(oshmem_group_t *osh_group);
 
 mca_scoll_base_module_t* mca_scoll_ucc_comm_query(oshmem_group_t *osh_group, int *priority);
 

--- a/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_alltoall.c
@@ -46,6 +46,12 @@ static inline ucc_status_t mca_scoll_ucc_alltoall_init(const void *sbuf, void *r
         .global_work_buffer = ucc_module->pSync,
     };
 
+    if (NULL == mca_scoll_ucc_component.ucc_context) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_init_ctx(ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
+
     if (NULL == ucc_module->ucc_team) {
         if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
             return OSHMEM_ERROR;

--- a/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_barrier.c
@@ -19,11 +19,19 @@ static inline ucc_status_t mca_scoll_ucc_barrier_init(mca_scoll_ucc_module_t * u
         .mask = 0,
         .coll_type = UCC_COLL_TYPE_BARRIER
     };
+
+    if (NULL == mca_scoll_ucc_component.ucc_context) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_init_ctx(ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
+
     if (NULL == ucc_module->ucc_team) {
         if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
             return OSHMEM_ERROR;
         }
     }
+
     SCOLL_UCC_REQ_INIT(req, coll, ucc_module);
     return UCC_OK;
 fallback:
@@ -49,4 +57,3 @@ fallback:
                       pSync, alg);
     return rc;
 }
-

--- a/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_broadcast.c
@@ -28,6 +28,13 @@ static inline ucc_status_t mca_scoll_ucc_broadcast_init(void * buf, int count,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         }
     };
+
+    if (NULL == mca_scoll_ucc_component.ucc_context) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_init_ctx(ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
+
     if (NULL == ucc_module->ucc_team) {
         if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
             return OSHMEM_ERROR;

--- a/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_collect.c
@@ -34,6 +34,12 @@ static inline ucc_status_t mca_scoll_ucc_collect_init(const void * sbuf, void * 
         },
     };
 
+    if (NULL == mca_scoll_ucc_component.ucc_context) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_init_ctx(ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
+
     if (NULL == ucc_module->ucc_team) {
         if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
             return OSHMEM_ERROR;

--- a/oshmem/mca/scoll/ucc/scoll_ucc_component.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_component.c
@@ -63,7 +63,8 @@ mca_scoll_ucc_component_t mca_scoll_ucc_component = {
     "basic",            /* cls */
     SCOLL_UCC_CTS_STR,  /* cts */
     0,                  /* nr_modules */
-    false               /* libucc_initialized */
+    false,              /* libucc_initialized */
+    NULL                /* ucc_context */
 };
 
 static int ucc_register(void)

--- a/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_reduce.c
@@ -54,6 +54,13 @@ static inline ucc_status_t mca_scoll_ucc_reduce_init(const void *sbuf, void *rbu
         coll.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
+
+    if (NULL == mca_scoll_ucc_component.ucc_context) {
+        if (OSHMEM_ERROR == mca_scoll_ucc_init_ctx(ucc_module->group)) {
+            return OSHMEM_ERROR;
+        }
+    }
+
     if (NULL == ucc_module->ucc_team) {
         if (OSHMEM_ERROR == mca_scoll_ucc_team_create(ucc_module, ucc_module->group)) {
             return OSHMEM_ERROR;


### PR DESCRIPTION
This PR delays UCC context creation until the first OpenSHMEM collective operation when using the SCOLL UCC module. By delaying the UCC context creation, this will defer the initialization overhead until it is actually needed.  

Signed-off-by: ferrol aderholdt <faderholdt@nvidia.com>