### PR TITLE
Optimize the file descriptor cleanup on OSX

### DIFF
--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -297,7 +297,11 @@ static void send_error_show_help(int fd, int exit_status,
    and the pipe up to the parent. */
 static int close_open_file_descriptors(int write_fd,
                                       orte_iof_base_io_conf_t opts) {
+#if defined(__OSX__)
+    DIR *dir = opendir("/dev/fd");
+#else  /* Linux */
     DIR *dir = opendir("/proc/self/fd");
+#endif  /* defined(__OSX__) */
     if (NULL == dir) {
         return ORTE_ERR_FILE_OPEN_FAILURE;
     }
@@ -310,7 +314,6 @@ static int close_open_file_descriptors(int write_fd,
         return ORTE_ERR_FILE_OPEN_FAILURE;
     }
 
-    
     while (NULL != (files = readdir(dir))) {
         if (!isdigit(files->d_name[0])) {
             continue;

--- a/orte/mca/odls/pspawn/odls_pspawn.c
+++ b/orte/mca/odls/pspawn/odls_pspawn.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -226,7 +226,11 @@ int orte_odls_pspawn_kill_local_procs(opal_pointer_array_t *procs)
    and the pipe up to the parent. */
 static int close_open_file_descriptors(posix_spawn_file_actions_t *factions)
 {
+#if defined(__OSX__)
+    DIR *dir = opendir("/dev/fd");
+#else  /* Linux */
     DIR *dir = opendir("/proc/self/fd");
+#endif  /* defined(__OSX__) */
     if (NULL == dir) {
         return ORTE_ERR_FILE_OPEN_FAILURE;
     }


### PR DESCRIPTION
Here is the extension promised during the discussions on #10358. I don't understand why there are 3, almost identical copies of the close_open_file_descriptors, but I don't think it's worth the effort to fix that now. So, I patched them all.

bot:notacherrypick