### PR TITLE
opal: Segfault avoidence in class and mca/btl/ofi

### DIFF
--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -468,7 +468,7 @@ static inline void opal_obj_run_destructors(opal_object_t *object)
     assert(NULL != object->obj_class);
 
     cls_destruct = object->obj_class->cls_destruct_array;
-    while (NULL != *cls_destruct) {
+    while (NULL != cls_destruct) {
         (*cls_destruct)(object);
         cls_destruct++;
     }

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -625,8 +625,10 @@ fail:
 
     /* if the contexts have not been initiated, num_contexts should
      * be zero and we skip this. */
-    for (int i = 0; i < module->num_contexts; i++) {
-        mca_btl_ofi_context_finalize(&module->contexts[i], module->is_scalable_ep);
+    if (NULL != module->contexts) {
+        for (int i = 0; i < module->num_contexts; i++) {
+            mca_btl_ofi_context_finalize(&module->contexts[i], module->is_scalable_ep);
+        }
     }
     free(module->contexts);
 


### PR DESCRIPTION
Fixed a loop causing segfaults in opal_object.h and fixed goto fail
block to check for NULL before potential dereference as we go there
for NULL in what we dereference

Signed-off-by: Josh Fisher <josh.fisher@cornelisnetworks.com>