### PR TITLE
Fix offset detection in attr_subsys_construct

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -476,6 +476,8 @@ static attr_subsys_t *attr_subsys = NULL;
 static unsigned int int_pos = 12345;
 static unsigned int integer_pos = 12345;
 static int attr_sequence;
+static void *dummy = (void*)1;
+static int *p = (void*)&dummy;
 
 /*
  * MPI attributes are *not* high performance, so just use a One Big Lock
@@ -574,8 +576,6 @@ int ompi_attr_put_ref(void)
 static void attr_subsys_construct(attr_subsys_t *subsys)
 {
     int ret;
-    void *bogus = (void*) 1;
-    int *p = (int *) &bogus;
 
     subsys->keyval_hash = OBJ_NEW(opal_hash_table_t);
 


### PR DESCRIPTION
It appears that GCC starting from GCC 11 optimizes out the offset detection. By moving the pointers used for testing out of the function into TU scope we can suppress that optimization.

I have to admit that I am not sure I understand why we do this detection in the first place. There might be a better fix so I'm putting this PR out for review and discussion.

Fixes https://github.com/open-mpi/ompi/issues/10339

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>