### PR TITLE
v5.0.x: ompi/mca/sharedfp/sm: Include missing `sys/stat.h` in `sharedfp_sm.c`

### DIFF
--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -27,6 +27,11 @@
  */
 
 #include "ompi_config.h"
+
+#if HAVE_SYS_STAT_H
+#    include <sys/stat.h>
+#endif /* HAVE_SYS_STAT_H */
+
 #include "mpi.h"
 #include "opal/util/printf.h"
 #include "ompi/mca/sharedfp/sharedfp.h"


### PR DESCRIPTION
This is the v5.0.x cherry pick of #10385 from @giordano 

-----

Macros `S_IRUSR`, `S_IWUSR`, `S_IRGRP`, and `S_IROTH` are defined in
`sys/stat.h`.  See for reference
<https://pubs.opengroup.org/onlinepubs/7908799/xsh/sysstat.h.html> and
<https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html>.

The lack of this include causes a compilation error on FreeBSD.

Signed-off-by: Mosè Giordano <mose@gnu.org>
(cherry picked from commit 238f6fa984ad8b6475884a3f13705d1831b3d462)