### PR TITLE
Start[all] parameter check fixes

### DIFF
--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -78,7 +78,8 @@ int MPI_Start(MPI_Request *request)
     case OMPI_REQUEST_PML:
     case OMPI_REQUEST_COLL:
     case OMPI_REQUEST_PART:
-        if ( MPI_PARAM_CHECK && !(*request)->req_persistent) {
+        if ( MPI_PARAM_CHECK && !((*request)->req_persistent &&
+                                  OMPI_REQUEST_INACTIVE == (*request)->req_state)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_REQUEST, FUNC_NAME);
         }
 

--- a/ompi/mpi/c/startall.c
+++ b/ompi/mpi/c/startall.c
@@ -69,6 +69,7 @@ int MPI_Startall(int count, MPI_Request requests[])
                     ! requests[i]->req_persistent ||
                     (OMPI_REQUEST_PML  != requests[i]->req_type &&
                      OMPI_REQUEST_COLL != requests[i]->req_type &&
+                     OMPI_REQUEST_PART != requests[i]->req_type &&
                      OMPI_REQUEST_NOOP != requests[i]->req_type)) {
                     rc = MPI_ERR_REQUEST;
                     break;


### PR DESCRIPTION
This PR fixes two glitches in the parameter check in `MPI_Start` and `MPI_Startall`:

1) `MPI_Startall` wouldn't accept partitioned requests if parameter checking was enabled.
2) Check for the request state to be `OMPI_REQUEST_INACTIVE` in `MPI_Start` to mirror the check in `MPI_Startall`.