### PR TITLE
osc/ucx: trigger opal progress only if no progress is made inside flush

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -292,7 +292,9 @@ static inline int opal_common_ucx_wait_request_mt(ucs_status_ptr_t request, cons
             ctr--;
         } while (ctr > 0 && ret > 0 && status == UCS_INPROGRESS);
         opal_mutex_unlock(&winfo->mutex);
-        opal_progress();
+        if (!ctr) {
+            opal_progress();
+        }
     } while (status == UCS_INPROGRESS);
 
     return OPAL_SUCCESS;


### PR DESCRIPTION
Signed-off-by: Tomislav Janjusic <tomislavj@nvidia.com>