### PR TITLE
Removed deadlock in find dynamic region

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -468,12 +468,9 @@ int ompi_osc_rdma_find_dynamic_region (ompi_osc_rdma_module_t *module, ompi_osc_
                      " (len %lu)", base, base + len, (unsigned long) len);
 
     OPAL_THREAD_LOCK(&module->lock);
-    // Make sure region isn't being touched.
-    ompi_osc_rdma_lock_acquire_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
     if (!ompi_osc_rdma_peer_local_state (peer)) {
         ret = ompi_osc_rdma_refresh_dynamic_region (module, dy_peer);
         if (OMPI_SUCCESS != ret) {
-            ompi_osc_rdma_lock_release_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
             return ret;
         }
 
@@ -490,7 +487,6 @@ int ompi_osc_rdma_find_dynamic_region (ompi_osc_rdma_module_t *module, ompi_osc_
         ret = OMPI_ERR_RMA_RANGE;
     }
     OPAL_THREAD_UNLOCK(&module->lock);
-    ompi_osc_rdma_lock_release_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
 
     /* round a matching region */
     return ret;


### PR DESCRIPTION
Fixing the PR https://github.com/open-mpi/ompi/pull/10413

This is my solution to issue https://github.com/open-mpi/ompi/issues/10328. The problem with this code is that inside of `ompi_osc_rdma_refresh_dynamic_region` there is a `ompi_osc_rdma_lock_acquire_shared` to the same lock used in `ompi_osc_rdma_lock_acquire_exclusive` generation a deadlock. My solution was simply to remove the outermost lock. However, I don't know if this is the better solution, but, with these changes, my test codes ran as I expected.

