### PR TITLE
hook/comm_method: Fix segv when not fully conected

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method.h
+++ b/ompi/mca/hook/comm_method/hook_comm_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,14 +18,14 @@
 
 BEGIN_C_DECLS
 
-OMPI_MODULE_DECLSPEC extern const ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component;
+OMPI_MODULE_DECLSPEC extern ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component;
 
 extern int mca_hook_comm_method_verbose;
 extern int mca_hook_comm_method_output;
 extern bool mca_hook_comm_method_enable_mpi_init;
 extern bool mca_hook_comm_method_enable_mpi_finalize;
 extern int mca_hook_comm_method_max;
-extern int mca_hook_comm_method_brief;
+extern bool mca_hook_comm_method_brief;
 extern char *mca_hook_comm_method_fakefile;
 
 void ompi_hook_comm_method_mpi_init_bottom(int argc, char **argv, int requested, int *provided);

--- a/ompi/mca/hook/comm_method/hook_comm_method_component.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_component.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +25,7 @@ const char *mca_hook_comm_method_component_version_string =
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-const ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component = {
+ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
@@ -79,7 +79,7 @@ bool mca_hook_comm_method_enable_mpi_init = false;
 bool mca_hook_comm_method_enable_mpi_finalize = false;
 uint32_t mca_hook_comm_method_enabled_flags = 0x00;
 int mca_hook_comm_method_max = 12;
-int mca_hook_comm_method_brief = 0;
+bool mca_hook_comm_method_brief = false;
 char *mca_hook_comm_method_fakefile = NULL;
 
 static mca_base_var_enum_value_flag_t mca_hook_comm_method_modes[] = {
@@ -174,7 +174,7 @@ static int ompi_hook_comm_method_component_register(void)
     // hook_comm_method_brief
     (void) mca_base_component_var_register(&mca_hook_comm_method_component.hookm_version, "brief",
                                  "Only print the comm method summary, skip the 2d table.",
-                                 MCA_BASE_VAR_TYPE_INT, NULL,
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL,
                                  0, 0,
                                  OPAL_INFO_LVL_3,
                                  MCA_BASE_VAR_SCOPE_READONLY,


### PR DESCRIPTION
In a sparsely connected application, not all nodes are connected. So the `ompi_group_peer_lookup_existing` may return `NULL`. In `MPI_Finalize` we want the comm table to show those empty connections with the `n/a` indicator (in case that is useful to the end-user). This is in contrast to `MPI_Init` where we fully connect the peers.

 * Remove `const` from `mca_hook_comm_method_component` to make it consistent with other MCA components
 * Change the datatype of `mca_hook_comm_method_brief` to a `bool` since that is how it is being used. This also makes it easier for the user to pass a boolean on the command line (in addition to `0`/`1`).
 * A little "magic number" cleanup.