### PR TITLE
v4.0.x: odls/default: cap the max number of child FDs to close

### DIFF
--- a/orte/mca/odls/default/odls_default.h
+++ b/orte/mca/odls/default/odls_default.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +36,7 @@ BEGIN_C_DECLS
  */
 int orte_odls_default_component_open(void);
 int orte_odls_default_component_close(void);
+int orte_odls_default_component_register(void);
 int orte_odls_default_component_query(mca_base_module_t **module, int *priority);
 
 /*
@@ -42,6 +44,11 @@ int orte_odls_default_component_query(mca_base_module_t **module, int *priority)
  */
 extern orte_odls_base_module_t orte_odls_default_module;
 ORTE_MODULE_DECLSPEC extern orte_odls_base_component_t mca_odls_default_component;
+
+/* In non-Linux environments where we can't just see which fd's are
+   open (e.g., MacOS), use this value as the maximum number of FDs
+   to close when forking a new child process. */
+extern int orte_odls_default_maxfd;
 
 END_C_DECLS
 

--- a/orte/mca/odls/default/odls_default_component.c
+++ b/orte/mca/odls/default/odls_default_component.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,6 +61,7 @@ orte_odls_base_component_t mca_odls_default_component = {
         /* Component open and close functions */
         .mca_open_component = orte_odls_default_component_open,
         .mca_close_component = orte_odls_default_component_close,
+        .mca_register_component_params = orte_odls_default_component_register,
         .mca_query_component = orte_odls_default_component_query,
     },
     .base_data = {
@@ -68,10 +70,25 @@ orte_odls_base_component_t mca_odls_default_component = {
     },
 };
 
+int orte_odls_default_maxfd = 1024;
 
 
 int orte_odls_default_component_open(void)
 {
+    return ORTE_SUCCESS;
+}
+
+int orte_odls_default_component_register(void)
+{
+    mca_base_component_var_register(&mca_odls_default_component.version, "maxfd",
+                                    "In non-Linux environments, use this value as a maximum number of file descriptors to close when forking a new child process",
+                                    MCA_BASE_VAR_TYPE_INT,
+                                    NULL,
+                                    0,
+                                    0,
+                                    OPAL_INFO_LVL_6,
+                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    &orte_odls_default_maxfd);
     return ORTE_SUCCESS;
 }
 


### PR DESCRIPTION
On some versions of MacOS (e.g., 12.3.1), we have seen
sysconf(_SC_OPEN_MAX) -- and "ulimit -n" -- return very large numbers,
and sometime return -1 (which means "unlimited").  This can result in
an unreasonably large loop over closing all FDs (especially if -1 gets
interpreted as LONG_MAX).
https://github.com/open-mpi/ompi/issues/10358 has some links to others
who have seen this kind of behavior.

Add an MCA param (orte_odls_default_maxfd, defaulting to 1024) that
caps the max number of FDs to close in non-Linux environments.  Use an
MCA param because we're picking this max value fairly arbitrarily;
give users a way to change it someday, if needed.

Thanks to Scott Sayres for raising the issue.

This is a cherry pick from the v4.1.x branch because this code (i.e.,
ORTE) no longer exists on main.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit da394287afd20b651d94668f947bb4045317e2f8)