### PR TITLE
ofi: add inject path to ofi btl

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -162,6 +162,10 @@ struct mca_btl_ofi_component_t {
 
     size_t namelen;
 
+    /** Maximum inject size */
+    size_t max_inject_size;
+    bool disable_inject;
+
     /** All BTL OFI modules (1 per tl) */
     mca_btl_ofi_module_t *modules[MCA_BTL_OFI_MAX_MODULES];
 };

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -189,6 +189,13 @@ static int mca_btl_ofi_component_register(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_btl_ofi_component.rd_num);
 
+    mca_btl_ofi_component.disable_inject = false;
+    (void) mca_base_component_var_register(&mca_btl_ofi_component.super.btl_version, "disable_inject",
+                                           "disable use of fi_inject for short messages.",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_btl_ofi_component.disable_inject);
+
     /* for now we want this component to lose to the MTL. */
     module->super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH - 50;
 
@@ -476,6 +483,11 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         BTL_VERBOSE(("%s failed fi_domain with err=%s", linux_device_name, fi_strerror(-rc)));
         goto fail;
     }
+
+    /**
+     * Save the maximum sizes.
+     */
+    mca_btl_ofi_component.max_inject_size = ofi_info->tx_attr->inject_size;
 
     /* AV */
     av_attr.type = FI_AV_MAP;


### PR DESCRIPTION
We are working with a provider where some apps may do better using the OB1+OFI BTL than the OFI MTL.
To help some with performance, particularly for small message injection rate (e.g. osu_mbw_mr)
this patch adds an fi_inject option to the OFI BTL send method for messages that are
less than or equal to a provider's maximum inject message size.

Its important to be able to fall back to normal fi_send as several providers return -FI_EAGAIN regularly.

This patch improves the 8-byte message performance (as measured by osu_mbw_mr) by about 30%
when using the OB1 PML and OFI BTL and the PSM2 provider.

A new MCA parameter is added to be able to disable the inject path - btl_ofi_disable_inject.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 6eca301fa286bcf399a8cb7e963e315b37a68efa)