### PR TITLE
Errorhandler: don't fallback to COMM_WORLD, pass NULL instead

### DIFF
--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -200,9 +200,9 @@ int ompi_errhandler_request_invoke(int count,
         break;
     default:
         /* Covers REQUEST_GEN, REQUEST_NULL, REQUEST_MAX */
-        return ompi_errhandler_invoke(MPI_COMM_WORLD->error_handler,
-                                      MPI_COMM_WORLD,
-                                      MPI_COMM_WORLD->errhandler_type,
+        return ompi_errhandler_invoke(NULL,
+                                      NULL,
+                                      0,
                                       ec, message);
         break;
     }


### PR DESCRIPTION
MPI 4.0, page 27 says

> some errors may not have a communicator, window, or file on which
> an error may be raised. In such cases,
> these errors will be raised on the communicator `MPI_COMM_SELF` when
> using the World Model (see Section 11.2) [...]

By passing `NULL` (instead of `MPI_COMM_WORLD`) to `ompi_errhandler_invoke`
we trigger the right selection of the object to invoke the error on.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>