### PR TITLE
Fix typos in the oshmem/ subdirectory

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -45,7 +45,7 @@ OSHMEM_DECLSPEC  int pshmem_my_pe(void);
 OSHMEM_DECLSPEC  void pshmem_query_thread(int *provided);
 
 /*
- * Accessability routines
+ * Accessibility routines
  */
 OSHMEM_DECLSPEC int pshmem_pe_accessible(int pe);
 OSHMEM_DECLSPEC int pshmem_addr_accessible(const void *addr, int pe);

--- a/oshmem/include/shmem-compat.h
+++ b/oshmem/include/shmem-compat.h
@@ -1,4 +1,4 @@
-/* oshmem/include/shmem-compat.h. This file contains OpenSHMEM lagacy API  */
+/* oshmem/include/shmem-compat.h. This file contains OpenSHMEM legacy API  */
 /*
  * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -185,7 +185,7 @@ OSHMEM_DECLSPEC void shmem_info_get_version(int *major, int *minor);
 OSHMEM_DECLSPEC void shmem_info_get_name(char *name);
 
 /*
- * Accessability routines
+ * Accessibility routines
  */
 OSHMEM_DECLSPEC int shmem_pe_accessible(int pe);
 OSHMEM_DECLSPEC int shmem_addr_accessible(const void *addr, int pe);
@@ -2510,7 +2510,7 @@ OSHMEM_DECLSPEC void shmem_longlong_inc(long long *target, int pe);
 
 
 /*
- * Nonblocking Atomic Memroy Operations
+ * Nonblocking Atomic Memory Operations
  */
 
 /* Atomic Nonblocking Fetch */

--- a/oshmem/mca/atomic/atomic.h
+++ b/oshmem/mca/atomic/atomic.h
@@ -180,9 +180,9 @@ struct mca_atomic_base_component_1_0_0_t {
 };
 typedef struct mca_atomic_base_component_1_0_0_t mca_atomic_base_component_1_0_0_t;
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
  want to always keep up with the most recent version of the
- interace. */
+ interface. */
 typedef struct mca_atomic_base_component_1_0_0_t mca_atomic_base_component_t;
 
 /**
@@ -299,9 +299,9 @@ struct mca_atomic_base_module_1_0_0_t {
 };
 typedef struct mca_atomic_base_module_1_0_0_t mca_atomic_base_module_1_0_0_t;
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
  want to always keep up with the most recent version of the
- interace. */
+ interface. */
 typedef struct mca_atomic_base_module_1_0_0_t mca_atomic_base_module_t;
 OSHMEM_DECLSPEC OBJ_CLASS_DECLARATION(mca_atomic_base_module_t);
 

--- a/oshmem/mca/memheap/README.md
+++ b/oshmem/mca/memheap/README.md
@@ -3,7 +3,7 @@
 Copyright (c) 2013      Mellanox Technologies, Inc.
                         All rights reserved
 
-MEMHEAP Infrustructure is responsible for managing the symmetric heap.
+MEMHEAP Infrastructure is responsible for managing the symmetric heap.
 The framework currently has following components: buddy and
 ptmalloc. buddy which uses a buddy allocator in order to manage the
 Memory allocations on the symmetric heap. Ptmalloc is an adaptation of
@@ -11,7 +11,7 @@ ptmalloc3.
 
 Additional components may be added easily to the framework by defining
 the component's and the module's base and extended structures, and
-their funtionalities.
+their functionalities.
 
 The buddy allocator has the following data structures:
 
@@ -54,7 +54,7 @@ The supported activities are:
 
 1. buddy_init (Initialization)
 1. buddy_alloc (Allocates a variable on the symmetric heap)
-1. buddy_free (frees a variable previously allocated on the symetric heap)
+1. buddy_free (frees a variable previously allocated on the symmetric heap)
 1. buddy_finalize (Finalization).
 
 Data members of buddy module:

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -280,7 +280,7 @@ static void do_recv(int source_pe, pmix_data_buffer_t* buffer)
 
 /**
  * simple/fast version of MPI_Test that
- * - only works with persistant request
+ * - only works with persistent request
  * - does not do any progress
  * - can be safely called from within opal_progress()
  */
