### PR TITLE
Op: Treat unsigned long as unsigned, not signed long

### DIFF
--- a/ompi/mca/op/base/op_base_functions.c
+++ b/ompi/mca/op/base/op_base_functions.c
@@ -162,7 +162,7 @@ FUNC_FUNC(max, uint32_t, uint32_t)
 FUNC_FUNC(max,  int64_t,  int64_t)
 FUNC_FUNC(max, uint64_t, uint64_t)
 FUNC_FUNC(max,  long,  long)
-FUNC_FUNC(max,  unsigned_long,  long)
+FUNC_FUNC(max,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -228,7 +228,7 @@ FUNC_FUNC(min, uint32_t, uint32_t)
 FUNC_FUNC(min,  int64_t,  int64_t)
 FUNC_FUNC(min, uint64_t, uint64_t)
 FUNC_FUNC(min,  long,  long)
-FUNC_FUNC(min,  unsigned_long,  long)
+FUNC_FUNC(min,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -291,7 +291,7 @@ OP_FUNC(sum, uint32_t, uint32_t, +=)
 OP_FUNC(sum,  int64_t,  int64_t, +=)
 OP_FUNC(sum, uint64_t, uint64_t, +=)
 OP_FUNC(sum,  long,  long, +=)
-OP_FUNC(sum,  unsigned_long,  long, +=)
+OP_FUNC(sum,  unsigned_long, unsigned long, +=)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -363,7 +363,7 @@ OP_FUNC(prod, uint32_t, uint32_t, *=)
 OP_FUNC(prod,  int64_t,  int64_t, *=)
 OP_FUNC(prod, uint64_t, uint64_t, *=)
 OP_FUNC(prod,  long,  long, *=)
-OP_FUNC(prod,  unsigned_long,  long, *=)
+OP_FUNC(prod,  unsigned_long, unsigned long, *=)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -437,7 +437,7 @@ FUNC_FUNC(land, uint32_t, uint32_t)
 FUNC_FUNC(land,  int64_t,  int64_t)
 FUNC_FUNC(land, uint64_t, uint64_t)
 FUNC_FUNC(land,  long,  long)
-FUNC_FUNC(land,  unsigned_long,  long)
+FUNC_FUNC(land,  unsigned_long, unsigned long)
 
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
@@ -462,7 +462,7 @@ FUNC_FUNC(lor, uint32_t, uint32_t)
 FUNC_FUNC(lor,  int64_t,  int64_t)
 FUNC_FUNC(lor, uint64_t, uint64_t)
 FUNC_FUNC(lor,  long,  long)
-FUNC_FUNC(lor,  unsigned_long,  long)
+FUNC_FUNC(lor,  unsigned_long, unsigned long)
 
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
@@ -487,7 +487,7 @@ FUNC_FUNC(lxor, uint32_t, uint32_t)
 FUNC_FUNC(lxor,  int64_t,  int64_t)
 FUNC_FUNC(lxor, uint64_t, uint64_t)
 FUNC_FUNC(lxor,  long,  long)
-FUNC_FUNC(lxor,  unsigned_long,  long)
+FUNC_FUNC(lxor,  unsigned_long, unsigned long)
 
 
 /* Logical */
@@ -513,7 +513,7 @@ FUNC_FUNC(band, uint32_t, uint32_t)
 FUNC_FUNC(band,  int64_t,  int64_t)
 FUNC_FUNC(band, uint64_t, uint64_t)
 FUNC_FUNC(band,  long,  long)
-FUNC_FUNC(band,  unsigned_long,  long)
+FUNC_FUNC(band,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -553,7 +553,7 @@ FUNC_FUNC(bor, uint32_t, uint32_t)
 FUNC_FUNC(bor,  int64_t,  int64_t)
 FUNC_FUNC(bor, uint64_t, uint64_t)
 FUNC_FUNC(bor,  long,  long)
-FUNC_FUNC(bor,  unsigned_long,  long)
+FUNC_FUNC(bor,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -593,7 +593,7 @@ FUNC_FUNC(bxor, uint32_t, uint32_t)
 FUNC_FUNC(bxor,  int64_t,  int64_t)
 FUNC_FUNC(bxor, uint64_t, uint64_t)
 FUNC_FUNC(bxor,  long,  long)
-FUNC_FUNC(bxor,  unsigned_long,  long)
+FUNC_FUNC(bxor,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -822,7 +822,7 @@ FUNC_FUNC_3BUF(max, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(max,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(max, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(max,  long,  long)
-FUNC_FUNC_3BUF(max,  unsigned_long,  long)
+FUNC_FUNC_3BUF(max,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -888,7 +888,7 @@ FUNC_FUNC_3BUF(min, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(min,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(min, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(min,  long,  long)
-FUNC_FUNC_3BUF(min,  unsigned_long,  long)
+FUNC_FUNC_3BUF(min,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -951,7 +951,7 @@ OP_FUNC_3BUF(sum, uint32_t, uint32_t, +)
 OP_FUNC_3BUF(sum,  int64_t,  int64_t, +)
 OP_FUNC_3BUF(sum, uint64_t, uint64_t, +)
 OP_FUNC_3BUF(sum,  long,  long, +)
-OP_FUNC_3BUF(sum,  unsigned_long,  long, +)
+OP_FUNC_3BUF(sum,  unsigned_long, unsigned long, +)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -1023,7 +1023,7 @@ OP_FUNC_3BUF(prod, uint32_t, uint32_t, *)
 OP_FUNC_3BUF(prod,  int64_t,  int64_t, *)
 OP_FUNC_3BUF(prod, uint64_t, uint64_t, *)
 OP_FUNC_3BUF(prod,  long,  long, *)
-OP_FUNC_3BUF(prod,  unsigned_long,  long, *)
+OP_FUNC_3BUF(prod,  unsigned_long, unsigned long, *)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -1097,7 +1097,7 @@ FUNC_FUNC_3BUF(land, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(land,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(land, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(land,  long,  long)
-FUNC_FUNC_3BUF(land,  unsigned_long,  long)
+FUNC_FUNC_3BUF(land,  unsigned_long, unsigned long)
 
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
@@ -1122,7 +1122,7 @@ FUNC_FUNC_3BUF(lor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(lor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(lor, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(lor,  long,  long)
-FUNC_FUNC_3BUF(lor,  unsigned_long,  long)
+FUNC_FUNC_3BUF(lor,  unsigned_long, unsigned long)
 
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
@@ -1147,7 +1147,7 @@ FUNC_FUNC_3BUF(lxor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(lxor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(lxor, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(lxor,  long,  long)
-FUNC_FUNC_3BUF(lxor,  unsigned_long,  long)
+FUNC_FUNC_3BUF(lxor,  unsigned_long, unsigned long)
 
 /* Logical */
 #if OMPI_HAVE_FORTRAN_LOGICAL
@@ -1172,7 +1172,7 @@ FUNC_FUNC_3BUF(band, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(band,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(band, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(band,  long,  long)
-FUNC_FUNC_3BUF(band,  unsigned_long,  long)
+FUNC_FUNC_3BUF(band,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -1212,7 +1212,7 @@ FUNC_FUNC_3BUF(bor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(bor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(bor, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(bor,  long,  long)
-FUNC_FUNC_3BUF(bor,  unsigned_long,  long)
+FUNC_FUNC_3BUF(bor,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER
@@ -1252,7 +1252,7 @@ FUNC_FUNC_3BUF(bxor, uint32_t, uint32_t)
 FUNC_FUNC_3BUF(bxor,  int64_t,  int64_t)
 FUNC_FUNC_3BUF(bxor, uint64_t, uint64_t)
 FUNC_FUNC_3BUF(bxor,  long,  long)
-FUNC_FUNC_3BUF(bxor,  unsigned_long,  long)
+FUNC_FUNC_3BUF(bxor,  unsigned_long, unsigned long)
 
 /* Fortran integer */
 #if OMPI_HAVE_FORTRAN_INTEGER


### PR DESCRIPTION
This likely had no impact on arithmetic operations but bites us on min and max. We should use `unsigned long` consistently though.

Fixes #10525

Needs backports to 5.0.x and 4.1.x (also 4.0.x?)

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>