### PR TITLE
Start fixes: parameter check and return code [v4.0.x]

### DIFF
--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -68,7 +68,8 @@ int MPI_Start(MPI_Request *request)
     switch((*request)->req_type) {
     case OMPI_REQUEST_PML:
     case OMPI_REQUEST_COLL:
-        if ( MPI_PARAM_CHECK && !(*request)->req_persistent) {
+        if ( MPI_PARAM_CHECK && !((*request)->req_persistent &&
+                                  OMPI_REQUEST_INACTIVE == (*request)->req_state)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_REQUEST, FUNC_NAME);
         }
         OPAL_CR_ENTER_LIBRARY();

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -76,7 +76,7 @@ int MPI_Start(MPI_Request *request)
         ret = (*request)->req_start(1, request);
 
         OPAL_CR_EXIT_LIBRARY();
-        return ret;
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_REQUEST, FUNC_NAME);
 
     case OMPI_REQUEST_NOOP:
         /**


### PR DESCRIPTION
This PR fixes two two glitches in MPI_Start:

- Check for the request state to be OMPI_REQUEST_INACTIVE in MPI_Start to mirror the check in MPI_Startall.
- Check return value of request start function to prevent error codes from leaking.

Not sure if we still backport fixes to v4.0.x. If not this PR can just be closed.

Partial backport of https://github.com/open-mpi/ompi/pull/10543 to v4.0.x (partitioned communication was never backported to v4.0.x)