### PR TITLE
(s)coll/ucc: don't force cls by default

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -49,7 +49,7 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
     0,                 /* ucc_verbose                 */
     0,                 /* ucc_enable                  */
     2,                 /* ucc_np                      */
-    "basic",           /* cls                         */
+    "",                /* cls                         */
     COLL_UCC_CTS_STR,  /* requested coll_types string */
     UCC_VERSION_STRING /* ucc version                 */
 };

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -234,10 +234,12 @@ static int mca_coll_ucc_init_ctx() {
         UCC_ERROR("UCC lib config read failed");
         return OMPI_ERROR;
     }
-    if (UCC_OK != ucc_lib_config_modify(lib_config, "CLS", cm->cls)) {
-        ucc_lib_config_release(lib_config);
-        UCC_ERROR("failed to modify UCC lib config to set CLS");
-        return OMPI_ERROR;
+    if (strlen(cm->cls) > 0) {
+        if (UCC_OK != ucc_lib_config_modify(lib_config, "CLS", cm->cls)) {
+            ucc_lib_config_release(lib_config);
+            UCC_ERROR("failed to modify UCC lib config to set CLS");
+            return OMPI_ERROR;
+        }
     }
 
     if (UCC_OK != ucc_init(&lib_params, lib_config, &cm->ucc_lib)) {

--- a/oshmem/mca/scoll/ucc/scoll_ucc_component.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_component.c
@@ -60,7 +60,7 @@ mca_scoll_ucc_component_t mca_scoll_ucc_component = {
     0,                  /* verbose level */
     0,                  /* ucc_enable */
     2,                  /* ucc_np */
-    "basic",            /* cls */
+    "",                 /* cls */
     SCOLL_UCC_CTS_STR,  /* cts */
     0,                  /* nr_modules */
     false,              /* libucc_initialized */

--- a/oshmem/mca/scoll/ucc/scoll_ucc_module.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_module.c
@@ -217,13 +217,13 @@ static int mca_scoll_ucc_init(oshmem_group_t *osh_group)
         UCC_ERROR("UCC lib config read failed");
         return OSHMEM_ERROR;
     }
-
-    if (UCC_OK != ucc_lib_config_modify(lib_config, "CLS", cm->cls)) {
-        ucc_lib_config_release(lib_config);
-        UCC_ERROR("failed to modify UCC lib config to set CLS");
-        return OSHMEM_ERROR;
+    if (strlen(cm->cls) > 0) {
+        if (UCC_OK != ucc_lib_config_modify(lib_config, "CLS", cm->cls)) {
+            ucc_lib_config_release(lib_config);
+            UCC_ERROR("failed to modify UCC lib config to set CLS");
+            return OSHMEM_ERROR;
+        }
     }
-
     if (UCC_OK != ucc_init(&lib_params, lib_config, &cm->ucc_lib)) {
         UCC_ERROR("UCC lib init failed");
         ucc_lib_config_release(lib_config);


### PR DESCRIPTION
By default neither COLL/UCC nor SCOLL/UCC should modify CLS of a lib explicitly. They should rather rely on the env vars unless explicitly required by user. 
W/o this change UCC_CLS has no effect since the lib setting is overwritten by ucc_lib_config_modify directly.