### PR TITLE
Fix typos in the docs/ sub-directory

### DIFF
--- a/docs/building-apps/building-static-apps.rst
+++ b/docs/building-apps/building-static-apps.rst
@@ -74,7 +74,7 @@ sub-optimal:
 
    For example, if you launch N copies of your fully-statically-linked
    MPI application on a node, it will consume (N *
-   size_of_the_application) bytes of RAM.  Alternatiely, launching N
+   size_of_the_application) bytes of RAM.  Alternately, launching N
    copies of a dynamically-linked MPI application |mdash| where each
    of the copies have the same dependent libraries |mdash| will only
    load each shared dependent library into RAM once.
@@ -157,7 +157,7 @@ libraries that require additional steps to produce working
 fully-static MPI applications.  For example, any library that has its
 own run-time plugin system (i.e., that opens dynamically shared
 objects ("DSOs") at run time) will have additional complications in
-producting fully-static builds.
+producing fully-static builds.
 
 In such cases, you generally want to run ``mpicc ... --showme`` to see
 the compiler / linker commands that Open MPI's wrapper commands will

--- a/docs/faq/debugging.rst
+++ b/docs/faq/debugging.rst
@@ -509,7 +509,7 @@ There are two cases:
    .. We do not make the code block below as "c" because the Sphinx C
       syntax highlighter fails to parse it as C and emits a warning.
       So we might as well just leave it as a plan verbatim block
-      (i.e., not syntax hilighted).
+      (i.e., not syntax highlighted).
 
    .. code-block::
 

--- a/docs/faq/general-tuning.rst
+++ b/docs/faq/general-tuning.rst
@@ -166,7 +166,7 @@ files.  If you need a component to be available to all nodes where you
 run MPI jobs, then you need to ensure that it is visible on all nodes
 (typically either by installing it on all nodes for non-networked
 filesystem installs, or by installing them in a directory that is
-visibile to all nodes via a networked filesystem).  Open MPI does not
+visible to all nodes via a networked filesystem).  Open MPI does not
 automatically send components to remote nodes when MPI jobs are run.
 
 /////////////////////////////////////////////////////////////////////////
@@ -588,7 +588,7 @@ allocated.
 How do I tell Open MPI to use processor and/or memory affinity?
 ---------------------------------------------------------------
 
-Open MPI will, by default, enable processor and memory affinty when
+Open MPI will, by default, enable processor and memory affinity when
 not running in an oversubscribed environment (i.e., when the number of
 MPI processes are less than or equal two the number of processors
 available).

--- a/docs/faq/running-mpi-apps.rst
+++ b/docs/faq/running-mpi-apps.rst
@@ -1312,8 +1312,8 @@ not 4), and can cause extremely bad performance.
 
 /////////////////////////////////////////////////////////////////////////
 
-Can I force Agressive or Degraded performance modes?
-----------------------------------------------------
+Can I force Aggressive or Degraded performance modes?
+-----------------------------------------------------
 
 Yes.
 

--- a/docs/faq/troubleshooting.rst
+++ b/docs/faq/troubleshooting.rst
@@ -61,7 +61,7 @@ why this can happen.
     linker is smart enough to not load ``libmpi`` twice |mdash| but it
     does keeps ``libmpi`` in a public scope.
   * Use the ``--disable-dlopen`` or ``--disable-mca-dso`` options to
-    Open MPI's ``configure`` script (see this TODO NONEXISTANT FAQ entry
+    Open MPI's ``configure`` script (see this TODO NONEXISTENT FAQ entry
     for more details on these
     options).  These options slurp all of Open MPI's plugins up in to
     ``libmpi`` |mdash| meaning that the plugins physically reside in

--- a/docs/features/extensions.rst
+++ b/docs/features/extensions.rst
@@ -15,8 +15,8 @@ to MPI applications.
    provide new functionality to users, typically before it becomes
    standardized by the MPI Forum.
 
-Available extenions
--------------------
+Available extensions
+--------------------
 
 The following extensions are included in this version of Open MPI:
 

