### PR TITLE
Properly initialize group pointer passed to ompi_group_from_pset [v5.0.x]

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -192,8 +192,8 @@ int ompi_comm_init(void)
 
 int ompi_comm_init_mpi3 (void)
 {
-    ompi_group_t *group;
     int ret;
+    ompi_group_t *group = NULL;
 
     /* the intrinsic communicators have been initialized */
     ompi_comm_intrinsic_init = true;


### PR DESCRIPTION
The `group` pointer passed from `ompi_comm_init` is checked for equality with MPI_GROUP_NULL in `ompi_group_from_pset` but is never initialized. Valgrind complains about a jump based on uninitialized values. Stack values are never default initialized so we have to explicitly initialize it to `NULL`.

Backport of https://github.com/open-mpi/ompi/pull/10306 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 8a3a724c03a20c6f4ee3755e91e177daaa5fb5da)