@@ -618,7 +618,7 @@ void mca_memheap_modex_recv_all(void)
 
     rcv_buffer = malloc (buffer_size);
     if (NULL == rcv_buffer) {
-        MEMHEAP_ERROR("failed to allocate recieve buffer");
+        MEMHEAP_ERROR("failed to allocate receive buffer");
         rc = OSHMEM_ERR_OUT_OF_RESOURCE;
         goto exit_fatal;
     }

--- a/oshmem/mca/memheap/buddy/memheap_buddy_component.c
+++ b/oshmem/mca/memheap/buddy/memheap_buddy_component.c
@@ -57,7 +57,7 @@ mca_memheap_buddy_component_query(mca_base_module_t **module, int *priority)
 }
 
 /*
- * This function is automaticaly called from mca_base_components_close.
+ * This function is automatically called from mca_base_components_close.
  * It releases the component's allocated memory.
  */
 int mca_memheap_buddy_component_close()

--- a/oshmem/mca/memheap/memheap.h
+++ b/oshmem/mca/memheap/memheap.h
@@ -88,7 +88,7 @@ typedef struct mca_memheap_base_component_2_0_0_t mca_memheap_base_component_t;
  * memheap module descriptor
  */
 struct mca_memheap_base_module_t {
-    mca_memheap_base_component_t                   *memheap_component;  /** Memory Heap Management Componenet */
+    mca_memheap_base_component_t                   *memheap_component;  /** Memory Heap Management Component */
     mca_memheap_base_module_finalize_fn_t           memheap_finalize;
     mca_memheap_base_module_alloc_fn_t              memheap_alloc;
     mca_memheap_base_module_memalign_fn_t           memheap_memalign;

--- a/oshmem/mca/memheap/ptmalloc/malloc.c
+++ b/oshmem/mca/memheap/ptmalloc/malloc.c
@@ -1443,7 +1443,7 @@ static FORCEINLINE void* win32direct_mmap(size_t size) {
   return (ptr != 0)? ptr: MFAIL;
 }
 
-/* This function supports releasing coalesed segments */
+/* This function supports releasing coalesced segments */
 static FORCEINLINE int win32munmap(void* ptr, size_t size) {
   MEMORY_BASIC_INFORMATION minfo;
   char* cptr = (char*)ptr;
@@ -1480,7 +1480,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
 #define CALL_MORECORE(S)     MFAIL
 #endif /* HAVE_MORECORE */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */
@@ -2094,7 +2094,7 @@ nextchunk-> +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   work in the same way as fd/bk pointers of small chunks.
 
   Each tree contains a power of 2 sized range of chunk sizes (the
-  smallest is 0x100 <= x < 0x180), which is is divided in half at each
+  smallest is 0x100 <= x < 0x180), which is divided in half at each
   tree level, with the chunks in the smaller half of the range (0x100
   <= x < 0x140 for the top nose) in the left subtree and the larger
   half (0x140 <= x < 0x180) in the right subtree.  This is, of course,
@@ -2284,7 +2284,7 @@ typedef struct malloc_segment* msegmentptr;
 
   Trim support
     Fields holding the amount of unused topmost memory that should trigger
-    timming, and a counter to force periodic scanning to release unused
+    timing, and a counter to force periodic scanning to release unused
     non-topmost segments.
 
   Locking
@@ -2692,7 +2692,7 @@ static size_t traverse_and_check(mstate m);
   http://www.usenix.org/events/lisa03/tech/robertson.html The footer
   of an inuse chunk holds the xor of its mstate and a random seed,
   that is checked upon calls to free() and realloc().  This is
-  (probablistically) unguessable from outside the program, but can be
+  (probabilistically) unguessable from outside the program, but can be
   computed by any code successfully malloc'ing any chunk, so does not
   itself provide protection against code that has already broken
   security through some other means.  Unlike Robertson et al, we
@@ -4539,7 +4539,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -5430,10 +5430,10 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc_component.c
+++ b/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc_component.c
@@ -58,7 +58,7 @@ mca_memheap_ptmalloc_component_query(mca_base_module_t **module, int *priority)
 }
 
 /*
- * This function is automaticaly called from mca_base_components_close.
+ * This function is automatically called from mca_base_components_close.
  * It releases the component's allocated memory.
  */
 int mca_memheap_ptmalloc_component_close()