--- a/docs/features/ulfm.rst
+++ b/docs/features/ulfm.rst
@@ -110,7 +110,7 @@ is definitely built.
 Support notes
 ^^^^^^^^^^^^^
 
-* ULFM Fault Tolerance does not apply to OpenSHMEM.  It is recomended
+* ULFM Fault Tolerance does not apply to OpenSHMEM.  It is recommended
   that if you are going to use ULFM, you should disable building
   OpenSHMEM with ``--disable-oshmem``.
 
@@ -139,7 +139,7 @@ All runtime disabled components are listed in the ``ft-mpi`` aggregate
 MCA param file
 ``$installdir/share/openmpi/amca-param-sets/ft-mpi``. You can tune the
 runtime behavior with ULFM by either setting or unsetting variables in
-this file (or by overiding the variable on the command line (e.g.,
+this file (or by overriding the variable on the command line (e.g.,
 ``--mca btl ofi,self``). Note that if fault tolerance is disabled at
 runtime, these components will load normally (this may change observed
 performance when comparing with and without fault tolerance).
@@ -305,7 +305,7 @@ Known Limitations in ULFM
 * InfiniBand support is provided through the UCT BTL; fault tolerant
   operation over the UCX PML is not yet supported for production runs.
 * TOPO, FILE, RMA are not fault tolerant. They are expected to work
-  properly before the occurence of the first failure.
+  properly before the occurrence of the first failure.
 
 Changelog
 ---------
@@ -460,7 +460,7 @@ ULFM Standalone Release 1.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Focus has been toward improving performance, both before and after the
-occurence of failures.  The list of new features includes:
+occurrence of failures.  The list of new features includes:
 
 * Support for the non-blocking version of the agreement, MPI_COMM_IAGREE.
 * Compliance with the latest ULFM specification draft. In particular,

--- a/docs/getting-help.rst
+++ b/docs/getting-help.rst
@@ -58,7 +58,7 @@ places.  If you have:
    .. important:: Please **use a descriptive "subject" line in your
       email!** Some Open MPI question-answering people decide whether
       to read a mail based on its subject line (e.g., to see if it's a
-      question that they can answer).  So please plese please use a
+      question that they can answer).  So please please please use a
       good subject line that succinctly describes your problem.
 
 #. **A bug report:** you should probably post it to `Open MPI's Github
@@ -89,7 +89,7 @@ Please provide *all* of the following information:
    are not helpful; we need to know as much information about your
    environment as possible in order to provide meaningful assistance.
 
-   **The best way to get help** is to provide a "recipie" for
+   **The best way to get help** is to provide a "recipe" for
    reproducing the problem.  This will allow the Open MPI developers
    to see the error for themselves, and therefore be able to fix it.
 
@@ -191,8 +191,8 @@ Please provide *all* of the following information:
    are not helpful; we need to know as much information about your
    environment as possible in order to provide meaningful assistance.
 
-   **The best way to get help** is to provide a "recipie" for
-   reproducing the problaem.  This will allow the Open MPI developers
+   **The best way to get help** is to provide a "recipe" for
+   reproducing the problem.  This will allow the Open MPI developers
    to see the error for themselves, and therefore be able to fix it.
 
 #. The version of Open MPI that you're using.

--- a/docs/installing-open-mpi/installation-location.rst
+++ b/docs/installing-open-mpi/installation-location.rst
@@ -158,7 +158,7 @@ upgrading your Open MPI installation:
 Relocating an Open MPI installation
 -----------------------------------
 
-It can be desireable to initially install Open MPI to one location
+It can be desirable to initially install Open MPI to one location
 (e.g., ``/path/to/openmpi``) and then later move it to another
 location (e.g., ``/opt/myproduct/bundled-openmpi-a.b.c``).
 

--- a/docs/installing-open-mpi/quickstart.rst
+++ b/docs/installing-open-mpi/quickstart.rst
@@ -55,5 +55,5 @@ The above patterns can be used in many environments.
 
 Note that there are many, many configuration options available in the
 ``./configure`` step.  Some of them may be needed for your particular
-HPC network interconnect type and/or computing environmnet; see the
-rest of this chapter for desciptions of the available options.
+HPC network interconnect type and/or computing environment; see the
+rest of this chapter for descriptions of the available options.

--- a/docs/installing-open-mpi/required-support-libraries.rst
+++ b/docs/installing-open-mpi/required-support-libraries.rst
@@ -61,7 +61,7 @@ At run time, it is critical that the run-time linker loads *exactly
 one copy* of each of these libraries.
 
 .. note:: The required support libraries can have other dependencies,
-          but for simplicitly and relevance to building Open MPI,
+          but for simplicity and relevance to building Open MPI,
           those other dependencies are not discussed here.
 
 Potential problems
@@ -218,7 +218,7 @@ versions of the required libraries.
    default search behavior for these libraries.  Remember the critical
    requirement: that Open MPI infrastructure and applications load
    *exactly one copy* of each support library.  For simplicity, it may
-   be desireable to ensure to use exactly the support libraries that
+   be desirable to ensure to use exactly the support libraries that
    Open MPI was compiled and built against.
 
    For example, using the Open MPI installed from the sample

--- a/docs/man-openmpi/man1/mpirun.1.rst
+++ b/docs/man-openmpi/man1/mpirun.1.rst
@@ -230,7 +230,7 @@ behavior in prior releases where daemons were only launched after
 mapping was complete, and thus only occurred on nodes where
 application processes would actually be executing.
 
-* ``-H``, ``--host <host1,host2,...,hostN>``: ist of hosts on which to
+* ``-H``, ``--host <host1,host2,...,hostN>``: list of hosts on which to
   invoke processes.
 
 * ``--hostfile <hostfile>``: Provide a hostfile to use.
@@ -707,7 +707,7 @@ the specified host ``dd`` is not in the specified hostfile.
 
 When running under resource managers (e.g., SLURM, Torque, etc.), Open
 MPI will obtain both the hostnames and the number of slots directly
-from the resource manger.
+from the resource manager.
 
 Specifying Number of Processes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1494,7 +1494,7 @@ desire to be able to enable root execution of ``mpirun`` via an
 environmental control (vs. the existing ``--allow-run-as-root``
 command line parameter).  The compromise of using two environment
 variables was reached: it allows root execution via an environmental
-control, but it conveys the Open MPI team's strong recomendation
+control, but it conveys the Open MPI team's strong recommendation
 against this behavior.
 
 Exit status
@@ -1535,7 +1535,7 @@ non-zero status. The MCA parameter ``orte_abort_on_non_zero_status``
 can be set to "false" (or "0") to cause Open MPI to not abort a job if
 one or more processes return a non-zero status. In that situation the
 Open MPI records and notes that processes exited with non-zero
-termination status to report the approprate exit status of ``mpirun`` (per
+termination status to report the appropriate exit status of ``mpirun`` (per
 bullet points above).
 
 .. error:: TODO The ``orte_abort...`` name above is definitely wrong for

--- a/docs/man-openmpi/man1/ompi-wrapper-compiler.1.rst
+++ b/docs/man-openmpi/man1/ompi-wrapper-compiler.1.rst
@@ -110,7 +110,7 @@ Open MPI provides wrapper compilers for several languages:
 
 * ``mpicc``: C
 
-* ``mpic++``, ``mpicxx`` (and on systems with case-senstive file
+* ``mpic++``, ``mpicxx`` (and on systems with case-sensitive file
   systems, ``mpiCC``): C++
 
   .. note:: ``mpic++``, ``mpicxx``, and ``mpiCC`` all invoke the same
@@ -123,7 +123,7 @@ Open MPI provides wrapper compilers for several languages:
 * ``mpijavac``: Java
 
 The wrapper compilers for each of the languages are identical; they
-can be use interchangably.  The different names are provided solely
+can be use interchangeably.  The different names are provided solely
 for backwards compatibility.
 
 

--- a/docs/man-openmpi/man1/ompi_info.1.rst
+++ b/docs/man-openmpi/man1/ompi_info.1.rst
@@ -100,7 +100,7 @@ LEVELS
 ------
 
 Open MPI has many, many run-time tunable parameters (called "MCA
-parameters"), and usually only a handfull of them are useful to a given
+parameters"), and usually only a handful of them are useful to a given
 user.
 
 As such, Open MPI has divided these parameters up into nine distinct

--- a/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
@@ -64,7 +64,7 @@ Output Parameters
 Description
 -----------
 
-:ref:`MPI_Cart_coords` provies a mapping of ``rank``\ s to Cartesian
+:ref:`MPI_Cart_coords` provides a mapping of ``rank``\ s to Cartesian
 coordinates.
 
 Errors

--- a/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
@@ -66,7 +66,7 @@ DESCRIPTION
 -----------
 
 This function partitions the group associated with *comm* into disjoint
-subgroups, based on the type specied by *split_type*. Each subgroup
+subgroups, based on the type specified by *split_type*. Each subgroup
 contains all processes of the same type. Within each subgroup, the
 processes are ranked in the order defined by the value of the argument
 *key*, with ties broken according to their rank in the old group. A new

--- a/docs/man-openmpi/man3/MPI_Dist_graph_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_create.3.rst
@@ -77,13 +77,13 @@ DESCRIPTION
 -----------
 
 :ref:`MPI_Dist_graph_create` creates a new communicator *comm_dist_graph* with
-distrubuted graph topology and returns a handle to the new communicator.
+distributed graph topology and returns a handle to the new communicator.
 The number of processes in *comm_dist_graph* is identical to the number
 of processes in *comm_old*. Concretely, each process calls the
 constructor with a set of directed (source,destination) communication
 edges as described below. Every process passes an array of *n* source
 nodes in the *sources* array. For each source node, a non-negative
-number of destination nodes is specied in the *degrees* array. The
+number of destination nodes is specified in the *degrees* array. The
 destination nodes are stored in the corresponding consecutive segment of
 the *destinations* array. More precisely, if the i-th node in sources is
 s, this specifies *degrees*\ [i] *edges* (s,d) with d of the j-th such
@@ -100,7 +100,7 @@ numbers of source and destination nodes, as well as different source to
 destination edges. This allows a fully distributed specification of the
 communication graph. Isolated processes (i.e., processes with no
 outgoing or incoming edges, that is, processes that do not occur as
-source or destination node in the graph specication) are allowed. The
+source or destination node in the graph specification) are allowed. The
 call to :ref:`MPI_Dist_graph_create` is collective.
 
 If reorder = false, all processes will have the same rank in
@@ -114,13 +114,13 @@ or intensity of communication on that edge, and may be used to compute a
 WEIGHTS
 -------
 
-Weights are specied as non-negative integers and can be used to
+Weights are specified as non-negative integers and can be used to
 influence the process remapping strategy and other internal MPI
 optimizations. For instance, approximate count arguments of later
-communication calls along specic edges could be used as their edge
+communication calls along specific edges could be used as their edge
 weights. Multiplicity of edges can likewise indicate more intense
 communication between pairs of processes. However, the exact meaning of
-edge weights is not specied by the MPI standard and is left to the
+edge weights is not specified by the MPI standard and is left to the
 implementation. An application can supply the special value
 MPI_UNWEIGHTED for the weight array to indicate that all edges have the
 same (effectively no) weight. It is erroneous to supply MPI_UNWEIGHTED

--- a/docs/man-openmpi/man3/MPI_Dist_graph_create_adjacent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_create_adjacent.3.rst
@@ -78,8 +78,8 @@ OUTPUT PARAMETERS
 DESCRIPTION
 -----------
 
-:ref:`MPI_Dist_graph_create_adjacent` creats a new communicator
-*comm_dist_graph* with distrubuted graph topology and returns a handle
+:ref:`MPI_Dist_graph_create_adjacent` creates a new communicator
+*comm_dist_graph* with distributed graph topology and returns a handle
 to the new communicator. The number of processes in *comm_dist_graph* is
 identical to the number of processes in *comm_old*. Each process passes
 all information about its incoming and outgoing edges in the virtual
@@ -91,24 +91,24 @@ not matter. The complete communication topology is the combination of
 all edges shown in the *sources* arrays of all processes in comm_old,
 which must be identical to the combination of all edges shown in the
 *destinations* arrays. Source and destination ranks must be process
-ranks of comm_old. This allows a fully distributed specication of the
+ranks of comm_old. This allows a fully distributed specification of the
 communication graph. Isolated processes (i.e., processes with no
-outgoing or incoming edges, that is, processes that have specied
+outgoing or incoming edges, that is, processes that have specified
 indegree and outdegree as zero and thus do not occur as source or
-destination rank in the graph specication) are allowed. The call to
+destination rank in the graph specification) are allowed. The call to
 :ref:`MPI_Dist_graph_create_adjacent` is collective.
 
 
 WEIGHTS
 -------
 
-Weights are specied as non-negative integers and can be used to
+Weights are specified as non-negative integers and can be used to
 influence the process remapping strategy and other internal MPI
 optimizations. For instance, approximate count arguments of later
-communication calls along specic edges could be used as their edge
+communication calls along specific edges could be used as their edge
 weights. Multiplicity of edges can likewise indicate more intense
 communication between pairs of processes. However, the exact meaning of
-edge weights is not specied by the MPI standard and is left to the
+edge weights is not specified by the MPI standard and is left to the
 implementation. An application can supply the special value
 MPI_UNWEIGHTED for the weight array to indicate that all edges have the
 same (effectively no) weight. It is erroneous to supply MPI_UNWEIGHTED

--- a/docs/man-openmpi/man3/MPI_Recv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Recv.3.rst
@@ -111,7 +111,7 @@ receive operation. The receive operation may specify a wildcard value
 for source and/or tag, indicating that any source and/or tag are
 acceptable. The wildcard value for source is source = MPI_ANY_SOURCE.
 The wildcard value for tag is tag = MPI_ANY_TAG. There is no wildcard
-value for comm. The scope of these wildcards is limited to the proceses
+value for comm. The scope of these wildcards is limited to the processes
 in the group of the specified communicator.
 
 The message tag is specified by the tag argument of the receive

--- a/docs/man-openmpi/man3/MPI_Request_get_status.3.rst
+++ b/docs/man-openmpi/man3/MPI_Request_get_status.3.rst
@@ -64,7 +64,7 @@ DESCRIPTION
 :ref:`MPI_Request_get_status` sets *flag*\ =\ *true* if the operation is
 complete or sets *flag*\ =\ *false* if it is not complete. If the
 operation is complete, it returns in *status* the request status. It
-does not deallocate or inactivate the request; a subsequent call to
+does not deallocate or deactivate the request; a subsequent call to
 test, wait, or free should be executed with that request.
 
 If your application does not need to examine the *status* field, you can

--- a/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
@@ -62,7 +62,7 @@ Description
 
 :ref:`MPI_Session_get_pset_info` is used to query properties of a specific
 process set. The returned info object can be queried with existing MPI
-info object query functions. One key/value pair must be de ned,
+info object query functions. One key/value pair must be defined,
 "mpi_size". The value of the "mpi_size" key specifies the number of MPI
 processes in the process set.
 

--- a/docs/man-openmpi/man3/MPI_T_cvar_handle_alloc.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_cvar_handle_alloc.3.rst
@@ -7,7 +7,7 @@ MPI_T_cvar_handle_alloc
 .. include_body
 
 :ref:`MPI_T_cvar_handle_alloc`, :ref:`MPI_T_cvar_handle_free` - Allocate/free
-contol variable handles
+control variable handles
 
 
 SYNTAX

--- a/docs/man-openmpi/man3/MPI_T_pvar_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_pvar_get_info.3.rst
@@ -85,7 +85,7 @@ initial value, valid types, and behavior. The class returned in the
   MPI_DOUBLE. The starting value is the current size of the resource.
 
 * ``MPI_T_PVAR_CLASS_PERCENTAGE``: Variable represents the current
-  precentage utilization level of a resource. Variables of this class
+  percentage utilization level of a resource. Variables of this class
   are represented by an MPI_DOUBLE.  The starting value is the current
   percentage utilization of the resource.
 

--- a/docs/man-openmpi/man3/MPI_T_pvar_get_num.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_pvar_get_num.3.rst
@@ -32,7 +32,7 @@ DESCRIPTION
 
 :ref:`MPI_T_pvar_get_num` can be used to query the current number of
 performance variables. The number of performance variables may increase
-throughout the exection of the process but will never decrease.
+throughout the execution of the process but will never decrease.
 
 
 ERRORS

--- a/docs/man-openshmem/man1/oshmem-wrapper-compiler.1.rst
+++ b/docs/man-openshmem/man1/oshmem-wrapper-compiler.1.rst
@@ -113,7 +113,7 @@ Open MPI provides wrapper compilers for several languages:
 * ``oshfort``, ``shmemfort``: Fortran
 
 The wrapper compilers for each of the languages are identical; they
-can be use interchangably.  The different names are provided solely
+can be use interchangeably.  The different names are provided solely
 for backwards compatibility.
 
 

--- a/docs/man-openshmem/man3/shmalloc.3.rst
+++ b/docs/man-openshmem/man3/shmalloc.3.rst
@@ -80,7 +80,7 @@ NOTES
 
 The total size of the symmetric heap is determined at job startup. One
 can adjust the size of the heap using the SHMEM_SYMMETRIC_HEAP_SIZE
-environment variable. See the *intro_shmem*\ (3) man page for futher
+environment variable. See the *intro_shmem*\ (3) man page for further
 details. The shmalloc, shfree, and shrealloc functions differ from the
 private heap allocation functions in that all PEs in an application must
 call them (a barrier is used to ensure this).

--- a/docs/man-openshmem/man3/shmem_malloc.3.rst
+++ b/docs/man-openshmem/man3/shmem_malloc.3.rst
@@ -85,7 +85,7 @@ NOTES
 
 The total size of the symmetric heap is determined at job startup. One
 can adjust the size of the heap using the SHMEM_SYMMETRIC_HEAP_SIZE
-environment variable. See the *intro_shmem*\ (3) man page for futher
+environment variable. See the *intro_shmem*\ (3) man page for further
 details. The :ref:`shmem_malloc`, :ref:`shmem_free`, and :ref:`shmem_realloc` functions
 differ from the private heap allocation functions in that all PEs in an
 application must call them (a barrier is used to ensure this).

--- a/docs/man-openshmem/man3/shmem_udcflush.3.rst
+++ b/docs/man-openshmem/man3/shmem_udcflush.3.rst
@@ -76,7 +76,7 @@ with the address specified by target.
 NOTES
 -----
 
-These routines have been retained for improved backward compatability
+These routines have been retained for improved backward compatibility
 with legacy architectures.
 
 

--- a/docs/networking/cuda.rst
+++ b/docs/networking/cuda.rst
@@ -43,7 +43,7 @@ Open MPI offers two flavors of CUDA support:
 #. Via internal Open MPI CUDA support
 
 Regardless of which flavor of CUDA support (or both) you plan to use,
-Open MPI should be conigured using the ``--with-cuda=<path-to-cuda>``
+Open MPI should be configured using the ``--with-cuda=<path-to-cuda>``
 configure option to build CUDA support into Open MPI.
 
 This affects the smcuda shared memory btl, as well as the uct btl.

--- a/docs/networking/iwarp.rst
+++ b/docs/networking/iwarp.rst
@@ -16,7 +16,7 @@ supported via the OFI (``ofi``) MTL via the CM (``cm``) PML.
 Specifically, iWARP support is provides through the ``rxm`` provider
 of the OpenFabrics Interfaces library ``libfabric``.  There is
 software emulation involved in the MPI support of iWARP devices (and
-therefore at least some level of performance degredation), but the
+therefore at least some level of performance degradation), but the
 current iWARP vendors have chosen not to provide a higher-performance
 option.
 

--- a/docs/networking/tcp.rst
+++ b/docs/networking/tcp.rst
@@ -144,7 +144,7 @@ mailing list:
 
 #. **Connection reset by peer:** These types of errors *usually* occur
    after ``MPI_INIT`` has completed, and typically indicate that an
-   MPI process has died unexpectedly (e.g., due to a catastrphic error
+   MPI process has died unexpectedly (e.g., due to a catastrophic error
    such as a segmentation fault).  The specific error message
    indicates that a peer MPI process tried to write to the now-dead
    MPI process and failed.

--- a/docs/release-notes/compilers.rst
+++ b/docs/release-notes/compilers.rst
@@ -11,7 +11,7 @@ Compiler Notes
 
 * 32-bit platforms are only supported with a recent compiler that
   supports C11 atomics. This includes GCC 4.9.x+ (although GCC 6.x or
-  newer is recommened), the Intel compiler suite 16, and clang 3.1.
+  newer is recommended), the Intel compiler suite 16, and clang 3.1.
 
 * Mixing compilers from different vendors when building Open MPI
   (e.g., using the C/C++ compiler from one vendor and the Fortran

--- a/docs/running-apps/localhost.rst
+++ b/docs/running-apps/localhost.rst
@@ -48,7 +48,7 @@ The ``sm`` BTL supports two modes of shared memory communication:
 
    This mechanism is always available.
 
-#. **Sinlge copy:** In this mode, the sender or receiver makes a
+#. **Single copy:** In this mode, the sender or receiver makes a
    single copy of the message data from the source buffer in one
    process to the destination buffer in another process.  Open MPI
    supports three flavors of shared memory single-copy transfers:

--- a/docs/running-apps/slurm.rst
+++ b/docs/running-apps/slurm.rst
@@ -23,7 +23,7 @@ controlling the individual MPI processes.
 Hence, it is unnecessary to specify the ``--hostfile``,
 ``--host``, or ``-n`` options to ``mpirun``.
 
-.. note:: Using ``mpirun`` is the recomended method for launching Open
+.. note:: Using ``mpirun`` is the recommended method for launching Open
    MPI jobs in Slurm jobs.
 
    ``mpirun``'s Slurm support should always be available, regardless
@@ -54,7 +54,7 @@ Or, if submitting a script:
    srun: jobid 1235 submitted
    shell$
 
-Similar to the ``salloc`` case, no command line options specifing
+Similar to the ``salloc`` case, no command line options specifying
 number of MPI processes were necessary, since Open MPI will obtain
 that information directly from Slurm at run time.
 
@@ -101,7 +101,7 @@ Or you can use ``sbatch`` with a script:
    shell$
 
 Similar using ``mpirun`` inside of an ``sbatch`` batch script, no
-``srun`` command line options specifing number of processes were
+``srun`` command line options specifying number of processes were
 necessary, because ``sbatch`` set all the relevant Slurm-level
 parameters about number of processes, cores, partition, etc.
 

--- a/docs/running-apps/ssh.rst
+++ b/docs/running-apps/ssh.rst
@@ -30,7 +30,7 @@ Consult instructions and tutorials from around the internet to learn
 how to setup SSH keys.  Try Google search terms like "passwordless
 SSH" or "SSH key authentication".
 
-For simplicity, it may be desireable to configure your SSH keys
+For simplicity, it may be desirable to configure your SSH keys
 without passphrases.  This adds some risk, however (e.g., if your SSH
 keys are compromised).  But it simplifies your SSH setup because you
 will not need to use ``ssh-agent``.  Evaluate the risk level you are
@@ -63,7 +63,7 @@ If, however, Open MPI is installed into a path that is not searched by
 default, you will need to provide assistance so that Open MPI can find
 its executables and libraries.
 
-.. important:: For simplicitly, it is *strongly* recomended that you
+.. important:: For simplicity, it is *strongly* recommended that you
    install Open MPI in the same location on all nodes in your job.
    See the :doc:`Installation location section
    </installing-open-mpi/installation-location>` for more details.


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rd-party,./docs/news -L ans,chello,configury,inout,scoll`