### PR TITLE
v5.0.x: The matching lock should be acquired only once.

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -648,12 +648,12 @@ int mca_pml_ob1_merge_cant_match( ompi_communicator_t * ompi_comm )
     mca_pml_ob1_comm_proc_t* proc;
     int cnt = 0;
 
+    OB1_MATCHING_LOCK(&pml_comm->matching_lock);
     for (uint32_t i = 0; i < pml_comm->num_procs; i++) {
         if ((NULL == (proc = pml_comm->procs[i])) || (NULL != proc->frags_cant_match)) {
             continue;
         }
 
-        OB1_MATCHING_LOCK(&pml_comm->matching_lock);
         /* Acquire all cant_match frags from the peer */
         frags_cant_match = proc->frags_cant_match;
         proc->frags_cant_match = NULL;


### PR DESCRIPTION
The lock will then be released in mca_pml_ob1_recv_frag_match_proc
and reaquired in the while loop.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 77c3a193b94284ddbc3c3b860ce1f232c77e4c6d)