### PR TITLE
v4.0.x: two cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,29 +125,10 @@ AC_DEFUN([OMPI_CHECK_DIR_FOR_SPACES],[
            AC_MSG_ERROR([Cannot continue.])])
 ])
 
-AC_DEFUN([OMPI_CANONICALIZE_PATH],[
-    case $host_os in
-    darwin*)
-        # MacOS does not have "readlink -f" or realpath (at least as
-        # of MacOS Cataline / 10.15).  Instead, use Python, because we
-        # know MacOS comes with a /usr/bin/python that has
-        # os.path.realpath.
-        $2=`/usr/bin/python -c 'import os; print os.path.realpath("'$1'")'`
-        ;;
-    *)
-        $2=`readlink -f $1`
-        ;;
-    esac
-])
-
-OMPI_CHECK_DIR_FOR_SPACES([$srcdir], [a], [source tree])
-OMPI_CANONICALIZE_PATH([$srcdir], [ompi_dir])
-OMPI_CHECK_DIR_FOR_SPACES([$ompi_dir], [an], [absolute source tree])
-OMPI_CANONICALIZE_PATH([.], [ompi_dir])
+ompi_dir=`pwd`
 OMPI_CHECK_DIR_FOR_SPACES([$ompi_dir], [a], [build tree])
+OMPI_CHECK_DIR_FOR_SPACES([$srcdir], [a], [source tree])
 OMPI_CHECK_DIR_FOR_SPACES([$prefix], [a], [prefix])
-OMPI_CANONICALIZE_PATH([$prefix], [ompi_dir])
-OMPI_CHECK_DIR_FOR_SPACES([$ompi_dir], [an], [absolute prefix])
 
 opal_show_subtitle "Checking versions"
 

--- a/ompi/mpi/java/c/mpi_Info.c
+++ b/ompi/mpi/java/c/mpi_Info.c
@@ -45,17 +45,20 @@ JNIEXPORT jlong JNICALL Java_mpi_Info_getNull(JNIEnv *env, jclass clazz)
     return (jlong)MPI_INFO_NULL;
 }
 
+// At least some versions of jni.h have a global named "jvalue", and
+// we get a compiler warning if we have a parameter or variable of the
+// same name.  So use "ljvalue" instead.
 JNIEXPORT void JNICALL Java_mpi_Info_set(
-        JNIEnv *env, jobject jthis, jlong handle, jstring jkey, jstring jvalue)
+        JNIEnv *env, jobject jthis, jlong handle, jstring jkey, jstring ljvalue)
 {
-    const char *key   = (*env)->GetStringUTFChars(env, jkey,   NULL),
-               *value = (*env)->GetStringUTFChars(env, jvalue, NULL);
+    const char *key   = (*env)->GetStringUTFChars(env, jkey,    NULL),
+               *value = (*env)->GetStringUTFChars(env, ljvalue, NULL);
 
     int rc = MPI_Info_set((MPI_Info)handle, (char*)key, (char*)value);
     ompi_java_exceptionCheck(env, rc);
 
-    (*env)->ReleaseStringUTFChars(env, jkey,   key);
-    (*env)->ReleaseStringUTFChars(env, jvalue, value);
+    (*env)->ReleaseStringUTFChars(env, jkey,    key);
+    (*env)->ReleaseStringUTFChars(env, ljvalue, value);
 }
 
 JNIEXPORT jstring JNICALL Java_mpi_Info_get(
@@ -83,9 +86,12 @@ JNIEXPORT jstring JNICALL Java_mpi_Info_get(
         return NULL;
     }
 
-    jstring jvalue = (*env)->NewStringUTF(env, value);
+    // At least some versions of jni.h have a global named "jvalue",
+    // and we get a compiler warning if we have a parameter or
+    // variable of the same name.  So use "ljvalue" instead.
+    jstring ljvalue = (*env)->NewStringUTF(env, value);
     free(value);
-    return jvalue;
+    return ljvalue;
 }
 
 JNIEXPORT void JNICALL Java_mpi_Info_delete(


### PR DESCRIPTION
This is a cherry pick of 2 minor fixes from #10246 (the other commits on that PR were either unrelated to v4.0.x or configure output cleanups that we really shouldn't do so late in the v4.0.x series).

* Fix the "check for spaces in directories" configure test
* Fix a name conflict in the Java MPI bindings