### PR TITLE
fbtl/posix: fix length calculation for data sieving

### DIFF
--- a/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
@@ -160,7 +160,8 @@ ssize_t mca_fbtl_posix_preadv_datasieving (ompio_file_t *fh, struct flock *lock,
         }
         
         size_t sstart = (size_t)fh->f_io_array[startindex].offset;
-        size_t slen=0;
+        size_t slen=0, maxlen=0;
+        int maxindex = startindex;
 
         for ( j = startindex; j < fh->f_num_of_io_entries; j++ ) {
             endindex = j;
@@ -169,15 +170,19 @@ ssize_t mca_fbtl_posix_preadv_datasieving (ompio_file_t *fh, struct flock *lock,
                 endindex = j-1;
                 break;
             }
+            if (slen > maxlen) {
+                maxlen   = slen;
+                maxindex = endindex;
+            }
         }
         // Need to increment the value of endindex
         // by one for the loop syntax to work correctly.
         endindex++;
         
         start = (size_t)fh->f_io_array[startindex].offset;
-        end   = (size_t)fh->f_io_array[endindex-1].offset + fh->f_io_array[endindex-1].length;
+        end   = (size_t)fh->f_io_array[maxindex].offset + fh->f_io_array[maxindex].length;
         len   = end - start;
-        
+
         if ( len > bufsize ) {
             if ( NULL != temp_buf ) {
                 free ( temp_buf);


### PR DESCRIPTION
This commit fixes the calculation of the buffer length that
needs to be read when using data sieving. The original code implicitely
assumed that the ub of an iov at index j+1 is larger than
the ub of the iov at index j. This is not necessarily the case
for read operations. Hence, the code needs to keep track of the max.
ub found.

Fixes issue #10546

Signed-off-by: Edgar Gabriel <edgar.gabriel1@outlook.com>