### PR TITLE
v4.1.x: opal: Segfault avoidance in mca/btl/ofi

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -675,8 +675,10 @@ fail:
 
     /* if the contexts have not been initiated, num_contexts should
      * be zero and we skip this. */
-    for (int i=0; i < module->num_contexts; i++) {
-        mca_btl_ofi_context_finalize(&module->contexts[i], module->is_scalable_ep);
+    if (NULL != module->contexts) {
+        for (int i = 0; i < module->num_contexts; i++) {
+            mca_btl_ofi_context_finalize(&module->contexts[i], module->is_scalable_ep);
+        }
     }
     free(module->contexts);
 

--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -326,7 +326,9 @@ void mca_btl_ofi_context_finalize(mca_btl_ofi_context_t *context, bool scalable_
     }
 
     /* Can we destruct the object that hasn't been constructed? */
-    OBJ_DESTRUCT(&context->rdma_comp_list);
+    if (context->rdma_comp_list.fl_num_allocated != 0){
+        OBJ_DESTRUCT(&context->rdma_comp_list);
+    }
 
     if (TWO_SIDED_ENABLED) {
         OBJ_DESTRUCT(&context->frag_comp_list);


### PR DESCRIPTION
Added a check before destructing rdma_comp_list and fixed goto fail
block to check for NULL before potential dereference as we go there
for NULL in what we dereference

Signed-off-by: Josh Fisher <josh.fisher@cornelisnetworks.com>
(cherry picked from commit 26d02016b2305b6d0be945fd2b7ef0a8a4b520eb)