### PR TITLE
Topic/fixes

### DIFF
--- a/ompi/mpi/c/parrived.c
+++ b/ompi/mpi/c/parrived.c
@@ -47,7 +47,7 @@ int MPI_Parrived(MPI_Request request, MPI_Count partition,  int *flag)
 {
     int rc;
 
-    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
+    SPC_RECORD(OMPI_SPC_PARRIVED, 1);
 
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -48,8 +48,6 @@ int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype data
 {
     int rc;
 
-    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
-
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/mpi/c/psend_init.c
+++ b/ompi/mpi/c/psend_init.c
@@ -48,8 +48,6 @@ int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatyp
 {
     int rc;
 
-    SPC_RECORD(OMPI_SPC_ARRIVED, 1);
-
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -85,7 +85,7 @@ int MPI_Start(MPI_Request *request)
 
         ret = (*request)->req_start(1, request);
 
-        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+        OMPI_ERRHANDLER_NOHANDLE_RETURN(ret, ret, FUNC_NAME);
 
     case OMPI_REQUEST_NOOP:
         /**

--- a/ompi/runtime/ompi_spc.c
+++ b/ompi/runtime/ompi_spc.c
@@ -166,9 +166,11 @@ static const ompi_spc_event_t ompi_spc_events_desc[OMPI_SPC_NUM_COUNTERS] = {
     SET_COUNTER_ARRAY(OMPI_SPC_MAX_UNEXPECTED_IN_QUEUE, "The maximum number of messages that the unexpected message queue(s) within an MPI process "
                                                     "contained at once since the last reset of this counter. Note: This counter is reset each time it is read.", true, false),
     SET_COUNTER_ARRAY(OMPI_SPC_MAX_OOS_IN_QUEUE, "The maximum number of messages that the out of sequence message queue(s) within an MPI process "
-                                             "contained at once since the last reset of this counter. Note: This counter is reset each time it is read.", true, false)
+                                             "contained at once since the last reset of this counter. Note: This counter is reset each time it is read.", true, false),
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV, "The number of times MPI_Isendrecv was called.", false, false),
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV_REPLACE, "The number of times MPI_Isendrecv_replace was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PARRIVED, "The number of times MPI_Parrived was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY, "The number of times MPI_Pready (or similar functions) was called.", false, false),
 };
 
 /* An array of event structures to store the event data (value, attachments, flags) */

--- a/ompi/runtime/ompi_spc.h
+++ b/ompi/runtime/ompi_spc.h
@@ -154,6 +154,8 @@ typedef enum ompi_spc_counters {
     OMPI_SPC_MAX_OOS_IN_QUEUE,
     OMPI_SPC_ISENDRECV,
     OMPI_SPC_ISENDRECV_REPLACE,
+    OMPI_SPC_PARRIVED,
+    OMPI_SPC_PREADY,
     OMPI_SPC_NUM_COUNTERS /* This serves as the number of counters.  It must be last. */
 } ompi_spc_counters_t;
 

--- a/opal/include/opal/opal_portable_platform_real.h
+++ b/opal/include/opal/opal_portable_platform_real.h
@@ -1053,9 +1053,9 @@
 #elif defined(__LITTLE_ENDIAN__) || defined(WORDS_LITTLEENDIAN) || \
     ( __BYTE_ORDER__ > 0 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
   #define PLATFORM_ARCH_LITTLE_ENDIAN 1
-#elif _PLATFORM_ARCH_BIG_ENDIAN
+#elif defined(_PLATFORM_ARCH_BIG_ENDIAN)
   #define PLATFORM_ARCH_BIG_ENDIAN 1
-#elif _PLATFORM_ARCH_LITTLE_ENDIAN
+#elif defined(_PLATFORM_ARCH_LITTLE_ENDIAN)
   #define PLATFORM_ARCH_LITTLE_ENDIAN 1
 #endif
 #undef _PLATFORM_ARCH_BIG_ENDIAN
@@ -1086,9 +1086,9 @@
       defined(__arch32__) || defined(__32BIT__) || \
       __INTPTR_MAX__ == 2147483647
   #define PLATFORM_ARCH_32 1
-#elif _PLATFORM_ARCH_64
+#elif defined(_PLATFORM_ARCH_64)
   #define PLATFORM_ARCH_64 1
-#elif _PLATFORM_ARCH_32
+#elif defined(_PLATFORM_ARCH_32)
   #define PLATFORM_ARCH_32 1
 #endif
 #undef _PLATFORM_ARCH_64


### PR DESCRIPTION
Fixes a bunch of issues related to OMPI compilation (incorrect use of defines, missing SPC constants) and an issue related to error returning from MPI_Start. Need to be pushed on all branches.