### PR TITLE
Start fixes: parameter check and return code [v4.1.x]

### DIFF
--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -68,7 +68,8 @@ int MPI_Start(MPI_Request *request)
     switch((*request)->req_type) {
     case OMPI_REQUEST_PML:
     case OMPI_REQUEST_COLL:
-        if ( MPI_PARAM_CHECK && !(*request)->req_persistent) {
+        if ( MPI_PARAM_CHECK && !((*request)->req_persistent &&
+                                  OMPI_REQUEST_INACTIVE == (*request)->req_state)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_REQUEST, FUNC_NAME);
         }
         OPAL_CR_ENTER_LIBRARY();


### PR DESCRIPTION
This PR fixes two two glitches in MPI_Start:

- Check for the request state to be OMPI_REQUEST_INACTIVE in MPI_Start to mirror the check in MPI_Startall.
- ~Check return value of request start function to prevent error codes from leaking.~

Partial backport of https://github.com/open-mpi/ompi/pull/10543 to v4.1.x (partitioned communication was never backported to v4.1.x)