### PR TITLE
v5.0.x: Fix typos in the opal/ subdirectory

### DIFF
--- a/opal/class/opal_bitmap.h
+++ b/opal/class/opal_bitmap.h
@@ -83,7 +83,7 @@ OPAL_DECLSPEC int opal_bitmap_init(opal_bitmap_t *bm, int size);
 
 /**
  * Set a bit of the bitmap. If the bit asked for is beyond the current
- * size of the bitmap, then the bitmap is extended to accomodate the
+ * size of the bitmap, then the bitmap is extended to accommodate the
  * bit
  *
  * @param  bitmap The input bitmap (IN)

--- a/opal/class/opal_cstring.h
+++ b/opal/class/opal_cstring.h
@@ -137,7 +137,7 @@ int opal_cstring_to_int(opal_cstring_t *string, int *interp);
  * @retval OPAL_SUCCESS string was successfully interpreted
  * @retval OPAL_ERR_BAD_PARAM string was not able to be interpreted
  *
- *   The string value will be cast to the boolen output in
+ *   The string value will be cast to the boolean output in
  *   the following manner:
  *
  *   - If the string value is digits, the return value is "(bool)

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
- *                         reseved.
+ *                         reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021      Google, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -222,7 +222,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic(opal_fifo_t *fifo)
     /* use load-linked store-conditional to avoid ABA issues */
     do {
         if (++attempt == 5) {
-            /* deliberatly suspend this thread to allow other threads to run. this should
+            /* deliberately suspend this thread to allow other threads to run. this should
              * only occur during periods of contention on the lifo. */
             _opal_lifo_release_cpu();
             attempt = 0;

--- a/opal/class/opal_free_list.h
+++ b/opal/class/opal_free_list.h
@@ -175,13 +175,13 @@ OPAL_DECLSPEC int opal_free_list_grow_st(opal_free_list_t *flist, size_t num_ele
 OPAL_DECLSPEC int opal_free_list_resize_mt(opal_free_list_t *flist, size_t size);
 
 /**
- * Attemp to obtain an item from a free list.
+ * Attempt to obtain an item from a free list.
  *
  * @param fl (IN)        Free list.
  * @param item (OUT)     Allocated item.
  *
  * If the requested item is not available the free list is grown to
- * accomodate the request - unless the max number of allocations has
+ * accommodate the request - unless the max number of allocations has
  * been reached.  If this is the case - a NULL pointer is returned
  * to the caller. This function comes in three flavor: thread safe
  * (opal_free_list_get_mt), single threaded (opal_free_list_get_st),
@@ -230,7 +230,7 @@ static inline opal_free_list_item_t *opal_free_list_get(opal_free_list_t *flist)
  * @param item (OUT)     Allocated item.
  *
  * If the requested item is not available the free list is grown to
- * accomodate the request - unless the max number of allocations has
+ * accommodate the request - unless the max number of allocations has
  * been reached. In this case the caller is blocked until an item
  * is returned to the list.
  */
@@ -259,8 +259,8 @@ static inline opal_free_list_item_t *opal_free_list_wait_mt(opal_free_list_t *fl
                 }
             }
         } else {
-            /* If I wasn't able to get the lock in the begining when I finaly grab it
-             * the one holding the lock in the begining already grow the list. I will
+            /* If I wasn't able to get the lock in the beginning when I finally grab it
+             * the one holding the lock in the beginning already grow the list. I will
              * release the lock and try to get a new element until I succeed.
              */
             opal_mutex_lock(&fl->fl_lock);

--- a/opal/class/opal_graph.c
+++ b/opal/class/opal_graph.c
@@ -627,7 +627,7 @@ uint32_t opal_graph_dijkstra(opal_graph_t *graph, opal_graph_vertex_t *vertex,
     /* run on all the vertices of the graph */
     i = 0;
     OPAL_LIST_FOREACH (adj_list, graph->adjacency_list, opal_adjacency_list_t) {
-        /* insert the vertices pointes to the working queue */
+        /* insert the vertices points to the working queue */
         Q[i].vertex = adj_list->vertex;
         /**
          * assign an infinity distance to all the vertices in the queue
@@ -677,7 +677,7 @@ uint32_t opal_graph_dijkstra(opal_graph_t *graph, opal_graph_vertex_t *vertex,
 
 /**
  * This graph API duplicates a graph. Note that this API does
- * not copy the graph but builds a new graph while coping just
+ * not copy the graph but builds a new graph while copying just
  * the vertex data.
  *
  * @param dest The new created graph.

--- a/opal/class/opal_graph.h
+++ b/opal/class/opal_graph.h
@@ -19,7 +19,7 @@
 /**
  * @file
  * The opal_graph interface is used to provide a generic graph infrastructure
- * to Open-MPI. The graph is represented as an adjacentcy list.
+ * to Open-MPI. The graph is represented as an adjacency list.
  * The graph is a list of vertices. The graph is a weighted directional graph.
  * Each vertex contains a pointer to a vertex data.
  * This pointer can point to the structure that this vertex belongs to.
@@ -53,7 +53,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_adjacency_list_t);
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_graph_t);
 
 /**
- * Function pointer for coping a vertex data from one vertex to
+ * Function pointer for copying a vertex data from one vertex to
  * another
  *
  * @param dst The destination pointer of vertex_data
@@ -83,7 +83,7 @@ typedef void *(*opal_graph_alloc_vertex_data)(void);
  *@param vertex_data1
  *@param vertex_data2
  *
- *@return int The comparition results. 1- vertex_data1 is bigger
+ *@return int The comparison results. 1- vertex_data1 is bigger
  *        then vertex_data2, 0- vertex_data1 is equal to
  *        vertex_data2 and -1- vertex_data1 is smaller the
  *        vertex_data2.
@@ -310,7 +310,7 @@ OPAL_DECLSPEC int opal_graph_get_adjacent_vertices(opal_graph_t *graph, opal_gra
 
 /**
  * This graph API duplicates a graph. Note that this API does
- * not copy the graph but builds a new graph while coping just
+ * not copy the graph but builds a new graph while copying just
  * the vertices data.
  *
  * @param dest The new created graph.

--- a/opal/class/opal_hash_table.c
+++ b/opal/class/opal_hash_table.c
@@ -37,7 +37,7 @@
  * Sketch: [Contributed by David Linden of Hewlett-Packard]
  *
  * This has been found to be good for search and insert and
- * (seldom-)remove, all with probablistic O(1) time.  Having a good
+ * (seldom-)remove, all with probabilistic O(1) time.  Having a good
  * distribution of the hash indices is important, so even if you know
  * the keys distribute well under a mask, that micro-optimization
  * isn't worth doing.
@@ -299,7 +299,7 @@ opal_hash_table_remove_elt_at(opal_hash_table_t *ht, size_t ii)
                 /* already in place, either ideal or best-for-now */
                 break;
             } else if (!elts[jj].valid) {
-                /* move it down, and invaildate where it came from */
+                /* move it down, and invalidate where it came from */
                 elts[jj] = elts[ii];
                 elts[ii].valid = 0;
                 break;

--- a/opal/class/opal_hotel.h
+++ b/opal/class/opal_hotel.h
@@ -154,7 +154,7 @@ OBJ_CLASS_DECLARATION(opal_hotel_t);
  * already been ("forcibly") checked out *before* the
  * eviction_callback_fn is invoked.
  *
- * @return OPAL_SUCCESS if all initializations were succesful. Otherwise,
+ * @return OPAL_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 OPAL_DECLSPEC int opal_hotel_init(opal_hotel_t *hotel, int num_rooms, opal_event_base_t *evbase,

--- a/opal/class/opal_interval_tree.c
+++ b/opal/class/opal_interval_tree.c
@@ -87,7 +87,7 @@ static void opal_interval_tree_construct(opal_interval_tree_t *tree)
     tree->reader_count = 0;
     tree->epoch = 0;
 
-    /* set all reader epochs to UINT_MAX. this value is used to simplfy
+    /* set all reader epochs to UINT_MAX. this value is used to simplify
      * checks against the current epoch. */
     for (int i = 0; i < OPAL_INTERVAL_TREE_MAX_READERS; ++i) {
         tree->reader_epochs[i] = UINT_MAX;
@@ -788,7 +788,7 @@ static opal_interval_tree_node_t *left_rotate(opal_interval_tree_t *tree,
 
     rp_publish(&y->left, x_copy);
 
-    /* normlly we would have to check to see if we are at the root.
+    /* normally we would have to check to see if we are at the root.
      * however, the root sentinal takes care of it for us */
     if (x == parent->left) {
         rp_publish(&parent->left, y);

--- a/opal/class/opal_interval_tree.h
+++ b/opal/class/opal_interval_tree.h
@@ -114,7 +114,7 @@ typedef int (*opal_interval_tree_condition_fn_t)(void *);
 typedef int (*opal_interval_tree_action_fn_t)(uint64_t low, uint64_t high, void *data, void *ctx);
 
 /*
- * Public function protoypes
+ * Public function prototypes
  */
 
 /**
@@ -189,7 +189,7 @@ OPAL_DECLSPEC int opal_interval_tree_destroy(opal_interval_tree_t *tree);
  * @param tree a pointer to the tree
  * @param low low value of interval
  * @param high high value of interval
- * @param partial_ok traverse nodes that parially overlap the given range
+ * @param partial_ok traverse nodes that partially overlap the given range
  * @param action a pointer to the action function
  * @param ctx context to pass to action function
  *
@@ -205,7 +205,7 @@ OPAL_DECLSPEC int opal_interval_tree_traverse(opal_interval_tree_t *tree, uint64
  *
  * @param tree a pointer to the tree data structure
  *
- * @retval int the nuber of items on the tree
+ * @retval int the number of items on the tree
  */
 OPAL_DECLSPEC size_t opal_interval_tree_size(opal_interval_tree_t *tree);
 

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
- *                         reseved.
+ *                         reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights reserved.
@@ -223,7 +223,7 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
 
     do {
         if (++attempt == 5) {
-            /* deliberatly suspend this thread to allow other threads to run. this should
+            /* deliberately suspend this thread to allow other threads to run. this should
              * only occur during periods of contention on the lifo. */
             _opal_lifo_release_cpu();
             attempt = 0;

--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -369,7 +369,7 @@ static inline opal_list_item_t *opal_list_get_last(opal_list_t *list)
  * Similar to the STL, this is a special invalid list item -- it
  * should \em not be used for storage.  It is only suitable for
  * comparison to other items in the list to see if they are valid or
- * not; it's ususally used when iterating through the items in a list.
+ * not; it's usually used when iterating through the items in a list.
  *
  * This is an inlined function in compilers that support inlining, so
  * it's usually a cheap operation.
@@ -391,7 +391,7 @@ static inline opal_list_item_t *opal_list_get_begin(opal_list_t *list)
  * Similar to the STL, this is a special invalid list item -- it
  * should \em not be used for storage.  It is only suitable for
  * comparison to other items in the list to see if they are valid or
- * not; it's ususally used when iterating through the items in a list.
+ * not; it's usually used when iterating through the items in a list.
  *
  * This is an inlined function in compilers that support inlining, so
  * it's usually a cheap operation.
@@ -602,7 +602,7 @@ static inline void opal_list_prepend(opal_list_t *list, opal_list_item_t *item)
     /* reset item's previous pointer */
     item->opal_list_prev = sentinel;
 
-    /* reset previous first element's previous poiner */
+    /* reset previous first element's previous pointer */
     sentinel->opal_list_next->opal_list_prev = item;
 
     /* reset head's next pointer */
@@ -838,7 +838,7 @@ OPAL_DECLSPEC void opal_list_join(opal_list_t *thislist, opal_list_item_t *pos, 
  * last) elements of \c xlist are moved into \c thislist,
  * inserting them before \c pos.  \c pos must be a valid iterator
  * in \c thislist and \c [first, last) must be a valid range in \c
- * xlist.  \c postition must not be in the range \c [first, last).
+ * xlist.  \c position must not be in the range \c [first, last).
  * It is, however, valid for \c xlist and \c thislist to be the
  * same list.
  *

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -196,8 +196,8 @@ struct opal_object_t {
     opal_atomic_int32_t obj_reference_count; /**< reference count */
 #if OPAL_ENABLE_DEBUG
     const char
-        *cls_init_file_name; /**< In debug mode store the file where the object get contructed */
-    int cls_init_lineno; /**< In debug mode store the line number where the object get contructed */
+        *cls_init_file_name; /**< In debug mode store the file where the object get constructed */
+    int cls_init_lineno; /**< In debug mode store the line number where the object get constructed */
 #endif /* OPAL_ENABLE_DEBUG */
 };
 

--- a/opal/class/opal_pointer_array.h
+++ b/opal/class/opal_pointer_array.h
@@ -83,7 +83,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_pointer_array_t);
  * @param max_size The maximum size of the array (IN)
  * @param block_size The size for all subsequent grows of the array (IN).
  *
- * @return OPAL_SUCCESS if all initializations were succesfull. Otherwise,
+ * @return OPAL_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 OPAL_DECLSPEC int opal_pointer_array_init(opal_pointer_array_t *array, int initial_allocation,

--- a/opal/class/opal_rb_tree.c
+++ b/opal/class/opal_rb_tree.c
@@ -473,7 +473,7 @@ static void left_rotate(opal_rb_tree_t *tree, opal_rb_tree_node_t *x)
         y->left->parent = x;
     }
 
-    /* normlly we would have to check to see if we are at the root.
+    /* normally we would have to check to see if we are at the root.
      * however, the root sentinal takes care of it for us */
     if (x == x->parent->left) {
         x->parent->left = y;

--- a/opal/class/opal_rb_tree.h
+++ b/opal/class/opal_rb_tree.h
@@ -100,7 +100,7 @@ typedef int (*opal_rb_tree_condition_fn_t)(void *);
 typedef void (*opal_rb_tree_action_fn_t)(void *, void *);
 
 /*
- * Public function protoypes
+ * Public function prototypes
  */
 
 /**
@@ -194,7 +194,7 @@ OPAL_DECLSPEC int opal_rb_tree_traverse(opal_rb_tree_t *tree, opal_rb_tree_condi
  *
  * @param tree a pointer to the tree data structure
  *
- * @retval int the nuber of items on the tree
+ * @retval int the number of items on the tree
  */
 OPAL_DECLSPEC int opal_rb_tree_size(opal_rb_tree_t *tree);
 

--- a/opal/class/opal_ring_buffer.h
+++ b/opal/class/opal_ring_buffer.h
@@ -65,7 +65,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_ring_buffer_t);
  * @param ring Pointer to a ring buffer (IN/OUT)
  * @param size The number of elements in the ring (IN)
  *
- * @return OPAL_SUCCESS if all initializations were succesful. Otherwise,
+ * @return OPAL_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 OPAL_DECLSPEC int opal_ring_buffer_init(opal_ring_buffer_t *ring, int size);

--- a/opal/class/opal_value_array.h
+++ b/opal/class/opal_value_array.h
@@ -96,7 +96,7 @@ static inline int opal_value_array_reserve(opal_value_array_t *array, size_t siz
 }
 
 /**
- *  Retreives the number of elements in the array.
+ *  Retrieves the number of elements in the array.
  *
  *  @param   array   The input array (IN).
  *  @return  The number of elements currently in use.

--- a/opal/cuda/README.md
+++ b/opal/cuda/README.md
@@ -5,7 +5,7 @@ Most of the developers at the time didn't really understand CUDA (or
 GPUs), and the developers working on CUDA were new to Open MPI's
 abstractions.  It was also unclear whether there would be another
 interface for someone else's GPUs or whether the world would choose
-CUDA.  With this backrgound, choices were made.
+CUDA.  With this background, choices were made.
 
 The initial implementation put much of the cuda buffer handling
 functions in the datatype engine, including the code to determine if

--- a/opal/cuda/common_cuda.c
+++ b/opal/cuda/common_cuda.c
@@ -217,7 +217,7 @@ static void cuda_dump_memhandle(int, void *, char *) __opal_attribute_unused__;
 #    define CUDA_DUMP_EVTHANDLE(a)
 #endif /* OPAL_ENABLE_DEBUG */
 
-/* This is a seperate function so we can see these variables with ompi_info and
+/* This is a separate function so we can see these variables with ompi_info and
  * also set them with the tools interface */
 void mca_common_cuda_register_mca_variables(void)
 {
@@ -258,7 +258,7 @@ void mca_common_cuda_register_mca_variables(void)
 
     /* Use this parameter to increase the number of outstanding events allows */
     (void) mca_base_var_register("ompi", "mpi", "common_cuda", "event_max",
-                                 "Set number of oustanding CUDA events", MCA_BASE_VAR_TYPE_INT,
+                                 "Set number of outstanding CUDA events", MCA_BASE_VAR_TYPE_INT,
                                  NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
                                  &cuda_event_max);
 
@@ -289,7 +289,7 @@ void mca_common_cuda_register_mca_variables(void)
 /**
  * This is the first stage of initialization.  This function is called
  * explicitly by any BTLs that can support CUDA-aware. It is called during
- * the component open phase of initialization. This fuction will look for
+ * the component open phase of initialization. This function will look for
  * the SONAME of the library which is libcuda.so.1. In most cases, this will
  * result in the library found.  However, there are some setups that require
  * the extra steps for searching. This function will then load the symbols
@@ -1788,11 +1788,11 @@ static int mca_common_cuda_is_gpu_buffer(const void *pUserBuf, opal_convertor_t 
         }
     }
 
-    /* WORKAROUND - They are times when the above code determines a pice of memory
+    /* WORKAROUND - They are times when the above code determines a piece of memory
      * is GPU memory, but it actually is not.  That has been seen on multi-GPU systems
      * with 6 or 8 GPUs on them. Therefore, we will do this extra check.  Note if we
      * made it this far, then the assumption at this point is we have GPU memory.
-     * Unfotunately, this extra call is costing us another 100 ns almost doubling
+     * Unfortunately, this extra call is costing us another 100 ns almost doubling
      * the cost of this entire function. */
     if (OPAL_LIKELY(mca_common_cuda_gpu_mem_check_workaround)) {
         CUdeviceptr pbase;
@@ -2132,7 +2132,7 @@ bool opal_cuda_check_bufs(char *dest, char *src)
 /* Checks the type of pointer
  *
  * @param buf   check one pointer providing a convertor.
- *  Provides aditional information, e.g. managed vs. unmanaged GPU buffer
+ *  Provides additional information, e.g. managed vs. unmanaged GPU buffer
  */
 bool opal_cuda_check_one_buf(char *buf, opal_convertor_t *convertor)
 {

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -153,7 +153,7 @@ opal_convertor_master_t *opal_convertor_find_or_create_master(uint32_t remote_ar
     /**
      * Now we can compute the conversion mask. For all sizes where the remote
      * and local architecture differ a conversion is needed. Moreover, if the
-     * 2 architectures don't have the same endianess all data with a length
+     * 2 architectures don't have the same endianness all data with a length
      * over 2 bytes (with the exception of logicals) have to be byte-swapped.
      */
     for (i = OPAL_DATATYPE_FIRST_TYPE; i < OPAL_DATATYPE_MAX_PREDEFINED; i++) {
@@ -187,7 +187,7 @@ opal_convertor_master_t *opal_convertor_find_or_create_master(uint32_t remote_ar
         }
     }
 
-    /* We're done so far, return the mater convertor */
+    /* We're done so far, return the master convertor */
     return master;
 }
 
@@ -224,7 +224,7 @@ opal_convertor_t *opal_convertor_create(int32_t remote_arch, int32_t mode)
 /**
  * Return 0 if everything went OK and if there is still room before the complete
  *          conversion of the data (need additional call with others input buffers )
- *        1 if everything went fine and the data was completly converted
+ *        1 if everything went fine and the data was completely converted
  *       -1 something wrong occurs.
  */
 int32_t opal_convertor_pack(opal_convertor_t *pConv, struct iovec *iov, uint32_t *out_size,
@@ -293,7 +293,7 @@ int32_t opal_convertor_unpack(opal_convertor_t *pConv, struct iovec *iov, uint32
     if (OPAL_LIKELY(pConv->flags & CONVERTOR_NO_OP)) {
         /**
          * We are doing conversion on a contiguous datatype on a homogeneous
-         * environment. The convertor contain minimal informations, we only
+         * environment. The convertor contain minimal information, we only
          * use the bConverted to manage the conversion.
          */
         uint32_t i;
@@ -363,7 +363,7 @@ static inline int opal_convertor_create_stack_with_pos_contig(opal_convertor_t *
     /* now compute the number of pending bytes */
     count = starting_point % pData->size;
     /**
-     * We save the current displacement starting from the begining
+     * We save the current displacement starting from the beginning
      * of this data.
      */
     if (OPAL_LIKELY(0 == count)) {

--- a/opal/datatype/opal_convertor_internal.h
+++ b/opal/datatype/opal_convertor_internal.h
@@ -37,7 +37,7 @@ typedef struct opal_convertor_master_t {
 
 /*
  * Find or create a new master convertor based on a specific architecture. The master
- * convertor hold all informations related to a defined architecture, such as the sizes
+ * convertor hold all information related to a defined architecture, such as the sizes
  * of the predefined data-types, the conversion functions, ...
  */
 opal_convertor_master_t *opal_convertor_find_or_create_master(uint32_t remote_arch);

--- a/opal/datatype/opal_convertor_raw.c
+++ b/opal/datatype/opal_convertor_raw.c
@@ -83,7 +83,7 @@ int32_t opal_convertor_raw(opal_convertor_t *pConvertor, struct iovec *iov, uint
         return 1; /* We're still done */
     }
     if (OPAL_LIKELY(pConvertor->flags & CONVERTOR_NO_OP)) {
-        /* The convertor contain minimal informations, we only use the bConverted
+        /* The convertor contain minimal information, we only use the bConverted
          * to manage the conversion. This function work even after the convertor
          * was moved to a specific position.
          */

--- a/opal/datatype/opal_copy_functions_heterogeneous.c
+++ b/opal/datatype/opal_copy_functions_heterogeneous.c
@@ -136,7 +136,7 @@ static inline void opal_dt_swap_long_double(void *to_p, const void *from_p, cons
 /**
  * BEWARE: Do not use the following macro with composed types such as
  * complex. As the swap is done using the entire type sizeof, the
- * wrong endianess translation will be done.  Instead, use the
+ * wrong endianness translation will be done.  Instead, use the
  * COPY_2SAMETYPE_HETEROGENEOUS.
  */
 #define COPY_TYPE_HETEROGENEOUS(TYPENAME, TYPE) COPY_TYPE_HETEROGENEOUS_INTERNAL(TYPENAME, TYPE, 0)
@@ -469,7 +469,7 @@ copy_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
     datatype_check("long", sizeof(long), pConvertor->master->remote_sizes[OPAL_DATATYPE_LONG], &count, from, from_len, from_extent, to,
                    to_length, to_extent);
     if (!((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_LONGIS64)) {  /* same sizeof(long) */
-        if ((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_ISBIGENDIAN) {  /* different endianess */
+        if ((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_ISBIGENDIAN) {  /* different endianness */
             for (i = 0; i < count; i++) {
                 opal_dt_swap_bytes(to, from, sizeof(long), 1);
                 to += to_extent;
@@ -505,7 +505,7 @@ copy_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
                         from += from_extent;
                     }
                 }
-            } else {  /* both have the same endianess */
+            } else {  /* both have the same endianness */
                 if (opal_local_arch & OPAL_ARCH_LONGIS64) {
                     for (i = 0; i < count; i++) { /* from 8 to 4 bytes */
                         long val = *(long*)from;
@@ -542,7 +542,7 @@ copy_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
                         from += from_extent;
                     }
                 }
-            } else {  /* both have the same endianess */
+            } else {  /* both have the same endianness */
                 if (opal_local_arch & OPAL_ARCH_LONGIS64) {
                     for (i = 0; i < count; i++) { /* from 8 to 4 bytes */
                         int32_t val = *(int32_t*)from;
@@ -576,7 +576,7 @@ copy_unsigned_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
     datatype_check("unsigned long", sizeof(unsigned long), pConvertor->master->remote_sizes[OPAL_DATATYPE_UNSIGNED_LONG],
                    &count, from, from_len, from_extent, to, to_length, to_extent);
     if (!((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_LONGIS64)) {  /* same sizeof(long) */
-        if ((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_ISBIGENDIAN) {  /* different endianess */
+        if ((pConvertor->remoteArch ^ opal_local_arch) & OPAL_ARCH_ISBIGENDIAN) {  /* different endianness */
             for (i = 0; i < count; i++) {
                 opal_dt_swap_bytes(to, from, sizeof(unsigned long), 1);
                 to += to_extent;
@@ -612,7 +612,7 @@ copy_unsigned_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
                         from += from_extent;
                     }
                 }
-            } else {  /* both have the same endianess */
+            } else {  /* both have the same endianness */
                 if (opal_local_arch & OPAL_ARCH_LONGIS64) {
                     for (i = 0; i < count; i++) { /* from 8 to 4 bytes */
                         unsigned long val = *(unsigned long*)from;
@@ -649,7 +649,7 @@ copy_unsigned_long_heterogeneous(opal_convertor_t *pConvertor, size_t count,
                         from += from_extent;
                     }
                 }
-            } else {  /* both have the same endianess */
+            } else {  /* both have the same endianness */
                 if (opal_local_arch & OPAL_ARCH_LONGIS64) {
                     for (i = 0; i < count; i++) { /* from 8 to 4 bytes */
                         uint32_t val = *(uint32_t*)from;

--- a/opal/datatype/opal_datatype_add.c
+++ b/opal/datatype/opal_datatype_add.c
@@ -115,7 +115,7 @@ static inline int IMAX(int a, int b)
  * displacement.
  */
 
-/* we have 3 differents structures to update:
+/* we have 3 different structures to update:
  * - the first is the real representation of the datatype
  * - the second is the internal representation using extents
  * - the last is the representation used for send operations
@@ -188,8 +188,8 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
     OPAL_DATATYPE_LB_UB_CONT(count, disp, pdtAdd->lb, pdtAdd->ub, extent, lb, ub);
 
     /* Compute the true_lb and true_ub for the datatype to be added, taking
-     * in account the number of repetions. These values do not include the
-     * potential gaps at the begining and at the end of the datatype.
+     * in account the number of repetitions. These values do not include the
+     * potential gaps at the beginning and at the end of the datatype.
      */
     true_lb = lb - (pdtAdd->lb - pdtAdd->true_lb);
     true_ub = ub - (pdtAdd->ub - pdtAdd->true_ub);
@@ -226,7 +226,7 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
 
     /* the same apply for the upper bound except for the case where
      * either of them has the flag UB, in which case we should
-     * compute the UB including the natural alignement of the data.
+     * compute the UB including the natural alignment of the data.
      */
     if ((pdtBase->flags ^ pdtAdd->flags) & OPAL_DATATYPE_FLAG_USER_UB) {
         if (pdtBase->flags & OPAL_DATATYPE_FLAG_USER_UB) {
@@ -235,7 +235,7 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
         pdtBase->flags |= OPAL_DATATYPE_FLAG_USER_UB;
     } else {
         /* both of them have the UB flag or both of them dont have it */
-        /* we should compute the extent depending on the alignement */
+        /* we should compute the extent depending on the alignment */
         ub = LMAX(pdtBase->ub, ub);
     }
     /* While the true_lb and true_ub have to be ordered to have the true_lb lower
@@ -245,11 +245,11 @@ int32_t opal_datatype_add(opal_datatype_t *pdtBase, const opal_datatype_t *pdtAd
     pdtBase->lb = lb;
     pdtBase->ub = ub;
 
-    /* compute the new memory alignement */
+    /* compute the new memory alignment */
     pdtBase->align = IMAX(pdtBase->align, pdtAdd->align);
 
     /* Now that we have the new ub and the alignment we should update the ub to match
-     * the new alignement. We have to add an epsilon that is the least nonnegative
+     * the new alignment. We have to add an epsilon that is the least nonnegative
      * increment needed to roung the extent to the next multiple of the alignment.
      * This rule apply only if there is user specified upper bound as stated in the
      * MPI standard MPI 1.2 page 71.

--- a/opal/datatype/opal_datatype_get_count.c
+++ b/opal/datatype/opal_datatype_get_count.c
@@ -59,7 +59,7 @@ ssize_t opal_datatype_get_element_count(const opal_datatype_t *datatype, size_t 
                 }
                 pos_desc++; /* advance to the next element after the end loop */
             } else {
-                pos_desc = pStack->index + 1; /* go back to the begining of the loop */
+                pos_desc = pStack->index + 1; /* go back to the beginning of the loop */
             }
             continue;
         }
@@ -129,7 +129,7 @@ int32_t opal_datatype_set_element_count(const opal_datatype_t *datatype, size_t 
                 }
                 pos_desc++; /* advance to the next element after the end loop */
             } else {
-                pos_desc = pStack->index + 1; /* go back to the begining of the loop */
+                pos_desc = pStack->index + 1; /* go back to the beginning of the loop */
             }
             continue;
         }
@@ -195,7 +195,7 @@ int opal_datatype_compute_ptypes(opal_datatype_t *datatype)
                 }
                 pos_desc++; /* advance to the next element after the end loop */
             } else {
-                pos_desc = pStack->index + 1; /* go back to the begining of the loop */
+                pos_desc = pStack->index + 1; /* go back to the beginning of the loop */
             }
             continue;
         }

--- a/opal/datatype/opal_datatype_internal.h
+++ b/opal/datatype/opal_datatype_internal.h
@@ -133,7 +133,7 @@ struct ddt_elem_desc {
 typedef struct ddt_elem_desc ddt_elem_desc_t;
 
 /**
- * The loop description, with it's two markers: one for the begining and one for
+ * The loop description, with it's two markers: one for the beginning and one for
  * the end. The initial marker contains the number of repetitions, the number of
  * elements in the loop, and the extent of each loop. The end marker contains in
  * addition to the number of elements (so that we can easily pair together the

--- a/opal/datatype/opal_datatype_module.c
+++ b/opal/datatype/opal_datatype_module.c
@@ -39,7 +39,7 @@
 #include "opal/util/arch.h"
 #include "opal/util/output.h"
 
-/* by default the debuging is turned off */
+/* by default the debugging is turned off */
 int opal_datatype_dfd = -1;
 bool opal_ddt_unpack_debug = false;
 bool opal_ddt_pack_debug = false;
@@ -50,7 +50,7 @@ int opal_ddt_verbose = -1; /* Has the datatype verbose it's own output stream */
 
 extern int opal_cuda_verbose;
 
-/* Using this macro implies that at this point _all_ informations needed
+/* Using this macro implies that at this point _all_ information needed
  * to fill up the datatype are known.
  * We fill all the static information, the pointer to desc.desc is setup
  * into an array, which is initialized at runtime.
@@ -249,7 +249,7 @@ static void opal_datatype_finalize(void)
      */
 
     /* As they are statically allocated they cannot be released. But we
-     * can call OBJ_DESTRUCT, just to free all internally allocated ressources.
+     * can call OBJ_DESTRUCT, just to free all internally allocated resources.
      */
     /* clear all master convertors */
     opal_convertor_destroy_masters();

--- a/opal/datatype/opal_datatype_pack.c
+++ b/opal/datatype/opal_datatype_pack.c
@@ -57,7 +57,7 @@
 #endif /* defined(CHECKSUM) */
 
 /* the contig versions does not use the stack. They can easily retrieve
- * the status with just the informations from pConvertor->bConverted.
+ * the status with just the information from pConvertor->bConverted.
  */
 int32_t opal_pack_homogeneous_contig_function(opal_convertor_t *pConv, struct iovec *iov,
                                               uint32_t *out_size, size_t *max_data)
@@ -115,7 +115,7 @@ int32_t opal_pack_homogeneous_contig_with_gaps_function(opal_convertor_t *pConv,
     uint32_t idx;
     size_t i;
 
-    /* The memory layout is contiguous with gaps in the begining and at the end. The datatype
+    /* The memory layout is contiguous with gaps in the beginning and at the end. The datatype
      * true_lb is the initial displacement, the size the length of the contiguous area and the
      * extent represent how much we should jump between elements.
      */
@@ -240,7 +240,7 @@ update_status_and_return:
  * - a datatype (with the flag DT_DATA set) will have the contiguous flags set if and only if
  *   the data is really contiguous (extent equal with size)
  * - for the OPAL_DATATYPE_LOOP type the DT_CONTIGUOUS flag set means that the content of the loop
- * is contiguous but with a gap in the begining or at the end.
+ * is contiguous but with a gap in the beginning or at the end.
  * - the DT_CONTIGUOUS flag for the type OPAL_DATATYPE_END_LOOP is meaningless.
  */
 int32_t opal_generic_simple_pack_function(opal_convertor_t *pConvertor, struct iovec *iov,
@@ -329,7 +329,7 @@ int32_t opal_generic_simple_pack_function(opal_convertor_t *pConvertor, struct i
                     pStack--;
                     pos_desc++; /* and move to the next element */
                 } else {
-                    pos_desc = pStack->index + 1; /* jump back to the begining of the loop */
+                    pos_desc = pStack->index + 1; /* jump back to the beginning of the loop */
                     if (pStack->index == -1) {    /* If it's the datatype count loop */
                         pStack->disp += (pData->ub - pData->lb); /* jump by the datatype extent */
                     } else {

--- a/opal/datatype/opal_datatype_pack.h
+++ b/opal/datatype/opal_datatype_pack.h
@@ -101,7 +101,7 @@ static inline void pack_predefined_data(opal_convertor_t *CONVERTOR, const dt_el
     if ((blocklen_bytes * cando_count) > *(SPACE))
         cando_count = (*SPACE) / blocklen_bytes;
 
-    /* premptively update the number of COUNT we will return. */
+    /* preemptively update the number of COUNT we will return. */
     *(COUNT) -= cando_count;
 
     if (_elem->blocklen < 9) {

--- a/opal/datatype/opal_datatype_position.c
+++ b/opal/datatype/opal_datatype_position.c
@@ -48,7 +48,7 @@
  * - a datatype (with the flag DT_DATA set) will have the contiguous flags set if and only if
  *   the data is really contiguous (extent equal with size)
  * - for the OPAL_DATATYPE_LOOP type the DT_CONTIGUOUS flag set means that the content of the loop
- * is contiguous but with a gap in the begining or at the end.
+ * is contiguous but with a gap in the beginning or at the end.
  * - the DT_CONTIGUOUS flag for the type OPAL_DATATYPE_END_LOOP is meaningless.
  */
 

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -272,7 +272,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
  * - a datatype (with the flag DT_DATA set) will have the contiguous flags set if and only if
  *   the data is really contiguous (extent equal with size)
  * - for the OPAL_DATATYPE_LOOP type the DT_CONTIGUOUS flag set means that the content of the loop
- * is contiguous but with a gap in the begining or at the end.
+ * is contiguous but with a gap in the beginning or at the end.
  * - the DT_CONTIGUOUS flag for the type OPAL_DATATYPE_END_LOOP is meaningless.
  */
 int32_t opal_generic_simple_unpack_function(opal_convertor_t *pConvertor, struct iovec *iov,

--- a/opal/etc/Makefile.am
+++ b/opal/etc/Makefile.am
@@ -54,7 +54,7 @@ install-data-local:
 
 # Only remove if exactly the same as what in our tree
 # NOTE TO READER: Bourne shell if ... fi evaluates the body if
-#    the return of the evaluted command is 0 (as opposed to non-zero
+#    the return of the evaluated command is 0 (as opposed to non-zero
 #    as used by everyone else)
 uninstall-local:
 	@ p="$(opal_config_files)"; \

--- a/opal/include/opal/opal_portable_platform_real.h
+++ b/opal/include/opal/opal_portable_platform_real.h
@@ -330,7 +330,7 @@
       /* Include below might fail for ancient versions lacking this header, but testing shows it
          works back to at least 5.1-3 (Nov 2003), and based on docs probably back to 3.2 (Sep 2000) */
         #define PLATFORM_COMPILER_VERSION 0       
-    #elif defined(__x86_64__) /* bug 1753 - 64-bit omp.h upgrade happenned in <6.0-8,6.1-1] */
+    #elif defined(__x86_64__) /* bug 1753 - 64-bit omp.h upgrade happened in <6.0-8,6.1-1] */
       #include "omp.h"
       #if defined(_PGOMP_H)
         /* 6.1.1 or newer */
@@ -341,7 +341,7 @@
         #define PLATFORM_COMPILER_VERSION 0
         #define PLATFORM_COMPILER_VERSION_STR "<=6.0-8"
       #endif
-    #else /* 32-bit omp.h upgrade happenned in <5.2-4,6.0-8] */
+    #else /* 32-bit omp.h upgrade happened in <5.2-4,6.0-8] */
       #include "omp.h"
       #if defined(_PGOMP_H)
         /* 6.0-8 or newer */
@@ -590,7 +590,7 @@
     #define PLATFORM_COMPILER_VERSION_STR __clang_version__
   #endif
 
-// NOTE: PLATFORM_COMPILER_FAMILYID "20" is allocted to NVHPC, appearing earlier
+// NOTE: PLATFORM_COMPILER_FAMILYID "20" is allocated to NVHPC, appearing earlier
 
 #else /* unknown compiler */
   #define PLATFORM_COMPILER_UNKNOWN  1

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -114,7 +114,7 @@ static inline void opal_atomic_wmb(void);
  * The stdc implementation is implemetned as macros around the C11
  * atomic interface (which is a type-independent interface).  While it
  * would be better to have type checking so developers using the C11
- * interface didn't accidently munge something that broke on other
+ * interface didn't accidentally munge something that broke on other
  * implementations, there are a ton of warnings due to volatile casing
  * in the opal_lifo code. Don't enforce the types of the function
  * calls on C11 until we can sort that out.
@@ -122,11 +122,11 @@ static inline void opal_atomic_wmb(void);
 #if OPAL_USE_C11_ATOMICS == 0
 
 /**
- * Atomic compare and set of 32 bit intergers with acquire and release semantics.
+ * Atomic compare and set of 32 bit integers with acquire and release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -136,11 +136,11 @@ static inline bool opal_atomic_compare_exchange_strong_32(opal_atomic_int32_t *a
                                                           int32_t newval);
 
 /**
- * Atomic compare and set of 32 bit intergers with acquire semantics.
+ * Atomic compare and set of 32 bit integers with acquire semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -150,11 +150,11 @@ static inline bool opal_atomic_compare_exchange_strong_acq_32(opal_atomic_int32_
                                                               int32_t newval);
 
 /**
- * Atomic compare and set of 32 bit intergers with release semantics.
+ * Atomic compare and set of 32 bit integers with release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -164,11 +164,11 @@ static inline bool opal_atomic_compare_exchange_strong_rel_32(opal_atomic_int32_
                                                               int32_t newval);
 
 /**
- * Atomic compare and set of 64 bit intergers with acquire and release semantics.
+ * Atomic compare and set of 64 bit integers with acquire and release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -178,11 +178,11 @@ static inline bool opal_atomic_compare_exchange_strong_64(opal_atomic_int64_t *a
                                                           int64_t newval);
 
 /**
- * Atomic compare and set of 64 bit intergers with acquire semantics.
+ * Atomic compare and set of 64 bit integers with acquire semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -192,11 +192,11 @@ static inline bool opal_atomic_compare_exchange_strong_acq_64(opal_atomic_int64_
                                                               int64_t newval);
 
 /**
- * Atomic compare and set of 64 bit intergers with release semantics.
+ * Atomic compare and set of 64 bit integers with release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -206,11 +206,11 @@ static inline bool opal_atomic_compare_exchange_strong_rel_64(opal_atomic_int64_
                                                               int64_t newval);
 
 /**
- * Atomic compare and set of pointer-sized intergers with acquire and release semantics.
+ * Atomic compare and set of pointer-sized integers with acquire and release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -220,11 +220,11 @@ static inline bool opal_atomic_compare_exchange_strong_ptr(opal_atomic_intptr_t 
                                                            intptr_t *oldval, intptr_t newval);
 
 /**
- * Atomic compare and set of pointer-sized intergers with acquire semantics.
+ * Atomic compare and set of pointer-sized integers with acquire semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -234,11 +234,11 @@ static inline bool opal_atomic_compare_exchange_strong_acq_ptr(opal_atomic_intpt
                                                                intptr_t *oldval, intptr_t newval);
 
 /**
- * Atomic compare and set of pointer-sized intergers with release semantics.
+ * Atomic compare and set of pointer-sized integers with release semantics.
  *
  * @param addr          Address of value to be swapped
  * @param oldval        Comparison value
- * @param newval        New value to set if comparision is true
+ * @param newval        New value to set if comparison is true
  *
  * @returns If newval was written into addr, the function returns
  * true.  Otherwise, the function returns false and the value of addr
@@ -382,10 +382,10 @@ static inline void opal_atomic_add(type *addr, type delta);
  * Optional.  Check OPAL_HAVE_ATOMIC_LLSC_32,
  * OPAL_HAVE_ATOMIC_LLSC_64, or OPAL_HAVE_ATOMIC_LLSC_PTR before
  * using.  Implemented as macros due to function call behaviors;
- * prototyped here as C++-style fuctions for readability.
+ * prototyped here as C++-style functions for readability.
  *
  * C11 and GCC built-in atomics don't provide native LL/SC support, so
- * if there is an architectual implementation, we use it even if
+ * if there is an architectural implementation, we use it even if
  * we are using the C11 or GCC built-in atomics.
  *
  *********************************************************************/

--- a/opal/include/opal/sys/powerpc/atomic_helper.h
+++ b/opal/include/opal/sys/powerpc/atomic_helper.h
@@ -25,7 +25,7 @@
 #define OPAL_SYS_ARCH_ATOMIC_HELPER_H 1
 
 #if defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)
-/* work-around bizzare xlc bug in which it sign-extends
+/* work-around bizarre xlc bug in which it sign-extends
    a pointer to a 32-bit signed integer */
 #    define OPAL_ASM_ADDR(a) ((uintptr_t) a)
 #else

--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
+ * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -129,7 +129,7 @@
 #    define __opal_attribute_format__(a, b, c)
 #endif
 
-/* Use this __atribute__ on function-ptr declarations, only */
+/* Use this __attribute__ on function-ptr declarations, only */
 #if OPAL_HAVE_ATTRIBUTE_FORMAT_FUNCPTR
 #    define __opal_attribute_format_funcptr__(a, b, c) __attribute__((__format__(a, b, c)))
 #else
@@ -180,7 +180,7 @@
 #    define __opal_attribute_noreturn__
 #endif
 
-/* Use this __atribute__ on function-ptr declarations, only */
+/* Use this __attribute__ on function-ptr declarations, only */
 #if OPAL_HAVE_ATTRIBUTE_NORETURN_FUNCPTR
 #    define __opal_attribute_noreturn_funcptr__ __attribute__((__noreturn__))
 #else
@@ -404,7 +404,7 @@
 #    endif
 
 /*
- * On some homogenous big-iron machines (Sandia's Red Storm), there
+ * On some homogeneous big-iron machines (Sandia's Red Storm), there
  * are no htonl and friends.  If that's the case, provide stubs.  I
  * would hope we never find a platform that doesn't have these macros
  * and would want to talk to the outside world... On other platforms
@@ -494,7 +494,7 @@ static inline uint16_t ntohs(uint16_t netvar)
 /* Prior to Mac OS X 10.3, the length modifier "ll" wasn't
    supported, but "q" was for long long.  This isn't ANSI
    C and causes a warning when using PRI?64 macros.  We
-   don't support versions prior to OS X 10.3, so we dont'
+   don't support versions prior to OS X 10.3, so we don't
    need such backward compatibility.  Instead, redefine
    the macros to be "ll", which is ANSI C and doesn't
    cause a compiler warning. */

--- a/opal/mca/allocator/bucket/allocator_bucket.c
+++ b/opal/mca/allocator/bucket/allocator_bucket.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
- *                         reseved.
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.c
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.c
@@ -397,7 +397,7 @@ int mca_allocator_bucket_cleanup(mca_allocator_base_module_t *mem)
                 }
             }
         }
-        /* relese the lock on the bucket */
+        /* release the lock on the bucket */
         OPAL_THREAD_UNLOCK(&(mem_options->buckets[i].lock));
     }
     return (OPAL_SUCCESS);

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.h
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
- *                         reseved.
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/base/base.h
+++ b/opal/mca/base/base.h
@@ -126,7 +126,7 @@ OPAL_DECLSPEC int mca_base_open(void);
  * @return OPAL_ERROR Upon failure
  *
  * This function closes down the entire MCA.  It clears all MCA
- * parameters and closes down the MCA component respository.
+ * parameters and closes down the MCA component repository.
  *
  * It must be the last MCA function invoked.  It is normally invoked
  * during the finalize stage.

--- a/opal/mca/base/help-mca-var.txt
+++ b/opal/mca/base/help-mca-var.txt
@@ -74,7 +74,7 @@ variables are supposed to affect.
 [re-register-with-different-type]
 An MCA variable was re-registered with a different type (i.e., it was
 either originally registered as an INT and re-registered as a STRING,
-or it was originially registered as a STRING and re-registered as an
+or it was originally registered as a STRING and re-registered as an
 INT).  This a developer error; your job may abort.
 
   MCA variable name: %s

--- a/opal/mca/base/mca_base_component_compare.c
+++ b/opal/mca/base/mca_base_component_compare.c
@@ -31,7 +31,7 @@
  * the types of the modules are the same.  Sort first by priority,
  * second by module name, third by module version.
  *
- * Note that we acutally want a *reverse* ordering here -- the al_*
+ * Note that we actually want a *reverse* ordering here -- the al_*
  * functions will put "smaller" items at the head, and "larger" items
  * at the tail.  Since we want the highest priority at the head, it
  * may help the gentle reader to consider this an inverse comparison.

--- a/opal/mca/base/mca_base_components_open.c
+++ b/opal/mca/base/mca_base_components_open.c
@@ -86,7 +86,7 @@ static int open_components(mca_base_framework_t *framework)
      *
      * JJH Note: Currently checkpoint/restart is the only user of this
      *           functionality. If other component constraint options are
-     *           added, then this logic can be used for all contraint
+     *           added, then this logic can be used for all constraint
      *           options.
      *
      * NTH: Logic moved to mca_base_components_filter.

--- a/opal/mca/base/mca_base_list.c
+++ b/opal/mca/base/mca_base_list.c
@@ -39,7 +39,7 @@ OBJ_CLASS_INSTANCE(mca_base_component_priority_list_item_t, mca_base_component_l
                    cpl_constructor, NULL);
 
 /*
- * Just do basic sentinel intialization
+ * Just do basic sentinel initialization
  */
 static void cl_constructor(opal_object_t *obj)
 {
@@ -48,7 +48,7 @@ static void cl_constructor(opal_object_t *obj)
 }
 
 /*
- * Just do basic sentinel intialization
+ * Just do basic sentinel initialization
  */
 static void cpl_constructor(opal_object_t *obj)
 {

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -575,7 +575,7 @@ int mca_base_pvar_handle_update(mca_base_pvar_handle_t *handle)
 
         if (mca_base_pvar_is_sum(handle->pvar)) {
             for (i = 0; i < handle->count; ++i) {
-                /* the instance started at 0. need to subract the initial value off the
+                /* the instance started at 0. need to subtract the initial value off the
                    result. */
                 switch (handle->pvar->type) {
                 case MCA_BASE_VAR_TYPE_UNSIGNED_INT:
@@ -802,7 +802,7 @@ int mca_base_pvar_handle_reset(mca_base_pvar_handle_t *handle)
         return OPAL_ERR_NOT_BOUND;
     }
 
-    /* reset this handle to a state analagous to when it was created */
+    /* reset this handle to a state analogous to when it was created */
     if (mca_base_pvar_is_sum(handle->pvar)) {
         /* reset the running sum to 0 */
         memset(handle->current_value, 0, handle->count * ompi_var_type_sizes[handle->pvar->type]);
@@ -812,7 +812,7 @@ int mca_base_pvar_handle_reset(mca_base_pvar_handle_t *handle)
         }
     } else if (mca_base_pvar_handle_is_running(handle)
                && mca_base_pvar_is_watermark(handle->pvar)) {
-        /* watermarks should get set to the current value if runnning. */
+        /* watermarks should get set to the current value if running. */
 
         ret = handle->pvar->get_value(handle->pvar, handle->current_value, handle->obj_handle);
     } else if (mca_base_pvar_is_readonly(handle->pvar)) {

--- a/opal/mca/base/mca_base_pvar.h
+++ b/opal/mca/base/mca_base_pvar.h
@@ -54,7 +54,7 @@ typedef enum {
         return value should be the size of the bound communicator. */
     MCA_BASE_PVAR_HANDLE_BIND,
     /** A handle associated with this variable has been started. It is
-        recommended that any computation that might affect perfomance
+        recommended that any computation that might affect performance
         only be performed when a bound handle has been started. */
     MCA_BASE_PVAR_HANDLE_START,
     /** A handle associated with this variable has been stopped */
@@ -82,7 +82,7 @@ enum {
     /** Variable describes the low-watermark of the utilization
        of a resource */
     MCA_BASE_PVAR_CLASS_LOWWATERMARK,
-    /** Variable counts the number of occurences of a specific event */
+    /** Variable counts the number of occurrences of a specific event */
     MCA_BASE_PVAR_CLASS_COUNTER,
     /** Variable represents a sum of arguments processed during a
        specific event */
@@ -147,7 +147,7 @@ typedef int (*mca_base_set_value_fn_t)(struct mca_base_pvar_t *pvar, const void 
 /**
  * Function to notify of a pvar handle event.
  *
- * @param[in]  pvar  Performance variable the handle is assocaited with
+ * @param[in]  pvar  Performance variable the handle is associated with
  * @param[in]  event Event that has occurred. See mca_base_pvar_event_t.
  * @param[in]  obj   Bound object
  * @param[out] count Value count for this object (on MCA_BASE_PVAR_HANDLE_BIND)
@@ -320,7 +320,7 @@ mca_base_pvar_register(const char *project, const char *framework, const char *c
                        mca_base_set_value_fn_t set_value, mca_base_notify_fn_t notify, void *ctx);
 
 /**
- * Convinience function for registering a performance variable
+ * Convenience function for registering a performance variable
  * associated with a component.
  *
  * While quite similar to mca_base_pvar_register(), there is one key
@@ -429,7 +429,7 @@ OPAL_DECLSPEC int mca_base_pvar_dump(int index, char ***out, mca_base_var_dump_t
 int mca_base_pvar_mark_invalid(int index);
 
 /**
- * Convienience functions for performance variables
+ * Convenience functions for performance variables
  */
 static inline bool mca_base_pvar_is_sum(const mca_base_pvar_t *pvar)
 {
@@ -532,7 +532,7 @@ OPAL_DECLSPEC int mca_base_pvar_handle_write_value(mca_base_pvar_handle_t *handl
                                                    const void *value);
 
 /**
- * Convienience function for sending notification of a handle change
+ * Convenience function for sending notification of a handle change
  *
  * @param[in]  handle Handle event occurred on
  * @param[in]  event  Event that occurred

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -566,7 +566,7 @@ int mca_base_var_get_value(int vari, const void *value, mca_base_var_source_t *s
     }
 
     if (NULL != value) {
-        /* Return a poiner to our backing store (either a char **, int *,
+        /* Return a pointer to our backing store (either a char **, int *,
            or bool *) */
         *tmp = var->mbv_storage;
     }
@@ -2143,7 +2143,7 @@ int mca_base_var_dump(int vari, char ***out, mca_base_var_dump_type_t output_typ
         opal_asprintf(out[0] + line++, "%sstatus:%s", tmp,
                       VAR_IS_SETTABLE(var[0]) ? "writeable" : "read-only");
 
-        /* Output the info level of this parametere */
+        /* Output the info level of this parameter */
         opal_asprintf(out[0] + line++, "%slevel:%d", tmp, var->mbv_info_lvl + 1);
 
         /* If it has a help message, output the help message */

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -55,7 +55,7 @@
  * - If nothing else was found, use the variable's default value.
  *
  * Note that there is a second header file (mca_base_vari.h)
- * that contains several internal type delcarations for the variable
+ * that contains several internal type declarations for the variable
  * system.  The internal file is only used within the variable system
  * itself; it should not be required by any other Open MPI entities.
  */
@@ -136,7 +136,7 @@ typedef enum {
  * MCA variable scopes
  *
  * Equivalent to MPI_T scopes with the same base name (e.g.,
- * MCA_BASE_VAR_SCOPE_CONSTANT corresponts to MPI_T_SCOPE_CONSTANT).
+ * MCA_BASE_VAR_SCOPE_CONSTANT corresponds to MPI_T_SCOPE_CONSTANT).
  */
 typedef enum {
     /** The value of this variable will not change after it is
@@ -330,7 +330,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_base_var_t);
  *
  * @retval OPAL_SUCCESS
  *
- * This function initalizes the MCA variable system.  It is
+ * This function initializes the MCA variable system.  It is
  * invoked internally (by mca_base_open()) and is only documented
  * here for completeness.
  */
@@ -480,7 +480,7 @@ OPAL_DECLSPEC int mca_base_framework_var_register(
  * creates a new name that by which the same variable value is
  * accessible.
  *
- * Note that the original variable name has precendence over all
+ * Note that the original variable name has precedence over all
  * synonyms.  For example, consider the case if variable is
  * originally registered under the name "A" and is later
  * registered with synonyms "B" and "C".  If the user sets values
@@ -503,7 +503,7 @@ OPAL_DECLSPEC int mca_base_var_register_synonym(int synonym_for, const char *pro
  * @param vari Index returned from mca_base_var_register() or
  * mca_base_var_register_synonym().
  *
- * Deregistering a variable does not free the variable or any memory assoicated
+ * Deregistering a variable does not free the variable or any memory associated
  * with it. All memory will be freed and the variable index released when
  * mca_base_var_finalize() is called.
  *
@@ -675,7 +675,7 @@ OPAL_DECLSPEC int mca_base_var_get(int vari, const mca_base_var_t **var);
 OPAL_DECLSPEC int mca_base_var_get_count(void);
 
 /**
- * Obtain a list of enironment variables describing the all
+ * Obtain a list of environment variables describing the all
  * valid (non-default) MCA variables and their sources.
  *
  * @param[out] env A pointer to an argv-style array of key=value

--- a/opal/mca/base/mca_base_var_enum.h
+++ b/opal/mca/base/mca_base_var_enum.h
@@ -85,7 +85,7 @@ typedef int (*mca_base_var_enum_dump_fn_t)(mca_base_var_enum_t *self, char **out
  * @retval OPAL_SUCCESS on success
  * @retval OPAL_ERR_VALUE_OUT_OF_BOUNDS if not found
  *
- * @long This function returns the string value for a given interger value in the
+ * @long This function returns the string value for a given integer value in the
  * {string_value} parameter. The {string_value} parameter may be NULL in which case
  * no string is returned. If a string is returned in {string_value} the caller
  * must free the string with free().

--- a/opal/mca/base/mca_base_var_group.h
+++ b/opal/mca/base/mca_base_var_group.h
@@ -72,7 +72,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_base_var_group_t);
  * @param[in] project_name Project name for this group.
  * @param[in] framework_name Framework name for this group.
  * @param[in] component_name Component name for this group.
- * @param[in] descrition Description of this group.
+ * @param[in] description Description of this group.
  *
  * @retval index Unique group index
  * @return opal error code on Error

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -212,7 +212,7 @@ struct am_rdma_operation_t {
     /** endpoint used to communicate with the origin */
     struct mca_btl_base_endpoint_t *endpoint;
     /** response descriptor (if allocated). this will be stored
-     * if the send operation was unsuccessfull and the response
+     * if the send operation was unsuccessful and the response
      * needs to be retried. */
     mca_btl_base_descriptor_t *descriptor;
     /** incoming operation header */

--- a/opal/mca/btl/base/btl_base_am_rdma.h
+++ b/opal/mca/btl/base/btl_base_am_rdma.h
@@ -43,7 +43,7 @@
  * MCA_BTL_FLAGS_ATOMIC_AM_FOP, etc.).
  *
  * Second, this interface can be used to provide different
- * sementicsthan a BTL natively provides.  This mode is not
+ * semantics than a BTL natively provides.  This mode is not
  * transparent to the caller (unlike the first mode).  Instead, the
  * caller must manage calling the active message put/get/atomic
  * interface directly (rather than through the BTL function pointers).

--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -219,7 +219,7 @@ static int mca_btl_base_close(void)
 
     OPAL_LIST_FOREACH_SAFE (sm, next, &mca_btl_base_modules_initialized,
                             mca_btl_base_selected_module_t) {
-        /* Blatently ignore the return code (what would we do to recover,
+        /* Blatantly ignore the return code (what would we do to recover,
            anyway?  This component is going away, so errors don't matter
            anymore) */
 

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -44,7 +44,7 @@
  * transport are not available.
  *
  * The mca_btl_base_component_init_fn_t() is then called for each of the
- * components that are succesfully opened. The component init function may
+ * components that are successfully opened. The component init function may
  * return either:
  *
  * (1) a NULL list of BTL modules if the transport is not available,
@@ -197,7 +197,7 @@ typedef uint8_t mca_btl_base_tag_t;
 #define MCA_BTL_TAG_SMCUDA (MCA_BTL_TAG_BTL + 2)
 #define MCA_BTL_TAG_SM     (MCA_BTL_TAG_BTL + 3)
 
-/* prefered protocol */
+/* preferred protocol */
 #define MCA_BTL_FLAGS_SEND 0x0001
 #define MCA_BTL_FLAGS_PUT  0x0002
 #define MCA_BTL_FLAGS_GET  0x0004
@@ -263,9 +263,9 @@ typedef uint8_t mca_btl_base_tag_t;
 /* The BTL has active-message based atomics */
 #define MCA_BTL_FLAGS_ATOMIC_AM_FOP 0x400000
 
-/** Ths BTL's RDMA/atomics operation supports remote completion.
+/** The BTL's RDMA/atomics operation supports remote completion.
  * When the BTL reported the completion of a RDMA/atomic operation
- * on the initator side, the operation also finished on the target side.
+ * on the initiator side, the operation also finished on the target side.
  *
  * Note, this flag is for put and atomic write operations. Operations
  * like get, atomic fetch and atomic swap support remote
@@ -498,7 +498,7 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_btl_base_descriptor_t);
  */
 #define MCA_BTL_DES_FLAGS_BTL_OWNERSHIP 0x0002
 /* Allow the BTL to avoid calling the descriptor callback
- * if the send succeded in the btl_send (i.e in the fast path).
+ * if the send succeeded in the btl_send (i.e in the fast path).
  */
 #define MCA_BTL_DES_SEND_ALWAYS_CALLBACK 0x0004
 
@@ -879,7 +879,7 @@ typedef int (*mca_btl_base_module_deregister_mem_fn_t)(
  *
  * @param[IN] btl          BTL module
  * @param[IN] endpoint     BTL addressing information
- * @param[IN] descriptor   Description of the data to be transfered
+ * @param[IN] descriptor   Description of the data to be transferred
  * @param[IN] tag          The tag value used to notify the peer.
  *
  * @retval 1               The descriptor was successfully sent (see
@@ -1063,7 +1063,7 @@ typedef int (*mca_btl_base_module_atomic_op64_fn_t)(
  * @param[IN] btl             BTL module
  * @param[IN] endpoint        BTL addressing information
  * @param[IN] local_address (OUT) Local address to store the result in
- * @param[IN] remote_address  Remote address perfom operation on to (registered remotely)
+ * @param[IN] remote_address  Remote address perform operation on to (registered remotely)
  * @param[IN] local_handle    Local registration handle for region containing
  *                            (local_address, local_address + 8)
  * @param[IN] remote_handle   Remote registration handle for region containing
@@ -1110,7 +1110,7 @@ typedef int (*mca_btl_base_module_atomic_fop64_fn_t)(
  * @param[IN] btl             BTL module
  * @param[IN] endpoint        BTL addressing information
  * @param[OUT] local_address  Local address to store the result in
- * @param[IN] remote_address  Remote address perfom operation on to (registered remotely)
+ * @param[IN] remote_address  Remote address perform operation on to (registered remotely)
  * @param[IN] local_handle    Local registration handle for region containing
  *                            (local_address, local_address + 8)
  * @param[IN] remote_handle   Remote registration handle for region containing

--- a/opal/mca/btl/ofi/README.md
+++ b/opal/mca/btl/ofi/README.md
@@ -102,7 +102,7 @@ advised that the number of context should be equal to number of
 physical core for optimal performance.
 
 User can disable scalable endpoint by MCA parameter
-`btl_ofi_disable_sep`.  With scalable endpoint disbled, the BTL will
+`btl_ofi_disable_sep`.  With scalable endpoint disabled, the BTL will
 alias OFI endpoint to both tx and rx context.
 
 ## Two sided communication

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -376,7 +376,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init(int *num_btl_modules,
              * however some may have multiple info objects with different
              * attributes for the same NIC. The initial provider attributes
              * are used to ensure that all NICs we return provide the same
-             * capabilities as the inital one.
+             * capabilities as the initial one.
              */
             selected_info = opal_mca_common_ofi_select_provider(info, &opal_process_info);
             rc = mca_btl_ofi_init_device(selected_info);
@@ -459,7 +459,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
      * domain open.  Silently ignore not-supported errors, as they
      * are not critical to program correctness, but only indicate
      * that LIbfabric will have to pick a different, possibly less
-     * optimial, monitor. */
+     * optimal, monitor. */
     rc = opal_common_ofi_export_memory_monitor();
     if (0 != rc && -FI_ENOSYS != rc) {
         BTL_VERBOSE(("Failed to inject Libfabric memory monitor: %s",
@@ -670,7 +670,7 @@ fail:
 /**
  * @brief OFI BTL progress function
  *
- * This function explictly progresses all workers.
+ * This function explicitly progresses all workers.
  */
 static int mca_btl_ofi_component_progress(void)
 {

--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -386,7 +386,7 @@ int mca_btl_ofi_context_progress(mca_btl_ofi_context_t *context)
         MCA_BTL_OFI_ABORT();
     }
 #ifdef FI_EINTR
-    /* sometimes, sockets provider complain about interupt. We do nothing. */
+    /* sometimes, sockets provider complain about interrupt. We do nothing. */
     else if (OPAL_UNLIKELY(ret == -FI_EINTR)) {
 
     }

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -54,7 +54,7 @@ struct mca_btl_portals4_component_t {
      * portals4_init_interface(). */
     int need_init;
 
-    /* Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false) */
+    /* Use the logical to physical table to accelerate portals4 addressing: 1 (true) : 0 (false) */
     int use_logical;
 
     /* initial size of free lists */

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -72,7 +72,7 @@ static int mca_btl_portals4_component_register(void)
     mca_btl_portals4_component.use_logical = 0;
     (void) mca_base_component_var_register(
         &mca_btl_portals4_component.super.btl_version, "use_logical",
-        "Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false)",
+        "Use the logical to physical table to accelerate portals4 addressing: 1 (true) : 0 (false)",
         MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
         &mca_btl_portals4_component.use_logical);
 

--- a/opal/mca/btl/portals4/configure.m4
+++ b/opal/mca/btl/portals4/configure.m4
@@ -36,7 +36,7 @@ AC_DEFUN([MCA_opal_btl_portals4_CONFIG],[
            $1],
           [$2])
 
-    # need to propogate CPPFLAGS to all of OPAL
+    # need to propagate CPPFLAGS to all of OPAL
     AS_IF([test "$DIRECT_btl" = "portals4"],
           [CPPFLAGS="$CPPFLAGS $btl_portals4_CPPFLAGS"])
 

--- a/opal/mca/btl/self/btl_self.c
+++ b/opal/mca/btl/self/btl_self.c
@@ -160,7 +160,7 @@ static struct mca_btl_base_descriptor_t *mca_btl_self_prepare_src(
         return NULL;
     }
 
-    /* non-contigous data */
+    /* non-contiguous data */
     if (OPAL_UNLIKELY(!inline_send)) {
         struct iovec iov = {.iov_len = *size,
                             .iov_base = (IOVBASE_TYPE *) ((uintptr_t) frag->data + reserve)};

--- a/opal/mca/btl/sm/btl_sm.h
+++ b/opal/mca/btl/sm/btl_sm.h
@@ -66,7 +66,7 @@ BEGIN_C_DECLS
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
 /*
- * Shared Memory resource managment
+ * Shared Memory resource management
  */
 
 struct sm_fifo_t;

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -124,7 +124,7 @@ static int mca_btl_sm_component_register(void)
     mca_btl_sm_component.memcpy_limit = 524288;
     (void) mca_base_component_var_register(&mca_btl_sm_component.super.btl_version, "memcpy_limit",
                                            "Message size to switch from using "
-                                           "memove to memcpy. The relative speed of these two "
+                                           "memmove to memcpy. The relative speed of these two "
                                            "routines can vary by size.",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0,
                                            MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_5,
@@ -484,7 +484,7 @@ static int mca_btl_sm_poll_fifo(void)
  * @param ep (IN)       Sm BTL endpoint
  *
  * This is called with the component lock held so the component lock does
- * not need to be aquired before modifying the pending_endpoints list.
+ * not need to be acquired before modifying the pending_endpoints list.
  */
 static void mca_btl_sm_progress_waiting(mca_btl_base_endpoint_t *ep)
 {

--- a/opal/mca/btl/sm/btl_sm_types.h
+++ b/opal/mca/btl/sm/btl_sm_types.h
@@ -69,7 +69,7 @@ typedef struct mca_btl_base_endpoint_t {
     } fbox_out;
 
     uint16_t peer_smp_rank;        /**< my peer's SMP process rank.  Used for accessing
-                                    *   SMP specfic data structures. */
+                                    *   SMP specific data structures. */
     opal_atomic_size_t send_count; /**< number of fragments sent to this peer */
     char *segment_base;            /**< start of the peer's segment (in the address space
                                     *   of this process) */

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -351,7 +351,7 @@ static int smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl, int32_t my_s
     }
 #if OPAL_CUDA_SUPPORT
     /* Register the entire shared memory region with the CUDA library which will
-     * force it to be pinned.  This aproach was chosen as there is no way for this
+     * force it to be pinned.  This approach was chosen as there is no way for this
      * local process to know which parts of the memory are being utilized by a
      * remote process. */
     opal_output_verbose(10, opal_btl_base_framework.framework_output,
@@ -1064,7 +1064,7 @@ int mca_btl_smcuda_get_cuda(struct mca_btl_base_module_t *btl, struct mca_btl_ba
     frag->local_handle = local_handle;
 
     /* Set to 0 for debugging since it is a list item but I am not
-     * intializing it properly and it is annoying to see all the
+     * initializing it properly and it is annoying to see all the
      * garbage in the debugger.  */
 
     memset(&rget_reg, 0, sizeof(rget_reg));

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -103,7 +103,7 @@ struct sm_fifo_t {
 typedef struct sm_fifo_t sm_fifo_t;
 
 /*
- * Shared Memory resource managment
+ * Shared Memory resource management
  */
 
 #if OPAL_ENABLE_PROGRESS_THREADS == 1
@@ -130,7 +130,7 @@ struct mca_btl_smcuda_component_t {
     mca_mpool_base_module_t *sm_mpool;   /**< mpool on local node */
     void *sm_mpool_base;                 /**< base address of shared memory pool */
     size_t eager_limit;                  /**< first fragment size */
-    size_t max_frag_size;                /**< maximum (second and beyone) fragment size */
+    size_t max_frag_size;                /**< maximum (second and beyond) fragment size */
     opal_mutex_t sm_lock;
     mca_common_sm_module_t *sm_seg;  /**< description of shared memory segment */
     volatile sm_fifo_t **shm_fifo;   /**< pointer to fifo 2D array in shared memory */
@@ -147,7 +147,7 @@ struct mca_btl_smcuda_component_t {
     int nfifos;                      /**< number of FIFOs per receiver */
     int32_t num_smp_procs;           /**< current number of smp procs on this host */
     int32_t my_smp_rank;             /**< My SMP process rank.  Used for accessing
-                                      *   SMP specfic data structures. */
+                                      *   SMP specific data structures. */
     opal_free_list_t sm_frags_eager; /**< free list of sm first */
     opal_free_list_t sm_frags_max;   /**< free list of sm second */
     opal_free_list_t sm_frags_user;

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -125,7 +125,7 @@ static inline unsigned int mca_btl_smcuda_param_register_uint(const char *param_
 
 static int mca_btl_smcuda_component_verify(void)
 {
-    /* We canot support async memcpy right now */
+    /* We cannot support async memcpy right now */
     if ((mca_btl_smcuda.super.btl_flags & MCA_BTL_FLAGS_CUDA_COPY_ASYNC_RECV)
         || (mca_btl_smcuda.super.btl_flags & MCA_BTL_FLAGS_CUDA_COPY_ASYNC_SEND)) {
         opal_output_verbose(10, opal_btl_base_framework.framework_output,
@@ -208,7 +208,7 @@ static int smcuda_register(void)
     /* Call the BTL based to register its MCA params */
     mca_btl_base_param_register(&mca_btl_smcuda_component.super.btl_version, &mca_btl_smcuda.super);
 #if OPAL_CUDA_SUPPORT
-    /* If user has not set the value, then set to the defalt */
+    /* If user has not set the value, then set to the default */
     if (0 == mca_btl_smcuda.super.btl_cuda_max_send_size) {
         mca_btl_smcuda.super.btl_cuda_max_send_size = 128 * 1024;
     }
@@ -362,7 +362,7 @@ static int create_and_attach(mca_btl_smcuda_component_t *comp_ptr, size_t size, 
                                                                data_seg_alignment))) {
         opal_output(0,
                     "create_and_attach: unable to create shared memory "
-                    "BTL coordinating strucure :: size %lu \n",
+                    "BTL coordinating structure :: size %lu \n",
                     (unsigned long) size);
         return OPAL_ERROR;
     }
@@ -495,7 +495,7 @@ static int create_rndv_file(mca_btl_smcuda_component_t *comp_ptr,
             size = mca_btl_smcuda_component.mpool_min_size;
         }
 
-        /* we only need the shmem_ds info at this point. initilization will be
+        /* we only need the shmem_ds info at this point. initialization will be
          * completed in the mpool module code. the idea is that we just need this
          * info so we can populate the rndv file (or modex when we have it). */
         if (OPAL_SUCCESS
@@ -706,7 +706,7 @@ static void btl_smcuda_control(mca_btl_base_module_t *btl,
              * same device and use_cuda_ipc_same_gpu is 1 (default),
              * then assume CUDA IPC is possible.  This could be a
              * device running in DEFAULT mode or running under MPS.
-             * Otherwise, check peer acces to determine CUDA IPC
+             * Otherwise, check peer access to determine CUDA IPC
              * support.  If the CUDA API call fails, then just move
              * endpoint into bad state.  No need to send a reply. */
             if (mydevnum == ctrlhdr.cudev) {
@@ -950,7 +950,7 @@ void btl_smcuda_process_pending_sends(struct mca_btl_base_endpoint_t *ep)
         OPAL_THREAD_UNLOCK(&ep->endpoint_lock);
 
         if (NULL == si)
-            return; /* Another thread got in before us. Thats ok. */
+            return; /* Another thread got in before us. That's ok. */
 
         OPAL_THREAD_ADD_FETCH32(&mca_btl_smcuda_component.num_pending_sends, -1);
 
@@ -996,7 +996,7 @@ int mca_btl_smcuda_component_progress(void)
     for (j = 0; j < FIFO_MAP_NUM(mca_btl_smcuda_component.num_smp_procs); j++) {
         fifo = &(mca_btl_smcuda_component.fifo[my_smp_rank][j]);
     recheck_peer:
-        /* aquire thread lock */
+        /* acquire thread lock */
         if (opal_using_threads()) {
             opal_atomic_lock(&(fifo->tail_lock));
         }

--- a/opal/mca/btl/smcuda/btl_smcuda_endpoint.h
+++ b/opal/mca/btl/smcuda/btl_smcuda_endpoint.h
@@ -34,9 +34,9 @@
 
 struct mca_btl_base_endpoint_t {
     int my_smp_rank;   /**< My SMP process rank.  Used for accessing
-                        *   SMP specfic data structures. */
+                        *   SMP specific data structures. */
     int peer_smp_rank; /**< My peer's SMP process rank.  Used for accessing
-                        *   SMP specfic data structures. */
+                        *   SMP specific data structures. */
 #if OPAL_CUDA_SUPPORT
     mca_rcache_base_module_t *rcache; /**< rcache for remotely registered memory */
 #endif                                /* OPAL_CUDA_SUPPORT */

--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -295,7 +295,7 @@ mca_btl_base_descriptor_t *mca_btl_tcp_prepare_src(struct mca_btl_base_module_t 
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
- * @param descriptor (IN)  Description of the data to be transfered
+ * @param descriptor (IN)  Description of the data to be transferred
  * @param tag (IN)         The tag value used to notify the peer.
  */
 

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -121,8 +121,8 @@ struct mca_btl_tcp_component_t {
 #endif
     /* Port range restriction */
 
-    char *tcp_if_include;   /**< comma seperated list of interface to include */
-    char *tcp_if_exclude;   /**< comma seperated list of interface to exclude */
+    char *tcp_if_include;   /**< comma separated list of interface to include */
+    char *tcp_if_exclude;   /**< comma separated list of interface to exclude */
     int tcp_sndbuf;         /**< socket sndbuf size */
     int tcp_rcvbuf;         /**< socket rcvbuf size */
     int tcp_disable_family; /**< disabled AF_family */
@@ -191,8 +191,8 @@ extern mca_btl_tcp_module_t mca_btl_tcp_module;
  * TCP component initialization.
  *
  * @param num_btl_modules (OUT)           Number of BTLs returned in BTL array.
- * @param allow_multi_user_threads (OUT)  Flag indicating wether BTL supports user threads (TRUE)
- * @param have_hidden_threads (OUT)       Flag indicating wether BTL uses threads (TRUE)
+ * @param allow_multi_user_threads (OUT)  Flag indicating whether BTL supports user threads (TRUE)
+ * @param have_hidden_threads (OUT)       Flag indicating whether BTL uses threads (TRUE)
  */
 extern mca_btl_base_module_t **mca_btl_tcp_component_init(int *num_btl_modules,
                                                           bool allow_multi_user_threads,
@@ -243,7 +243,7 @@ extern int mca_btl_tcp_del_procs(struct mca_btl_base_module_t *btl, size_t nproc
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
- * @param descriptor (IN)  Description of the data to be transfered
+ * @param descriptor (IN)  Description of the data to be transferred
  * @param tag (IN)         The tag value used to notify the peer.
  */
 
@@ -297,7 +297,7 @@ extern int mca_btl_tcp_free(struct mca_btl_base_module_t *btl, mca_btl_base_desc
 
 /**
  * Prepare a descriptor for send/rdma using the supplied
- * convertor. If the convertor references data that is contigous,
+ * convertor. If the convertor references data that is contiguous,
  * the descriptor may simply point to the user buffer. Otherwise,
  * this routine is responsible for allocating buffer space and
  * packing if required.

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -508,7 +508,7 @@ static int mca_btl_tcp_create(const int if_kindex, const char *if_name)
      * split_and_resolve and pass the address used to select the
      * device into mca_btl_tcp_create().  This is a cleanup of the
      * logic that's been in use for years, but the case it doesn't
-     * cover is (say) only specifing mca_btl_if_include 10.0.0.0/16
+     * cover is (say) only specifying mca_btl_if_include 10.0.0.0/16
      * when the interface has addresses of both 10.0.0.1 and 10.1.0.1;
      * there's absolutely nothing that keeps this code from picking
      * 10.1.0.1 as the one that is published in the modex and used for
@@ -1048,7 +1048,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
         return OPAL_ERROR;
     }
 socket_binded:
-    /* resolve system assignend port */
+    /* resolve system assigned port */
     if (getsockname(sd, (struct sockaddr *) &inaddr, &addrlen) < 0) {
         BTL_ERROR(
             ("getsockname() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
@@ -1321,7 +1321,7 @@ mca_btl_base_module_t **mca_btl_tcp_component_init(int *num_btl_modules,
         }
     }
 
-    /* Avoid a race in wire-up when using threads (progess or user)
+    /* Avoid a race in wire-up when using threads (progress or user)
        and multiple BTL modules.  The details of the race are in
        https://github.com/open-mpi/ompi/issues/3035#issuecomment-429500032,
        but the summary is that the lookup code in
@@ -1407,7 +1407,7 @@ static void mca_btl_tcp_component_recv_handler(int sd, short flags, void *user)
     struct timeval save, tv;
     socklen_t rcvtimeo_save_len = sizeof(save);
 
-    /* Note, Socket will be in blocking mode during intial handshake
+    /* Note, Socket will be in blocking mode during initial handshake
      * hence setting SO_RCVTIMEO to say 2 seconds here to avoid waiting
      * forever when connecting to older versions (that reply to the
      * handshake with only the guid) or when the remote side isn't OMPI

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -133,7 +133,7 @@ static void mca_btl_tcp_endpoint_send_handler(int sd, short flags, void *user);
  * The lack of protection in the mca_btl_tcp_endpoint_dump function is voluntary
  * so that it can be called regardless of the state of the mutexes. As a result,
  * when multiple threads work on the same endpoint not only the information
- * displayed might be inacurate, but when we manipulate the pending fragments we
+ * displayed might be inaccurate, but when we manipulate the pending fragments we
  * might access freed memory. Thus, the caller should lock the endpoint prior
  * to the call.
  */
@@ -964,7 +964,7 @@ static void mca_btl_tcp_endpoint_recv_handler(int sd, short flags, void *user)
      * event_base lock (while holding the endpoint_recv lock).
      *
      * If we can't lock this mutex, it is OK to cancel the receive operation, it
-     * will be eventually triggered again shorthly.
+     * will be eventually triggered again shortly.
      */
     if (OPAL_THREAD_TRYLOCK(&btl_endpoint->endpoint_recv_lock)) {
         return;
@@ -985,7 +985,7 @@ static void mca_btl_tcp_endpoint_recv_handler(int sd, short flags, void *user)
                the magic string ID failed). recv_connect_ack already cleaned
                up the socket. */
             /* If we get OPAL_ERROR, the other end closed the connection
-             * because it has initiated a symetrical connexion on its end.
+             * because it has initiated a symmetrical connexion on its end.
              * recv_connect_ack already cleaned up the socket. */
         } else {
             /* Otherwise, it probably *was* an OMPI peer process on
@@ -1046,7 +1046,7 @@ static void mca_btl_tcp_endpoint_recv_handler(int sd, short flags, void *user)
 #if MCA_BTL_TCP_ENDPOINT_CACHE
             if (0 != btl_endpoint->endpoint_cache_length) {
                 /* If the cache still contain some data we can reuse the same fragment
-                 * until we flush it completly.
+                 * until we flush it completely.
                  */
                 MCA_BTL_TCP_FRAG_INIT_DST(frag, btl_endpoint);
                 goto data_still_pending_on_endpoint;

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -643,7 +643,7 @@ void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t *btl_proc, struct sockaddr *addr
         default:;
         }
 
-        /* Set state to CONNECTING to ensure that subsequent conenctions do not attempt to re-use
+        /* Set state to CONNECTING to ensure that subsequent connections do not attempt to re-use
          * endpoint in the num_links > 1 case*/
         btl_endpoint->endpoint_state = MCA_BTL_TCP_CONNECTING;
         (void) mca_btl_tcp_endpoint_accept(btl_endpoint, addr, sd);

--- a/opal/mca/btl/template/btl_template.c
+++ b/opal/mca/btl/template/btl_template.c
@@ -259,7 +259,7 @@ mca_btl_base_descriptor_t *mca_btl_template_prepare_src(struct mca_btl_base_modu
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
- * @param descriptor (IN)  Description of the data to be transfered
+ * @param descriptor (IN)  Description of the data to be transferred
  * @param tag (IN)         The tag value used to notify the peer.
  */
 

--- a/opal/mca/btl/template/btl_template.h
+++ b/opal/mca/btl/template/btl_template.h
@@ -104,8 +104,8 @@ extern mca_btl_template_module_t mca_btl_template_module;
  * TEMPLATE component initialization.
  *
  * @param num_btl_modules (OUT)           Number of BTLs returned in BTL array.
- * @param allow_multi_user_threads (OUT)  Flag indicating wether BTL supports user threads (TRUE)
- * @param have_hidden_threads (OUT)       Flag indicating wether BTL uses threads (TRUE)
+ * @param allow_multi_user_threads (OUT)  Flag indicating whether BTL supports user threads (TRUE)
+ * @param have_hidden_threads (OUT)       Flag indicating whether BTL uses threads (TRUE)
  */
 extern mca_btl_base_module_t **mca_btl_template_component_init(int *num_btl_modules,
                                                                bool allow_multi_user_threads,
@@ -162,7 +162,7 @@ extern int mca_btl_template_del_procs(struct mca_btl_base_module_t *btl, size_t 
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
- * @param descriptor (IN)  Description of the data to be transfered
+ * @param descriptor (IN)  Description of the data to be transferred
  * @param tag (IN)         The tag value used to notify the peer.
  */
 
@@ -323,7 +323,7 @@ extern int mca_btl_template_free(struct mca_btl_base_module_t *btl, mca_btl_base
 
 /**
  * Prepare a descriptor for send/rdma using the supplied
- * convertor. If the convertor references data that is contigous,
+ * convertor. If the convertor references data that is contiguous,
  * the descriptor may simply point to the user buffer. Otherwise,
  * this routine is responsible for allocating buffer space and
  * packing if required.

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -610,7 +610,7 @@ static int mca_btl_uct_component_progress_pending(mca_btl_uct_module_t *uct_btl)
 /**
  * @brief UCT BTL progress function
  *
- * This function explictly progresses all workers.
+ * This function explicitly progresses all workers.
  */
 static int mca_btl_uct_component_progress(void)
 {

--- a/opal/mca/btl/uct/btl_uct_device_context.h
+++ b/opal/mca/btl/uct/btl_uct_device_context.h
@@ -32,7 +32,7 @@ mca_btl_uct_device_context_t *mca_btl_uct_context_create(mca_btl_uct_module_t *m
  *
  * @param[in] context   btl uct device context
  *
- * This call frees a device context and all assoicated resources. It is not
+ * This call frees a device context and all associated resources. It is not
  * valid to use the device context after this returns.
  */
 void mca_btl_uct_context_destroy(mca_btl_uct_device_context_t *context);

--- a/opal/mca/btl/uct/btl_uct_tl.c
+++ b/opal/mca/btl/uct/btl_uct_tl.c
@@ -78,7 +78,7 @@ static void mca_btl_uct_module_set_atomic_flags(mca_btl_uct_module_t *module, mc
     uint64_t atomic_flags32 = MCA_BTL_UCT_TL_ATTR(tl, 0).cap.atomic32.fop_flags;
     uint64_t atomic_flags64 = MCA_BTL_UCT_TL_ATTR(tl, 0).cap.atomic64.fop_flags;
 
-    /* NTH: don't really have a way to seperate 32-bit and 64-bit right now */
+    /* NTH: don't really have a way to separate 32-bit and 64-bit right now */
     uint64_t all_flags = atomic_flags32 & atomic_flags64;
 
     module->super.btl_atomic_flags = 0;

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -92,7 +92,7 @@ struct mca_btl_uct_conn_req_t {
 typedef struct mca_btl_uct_conn_req_t mca_btl_uct_conn_req_t;
 
 /**
- * @brief Transport endpoint stucture
+ * @brief Transport endpoint structure
  */
 struct mca_btl_uct_tl_endpoint_t {
     /** current flags (connected, requested, etc) */
@@ -315,7 +315,7 @@ struct mca_btl_uct_tl_t {
     /** device name for this tl (used for creating device contexts) */
     char *uct_dev_name;
 
-    /** maxiumum number of device contexts that can be created */
+    /** maximum number of device contexts that can be created */
     int max_device_contexts;
 
     /** array of device contexts */

--- a/opal/mca/btl/ugni/btl_ugni.h
+++ b/opal/mca/btl/ugni/btl_ugni.h
@@ -380,7 +380,7 @@ struct mca_btl_base_endpoint_t *mca_btl_ugni_get_ep(struct mca_btl_base_module_t
  *
  * @param btl (IN)         BTL module
  * @param endpoint (IN)    BTL addressing information
- * @param descriptor (IN)  Description of the data to be transfered
+ * @param descriptor (IN)  Description of the data to be transferred
  * @param tag (IN)         The tag value used to notify the peer.
  */
 int mca_btl_ugni_send(struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *btl_peer,
@@ -470,7 +470,7 @@ int mca_btl_ugni_fini(void);
 int mca_btl_ugni_module_init(mca_btl_ugni_module_t *ugni_module);
 
 /**
- * Intialize a virtual device for device index 0.
+ * Initialize a virtual device for device index 0.
  *
  * @param[inout] device         Device to initialize
  * @param[in] virtual_device_id Virtual device identified (up to max handles)

--- a/opal/mca/btl/ugni/btl_ugni_endpoint.c
+++ b/opal/mca/btl/ugni/btl_ugni_endpoint.c
@@ -223,7 +223,7 @@ static inline int mca_btl_ugni_ep_connect_start(mca_btl_base_endpoint_t *ep)
                  ep->ep_rem_addr, ep->ep_rem_id, (void *) ep->peer_proc));
 
     /* bind endpoint to remote address */
-    /* we bind two endpoints to seperate out local smsg completion and local fma completion */
+    /* we bind two endpoints to separate out local smsg completion and local fma completion */
     mca_btl_ugni_device_lock(device);
     rc = mca_btl_ugni_ep_handle_init(ep, device->dev_smsg_local_cq.gni_handle, device,
                                      &ep->smsg_ep_handle);

--- a/opal/mca/btl/ugni/btl_ugni_frag.h
+++ b/opal/mca/btl/ugni/btl_ugni_frag.h
@@ -86,7 +86,7 @@ typedef struct mca_btl_ugni_base_frag_t mca_btl_ugni_rdma_frag_t;
 typedef struct mca_btl_ugni_base_frag_t mca_btl_ugni_eager_frag_t;
 
 typedef struct mca_btl_ugni_post_descriptor_t {
-    /** endpoint currently associated with this desctiptor */
+    /** endpoint currently associated with this descriptor */
     mca_btl_base_endpoint_t *endpoint;
     /** local memory handle (for callback) */
     mca_btl_base_registration_handle_t *local_handle;

--- a/opal/mca/btl/ugni/btl_ugni_init.c
+++ b/opal/mca/btl/ugni/btl_ugni_init.c
@@ -132,7 +132,7 @@ int mca_btl_ugni_device_init(mca_btl_ugni_device_t *device, int virtual_device_i
 
     device->dev_index = virtual_device_id;
 
-    /* Create a NIC Adress */
+    /* Create a NIC Address */
     OPAL_OUTPUT((-1, "Got NIC Addr: 0x%08x, CPU ID: %d", mca_btl_ugni_component.dev_addr, 0));
 
     /* Attach device to the communication domain */

--- a/opal/mca/btl/ugni/btl_ugni_module.c
+++ b/opal/mca/btl/ugni/btl_ugni_module.c
@@ -340,7 +340,7 @@ int mca_btl_ugni_device_handle_event_error(mca_btl_ugni_rdma_desc_t *rdma_desc,
         char char_buffer[1024];
         GNI_CqErrorStr(event_data, char_buffer, sizeof(char_buffer));
 
-        BTL_ERROR(("giving up on desciptor %p, recoverable %d: %s", (void *) rdma_desc, recoverable,
+        BTL_ERROR(("giving up on descriptor %p, recoverable %d: %s", (void *) rdma_desc, recoverable,
                    char_buffer));
 
         return OPAL_ERROR;

--- a/opal/mca/btl/ugni/btl_ugni_rdma.h
+++ b/opal/mca/btl/ugni/btl_ugni_rdma.h
@@ -82,8 +82,8 @@ static inline int mca_btl_ugni_post_bte(mca_btl_base_endpoint_t *endpoint, gni_p
     mca_btl_ugni_post_descriptor_t post_desc;
     int rc;
 
-    /* There is a performance benefit to throttling the total number of active BTE tranactions. Not
-     * sure what the optimium is but the limit is inforced as a soft limit. */
+    /* There is a performance benefit to throttling the total number of active BTE transactions. Not
+     * sure what the optimium is but the limit is enforced as a soft limit. */
     if (module->active_rdma_count >= mca_btl_ugni_component.active_rdma_threshold) {
         return OPAL_ERR_OUT_OF_RESOURCE;
     }

--- a/opal/mca/btl/ugni/btl_ugni_send.c
+++ b/opal/mca/btl/ugni/btl_ugni_send.c
@@ -127,7 +127,7 @@ int mca_btl_ugni_sendi(struct mca_btl_base_module_t *btl, struct mca_btl_base_en
 
     do {
         BTL_VERBOSE(("btl/ugni isend sending fragment from %d -> %d. length = %" PRIu64
-                     " endoint state %d",
+                     " endpoint state %d",
                      OPAL_PROC_MY_NAME.vpid, endpoint->peer_proc->proc_name.vpid,
                      payload_size + header_size, endpoint->state));
 

--- a/opal/mca/btl/usnic/README.md
+++ b/opal/mca/btl/usnic/README.md
@@ -194,12 +194,12 @@ is a receive on the priority queue, then it is handled by a routine
 called `opal_btl_usnic_recv_fast()` which does nothing but validates
 that the packet is OK to be received (sequence number OK and not a
 DUP) and then delivers it to the PML.  This packet is recorded in the
-channel structure, and all bookeeping for the packet is deferred until
+channel structure, and all bookkeeping for the packet is deferred until
 the next time `component_progress` is called again.
 
 This fast path cannot be taken every time we pass through
 `component_progress` because there will be other completions that need
-processing, and the receive bookeeping for one fast receive must be
+processing, and the receive bookkeeping for one fast receive must be
 complete before allowing another fast receive to occur, as only one
 recv segment can be saved for deferred processing at a time.  This is
 handled by maintaining a variable in `opal_btl_usnic_recv_fast()`

--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -97,7 +97,7 @@ extern opal_rng_buff_t opal_btl_usnic_rand_buff;
 /* Set to >0 to randomly drop received frags.  The higher the number,
    the more frequent the drops. */
 #define WANT_RECV_DROPS 0
-/* Set to >0 to randomly fail to send an ACK, mimicing a lost ACK.
+/* Set to >0 to randomly fail to send an ACK, mimicking a lost ACK.
    The higher the number, the more frequent the failed-to-send-ACK. */
 #define WANT_FAIL_TO_SEND_ACK 0
 /* Set to >0 to randomly fail to resend a frag (causing it to be
@@ -180,7 +180,7 @@ typedef struct opal_btl_usnic_component_t {
     /** max receive descriptors per module */
     int32_t rd_num;
 
-    /** max send/receive desriptors for priority channel */
+    /** max send/receive descriptors for priority channel */
     int32_t prio_sd_num;
     int32_t prio_rd_num;
 

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -34,7 +34,7 @@
 /* Free lists are unified into OPAL free lists */
 #include "opal/class/opal_free_list.h"
 
-/* Inclue the progress thread stuff */
+/* Include the progress thread stuff */
 #include "opal/runtime/opal_progress_threads.h"
 
 #define USNIC_OUT opal_btl_base_framework.framework_output

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -258,7 +258,7 @@ static int usnic_modex_send(void)
 
 /*
  * See if our memlock limit is >64K.  64K is the RHEL default memlock
- * limit; this check is a first-line-of-defense hueristic to see if
+ * limit; this check is a first-line-of-defense heuristic to see if
  * the user has set the memlock limit to *something*.
  *
  * We have other checks elsewhere (e.g., to ensure that QPs are able
@@ -290,7 +290,7 @@ static int check_reg_mem_basics(void)
     return OPAL_ERR_OUT_OF_RESOURCE;
 #else
     /* If we don't have RLIMIT_MEMLOCK, then just bypass this
-       safety/hueristic check. */
+       safety/heuristic check. */
     return OPAL_SUCCESS;
 #endif
 }
@@ -944,7 +944,7 @@ usnic_component_init(int *num_btl_modules, bool want_progress_threads, bool want
         opal_output_verbose(5, USNIC_OUT, "btl:usnic: %s eager rndv limit = %" PRIsize_t, devname,
                             module->super.btl_rndv_eager_limit);
         opal_output_verbose(5, USNIC_OUT,
-                            "btl:usnic: %s max send size= %" PRIsize_t " (not overrideable)",
+                            "btl:usnic: %s max send size= %" PRIsize_t " (not overridable)",
                             devname, module->super.btl_max_send_size);
         opal_output_verbose(5, USNIC_OUT, "btl:usnic: %s exclusivity = %d", devname,
                             module->super.btl_exclusivity);

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.h
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.h
@@ -105,7 +105,7 @@ typedef struct opal_btl_usnic_rx_frag_info_t {
     bool rfi_data_in_pool;             /* data in data_pool if true, else malloced */
     int rfi_data_pool;                 /* if <0, data malloced, else rx buf pool */
     char *rfi_data;                    /* pointer to assembly area */
-    opal_free_list_item_t *rfi_fl_elt; /* free list elemement from buf pool
+    opal_free_list_item_t *rfi_fl_elt; /* free list element from buf pool
                                           when rfi_data_pool is nonzero */
 } opal_btl_usnic_rx_frag_info_t;
 
@@ -187,7 +187,7 @@ typedef mca_btl_base_endpoint_t opal_btl_usnic_endpoint_t;
 OBJ_CLASS_DECLARATION(opal_btl_usnic_endpoint_t);
 
 /*
- * Helper struct for the asynchornous creation of fi_addr array
+ * Helper struct for the asynchronous creation of fi_addr array
  */
 typedef struct {
     opal_btl_usnic_endpoint_t *endpoint;

--- a/opal/mca/btl/usnic/btl_usnic_frag.c
+++ b/opal/mca/btl/usnic/btl_usnic_frag.c
@@ -54,7 +54,7 @@ static void chunk_seg_constructor(opal_btl_usnic_chunk_segment_t *cseg)
     bseg = &cseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_CHUNK;
 
-    /* some more common initializaiton */
+    /* some more common initialization */
     common_send_seg_helper(cseg);
 
     /* payload starts next byte beyond BTL chunk header */
@@ -70,7 +70,7 @@ static void frag_seg_constructor(opal_btl_usnic_frag_segment_t *fseg)
     bseg = &fseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_FRAG;
 
-    /* some more common initializaiton */
+    /* some more common initialization */
     common_send_seg_helper(fseg);
 
     /* payload starts next byte beyond BTL header */
@@ -86,7 +86,7 @@ static void ack_seg_constructor(opal_btl_usnic_ack_segment_t *ack)
     bseg = &ack->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_ACK;
 
-    /* some more common initializaiton */
+    /* some more common initialization */
     common_send_seg_helper(ack);
 
     /* ACK value embedded in BTL header */

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -44,7 +44,7 @@ struct opal_btl_usnic_module_t;
 
 /**
  * Fragment types
- * The upper layer may give us very large "fragements" to send, larger than
+ * The upper layer may give us very large "fragments" to send, larger than
  * an MTU.  We break fragments into segments for sending, a segment being
  * defined to fit within an MTU.
  */
@@ -138,8 +138,8 @@ typedef struct {
     opal_btl_usnic_seq_t pkt_seq;
     opal_btl_usnic_seq_t ack_seq; /* for piggy-backing ACKs */
 
-    /* payload legnth (in bytes).  We unfortunately have to include
-       this in our header because the L2 layer may artifically inflate
+    /* payload length (in bytes).  We unfortunately have to include
+       this in our header because the L2 layer may artificially inflate
        the length of the packet to meet a minimum size */
     uint16_t payload_len;
 

--- a/opal/mca/btl/usnic/btl_usnic_mca.c
+++ b/opal/mca/btl/usnic/btl_usnic_mca.c
@@ -180,9 +180,9 @@ int opal_btl_usnic_component_register(void)
     want_numa_device_assignment = 1;
     CHECK(reg_int(
         "want_numa_device_assignment",
-        "If 1, use only Cisco VIC ports thare are a minimum NUMA distance from the MPI process for "
+        "If 1, use only Cisco VIC ports there are a minimum NUMA distance from the MPI process for "
         "short messages.  If 0, use all available Cisco VIC ports for short messages.  This "
-        "parameter is meaningless (and ignored) unless MPI proceses are bound to processor cores.  "
+        "parameter is meaningless (and ignored) unless MPI processes are bound to processor cores.  "
         "Defaults to 1 if NUMA support is included in Open MPI; -1 otherwise.",
         want_numa_device_assignment, &want_numa_device_assignment, 0, OPAL_INFO_LVL_5));
     mca_btl_usnic_component.want_numa_device_assignment = (1 == want_numa_device_assignment)

--- a/opal/mca/btl/usnic/btl_usnic_proc.c
+++ b/opal/mca/btl/usnic/btl_usnic_proc.c
@@ -672,7 +672,7 @@ int opal_btl_usnic_create_endpoint(opal_btl_usnic_module_t *module, opal_btl_usn
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-    /* Initalize the endpoint */
+    /* Initialize the endpoint */
     endpoint->endpoint_module = module;
     assert(modex_index >= 0 && modex_index < (int) proc->proc_modex_count);
     endpoint->endpoint_remote_modex = proc->proc_modex[modex_index];

--- a/opal/mca/btl/usnic/btl_usnic_recv.h
+++ b/opal/mca/btl/usnic/btl_usnic_recv.h
@@ -106,7 +106,7 @@ static inline void opal_btl_usnic_update_window(opal_btl_usnic_endpoint_t *endpo
         opal_btl_usnic_add_to_endpoints_needing_ack(endpoint);
     }
 
-    /* A hueristic: set to send this ACK after we have checked our
+    /* A heuristic: set to send this ACK after we have checked our
        incoming DATA_CHANNEL component.act_iteration_delay times
        (i.e., so we can piggyback an ACK on an outgoing send) */
     if (0 == endpoint->endpoint_acktime) {
@@ -208,7 +208,7 @@ static inline int opal_btl_usnic_check_rx_seq(opal_btl_usnic_endpoint_t *endpoin
        ACKed).
 
        We have saved all un-ACKed segment in an array on the
-       endpoint that is the same legnth as the receiver's window
+       endpoint that is the same length as the receiver's window
        (i.e., WINDOW_SIZE).  We can use the incoming segment sequence
        number to find its position in the array.  It's a little
        tricky because the left edge of the receiver window keeps

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -415,10 +415,10 @@ static void setup_mpit_pvars_counters(void)
 
     REGISTERC(num_total_sends, "Total number of sends (MPI data, ACKs, retransmissions, etc.)");
     REGISTERC(num_resends, "Total number of all retransmissions");
-    REGISTERC(num_timeout_retrans, "Number of times chunk retransmissions have occured because an "
+    REGISTERC(num_timeout_retrans, "Number of times chunk retransmissions have occurred because an "
                                    "ACK was not received within the timeout");
     REGISTERC(num_fast_retrans,
-              "Number of times chunk retransmissions have occured because due to a repeated ACK");
+              "Number of times chunk retransmissions have occurred because due to a repeated ACK");
     REGISTERC(num_chunk_sends,
               "Number of sends that were part of a larger MPI message fragment (i.e., the MPI "
               "message was so long that it had to be split into multiple MTU/network sends)");

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -518,7 +518,7 @@ static int count_providers(struct fi_info *provider_list)
     return num_provider;
 }
 
-/* Calculate the currrent process package rank.
+/* Calculate the current process package rank.
  *     @param (IN) process_info     struct opal_process_info_t information
  *                                  about the current process. used to get
  *                                  num_local_peers, myprocid.rank, and

--- a/opal/mca/common/sm/common_sm.c
+++ b/opal/mca/common/sm/common_sm.c
@@ -251,7 +251,7 @@ void *mca_common_sm_seg_alloc(void *ctx, size_t *size)
         seg->seg_offset += *size;
 
         /* fix up seg_offset so next allocation is aligned on a
-         * sizeof(long) boundry.  Do it here so that we don't have to
+         * sizeof(long) boundary.  Do it here so that we don't have to
          * check before checking remaining size in buffer
          */
         if ((fixup = (seg->seg_offset & (sizeof(long) - 1))) > 0) {

--- a/opal/mca/common/sm/help-mpi-common-sm.txt
+++ b/opal/mca/common/sm/help-mpi-common-sm.txt
@@ -21,4 +21,4 @@ Open MPI, and if not, contact the Open MPI developers.
   Local host:        %s
   Requested size:    %ul
   Control seg size:  %ul
-  Data seg aligment: %ul
+  Data seg alignment: %ul

--- a/opal/mca/dl/base/dl_base_open.c
+++ b/opal/mca/dl/base/dl_base_open.c
@@ -40,7 +40,7 @@ int opal_dl_base_open(mca_base_open_flag_t flags)
 }
 
 /* VERY IMPORTANT: This framework is static, and is opened before any
-   other dyanmic frameworks are opened (which makes sense, of course).
+   other dynamic frameworks are opened (which makes sense, of course).
    But we must mark this framework is NO_DSO so that the MCA framework
    base doesn't try to open any dynamic components in this
    framework. */

--- a/opal/mca/hwloc/base/base.h
+++ b/opal/mca/hwloc/base/base.h
@@ -37,7 +37,7 @@ BEGIN_C_DECLS
  * opal_hwloc_topology, nor does it set the process-wide memory
  * affinity policy.  Filling opal_hwloc_topology via
  * hwloc_topology_load() can be expensive (and/or serialized by the
- * OS); it may not be desireable to call this function in every MPI
+ * OS); it may not be desirable to call this function in every MPI
  * process on a machine.  Hence, it is the responsibility for an upper
  * layer to both fill opal_hwloc_topology in some scalable way.
  */

--- a/opal/mca/mca.h
+++ b/opal/mca/mca.h
@@ -144,7 +144,7 @@ typedef struct mca_base_module_2_0_0_t mca_base_module_2_0_0_t;
  *
  * If the component a) has no MCA parameters to register, b) no
  * resources to allocate, and c) can always be used in a process
- * (albiet perhaps not selected), it may provide NULL for this
+ * (albeit perhaps not selected), it may provide NULL for this
  * function.  In this cause, the MCA will act as if it called the open
  * function and it returned OPAL_SUCCESS.
  */
@@ -187,7 +187,7 @@ typedef int (*mca_base_close_component_1_0_0_fn_t)(void);
  *
  * This function is used by the mca_base_select function to find the
  * highest priority component to select. Frameworks are free to
- * implement their own query function, but must also implment their
+ * implement their own query function, but must also implement their
  * own select function as a result.
  */
 typedef int (*mca_base_query_component_2_0_0_fn_t)(mca_base_module_2_0_0_t **module, int *priority);
@@ -235,7 +235,7 @@ typedef int (*mca_base_query_component_2_0_0_fn_t)(mca_base_module_2_0_0_t **mod
  *
  * If the component a) has no MCA parameters to register, b) no
  * resources to allocate, and c) can always be used in a process
- * (albiet perhaps not selected), it may provide NULL for this
+ * (albeit perhaps not selected), it may provide NULL for this
  * function.  In this cause, the MCA will act as if it called the
  * registration function and it returned OPAL_SUCCESS.
  */

--- a/opal/mca/memory/base/memory_base_open.c
+++ b/opal/mca/memory/base/memory_base_open.c
@@ -53,7 +53,7 @@ static int empty_query(int *priority)
  * Local variables
  */
 static opal_memory_base_component_2_0_0_t empty_component = {
-    /* Empty / safe functions to call if no memory componet is selected */
+    /* Empty / safe functions to call if no memory component is selected */
     .memoryc_query = empty_query,
     .memoryc_process = empty_process,
     .memoryc_register = opal_memory_base_component_register_empty,

--- a/opal/mca/memory/malloc_solaris/memory_malloc_solaris_component.c
+++ b/opal/mca/memory/malloc_solaris/memory_malloc_solaris_component.c
@@ -99,7 +99,7 @@ static int opal_memory_malloc_query(int *priority)
 }
 
 /*
- * Three ways to call munmap.  Prefered is to call __munmap, which
+ * Three ways to call munmap.  Preferred is to call __munmap, which
  * will exist if munmap is a weak symbol.  If not available next try
  * the syscall, and if that doesn't work, try looking in the dynamic
  * libc.

--- a/opal/mca/memory/memory.h
+++ b/opal/mca/memory/memory.h
@@ -22,7 +22,7 @@
  * $HEADER$
  */
 
-/* NOTE: This framework accomodates two kinds of memory hooks systems:
+/* NOTE: This framework accommodates two kinds of memory hooks systems:
 
    1. Those that only require being setup once and then will
       automatically call back to internal component/module functions
@@ -80,7 +80,7 @@ typedef int (*opal_memory_base_component_process_fn_t)(void);
 
 /**
  * Prototype for a function that is invoked when the memory base is
- * trying to select a component. This funtionality is required.
+ * trying to select a component. This functionality is required.
  */
 typedef int (*opal_memory_base_component_query_fn_t)(int *priority);
 

--- a/opal/mca/mpool/base/mpool_base_basic.c
+++ b/opal/mca/mpool/base/mpool_base_basic.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
- * Copyrigth (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *

--- a/opal/mca/mpool/base/mpool_base_frame.c
+++ b/opal/mca/mpool/base/mpool_base_frame.c
@@ -110,7 +110,7 @@ static int mca_mpool_base_close(void)
     while (NULL != (item = opal_list_remove_first(&mca_mpool_base_modules))) {
         sm = (mca_mpool_base_selected_module_t *) item;
 
-        /* Blatently ignore the return code (what would we do to recover,
+        /* Blatantly ignore the return code (what would we do to recover,
            anyway?  This component is going away, so errors don't matter
            anymore).  Note that it's legal for the module to have NULL for
            the finalize function. */

--- a/opal/mca/mpool/mpool.h
+++ b/opal/mca/mpool/mpool.h
@@ -114,7 +114,7 @@ typedef struct mca_mpool_base_component_3_1_0_t mca_mpool_base_component_t;
  *  details.
  */
 struct mca_mpool_base_module_t {
-    mca_mpool_base_component_t *mpool_component;      /**< component stuct */
+    mca_mpool_base_component_t *mpool_component;      /**< component struct */
     mca_mpool_base_module_address_fn_t mpool_base;    /**< returns the base address */
     mca_mpool_base_module_alloc_fn_t mpool_alloc;     /**< allocate function */
     mca_mpool_base_module_realloc_fn_t mpool_realloc; /**< reallocate function */
@@ -138,7 +138,7 @@ struct mca_mpool_base_module_t {
  * key in info that does not match any mpool, an error will be returned.
  *
  * If the info parameter is MPI_INFO_NULL, then this function will try to allocate
- * the memory and register it wih as many mpools as possible. However,
+ * the memory and register it with as many mpools as possible. However,
  * if any of the registratons fail the mpool will simply be ignored.
  *
  * @param size the size of the memory area to allocate

--- a/opal/mca/patcher/overwrite/patcher_overwrite.h
+++ b/opal/mca/patcher/overwrite/patcher_overwrite.h
@@ -11,7 +11,7 @@
 /**
  * @file pather_overwrite.h
  *
- * This component works by overwritting the first couple instructions in
+ * This component works by overwriting the first couple instructions in
  * the target function with a jump instruction to the hook function. The
  * hook function will be expected to implement the functionality of the
  * hooked function when using this module.

--- a/opal/mca/patcher/overwrite/patcher_overwrite_module.c
+++ b/opal/mca/patcher/overwrite/patcher_overwrite_module.c
@@ -223,7 +223,7 @@ static int mca_patcher_overwrite_apply_patch(mca_patcher_base_patch_t *patch)
  * 1: Directly check constant instructions (ignoring addresses as parameters)
  * 2: Generate a bit mask by passing min and max values to underlying helper
  *    functions and negate the XOR'ed results. These results can be used to
- *    mask off transient values (like addresess) and non-instruction values
+ *    mask off transient values (like addresses) and non-instruction values
  *    (like register contents). Once the masks are applied, the results are
  *    compared against the min values directly to check for equality. If equal,
  *    we consider the memory to be previously patched.
@@ -338,7 +338,7 @@ static int mca_patcher_overwrite_patch_symbol(const char *func_symbol_name, uint
     old_addr = (unsigned long) sym_addr;
 
     if (func_old_addr) {
-        /* we will be overwritting part of the original function. do not return
+        /* we will be overwriting part of the original function. do not return
          * its address */
         *func_old_addr = 0;
     }

--- a/opal/mca/rcache/base/rcache_base_frame.c
+++ b/opal/mca/rcache/base/rcache_base_frame.c
@@ -85,7 +85,7 @@ static int mca_rcache_base_close(void)
     while (NULL != (item = opal_list_remove_first(&mca_rcache_base_modules))) {
         sm = (mca_rcache_base_selected_module_t *) item;
 
-        /* Blatently ignore the return code (what would we do to recover,
+        /* Blatantly ignore the return code (what would we do to recover,
            anyway?  This component is going away, so errors don't matter
            anymore).  Note that it's legal for the module to have NULL for
            the finalize function. */

--- a/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
+++ b/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
@@ -184,7 +184,7 @@ int mca_rcache_rgpusm_register(mca_rcache_base_module_t *rcache, void *addr, siz
     /* This chunk of code handles the case where leave pinned is not
      * set and we do not use the cache.  This is not typically how we
      * will be running.  This means that one can have an unlimited
-     * number of registrations occuring at the same time.  Since we
+     * number of registrations occurring at the same time.  Since we
      * are not leaving the registrations pinned, the number of
      * registrations is unlimited and there is no need for a cache. */
     if (!mca_rcache_rgpusm_component.leave_pinned

--- a/opal/mca/reachable/netlink/configure.m4
+++ b/opal/mca/reachable/netlink/configure.m4
@@ -33,7 +33,7 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
          with_libnl_route_incdir=${with_libnl_incdir}
 
          # The first argument of OAC_CHECK_PACKAGE must be a valid
-         # shell variable name, which means no dashs.  Deal with that
+         # shell variable name, which means no dashes.  Deal with that
          # by being explicit with our module.
          m4_define([libnl_route_pkgconfig_module], [libnl-route-3.0])
          OAC_CHECK_PACKAGE([libnl_route],
@@ -44,7 +44,7 @@ AC_DEFUN([MCA_opal_reachable_netlink_CONFIG],[
                            [opal_reachable_netlink_happy=1],
                            [opal_reachable_netlink_happy=0])
 
-         # See if we have linux/netlink.h, which is part of the kernal
+         # See if we have linux/netlink.h, which is part of the kernel
          # ABI headers and not the libnl3 package (so we assume are in
          # default includes, as opposed to the libnl directory.
          AS_IF([test ${opal_reachable_netlink_happy} -eq 1],

--- a/opal/mca/reachable/netlink/reachable_netlink_utils_common.c
+++ b/opal/mca/reachable/netlink/reachable_netlink_utils_common.c
@@ -153,7 +153,7 @@ static int opal_reachable_netlink_sk_alloc(struct opal_reachable_netlink_sk **p_
 
     err = nl_connect(nlh, protocol);
     if (err < 0) {
-        opal_output(0, "Failed to connnect netlink route socket error: %s\n", NL_GETERROR(err));
+        opal_output(0, "Failed to connect netlink route socket error: %s\n", NL_GETERROR(err));
         err = EINVAL;
         goto err_free_nlh;
     }
@@ -317,7 +317,7 @@ int opal_reachable_netlink_rt_lookup(uint32_t src_addr, uint32_t dst_addr, int o
         goto out;
     }
 
-    /* recieve results */
+    /* receive results */
     NL_RECVMSGS(unlsk->nlh, arg, EHOSTUNREACH, err, out);
 
     /* check whether a route was found */

--- a/opal/mca/shmem/mmap/help-opal-shmem-mmap.txt
+++ b/opal/mca/shmem/mmap/help-opal-shmem-mmap.txt
@@ -40,7 +40,7 @@ the MCA parameter "orte_no_session_dir".
   Local host: %s
   Filename:   %s
 
-You can set the MCA paramter shmem_mmap_enable_nfs_warning to 0 to
+You can set the MCA parameter shmem_mmap_enable_nfs_warning to 0 to
 disable this message.
 #
 [target full]

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -409,7 +409,7 @@ out:
             rc = OPAL_ERROR;
         }
     }
-    /* an error occured, so invalidate the shmem object and munmap if needed */
+    /* an error occurred, so invalidate the shmem object and munmap if needed */
     if (OPAL_SUCCESS != rc) {
         if (MAP_FAILED != segment) {
             munmap(segment, size);
@@ -532,7 +532,7 @@ static int segment_unlink(opal_shmem_ds_t *ds_buf)
      * across unlinks. other information stored in flags will remain untouched.
      */
     ds_buf->seg_id = OPAL_SHMEM_DS_ID_INVALID;
-    /* note: this is only chaning the valid bit to 0. */
+    /* note: this is only changing the valid bit to 0. */
     OPAL_SHMEM_DS_INVALIDATE(ds_buf);
     return OPAL_SUCCESS;
 }

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -232,7 +232,7 @@ out:
             rc = OPAL_ERROR;
         }
     }
-    /* an error occured, so invalidate the shmem object and release any
+    /* an error occurred, so invalidate the shmem object and release any
      * allocated resources.
      */
     if (OPAL_SUCCESS != rc) {
@@ -362,7 +362,7 @@ static int segment_unlink(opal_shmem_ds_t *ds_buf)
      * across unlinks. other information stored in flags will remain untouched.
      */
     ds_buf->seg_id = OPAL_SHMEM_DS_ID_INVALID;
-    /* note: this is only chaning the valid bit to 0. */
+    /* note: this is only changing the valid bit to 0. */
     OPAL_SHMEM_DS_INVALIDATE(ds_buf);
     return OPAL_SUCCESS;
 }

--- a/opal/mca/shmem/sysv/shmem_sysv_module.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_module.c
@@ -171,7 +171,7 @@ static int segment_create(opal_shmem_ds_t *ds_buf, const char *file_name, size_t
         rc = OPAL_ERROR;
         goto out;
     }
-    /* attach to the sement */
+    /* attach to the segment */
     else if ((void *) -1 == (segment = shmat(ds_buf->seg_id, NULL, 0))) {
         int err = errno;
         const char *hn;
@@ -220,7 +220,7 @@ static int segment_create(opal_shmem_ds_t *ds_buf, const char *file_name, size_t
     }
 
 out:
-    /* an error occured, so invalidate the shmem object and release any
+    /* an error occurred, so invalidate the shmem object and release any
      * allocated resources.
      */
     if (OPAL_SUCCESS != rc) {
@@ -315,7 +315,7 @@ static int segment_unlink(opal_shmem_ds_t *ds_buf)
      * across unlinks. other information stored in flags will remain untouched.
      */
     ds_buf->seg_id = OPAL_SHMEM_DS_ID_INVALID;
-    /* note: this is only chaning the valid bit to 0. */
+    /* note: this is only changing the valid bit to 0. */
     OPAL_SHMEM_DS_INVALIDATE(ds_buf);
     return OPAL_SUCCESS;
 }

--- a/opal/mca/smsc/knem/smsc_knem_component.c
+++ b/opal/mca/smsc/knem/smsc_knem_component.c
@@ -143,7 +143,7 @@ static int mca_smsc_knem_dereg(void *reg_data, mca_rcache_base_registration_t *r
 {
     mca_smsc_knem_registration_handle_t *knem_reg = (mca_smsc_knem_registration_handle_t *) reg;
 
-    /* NTH: explicity ignore the return code. Don't care about this cookie anymore anyway. */
+    /* NTH: explicitly ignore the return code. Don't care about this cookie anymore anyway. */
     (void) ioctl(mca_smsc_knem_component.knem_fd, KNEM_CMD_DESTROY_REGION, &knem_reg->data.cookie);
 
     return OPAL_SUCCESS;

--- a/opal/mca/smsc/smsc.h
+++ b/opal/mca/smsc/smsc.h
@@ -161,7 +161,7 @@ struct mca_smsc_module_t {
     /** Map a peer memory region into this processes address space. The module is allowed to cache
      * the mapping and return it in subsequent calls. */
     mca_smsc_module_map_peer_region_fn_t map_peer_region;
-    /** Delete a mapping. This is allowed to leave the mappping in place. */
+    /** Delete a mapping. This is allowed to leave the mapping in place. */
     mca_smsc_module_unmap_peer_region_fn_t unmap_peer_region;
 
     /* Defined if MCA_SMSC_FEATURE_REQUIRES_REGISTRATION is set. */

--- a/opal/mca/smsc/xpmem/smsc_xpmem_component.c
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_component.c
@@ -119,7 +119,7 @@ static int mca_smsc_xpmem_component_query(void)
     while (fgets(buffer, sizeof(buffer), fh)) {
         uintptr_t low, high;
         char *tmp;
-        /* each line of /proc/self/maps starts with low-high in hexidecimal (without a 0x) */
+        /* each line of /proc/self/maps starts with low-high in hexadecimal (without a 0x) */
         low = strtoul(buffer, &tmp, 16);
         high = strtoul(tmp + 1, NULL, 16);
         if (address_max < high) {
@@ -135,7 +135,7 @@ static int mca_smsc_xpmem_component_query(void)
         return OPAL_ERR_NOT_AVAILABLE;
     }
 
-    /* save the calcuated maximum */
+    /* save the calculated maximum */
     mca_smsc_xpmem_component.my_address_max = address_max - 1;
 
     /* it is safe to use XPMEM_MAXADDR_SIZE here (which is always (size_t)-1 even though

--- a/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
@@ -59,7 +59,7 @@ struct mca_smsc_xpmem_component_t {
      * larger value will produce fewer entries in the cache but will increase attachment time. */
     unsigned int log_attach_align;
     /** maximum size that will be used with a single memcpy call. on some systems we see better
-     * peformance if we chunk the copy into multiple memcpy calls. */
+     * performance if we chunk the copy into multiple memcpy calls. */
     uint64_t memcpy_chunk_size;
 };
 

--- a/opal/mca/threads/README.md
+++ b/opal/mca/threads/README.md
@@ -18,7 +18,7 @@ The MCA for threading libraries is implemented in two places, once as a set of `
 
 For performance reasons, in particular synchronization overhead, it is not possible to implement a threading model as a traditional MCA. This means --at least in the short term-- that threading models are chosen at compile time rather than runtime options, using mechanisms similar to Open MPI's libevent integration.
 
-The .h files are meant to be run on the fast path containing inline synchonization functions (threads_<threading_model>_mutex.h, thread local storage (threads_<threading_model>_tsd.h) and the opal_thread structure (threads_<threading_model>_thread.h).
+The .h files are meant to be run on the fast path containing inline synchronization functions (threads_<threading_model>_mutex.h, thread local storage (threads_<threading_model>_tsd.h) and the opal_thread structure (threads_<threading_model>_thread.h).
 
 The rest of the threading implementation follows the normal MCA model:
 

--- a/opal/mca/timer/darwin/timer_darwin_component.c
+++ b/opal/mca/timer/darwin/timer_darwin_component.c
@@ -65,8 +65,8 @@ const opal_timer_base_component_2_0_0_t mca_timer_darwin_component = {
    arithmetic errors due to integer math.  But since we want the
    least amount of math in the critical path as possible and
    mach_absolute_time is already a cycle counter, we claim we have
-   native cycle count support and set the frequencey to be the
-   frequencey of the global clock, which is sTBI.denom *
+   native cycle count support and set the frequency to be the
+   frequency of the global clock, which is sTBI.denom *
    (1000000000 / sTBI.numer), which is sTBI.denom * (1 / 1), or
    sTBI.denom.
 
@@ -82,7 +82,7 @@ const opal_timer_base_component_2_0_0_t mca_timer_darwin_component = {
 
    More generally, since mach_timebase_info() gives the "keys" to
    transition the return from mach_absolute_time() into
-   nanoseconds, taking the reverse of that and multipling by
+   nanoseconds, taking the reverse of that and multiplying by
    1000000000 will give you a frequency in cycles / second if you
    think of mach_absolute_time() always returning a cycle count.
 */

--- a/opal/memoryhooks/memory.c
+++ b/opal/memoryhooks/memory.c
@@ -77,7 +77,7 @@ static void opal_mem_hooks_finalize(void)
     release_run_callbacks = false;
     opal_atomic_mb();
 
-    /* aquire the lock, just to make sure no one is currently
+    /* acquire the lock, just to make sure no one is currently
        twiddling with the list.  We know this won't last long, since
        no new calls will come in after we set run_callbacks to false */
     opal_atomic_lock(&release_lock);

--- a/opal/memoryhooks/memory.h
+++ b/opal/memoryhooks/memory.h
@@ -69,7 +69,7 @@ OPAL_DECLSPEC int opal_mem_hooks_init(void);
  * support is provided or a bit-wise OR of the available return values
  * if support is provided.
  *
- * @retval OPAL_MEMORY_FREE_SUPPORT   Memory hooks subsytem can trigger
+ * @retval OPAL_MEMORY_FREE_SUPPORT   Memory hooks subsystem can trigger
  *                                    callback events when memory is going
  *                                    to be released by the process, either
  *                                    by the user calling an allocator
@@ -96,7 +96,7 @@ OPAL_DECLSPEC int opal_mem_hooks_support_level(void);
  * opal_mem_hooks_register_release().
  *
  * @param buf     Pointer to the start of the allocation
- * @param lentgh  Length of the allocation
+ * @param length  Length of the allocation
  * @param cbdata  Data passed to memory hooks when callback
  *                was registered
  * @param from_alloc True if the callback is caused by a call to the

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -519,7 +519,7 @@ int opal_init_util(int *pargc, char ***pargv)
 
     OPAL_TIMING_ENV_NEXT(otmng, "opal_show_help_init");
 
-    /* register handler for errnum -> string converstion */
+    /* register handler for errnum -> string conversion */
     if (OPAL_SUCCESS
         != (ret = opal_error_register("OPAL", OPAL_ERR_BASE, OPAL_ERR_MAX, opal_err2str))) {
         return opal_init_error("opal_error_register", ret);
@@ -683,7 +683,7 @@ int opal_init(int *pargc, char ***pargv)
         return opal_init_error("opal_shmem_base_select", ret);
     }
 
-    /* Intitialize reachable framework */
+    /* Initialize reachable framework */
     if (OPAL_SUCCESS != (ret = opal_reachable_base_select())) {
         return opal_init_error("opal_reachable_base_select", ret);
     }

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -85,8 +85,8 @@ static int debug_output = -1;
 #endif
 
 /**
- * Fake callback used for threading purpose when one thread
- * progesses callbacks while another unregister somes. The root
+ * Fake callback used for threading purposes when one thread
+ * progresses callbacks while another unregisters some. The root
  * of the problem is that we allow modifications of the callback
  * array directly from the callbacks themselves. Now if
  * writing a pointer is atomic, we should not have any more
@@ -204,11 +204,11 @@ static int opal_progress_events(void)
 
 /*
  * Progress the event library and any functions that have registered to
- * be called.  We don't propogate errors from the progress functions,
+ * be called.  We don't propagate errors from the progress functions,
  * so no action is taken if they return failures.  The functions are
  * expected to return the number of events progressed, to determine
  * whether or not we should yield the CPU during MPI progress.
- * This is only losely tracked, as an error return can cause the number
+ * This is only loosely tracked, as an error return can cause the number
  * of progressed events to appear lower than it actually is.  We don't
  * care, as the cost of that happening is far outweighed by the cost
  * of the if checks (they were resulting in bad pipe stalling behavior)

--- a/opal/test/reachable/reachable_weighted.c
+++ b/opal/test/reachable/reachable_weighted.c
@@ -558,7 +558,7 @@ int ranking_test()
 
     /* TEST8
      * Compares interface pairs with bandwidth 10->11 and 11->10.
-     * These connections should be equivilant, as they have the same
+     * These connections should be equivalent, as they have the same
      * bandwidth and same discrepancy.
      */
     test_no++;

--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -149,7 +149,7 @@ struct options_data_t {
      * language-binding specific file (for example, a C++ header file)
      * when invoking an optional language binding. */
     char *req_file;
-    /* Default includedir, before variable expansion.  Almost alwyas
+    /* Default includedir, before variable expansion.  Almost always
      * set as ${includedir} outside of multilib situations. */
     char *path_includedir;
     /* Default libdir, before variable expansion.  Almost always set
@@ -610,7 +610,7 @@ int main(int argc, char *argv[])
             old_match = temp;
             temp = strstr(temp + 1, extension);
         }
-        /* Only if there was a match of .exe, erase the last occurence of .exe */
+        /* Only if there was a match of .exe, erase the last occurrence of .exe */
         if (NULL != old_match) {
             *old_match = '\0';
         }
@@ -836,7 +836,7 @@ int main(int argc, char *argv[])
                    || 0 == strcmp(user_argv[i], "-Wl,-Bdynamic")) {
             flags &= ~COMP_WANT_STATIC;
         } else if (0 == strcmp(user_argv[i], "--openmpi:linkall")) {
-            /* This is an intentionally undocummented wrapper compiler
+            /* This is an intentionally undocumented wrapper compiler
                switch.  It should only be used by Open MPI developers
                -- not end users.  It will cause mpicc to use the
                static library list, even if we're compiling

--- a/opal/util/arch.c
+++ b/opal/util/arch.c
@@ -43,12 +43,12 @@ static inline int32_t opal_arch_isbigendian(void)
 /* we must find which representation of long double is used
  * intel or sparc. Both of them represent the long doubles using a close to
  * IEEE representation (seeeeeee..emmm...m) where the mantissa look like
- * 1.????. For the intel representaion the 1 is explicit, and for the sparc
+ * 1.????. For the intel representation the 1 is explicit, and for the sparc
  * the first one is implicit. If we take the number 2.0 the exponent is 1
  * and the mantissa is 1.0 (the sign of course should be 0). So if we check
  * for the first one in the binary representation of the number, we will
- * find the bit from the exponent, so the next one should be the begining
- * of the mantissa. If it's 1 then we have an intel representaion, if not
+ * find the bit from the exponent, so the next one should be the beginning
+ * of the mantissa. If it's 1 then we have an intel representation, if not
  * we have a sparc one. QED
  */
 static inline int32_t opal_arch_ldisintel(void)

--- a/opal/util/arch.h
+++ b/opal/util/arch.h
@@ -86,7 +86,7 @@
 **   real
 **   double precision
 **
-**   Unfortunatly, here we have to take care, whether float and real,
+**   Unfortunately, here we have to take care, whether float and real,
 **   respectively double and double precision do match...
 **
 **  a) fr32 (float and real are 32 bits) (e.g. SGI n32 and 64, SUN, NEC SX5,...)
@@ -126,7 +126,7 @@
 **                (128                 106       10) (special flags required).
 **  SX5:           128                 105       22
 **
-** We will not implement all of these routiens, but we consider them
+** We will not implement all of these routines, but we consider them
 ** now when defining the header-settings
 **
 ***********************************************************************/
@@ -171,7 +171,7 @@
 **   bits 7 & 8: reserved for later use. currently set to 00
 ** 2. Byte:
 **   bits 1 & 2: length of long: 00 = 32, 01 = 64
-**   bits 3 & 4: lenght of long long (not used currently, set to 00).
+**   bits 3 & 4: length of long long (not used currently, set to 00).
 **   bits 5 & 6: length of C/C++ bool (00 = 8, 01 = 16, 10 = 32)
 **   bits 7 & 8: length of Fortran Logical (00 = 8, 01 = 16, 10 = 32)
 ** 3. Byte:

--- a/opal/util/argv.h
+++ b/opal/util/argv.h
@@ -51,7 +51,7 @@ BEGIN_C_DECLS
  * @retval OPAL_ERROR On failure
  *
  * This function adds a string to an argv array of strings by value;
- * it is permissable to pass a string on the stack as the str
+ * it is permissible to pass a string on the stack as the str
  * argument to this function.
  *
  * To add the first entry to an argv array, call this function with
@@ -83,7 +83,7 @@ OPAL_DECLSPEC int opal_argv_append(int *argc, char ***argv, const char *arg)
  * except that it does not take a pointer to an argc (integer
  * representing the size of the array).  This is handy for
  * argv-style arrays that do not have integers that are actively
- * maintaing their sizes.
+ * maintaining their sizes.
  */
 OPAL_DECLSPEC int opal_argv_append_nosize(char ***argv, const char *arg);
 
@@ -267,7 +267,7 @@ OPAL_DECLSPEC int opal_argv_delete(int *argc, char ***argv, int start, int num_t
  * another.  The first token in source will be inserted at index
  * start in the target argv; all other tokens will follow it.
  * Similar to opal_argv_append(), the target may be realloc()'ed
- * to accomodate the new storage requirements.
+ * to accommodate the new storage requirements.
  *
  * The source array is left unaffected -- its contents are copied
  * by value over to the target array (i.e., the strings that
@@ -290,7 +290,7 @@ OPAL_DECLSPEC int opal_argv_insert(char ***target, int start, char **source);
  * another.  The token will be inserted at the specified index
  * in the target argv; all other tokens will be shifted down.
  * Similar to opal_argv_append(), the target may be realloc()'ed
- * to accomodate the new storage requirements.
+ * to accommodate the new storage requirements.
  *
  * The source token is left unaffected -- its contents are copied
  * by value over to the target array (i.e., the string that

--- a/opal/util/basename.h
+++ b/opal/util/basename.h
@@ -19,7 +19,7 @@
 /**
  * @file
  *
- * Returns an OS-independant basename() of a given filename.
+ * Returns an OS-independent basename() of a given filename.
  */
 
 #ifndef OPAL_BASENAME_H

--- a/opal/util/clock_gettime.h
+++ b/opal/util/clock_gettime.h
@@ -95,7 +95,7 @@ static inline int opal_clock_gettime(struct timespec *spec)
  * Simple, portable wrapper around clock_getres(3) for high-precision time.
  *
  * If the underlying system does not have clock_gettime(3), return usec
- * precison (because opal_clock_gettime() will be using gettimeofday(3)).
+ * precision (because opal_clock_gettime() will be using gettimeofday(3)).
  *
  * @param spec (OUT) Struct to return the resolution
  * @return Return value from underlying clock_getres()

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -85,7 +85,7 @@ struct ompi_cmd_line_param_t {
     opal_list_item_t super;
 
     /* Note that clp_arg points to storage "owned" by someone else; it
-       has the original option string by referene, not by value.
+       has the original option string by reference, not by value.
        Hence, it should not be free()'ed. */
 
     char *clp_arg;
@@ -269,7 +269,7 @@ int opal_cmd_line_parse(opal_cmd_line_t *cmd, bool ignore_unknown, bool ignore_u
     }
 
     /* Now traverse the easy-to-parse sequence of tokens.  Note that
-       incrementing i must happen elsehwere; it can't be the third
+       incrementing i must happen elsewhere; it can't be the third
        clause in the "if" statement. */
 
     param = NULL;
@@ -608,7 +608,7 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
 
                 /* Loop over adding the description to the array, breaking
                    the string at most at MAX_WIDTH characters.  We need a
-                   modifyable description (for simplicity), so strdup the
+                   modifiable description (for simplicity), so strdup the
                    clo_description (because it's likely a compiler
                    constant, and may barf if we write temporary \0's in
                    the middle). */
@@ -1073,7 +1073,7 @@ static int split_shorts(opal_cmd_line_t *cmd, char *token, char **args, int *out
         }
 
         /* If we do find the option, copy it and all of its parameters
-           to the output args.  If we run out of paramters (i.e., no
+           to the output args.  If we run out of parameters (i.e., no
            more tokens in the original argv), that error will be
            handled at a higher level) */
 

--- a/opal/util/cmd_line.h
+++ b/opal/util/cmd_line.h
@@ -251,7 +251,7 @@ typedef struct opal_cmd_line_init_t opal_cmd_line_init_t;
  *
  * This handle is used for accessing all command line functionality
  * (i.e., all opal_cmd_line*() functions).  Multiple handles can be
- * created and simultaneously processed; each handle is independant
+ * created and simultaneously processed; each handle is independent
  * from others.
  *
  * The opal_cmd_line_t handles are [simplisticly] thread safe;

--- a/opal/util/if.c
+++ b/opal/util/if.c
@@ -148,7 +148,7 @@ int opal_ifindextokindex(int if_index)
 }
 
 /*
- *  Attempt to resolve the adddress (given as either IPv4/IPv6 string
+ *  Attempt to resolve the address (given as either IPv4/IPv6 string
  *  or hostname) and lookup corresponding interface.
  */
 

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -163,7 +163,7 @@ int opal_info_free(opal_info_t **info);
 
 /**
  *   Get a (key, value) pair from an 'MPI_Info' object and assign it
- *   into a boolen output.
+ *   into a boolean output.
  *
  *   This call marks the entry referenced.
  *
@@ -175,7 +175,7 @@ int opal_info_free(opal_info_t **info);
  *
  *   @retval OPAL_SUCCESS
  *
- *   If found, the string value will be cast to the boolen output in
+ *   If found, the string value will be cast to the boolean output in
  *   the following manner:
  *
  *   - If the string value is digits, the return value is "(bool)
@@ -221,7 +221,7 @@ OPAL_DECLSPEC int opal_info_get_value_enum(opal_info_t *info, const char *key, i
  *   @retval OPAL_SUCCESS
  *
  *   The \c string pointer will only be set if the key is found, i.e., if \c flag
- *   is set to \c true. It is the caller's responsibility to decremenet the
+ *   is set to \c true. It is the caller's responsibility to decrement the
  *   reference count of the \c string object by calling \c OBJ_RELEASE on it
  *   once the object is not needed any more.
  */
@@ -268,7 +268,7 @@ OPAL_DECLSPEC int opal_info_get_valuelen(opal_info_t *info, const char *key, int
  *   @retval OPAL_SUCCESS
  *   @retval OPAL_ERR_BAD_PARAM
  *
- *   It is the caller's responsibility to decremenet the reference count of the
+ *   It is the caller's responsibility to decrement the reference count of the
  *   \c key string by calling \c OBJ_RELEASE on it once the object is not needed
  *   any more.
  */

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -280,7 +280,7 @@ static int add_to_env_str(char *var, char *val)
     varsz = strlen(var);
     if (NULL != val) {
         valsz = strlen(val);
-        /* If we have a value, it will be preceeded by a '=', so be
+        /* If we have a value, it will be preceded by a '=', so be
            sure to account for that */
         valsz += 1;
     }

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -279,7 +279,7 @@ bool opal_net_samenetwork(const struct sockaddr *addr1, const struct sockaddr *a
         if (64 == prefixlen) {
             /* prefixlen is always /64, any other case would be routing.
                Compare the first eight bytes (64 bits) and hope that
-               endianess is not an issue on any system as long as
+               endianness is not an issue on any system as long as
                addresses are always stored in network byte order.
             */
             if (((const uint32_t *) (a6_1))[0] == ((const uint32_t *) (a6_2))[0]
@@ -378,7 +378,7 @@ char *opal_net_get_hostname(const struct sockaddr *addr)
     case AF_INET6:
 #        if defined(__NetBSD__)
         /* hotfix for netbsd: on my netbsd machine, getnameinfo
-           returns an unkown error code. */
+           returns an unknown error code. */
         if (NULL
             == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
             opal_output(0, "opal_sockaddr2str failed with error code %d", errno);

--- a/opal/util/net.h
+++ b/opal/util/net.h
@@ -41,7 +41,7 @@
 BEGIN_C_DECLS
 
 /**
- * Intiailize the network helper subsystem
+ * Initialize the network helper subsystem
  *
  * Initialize the network helper subsystem.  Should be called exactly
  * once for any process that will use any function in the network

--- a/opal/util/opal_environ.c
+++ b/opal/util/opal_environ.c
@@ -36,7 +36,7 @@
 
 /*
  * Merge two environ-like char arrays, ensuring that there are no
- * duplicate entires
+ * duplicate entries
  */
 char **opal_environ_merge(char **minor, char **major)
 {

--- a/opal/util/opal_environ.h
+++ b/opal/util/opal_environ.h
@@ -44,7 +44,7 @@ BEGIN_C_DECLS
  * @retval New array of environ
  *
  * Merge two environ-like arrays into a single, new array,
- * ensuring that there are no duplicate entires.  If there are
+ * ensuring that there are no duplicate entries.  If there are
  * duplicates, entries in the \em major array are favored over
  * those in the \em minor array.
  *
@@ -86,7 +86,7 @@ OPAL_DECLSPEC char **opal_environ_merge(char **minor,
  *
  * The \em env array will be grown if necessary.
  *
- * It is permissable to invoke this function with the
+ * It is permissible to invoke this function with the
  * system-defined \em environ variable.  For example:
  *
  * \code
@@ -99,7 +99,7 @@ OPAL_DECLSPEC char **opal_environ_merge(char **minor,
  * environment.  This may very well lead to a memory leak, so its
  * use is strongly discouraged.
  *
- * It is also permissable to call this function with an empty \em
+ * It is also permissible to call this function with an empty \em
  * env, as long as it is pre-initialized with NULL:
  *
  * \code

--- a/opal/util/opal_pty.c
+++ b/opal/util/opal_pty.c
@@ -199,7 +199,7 @@ static int ptym_open(char *pts_name)
                     continue; /* try next pty device */
                 }
             }
-            pts_name[5] = 't'; /* chage "pty" to "tty" */
+            pts_name[5] = 't'; /* change "pty" to "tty" */
             return fdm;        /* got it, return fd of master */
         }
     }

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -73,7 +73,7 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         return (OPAL_SUCCESS);
     }
 
-    /* didnt work, so now have to build our way down the tree */
+    /* didn't work, so now have to build our way down the tree */
     /* Split the requested path up into its individual parts */
 
     parts = opal_argv_split(path, path_sep[0]);
@@ -101,7 +101,7 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         }
 
         /* If it's not the first part, ensure that there's a
-           preceeding path_sep and then append this part */
+           preceding path_sep and then append this part */
 
         else {
             if (path_sep[0] != tmp[strlen(tmp) - 1]) {
@@ -202,7 +202,7 @@ int opal_os_dirpath_destroy(const char *path, bool recursive,
         }
 
         /*
-         * If not recursively decending, then if we find a directory then fail
+         * If not recursively descending, then if we find a directory then fail
          * since we were not told to remove it.
          */
         if (is_dir && !recursive) {

--- a/opal/util/os_dirpath.h
+++ b/opal/util/os_dirpath.h
@@ -108,7 +108,7 @@ typedef bool (*opal_os_dirpath_destroy_callback_fn_t)(const char *root, const ch
  * @retval OPAL_SUCCESS If the directory was successfully removed or removed to the
  *                      specification of the user (i.e., obeyed the callback function).
  * @retval OPAL_ERR_NOT_FOUND If directory does not exist.
- * @retval OPAL_ERROR If the directory cannnot be removed, accessed properly, or contains
+ * @retval OPAL_ERROR If the directory cannot be removed, accessed properly, or contains
  *                    directories that could not be removed..
  */
 OPAL_DECLSPEC int opal_os_dirpath_destroy(const char *path, bool recursive,

--- a/opal/util/path.c
+++ b/opal/util/path.c
@@ -488,7 +488,7 @@ static char *opal_check_mtab(char *dev_path)
 #    define PAN_KERNEL_FS_CLIENT_SUPER_MAGIC 0xAAD7AAEA /* Panasas FS */
 #endif
 #ifndef GPFS_SUPER_MAGIC
-#    define GPFS_SUPER_MAGIC 0x47504653 /* Thats GPFS in ASCII */
+#    define GPFS_SUPER_MAGIC 0x47504653 /* That's GPFS in ASCII */
 #endif
 #ifndef AUTOFS_SUPER_MAGIC
 #    define AUTOFS_SUPER_MAGIC 0x0187

--- a/opal/util/show_help.c
+++ b/opal/util/show_help.c
@@ -144,7 +144,7 @@ static void local_delivery(const char *file, const char *topic, char *msg) {
 // Not available in PMIx releases of v4.1.2 and earlier.
 // This should be available in future v4.1 and v4.2 releases,
 // as well as future major releases.
-// Disabling the aggregate behavior here, but stil log it, as
+// Disabling the aggregate behavior here, but still log it, as
 // seeing duplicate messages is better than not seeing anything at all.
 #ifdef PMIX_LOG_AGG
         PMIX_INFO_CREATE(dirs, 3);

--- a/opal/util/show_help.h
+++ b/opal/util/show_help.h
@@ -49,7 +49,7 @@
  * appropriate help message to display.  It looks for the message name
  * in the file, reads in the message, and displays it.  printf()-like
  * substitutions are performed (e.g., %d, %s, etc.) --
- * opal_show_help() takes a variable legnth argument list that are
+ * opal_show_help() takes a variable length argument list that are
  * used for these substitutions.
  *
  * The format of the help file is simplistic:
@@ -163,7 +163,7 @@ OPAL_DECLSPEC char *opal_show_help_vstring(const char *filename, const char *top
  * of the show_help functionality. OMPI defines the show_help directory
  * based on where OMPI was installed. However, if the library wants to
  * use show_help to provide error output specific to itself, then it
- * nees to tell show_help how to find its own show_help files.
+ * needs to tell show_help how to find its own show_help files.
  */
 OPAL_DECLSPEC int opal_show_help_add_dir(const char *directory);
 

--- a/opal/util/string_copy.c
+++ b/opal/util/string_copy.c
@@ -19,7 +19,7 @@ void opal_string_copy(char *dest, const char *src, size_t dest_len)
     char *new_dest = dest;
 
     // Open MPI does not do *giant* string copies.  Hence, we use the
-    // hueristic: if "dest_len" is too large, this is a programmer
+    // heuristic: if "dest_len" is too large, this is a programmer
     // error.  We pseudo-arbitrarily pick a large value to be the max
     // allowable dest_len: 128K.  If we ever need to increase this
     // value someday (because something has a legit reason to

--- a/opal/win32/opal_socket.c
+++ b/opal/win32/opal_socket.c
@@ -45,7 +45,7 @@ int create_socketpair(int family, int type, int protocol, int fd[2])
         return -1;
     }
     if (!fd) {
-        opal_output(0, "Invalid socked: %d", (ERR(EINVAL)));
+        opal_output(0, "Invalid socket: %d", (ERR(EINVAL)));
         return -1;
     }
 

--- a/opal/win32/win_compat.h
+++ b/opal/win32/win_compat.h
@@ -119,7 +119,7 @@ typedef unsigned int uint;
  * Microsoft compiler complain about non conformance of the default UNIX function.
  * Non conformance to the POSIX standard, and they suggest to use the version
  * starting with an _ instead. So, in order to keep cl.exe happy (and quiet) we can
- * use the followings defines.
+ * use the following defines.
  */
 #    define getpid                  _getpid
 #    define strdup                  _strdup


### PR DESCRIPTION
Found via `codespell`

Signed-off-by: luz paz <luzpaz@github.com>
(cherry picked from commit 8d3b1fa6b664e4ab809f3da3e0566d57653aad95)

FYI @luzpaz 