### PR TITLE
v5.0: Implement reporting of transport/device names used by MPI application when using UCX

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -111,6 +111,9 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                           [AC_DEFINE([HAVE_UCP_ATTR_MEMORY_TYPES], [1],
                                      [have memory types attribute])], [],
                           [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([UCP_EP_ATTR_FIELD_TRANSPORTS],
+                          [], [],
+                          [#include <ucp/api/ucp.h>])
            AC_CHECK_DECLS([ucp_tag_send_nbx,
                            ucp_tag_send_sync_nbx,
                            ucp_tag_recv_nbx],

--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -144,13 +144,13 @@ comm_method_string(MPI_Comm comm, int rank, int *comm_mode) {
             strcat(string, ";");
             strcat(string, transports->entries[i].device_name);
         }
+        free(transports->entries);
+        free(transports);
     }
     if (comm_mode) {
         // UCX is used for PML mode only
         *comm_mode = MODE_IS_PML;
     }
-    free(transports->entries);
-    free(transports);
     return string;
 }
 

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -88,7 +88,8 @@ mca_pml_base_module_t mca_pml = {
     NULL,                    /* pml_dump */
     0,                       /* pml_max_contextid */
     0,                       /* pml_max_tag */
-    0                        /* pml_flags */
+    0,                       /* pml_flags */
+    NULL                     /* pml_get_transports */
 };
 
 mca_pml_base_component_t mca_pml_base_selected_component = {{0}};

--- a/ompi/mca/pml/pml.h
+++ b/ompi/mca/pml/pml.h
@@ -99,6 +99,29 @@ typedef struct mca_pml_base_module_2_1_0_t * (*mca_pml_base_component_init_fn_t)
     bool enable_progress_threads,
     bool enable_mpi_threads);
 
+/**
+ * @brief A transport name and device name pair used by an endpoint.
+ * @ref mca_pml.pml_get_transports
+ */
+typedef struct mca_pml_transport_entry_t {
+    // The name of a transport layer used by this endpoint.
+    const char *transport_name;
+    // The name of the device used with this transport by this endpoint.
+    const char *device_name;
+} mca_pml_transport_entry_t;
+
+/**
+ * @brief  Structure containing an array of transport layers and device names
+ * used by a PML.
+ * @ref mca_pml.pml_get_transports
+ */
+typedef struct mca_pml_transports_t {
+    // Number of transport/device name pairs.
+    unsigned int count;
+    // Pointer to array of transport/device name pairs used by this endpoint.
+    mca_pml_transport_entry_t *entries;
+} mca_pml_transports_t;
+
 typedef int (*mca_pml_base_component_finalize_fn_t)(void);
 
 /**
@@ -167,6 +190,16 @@ typedef int (*mca_pml_base_module_enable_fn_t)(
  *                   to progress.
 */
 typedef int (*mca_pml_base_module_progress_fn_t)(void);
+
+/**
+ * Get the set of transports and devices used to communicate with specified rank
+ *
+ * @param comm Communicator
+ * @param rank Task rank of other task
+ * @return Pointer to structure containing set of transports and device names or NULL
+ */
+typedef mca_pml_transports_t *(*mca_pml_base_module_get_transports_t)(struct ompi_communicator_t *comm,
+                                                                      int rank);
 
 /**
  * MPI Interface Functions
@@ -533,6 +566,8 @@ struct mca_pml_base_module_2_1_0_t {
     uint32_t                              pml_max_contextid;
     int                                   pml_max_tag;
     int                                   pml_flags;
+
+    mca_pml_base_module_get_transports_t pml_get_transports;
 };
 typedef struct mca_pml_base_module_2_1_0_t mca_pml_base_module_2_1_0_t;
 typedef mca_pml_base_module_2_1_0_t mca_pml_base_module_t;


### PR DESCRIPTION
Implement reporting of UCX transport/device name pairs used between pairs of MPI application tasks.

The report is enabled by using the --mca hook_comm_method_display 1 option to generate a report when MPI_Init completes and by using the --mca hook_comm_method_display 2 option to generate a report at entry to MPI_Finalize.

This is a cherry pick of #10397 from the OMPI main branch

Signed-off-by: David Wootton [dwootton@us.ibm.com](mailto:dwootton@us.ibm.com)