### PR TITLE
v4.1.x: osc/rdma: removed deadlock in find dynamic region

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -466,12 +466,9 @@ int ompi_osc_rdma_find_dynamic_region (ompi_osc_rdma_module_t *module, ompi_osc_
                      " (len %lu)", base, base + len, (unsigned long) len);
 
     OPAL_THREAD_LOCK(&module->lock);
-    // Make sure region isn't being touched.
-    ompi_osc_rdma_lock_acquire_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
     if (!ompi_osc_rdma_peer_local_state (peer)) {
         ret = ompi_osc_rdma_refresh_dynamic_region (module, dy_peer);
         if (OMPI_SUCCESS != ret) {
-            ompi_osc_rdma_lock_release_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
             return ret;
         }
 
@@ -488,7 +485,6 @@ int ompi_osc_rdma_find_dynamic_region (ompi_osc_rdma_module_t *module, ompi_osc_
         ret = OMPI_ERR_RMA_RANGE;
     }
     OPAL_THREAD_UNLOCK(&module->lock);
-    ompi_osc_rdma_lock_release_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, regions_lock));
 
     /* round a matching region */
     return ret;


### PR DESCRIPTION
osc/rdma: removed deadlock in find dynamic region

Signed-off-by: João Batista Fernandes <jotabe.150@gmail.com>

(cherry picked from commit 9779b99e9a5885bc4c716dec65a48a07fbc1309c)