--- a/oshmem/mca/scoll/mpi/help-oshmem-scoll-mpi.txt
+++ b/oshmem/mca/scoll/mpi/help-oshmem-scoll-mpi.txt
@@ -9,7 +9,7 @@
 #
 [module_enable:fatal]
 scoll:mpi module reports issue during module enabling phase.
-Try to use scoll:mpi component with anoter one
+Try to use scoll:mpi component with another one
 for example scoll:basic
 
   Error: %s

--- a/oshmem/mca/scoll/scoll.h
+++ b/oshmem/mca/scoll/scoll.h
@@ -67,9 +67,9 @@ struct mca_scoll_base_component_1_0_0_t {
 };
 typedef struct mca_scoll_base_component_1_0_0_t mca_scoll_base_component_1_0_0_t;
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
  want to always keep up with the most recent version of the
- interace. */
+ interface. */
 typedef struct mca_scoll_base_component_1_0_0_t mca_scoll_base_component_t;
 
 /**

--- a/oshmem/mca/scoll/ucc/help-oshmem-scoll-ucc.txt
+++ b/oshmem/mca/scoll/ucc/help-oshmem-scoll-ucc.txt
@@ -9,7 +9,7 @@
 #
 [module_enable:fatal]
 scoll:ucc module reports issue during module enabling phase.
-Try to use scoll:ucc component with anoter one
+Try to use scoll:ucc component with another one
 for example scoll:basic
 
   Error: %s

--- a/oshmem/mca/spml/base/spml_base_select.c
+++ b/oshmem/mca/spml/base/spml_base_select.c
@@ -168,7 +168,7 @@ int mca_spml_base_select(bool enable_progress_threads, bool enable_mpi_threads)
 
             if (NULL != om->om_component->spmlm_finalize) {
 
-                /* Blatently ignore the return code (what would we do to
+                /* Blatantly ignore the return code (what would we do to
                  recover, anyway?  This component is going away, so errors
                  don't matter anymore) */
 

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -336,7 +336,7 @@ int mca_spml_ucx_del_procs(oshmem_group_t* group, size_t nprocs)
     return ret;
 }
 
-/* TODO: move func into common place, use it with rkey exchng too */
+/* TODO: move func into common place, use it with rkey exchange too */
 static int oshmem_shmem_xchng(
         void **local_data, unsigned int *local_size, int nprocs, int ucp_workers,
         void **rdata_p, unsigned int **roffsets_p, unsigned int **rsizes_p)

