### PR TITLE
sessions: fix arg checking for group_from_session_pset

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -1310,14 +1310,11 @@ int ompi_group_from_pset (ompi_instance_t *instance, const char *pset_name, ompi
     if (NULL == group_out) {
         return OMPI_ERR_BAD_PARAM;
     }
-    if (*group_out == MPI_GROUP_NULL) {
-        return OMPI_ERR_BAD_PARAM;
-    }
-    
+
     if (0 == strncmp (pset_name, "mpi://", 6)) {
         pset_name += 6;
         if (0 == strcasecmp (pset_name, "WORLD")) {
-        return ompi_instance_group_world (instance, group_out);
+            return ompi_instance_group_world (instance, group_out);
         }
         if (0 == strcasecmp (pset_name, "SELF")) {
             return ompi_instance_group_self (instance, group_out);


### PR DESCRIPTION
The group handle to MPI_Group_from_session_pset is an OUT parameter as defined in the MPI 4.0 spec.
The spec is silent about what the value pointed to by the group handle argument can/should be.

Note the second example in section 11.4 of the specification fails unless this patch is applied.

Related to issue #10577

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit 5408bab3403a4080480d78943e911e4548e6777b)