### PR TITLE
romio341: do not include auto-generated file in the dist tarball

### DIFF
--- a/3rd-party/romio341/mpl/Makefile.am
+++ b/3rd-party/romio341/mpl/Makefile.am
@@ -36,7 +36,6 @@ mpl_headers =               \
     include/mpl_gpu_fallback.h\
     include/mpl_gpu_ze.h    \
     include/mpl_math.h      \
-    include/mplconfig.h     \
     include/utlist.h    \
     include/mpl_valgrind.h  \
     include/mpl_env.h       \
@@ -75,9 +74,11 @@ mpl_headers =               \
 
 if MPL_EMBEDDED_MODE
 noinst_HEADERS += $(mpl_headers)
+nodist_noinst_HEADERS = include/mplconfig.h
 noinst_LTLIBRARIES = lib@MPLLIBNAME@.la
 else !MPL_EMBEDDED_MODE
 include_HEADERS = $(mpl_headers)
+nodist_include_HEADERS = include/mplconfig.h
 lib_LTLIBRARIES = lib@MPLLIBNAME@.la
 endif !MPL_EMBEDDED_MODE
 


### PR DESCRIPTION
3rd-party/romio341/mpl/include/mplconfig.h is automatically generated
and hence should not be part of the dist tarball.

Refs. open-mpi/ompi#10373

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>