### PR TITLE
OSC UCX: Enable software atomicity when lock is set to MPI_MODE_NOCHECK

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_passive_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_passive_target.c
@@ -124,6 +124,11 @@ int ompi_osc_ucx_lock(int lock_type, int target, int mpi_assert, struct ompi_win
         }
     } else {
         lock->is_nocheck = true;
+        if (lock_type == MPI_LOCK_EXCLUSIVE) {
+            lock->type = LOCK_EXCLUSIVE;
+        } else {
+            lock->type = LOCK_SHARED;
+        }
     }
 
     if (ret == OMPI_SUCCESS) {


### PR DESCRIPTION
OSC UCX: Enable software atomicity when lock is set to MPI_MODE_NOCHECK


Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>