### PR TITLE
Fix SIGSEGV due to null pointer in prot_hook_comm_method_fns.c(comm_method_string)

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -144,13 +144,13 @@ comm_method_string(MPI_Comm comm, int rank, int *comm_mode) {
             strcat(string, ";");
             strcat(string, transports->entries[i].device_name);
         }
+        free(transports->entries);
+        free(transports);
     }
     if (comm_mode) {
         // UCX is used for PML mode only
         *comm_mode = MODE_IS_PML;
     }
-    free(transports->entries);
-    free(transports);
     return string;
 }
 


### PR DESCRIPTION
Fix a SIGSEGV that occurs if a call to the function pointed to by mca_pml.pml_get_transports returns NULL, either because UCX has no transport information, or UCX is not being used.

Signed-off-by: David Wootton <dwootton@us.ibm.com>