### PR TITLE
v5.0.x: Propagate dependency versions to configure and docs.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -19,6 +19,17 @@ major=5
 minor=0
 release=0
 
+# OMPI required dependency versions.
+# List in x.y.z format.
+pmix_min_version=4.1.2
+prte_min_version=2.0.2
+hwloc_min_version=1.11.0
+event_min_version=2.0.21
+automake_min_version=1.13.4
+autoconf_min_version=2.69.0
+libtool_min_version=2.4.2
+flex_min_version=2.5.4
+
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
 # have to be numeric.  Common examples include: a1 (alpha release 1),

--- a/autogen.pl
+++ b/autogen.pl
@@ -65,9 +65,9 @@ my $include_list;
 my $exclude_list;
 
 # Minimum versions
-my $ompi_automake_version = "1.13.4";
-my $ompi_autoconf_version = "2.69";
-my $ompi_libtool_version = "2.4.2";
+my $ompi_automake_version;
+my $ompi_autoconf_version;
+my $ompi_libtool_version;
 
 # Search paths
 my $ompi_autoconf_search = "autoconf";
@@ -1063,6 +1063,60 @@ sub patch_autotools_output {
     unlink("configure.patched");
 }
 
+sub export_version {
+    my ($name,$version) = @_;
+    $version =~ s/[^a-zA-Z0-9,.]//g;
+    my @version_splits = split(/\./,$version);
+    my $hex = sprintf("0x%04x%02x%02x", $version_splits[0], $version_splits[1], $version_splits[2]);
+    $m4 .= "m4_define([OMPI_${name}_MIN_VERSION], [$version])\n";
+    $m4 .= "m4_define([OMPI_${name}_NUMERIC_MIN_VERSION], [$hex])\n";
+}
+
+sub get_and_define_min_versions() {
+
+    open(IN, "VERSION") || my_die "Can't open VERSION";
+    while (<IN>) {
+          my $line = $_;
+          my @fields = split(/=/,$line);
+          if ($fields[0] eq "automake_min_version") {
+              if ($fields[1] ne "\n") {
+                  $ompi_automake_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "autoconf_min_version") {
+              if ($fields[1] ne "\n") {
+                  $ompi_autoconf_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "libtool_min_version") {
+              if ($fields[1] ne "\n") {
+                  $ompi_libtool_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "pmix_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PMIX", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "prte_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PRTE", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "hwloc_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("HWLOC", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "event_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("EVENT", $fields[1]);
+              }
+          }
+    }
+    close(IN);
+}
+
 sub in_tarball {
     my $tarball = 0;
     open(IN, "VERSION") || my_die "Can't open VERSION";
@@ -1292,6 +1346,8 @@ my $step = 1;
 verbose "Open MPI autogen (buckle up!)
 
 $step. Checking tool versions\n\n";
+
+get_and_define_min_versions();
 
 # Check the autotools revision levels
 &find_and_check("autoconf", $ompi_autoconf_search, $ompi_autoconf_version);

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -18,7 +18,7 @@ dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
-dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -240,7 +240,7 @@ dnl _OMPI_SETUP_PRRTE_EXTERNAL([action if success], [action if not success])
 dnl
 dnl Try to find an external prrte with sufficient version.
 AC_DEFUN([_OMPI_SETUP_PRRTE_EXTERNAL], [
-    OPAL_VAR_SCOPE_PUSH([setup_prrte_external_happy opal_prrte_CPPFLAGS_save])
+    OPAL_VAR_SCOPE_PUSH([ompi_prte_min_version ompi_prte_min_num_version setup_prrte_external_happy opal_prrte_CPPFLAGS_save])
 
     opal_prrte_CPPFLAGS_save=$CPPFLAGS
 
@@ -250,13 +250,15 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_EXTERNAL], [
     AC_CHECK_HEADER([prte.h], [setup_prrte_external_happy=yes],
                     [setup_prrte_external_happy=no])
 
+    ompi_prte_min_version=OMPI_PRTE_MIN_VERSION
+    ompi_prte_min_num_version=OMPI_PRTE_NUMERIC_MIN_VERSION
     AS_IF([test "${setup_prrte_external_happy}" = "yes"],
-          [AC_CACHE_CHECK([if external PRRTE version is 2.0.0 or greater],
+          [AC_CACHE_CHECK([if external PRRTE version is OMPI_PRTE_MIN_VERSION or greater],
               [ompi_setup_prrte_cv_version_happy],
               [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <prte_version.h>
                  ]], [[
-#if PRTE_NUMERIC_VERSION < 0x00020000
-#error "prrte API version is less than 2.0.0"
+#if PRTE_NUMERIC_VERSION < $ompi_prte_min_num_version
+#error "prrte API version is less than $ompi_prte_min_version"
 #endif
                  ]])],
                  [ompi_setup_prrte_cv_version_happy="yes"],

--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2014-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -95,7 +96,7 @@ dnl
 dnl only safe to call from OPAL_CONFIG_HWLOC, assumes variables from
 dnl there are set.
 AC_DEFUN([_OPAL_CONFIG_HWLOC_EXTERNAL], [
-    OPAL_VAR_SCOPE_PUSH([opal_hwloc_CPPFLAGS_save opal_hwloc_LDFLAGS_save opal_hwloc_LIBS_save opal_hwloc_external_support])
+    OPAL_VAR_SCOPE_PUSH([opal_hwloc_min_num_version opal_hwloc_min_version opal_hwloc_CPPFLAGS_save opal_hwloc_LDFLAGS_save opal_hwloc_LIBS_save opal_hwloc_external_support])
 
     OAC_CHECK_PACKAGE([hwloc],
                       [opal_hwloc],
@@ -114,17 +115,19 @@ AC_DEFUN([_OPAL_CONFIG_HWLOC_EXTERNAL], [
     OPAL_FLAGS_APPEND_UNIQ([LDFLAGS], [$opal_hwloc_LDFLAGS])
     OPAL_FLAGS_APPEND_UNIQ([LIBS], [$opal_hwloc_LIBS])
 
+    opal_hwloc_min_num_version=OMPI_HWLOC_NUMERIC_MIN_VERSION
+    opal_hwloc_min_version=OMPI_HWLOC_NUMERIC_MIN_VERSION
     AS_IF([test "$opal_hwloc_external_support" = "yes"],
-          [AC_MSG_CHECKING([if external hwloc version is 1.11.0 or greater])
+          [AC_MSG_CHECKING([if external hwloc version is OMPI_HWLOC_MIN_VERSION or greater])
            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <hwloc.h>
                               ]], [[
-#if HWLOC_API_VERSION < 0x00010500
-#error "hwloc API version is less than 0x00011100"
+#if HWLOC_API_VERSION < $opal_hwloc_min_num_version
+#error "hwloc API version is less than $opal_hwloc_min_version"
 #endif
                                ]])],
                    [AC_MSG_RESULT([yes])],
                    [AC_MSG_RESULT([no])
-                    AC_MSG_WARN([external hwloc version is too old (1.11.0 or later required)])
+                    AC_MSG_WARN([external hwloc version is too old (OMPI_HWLOC_MIN_VERSION or later required)])
                     opal_hwloc_external_support="no"])])
 
     AS_IF([test "$opal_hwloc_external_support" = "yes"],

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reser
 dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -98,7 +99,7 @@ dnl
 dnl only safe to call from OPAL_CONFIG_LIBEVENT, assumes variables
 dnl from there are set.
 AC_DEFUN([_OPAL_CONFIG_LIBEVENT_EXTERNAL], [
-    OPAL_VAR_SCOPE_PUSH([opal_libevent_CPPFLAGS_save opal_libevent_LDFLAGS_save opal_libevent_LIBS_save opal_libevent_external_support])
+    OPAL_VAR_SCOPE_PUSH([opal_event_min_version opal_event_min_num_version opal_libevent_CPPFLAGS_save opal_libevent_LDFLAGS_save opal_libevent_LIBS_save opal_libevent_external_support])
 
     dnl Look at libevent_core, not libevent_pthread, because
     dnl trying to avoid picking up libevent.so.  The wrappers and
@@ -160,22 +161,24 @@ AC_DEFUN([_OPAL_CONFIG_LIBEVENT_EXTERNAL], [
     # isn't what we want, because we really want to prefer external
     # versions.  Pin the "oldest supported" external version to
     # 2.0.21, which we know works from testing on RHEL7.
+    opal_event_min_num_version=OMPI_EVENT_NUMERIC_MIN_VERSION
+    opal_event_min_version=OMPI_EVENT_MIN_VERSION
     AS_IF([test "$opal_libevent_external_support" = "yes"],
-          [AC_CACHE_CHECK([if external libevent version is 2.0.21 or greater],
+          [AC_CACHE_CHECK([if external libevent version is OMPI_EVENT_MIN_VERSION or greater],
               [opal_libevent_cv_version_check],
               [AC_COMPILE_IFELSE(
                   [AC_LANG_PROGRAM([[#include <event2/event.h>]],
                                    [[
-#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-#error "libevent API version is less than 0x02001500"
-#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-#error "libevent API version is less than 0x02001500"
+#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < $opal_event_min_num_version
+#error "libevent API version is less than $opal_event_min_version"
+#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < $opal_event_min_num_version
+#error "libevent API version is less than $opal_event_min_version"
 #endif
                                     ]])],
                   [opal_libevent_cv_version_check="yes"],
                   [opal_libevent_cv_version_check="no"])])
           AS_IF([test "${opal_libevent_cv_version_check}" = "no"],
-                [AC_MSG_WARN([external libevent version is too old (2.0.21 or later required)])
+                [AC_MSG_WARN([external libevent version is too old (OMPI_EVENT_MIN_VERSION or later required)])
                  opal_libevent_external_support=no])])
 
     CPPFLAGS="$opal_libevent_CPPFLAGS_save"

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -16,7 +16,7 @@ dnl                         reserved.
 dnl Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014-2021 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
-dnl Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
@@ -163,7 +163,7 @@ dnl
 dnl only safe to call from OPAL_CONFIG_PMIX, assumes variables from
 dnl there are set.
 AC_DEFUN([_OPAL_CONFIG_PMIX_EXTERNAL], [
-    OPAL_VAR_SCOPE_PUSH([opal_pmix_CPPFLAGS_save opal_pmix_LDFLAGS_save opal_pmix_LIBS_save opal_pmix_external_support])
+    OPAL_VAR_SCOPE_PUSH([opal_pmix_min_version opal_pmix_min_num_version opal_pmix_CPPFLAGS_save opal_pmix_LDFLAGS_save opal_pmix_LIBS_save opal_pmix_external_support])
 
     opal_pmix_external_support="yes"
 
@@ -191,12 +191,14 @@ AC_DEFUN([_OPAL_CONFIG_PMIX_EXTERNAL], [
            LDFLAGS="$opal_pmix_LDFLAGS_save $opal_pmix_LDFLAGS"
            LIBS="$opal_pmix_LIBS_save $opal_pmix_LIBS"
 
+           opal_pmix_min_num_version=OMPI_PMIX_NUMERIC_MIN_VERSION
+           opal_pmix_min_version=OMPI_PMIX_MIN_VERSION
            AS_IF([test "$opal_pmix_external_support" = "yes"],
-                 [AC_MSG_CHECKING([if external PMIx version is 3.1.5 or greater])
+                 [AC_MSG_CHECKING([if external PMIx version is OMPI_PMIX_MIN_VERSION or greater])
                     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <pmix_version.h>
                           ]], [[
-#if PMIX_NUMERIC_VERSION < 0x00030105
-#error "pmix API version is less than 3.1.5"
+#if PMIX_NUMERIC_VERSION < $opal_pmix_min_num_version
+#error "pmix API version is less than $opal_pmix_min_version"
 #endif
                           ]])],
                           [AC_MSG_RESULT([yes])],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,15 @@ for ompi_line in ompi_lines:
 ompi_series = f"v{ompi_data['major']}.{ompi_data['minor']}.x"
 ompi_ver = f"v{ompi_data['major']}.{ompi_data['minor']}.{ompi_data['release']}{ompi_data['greek']}"
 
+pmix_min_version = f"{ompi_data['pmix_min_version']}"
+prte_min_version = f"{ompi_data['prte_min_version']}"
+hwloc_min_version = f"{ompi_data['hwloc_min_version']}"
+event_min_version = f"{ompi_data['event_min_version']}"
+automake_min_version = f"{ompi_data['automake_min_version']}"
+autoconf_min_version = f"{ompi_data['autoconf_min_version']}"
+libtool_min_version = f"{ompi_data['libtool_min_version']}"
+flex_min_version = f"{ompi_data['flex_min_version']}"
+
 # "release" is a sphinx config variable: assign it to the computed
 # Open MPI version number.  The ompi_ver string begins with a "v"; the
 # Sphinx release variable should not include this prefix "v".
@@ -179,4 +188,12 @@ rst_prolog = f"""
 .. |year| replace:: {year}
 .. |ompi_ver| replace:: {ompi_ver}
 .. |ompi_series| replace:: {ompi_series}
+.. |pmix_min_version| replace:: {pmix_min_version}
+.. |prte_min_version| replace:: {prte_min_version}
+.. |hwloc_min_version| replace:: {hwloc_min_version}
+.. |event_min_version| replace:: {event_min_version}
+.. |automake_min_version| replace:: {automake_min_version}
+.. |autoconf_min_version| replace:: {autoconf_min_version}
+.. |libtool_min_version| replace:: {libtool_min_version}
+.. |flex_min_version| replace:: {flex_min_version}
 """

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -20,6 +20,19 @@ must be installed (i.e., `GNU Autoconf
 <https://www.gnu.org/software/automake/>`_, and `GNU Libtool
 <https://www.gnu.org/software/libtool/>`_).
 
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Tool
+     - Minimum version
+   * - Autoconf
+     - |autoconf_min_version|
+   * - Automake
+     - |automake_min_version|
+   * - Libtool
+     - |libtool_min_version|
+
 .. note:: The GNU Autotools are *not* required when building Open MPI
           from distribution tarballs.  Open MPI distribution tarballs
           are bootstrapped such that end-users do not need to have the
@@ -38,6 +51,8 @@ more detail.
 Flex
 ----
 
+Minimum supported version: |flex_min_version|.
+
 `Flex <https://github.com/westes/flex>`_ is used during the
 compilation of a developer's checkout (it is not used to build
 official distribution tarballs).  Other flavors of lex are *not*
@@ -49,7 +64,7 @@ Note that no testing has been performed to see what the minimum
 version of Flex is required by Open MPI.  We suggest that you use
 v2.5.35 at the earliest.
 
-For now, Open MPI will allow developer builds with Flex 2.5.4.  This
+For now, Open MPI will allow developer builds with Flex |flex_min_version|.  This
 is primarily motivated by the fact that RedHat/CentOS 5 ships with
 Flex 2.5.4.  It is likely that someday Open MPI developer builds will
 require Flex version >=2.5.35.

--- a/docs/installing-open-mpi/required-support-libraries.rst
+++ b/docs/installing-open-mpi/required-support-libraries.rst
@@ -3,30 +3,41 @@
 Required support libraries
 ==========================
 
-Open MPI uses the following support libraries:
+Open MPI requires the following support libraries with the minimum listed versions:
 
-#. `Hardware Locality (hwloc)
-   <https://www.open-mpi.org/projects/hwloc/>`_: This library is
-   required; Open MPI will not build without it.
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10 25
 
-#. `Libevent <https://libevent.org/>`_: This library is required; Open
-   MPI will not build without it.
+   * - Library
+     - Minimum version
+     - Notes
+   * - `Hardware Locality <https://www.open-mpi.org/projects/hwloc/>`_
+     - |hwloc_min_version|
+     - | This library is required; Open MPI will not build without it.
+   * - `Libevent <https://libevent.org/>`_
+     - |event_min_version|
+     - | This library is required; Open MPI will not build without it.
+   * - `PMIx <https://pmix.org/>`_
+     - |pmix_min_version|
+     - | This library is required; Open MPI will not build without it.
+   * - `PRRTE <https://github.com/openpmix/prrte>`_
+     - |prte_min_version|
+     - | This library is optional in some environments. PRRTE provides
+       | Open MPI's full-featured ``mpirun`` / ``mpiexec`` MPI
+       | application launchers (the two are identical; they are symbolic
+       | links to the same executable).
 
-#. `PMIx <https://pmix.org/>`_: This library is required; Open MPI
-   will not build without it.
-
-#. `PRRTE <https://github.com/openpmix/prrte>`_: This library is
-   optional in some environments.  PRRTE provides Open MPI's
-   full-featured ``mpirun`` / ``mpiexec`` MPI application launchers
-   (the two are identical; they are symbolic links to the same executable).
-
-   * If your environment uses another MPI application launcher
-     (e.g., Slurm users can use the ``srun`` launcher to "direct
-     launch" Open MPI applications), then the use of PRRTE is
-     optional.
-   * If your environment has no other MPI application launcher, then
-     you need to install PRRTE and build Open MPI with PRRTE
-     support.
+       * | If your environment uses another MPI application launcher
+         | (e.g., Slurm users can use the ``srun`` launcher to "direct
+         | launch" Open MPI applications), then the use of PRRTE is
+         | optional.
+       * | If your environment has no other MPI application launcher, then
+         | you need to install PRRTE and build Open MPI with PRRTE
+         | support.
+       * | Open MPI can use the copy of PRRTE embedded in its source code
+         | tree, or compile/link against an external PRRTE installation.
+         | :ref:`See this section for details about how to specify each method <label-building-ompi-cli-options-support-libraries>`.
 
 Since these support libraries are fundamental to Open MPI's operation,
 they are directly incorporated into Open MPI's configure, build, and


### PR DESCRIPTION
- This centralizes current known versions (!these are subject to change!)
  as configure currently has them, and/or how they are currently
  documented, to the VERSION file. This consolidates these versions
  to one place so autogen/configury/docs can pick them all up.

  * Dependency versions should be added in a MAJOR.MINOR.RELEASE format
    to the VERSION file. This makes it easy to convert to a numeric version,
    which makes comparisons easy. The logic for making this conversion
    I borrowed from this PMIx change: https://github.com/openpmix/openpmix/pull/1106.

  1. Add the new dependency to the VERSION file (x_min_version=x.y.z).
  2. Add the two lines of python code to docs/conf.py to read it and replace any instances in the docs
     with |x_min_version|.
  3. If there are any configure checks for this version, add a check for it
     to get_and_define_min_versions() in autogen.pl to parse and propagate the version variables
     to configure.

- This indirectly fixes a bug where we documented HWLOC v1.11.0 as the minumum
  supported version, but would accept 1.05.0 or higher.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 40088c0238e5ac2490d62e147219709470af5d7c)