### PR TITLE
sessions: remove sessions attr del function def

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -513,7 +513,6 @@ typedef int (MPI_Type_delete_attr_function)(MPI_Datatype, int,
 typedef int (MPI_Win_copy_attr_function)(MPI_Win, int, void *,
                                            void *, void *, int *);
 typedef int (MPI_Win_delete_attr_function)(MPI_Win, int, void *, void *);
-typedef int (MPI_Session_delete_attr_function)(MPI_Session, int, void *, void *);
 typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_cancel_function)(void *, int);


### PR DESCRIPTION
The sessions attribute functionality was never approved as part of the MPI-4 sessions feature.
Remove a vestige of this from Open MPI.

Related to #10388
Related to #9097

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit c488c607557fe9e49000583a478f8b1341232326)