### PR TITLE
github-labeler: add label corresponding to the target branch

### DIFF
--- a/.github/workflows/github-labeler.py
+++ b/.github/workflows/github-labeler.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+"""
+
+The script applies a label in the form "Target: {branchName}. If necessary, it
+removes labels in the same form, but NOT for the target branch. For instance, if
+someone edited the target branch from v4.0.x to v5.0.x
+
+"""
+
+import os
+import re
+import sys
+
+from github import Github
+
+# ==============================================================================
+
+GITHUB_BASE_REF = os.environ.get('GITHUB_BASE_REF')
+GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+GITHUB_REPOSITORY = os.environ.get('GITHUB_REPOSITORY')
+PR_NUM = os.environ.get('PR_NUM')
+
+# Sanity check
+if (GITHUB_BASE_REF is None or
+    GITHUB_TOKEN is None or
+    GITHUB_REPOSITORY is None or
+    PR_NUM is None):
+    print("Error: this script is designed to run as a Github Action")
+    exit(1)
+
+# ==============================================================================
+
+# Given a pullRequest object, the function checks what labels are currently on
+# the pull request, removes any matching the form "Target: {branch}" (if
+# {branch} is not the current target branch), and adds the correct label.
+def ensureLabels(pullRequest):
+    needsLabel = True
+    targetPrefix = "Target: "
+    targetLabel = f"{targetPrefix}{GITHUB_BASE_REF}"
+    for label in pullRequest.get_labels():
+        if label.name.startswith(targetPrefix):
+            if label.name == targetLabel:
+                needsLabel = False
+            else:
+                print(f"Removing label '{label.name}")
+                pullRequest.remove_from_labels(label)
+    if needsLabel:
+        print(f"Adding label '{targetLabel}")
+        pullRequest.add_to_labels(targetLabel)
+    return None
+
+# ==============================================================================
+
+g = Github(GITHUB_TOKEN)
+repo = g.get_repo(GITHUB_REPOSITORY)
+prNum = int(PR_NUM)
+pr = repo.get_pull(prNum)
+ensureLabels(pr)

--- a/.github/workflows/github-labeler.yaml
+++ b/.github/workflows/github-labeler.yaml
@@ -1,0 +1,36 @@
+name: GitHub Action Labeler
+
+# We're using pull_request_target here instead of just pull_request so that the
+# action runs in the context of the base of the pull request, rather than in the
+# context of the merge commit. For more detail about the differences, see:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+on:
+    pull_request_target:
+        # We don't need this to be run on all types of PR behavior
+        # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+        # You can change the base branch, so update the label if it's edited.
+        types:
+          - opened
+          - edited
+
+jobs:
+    ci:
+        name: Label Bot
+        runs-on: ubuntu-latest
+        steps:
+          - name: Check out the code
+            uses: actions/checkout@v2
+
+          - name: Setup Python
+            uses: actions/setup-python@v2
+            with:
+              python-version: '3.x'
+
+          - name: Get the PyGithub module
+            run: pip install PyGithub
+
+          - name: Label the PR (if needed)
+            run: $GITHUB_WORKSPACE/.github/workflows/github-labeler.py
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                PR_NUM: ${{ github.event.number }}


### PR DESCRIPTION
This is a small GitHub action and corresponding Python script which automatically adds labels to pull requests on PR creation and edits (i.e., when the base branch changes). It adds labels in the form of "Target: {base}", corresponding to the base branch of the PR. (NOTE: it does NOT create labels, so the maintainers are still in control of which labels exist).

If the PR is labeled incorrectly - either by a user choosing the wrong label, or by the base branch changing - the action will remove the incorrect "Target: {base}" label and add the correct one. If the PR is labeled correctly, no action is taken.

Signed-off-by: Joe Downs <joe@dwns.dev>