### PR TITLE
V5.0.x  OSC/UCX: Fix the get/put race condition in get_accumulate

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -945,6 +945,11 @@ int get_accumulate_req(const void *origin_addr, int origin_count,
         return ret;
     }
 
+    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
+    if (ret != OMPI_SUCCESS) {
+        return ret;
+    }
+
     if (op != &ompi_mpi_op_no_op.op) {
         if (op == &ompi_mpi_op_replace.op) {
             ret = ompi_osc_ucx_put(origin_addr, origin_count, origin_dt,


### PR DESCRIPTION
V5.0.x OSC/UCX: Fix the get/put race condition in get_accumulate

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit ccd615db84fe07fcfc8bd07246adbf7555c2765e)