### PR TITLE
[v5.0.x] btl/base: push operation->hdr to am_rdma_respond for queued operation

### DIFF
--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -605,6 +605,7 @@ static int am_rdma_respond(mca_btl_base_module_t *btl,
     *descriptor = NULL;
 
     if (NULL == send_descriptor) {
+        assert(NULL != hdr);
         am_rdma_response_hdr_t *resp_hdr;
         size_t data_size = am_rdma_is_atomic(hdr->type) ? hdr->data.atomic.size
                                                                   : hdr->data.rdma.size;
@@ -780,7 +781,7 @@ static void am_rdma_retry_operation(am_rdma_operation_t *operation)
     } else {
         ret = am_rdma_respond(operation->btl, operation->endpoint,
                               &operation->descriptor,
-                              /*addr=*/NULL, /*hdr=*/NULL);
+                              /*addr=*/NULL, &operation->hdr);
     }
 
     if (OPAL_SUCCESS == ret) {


### PR DESCRIPTION
Currently, when calling am_rdma_respond() for a queued
operation, amd_rdma_retry_operation() pass NULL for the hdr argument.

The idea is that hdr is only used for allocating operation->descriptor.
A queued operation should already have a descriptor, therefore does
not need hdr.

This missed the possibility that the allocation of descriptor
in am_rdma_respond() can fail, which will lead to the operation
to be queued without a descriptor.

This patch make retry_operation() to pass operation->hdr to
am_rdma_repsond() to address the issue.

It also added an assertion in am_rdma_repsond() about hdr must
not be NULL before hdr is being used.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 1758e3d274cc64e775bde7e4681681858d291f23)