### PR TITLE
Correctly retain the datatypes for topological communicators.

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2021 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -68,6 +68,8 @@ struct ompi_coll_base_nbc_request_t {
             struct {
                 ompi_datatype_t * const *stypes;
                 ompi_datatype_t * const *rtypes;
+                int scount;
+                int rcount;
             } vecs;
         } refcounted;
         void* release_arrays[OMPI_REQ_NB_RELEASE_ARRAYS];
@@ -175,7 +177,7 @@ int ompi_coll_base_retain_op( ompi_request_t *request,
  * (will be cast internally).
  */
 int ompi_coll_base_retain_datatypes( ompi_request_t *request,
-                                      ompi_datatype_t *stype,
+                                     ompi_datatype_t *stype,
                                      ompi_datatype_t *rtype);
 
 /**
@@ -185,7 +187,8 @@ int ompi_coll_base_retain_datatypes( ompi_request_t *request,
  */
 int ompi_coll_base_retain_datatypes_w( ompi_request_t *request,
                                        ompi_datatype_t * const stypes[],
-                                       ompi_datatype_t * const rtypes[]);
+                                       ompi_datatype_t * const rtypes[],
+                                       bool use_topo);
 
 /* File reading function */
 int ompi_coll_base_file_getnext_long(FILE *fptr, int *fileline, long* val);

--- a/ompi/mpi/c/alltoallw_init.c
+++ b/ompi/mpi/c/alltoallw_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -127,7 +127,7 @@ int MPI_Alltoallw_init(const void *sendbuf, const int sendcounts[], const int sd
                                             rdispls, recvtypes, comm, info, request,
                                             comm->c_coll->coll_alltoallw_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes);
+        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes, false);
     }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ialltoallw.c
+++ b/ompi/mpi/c/ialltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -121,7 +121,7 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
                                        rdispls, recvtypes, comm, request,
                                        comm->c_coll->coll_ialltoallw_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes);
+        ompi_coll_base_retain_datatypes_w(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtypes, recvtypes, false);
     }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -146,7 +146,7 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
                                                 recvbuf, recvcounts, rdispls, recvtypes, comm, request,
                                                 comm->c_coll->coll_ineighbor_alltoallw_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes);
+        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes, true);
     }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/neighbor_alltoallw_init.c
+++ b/ompi/mpi/c/neighbor_alltoallw_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -148,7 +148,7 @@ int MPI_Neighbor_alltoallw_init(const void *sendbuf, const int sendcounts[], con
                                                      info, request,
                                                      comm->c_coll->coll_neighbor_alltoallw_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
-        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes);
+        ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes, true);
     }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }


### PR DESCRIPTION
I do not recall which issue this is related to, and I was not able to
find it on github either, but this patch addresed the number of
datatypes to release/retain for collective communications on topological
communicators.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>