### PR TITLE
coll/HAN: Don't DQ HAN dynamic @ intra-node subcomm + typo fixes

### DIFF
--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -110,7 +110,7 @@ mca_coll_han_allreduce_intra(const void *sbuf,
         /* HAN cannot work with this communicator so fallback on all collectives */
         HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_allreduce(sbuf, rbuf, count, dtype, op,
-                                            comm, comm->c_coll->coll_reduce_module);
+                                            comm, comm->c_coll->coll_allreduce_module);
     }
 
     ptrdiff_t extent, lb;
@@ -444,7 +444,7 @@ mca_coll_han_allreduce_intra_simple(const void *sbuf,
         /* HAN cannot work with this communicator so fallback on all collectives */
         HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_allreduce(sbuf, rbuf, count, dtype, op,
-                                            comm, comm->c_coll->coll_reduce_module);
+                                            comm, comm->c_coll->coll_allreduce_module);
     }
 
     low_comm = han_module->sub_comm[INTRA_NODE];


### PR DESCRIPTION
HAN disables itself when running in a single node, but that shouldn't include the subcommunicator created by HAN-dynamic.
See also #10438.

Tested on v5.0.x
Signed-off-by: George Katevenis <gkatev@ics.forth.gr>