### PR TITLE
v5.0.x: oshmem: making  shmem_calloc spec-compliant regarding zero-byte inputs

### DIFF
--- a/oshmem/shmem/c/shmem_alloc.c
+++ b/oshmem/shmem/c/shmem_alloc.c
@@ -39,6 +39,7 @@ void* shmem_malloc(size_t size)
 void* shmem_calloc(size_t count, size_t size)
 {
     size_t req_sz = count * size;
+    if (!req_sz) return NULL;
     void *ptr = _shmalloc(req_sz);
     if (ptr) {
         memset(ptr, 0, req_sz);


### PR DESCRIPTION
V5.0.x: oshmem: making  shmem_calloc spec-compliant regarding zero-byte inputs

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit 09a9577850dd1a77bd6932ce4737f8dd0f8ac4f7)