### PR TITLE
oversubscribe: put back in a bit of code squashed by sessions

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -398,6 +398,12 @@ static int ompi_mpi_instance_init_common (void)
     OMPI_TIMING_IMPORT_OPAL("rte_init");
 
     ompi_rte_initialized = true;
+    /* if we are oversubscribed, then set yield_when_idle
+     * accordingly */
+    if (ompi_mpi_oversubscribed) {
+        ompi_mpi_yield_when_idle = true;
+    }
+
 
     /* Register the default errhandler callback  */
     /* give it a name so we can distinguish it */


### PR DESCRIPTION
The sessions related commit 7291361 inadvertenly removed a bit of commit 2b335ed.
Put it back in.

Leave a chatty string to help with testing.  this will be removed before merging.

Related to issue #10426

Signed-off-by: Howard Pritchard <howardp@lanl.gov>