### PR TITLE
v5.0.x: Initial fix for partcomm initialization.

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -43,6 +43,7 @@
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/mca/osc/base/base.h"
+#include "ompi/mca/part/base/base.h"
 #include "ompi/mca/io/base/base.h"
 #include "ompi/mca/topo/base/base.h"
 #include "opal/mca/pmix/base/base.h"
@@ -624,6 +625,15 @@ static int ompi_mpi_instance_init_common (void)
     /* initialize windows */
     if (OMPI_SUCCESS != (ret = ompi_win_init ())) {
         return ompi_instance_print_error ("ompi_win_init() failed", ret);
+    }
+
+    /* initialize partcomm */
+    if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_part_base_framework, 0))) {
+        return ompi_instance_print_error ("mca_part_base_select() failed", ret);
+    }
+
+    if (OMPI_SUCCESS != (ret = mca_part_base_select (true, true))) {
+        return ompi_instance_print_error ("mca_part_base_select() failed", ret);
     }
 
     /* Setup the dynamic process management (DPM) subsystem */


### PR DESCRIPTION
Signed-off-by: Matthew G. F. Dosanjh <mdosanj@sandia.gov>
(cherry picked from commit b9e5d87ff7837710bbfde0afc82737042f2b9859)

Refs: https://github.com/open-mpi/ompi/issues/10390