### PR TITLE
OSC/UCX Dynamic window fixes

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -24,7 +24,7 @@
 #define OSC_UCX_VERBOSE MCA_COMMON_UCX_VERBOSE
 
 #define OMPI_OSC_UCX_POST_PEER_MAX 32
-#define OMPI_OSC_UCX_ATTACH_MAX    32
+#define OMPI_OSC_UCX_ATTACH_MAX    48
 #define OMPI_OSC_UCX_MEM_ADDR_MAX_LEN  1024
 
 typedef struct ompi_osc_ucx_component {

--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -74,20 +74,9 @@ int ompi_osc_ucx_fence(int mpi_assert, struct ompi_win_t *win) {
     }
 
     if (!(mpi_assert & MPI_MODE_NOPRECEDE)) {
-        if (module->flavor == MPI_WIN_FLAVOR_DYNAMIC) {
-            int i; 
-            for (i = 0; i < OMPI_OSC_UCX_ATTACH_MAX; i++) {
-                ret = opal_common_ucx_wpmem_flush(module->local_dynamic_win_info[i].mem,
-                            OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
-                if (ret != OMPI_SUCCESS) {
-                    return ret;
-                }
-            }
-        } else {
-            ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
-            if (ret != OMPI_SUCCESS) {
-                return ret;
-            }
+        ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
+        if (ret != OMPI_SUCCESS) {
+            return ret;
         }
     }
 
@@ -183,7 +172,7 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
 
     module->epoch_type.access = NONE_EPOCH;
 
-    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
+    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
@@ -199,7 +188,7 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
             OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_post failed: %d", ret);
         }
 
-        ret = opal_common_ucx_wpmem_flush(module->state_mem, OPAL_COMMON_UCX_SCOPE_EP,
+        ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_EP,
                                         module->start_grp_ranks[i]);
         if (ret != OMPI_SUCCESS) {
             return ret;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -305,13 +305,14 @@ static int exchange_len_info(void *my_info, size_t my_info_len, char **recv_info
     int ret = OMPI_SUCCESS;
     struct ompi_communicator_t *comm = (struct ompi_communicator_t *)metadata;
     int comm_size = ompi_comm_size(comm);
-    int lens[comm_size];
+    int *lens = calloc(comm_size, sizeof(int));
     int total_len, i;
 
     ret = comm->c_coll->coll_allgather(&my_info_len, 1, MPI_INT,
                                        lens, 1, MPI_INT, comm,
                                        comm->c_coll->coll_allgather_module);
     if (OMPI_SUCCESS != ret) {
+        free(lens);
         return ret;
     }
 
@@ -327,9 +328,11 @@ static int exchange_len_info(void *my_info, size_t my_info_len, char **recv_info
                                         (void *)(*recv_info_ptr), lens, (*disps_ptr), MPI_BYTE,
                                         comm, comm->c_coll->coll_allgatherv_module);
     if (OMPI_SUCCESS != ret) {
+        free(lens);
         return ret;
     }
 
+    free(lens);
     return ret;
 }
 
@@ -436,11 +439,11 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, in
     bool env_initialized = false;
     void *state_base = NULL;
     opal_common_ucx_mem_type_t mem_type;
-    uint64_t zero = 0;
     char *my_mem_addr;
     int my_mem_addr_size;
-    void * my_info = NULL;
+    uint64_t my_info[2] = {0};
     char *recv_buf = NULL;
+    void *dynamic_base = NULL;
     unsigned long total, *rbuf;
     int flag;
     size_t pagesize;
@@ -694,28 +697,31 @@ select_unlock:
         *base = module->shmem_addrs[ompi_comm_rank(module->comm)];
     }
 
-    if (flavor == MPI_WIN_FLAVOR_ALLOCATE || flavor == MPI_WIN_FLAVOR_CREATE ||
-            flavor == MPI_WIN_FLAVOR_SHARED) {
-        switch (flavor) {
-        case MPI_WIN_FLAVOR_ALLOCATE:
-            mem_type = OPAL_COMMON_UCX_MEM_ALLOCATE_MAP;
-            break;
-        case MPI_WIN_FLAVOR_CREATE:
-            mem_type = OPAL_COMMON_UCX_MEM_MAP;
-            break;
-        case MPI_WIN_FLAVOR_SHARED:
-            mem_type = OPAL_COMMON_UCX_MEM_MAP;
-            break;
-        }
-        ret = opal_common_ucx_wpmem_create(module->ctx, base, module->size,
-                                         mem_type, &exchange_len_info,
-                                         OPAL_COMMON_UCX_WPMEM_ADDR_EXCHANGE_FULL,
-                                         (void *)module->comm,
-                                           &my_mem_addr, &my_mem_addr_size,
-                                           &module->mem);
-        if (ret != OMPI_SUCCESS) {
-            goto error;
-        }
+    void **mem_base = base;
+    switch (flavor) {
+    case MPI_WIN_FLAVOR_DYNAMIC:
+        mem_type = OPAL_COMMON_UCX_MEM_ALLOCATE_MAP;
+        module->size = 0;
+        mem_base = &dynamic_base;
+        break;
+    case MPI_WIN_FLAVOR_ALLOCATE:
+        mem_type = OPAL_COMMON_UCX_MEM_ALLOCATE_MAP;
+        break;
+    case MPI_WIN_FLAVOR_CREATE:
+        mem_type = OPAL_COMMON_UCX_MEM_MAP;
+        break;
+    case MPI_WIN_FLAVOR_SHARED:
+        mem_type = OPAL_COMMON_UCX_MEM_MAP;
+        break;
+    }
+    ret = opal_common_ucx_wpmem_create(module->ctx, mem_base, module->size,
+                                     mem_type, &exchange_len_info,
+                                     OPAL_COMMON_UCX_WPMEM_ADDR_EXCHANGE_FULL,
+                                     (void *)module->comm,
+                                       &my_mem_addr, &my_mem_addr_size,
+                                       &module->mem);
+    if (ret != OMPI_SUCCESS) {
+        goto error;
     }
 
     state_base = (void *)&(module->state);
@@ -732,19 +738,13 @@ select_unlock:
     }
 
     /* exchange window addrs */
-    my_info = malloc(2 * sizeof(uint64_t));
-    if (my_info == NULL) {
-        ret = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-        goto error;
-    }
-
     if (flavor == MPI_WIN_FLAVOR_ALLOCATE || flavor == MPI_WIN_FLAVOR_CREATE ||
             flavor == MPI_WIN_FLAVOR_SHARED) {
-        memcpy(my_info, base, sizeof(uint64_t));
-    } else {
-        memcpy(my_info, &zero, sizeof(uint64_t));
+        my_info[0] = *base;
+    } else if (flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+        my_info[0] = dynamic_base;
     }
-    memcpy((char*)my_info + sizeof(uint64_t), &state_base, sizeof(uint64_t));
+    my_info[1] = state_base;
 
     recv_buf = (char *)calloc(comm_size, 2 * sizeof(uint64_t));
     ret = comm->c_coll->coll_allgather((void *)my_info, 2 * sizeof(uint64_t),
@@ -862,14 +862,14 @@ int ompi_osc_ucx_win_attach(struct ompi_win_t *win, void *base, size_t len) {
 
     if (module->state.dynamic_win_count > 0) {
         contain_index = ompi_osc_find_attached_region_position((ompi_osc_dynamic_win_info_t *)module->state.dynamic_wins,
-                                                               0, (int)module->state.dynamic_win_count,
+                                                               0, (int)module->state.dynamic_win_count - 1,
                                                                (uint64_t)base, len, &insert_index);
         if (contain_index >= 0) {
             module->local_dynamic_win_info[contain_index].refcnt++;
             return ret;
         }
 
-        assert(insert_index >= 0 && (uint64_t)insert_index < module->state.dynamic_win_count);
+        assert(insert_index >= 0 && (uint64_t)insert_index <= module->state.dynamic_win_count);
 
         memmove((void *)&module->local_dynamic_win_info[insert_index+1],
                 (void *)&module->local_dynamic_win_info[insert_index],
@@ -949,9 +949,7 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
     }
     OBJ_DESTRUCT(&module->pending_posts);
 
-    if (NULL != module->mem) {
-        opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
-    }
+    opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
 
     ret = module->comm->c_coll->coll_barrier(module->comm,
                                              module->comm->c_coll->coll_barrier_module);
@@ -968,12 +966,18 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
             free(module->sizes);
     }
 
-   /* MPI_Win_free should detach any memory attached to dynamic windows */
-    for (i = 0; i < module->state.dynamic_win_count; i++) {
-        assert(module->local_dynamic_win_info[i].refcnt == 1);
-        opal_common_ucx_wpmem_free(module->local_dynamic_win_info[i].mem);
+    if (module->flavor == MPI_WIN_FLAVOR_DYNAMIC) {
+       /* MPI_Win_free should detach any memory attached to dynamic windows */
+        for (i = 0; i < module->state.dynamic_win_count; i++) {
+            assert(module->local_dynamic_win_info[i].refcnt >= 1);
+            opal_common_ucx_wpmem_free(module->local_dynamic_win_info[i].mem);
+        }
+        module->state.dynamic_win_count = 0;
+
+        if (module->addrs[ompi_comm_rank(module->comm)] != NULL) {
+            free(module->addrs[ompi_comm_rank(module->comm)]);
+        }
     }
-    module->state.dynamic_win_count = 0;
 
     free(module->addrs);
     free(module->state_addrs);

--- a/ompi/mca/osc/ucx/osc_ucx_passive_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_passive_target.c
@@ -157,8 +157,7 @@ int ompi_osc_ucx_unlock(int target, struct ompi_win_t *win) {
 
     opal_hash_table_remove_value_uint32(&module->outstanding_locks,
                                         (uint32_t)target);
-
-    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
+    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_EP, target);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
@@ -228,20 +227,10 @@ int ompi_osc_ucx_unlock_all(struct ompi_win_t *win) {
     }
 
     assert(module->lock_count == 0);
-
-    if (module->flavor == MPI_WIN_FLAVOR_DYNAMIC) {
-        for (uint64_t i = 0; i < module->state.dynamic_win_count; i++) {
-            ret = opal_common_ucx_wpmem_flush(module->local_dynamic_win_info[i].mem , OPAL_COMMON_UCX_SCOPE_WORKER, 0);
-            if (ret != OMPI_SUCCESS) {
-                return ret;
-            }
-        }
-    }
-    else {
-        ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
-        if (ret != OMPI_SUCCESS) {
-            return ret;
-        }
+ 
+    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+    if (ret != OMPI_SUCCESS) {
+        return ret;
     }
 
     if (!module->lock_all_is_nocheck) {
@@ -284,7 +273,7 @@ int ompi_osc_ucx_flush(int target, struct ompi_win_t *win) {
         return OMPI_ERR_RMA_SYNC;
     }
 
-    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
+    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_EP, target);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
@@ -301,7 +290,7 @@ int ompi_osc_ucx_flush_all(struct ompi_win_t *win) {
         return OMPI_ERR_RMA_SYNC;
     }
 
-    ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -784,18 +784,16 @@ OPAL_DECLSPEC int opal_common_ucx_winfo_flush(opal_common_ucx_winfo_t *winfo, in
     return rc;
 }
 
-OPAL_DECLSPEC int opal_common_ucx_wpmem_flush(opal_common_ucx_wpmem_t *mem,
+OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
                                               opal_common_ucx_flush_scope_t scope, int target)
 {
     _ctx_record_t *ctx_rec;
-    opal_common_ucx_ctx_t *ctx;
     int rc = OPAL_SUCCESS;
 
-    if (NULL == mem) {
+    if (NULL == ctx) {
         return OPAL_SUCCESS;
     }
 
-    ctx = mem->ctx;
     opal_mutex_lock(&ctx->mutex);
 
     OPAL_LIST_FOREACH (ctx_rec, &ctx->ctx_records, _ctx_record_t) {

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -245,7 +245,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpmem_create(opal_common_ucx_ctx_t *ctx, void 
                                                opal_common_ucx_wpmem_t **mem_ptr);
 OPAL_DECLSPEC void opal_common_ucx_wpmem_free(opal_common_ucx_wpmem_t *mem);
 
-OPAL_DECLSPEC int opal_common_ucx_wpmem_flush(opal_common_ucx_wpmem_t *mem,
+OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
                                               opal_common_ucx_flush_scope_t scope, int target);
 OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem,
                                                     int target,


### PR DESCRIPTION
OSC/UCX Dynamic window fixes:   

     - Support for non-uniform window attach scenarios (some processes
             perform window attach more than other processes in the same dynamic window)
     - Enhancing the assertions
     - Code re-organizations
     - Some bug fixes in window management

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>