--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
@@ -32,7 +32,7 @@
  */
 
 /**
- * if 32 bit we set sshmem_base_start_adress to 0
+ * if 32 bit we set sshmem_base_start_address to 0
  * to let OS allocate segment automatically
  */
 #if UINTPTR_MAX == 0xFFFFFFFF

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
@@ -259,7 +259,7 @@ segment_detach(map_segment_t *ds_buf, sshmem_mkey_t *mkey)
 
     if (mca_sshmem_sysv_component.use_hp != 0) {
         /**
-         *  Workaround kernel panic when detaching huge pages from user space simultanously from several processes
+         *  Workaround kernel panic when detaching huge pages from user space simultaneously from several processes
          *  dont detach here instead let kernel do it during process cleanup
          */
         /* shmdt((void *)ds_buf->seg_base_addr); */

--- a/oshmem/request/request.h
+++ b/oshmem/request/request.h
@@ -83,7 +83,7 @@ typedef int (*oshmem_request_cancel_fn_t)(struct oshmem_request_t* request,
 /*
  * Optional function called when the request is completed from the SHMEM
  * library perspective. This function is not allowed to release any
- * ressources related to the request.
+ * resources related to the request.
  */
 typedef int (*oshmem_request_complete_fn_t)(struct oshmem_request_t* request);
 
@@ -133,7 +133,7 @@ struct oshmem_request_t {
 typedef struct oshmem_request_t oshmem_request_t;
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See oshmem/communicator/communicator.h comments with struct oshmem_group_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -172,7 +172,7 @@ typedef struct oshmem_predefined_request_t oshmem_predefined_request_t;
  * This function should be called only from the SHMEM layer. It should
  * never be called from the SPML. It take care of the upper level clean-up.
  * When the user call MPI_Request_free we should release all SHMEM level
- * ressources, so we have to call this function too.
+ * resources, so we have to call this function too.
  */
 #define OSHMEM_REQUEST_FINI(request)                                      \
 do {                                                                    \
@@ -221,7 +221,7 @@ typedef int (*oshmem_request_test_any_fn_t)(size_t count,
  *
  * @param count (IN)      Number of requests
  * @param requests (IN)   Array of requests
- * @param completed (OUT) Flag indicating wether all requests completed.
+ * @param completed (OUT) Flag indicating whether all requests completed.
  * @param statuses (OUT)  Array of completion statuses.
  * @return                OSHMEM_SUCCESS or failure status.
  *

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -105,8 +105,8 @@ static void* shmem_opal_thread(void* argc)
 {
 /*
  * WHAT: sleep() invocation
- * WHY:  there occures a segfault sometimes and sleep()
- *       reduces it's possibility
+ * WHY:  there occurs a segfault sometimes and sleep()
+ *       reduces its possibility
  */
     sleep(1);
     while(oshmem_shmem_initialized)

--- a/oshmem/runtime/runtime.h
+++ b/oshmem/runtime/runtime.h
@@ -82,7 +82,7 @@ OSHMEM_DECLSPEC extern shmem_ctx_t oshmem_ctx_default;
 #define OSHMEM_THREADLEVEL_SERIALIZED_BF 0x00000004
 #define OSHMEM_THREADLEVEL_MULTIPLE_BF   0x00000008
 
-/** In ompi_mpi_init: the lists of Fortran 90 mathing datatypes.
+/** In ompi_mpi_init: the lists of Fortran 90 matching datatypes.
  * We need these lists and hashtables in order to satisfy the new
  * requirements introduced in MPI 2-1 Sect. 10.2.5,
  * MPI_TYPE_CREATE_F90_xxxx, page 295, line 47.
@@ -105,12 +105,12 @@ OSHMEM_DECLSPEC extern const char oshmem_version_string[];
  * @returns OSHMEM_SUCCESS if successful
  * @returns Error code if unsuccessful
  *
- * Intialize all support code needed for SHMEM applications.  This
+ * Initialize all support code needed for SHMEM applications.  This
  * function should only be called by SHMEM applications (including
  * singletons).  If this function is called, ompi_init() and
  * ompi_rte_init() should *not* be called.
  *
- * It is permissable to pass in (0, NULL) for (argc, argv).
+ * It is permissible to pass in (0, NULL) for (argc, argv).
  */
 int oshmem_shmem_init(int argc, char **argv, int requested, int *provided);
 

--- a/oshmem/shmem/c/profile-defines.h
+++ b/oshmem/shmem/c/profile-defines.h
@@ -40,7 +40,7 @@
 #define _my_pe                       p_my_pe /* shmem-compat.h */
 
 /*
- * Accessability routines
+ * Accessibility routines
  */
 #define shmem_pe_accessible          pshmem_pe_accessible
 #define shmem_addr_accessible        pshmem_addr_accessible

--- a/oshmem/util/oshmem_util.h
+++ b/oshmem/util/oshmem_util.h
@@ -30,7 +30,7 @@ void oshmem_output_verbose(int level, int output_id, const char* prefix,
     const char* file, int line, const char* function, const char* format, ...);
 
 /*
- * Temporary wrapper which ingores output verbosity level
+ * Temporary wrapper which ignores output verbosity level
  * to ensure error messages are seeing by user
  */
 void oshmem_output(int output_id, const char* prefix, const char* file,


### PR DESCRIPTION
Found via `codespell`