### PR TITLE
mpirun: Refactor to better play with prefixes

### DIFF
--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -1,8 +1,7 @@
 #
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
-#                         All Rights reserved.
+# Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -14,6 +13,8 @@
 if OMPI_WANT_PRRTE
 
 bin_PROGRAMS = mpirun
+
+dist_ompidata_DATA = help-mpirun.txt
 
 mpirun_SOURCES = \
     main.c

--- a/ompi/tools/mpirun/help-mpirun.txt
+++ b/ompi/tools/mpirun/help-mpirun.txt
@@ -1,0 +1,23 @@
+# -*- text -*-
+#
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI wrapper compiler error
+# messages.
+#
+[no-prterun-found]
+Open MPI's mpirun command was unable to find an underlying prterun
+command to execute.  Consider setting the OMPI_PRTERUN environment
+variable to help mpirun find the correct underlying prterun.
+[prterun-exec-failed]
+Open MPI's mpirun command could not execute the underlying prterun
+command.  The prterun command we tried to execute and the error
+message from exec() are below:
+
+  Command: %s
+  Error Message: %s


### PR DESCRIPTION
Rework mpirun to not use OMPI prefixes to find prterun unless
OMPI was built with an internal PRRTE.  The design for this
work is documented in https://github.com/open-mpi/ompi/issues/10252.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 4a008c160ecb3b03d6d90aec5da083bc458dae63)