### PR TITLE
Fix typos in ompi/mca subdirectory

### DIFF
--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -220,7 +220,7 @@ static int mca_bml_r2_endpoint_add_btl (struct ompi_proc_t *proc, mca_bml_base_e
 
     if ((btl_flags & (MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_GET | MCA_BTL_FLAGS_SEND)) == 0) {
         /* If no protocol specified, we have 2 choices: we ignore the BTL
-         * as we don't know which protocl to use, or we suppose that all
+         * as we don't know which protocol to use, or we suppose that all
          * BTLs support the send protocol. This is really a btl error as
          * these flags should have been sanitized by the btl. */
         btl_flags |= MCA_BTL_FLAGS_SEND;
@@ -634,7 +634,7 @@ static int mca_bml_r2_del_procs(size_t nprocs,
             }
 
             /* The reference stored in btl_eager and btl_rdma will automatically
-             * dissapear once the btl_array destructor is called. Thus, there is
+             * disappear once the btl_array destructor is called. Thus, there is
              * no need for extra cleaning here.
              */
         }
@@ -916,7 +916,7 @@ static int mca_bml_r2_register( mca_btl_base_tag_t tag,
 {
     mca_btl_base_active_message_trigger[tag].cbfunc = cbfunc;
     mca_btl_base_active_message_trigger[tag].cbdata = data;
-    /* Give an oportunity to the BTLs to do something special
+    /* Give an opportunity to the BTLs to do something special
      * for each registration.
      */
     {

--- a/ompi/mca/coll/adapt/coll_adapt_context.h
+++ b/ompi/mca/coll/adapt/coll_adapt_context.h
@@ -32,7 +32,7 @@ struct ompi_coll_adapt_constant_bcast_context_s {
     opal_mutex_t *mutex;
     int *recv_array;
     int *send_array;
-    /* Length of the fragment array, which is the number of recevied segments */
+    /* Length of the fragment array, which is the number of received segments */
     int num_recv_segs;
     /* Number of segments that is finishing recving */
     int num_recv_fini;
@@ -81,7 +81,7 @@ struct ompi_coll_adapt_constant_reduce_context_s {
     int ireduce_tag;
     /* How many sends are posted but not finished */
     int32_t ongoing_send;
-    /* Length of the fragment array, which is the number of recevied segments */
+    /* Length of the fragment array, which is the number of received segments */
     int32_t num_recv_segs;
     /* Number of sent segments */
     int32_t num_sent_segs;

--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -414,7 +414,7 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
     num_segs = (count + seg_count - 1) / seg_count;
     real_seg_size = (ptrdiff_t) seg_count *extent;
 
-    /* Set memory for recv_array and send_array, created on heap becasue they are needed to be accessed by other functions (callback functions) */
+    /* Set memory for recv_array and send_array, created on heap because they are needed to be accessed by other functions (callback functions) */
     if (num_segs != 0) {
         recv_array = (int *) malloc(sizeof(int) * num_segs);
     }
@@ -485,7 +485,7 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
                 context->frag_id = i;
                 /* The id of peer in in children_list */
                 context->child_id = j;
-                /* Actural rank of the peer */
+                /* Actual rank of the peer */
                 context->peer = tree->tree_next[j];
                 context->con = con;
                 OBJ_RETAIN(con);

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -741,7 +741,7 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
                 (ompi_coll_adapt_reduce_context_t *)opal_free_list_wait(mca_coll_adapt_component.adapt_ireduce_context_free_list);
             context->buff = (char *) sbuf + (ptrdiff_t) seg_index * (ptrdiff_t) segment_increment;
             context->seg_index = seg_index;
-            /* Actural rank of the peer */
+            /* Actual rank of the peer */
             context->peer = tree->tree_prev;
             context->con = con;
             context->inbuf = NULL;

--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -52,7 +52,7 @@
  * Example on 6 nodes:
  *   Initialization: everyone has its own buffer at location 0 in rbuf
  *                   This means if user specified MPI_IN_PLACE for sendbuf
- *                   we must copy our block from recvbuf to begining!
+ *                   we must copy our block from recvbuf to beginning!
  *    #     0      1      2      3      4      5
  *         [0]    [1]    [2]    [3]    [4]    [5]
  *   Step 0: send message to (rank - 2^0), receive message from (rank + 2^0)
@@ -124,7 +124,7 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
     /* Communication step:
        At every step i, rank r:
        - doubles the distance
-       - sends message which starts at begining of rbuf and has size
+       - sends message which starts at beginning of rbuf and has size
        (blockcount * rcount) to rank (r - distance)
        - receives message of size blockcount * rcount from rank (r + distance)
        at location (rbuf + distance * rcount * rext)
@@ -159,10 +159,10 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
     /* Finalization step:
        On all nodes except 0, data needs to be shifted locally:
        - create temporary shift buffer,
-       see discussion in coll_basic_reduce.c about the size and begining
+       see discussion in coll_basic_reduce.c about the size and beginning
        of temporary buffer.
        - copy blocks [0 .. (size - rank - 1)] from rbuf to shift buffer
-       - move blocks [(size - rank) .. size] from rbuf to begining of rbuf
+       - move blocks [(size - rank) .. size] from rbuf to beginning of rbuf
        - copy blocks from shift buffer starting at block [rank] in rbuf.
     */
     if (0 != rank) {
@@ -182,7 +182,7 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
                                                   shift_buf, rbuf);
         if (err < 0) { line = __LINE__; free(free_buf); goto err_hndl;  }
 
-        /* 2. move blocks [(size - rank) .. size] from rbuf to the begining of rbuf */
+        /* 2. move blocks [(size - rank) .. size] from rbuf to the beginning of rbuf */
         tmpsend = (char*) rbuf + (ptrdiff_t)(size - rank) * (ptrdiff_t)rcount * rext;
         err = ompi_datatype_copy_content_same_ddt(rdtype, (ptrdiff_t)rank * (ptrdiff_t)rcount,
                                                   rbuf, tmpsend);
@@ -532,7 +532,7 @@ int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
        [(r - i - 1 + size) % size]
        - sends message to rank [(r + 1) % size] containing data from rank
        [(r - i + size) % size]
-       - sends message which starts at begining of rbuf and has size
+       - sends message which starts at beginning of rbuf and has size
     */
     sendto = (rank + 1) % size;
     recvfrom  = (rank - 1 + size) % size;
@@ -685,7 +685,7 @@ ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
        - Rest of the steps:
        update recv_data_from according to offset, and
        exchange two blocks with appropriate neighbor.
-       the send location becomes previous receve location.
+       the send location becomes previous receive location.
     */
     tmprecv = (char*)rbuf + (ptrdiff_t)neighbor[0] * (ptrdiff_t)rcount * rext;
     tmpsend = (char*)rbuf + (ptrdiff_t)rank * (ptrdiff_t)rcount * rext;

--- a/ompi/mca/coll/base/coll_base_allgatherv.c
+++ b/ompi/mca/coll/base/coll_base_allgatherv.c
@@ -406,7 +406,7 @@ int ompi_coll_base_allgatherv_intra_ring(const void *sbuf, int scount,
        [(r - i - 1 + size) % size]
        - sends message to rank [(r + 1) % size] containing data from rank
        [(r - i + size) % size]
-       - sends message which starts at begining of rbuf and has size
+       - sends message which starts at beginning of rbuf and has size
     */
     sendto = (rank + 1) % size;
     recvfrom  = (rank - 1 + size) % size;
@@ -563,7 +563,7 @@ ompi_coll_base_allgatherv_intra_neighborexchange(const void *sbuf, int scount,
        - Rest of the steps:
        update recv_data_from according to offset, and
        exchange two blocks with appropriate neighbor.
-       the send location becomes previous receve location.
+       the send location becomes previous receive location.
        Note, we need to create indexed datatype to send and receive these
        blocks properly.
     */

--- a/ompi/mca/coll/base/coll_base_allreduce.c
+++ b/ompi/mca/coll/base/coll_base_allreduce.c
@@ -424,7 +424,7 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
        - wait on block (r + 1)
        - compute on block (r + 1)
        - send block (r + 1) to rank (r + 1)
-       Note that we must be careful when computing the begining of buffers and
+       Note that we must be careful when computing the beginning of buffers and
        for send operations and computation we must compute the exact block size.
     */
     send_to = (rank + 1) % size;
@@ -717,7 +717,7 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
            - wait on block (r + 1)
            - compute on block (r + 1)
            - send block (r + 1) to rank (r + 1)
-           Note that we must be careful when computing the begining of buffers and
+           Note that we must be careful when computing the beginning of buffers and
            for send operations and computation we must compute the exact block size.
         */
         send_to = (rank + 1) % size;
@@ -1122,7 +1122,7 @@ int ompi_coll_base_allreduce_intra_redscat_allgather(
 
         for (int mask = 1; mask < nprocs_pof2; mask <<= 1) {
             /*
-             * On each iteration: rindex[step] = sindex[step] -- begining of the
+             * On each iteration: rindex[step] = sindex[step] -- beginning of the
              * current window. Length of the current window is storded in wsize.
              */
             int vdest = vrank ^ mask;

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -196,7 +196,7 @@ ompi_coll_base_alltoallv_intra_pairwise(const void *sbuf, const int *scounts, co
     ompi_datatype_type_extent(sdtype, &sext);
     ompi_datatype_type_extent(rdtype, &rext);
 
-   /* Perform pairwise exchange starting from 1 since local exhange is done */
+   /* Perform pairwise exchange starting from 1 since local exchange is done */
     for (step = 0; step < size; step++) {
 
         /* Determine sender and receiver for this step. */

--- a/ompi/mca/coll/base/coll_base_barrier.c
+++ b/ompi/mca/coll/base/coll_base_barrier.c
@@ -83,7 +83,7 @@ ompi_coll_base_sendrecv_zero( int dest, int stag,
             if( MPI_ERR_PROC_FAILED_PENDING == rc ) {
                 rc = MPI_ERR_PROC_FAILED;
             }
-        } else /* this 'else' intentionaly spills outside the ifdef */
+        } else /* this 'else' intentionally spills outside the ifdef */
 #endif /* OPAL_ENABLE_FT_MPI */
         ompi_request_free(&req);
     }
@@ -95,7 +95,7 @@ ompi_coll_base_sendrecv_zero( int dest, int stag,
 }
 
 /*
- * Barrier is ment to be a synchronous operation, as some BTLs can mark
+ * Barrier is meant to be a synchronous operation, as some BTLs can mark
  * a request done before its passed to the NIC and progress might not be made
  * elsewhere we cannot allow a process to exit the barrier until its last
  * [round of] sends are completed.
@@ -110,7 +110,7 @@ ompi_coll_base_sendrecv_zero( int dest, int stag,
 /*
  * Simple double ring version of barrier
  *
- * synchronous gurantee made by last ring of sends are synchronous
+ * synchronous guarantee made by last ring of sends are synchronous
  *
  */
 int ompi_coll_base_barrier_intra_doublering(struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -369,7 +369,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
     int err=0, line, rank, size, segindex, i, lr, pair;
     uint32_t counts[2];
     int segcount[2];       /* Number of elements sent with each segment */
-    int num_segments[2];   /* Number of segmenets */
+    int num_segments[2];   /* Number of segments */
     int sendcount[2];      /* the same like segcount, except for the last segment */
     size_t realsegsize[2], type_size;
     char *tmpbuf[2];
@@ -507,7 +507,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
                 if (err != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }
             } /* end of for each child */
 
-            /* upate the base request */
+            /* update the base request */
             base_req = new_req;
             /* go to the next buffer (ie. the one corresponding to the next recv) */
             tmpbuf[lr] += realsegsize[lr];

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -453,7 +453,7 @@ static opal_list_t *check_components(opal_list_t * components,
     /* For all valid component reorder them not on their provided priorities but on
      * the order requested in the info key. As at this point the coll_include is
      * already ordered backward we can simply append the components.
-     * Note that the last element in selectable will have the highest priorty.
+     * Note that the last element in selectable will have the highest priority.
      */
     for (int idx = count_include-1; idx >= 0; --idx) {
         mca_coll_base_avail_coll_t *item;

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -519,7 +519,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_comm_t);
 
 /**
  * Free all requests in an array. As these requests are usually used during
- * collective communications, and as on a succesful collective they are
+ * collective communications, and as on a successful collective they are
  * expected to be released during the corresponding wait, the array should
  * generally be empty. However, this function might be used on error conditions
  * where it will allow a correct cleanup.
@@ -544,7 +544,7 @@ static inline void ompi_coll_base_free_reqs(ompi_request_t **reqs, int count)
                  * free, as this is the best that can be done in this case. */
                 ompi_request_cancel(reqs[i]);
                 ompi_request_wait(&reqs[i], MPI_STATUS_IGNORE);
-            } else /* this 'else' intentionaly spills outside the ifdef */
+            } else /* this 'else' intentionally spills outside the ifdef */
 #endif /* OPAL_ENABLE_FT_MPI */
             ompi_request_free(&reqs[i]);
         }

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -112,7 +112,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
         }
 
         /* If this is a non-commutative operation we must copy
-           sendbuf to the accumbuf, in order to simplfy the loops */
+           sendbuf to the accumbuf, in order to simplify the loops */
         
         if (!ompi_op_is_commute(op) && MPI_IN_PLACE != sendbuf) {
             ompi_datatype_copy_content_same_ddt(datatype, original_count,
@@ -250,14 +250,14 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
        the number of segments we have two options:
        - send all segments using blocking send to the parent, or
        - avoid overflooding the parent nodes by limiting the number of
-       outstanding requests to max_oustanding_reqs.
+       outstanding requests to max_outstanding_reqs.
        TODO/POSSIBLE IMPROVEMENT: If there is a way to determine the eager size
        for the current communication, synchronization should be used only
        when the message/segment size is smaller than the eager size.
     */
     else {
 
-        /* If the number of segments is less than a maximum number of oustanding
+        /* If the number of segments is less than a maximum number of outstanding
            requests or there is no limit on the maximum number of outstanding
            requests, we send data to the parent using blocking send */
         if ((0 == max_outstanding_reqs) ||
@@ -965,7 +965,7 @@ int ompi_coll_base_reduce_intra_redscat_gather(
 
         for (int mask = 1; mask < nprocs_pof2; mask <<= 1) {
             /*
-             * On each iteration: rindex[step] = sindex[step] -- begining of the
+             * On each iteration: rindex[step] = sindex[step] -- beginning of the
              * current window. Length of the current window is storded in wsize.
              */
             int vdest = vrank ^ mask;

--- a/ompi/mca/coll/base/coll_base_reduce_scatter.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter.c
@@ -545,7 +545,7 @@ ompi_coll_base_reduce_scatter_intra_ring( const void *sbuf, void *rbuf, const in
        - wait on block (r)
        - compute on block (r)
        - copy block (r) to rbuf
-       Note that we must be careful when computing the begining of buffers and
+       Note that we must be careful when computing the beginning of buffers and
        for send operations and computation we must compute the exact block size.
     */
     send_to = (rank + 1) % size;

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -94,7 +94,7 @@ int ompi_coll_base_sendrecv_actual( const void* sendbuf, size_t scount,
             if( MPI_ERR_PROC_FAILED_PENDING == err ) {
                 err = MPI_ERR_PROC_FAILED;
             }
-        } else /* this 'else' intentionaly spills outside the ifdef */
+        } else /* this 'else' intentionally spills outside the ifdef */
 #endif /* OPAL_ENABLE_FT_MPI */
         ompi_request_free(&req);
     }
@@ -130,7 +130,7 @@ int ompi_rounddown(int num, int factor)
 /**
  * Release all objects and arrays stored into the nbc_request.
  * The release_arrays are temporary memory to stored the values
- * converted from Fortran, and should dissapear in same time as the
+ * converted from Fortran, and should disappear in same time as the
  * request itself.
  */
 static void

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -196,7 +196,7 @@ int ompi_coll_base_file_getnext_string(FILE *fptr, int *fileline, char** val);
  */
 int ompi_coll_base_file_peek_next_char_is(FILE *fptr, int *fileline, int expected);
 
-/* Miscelaneous function */
+/* Miscellaneous function */
 const char* mca_coll_base_colltype_to_str(int collid);
 int mca_coll_base_name_to_colltype(const char* name);
 

--- a/ompi/mca/coll/basic/coll_basic_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_allgather.c
@@ -60,10 +60,10 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
     rsize = ompi_comm_remote_size(comm);
 
     /* Algorithm:
-     * - a gather to the root in remote group (simultaniously executed,
-     * thats why we cannot use coll_gather).
+     * - a gather to the root in remote group (simultaneously executed,
+     * that's why we cannot use coll_gather).
      * - exchange the temp-results between two roots
-     * - inter-bcast (again simultanious).
+     * - inter-bcast (again simultaneous).
      */
 
     /* Step one: gather operations: */
@@ -106,7 +106,7 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
         err = ompi_request_wait_all(rsize + 1, reqs, MPI_STATUSES_IGNORE);
         if (OMPI_SUCCESS != err) { line = __LINE__; goto exit; }
 
-        /* Step 2: exchange the resuts between the root processes */
+        /* Step 2: exchange the results between the root processes */
         span = opal_datatype_span(&sdtype->super, (int64_t)scount * (int64_t)size, &gap);
         tmpbuf_free = (char *) malloc(span);
         if (NULL == tmpbuf_free) { line = __LINE__; err = OMPI_ERR_OUT_OF_RESOURCE; goto exit; }

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -97,7 +97,7 @@ mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
      * and which one enters coll_reduce with providing
      * MPI_PROC_NULL as root argument etc.) Here,
      * we execute the data exchange for both groups
-     * simultaniously. */
+     * simultaneously. */
     /*****************************************************************/
     if (rank == root) {
         err = ompi_datatype_type_extent(dtype, &extent);

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
@@ -57,7 +57,7 @@
  *
  * NOTE: that the recursive halving algorithm should be faster than
  * the reduce/scatter for all message sizes.  However, the memory
- * usage for the recusive halving is msg_size + 2 * comm_size greater
+ * usage for the recursive halving is msg_size + 2 * comm_size greater
  * for the recursive halving, so I've limited where the recursive
  * halving is used to be nice to the app memory wise.  There are much
  * better algorithms for large messages with commutative operations,

--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -50,7 +50,7 @@
  * is associated with.
  *
  * The module destructors are called for each module used by the
- * communicator, at communicator desctruction time.
+ * communicator, at communicator destruction time.
  *
  * This can result in up to N different components being used for a
  * single communicator, one per needed collective function.
@@ -96,7 +96,7 @@ struct ompi_group_t;
  * once during MPI_INIT.
  *
  * @note The component framework is not lazily opened, so attempts
- * should be made to minimze the amount of memory allocated during
+ * should be made to minimize the amount of memory allocated during
  * this function.
  *
  * @param[in] enable_progress_threads True if the component needs to
@@ -492,14 +492,14 @@ struct mca_coll_base_component_2_4_0_t {
 
     /** Component initialization function */
     mca_coll_base_component_init_query_fn_t collm_init_query;
-    /** Query whether component is useable for given communicator */
+    /** Query whether component is usable for given communicator */
     mca_coll_base_component_comm_query_2_4_0_fn_t collm_comm_query;
 };
 typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_2_4_0_t;
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
-    interace. */
+    interface. */
 typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
 
 
@@ -621,9 +621,9 @@ struct mca_coll_base_module_2_4_0_t {
 };
 typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_2_4_0_t;
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
-    interace. */
+    interface. */
 typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_module_t);
 

--- a/ompi/mca/coll/ftagree/coll_ftagree_component.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_component.c
@@ -105,7 +105,7 @@ ftagree_register(void)
     if( ompi_ftmpi_enabled ) value = 1;
     else value = 0; /* NOFT: do not initialize ERA */
     (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
-                                           "agreement", "Agreement algorithm 0: Allreduce (NOT FAULT TOLERANT); 1: Early Returning Concensus (era); 2: Early Terminating Concensus (eta)",
+                                           "agreement", "Agreement algorithm 0: Allreduce (NOT FAULT TOLERANT); 1: Early Returning Consensus (era); 2: Early Terminating Consensus (eta)",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_6,
                                            MCA_BASE_VAR_SCOPE_READONLY,

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -1044,7 +1044,7 @@ static int era_tree_check_node(era_tree_t *tree, int tree_size, int r, int displ
     if( tree[r].rank_in_comm <
         tree[ tree[r].parent ].rank_in_comm ) {
         tree_errors++;
-        fprintf(stderr, "TC %s -- %d/%d(%d): broken hiearchy as my parent is %d in the communicator\n",
+        fprintf(stderr, "TC %s -- %d/%d(%d): broken hierarchy as my parent is %d in the communicator\n",
                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm, tree[tree[r].parent].rank_in_comm);
     }
 
@@ -1300,7 +1300,7 @@ static void era_call_tree_fn(era_agreement_info_t *ci)
     }
 #else
     /* Hierarchical tree disabled for now. ESS does not give daemon names
-     * anymore. TODO: ENABLE_FT_MPI: restore hierarchical tree capabilitiy. */
+     * anymore. TODO: ENABLE_FT_MPI: restore hierarchical tree capability. */
     era_tree_fn(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size);
 #endif
 }
@@ -1636,7 +1636,7 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
                                          ci->agreement_id.ERAID_KEY, &value) == OMPI_SUCCESS ) {
         /**
          * If the value was already decided, then this DOWN message
-         * *must* provide the same decision: it can only be a dupplicate.
+         * *must* provide the same decision: it can only be a duplicate.
          */
         era_value_t *old_agreement_value;
         old_agreement_value = (era_value_t*)value;
@@ -1749,7 +1749,7 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
     r = -1;
     while( (r = era_next_child(ci, r)) < ompi_comm_size(comm) ) {
 
-        /** Cleanup the early_requesters list, to avoid sending unecessary dupplicate messages */
+        /** Cleanup the early_requesters list, to avoid sending unnecessary duplicate messages */
         if( opal_list_get_size(&ci->early_requesters) > 0 ) {
             for(rl = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
                 rl != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -70,7 +70,7 @@ mca_coll_han_set_allreduce_args(mca_coll_han_allreduce_args_t * args,
 }
 
 /*
- * Each segment of the messsage needs to go though 4 steps to perform MPI_Allreduce:
+ * Each segment of the message needs to go though 4 steps to perform MPI_Allreduce:
  *     lr: lower level (shared-memory or intra-node) reduce,
  *     ur: upper level (inter-node) reduce,
  *     ub: upper level (inter-node) bcast,

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -51,7 +51,7 @@ mca_coll_han_set_bcast_args(mca_coll_han_bcast_args_t * args, mca_coll_task_t * 
 }
 
 /*
- * Each segment of the messsage needs to go though 2 steps to perform MPI_Bcast:
+ * Each segment of the message needs to go though 2 steps to perform MPI_Bcast:
  *     ub: upper level (inter-node) bcast
  *     lb: low level (shared-memory or intra-node) bcast.
  * Hence, in each iteration, there is a combination of collective operations which is called a task.

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -84,7 +84,7 @@ mca_coll_han_component_t mca_coll_han_component = {
         .collm_comm_query = mca_coll_han_comm_query,
     },
 
-    /* han-component specifc information */
+    /* han-component specific information */
 
     /* (default) priority */
     20,
@@ -336,7 +336,7 @@ static int han_register(void)
     /*
      * Simple algorithms MCA parameters :
      * using simple algorithms will just perform hierarchical communications.
-     * By default communications are also splitted into tasks
+     * By default communications are also split into tasks
      * to handle thread noise
      */
     for(coll = 0 ; coll < COLLCOUNT ; coll++) {

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -26,7 +26,7 @@
 
 /*
  * Tests if a dynamic collective is implemented
- * Usefull for file reading warnings and MCA parameter generation
+ * Useful for file reading warnings and MCA parameter generation
  * When a new dynamic collective is implemented, this function must
  * return true for it
  */

--- a/ompi/mca/coll/han/coll_han_dynamic.h
+++ b/ompi/mca/coll/han/coll_han_dynamic.h
@@ -53,13 +53,13 @@
  *     - File defined rules
  *
  * MCA parameter defined rules are stored in mca_coll_han_component.mca_rules.
- * This is a double indexed table. The first index is the coresponding collective
+ * This is a double indexed table. The first index is the corresponding collective
  * communication and the second index is the topological level aimed by the rule.
  * These parameters define the collective component to use for a specific
  * collective communication on a specific topologic level.
  *
  * File defined rules are stored in mca_coll_han_component.dynamic_rules.
- * These structures are defined bellow. The rule storage is directy deduced
+ * These structures are defined below. The rule storage is directly deduced
  * from the rule file format.
  *
  * File defined rules precede MCA parameter defined rules.

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -57,25 +57,25 @@ mca_coll_han_init_dynamic_rules(void)
     /* Loop counters */
     int i, j, k, l;
 
-    /* Collective informations */
+    /* Collective information */
     long nb_coll, coll_id;
     char * coll_name = NULL;
     collective_rule_t *coll_rules;
 
-    /* Topo informations */
+    /* Topo information */
     long nb_topo, topo_lvl;
     topologic_rule_t *topo_rules;
 
-    /* Configuration informations */
+    /* Configuration information */
     long nb_rules, conf_size;
     configuration_rule_t *conf_rules;
 
-    /* Message size informations */
+    /* Message size information */
     long nb_msg_size;
     size_t msg_size;
     msg_size_rule_t *msg_size_rules;
 
-    /* Component informations */
+    /* Component information */
     long component;
 
     /* If the dynamic rules are not used, do not even read the file */
@@ -175,7 +175,7 @@ mca_coll_han_init_dynamic_rules(void)
             goto file_reading_error;
         }
 
-        /* Store the collective rule informations */
+        /* Store the collective rule information */
         coll_rules[i].nb_topologic_levels = nb_topo;
         coll_rules[i].collective_id = (COLLTYPE_T)coll_id;
 
@@ -224,7 +224,7 @@ mca_coll_han_init_dynamic_rules(void)
                 goto file_reading_error;
             }
 
-            /* Store the topologic rule informations */
+            /* Store the topologic rule information */
             topo_rules[j].collective_id = coll_id;
             topo_rules[j].topologic_level = (TOPO_LVL_T)topo_lvl;
             topo_rules[j].nb_rules = nb_rules;
@@ -485,25 +485,25 @@ static void check_dynamic_rules(void)
     /* Loop counters */
     int i, j, k, l;
 
-    /* Collective informations */
+    /* Collective information */
     int nb_coll;
     COLLTYPE_T coll_id;
     collective_rule_t *coll_rules;
 
-    /* Topo informations */
+    /* Topo information */
     TOPO_LVL_T topo_lvl;
     topologic_rule_t *topo_rules;
 
-    /* Configuration informations */
+    /* Configuration information */
     int nb_rules, conf_size;
     configuration_rule_t *conf_rules;
 
-    /* Message size informations */
+    /* Message size information */
     int nb_msg_size;
     size_t msg_size;
     msg_size_rule_t *msg_size_rules;
 
-    /* Component informations */
+    /* Component information */
     COMPONENT_T component;
 
     nb_coll = mca_coll_han_component.dynamic_rules.nb_collectives;
@@ -564,24 +564,24 @@ void mca_coll_han_dump_dynamic_rules(void)
 {
     int nb_entries = 0;
 
-    /* Collective informations */
+    /* Collective information */
     int nb_coll;
     COLLTYPE_T coll_id;
     collective_rule_t *coll_rules;
 
-    /* Topo informations */
+    /* Topo information */
     TOPO_LVL_T topo_lvl;
     topologic_rule_t *topo_rules;
 
-    /* Configuration informations */
+    /* Configuration information */
     int nb_rules, conf_size;
     configuration_rule_t *conf_rules;
 
-    /* Message size informations */
+    /* Message size information */
     int nb_msg_size, msg_size;
     msg_size_rule_t *msg_size_rules;
 
-    /* Component informations */
+    /* Component information */
     COMPONENT_T component;
 
     nb_coll = mca_coll_han_component.dynamic_rules.nb_collectives;
@@ -609,7 +609,7 @@ void mca_coll_han_dump_dynamic_rules(void)
                     opal_output(mca_coll_han_component.han_output,
                                 "coll:han:dump_dynamic_rules %d collective %d (%s) "
                                 "topology level %d (%s) configuration size %d "
-                                "mesage size %d -> collective component %d (%s)\n",
+                                "message size %d -> collective component %d (%s)\n",
                                 nb_entries, coll_id, mca_coll_base_colltype_to_str(coll_id),
                                 topo_lvl, mca_coll_han_topo_lvl_to_str(topo_lvl), conf_size,
                                 msg_size, component, available_components[component].component_name);

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -22,7 +22,7 @@
 
 /*
  *@file
- * Coll han module managment file. Used for each new communicator.
+ * Coll han module management file. Used for each new communicator.
  */
 
 /*

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -51,7 +51,7 @@ mca_coll_han_set_reduce_args(mca_coll_han_reduce_args_t * args, mca_coll_task_t 
 }
 
 /*
- * Each segment of the messsage needs to go though 2 steps to perform MPI_Reduce:
+ * Each segment of the message needs to go though 2 steps to perform MPI_Reduce:
  *     lb: low level (shared-memory or intra-node) reduce.
  *     ub: upper level (inter-node) reduce
  * Hence, in each iteration, there is a combination of collective operations which is called a task.
@@ -364,7 +364,7 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
             free(tmp_buf);
         } else {
             /* Take advantage of any optimisation made for IN_PLACE
-             * communcations */
+             * communications */
             ret = up_comm->c_coll->coll_reduce(MPI_IN_PLACE, (char *)tmp_buf,
                         count, dtype, op, root_up_rank,
                         up_comm, up_comm->c_coll->coll_reduce_module);

--- a/ompi/mca/coll/han/coll_han_trigger.h
+++ b/ompi/mca/coll/han/coll_han_trigger.h
@@ -14,7 +14,7 @@
  * @file
  *
  * This file defines the API for tasks: a collective operation may be
- * splitted in tasks to balance compute load on all the resources.
+ * split in tasks to balance compute load on all the resources.
  * This solution provide some noise resiliency.
  */
 

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -31,7 +31,7 @@ int mca_coll_hcoll_init_query(bool enable_progress_threads, bool enable_mpi_thre
 {
 #if HCOLL_API < HCOLL_VERSION(3,2)
     if (enable_mpi_threads) {
-        HCOL_VERBOSE(1, "MPI_THREAD_MULTIPLE not suppported; skipping hcoll component");
+        HCOL_VERBOSE(1, "MPI_THREAD_MULTIPLE not supported; skipping hcoll component");
         return OMPI_ERROR;
     }
 #endif
@@ -289,7 +289,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
 
     if (!cm->libhcoll_initialized)
     {
-        /* libhcoll should be initialized here since current implmentation of
+        /* libhcoll should be initialized here since current implementation of
            mxm bcol in libhcoll needs world_group fully functional during init
            world_group, i.e. ompi_comm_world, is not ready at hcoll component open
            call */

--- a/ompi/mca/coll/inter/coll_inter_bcast.c
+++ b/ompi/mca/coll/inter/coll_inter_bcast.c
@@ -51,7 +51,7 @@ mca_coll_inter_bcast_inter(void *buff, int count,
         /* do nothing */
         err = OMPI_SUCCESS;
     } else if (MPI_ROOT != root) {
-        /* Non-root, first process recieves the data and bcast to others */
+        /* Non-root, first process receives the data and bcast to others */
 	if ( 0 == rank ) {
 	    err = MCA_PML_CALL(recv(buff, count, datatype, root,
 				    MCA_COLL_BASE_TAG_BCAST, comm,

--- a/ompi/mca/coll/inter/coll_inter_scatterv.c
+++ b/ompi/mca/coll/inter/coll_inter_scatterv.c
@@ -63,7 +63,7 @@ mca_coll_inter_scatterv_inter(const void *sbuf, const int *scounts,
         err = OMPI_SUCCESS;
     } else if (MPI_ROOT != root) {
 	if(0 == rank) {
-	    /* local root recieves the counts from the root */
+	    /* local root receives the counts from the root */
 	    counts = (int *)malloc(sizeof(int) * size_local);
 	    err = MCA_PML_CALL(recv(counts, size_local, MPI_INT,
 				    root, MCA_COLL_BASE_TAG_SCATTERV,

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -50,7 +50,7 @@ BEGIN_C_DECLS
 #undef NBC_CACHE_SCHEDULE
 #endif
 #define NBC_SCHED_DICT_UPPER 1024 /* max. number of dict entries */
-#define NBC_SCHED_DICT_LOWER 512  /* nuber of dict entries after wipe, if SCHED_DICT_UPPER is reached */
+#define NBC_SCHED_DICT_LOWER 512  /* number of dict entries after wipe, if SCHED_DICT_UPPER is reached */
 
 /********************* end of LibNBC tuning parameters ************************/
 

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -200,7 +200,7 @@ libnbc_register(void)
      * As a result we are adding an MCA parameter to make a conservative
      * decision to avoid this issue. If the user knows that their application
      * does not use data types in this way, then they can set this parameter
-     * to get the old behavior. Once the issue is truely fixed, then this
+     * to get the old behavior. Once the issue is truly fixed, then this
      * parameter can be removed.
      */
     libnbc_ibcast_skip_dt_decision = true;

--- a/ompi/mca/coll/libnbc/nbc_iallgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgatherv.c
@@ -23,7 +23,7 @@
 #include "nbc_internal.h"
 
 /* an allgatherv schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear MPI_Iallgatherv

--- a/ompi/mca/coll/libnbc/nbc_iallreduce.c
+++ b/ompi/mca/coll/libnbc/nbc_iallreduce.c
@@ -1079,7 +1079,7 @@ static inline int allred_sched_redscat_allgather(
         sindex[0] = rindex[0] = 0;
          for (int mask = 1; mask < nprocs_pof2; mask <<= 1) {
             /*
-             * On each iteration: rindex[step] = sindex[step] -- begining of the
+             * On each iteration: rindex[step] = sindex[step] -- beginning of the
              * current window. Length of the current window is storded in wsize.
              */
             int vdest = vrank ^ mask;

--- a/ompi/mca/coll/libnbc/nbc_ialltoallv.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallv.c
@@ -38,7 +38,7 @@ static inline int a2av_sched_inplace(int rank, int p, NBC_Schedule *schedule,
                                     MPI_Aint ext, MPI_Datatype type, ptrdiff_t gap);
 
 /* an alltoallv schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear Alltoallv */
@@ -77,8 +77,8 @@ static int nbc_alltoallv_init(const void* sendbuf, const int *sendcounts, const 
     span = opal_datatype_span(&recvtype->super, count, &gap);
     /**
      * If this process has no data to send or receive it can bail out early,
-     * but it needs to increase the nonblocking tag to stay in sycn with the
-     * rest of the processses.
+     * but it needs to increase the nonblocking tag to stay in sync with the
+     * rest of the processes.
      */
     if (OPAL_UNLIKELY(0 == span)) {
       ompi_coll_base_nbc_reserve_tags(comm, 1);

--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -37,7 +37,7 @@ static inline int a2aw_sched_inplace(int rank, int p, NBC_Schedule *schedule,
                                     struct ompi_datatype_t * const * types);
 
 /* an alltoallw schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear Alltoallw */
@@ -69,8 +69,8 @@ static int nbc_alltoallw_init(const void* sendbuf, const int *sendcounts, const 
     }
     /**
      * If this process has no data to send or receive it can bail out early,
-     * but it needs to increase the nonblocking tag to stay in sycn with the
-     * rest of the processses.
+     * but it needs to increase the nonblocking tag to stay in sync with the
+     * rest of the processes.
      */
     if (OPAL_UNLIKELY(0 == span)) {
       ompi_coll_base_nbc_reserve_tags(comm, 1);

--- a/ompi/mca/coll/libnbc/nbc_igatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_igatherv.c
@@ -25,7 +25,7 @@
 #include "nbc_internal.h"
 
 /* an gatherv schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 

--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -781,7 +781,7 @@ static inline int red_sched_redscat_gather(
 
         for (int mask = 1; mask < nprocs_pof2; mask <<= 1) {
             /*
-             * On each iteration: rindex[step] = sindex[step] -- begining of the
+             * On each iteration: rindex[step] = sindex[step] -- beginning of the
              * current window. Length of the current window is storded in wsize.
              */
             int vdest = vrank ^ mask;

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
@@ -26,7 +26,7 @@
 #include "nbc_internal.h"
 
 /* an reduce_csttare schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* binomial reduce to rank 0 followed by a linear scatter ...

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
@@ -24,7 +24,7 @@
 #include "nbc_internal.h"
 
 /* an reduce_csttare schedule can not be cached easily because the contents
- * ot the recvcount value may change, so a comparison of the address
+ * of the recvcount value may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* binomial reduce to rank 0 followed by a linear scatter ...

--- a/ompi/mca/coll/libnbc/nbc_iscatterv.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatterv.c
@@ -24,7 +24,7 @@
 #include "nbc_internal.h"
 
 /* a scatterv schedule can not be cached easily because the contents
- * ot the recvcounts array may change, so a comparison of the address
+ * of the recvcounts array may change, so a comparison of the address
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear MPI_Iscatterv */

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_allgather(const void *sbuf, int scount,
         if( i == my_rank ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -63,7 +63,7 @@ int mca_coll_monitoring_iallgather(const void *sbuf, int scount,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -63,7 +63,7 @@ int mca_coll_monitoring_iallgatherv(const void *sbuf, int scount,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -62,7 +62,7 @@ int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, int count,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
@@ -32,7 +32,7 @@ int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datat
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -61,7 +61,7 @@ int mca_coll_monitoring_ialltoall(const void *sbuf, int scount,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
@@ -33,7 +33,7 @@ int mca_coll_monitoring_alltoallv(const void *sbuf, const int *scounts, const in
         data_size = scounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -65,7 +65,7 @@ int mca_coll_monitoring_ialltoallv(const void *sbuf, const int *scounts,
         data_size = scounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
@@ -35,7 +35,7 @@ int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
         data_size = scounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -67,7 +67,7 @@ int mca_coll_monitoring_ialltoallw(const void *sbuf, const int *scounts,
         data_size = scounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_barrier.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_barrier.c
@@ -25,7 +25,7 @@ int mca_coll_monitoring_barrier(struct ompi_communicator_t *comm,
 	if( my_rank == i ) continue; /* No communication for self */
 	/**
 	 * If this fails the destination is not part of my MPI_COM_WORLD
-	 * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+	 * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
 	 */
 	if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
 	    mca_common_monitoring_record_coll(rank, 0);
@@ -47,7 +47,7 @@ int mca_coll_monitoring_ibarrier(struct ompi_communicator_t *comm,
 	if( my_rank == i ) continue; /* No communication for self */
 	/**
 	 * If this fails the destination is not part of my MPI_COM_WORLD
-	 * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+	 * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
 	 */
 	if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
 	    mca_common_monitoring_record_coll(rank, 0);

--- a/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
@@ -33,7 +33,7 @@ int mca_coll_monitoring_bcast(void *buff, int count,
             if( i == root ) continue; /* No self sending */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -62,7 +62,7 @@ int mca_coll_monitoring_ibcast(void *buff, int count,
             if( i == root ) continue; /* No self sending */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
@@ -33,7 +33,7 @@ int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
     for( i = my_rank + 1; i < comm_size; ++i ) {
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -60,7 +60,7 @@ int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, int count,
     for( i = my_rank + 1; i < comm_size; ++i ) {
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_gather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gather.c
@@ -32,7 +32,7 @@ int mca_coll_monitoring_gather(const void *sbuf, int scount,
             if( root == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -61,7 +61,7 @@ int mca_coll_monitoring_igather(const void *sbuf, int scount,
             if( root == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_gatherv(const void *sbuf, int scount,
             data_size = rcounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -66,7 +66,7 @@ int mca_coll_monitoring_igatherv(const void *sbuf, int scount,
             data_size = rcounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
@@ -43,7 +43,7 @@ int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -54,7 +54,7 @@ int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -96,7 +96,7 @@ int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -107,7 +107,7 @@ int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
@@ -44,7 +44,7 @@ int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -55,7 +55,7 @@ int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -98,7 +98,7 @@ int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -109,7 +109,7 @@ int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
@@ -44,7 +44,7 @@ int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -55,7 +55,7 @@ int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -98,7 +98,7 @@ int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
         if (MPI_PROC_NULL != srank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -109,7 +109,7 @@ int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
         if (MPI_PROC_NULL != drank) {
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
@@ -44,7 +44,7 @@ int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -57,7 +57,7 @@ int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -103,7 +103,7 @@ int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const int *scounts
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -116,7 +116,7 @@ int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const int *scounts
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
@@ -45,7 +45,7 @@ int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -59,7 +59,7 @@ int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -104,7 +104,7 @@ int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const int *scounts
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(srank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);
@@ -118,7 +118,7 @@ int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const int *scounts
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(drank, comm->c_remote_group, &world_rank) ) {
                 mca_common_monitoring_record_coll(world_rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
             if( root == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -64,7 +64,7 @@ int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
             if( root == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,
         data_size = rcounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -64,7 +64,7 @@ int mca_coll_monitoring_ireduce_scatter(const void *sbuf, void *rbuf,
         data_size = rcounts[i] * type_size;
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
@@ -34,7 +34,7 @@ int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -63,7 +63,7 @@ int mca_coll_monitoring_ireduce_scatter_block(const void *sbuf, void *rbuf,
         if( my_rank == i ) continue; /* No communication for self */
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_scan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scan.c
@@ -33,7 +33,7 @@ int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
     for( i = my_rank + 1; i < comm_size; ++i ) {
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);
@@ -60,7 +60,7 @@ int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, int count,
     for( i = my_rank + 1; i < comm_size; ++i ) {
         /**
          * If this fails the destination is not part of my MPI_COM_WORLD
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
          */
         if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
             mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
@@ -35,7 +35,7 @@ int mca_coll_monitoring_scatter(const void *sbuf, int scount,
             if( my_rank == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -68,7 +68,7 @@ int mca_coll_monitoring_iscatter(const void *sbuf, int scount,
             if( my_rank == i ) continue; /* No communication for self */
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
@@ -32,7 +32,7 @@ int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, const int
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);
@@ -62,7 +62,7 @@ int mca_coll_monitoring_iscatterv(const void *sbuf, const int *scounts, const in
             data_size = scounts[i] * type_size;
             /**
              * If this fails the destination is not part of my MPI_COM_WORLD
-             * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+             * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
              */
             if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, comm->c_remote_group, &rank) ) {
                 mca_common_monitoring_record_coll(rank, data_size);

--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -219,7 +219,7 @@ allreduce_kary_tree_top(const void *sendbuf, void *recvbuf, int count,
             }
 
             /*
-             ** Prepare ME for receving RTR
+             ** Prepare ME for receiving RTR
              ** Priority List, match also with "Overflow list Me" in coll_portals4_component
              */
 

--- a/ompi/mca/coll/sm/coll_sm.h
+++ b/ompi/mca/coll/sm/coll_sm.h
@@ -408,7 +408,7 @@ extern uint32_t mca_coll_sm_one;
     } while (0)
 
 /**
- * Macro for childen to wait for parent notification (use real rank).
+ * Macro for children to wait for parent notification (use real rank).
  * Save the value passed and then reset it when done.  Used in fan out
  * operations.
  */

--- a/ompi/mca/coll/sm/coll_sm_component.c
+++ b/ompi/mca/coll/sm/coll_sm_component.c
@@ -88,7 +88,7 @@ mca_coll_sm_component_t mca_coll_sm_component = {
         .collm_comm_query = mca_coll_sm_comm_query,
     },
 
-    /* sm-component specifc information */
+    /* sm-component specific information */
 
     /* (default) priority */
     /* JMS temporarily lowered until we can get more testing */

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -365,7 +365,7 @@ int ompi_coll_sm_lazy_enable(mca_coll_base_module_t *module,
     /* Once the communicator is bootstrapped, setup the pointers into
        the per-communicator shmem data segment.  First, setup the
        barrier buffers.  There are 2 sets of barrier buffers (because
-       there can never be more than one outstanding barrier occuring
+       there can never be more than one outstanding barrier occurring
        at any timie).  Setup pointers to my control buffers, my
        parents, and [the beginning of] my children (note that the
        children are contiguous, so having the first pointer and the

--- a/ompi/mca/coll/sm/coll_sm_reduce.c
+++ b/ompi/mca/coll/sm/coll_sm_reduce.c
@@ -151,7 +151,7 @@ int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, int count,
  *
  * 1. loop over all fragments (which must be done in units of an
  * integer number of datatypes -- remember that if this function is
- * called, we know that the datattype is smaller than the max size of
+ * called, we know that the datatype is smaller than the max size of
  * a fragment, so this is definitely possible)
  *
  * 2. loop over all the processes -- 0 to (comm_size-1).
@@ -160,7 +160,7 @@ int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, int count,
  *   fragment by fragment -- might as well copy the entire thing) the
  *   first time through the algorithm, and no-op every other time
  * - else, copy from the shmem fragment to the out buffer
- * For all other proceses:
+ * For all other processes:
  * - if root==i, combine the relevant fragment from the sbuf to the
  *   relevant fragment on the rbuf
  * - else, if the datatype is friendly, combine relevant fragment from
@@ -448,7 +448,7 @@ static int reduce_inorder(const void *sbuf, void* rbuf, int count,
                                            dtype);
                         }
                     } /* whether this process was me or not */
-                } /* loop over all proceses */
+                } /* loop over all processes */
 
                 /* We've iterated through all the processes -- now we
                    move on to the next segment */

--- a/ompi/mca/coll/tuned/coll_tuned_component.c
+++ b/ompi/mca/coll/tuned/coll_tuned_component.c
@@ -71,7 +71,7 @@ int   ompi_coll_tuned_scatter_large_msg = 0;
 int   ompi_coll_tuned_scatter_min_procs = 0;
 int   ompi_coll_tuned_scatter_blocking_send_ratio = 0;
 
-/* forced alogrithm variables */
+/* forced algorithm variables */
 /* indices for the MCA parameters */
 coll_tuned_force_algorithm_mca_param_indices_t ompi_coll_tuned_forced_params[COLLCOUNT] = {{0}};
 /* max algorithm values */
@@ -141,7 +141,7 @@ static int tuned_register(void)
     ompi_coll_tuned_init_tree_fanout = 4;
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "init_tree_fanout",
-                                           "Inital fanout used in the tree topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
+                                           "Initial fanout used in the tree topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_6,
                                            MCA_BASE_VAR_SCOPE_READONLY,
@@ -150,7 +150,7 @@ static int tuned_register(void)
     ompi_coll_tuned_init_chain_fanout = 4;
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "init_chain_fanout",
-                                           "Inital fanout used in the chain (fanout followed by pipeline) topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
+                                           "Initial fanout used in the chain (fanout followed by pipeline) topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_6,
                                            MCA_BASE_VAR_SCOPE_READONLY,
@@ -223,7 +223,7 @@ static int tuned_open(void)
     /* now check that the user hasn't overrode any of the decision functions if dynamic rules are enabled */
     /* the user can redo this before every comm dup/create if they like */
     /* this is useful for benchmarking and user knows best tuning */
-    /* as this is the component we only lookup the indicies of the mca params */
+    /* as this is the component we only lookup the indices of the mca params */
     /* the actual values are looked up during comm create via module init */
 
     /* intra functions first */
@@ -250,13 +250,13 @@ static int tuned_open(void)
 }
 
 /* here we should clean up state stored on the component */
-/* i.e. alg table and dynamic changable rules if allocated etc */
+/* i.e. alg table and dynamic changeable rules if allocated etc */
 static int tuned_close(void)
 {
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:component_close: called"));
 
     /* dealloc alg table if allocated */
-    /* dealloc dynamic changable rules if allocated */
+    /* dealloc dynamic changeable rules if allocated */
 
     OPAL_OUTPUT((ompi_coll_tuned_stream, "coll:tuned:component_close: done!"));
 

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_rules.h
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_rules.h
@@ -28,7 +28,7 @@ BEGIN_C_DECLS
 
 typedef struct msg_rule_s {
     /* paranoid / debug */
-    int mpi_comsize;  /* which MPI comm size this is is for */
+    int mpi_comsize;  /* which MPI comm size is this for */
 
     /* paranoid / debug */
     int alg_rule_id; /* unique alg rule id */
@@ -48,7 +48,7 @@ typedef struct msg_rule_s {
 
 typedef struct com_rule_s {
     /* paranoid / debug */
-    int mpi_comsize;  /* which MPI comm size this is is for */
+    int mpi_comsize;  /* which MPI comm size is this for */
 
     /* paranoid / debug */
     int alg_rule_id; /* unique alg rule id */

--- a/ompi/mca/common/monitoring/HowTo_pml_monitoring.tex
+++ b/ompi/mca/common/monitoring/HowTo_pml_monitoring.tex
@@ -356,7 +356,7 @@ later variables may be read using
 \texttt{MPI\brkunds{}T\brkunds{}pvar\brkunds{}read} but cannot be
 written. Stopping the \textit{flush} performance variable, with a call
 to \texttt{MPI\brkunds{}T\brkunds{}pvar\brkunds{}stop}, force the
-counters to be flushed into the given file, reseting to 0 the counters
+counters to be flushed into the given file, resetting to 0 the counters
 at the same time. Also, binding a new handle to the \textit{flush}
 variable will reset the counters. Finally, please note that the size
 and counter performance variables may overflow for multiple large
@@ -377,7 +377,7 @@ state the end of your use of performance and control variables.
 
 \subsection{Overview of the calls}
 
-To summarize the previous informations, here is the list of available
+To summarize the previous information, here is the list of available
 performance variables, and the outline of the different calls to be
 used to properly access monitored data through the \mpit{} interface.
 \begin{itemize}
@@ -631,7 +631,7 @@ A2A     0       0 bytes 0 msgs sent
 
 As it show on the sample profiling, for each kind of communication
 (point-to-point, one-sided and collective), you find all the related
-informations. There is one line per peers communicating. Each line
+information. There is one line per peers communicating. Each line
 start with a lettre describing the kind of communication, such as
 follows:
 

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -55,7 +55,7 @@ static opal_output_stream_t mca_common_monitoring_output_stream_obj = {
 };
 
 /*** MCA params to mark the monitoring as enabled. ***/
-/* This signals that the monitoring will highjack the PML, OSC and COLL */
+/* This signals that the monitoring will hijack the PML, OSC and COLL */
 int mca_common_monitoring_enabled = 0;
 int mca_common_monitoring_current_state = 0;
 /* Signals there will be an output of the monitored data at component close */
@@ -64,7 +64,7 @@ static int mca_common_monitoring_output_enabled = 0;
 static char* mca_common_monitoring_initial_filename = "";
 static char* mca_common_monitoring_current_filename = NULL;
 
-/* array for stroring monitoring data*/
+/* array for storing monitoring data*/
 static opal_atomic_size_t* pml_data = NULL;
 static opal_atomic_size_t* pml_count = NULL;
 static opal_atomic_size_t* filtered_pml_data = NULL;
@@ -91,35 +91,35 @@ static void mca_common_monitoring_reset ( void );
 /* Flushes the monitored data and reset the values */
 static int mca_common_monitoring_flush (int fd, char* filename);
 
-/* Retreive the PML recorded count of messages sent */
+/* Retrieve the PML recorded count of messages sent */
 static int mca_common_monitoring_get_pml_count (const struct mca_base_pvar_t *pvar,
                                                 void *value, void *obj_handle);
 
-/* Retreive the PML recorded amount of data sent */
+/* Retrieve the PML recorded amount of data sent */
 static int mca_common_monitoring_get_pml_size (const struct mca_base_pvar_t *pvar,
                                                void *value, void *obj_handle);
 
-/* Retreive the OSC recorded count of messages sent */
+/* Retrieve the OSC recorded count of messages sent */
 static int mca_common_monitoring_get_osc_sent_count (const struct mca_base_pvar_t *pvar,
                                                      void *value, void *obj_handle);
 
-/* Retreive the OSC recorded amount of data sent */
+/* Retrieve the OSC recorded amount of data sent */
 static int mca_common_monitoring_get_osc_sent_size (const struct mca_base_pvar_t *pvar,
                                                     void *value, void *obj_handle);
 
-/* Retreive the OSC recorded count of messages received */
+/* Retrieve the OSC recorded count of messages received */
 static int mca_common_monitoring_get_osc_recv_count (const struct mca_base_pvar_t *pvar,
                                                      void *value, void *obj_handle);
 
-/* Retreive the OSC recorded amount of data received */
+/* Retrieve the OSC recorded amount of data received */
 static int mca_common_monitoring_get_osc_recv_size (const struct mca_base_pvar_t *pvar,
                                                     void *value, void *obj_handle);
 
-/* Retreive the COLL recorded count of messages sent */
+/* Retrieve the COLL recorded count of messages sent */
 static int mca_common_monitoring_get_coll_count (const struct mca_base_pvar_t *pvar,
                                                  void *value, void *obj_handle);
 
-/* Retreive the COLL recorded amount of data sent */
+/* Retrieve the COLL recorded amount of data sent */
 static int mca_common_monitoring_get_coll_size (const struct mca_base_pvar_t *pvar,
                                                 void *value, void *obj_handle);
 
@@ -236,7 +236,7 @@ void mca_common_monitoring_finalize( void )
         0 < opal_atomic_sub_fetch_32(&mca_common_monitoring_hold, 1) ) return;
 
     OPAL_MONITORING_PRINT_INFO("common_component_finish");
-    /* Dump monitoring informations */
+    /* Dump monitoring information */
     mca_common_monitoring_flush(mca_common_monitoring_output_enabled,
                                 mca_common_monitoring_current_filename);
     /* Disable all monitoring */

--- a/ompi/mca/common/monitoring/common_monitoring.h
+++ b/ompi/mca/common/monitoring/common_monitoring.h
@@ -86,7 +86,7 @@ static inline int mca_common_monitoring_get_world_rank(int dest, ompi_group_t *g
     uint64_t rank, key = *((uint64_t*)&tmp);
     /**
      * If this fails the destination is not part of my MPI_COM_WORLD
-     * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+     * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
      */
     int ret = opal_hash_table_get_value_uint64(common_monitoring_translation_ht,
                                                key, (void *)&rank);
@@ -97,7 +97,7 @@ static inline int mca_common_monitoring_get_world_rank(int dest, ompi_group_t *g
 }
 
 /* Return the current status of the monitoring system 0 if off or the
- * seperation between internal tags and external tags is disabled. Any
+ * separation between internal tags and external tags is disabled. Any
  * other positive value if the segregation between point-to-point and
  * collective is enabled.
  */

--- a/ompi/mca/common/monitoring/common_monitoring_coll.c
+++ b/ompi/mca/common/monitoring/common_monitoring_coll.c
@@ -123,7 +123,7 @@ void mca_common_monitoring_coll_release(mca_monitoring_coll_data_t*data)
 {
 #if OPAL_ENABLE_DEBUG
     if( NULL == data ) {
-        OPAL_MONITORING_PRINT_ERR("coll: release: data structure empty or already desallocated");
+        OPAL_MONITORING_PRINT_ERR("coll: release: data structure empty or already deallocated");
         return;
     }
 #endif /* OPAL_ENABLE_DEBUG */
@@ -137,7 +137,7 @@ static void mca_common_monitoring_coll_cond_release(mca_monitoring_coll_data_t*d
 {
 #if OPAL_ENABLE_DEBUG
     if( NULL == data ) {
-        OPAL_MONITORING_PRINT_ERR("coll: release: data structure empty or already desallocated");
+        OPAL_MONITORING_PRINT_ERR("coll: release: data structure empty or already deallocated");
         return;
     }
 #endif /* OPAL_ENABLE_DEBUG */

--- a/ompi/mca/common/monitoring/monitoring_prof.c
+++ b/ompi/mca/common/monitoring/monitoring_prof.c
@@ -112,7 +112,7 @@ int MPI_Init(int* argc, char*** argv)
 
     MPIT_result = MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
     if (MPIT_result != MPI_SUCCESS) {
-        fprintf(stderr, "ERROR : failed to intialize MPI_T interface, preventing to get monitoring results: check your OpenMPI installation\n");
+        fprintf(stderr, "ERROR : failed to initialize MPI_T interface, preventing to get monitoring results: check your OpenMPI installation\n");
         PMPI_Abort(MPI_COMM_WORLD, MPIT_result);
     }
 

--- a/ompi/mca/common/monitoring/profile2mat.pl
+++ b/ompi/mca/common/monitoring/profile2mat.pl
@@ -15,15 +15,15 @@
 #
 # Author Emmanuel Jeannot <emmanuel.jeannot@inria.fr>
 #
-# Take a profile file and aggregates all the recorded communicaton into matrices.
-# It generated a matrices for teh number of messages, (msg),
+# Take a profile file and aggregates all the recorded communication into matrices.
+# It generated a matrices for the number of messages, (msg),
 # for the total bytes transmitted (size) and
 # the average nulber of bytes per messages (avg)
 #
-# The output matix is symetric
+# The output matrix is symmetric
 #
 # If possible it creates file with "internal" tags (collexctive and eta data),
-# "external" tags (point to point messages)  and "all" (every messgaes).
+# "external" tags (point to point messages)  and "all" (every messages).
 #
 # ensure that this script as the executable right: chmod +x ...
 #

--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -42,7 +42,7 @@
 #include "common_ompio.h"
 
 /*
-** This file contains all the functionality related to determing the number of aggregators
+** This file contains all the functionality related to determining the number of aggregators
 ** and the list of aggregators.
 **
 ** The first group functions determines the number of aggregators based on various characteristics
@@ -1418,7 +1418,7 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
     }
 
     //print decision list of aggregators
-    /*printf("RANK%d  : Printing decsion list   : \n",fh->f_rank);
+    /*printf("RANK%d  : Printing decision list   : \n",fh->f_rank);
     for( i = 0; i < fh->f_init_num_aggrs; i++){
         if(decision_list_tmp[i] == OMPIO_MERGE)
             printf("MERGE,");

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -73,7 +73,7 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
     size_t spc=0;
     ssize_t ret_code=0;
     int i = 0; /* index into the decoded iovec of the buffer */
-    int j = 0; /* index into the file vie iovec */
+    int j = 0; /* index into the file via iovec */
 
     if (fh->f_amode & MPI_MODE_WRONLY){
 //      opal_output(10, "Improper use of FILE Mode, Using WRONLY for Read!\n");
@@ -265,7 +265,7 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
         
         size_t max_data = 0;
         int i = 0; /* index into the decoded iovec of the buffer */
-        int j = 0; /* index into the file vie iovec */
+        int j = 0; /* index into the file via iovec */
         
         bool need_to_copy = false;    
     

--- a/ompi/mca/common/ompio/common_ompio_file_read_all.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read_all.c
@@ -110,7 +110,7 @@ mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
 #endif
 
     /**************************************************************************
-     ** 1. In case the data is not contigous in memory, decode it into an iovec
+     ** 1. In case the data is not contiguous in memory, decode it into an iovec
      **************************************************************************/
     ret = mca_common_ompio_decode_datatype ((struct ompio_file_t *)fh,
                                             datatype,
@@ -580,7 +580,7 @@ mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
 
         /*************************************************************************
 	 *** 7d. Calculate the displacement on where to put the data and allocate
-         ***     the recieve buffer (global_buf)
+         ***     the receive buffer (global_buf)
 	 *************************************************************************/
         if (my_aggregator == fh->f_rank) {
             entries_per_aggregator=0;

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -240,7 +240,7 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
         size_t max_data = 0;
         size_t total_bytes_written =0;
         int i = 0; /* index into the decoded iovec of the buffer */
-        int j = 0; /* index into the file vie iovec */
+        int j = 0; /* index into the file via iovec */
 
         bool need_to_copy = false;
 

--- a/ompi/mca/common/ompio/common_ompio_request.c
+++ b/ompi/mca/common/ompio/common_ompio_request.c
@@ -103,7 +103,7 @@ void mca_common_ompio_request_init ( void )
 void mca_common_ompio_request_fini ( void ) 
 {
     /* Destroy the list of pending requests */
-    /* JMS: Good opprotunity here to list out all the IO requests that
+    /* JMS: Good opportunity here to list out all the IO requests that
        were not destroyed / completed upon MPI_FINALIZE */
 
     OBJ_DESTRUCT(&mca_common_ompio_pending_requests);

--- a/ompi/mca/fbtl/base/fbtl_base_file_select.c
+++ b/ompi/mca/fbtl/base/fbtl_base_file_select.c
@@ -49,7 +49,7 @@ static OBJ_CLASS_INSTANCE(queried_module_t, opal_list_item_t, NULL, NULL);
 /*
  * Only one fbtl module can be attached to each file.
  *
- * This module calls the query funtion on all the components that were
+ * This module calls the query function on all the components that were
  * detected by fbtl_base_open. This function is called on a
  * per-file basis. This function has the following function.
  *
@@ -218,14 +218,14 @@ int mca_fbtl_base_file_select (struct ompio_file_t *file,
             * module of this component.
             *
             * ANJU: a component might not have all the functions
-            * defined.  Whereever a function pointer is null in the
+            * defined.  Wherever a function pointer is null in the
             * module structure we need to fill it in with the base
             * structure function pointers. This is yet to be done
             */
 
             /*
-             * We don return here coz we still need to go through and
-             * elease the other objects
+             * We don't return here coz we still need to go through and
+             * release the other objects
              */
 
             /*fill_null_pointers (om->om_module);*/
@@ -234,7 +234,7 @@ int mca_fbtl_base_file_select (struct ompio_file_t *file,
             file->f_fbtl_component = (mca_base_component_t *)best_component;
          } else {
             /*
-             * this is not the "choosen one", finalize
+             * this is not the "chosen one", finalize
              */
              if (NULL != om->om_component->fbtlm_file_unquery) {
                 /* unquery the component only if they have some clean

--- a/ompi/mca/fbtl/ime/fbtl_ime.c
+++ b/ompi/mca/fbtl/ime/fbtl_ime.c
@@ -20,7 +20,7 @@
  * *******************************************************************
  */
 static mca_fbtl_base_module_1_0_0_t ime =  {
-    mca_fbtl_ime_module_init,     /* initalise after being selected */
+    mca_fbtl_ime_module_init,     /* initialise after being selected */
     mca_fbtl_ime_module_finalize, /* close a module on a communicator */
     mca_fbtl_ime_preadv,          /* blocking read */
     mca_fbtl_ime_ipreadv,         /* non-blocking read*/
@@ -99,7 +99,7 @@ bool mca_fbtl_ime_progress ( mca_ompio_request_t *req)
             data->aio_req_status[i] = FBTL_IME_REQ_CLOSED;
         }
         else if ( data->aio_req_status[i] == FBTL_IME_REQ_ERROR ) {
-            /* an error occured. */
+            /* an error occurred. */
             data->aio_open_reqs--;
             lcount++;
             data->aio_req_fail_count++;

--- a/ompi/mca/fbtl/posix/fbtl_posix.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix.c
@@ -46,7 +46,7 @@ int fbtl_posix_max_aio_active_reqs=2048;
  * *******************************************************************
  */
 static mca_fbtl_base_module_1_0_0_t posix =  {
-    mca_fbtl_posix_module_init,     /* initalise after being selected */
+    mca_fbtl_posix_module_init,     /* initialise after being selected */
     mca_fbtl_posix_module_finalize, /* close a module on a communicator */
     mca_fbtl_posix_preadv,          /* blocking read */
 #if defined (FBTL_POSIX_HAVE_AIO)
@@ -189,7 +189,7 @@ bool mca_fbtl_posix_progress ( mca_ompio_request_t *req)
 		continue;
 	    }
 	    else {
-		/* an error occured. Mark the request done, but
+		/* an error occurred. Mark the request done, but
 		   set an error code in the status */
 		req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
 		req->req_ompi.req_status._ucount = data->aio_total_len;

--- a/ompi/mca/fbtl/pvfs2/fbtl_pvfs2.c
+++ b/ompi/mca/fbtl/pvfs2/fbtl_pvfs2.c
@@ -37,7 +37,7 @@
  * *******************************************************************
  */
 static mca_fbtl_base_module_1_0_0_t pvfs2 =  {
-    mca_fbtl_pvfs2_module_init,     /* initalise after being selected */
+    mca_fbtl_pvfs2_module_init,     /* initialise after being selected */
     mca_fbtl_pvfs2_module_finalize, /* close a module on a communicator */
     mca_fbtl_pvfs2_preadv,          /* blocking read */
     NULL,                           /* non-blocking read */

--- a/ompi/mca/fcoll/base/fcoll_base_coll_array.c
+++ b/ompi/mca/fcoll/base/fcoll_base_coll_array.c
@@ -151,7 +151,7 @@ int ompi_fcoll_base_coll_gatherv_array (void *sbuf,
         return err;
     }
 
-    /* writer processes, loop receiving data from proceses
+    /* writer processes, loop receiving data from processes
        belonging to each corresponding root */
 
     err = opal_datatype_get_extent (&rdtype->super, &lb, &extent);
@@ -240,7 +240,7 @@ int ompi_fcoll_base_coll_scatterv_array (void *sbuf,
         return err;
     }
 
-    /* writer processes, loop sending data to proceses
+    /* writer processes, loop sending data to processes
        belonging to each corresponding root */
 
     err = opal_datatype_get_extent (&sdtype->super, &lb, &extent);

--- a/ompi/mca/fcoll/base/fcoll_base_file_select.c
+++ b/ompi/mca/fcoll/base/fcoll_base_file_select.c
@@ -49,7 +49,7 @@ static OBJ_CLASS_INSTANCE(queried_module_t, opal_list_item_t, NULL, NULL);
 /*
  * Only one fcoll module can be attached to each file.
  *
- * This module calls the query funtion on all the components that were
+ * This module calls the query function on all the components that were
  * detected by fcoll_base_open. This function is called on a
  * per-file basis. This function has the following function.
  *
@@ -212,14 +212,14 @@ int mca_fcoll_base_file_select (struct ompio_file_t *file,
             * module of this component.
             *
             * ANJU: a component might not have all the functions
-            * defined.  Whereever a function pointer is null in the
+            * defined.  Wherever a function pointer is null in the
             * module structure we need to fill it in with the base
             * structure function pointers. This is yet to be done
             */
 
             /*
-             * We don return here coz we still need to go through and
-             * elease the other objects
+             * We don't return here coz we still need to go through and
+             * release the other objects
              */
 
             /*fill_null_pointers (om->om_module);*/
@@ -231,7 +231,7 @@ int mca_fcoll_base_file_select (struct ompio_file_t *file,
             */
          } else {
             /*
-             * this is not the "choosen one", finalize
+             * this is not the "chosen one", finalize
              */
              if (NULL != om->om_component->fcollm_file_unquery) {
                 /* unquery the component only if they have some clean

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -116,7 +116,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     opal_datatype_get_extent ( &datatype->super, &lb, &ftype_extent );
 
     /**************************************************************************
-     ** 1.  In case the data is not contigous in memory, decode it into an iovec
+     ** 1.  In case the data is not contiguous in memory, decode it into an iovec
      **************************************************************************/
     if ( ( ftype_extent == (ptrdiff_t) ftype_size)             &&
          opal_datatype_is_contiguous_memory_layout(&datatype->super,1) &&
@@ -622,7 +622,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
 
         /*************************************************************************
 	 *** 7d. Calculate the displacement on where to put the data and allocate
-         ***     the recieve buffer (global_buf)
+         ***     the receive buffer (global_buf)
 	 *************************************************************************/
         if (my_aggregator == fh->f_rank) {
             entries_per_aggregator=0;
@@ -802,7 +802,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
         }
         else if (bytes_sent) {
             /* allocate a send buffer and copy the data that needs
-               to be sent into it in case the data is non-contigous
+               to be sent into it in case the data is non-contiguous
                in memory */
             ptrdiff_t mem_address;
             size_t remaining = 0;
@@ -844,7 +844,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
 	}
 	total_bytes_written += bytes_sent;
 
-	/* Gather the sendbuf from each process in appropritate locations in
+	/* Gather the sendbuf from each process in appropriate locations in
            aggregators*/
 
 	if (bytes_sent){
@@ -927,7 +927,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
             fh->f_num_of_io_entries++;
 
             for (i=1;i<entries_per_aggregator;i++){
-                /* If the enrties are contiguous merge them,
+                /* If the entries are contiguous merge them,
                    else make a new entry */
                 if (file_offsets_for_agg[sorted_file_offsets[i-1]].offset +
                     file_offsets_for_agg[sorted_file_offsets[i-1]].length ==

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -154,7 +154,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     
     
     /**************************************************************************
-     ** 1.  In case the data is not contigous in memory, decode it into an iovec
+     ** 1.  In case the data is not contiguous in memory, decode it into an iovec
      **************************************************************************/
     bytes_per_cycle = fh->f_bytes_per_agg;
 
@@ -997,7 +997,7 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
     
     /*************************************************************************
      *** 7d. Calculate the displacement on where to put the data and allocate
-     ***     the recieve buffer (global_buf)
+     ***     the receive buffer (global_buf)
      *************************************************************************/
     if (aggregator == rank) {
         entries_per_aggregator=0;
@@ -1289,7 +1289,7 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
         data->num_io_entries++;
         
         for (i=1;i<entries_per_aggregator;i++){
-            /* If the enrties are contiguous merge them,
+            /* If the entries are contiguous merge them,
                else make a new entry */
             if (file_offsets_for_agg[sorted_file_offsets[i-1]].offset +
                 file_offsets_for_agg[sorted_file_offsets[i-1]].length ==

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -158,7 +158,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     
     
     /**************************************************************************
-     ** 1.  In case the data is not contigous in memory, decode it into an iovec
+     ** 1.  In case the data is not contiguous in memory, decode it into an iovec
      **************************************************************************/
     vulcan_num_io_procs = fh->f_get_mca_parameter_value ( "num_aggregators", strlen ("num_aggregators"));
     if ( OMPI_ERR_MAX == vulcan_num_io_procs ) {
@@ -168,7 +168,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     bytes_per_cycle = fh->f_bytes_per_agg;
 
     if( (1 == mca_fcoll_vulcan_async_io) && (NULL == fh->f_fbtl->fbtl_ipwritev) ) {
-        opal_output (1, "vulcan_write_all: fbtl Does NOT support ipwritev() (asynchrounous write) \n");
+        opal_output (1, "vulcan_write_all: fbtl Does NOT support ipwritev() (asynchronous write) \n");
         ret = MPI_ERR_UNSUPPORTED_OPERATION;
         goto exit;
     }
@@ -1024,7 +1024,7 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
     
     /*************************************************************************
      *** 7d. Calculate the displacement on where to put the data and allocate
-     ***     the recieve buffer (global_buf)
+     ***     the receive buffer (global_buf)
      *************************************************************************/
     if (aggregator == rank) {
         entries_per_aggregator=0;
@@ -1315,7 +1315,7 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
         data->num_io_entries++;
         
         for (i=1;i<entries_per_aggregator;i++){
-            /* If the enrties are contiguous merge them,
+            /* If the entries are contiguous merge them,
                else make a new entry */
             if (file_offsets_for_agg[sorted_file_offsets[i-1]].offset +
                 file_offsets_for_agg[sorted_file_offsets[i-1]].length ==

--- a/ompi/mca/fs/base/fs_base_file_select.c
+++ b/ompi/mca/fs/base/fs_base_file_select.c
@@ -49,7 +49,7 @@ static OBJ_CLASS_INSTANCE(queried_module_t, opal_list_item_t, NULL, NULL);
 /*
  * Only one fs module can be attached to each file.
  *
- * This module calls the query funtion on all the components that were
+ * This module calls the query function on all the components that were
  * detected by fs_base_open. This function is called on a
  * per-file basis. This function has the following function.
  *
@@ -213,14 +213,14 @@ int mca_fs_base_file_select (struct ompio_file_t *file,
             * module of this component.
             *
             * ANJU: a component might not have all the functions
-            * defined.  Whereever a function pointer is null in the
+            * defined.  Wherever a function pointer is null in the
             * module structure we need to fill it in with the base
             * structure function pointers. This is yet to be done
             */
 
             /*
-             * We don return here coz we still need to go through and
-             * elease the other objects
+             * We don't return here coz we still need to go through and
+             * release the other objects
              */
 
             /*fill_null_pointers (om->om_module);*/
@@ -229,7 +229,7 @@ int mca_fs_base_file_select (struct ompio_file_t *file,
             file->f_fs_component = (mca_base_component_t *)best_component;
          } else {
             /*
-             * this is not the "choosen one", finalize
+             * this is not the "chosen one", finalize
              */
              if (NULL != om->om_component->fsm_file_unquery) {
                 /* unquery the component only if they have some clean

--- a/ompi/mca/fs/gpfs/fs_gpfs.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs.c
@@ -52,7 +52,7 @@
  * *******************************************************************
  */
 static mca_fs_base_module_1_0_0_t gpfs =  {
-    mca_fs_gpfs_module_init, /* initalise after being selected */
+    mca_fs_gpfs_module_init, /* initialise after being selected */
     mca_fs_gpfs_module_finalize, /* close a module on a communicator */
     mca_fs_gpfs_file_open,
     mca_fs_base_file_close,

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c
@@ -461,7 +461,7 @@ int mca_fs_gpfs_io_selection(ompio_file_t *fh,
                 siox_attribute_array[i], fh->f_filename);
     i++;
 
-//CN: Code duplication en mass (9 times same code block wich changing key!)
+//CN: Code duplication en mass (9 times same code block with changing key!)
 //CN: do this with a loop over a list of sioxHintsKeys
     //START setting the siox activity attributes
     strcpy(sioxHintsKey, "sioxAccessRange");

--- a/ompi/mca/fs/ime/fs_ime.c
+++ b/ompi/mca/fs/ime/fs_ime.c
@@ -21,7 +21,7 @@
  * *******************************************************************
  */
 static mca_fs_base_module_1_0_0_t ime =  {
-    mca_fs_ime_module_init, /* initalise after being selected */
+    mca_fs_ime_module_init, /* initialise after being selected */
     mca_fs_ime_module_finalize, /* close a module on a communicator */
     mca_fs_ime_file_open,
     mca_fs_ime_file_close,

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -38,7 +38,7 @@
  * *******************************************************************
  */
 static mca_fs_base_module_1_0_0_t lustre =  {
-    mca_fs_lustre_module_init, /* initalise after being selected */
+    mca_fs_lustre_module_init, /* initialise after being selected */
     mca_fs_lustre_module_finalize, /* close a module on a communicator */
     mca_fs_lustre_file_open,
     mca_fs_base_file_close,

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -52,7 +52,7 @@
  * *******************************************************************
  */
 static mca_fs_base_module_1_0_0_t pvfs2 =  {
-    mca_fs_pvfs2_module_init, /* initalise after being selected */
+    mca_fs_pvfs2_module_init, /* initialise after being selected */
     mca_fs_pvfs2_module_finalize, /* close a module on a communicator */
     mca_fs_pvfs2_file_open,
     mca_fs_pvfs2_file_close,

--- a/ompi/mca/fs/ufs/fs_ufs.c
+++ b/ompi/mca/fs/ufs/fs_ufs.c
@@ -38,7 +38,7 @@
  * *******************************************************************
  */
 static mca_fs_base_module_1_0_0_t ufs =  {
-    mca_fs_ufs_module_init, /* initalise after being selected */
+    mca_fs_ufs_module_init, /* initialise after being selected */
     mca_fs_ufs_module_finalize, /* close a module on a communicator */
     mca_fs_ufs_file_open,
     mca_fs_base_file_close,

--- a/ompi/mca/hook/base/hook_base.c
+++ b/ompi/mca/hook/base/hook_base.c
@@ -196,7 +196,7 @@ MCA_BASE_FRAMEWORK_DECLARE(ompi, hook, "hook hooks",
 
 /*
  * Once the framework is open then call all available components with
- * the approprate function pointer. Call order:
+ * the appropriate function pointer. Call order:
  * 1) static components
  * 2) dynamic components
  * 3) 'registered' components (those registered by ompi_hook_base_register_callbacks)

--- a/ompi/mca/hook/hook.h
+++ b/ompi/mca/hook/hook.h
@@ -18,7 +18,7 @@
  *
  * Why not a PMPI library?
  *  - The desire is to allow a component to be built statically into the library
- *    for licensing and disgnostic purposes. As such we need the ability for
+ *    for licensing and diagnostic purposes. As such we need the ability for
  *    the component to be statically linked into the libmpi library.
  *
  * Why is there not a hook for location XYZ?
@@ -202,7 +202,7 @@ typedef struct ompi_hook_base_component_1_0_0_t ompi_hook_base_component_1_0_0_t
 typedef ompi_hook_base_component_1_0_0_t ompi_hook_base_component_t;
 /* 
  * Note: We do -not- expose a component object for this framework.
- * All interation with the component should go through the base/base.h interfaces.
+ * All interaction with the component should go through the base/base.h interfaces.
  * See that header for more information on calling functions.
  */
 

--- a/ompi/mca/io/base/io_base_delete.c
+++ b/ompi/mca/io/base/io_base_delete.c
@@ -125,7 +125,7 @@ int mca_io_base_delete(const char *filename, struct opal_info_t *info)
        everyone has available */
 #if 1
     /* For the moment, just take the top module off the list */
-    /* MSC actually take the buttom */
+    /* MSC actually take the bottom */
     item = opal_list_remove_last(selectable);
     avail = (avail_io_t *) item;
     selected = *avail;

--- a/ompi/mca/io/base/io_base_file_select.c
+++ b/ompi/mca/io/base/io_base_file_select.c
@@ -172,7 +172,7 @@ int mca_io_base_file_select(ompi_file_t *file,
 
 #if 1
     /* For the moment, just take the top module off the list */
-    /* MSC actually take the buttom */
+    /* MSC actually take the bottom */
     item = opal_list_remove_last(selectable);
     avail = (avail_io_t *) item;
     selected = *avail;
@@ -244,7 +244,7 @@ int mca_io_base_file_select(ompi_file_t *file,
     file->f_io_selected_module = selected.ai_module;
     file->f_io_selected_data = selected.ai_module_data;
 
-    /* Finally -- intialize the selected module. */
+    /* Finally -- initialize the selected module. */
 
     if (OMPI_SUCCESS != (err = module_init(file))) {
         return err;

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -55,7 +55,7 @@ int mca_io_ompio_file_open (ompi_communicator_t *comm,
 
     /* No locking required for file_open according to my understanding
        There is virtually no way on how to reach this point from multiple
-       threads simultaniously 
+       threads simultaneously 
     */
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
     if ( NULL == data ) {

--- a/ompi/mca/io/romio341/src/io_romio341_module.c
+++ b/ompi/mca/io/romio341/src/io_romio341_module.c
@@ -116,8 +116,8 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
     /*
      * Open MPI contiguous check return true for datatype with
      * gaps in the beginning and at the end. We have to provide
-     * a count of 2 in order to get these gaps taken into acount.
-     * In addition, if the data is contiguous but true_lb differes
+     * a count of 2 in order to get these gaps taken into account.
+     * In addition, if the data is contiguous but true_lb differs
      * from zero, ROMIO will ignore the displacement. Thus, lie!
      */
     *flag = ompi_datatype_is_contiguous_memory_layout(datatype, 2);

--- a/ompi/mca/mtl/mtl.h
+++ b/ompi/mca/mtl/mtl.h
@@ -79,7 +79,7 @@ typedef struct mca_mtl_request_t mca_mtl_request_t;
  *
  * @param enable_progress_threads (IN) Progress threads have been
  *                  enabled by the user and the component must be
- *                  capable of making asycnhronous progress (either
+ *                  capable of making asynchronous progress (either
  *                  with its own thread, with the kernel, or with
  *                  the event library.
  * @param enable_mpi_threads (IN) MPI threads have been enabled by the
@@ -115,7 +115,7 @@ typedef struct mca_mtl_base_component_2_0_0_t mca_mtl_base_component_t;
  * MCA->MTL Clean up any resources held by MTL module
  *
  * Opposite of module_init.  Called when communication will no longer
- * be necessary.  ussually this is during MPI_FINALIZE, but it can be
+ * be necessary.  Usually this is during MPI_FINALIZE, but it can be
  * earlier if the component was not selected to run.  Assuming
  * module_init was called, finalize will always be called before the
  * component_close function is called.
@@ -205,7 +205,7 @@ typedef int (*mca_mtl_base_module_del_procs_fn_t)(
  * \note Open MPI is built around non-blocking operations.  This
  * function is provided for networks where progressing events outside
  * of point-to-point (for example, collectives, I/O, one-sided) can
- * occur without a progress function regularily being triggered.
+ * occur without a progress function regularly being triggered.
  *
  * \note While MPI does not allow users to specify negative tags, they
  * are used internally in Open MPI to provide a unique channel for
@@ -233,7 +233,7 @@ typedef int (*mca_mtl_base_module_send_fn_t)(
  * bytes requested in the module structure available for the MTL
  * directly after the ompi_request_t structure.  The PML will handle
  * proper destruction of the request once it can safely be destructed
- * (it has been completed and freeed by a call to REQUEST_FReE or
+ * (it has been completed and freed by a call to REQUEST_FReE or
  * TEST/WAIT).  The MTL should remove all resources associated with
  * the request when it is marked as completed.
  *
@@ -278,7 +278,7 @@ typedef int (*mca_mtl_base_module_isend_fn_t)(
  * MPI_Irecv must be implemented by this call.
  *
  * The PML will handle creation of the request, leaving the number of
- * bytes requested in teh module structure available for the MTL,
+ * bytes requested in the module structure available for the MTL,
  * directly after the ompi_request_t structure.  The PML will handle
  * proper destruction of the request once it can safely be destroyed
  * (it has been completed and free'ed by a call to REQUEST_FREE or

--- a/ompi/mca/mtl/ofi/README.md
+++ b/ompi/mca/mtl/ofi/README.md
@@ -93,7 +93,7 @@ instead of creating them all at once during init time and this
 approach also favours only creating as many contexts as needed.
 
 1. Multi-communicator model:
-   With this approach, the MPI application is requried to first duplicate
+   With this approach, the MPI application is required to first duplicate
    the communicators it wants to use with MPI operations (ideally creating
    as many communicators as the number of threads it wants to use to call
    into MPI). The duplicated communicators are then used by the

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -169,7 +169,7 @@ ompi_mtl_ofi_context_progress(int ctxt_id)
         }
     } else if (OPAL_UNLIKELY(ret == -FI_EAVAIL)) {
         /**
-         * An error occured and is being reported via the CQ.
+         * An error occurred and is being reported via the CQ.
          * Read the error and forward it to the upper layer.
          */
         ret = fi_cq_readerr(ompi_mtl_ofi.ofi_ctxt[ctxt_id].cq,
@@ -1164,7 +1164,7 @@ ompi_mtl_ofi_recv_callback(struct fi_cq_tagged_entry *wc,
         /**
         * We must continue to use the user's original tag but remove the
         * sync_send protocol tag bit and instead apply the sync_send_ack
-        * tag bit to complete the initator's sync send receive.
+        * tag bit to complete the initiator's sync send receive.
         */
         tagged_msg.tag = (wc->tag | ompi_mtl_ofi.sync_send_ack) & ~ompi_mtl_ofi.sync_send;
         tagged_msg.context = NULL;
@@ -1184,7 +1184,7 @@ ompi_mtl_ofi_recv_callback(struct fi_cq_tagged_entry *wc,
 }
 
 /**
- * Called when an error occured on a recv request.
+ * Called when an error occurred on a recv request.
  */
 __opal_attribute_always_inline__ static inline int
 ompi_mtl_ofi_recv_error_callback(struct fi_cq_err_entry *error,
@@ -1337,7 +1337,7 @@ ompi_mtl_ofi_mrecv_callback(struct fi_cq_tagged_entry *wc,
 }
 
 /**
- * Called when an error occured on a mrecv request.
+ * Called when an error occurred on a mrecv request.
  */
 __opal_attribute_always_inline__ static inline int
 ompi_mtl_ofi_mrecv_error_callback(struct fi_cq_err_entry *error,

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -185,7 +185,7 @@ ompi_mtl_ofi_component_register(void)
     control_progress = MTL_OFI_PROG_UNSPEC;
     mca_base_component_var_register (&mca_mtl_ofi_component.super.mtl_version,
                                      "control_progress",
-                                     "Specify control progress model (default: unspecificed, use provider's default). Set to auto or manual for auto or manual progress respectively.",
+                                     "Specify control progress model (default: unspecified, use provider's default). Set to auto or manual for auto or manual progress respectively.",
                                      MCA_BASE_VAR_TYPE_INT, new_enum, 0, 0,
                                      OPAL_INFO_LVL_3,
                                      MCA_BASE_VAR_SCOPE_READONLY,
@@ -352,7 +352,7 @@ select_ofi_provider(struct fi_info *providers,
       * however some may have multiple info objects with different
       * attributes for the same NIC. The initial provider attributes
       * are used to ensure that all NICs we return provide the same
-      * capabilities as the inital one.
+      * capabilities as the initial one.
       *
       * We use package rank to select between NICs of equal distance
       * if we cannot calculate a package_rank, we fall back to using the
@@ -475,7 +475,7 @@ static int ompi_mtl_ofi_init_sep(struct fi_info *prov, int universe_size)
 
     /*
      * If SEP supported and Thread Grouping feature enabled, use
-     * num_ofi_contexts + 2. Extra 2 items is to accomodate Open MPI contextid
+     * num_ofi_contexts + 2. Extra 2 items is to accommodate Open MPI contextid
      * numbering- COMM_WORLD is 0, COMM_SELF is 1. Other user created
      * Comm contextid values are assigned sequentially starting with 3.
      */
@@ -923,7 +923,7 @@ select_prov:
      * that before domain open.  Silently ignore not-supported errors,
      * as they are not critical to program correctness, but only
      * indicate that LIbfabric will have to pick a different, possibly
-     * less optimial, monitor. */
+     * less optimal, monitor. */
     ret = opal_common_ofi_export_memory_monitor();
     if (0 != ret && -FI_ENOSYS != ret) {
         opal_output_verbose(1, opal_common_ofi.output,
@@ -967,7 +967,7 @@ select_prov:
      */
     ret = fi_domain(ompi_mtl_ofi.fabric,  /* In:  Fabric object                 */
                     prov,                 /* In:  Provider                      */
-                    &ompi_mtl_ofi.domain, /* Out: Domain oject                  */
+                    &ompi_mtl_ofi.domain, /* Out: Domain object                 */
                     NULL);                /* Optional context for domain events */
     if (0 != ret) {
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,

--- a/ompi/mca/mtl/portals4/configure.m4
+++ b/ompi/mca/mtl/portals4/configure.m4
@@ -40,7 +40,7 @@ AC_DEFUN([MCA_ompi_mtl_portals4_CONFIG],[
           [$1],
           [$2])
 
-    # need to propogate CPPFLAGS to all of OMPI
+    # need to propagate CPPFLAGS to all of OMPI
     AS_IF([test "$DIRECT_mtl" = "portals4"],
           [mtl_portals4_WRAPPER_EXTRA_CPPFLAGS="$mtl_portals4_CPPFLAGS"
            CPPFLAGS="$CPPFLAGS $mtl_portals4_CPPFLAGS"])

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -46,7 +46,7 @@ struct mca_mtl_portals4_module_t {
     /* add_procs() can get called multiple times.  this prevents multiple calls to portals4_init_interface(). */
     int32_t need_init;
 
-    /* Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false) */
+    /* Use the logical to physical table to accelerate portals4 addressing: 1 (true) : 0 (false) */
     int32_t use_logical;
 
     /* Process_id */

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -90,7 +90,7 @@ ompi_mtl_portals4_component_register(void)
     ompi_mtl_portals4.use_logical = 0;
     (void) mca_base_component_var_register(&mca_mtl_portals4_component.mtl_version,
                                            "use_logical",
-                                           "Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false)",
+                                           "Use the logical to physical table to accelerate portals4 addressing: 1 (true) : 0 (false)",
                                            MCA_BASE_VAR_TYPE_INT,
                                            NULL,
                                            0,

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -146,7 +146,7 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
         (!PtlHandleIsEqual(ptl_request->me_h, PTL_INVALID_HANDLE))) {
         /* long expected messages with the eager protocol
            (and also with the rndv protocol if the length
-           is less or egal to eager_limit) won't see a
+           is less or equal to eager_limit) won't see a
            get event to complete the message.  Give them an extra
            count to cause the message to complete with just the SEND
            and ACK events and remove the ME. (we wait for the counter
@@ -385,7 +385,7 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, uint32_t contextid, int
     }
 
     /* We have to wait for some GET events.
-       If the first put falls in overflow list, the number of GET event is egal to:
+       If the first put falls in overflow list, the number of GET event is equal to:
            (length - 1) / ompi_mtl_portals4.max_msg_size_mtl + 1
        else we will re-calculate this number when we received the first ACK event (with remote overflow list)
      */

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -155,8 +155,8 @@ static void ompi_mtl_psm2_set_shadow_env (struct ompi_mtl_psm2_shadow_variable *
         break;
     case MCA_BASE_VAR_TYPE_UNSIGNED_LONG:
         if (0 == strcmp (variable->env_name, "PSM2_TRACEMASK")) {
-            /* PSM2 documentation shows the tracemask as a hexidecimal number. to be consitent
-             * use hexidecimal here. */
+            /* PSM2 documentation shows the tracemask as a hexadecimal number. to be consistent
+             * use hexadecimal here. */
             ret = opal_asprintf (&env_value, "%s=0x%lx", variable->env_name, storage->ulval);
         } else {
             ret = opal_asprintf (&env_value, "%s=%lu", variable->env_name, storage->ulval);

--- a/ompi/mca/op/avx/op_avx_functions.c
+++ b/ompi/mca/op/avx/op_avx_functions.c
@@ -302,7 +302,7 @@ static void OP_CONCAT(ompi_op_avx_2buff_##name##_##type,PREPEND)(const void *_in
 #endif  /* defined(OMPI_MCA_OP_HAVE_AVX512) && (1 == OMPI_MCA_OP_HAVE_AVX512) */
 /**
  * There is no support for 16 to 8 conversion without AVX512BW and AVX512VL, so
- * there is no AVX-only optimized function posible for OP_AVX_AVX2_MUL.
+ * there is no AVX-only optimized function possible for OP_AVX_AVX2_MUL.
  */
 
 /* special case for int8 mul */
@@ -879,7 +879,7 @@ static void OP_CONCAT(ompi_op_avx_3buff_##name##_##type,PREPEND)(const void * re
 #endif  /* defined(OMPI_MCA_OP_HAVE_AVX512) && (1 == OMPI_MCA_OP_HAVE_AVX512) */
 /**
  * There is no support for 16 to 8 conversion without AVX512BW and AVX512VL, so
- * there is no AVX-only optimized function posible for OP_AVX_AVX2_MUL.
+ * there is no AVX-only optimized function possible for OP_AVX_AVX2_MUL.
  */
 
 /* special case for int8 mul */

--- a/ompi/mca/op/base/op_base_functions.c
+++ b/ompi/mca/op/base/op_base_functions.c
@@ -1343,11 +1343,11 @@ LOC_FUNC_3BUF(minloc, long_double_int, <)
  *
  * **NOTE** These #define's used to be strictly ordered but the use of
  * designated initializers removed this restrictions. When adding new
- * operators ALWAYS use a designated initalizer!
+ * operators ALWAYS use a designated initializer!
  */
 
 /** C integer ***********************************************************/
-#define C_INTEGER(name, ftype)                                              \
+#define C_INTEGER(name, ftype)                                             \
   [OMPI_OP_BASE_TYPE_INT8_T] = ompi_op_base_##ftype##_##name##_int8_t,     \
   [OMPI_OP_BASE_TYPE_UINT8_T] = ompi_op_base_##ftype##_##name##_uint8_t,   \
   [OMPI_OP_BASE_TYPE_INT16_T] = ompi_op_base_##ftype##_##name##_int16_t,   \
@@ -1624,7 +1624,7 @@ ompi_op_base_handler_fn_t ompi_op_base_functions[OMPI_OP_BASE_FORTRAN_OP_MAX][OM
         [OMPI_OP_BASE_FORTRAN_REPLACE] = {
             /* (MPI_ACCUMULATE is handled differently than the other
                reductions, so just zero out its function
-               impementations here to ensure that users don't invoke
+               implementations here to ensure that users don't invoke
                MPI_REPLACE with any reduction operations other than
                ACCUMULATE) */
             NULL,
@@ -1711,7 +1711,7 @@ ompi_op_base_3buff_handler_fn_t ompi_op_base_3buff_functions[OMPI_OP_BASE_FORTRA
         [OMPI_OP_BASE_FORTRAN_REPLACE] = {
             /* MPI_ACCUMULATE is handled differently than the other
                reductions, so just zero out its function
-               impementations here to ensure that users don't invoke
+               implementations here to ensure that users don't invoke
                MPI_REPLACE with any reduction operations other than
                ACCUMULATE */
             NULL,

--- a/ompi/mca/op/base/op_base_op_select.c
+++ b/ompi/mca/op/base/op_base_op_select.c
@@ -192,7 +192,7 @@ int ompi_op_base_op_select(ompi_op_t *op)
             /* Oops -- we found a mismatch.  This shouldn't happen; so
                go release everything and return an error (yes, re-use
                the "i" index because we're going to return without
-               completing the outter loop). */
+               completing the outer loop). */
             for (i = 0; i < OMPI_OP_BASE_TYPE_MAX; ++i) {
                 OBJ_RELEASE(op->o_func.intrinsic.modules[i]);
                 op->o_func.intrinsic.modules[i] = NULL;

--- a/ompi/mca/op/example/README.md
+++ b/ompi/mca/op/example/README.md
@@ -10,9 +10,9 @@ programming examples, there are many different ways to program the
 same end effect.  Feel free to customize / simplify / strip out what
 you don't need from this example.
 
-This example component supports a ficticious set of hardware that
+This example component supports a fictitious set of hardware that
 provides acceleation for the `MPI_MAX` and `MPI_BXOR` `MPI_Ops`.  The
-ficticious hardware has multiple versions, too: some versions only
+fictitious hardware has multiple versions, too: some versions only
 support single precision floating point types for `MAX` and single
 precision integer types for `BXOR`, whereas later versions support
 both single and double precision floating point types for `MAX` and

--- a/ompi/mca/op/example/configure.m4
+++ b/ompi/mca/op/example/configure.m4
@@ -27,8 +27,8 @@
 
 # Do *NOT* invoke AC_MSG_ERROR, or any other macro that will abort
 # configure, except upon catastrophic error.  For example, it *is* a
-# catastropic error if the user specifically requested your component
-# but it cannot be built.  If it *not* a catastropic error if your
+# catastrophic error if the user specifically requested your component
+# but it cannot be built.  If it *not* a catastrophic error if your
 # component cannot be built (but was not specifically requested).
 
 # See https://github.com/open-mpi/ompi/wiki/devel-CreateComponent

--- a/ompi/mca/op/op.h
+++ b/ompi/mca/op/op.h
@@ -285,7 +285,7 @@ typedef ompi_op_base_3buff_handler_fn_1_0_0_t ompi_op_base_3buff_handler_fn_t;
  * MPI_INIT.
  *
  * @note The component framework is not lazily opened, so attempts
- * should be made to minimze the amount of memory allocated during
+ * should be made to minimize the amount of memory allocated during
  * this function.
  *
  * @param[in] enable_progress_threads True if the component needs to
@@ -341,14 +341,14 @@ typedef struct ompi_op_base_component_1_0_0_t {
 
     /** Component initialization function */
     ompi_op_base_component_init_query_fn_t opc_init_query;
-    /** Query whether component is useable for given op */
+    /** Query whether component is usable for given op */
     ompi_op_base_component_op_query_1_0_0_fn_t opc_op_query;
 } ompi_op_base_component_1_0_0_t;
 
 
-/** Per guidence in mca.h, use the unversioned struct name if you just
+/** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
-    interace. */
+    interface. */
 typedef struct ompi_op_base_component_1_0_0_t ompi_op_base_component_t;
 
 /**

--- a/ompi/mca/osc/base/osc_base_obj_convert.c
+++ b/ompi/mca/osc/base/osc_base_obj_convert.c
@@ -213,7 +213,7 @@ int ompi_osc_base_sndrcv_op (const void *origin, int32_t origin_count,
 
         done = opal_convertor_raw (&origin_convertor, origin_iovec, &origin_iov_count, &origin_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (origin_iov_index != origin_iov_count) {
             if (target_iov_index == target_iov_count) {
                 /* decode segments of the target buffer */

--- a/ompi/mca/osc/base/osc_base_obj_convert.h
+++ b/ompi/mca/osc/base/osc_base_obj_convert.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
 /**
  * Create datatype based on packed payload
  *
- * Create a useable MPI datatype based on it's packed description.
+ * Create a usable MPI datatype based on its packed description.
  * The datatype is owned by the calling process and must be
  * OBJ_RELEASEd when no longer in use.
  *
@@ -44,7 +44,7 @@ BEGIN_C_DECLS
  *                    pointer to the payload will be moved past the
  *                    datatype information upon successful return.
  *
- * @retval NULL       A failure occrred
+ * @retval NULL       A failure occurred
  * @retval non-NULL   A fully operational datatype
  */
 static inline
@@ -61,14 +61,14 @@ ompi_osc_base_datatype_create(ompi_proc_t *remote_proc,  void **payload)
 /**
  * Create operation based on Fortran Index
  *
- * Create a useable MPI operation based on it's Fortran index, which is
+ * Create a usable MPI operation based on its Fortran index, which is
  * globally the same for predefined operations.  The op handle is
  * owned by the calling process and must be OBJ_RELEASEd when no
  * longer in use.
  *
- * @param op_id       The fortran index for the operaton
+ * @param op_id       The fortran index for the operation
  *
- * @retval NULL       A failure occrred
+ * @retval NULL       A failure occurred
  * @retval non-NULL   An op handle
  */
 static inline
@@ -102,7 +102,7 @@ OMPI_DECLSPEC int ompi_osc_base_get_primitive_type_info(ompi_datatype_t *datatyp
 
 
 /**
- * Apply the operation specified from inbuf to outbut
+ * Apply the operation specified from inbuf to outbuf
  *
  * Apply the specified reduction operation from inbuf to outbuf.
  * inbuf must contain count instances of datatype, in the local

--- a/ompi/mca/osc/monitoring/osc_monitoring_accumulate.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_accumulate.h
@@ -29,7 +29,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size;                                           \
@@ -56,7 +56,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -88,7 +88,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -116,7 +116,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -140,7 +140,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -162,7 +162,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size;                                           \

--- a/ompi/mca/osc/monitoring/osc_monitoring_comm.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_comm.h
@@ -30,7 +30,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -55,7 +55,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(target_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -78,7 +78,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(source_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \
@@ -103,7 +103,7 @@
         int world_rank;                                                 \
         /**                                                             \
          * If this fails the destination is not part of my MPI_COM_WORLD \
-         * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank \
+         * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank \
          */                                                             \
         if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(source_rank, win->w_group, &world_rank)) { \
             size_t type_size, data_size;                                \

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -167,7 +167,7 @@ struct ompi_osc_base_component_2_0_0_t {
     mca_base_component_data_t osc_data;
     /** Component initialization function */
     ompi_osc_base_component_init_fn_t osc_init;
-    /** Query whether component is useable for give comm/info */
+    /** Query whether component is usable for given comm/info */
     ompi_osc_base_component_query_fn_t osc_query;
     /** Create module for the given window */
     ompi_osc_base_component_select_fn_t osc_select;

--- a/ompi/mca/osc/portals4/configure.m4
+++ b/ompi/mca/osc/portals4/configure.m4
@@ -31,7 +31,7 @@ AC_DEFUN([MCA_ompi_osc_portals4_CONFIG],[
            $1],
           [$2])
 
-    # need to propogate CPPFLAGS to all of OMPI
+    # need to propagate CPPFLAGS to all of OMPI
     AS_IF([test "$DIRECT_osc" = "portals4"],
           [CPPFLAGS="$CPPFLAGS $osc_portals4_CPPFLAGS"])
 

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -1229,7 +1229,7 @@ put_to_noncontig(opal_atomic_int64_t *opcount,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (origin_iov_index == origin_iov_count) {
                 /* decode segments of the target buffer */
@@ -1338,7 +1338,7 @@ atomic_put_to_noncontig(ompi_osc_portals4_module_t *module,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (origin_iov_index == origin_iov_count) {
                 /* decode segments of the target buffer */
@@ -1456,7 +1456,7 @@ atomic_to_noncontig(ompi_osc_portals4_module_t *module,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (origin_iov_index == origin_iov_count) {
                 /* decode segments of the target buffer */
@@ -1563,7 +1563,7 @@ get_from_noncontig(opal_atomic_int64_t *opcount,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (origin_iov_index == origin_iov_count) {
                 /* decode segments of the target buffer */
@@ -1664,7 +1664,7 @@ atomic_get_from_noncontig(ompi_osc_portals4_module_t *module,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (origin_iov_index == origin_iov_count) {
                 /* decode segments of the target buffer */
@@ -1787,7 +1787,7 @@ swap_from_noncontig(ompi_osc_portals4_module_t *module,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (result_iov_index == result_iov_count) {
                 /* decode segments of the target buffer */
@@ -1939,7 +1939,7 @@ fetch_atomic_from_noncontig(ompi_osc_portals4_module_t *module,
         /* opal_convertor_raw returns done when it has reached the end of the data */
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (target_iov_index != target_iov_count) {
             if (result_iov_index == result_iov_count) {
                 /* decode segments of the target buffer */

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -115,7 +115,7 @@ struct ompi_osc_rdma_component_t {
     /** maximum count for network AMO usage */
     unsigned long network_amo_max_count;
 
-    /** memory alignmen to be used for new windows */
+    /** memory alignment to be used for new windows */
     size_t memory_alignment;
 };
 typedef struct ompi_osc_rdma_component_t ompi_osc_rdma_component_t;
@@ -219,7 +219,7 @@ struct ompi_osc_rdma_module_t {
     /** offset in the shared memory segment where the state array starts */
     size_t state_offset;
 
-    /** memory alignmen to be used for new windows */
+    /** memory alignment to be used for new windows */
     size_t memory_alignment;
 
     /* ********************* sync data ************************ */

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -568,7 +568,7 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
         target_iov_index = 0;
         done = opal_convertor_raw (&target_convertor, target_iovec, &target_iov_count, &target_size);
 
-        /* loop on the source segments (if any) until we have exhaused the decoded target data */
+        /* loop on the source segments (if any) until we have exhausted the decoded target data */
         while (target_iov_index != target_iov_count) {
             if (source_iov_count == source_iov_index) {
                 /* decode segments of the source data */

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -353,7 +353,7 @@ int ompi_osc_rdma_start_atomic (ompi_group_t *group, int mpi_assert, ompi_win_t 
     sync->num_peers = ompi_group_size (group);
     sync->sync.pscw.group = group;
 
-    /* haven't processed any post messaes yet */
+    /* haven't processed any post messages yet */
     state->num_post_msgs = 0;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "start group size %d", sync->num_peers);
@@ -577,7 +577,7 @@ int ompi_osc_rdma_fence_atomic (int mpi_assert, ompi_win_t *win)
     }
 
     /* NTH: locking here isn't really needed per-se but it may make user synchronization errors more
-     * predicable. if the user is using RMA correctly then there will be no contention on this lock. */
+     * predictable. if the user is using RMA correctly then there will be no contention on this lock. */
     OPAL_THREAD_LOCK(&module->lock);
 
     /* active sends are now active (we will close the epoch if NOSUCCEED is specified) */

--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -238,7 +238,7 @@ static int ompi_osc_rdma_master_noncontig (ompi_osc_rdma_sync_t *sync, void *loc
         /* opal_convertor_raw returns true when it has reached the end of the data */
         done = opal_convertor_raw (&remote_convertor, remote_iovec, &remote_iov_count, &remote_size);
 
-        /* loop on the target segments until we have exhaused the decoded source data */
+        /* loop on the target segments until we have exhausted the decoded source data */
         while (remote_iov_index != remote_iov_count) {
             if (local_iov_index == local_iov_count) {
                 /* decode segments of the target buffer */
@@ -516,7 +516,7 @@ int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *
         /* NTH: when using the btl_flush function there is no guarantee that the callback will happen
          * before the flush is complete. because of this there is a chance that the sync object will be
          * released before there is a callback. to handle this case we call different callback that doesn't
-         * use the sync object. its possible the btl sematics will change in the future and the callback
+         * use the sync object. its possible the btl semantics will change in the future and the callback
          * will happen *before* flush is considered complete. if that is the case this workaround can be
          * removed */
         cbcontext = (void *) module;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -209,7 +209,7 @@ static int ompi_osc_rdma_component_register (void)
     mca_osc_rdma_component.acc_use_amo = true;
     opal_asprintf(&description_str, "Enable the use of network atomic memory operations when using single "
              "intrinsic optimizations. If not set network compare-and-swap will be "
-             "used instread (default: %s)", mca_osc_rdma_component.acc_use_amo ? "true" : "false");
+             "used instead (default: %s)", mca_osc_rdma_component.acc_use_amo ? "true" : "false");
     (void) mca_base_component_var_register(&mca_osc_rdma_component.super.osc_version, "acc_use_amo", description_str,
                                            MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_GROUP,
                                            &mca_osc_rdma_component.acc_use_amo);
@@ -914,7 +914,7 @@ static int btl_latency_sort_fn(const void *a, const void *b)
  *
  * We directly use the active message rdma wrappers for alternate
  * BTLs, in all cases.  This greatly simplifies the alternate BTL
- * impementation, at the expense of some performance.  With the
+ * implementation, at the expense of some performance.  With the
  * AM wrappers, we can always enforce remote completion and the lack
  * of memory registration, at some performance cost.  But we can use
  * as many BTLs as we like.  The module's btl list is sorted by
@@ -1094,7 +1094,7 @@ static int ompi_osc_rdma_query_accelerated_btls (ompi_communicator_t *comm, ompi
      * reachability to self, which is not strictly needed if BTL and
      * CPU atomics are atomic with each other.  However, the set of
      * BTLs which can not send to self, which have RDMA semantics, an
-     * which have the rquired atomicity is currently the null set and
+     * which have the required atomicity is currently the null set and
      * almost certain to remain the null set, so we keep it simple.
      *
      * We only want BTLs that can reach all peers, so use rank 0's BTL

--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -214,7 +214,7 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
         return ret;
     }
 
-    /* do a binary seach for where the region should be inserted */
+    /* do a binary search for where the region should be inserted */
     if (region_count) {
         region = find_insertion_point ((ompi_osc_rdma_region_t *) module->state->regions, 0, region_count - 1,
                                        (intptr_t) base, module->region_size, &region_index);

--- a/ompi/mca/osc/rdma/osc_rdma_sync.h
+++ b/ompi/mca/osc/rdma/osc_rdma_sync.h
@@ -69,7 +69,7 @@ struct ompi_osc_rdma_sync_t {
 
             /** assert specified at lock acquire time. at this time Open MPI
              * only uses 5-bits for asserts. if this number goes over 16 this
-             * will need to be changed to accomodate. */
+             * will need to be changed to accommodate. */
             int16_t mpi_assert;
         } lock;
 

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -269,7 +269,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         /* Note that the alloc_shared_noncontig info key only has
          * meaning during window creation.  Once the window is
          * created, we can't move memory around without making
-         * everything miserable.  So we intentionally do not subcribe
+         * everything miserable.  So we intentionally do not subscribe
          * to updates on the info key, because there's no useful
          * update to occur. */
         module->noncontig = false;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -579,7 +579,7 @@ select_unlock:
         /* Note that the alloc_shared_noncontig info key only has
          * meaning during window creation.  Once the window is
          * created, we can't move memory around without making
-         * everything miserable.  So we intentionally do not subcribe
+         * everything miserable.  So we intentionally do not subscribe
          * to updates on the info key, because there's no useful
          * update to occur. */
         module->noncontig_shared_win = false;

--- a/ompi/mca/part/base/part_base_prequest.h
+++ b/ompi/mca/part/base/part_base_prequest.h
@@ -49,7 +49,7 @@ typedef enum {
 
 
 /**
- *  Base type for Partitoned P2P requests
+ *  Base type for Partitioned P2P requests
  */
 struct mca_part_base_prequest_t {
 

--- a/ompi/mca/part/base/part_base_select.c
+++ b/ompi/mca/part/base/part_base_select.c
@@ -190,7 +190,7 @@ int mca_part_base_select(bool enable_progress_threads,
 
             if (NULL != om->om_component->partm_finalize) {
 
-                /* Blatently ignore the return code (what would we do to
+                /* Blatantly ignore the return code (what would we do to
                    recover, anyway?  This component is going away, so errors
                    don't matter anymore) */
 

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -70,7 +70,7 @@ struct ompi_part_persist_t {
     ompi_communicator_t   *part_comm_setup; /* We create a second communicator to send set-up messages (rational: these 
                                                messages go in the opposite direction of normal messages, need to use MPI_ANY_SOURCE 
                                                to support different communicators, and thus need to have a unique tag. Because tags 
-                                               are controled by the sender in this model, we cannot assume that the tag will be 
+                                               are controlled by the sender in this model, we cannot assume that the tag will be 
                                                unused in part_comm. */
     ompi_request_t        *part_comm_sreq;
     int32_t                part_comm_sready;
@@ -245,7 +245,7 @@ mca_part_persist_progress(void)
                     dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
                     int32_t bytes = req->real_count * dt_size;
 
-                    /* Set up persistant sends */
+                    /* Set up persistent sends */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
                     for(i = 0; i < req->real_parts; i++) {
                          void *buf = ((void*) (((char*)req->req_addr) + (bytes * i)));
@@ -264,7 +264,7 @@ mca_part_persist_progress(void)
                     dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
                     int32_t bytes = req->real_count * dt_size;
 
-                    /* Set up persistant sends */
+                    /* Set up persistent sends */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
                     req->flags = (int*) calloc(req->real_parts,sizeof(int));
                     for(i = 0; i < req->real_parts; i++) {
@@ -362,7 +362,7 @@ mca_part_persist_precv_init(void *buf,
     req->first_send  = true; 
     req->flag_post_setup_recv = false;
     req->flags = NULL;
-    /* Non-blocking recive on setup info */
+    /* Non-blocking receive on setup info */
     err	= MCA_PML_CALL(irecv(&req->setup_info[1], sizeof(struct ompi_mca_persist_setup_t), MPI_BYTE, src, tag, comm, &req->setup_req[1])); 
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
 
@@ -452,7 +452,7 @@ mca_part_persist_psend_init(const void* buf,
     err = MCA_PML_CALL(isend(&(req->setup_info[0]), sizeof(struct ompi_mca_persist_setup_t), MPI_BYTE, dst, tag, MCA_PML_BASE_SEND_STANDARD, comm, &req->setup_req[0]));
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
 
-    /* Non-blocking recive on setup info */
+    /* Non-blocking receive on setup info */
     if(1 == ompi_part_persist.init_comms) {
         err = MCA_PML_CALL(irecv(&(req->setup_info[1]), sizeof(struct ompi_mca_persist_setup_t), MPI_BYTE, MPI_ANY_SOURCE, req->my_recv_tag, ompi_part_persist.part_comm_setup, &req->setup_req[1]));
         if(OMPI_SUCCESS != err) return OMPI_ERROR;
@@ -535,7 +535,7 @@ mca_part_persist_pready(size_t min_part,
     {
         err = req->persist_reqs[min_part]->req_start(max_part-min_part+1, (&(req->persist_reqs[min_part])));
         for(i = min_part; i <= max_part && OMPI_SUCCESS == err; i++) {
-            req->flags[i] = 0; /* Mark partion as ready for testing */
+            req->flags[i] = 0; /* Mark partition as ready for testing */
         }
     }
     else

--- a/ompi/mca/part/persist/part_persist_request.h
+++ b/ompi/mca/part/persist/part_persist_request.h
@@ -73,7 +73,7 @@ struct mca_part_persist_request_t {
     size_t real_count;
     size_t part_size; 
 
-    ompi_request_t** persist_reqs;            /**< requests for persistant sends/recvs */
+    ompi_request_t** persist_reqs;            /**< requests for persistent sends/recvs */
     ompi_request_t* setup_req [2];                /**< Request structure for setup messages */
 
 
@@ -81,20 +81,20 @@ struct mca_part_persist_request_t {
     int32_t req_partitions_recv;          /**< Recv side number of partitions */
 
     int32_t my_send_tag;                  /**< This is a counter for send tags for the actual data transfer. */
-    int32_t my_recv_tag;                  /**< This is a counter for recive tags, for incoming setup messages. */ 
+    int32_t my_recv_tag;                  /**< This is a counter for receive tags, for incoming setup messages. */ 
 
     int32_t world_peer;                   /**< peer's rank in MPI_COMM_WORLD */
 
     int32_t initialized;                  /**< flag for initialized state */
-    int32_t first_send;                   /**< flag for whether the first send has happend */
+    int32_t first_send;                   /**< flag for whether the first send has happened */
     int32_t flag_post_setup_recv;  
     size_t done_count;             /**< counter for the number of partitions marked ready */
 
     int32_t *flags;               /**< array of flags to determine whether a partition has arrived */
 
-    struct ompi_mca_persist_setup_t setup_info[2]; /**< Setup info to send durring initialization. */
+    struct ompi_mca_persist_setup_t setup_info[2]; /**< Setup info to send during initialization. */
   
-    struct mca_part_persist_list_t* progress_elem; /**< pointer to progress list element for removal durring free. */ 
+    struct mca_part_persist_list_t* progress_elem; /**< pointer to progress list element for removal during free. */ 
 
 };
 typedef struct mca_part_persist_request_t mca_part_persist_request_t;

--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -250,7 +250,7 @@ int mca_pml_base_bsend_request_start(ompi_request_t* request)
 
         OPAL_THREAD_UNLOCK(&mca_pml_bsend_mutex);
 
-        /* The convertor is already initialized in the begining so we just have to
+        /* The convertor is already initialized in the beginning so we just have to
          * pack the data in the newly allocated buffer.
          */
         iov.iov_base = (IOVBASE_TYPE*)sendreq->req_addr;

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -136,7 +136,7 @@ static int mca_pml_base_close(void)
         opal_progress_unregister(mca_pml.pml_progress);
     }
 
-    /* Blatently ignore the return code (what would we do to recover,
+    /* Blatantly ignore the return code (what would we do to recover,
        anyway?  This module is going away, so errors don't matter
        anymore) */
 

--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -194,7 +194,7 @@ int mca_pml_base_select(bool enable_progress_threads,
 
             if (NULL != om->om_component->pmlm_finalize) {
 
-                /* Blatently ignore the return code (what would we do to
+                /* Blatantly ignore the return code (what would we do to
                    recover, anyway?  This component is going away, so errors
                    don't matter anymore) */
 

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -243,8 +243,8 @@ mca_pml_cm_isend_init(const void* buf,
                                      datatype, sendmode, true, false, buf, count, flags);
 
     /* Work around a leak in start by marking this request as complete. The
-     * problem occured because we do not have a way to differentiate an
-     * inital request and an incomplete pml request in start. This line
+     * problem occurred because we do not have a way to differentiate an
+     * initial request and an incomplete pml request in start. This line
      * allows us to detect this state. */
     sendreq->req_send.req_base.req_pml_complete = true;
 

--- a/ompi/mca/pml/cm/pml_cm_component.c
+++ b/ompi/mca/pml/cm/pml_cm_component.c
@@ -141,7 +141,7 @@ mca_pml_cm_component_init(int* priority,
 
     opal_output_verbose( 10, 0,
                          "in cm pml priority is %d\n", *priority);
-    /* find a useable MTL */
+    /* find a usable MTL */
     ret = ompi_mtl_base_select(enable_progress_threads, enable_mpi_threads, priority);
     if (OMPI_SUCCESS != ret) {
         return NULL;

--- a/ompi/mca/pml/monitoring/pml_monitoring_irecv.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_irecv.c
@@ -16,7 +16,7 @@
 #include "pml_monitoring.h"
 
 
-/* EJ: loging is done on the sender. Nothing to do here */
+/* EJ: logging is done on the sender. Nothing to do here */
 
 int mca_pml_monitoring_irecv_init(void *buf,
                                   size_t count,

--- a/ompi/mca/pml/monitoring/pml_monitoring_isend.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_isend.c
@@ -40,7 +40,7 @@ int mca_pml_monitoring_isend(const void *buf,
     int world_rank;
     /**
      * If this fails the destination is not part of my MPI_COM_WORLD
-     * Lookup its name in the rank hastable to get its MPI_COMM_WORLD rank
+     * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
      */
     if(OPAL_SUCCESS == mca_common_monitoring_get_world_rank(dst, comm->c_remote_group, &world_rank)) {
         size_t type_size, data_size;

--- a/ompi/mca/pml/monitoring/pml_monitoring_start.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_start.c
@@ -16,7 +16,7 @@
 #include "pml_monitoring.h"
 #include "ompi/mca/pml/base/pml_base_request.h"
 
-/* manage persistant requests*/
+/* manage persistent requests*/
 int mca_pml_monitoring_start(size_t count,
                              ompi_request_t** requests)
 {

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_arrays.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_arrays.h
@@ -297,7 +297,7 @@ static inline void custom_match_print(custom_match_prq* list)
     custom_match_prq_node* elem;
     int i = 0;
     int j = 0;
-    printf("Elements in the list (this is currenly only partialy implemented):\n");
+    printf("Elements in the list (this is currently only partially implemented):\n");
     for(elem = list->head; elem; elem = elem->next)
     {
         printf("This is the %d linked list element\n", ++i);

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-byte.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-byte.h
@@ -464,7 +464,7 @@ static inline void custom_match_umq_append(custom_match_umq* list, int tag, int 
 {
     int8_t key = source ^ tag;
 #if CUSTOM_MATCH_DEBUG
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
     mca_pml_ob1_recv_frag_t *req = (mca_pml_ob1_recv_frag_t *)payload;
     printf("custom_match_umq_append list: %x key: %x payload: %x tag: %d src: %d\n", list, key, payload, req->hdr.hdr_match.hdr_tag, req->hdr.hdr_match.hdr_src);
 #endif

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-short.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-short.h
@@ -455,7 +455,7 @@ static inline void custom_match_umq_append(custom_match_umq* list, int tag, int 
 {
     int16_t key = source ^ tag;
 #if CUSTOM_MATCH_DEBUG_VERBOSE
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
     mca_pml_ob1_recv_frag_t *req = (mca_pml_ob1_recv_frag_t *)payload;
     printf("custom_match_umq_append list: %x key: %x payload: %x tag: %d src: %d\n", list, key, payload, req->hdr.hdr_match.hdr_tag, req->hdr.hdr_match.hdr_src);
 #endif

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-word.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_fuzzy512-word.h
@@ -97,7 +97,7 @@ static inline void* custom_match_prq_find_verify(custom_match_prq* list, int tag
     custom_match_prq_node* elem = list->head;
     int i;
     int32_t key = peer;
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
     __m512i search = _mm512_set1_epi32(key);
     while(elem)
     {
@@ -134,7 +134,7 @@ static inline void* custom_match_prq_find_dequeue_verify(custom_match_prq* list,
     custom_match_prq_node* elem = list->head;
     int i;
     int32_t key = peer;
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
     __m512i search = _mm512_set1_epi32(key);
     while(elem)
     {
@@ -384,7 +384,7 @@ static inline void* custom_match_umq_find_verify_hold(custom_match_umq* list, in
     custom_match_umq_node* elem = list->head;
     int i;
     int32_t key = peer;
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
     __m512i search = _mm512_set1_epi32(key);
 
     int32_t mask = ~0;
@@ -472,7 +472,7 @@ static inline void custom_match_umq_remove_hold(custom_match_umq* list, custom_m
 static inline void custom_match_umq_append(custom_match_umq* list, int tag, int source, void* payload)
 {
     int32_t key = source;
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
 #if CUSTOM_MATCH_DEBUG_VERBOSE
     mca_pml_ob1_recv_frag_t *req = (mca_pml_ob1_recv_frag_t *)payload;
     printf("custom_match_umq_append list: %x key: %x payload: %x tag: %d src: %d\n", list, key, payload, req->hdr.hdr_match.hdr_tag, req->hdr.hdr_match.hdr_src);

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_linkedlist.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_linkedlist.h
@@ -170,7 +170,7 @@ static inline void custom_match_prq_append(custom_match_prq* list, void* payload
     }
     mca_pml_base_request_t *req = (mca_pml_base_request_t *)payload;
 #if CUSTOM_MATCH_DEBUG_VERBOSE
-    printf("custom_match_prq_append list: %x tag: %x soruce: %x tag: %x peer: %x\n", list, tag, source, req->req_tag, req->req_peer);
+    printf("custom_match_prq_append list: %x tag: %x source: %x tag: %x peer: %x\n", list, tag, source, req->req_tag, req->req_peer);
 #endif
     int i;
     custom_match_prq_node* elem;
@@ -261,7 +261,7 @@ static inline void custom_match_print(custom_match_prq* list)
     custom_match_prq_node* elem;
     int i = 0;
     int j = 0;
-    printf("Elements in the list (this is currenly only partialy implemented):\n");
+    printf("Elements in the list (this is currently only partially implemented):\n");
     for(elem = list->head; elem; elem = elem->next)
     {
         printf("This is the %d linked list element\n", ++i);

--- a/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_vectors.h
+++ b/ompi/mca/pml/ob1/custommatch/pml_ob1_custom_match_vectors.h
@@ -315,7 +315,7 @@ static inline void custom_match_print(custom_match_prq* list)
     custom_match_prq_node* elem;
     int i = 0;
     int j = 0;
-    printf("Elements in the list (this is currenly only partialy implemented):\n");
+    printf("Elements in the list (this is currently only partially implemented):\n");
     for(elem = list->head; elem; elem = elem->next)
     {
         printf("This is the %d linked list element\n", ++i);
@@ -476,7 +476,7 @@ static inline void custom_match_umq_append(custom_match_umq* list, int tag, int 
 {
 #if CUSTOM_MATCH_DEBUG_VERBOSE
     int32_t key = source;
-    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higer order bits...
+    ((int8_t*)&key)[3] = (int8_t) tag; // MGFD TODO verify this set higher order bits...
 #endif
 #if CUSTOM_MATCH_DEBUG_VERBOSE
     mca_pml_ob1_recv_frag_t *req = (mca_pml_ob1_recv_frag_t *)payload;

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -24,7 +24,7 @@
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
- *                         reseved.
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -337,7 +337,7 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
             PERUSE_TRACE_MSG_EVENT(PERUSE_COMM_MSG_INSERT_IN_UNEX_Q, comm,
                                    hdr->hdr_src, hdr->hdr_tag, PERUSE_RECV);
             /* And now the ugly part. As some fragments can be inserted in the cant_match list,
-             * every time we succesfully add a fragment in the unexpected list we have to make
+             * every time we successfully add a fragment in the unexpected list we have to make
              * sure the next one is not in the cant_match. Otherwise, we will endup in a deadlock
              * situation as the cant_match is only checked when a new fragment is received from
              * the network.

--- a/ompi/mca/pml/ob1/pml_ob1_hdr.h
+++ b/ompi/mca/pml/ob1/pml_ob1_hdr.h
@@ -634,7 +634,7 @@ ob1_hdr_copy(mca_pml_ob1_hdr_t *src, mca_pml_ob1_hdr_t *dst)
 	    mca_pml_ob1_hdr_t *next_dst = (mca_pml_ob1_hdr_t *) ((uintptr_t) dst + sizeof (dst->hdr_cid));
 
 	    memcpy (&dst->hdr_cid, &src->hdr_cid, sizeof (src->hdr_cid));
-            /* can't call recusively and expect inlining */
+            /* can't call recursively and expect inlining */
             src = next_src;
             dst = next_dst;
             continue;

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -65,8 +65,8 @@ int mca_pml_ob1_irecv_init(void *addr,
                              PERUSE_RECV);
 
     /* Work around a leak in start by marking this request as complete. The
-     * problem occured because we do not have a way to differentiate an
-     * inital request and an incomplete pml request in start. This line
+     * problem occurred because we do not have a way to differentiate an
+     * initial request and an incomplete pml request in start. This line
      * allows us to detect this state. */
     recvreq->req_recv.req_base.req_pml_complete = true;
 

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -62,8 +62,8 @@ int mca_pml_ob1_isend_init(const void *buf,
                              PERUSE_SEND);
 
     /* Work around a leak in start by marking this request as complete. The
-     * problem occured because we do not have a way to differentiate an
-     * inital request and an incomplete pml request in start. This line
+     * problem occurred because we do not have a way to differentiate an
+     * initial request and an incomplete pml request in start. This line
      * allows us to detect this state. */
     sendreq->req_send.req_base.req_pml_complete = true;
 

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -290,7 +290,7 @@ remove_head_from_ordered_list(mca_pml_ob1_recv_frag_t** queue)
  *
  * @param hdr (IN)                  Header of received recv_frag.
  * @param segments (IN)             Received recv_frag descriptor.
- * @param num_segments (IN)         Flag indicating wether a match was made.
+ * @param num_segments (IN)         Flag indicating whether a match was made.
  * @param type (IN)                 Type of the message header.
  * @return                          OMPI_SUCCESS or error status on failure.
  */
@@ -309,7 +309,7 @@ static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
  * @param proc (IN)                 Proc for which we have received the message.
  * @param hdr (IN)                  Header of received recv_frag.
  * @param segments (IN)             Received recv_frag descriptor.
- * @param num_segments (IN)         Flag indicating wether a match was made.
+ * @param num_segments (IN)         Flag indicating whether a match was made.
  * @param type (IN)                 Type of the message header.
  * @return                          OMPI_SUCCESS or error status on failure.
  */
@@ -353,7 +353,7 @@ int mca_pml_ob1_revoke_comm( struct ompi_communicator_t* ompi_comm, bool coll_on
     OBJ_CONSTRUCT(&nack_list, opal_list_t);
 
     OPAL_THREAD_LOCK(&comm->matching_lock);
-    /* these assignement need to be here because we need the matching_lock */
+    /* these assignments need to be here because we need the matching_lock */
     ompi_comm->coll_revoked = true;
     if( !coll_only ) ompi_comm->comm_revoked = true;
 
@@ -502,7 +502,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
      * run, lock to make sure that if another thread is processing
      * a frag from the same message a match is made only once.
      * Also, this prevents other posted receives (for a pair of
-     * end points) from being processed, and potentially "loosing"
+     * end points) from being processed, and potentially "losing"
      * the fragment.
      */
     OB1_MATCHING_LOCK(&comm->matching_lock);
@@ -572,7 +572,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
             uint32_t iov_count = 1;
 
             /*
-             *  Make user buffer accessable(defined) before unpacking.
+             *  Make user buffer accessible(defined) before unpacking.
              */
             MEMCHECKER(
                        memchecker_call(&opal_memchecker_base_mem_defined,
@@ -598,7 +598,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
             SPC_USER_OR_MPI(match->req_recv.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)bytes_received,
                             OMPI_SPC_BYTES_RECEIVED_USER, OMPI_SPC_BYTES_RECEIVED_MPI);
             /*
-             *  Unpacking finished, make the user buffer unaccessable again.
+             *  Unpacking finished, make the user buffer unaccessible again.
              */
             MEMCHECKER(
                        memchecker_call(&opal_memchecker_base_mem_noaccess,
@@ -1024,7 +1024,7 @@ static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
  * RCS/CTS receive side matching
  *
  * @param hdr list of parameters needed for matching
- *                    This list is also embeded in frag,
+ *                    This list is also embedded in frag,
  *                    but this allows to save a memory copy when
  *                    a match is made in this routine. (IN)
  * @param frag   pointer to receive fragment which we want
@@ -1095,7 +1095,7 @@ static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
      * run, lock to make sure that if another thread is processing
      * a frag from the same message a match is made only once.
      * Also, this prevents other posted receives (for a pair of
-     * end points) from being processed, and potentially "loosing"
+     * end points) from being processed, and potentially "losing"
      * the fragment.
      */
     OB1_MATCHING_LOCK(&comm->matching_lock);
@@ -1219,7 +1219,7 @@ mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
     /*
      * Now that new message has arrived, check to see if
      * any fragments on the frags_cant_match list
-     * may now be used to form new matchs
+     * may now be used to form new matches
      */
     if(OPAL_UNLIKELY(NULL != proc->frags_cant_match)) {
         OB1_MATCHING_LOCK(&comm->matching_lock);

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -350,7 +350,7 @@ static int mca_pml_ob1_recv_request_ack(
             return OMPI_SUCCESS;
     }
 
-    /* let know to shedule function there is no need to put ACK flag. If not all message went over
+    /* let know to schedule function there is no need to put ACK flag. If not all message went over
      * RDMA then we cancel the GET protocol in order to switch back to send/recv. In this case send
      * back the remote send request, the peer kept a pointer to the frag locally. In the future we
      * might want to cancel the fragment itself, in which case we will have to send back the remote
@@ -584,7 +584,7 @@ void mca_pml_ob1_recv_request_progress_frag( mca_pml_ob1_recv_request_t* recvreq
                                      bytes_received,
                                      bytes_delivered );
     /*
-     *  Unpacking finished, make the user buffer unaccessable again.
+     *  Unpacking finished, make the user buffer unaccessible again.
      */
     MEMCHECKER(
                memchecker_call(&opal_memchecker_base_mem_noaccess,
@@ -929,7 +929,7 @@ void mca_pml_ob1_recv_request_progress_match( mca_pml_ob1_recv_request_t* recvre
 
     MCA_PML_OB1_RECV_REQUEST_MATCHED(recvreq, &hdr->hdr_match);
     /*
-     *  Make user buffer accessable(defined) before unpacking.
+     *  Make user buffer accessible(defined) before unpacking.
      */
     MEMCHECKER(
                memchecker_call(&opal_memchecker_base_mem_defined,
@@ -945,7 +945,7 @@ void mca_pml_ob1_recv_request_progress_match( mca_pml_ob1_recv_request_t* recvre
                                      bytes_received,
                                      bytes_delivered);
     /*
-     *  Unpacking finished, make the user buffer unaccessable again.
+     *  Unpacking finished, make the user buffer unaccessible again.
      */
     MEMCHECKER(
                memchecker_call(&opal_memchecker_base_mem_noaccess,

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -680,7 +680,7 @@ int mca_pml_ob1_send_request_start_copy( mca_pml_ob1_send_request_t* sendreq,
         (void)opal_convertor_pack( &sendreq->req_send.req_base.req_convertor,
                                    &iov, &iov_count, &max_data );
          /*
-          *  Packing finished, make the user buffer unaccessable.
+          *  Packing finished, make the user buffer unaccessible.
           */
         MEMCHECKER(
             memchecker_call(&opal_memchecker_base_mem_noaccess,
@@ -803,7 +803,7 @@ int mca_pml_ob1_send_request_start_prepare( mca_pml_ob1_send_request_t* sendreq,
 
 
 /**
- *  We have contigous data that is registered - schedule across
+ *  We have contiguous data that is registered - schedule across
  *  available nics.
  */
 
@@ -1129,7 +1129,7 @@ mca_pml_ob1_send_request_schedule_once(mca_pml_ob1_send_request_t* sendreq)
             add_request_to_send_pending(sendreq,
                     MCA_PML_OB1_SEND_PENDING_SCHEDULE, true);
             /* Note that request remains locked. send_request_process_pending()
-             * function will call shedule_exclusive() directly without taking
+             * function will call schedule_exclusive() directly without taking
              * the lock */
             return OMPI_ERR_OUT_OF_RESOURCE;
         }

--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -186,10 +186,10 @@ static void mca_pml_ucx_request_init_common(ompi_request_t* ompi_req,
     ompi_req->req_start            = mca_pml_ucx_start;
     ompi_req->req_free             = req_free;
     ompi_req->req_cancel           = req_cancel;
-    /* This field is used to attach persistant request to a temporary req.
+    /* This field is used to attach persistent request to a temporary req.
      * Receive (ucp_tag_recv_nb) may call completion callback
      * before the field is set. If the field is not NULL then mca_pml_ucx_preq_completion() 
-     * will try to complete bogus persistant request.
+     * will try to complete bogus persistent request.
      */ 
     ompi_req->req_complete_cb_data = NULL;
 }

--- a/ompi/mca/sharedfp/base/sharedfp_base_file_select.c
+++ b/ompi/mca/sharedfp/base/sharedfp_base_file_select.c
@@ -50,7 +50,7 @@ static OBJ_CLASS_INSTANCE(queried_module_t, opal_list_item_t, NULL, NULL);
 /*
  * Only one sharedfp module can be attached to each file.
  *
- * This module calls the query funtion on all the components that were
+ * This module calls the query function on all the components that were
  * detected by sharedfp_base_open. This function is called on a
  * per-file basis. This function has the following function.
  *
@@ -220,14 +220,14 @@ int mca_sharedfp_base_file_select (struct ompio_file_t *file,
             * module of this component.
             *
             * ANJU: a component might not have all the functions
-            * defined.  Whereever a function pointer is null in the
+            * defined.  Wherever a function pointer is null in the
             * module structure we need to fill it in with the base
             * structure function pointers. This is yet to be done
             */
 
             /*
-             * We don return here coz we still need to go through and
-             * elease the other objects
+             * We don't return here coz we still need to go through and
+             * release the other objects
              */
 
             /*fill_null_pointers (om->om_module);*/
@@ -237,7 +237,7 @@ int mca_sharedfp_base_file_select (struct ompio_file_t *file,
 
          } else {
             /*
-             * this is not the "choosen one", finalize
+             * this is not the "chosen one", finalize
              */
              if (NULL != om->om_component->sharedfpm_file_unquery) {
                 /* unquery the component only if they have some clean

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -39,7 +39,7 @@
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
 static mca_sharedfp_base_module_1_0_0_t individual =  {
-    mca_sharedfp_individual_module_init, /* initalise after being selected */
+    mca_sharedfp_individual_module_init, /* initialise after being selected */
     mca_sharedfp_individual_module_finalize, /* close a module on a communicator */
     mca_sharedfp_individual_seek,
     mca_sharedfp_individual_get_position,

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
@@ -192,7 +192,7 @@ int mca_sharedfp_individual_file_close (ompio_file_t *fh)
     }
     sh = fh->f_sharedfp_data;
 
-    /* Merge data from individal files to final output file */
+    /* Merge data from individual files to final output file */
     err = mca_sharedfp_individual_collaborate_data (sh, fh);
 
     headnode = (mca_sharedfp_individual_header_record*)(sh->selected_module_data);
@@ -201,7 +201,7 @@ int mca_sharedfp_individual_file_close (ompio_file_t *fh)
         if (headnode->datafilehandle)  {
             /*TODO: properly deal with returned error code*/
             err = mca_common_ompio_file_close(headnode->datafilehandle);
-            /* NOTE: No neeed to manually delete the file,
+            /* NOTE: No need to manually delete the file,
 	    ** the amode should have been set to delete on close
 	    */
         }
@@ -213,7 +213,7 @@ int mca_sharedfp_individual_file_close (ompio_file_t *fh)
         if (headnode->metadatafilehandle)  {
             /*TODO: properly deal with returned error code*/
             err = mca_common_ompio_file_close(headnode->metadatafilehandle);
-            /* NOTE: No neeed to manually delete the file,
+            /* NOTE: No need to manually delete the file,
 	    ** the amode should have been set to delete on close
 	    */
         }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
@@ -43,7 +43,7 @@
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
 static mca_sharedfp_base_module_1_0_0_t lockedfile =  {
-    mca_sharedfp_lockedfile_module_init, /* initalise after being selected */
+    mca_sharedfp_lockedfile_module_init, /* initialise after being selected */
     mca_sharedfp_lockedfile_module_finalize, /* close a module on a communicator */
     mca_sharedfp_lockedfile_seek,
     mca_sharedfp_lockedfile_get_position,

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_request_position.c
@@ -64,9 +64,9 @@ int mca_sharedfp_lockedfile_request_position(struct mca_sharedfp_base_data_t * s
     fl.l_pid    = getpid();
 
 
-    /* Aquire an exclusive lock */
+    /* Acquire an exclusive lock */
     if (fcntl(fd, F_SETLKW, &fl) == -1) {
-        opal_output(0,"sharedfp_lockedfile_request_position: errorr acquiring lock: fcntl(%d,F_SETLKW,&fl)\n",fd);
+        opal_output(0,"sharedfp_lockedfile_request_position: error acquiring lock: fcntl(%d,F_SETLKW,&fl)\n",fd);
         opal_output(0,"sharedfp_lockedfile_request_position: error(%i): %s", errno, strerror(errno));
         return OMPI_ERROR;
     }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
@@ -96,7 +96,7 @@ mca_sharedfp_lockedfile_seek (ompio_file_t *fh,
         fd_lockedfilehandle = lockedfile_data->handle;
 
 	opal_output(ompi_sharedfp_base_framework.framework_output,
-		    "sharedfp_lockedfile_seek: Aquiring lock...");
+		    "sharedfp_lockedfile_seek: Acquiring lock...");
 
         /* set up the flock structure */
         fl.l_type   = F_WRLCK;
@@ -105,9 +105,9 @@ mca_sharedfp_lockedfile_seek (ompio_file_t *fh,
         fl.l_len    = 0;
         fl.l_pid    = getpid();
 
-        /* Aquire an exclusive lock */
+        /* Acquire an exclusive lock */
         if ( fcntl(fd_lockedfilehandle, F_SETLKW, &fl) == -1) {
-            opal_output(0, "Erorr acquiring lock: fcntl(%d,F_SETLKW,&fl)\n",fd_lockedfilehandle);
+            opal_output(0, "Error acquiring lock: fcntl(%d,F_SETLKW,&fl)\n",fd_lockedfilehandle);
             opal_output(0,"error(%i): %s", errno, strerror(errno));
             return OMPI_ERROR;
         }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -47,7 +47,7 @@
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
 static mca_sharedfp_base_module_1_0_0_t sm =  {
-    mca_sharedfp_sm_module_init, /* initalise after being selected */
+    mca_sharedfp_sm_module_init, /* initialise after being selected */
     mca_sharedfp_sm_module_finalize, /* close a module on a communicator */
     mca_sharedfp_sm_seek,
     mca_sharedfp_sm_get_position,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_request_position.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_request_position.c
@@ -47,12 +47,12 @@ int mca_sharedfp_sm_request_position(ompio_file_t *fh,
     *offset = 0;
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "Aquiring lock, rank=%d...",fh->f_rank);
+                    "Acquiring lock, rank=%d...",fh->f_rank);
     }
 
     sm_offset_ptr = sm_data->sm_offset_ptr;
 
-    /* Aquire an exclusive lock */
+    /* Acquire an exclusive lock */
 
     sem_wait(sm_data->mutex);
 

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
@@ -112,10 +112,10 @@ mca_sharedfp_sm_seek (ompio_file_t *fh,
         /*--------------------*/
         if ( mca_sharedfp_sm_verbose ) {
             opal_output(ompi_sharedfp_base_framework.framework_output,
-                        "sharedfp_sm_seek: Aquiring lock, rank=%d...",fh->f_rank); fflush(stdout);
+                        "sharedfp_sm_seek: Acquiring lock, rank=%d...",fh->f_rank); fflush(stdout);
         }
 
-        /* Aquire an exclusive lock */
+        /* Acquire an exclusive lock */
         sm_offset_ptr = sm_data->sm_offset_ptr;
 
         sem_wait(sm_data->mutex);

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
@@ -91,7 +91,7 @@ int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
 
     if( NULL == fh->f_sharedfp_data){
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "sharedfp_sm_write_ordered: module not initialzed \n");
+                    "sharedfp_sm_write_ordered: module not initialized \n");
         return OMPI_ERROR;
     }
 

--- a/ompi/mca/topo/base/topo_base_comm_select.c
+++ b/ompi/mca/topo/base/topo_base_comm_select.c
@@ -61,7 +61,7 @@ static OBJ_CLASS_INSTANCE(queried_module_t, opal_list_item_t, NULL, NULL);
  * communicator provided as argument is the old communicator, and the
  * newly selected topology is __not__ supposed to be attached to it.
  *
- * This module calls the query funtion on all the components that were
+ * This module calls the query function on all the components that were
  * detected by topo_base_open. This function is called on a
  * per-communicator basis. This function has the following function.
  *
@@ -227,7 +227,7 @@ static int _mca_topo_base_select (const ompi_communicator_t *comm, const ompi_gr
             * module of this component.
             *
             * ANJU: a component might not have all the functions
-            * defined.  Whereever a function pointer is null in the
+            * defined.  Wherever a function pointer is null in the
             * module structure we need to fill it in with the base
             * structure function pointers. This is yet to be done
             */
@@ -235,7 +235,7 @@ static int _mca_topo_base_select (const ompi_communicator_t *comm, const ompi_gr
             om->om_module->topo_component = best_component;
             *selected_module = om->om_module;
          } else {
-             /* this is not the "choosen one", finalize */
+             /* this is not the "chosen one", finalize */
               opal_output_verbose(10, ompi_topo_base_framework.framework_output,
                                   "select: component %s is not selected",
                                   om->om_component->topoc_version.mca_component_name);
@@ -276,7 +276,7 @@ int mca_topo_base_group_select(const ompi_group_t *group, mca_topo_base_module_t
  * This function fills in the null function pointers, in other words,
  * those functions which are not implemented by the module with the
  * pointers from the base function. Somewhere, I need to incoroporate
- * a check for the common minimum funtions being implemented by the
+ * a check for the common minimum functions being implemented by the
  * module.
  */
 static void fill_null_pointers(int type, mca_topo_base_module_t *module)

--- a/ompi/mca/topo/basic/topo_basic_component.c
+++ b/ompi/mca/topo/basic/topo_basic_component.c
@@ -26,7 +26,7 @@ const char *mca_topo_basic_component_version_string =
     "Open MPI basic topology MCA component version" OMPI_VERSION;
 
 /*
- * Local funtions
+ * Local functions
  */
 static int init_query(bool enable_progress_threads, bool enable_mpi_threads);
 static struct mca_topo_base_module_t *

--- a/ompi/mca/topo/example/topo_example_component.c
+++ b/ompi/mca/topo/example/topo_example_component.c
@@ -31,7 +31,7 @@ const char *mca_topo_example_component_version_string =
     "Open MPI example topology MCA component version" OMPI_VERSION;
 
 /*
- * Local funtions
+ * Local functions
  */
 static int init_query(bool enable_progress_threads, bool enable_mpi_threads);
 static struct mca_topo_base_module_t *

--- a/ompi/mca/topo/treematch/topo_treematch_component.c
+++ b/ompi/mca/topo/treematch/topo_treematch_component.c
@@ -23,7 +23,7 @@ const char *mca_topo_treematch_component_version_string =
     "Open MPI treematch topology MCA component version" OMPI_VERSION;
 
 /*
- * Local funtions
+ * Local functions
  */
 static int init_query(bool enable_progress_threads, bool enable_mpi_threads);
 static struct mca_topo_base_module_t *

--- a/ompi/mca/vprotocol/base/vprotocol_base_select.c
+++ b/ompi/mca/vprotocol/base/vprotocol_base_select.c
@@ -114,7 +114,7 @@ int mca_vprotocol_base_select(bool enable_progress_threads,
             /* Finalize */
             V_OUTPUT_VERBOSE(500, "vprotocol select: component %s not selected / finalized", om->om_component->pmlm_version.mca_component_name);
             if (NULL != om->om_component->pmlm_finalize) {
-                /* Blatently ignore the return code (what would we do to
+                /* Blatantly ignore the return code (what would we do to
                 recover, anyway?  This component is going away, so errors
                 don't matter anymore) */
                 om->om_component->pmlm_finalize();

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
@@ -102,7 +102,7 @@ void vprotocol_pessimist_matching_replay(int *src) {
         else if(mevent->reqid > max)
             max = mevent->reqid;
     }
-    /* not forcing a ANY SOURCE event whose recieve clock is lower than max
+    /* not forcing a ANY SOURCE event whose receive clock is lower than max
      * is a bug indicating we have missed an event during logging ! */
     assert(((*src) != MPI_ANY_SOURCE) || (mca_vprotocol_pessimist.clock > max));
 #else

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_proc.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_proc.c
@@ -13,7 +13,7 @@
 
 int mca_vprotocol_pessimist_add_procs(struct ompi_proc_t **procs, size_t nprocs)
 {
-  /* TODO: for each proc, retrieve post send of sender based request, post recieve of list
+  /* TODO: for each proc, retrieve post send of sender based request, post receive of list
       block any other communications until we are up. To be determined how i manage to send (or resend) data to failed nodes
   */
   return mca_pml_v.host_pml.pml_add_procs(procs, nprocs);

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_progress.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_progress.c
@@ -21,7 +21,7 @@ int mca_vprotocol_pessimist_progress(void)
     printf("PROGRESS\n");
     /* First let the real progress take place */
     ret = mca_pml_v.host_pml.pml_progress();
-    /* Then progess the sender_based copies */
+    /* Then progress the sender_based copies */
     vprotocol_pessimist_sb_progress_all_reqs();
     return ret;
 }

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_request.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_request.c
@@ -31,7 +31,7 @@ static void vprotocol_pessimist_request_construct(mca_pml_base_request_t *req)
     ftreq->pml_req_free = req->req_ompi.req_free;
     ftreq->event = NULL;
     ftreq->sb.bytes_progressed = 0;
-    assert(ftreq->pml_req_free == req->req_ompi.req_free); /* detection of aligment issues on different arch */
+    assert(ftreq->pml_req_free == req->req_ompi.req_free); /* detection of alignment issues on different arch */
     req->req_ompi.req_free = mca_vprotocol_pessimist_request_free;
     OBJ_CONSTRUCT(& ftreq->list_item, opal_list_item_t);
 }

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
@@ -127,7 +127,7 @@ void vprotocol_pessimist_sender_based_alloc(size_t len)
         ompi_comm_dup(MPI_COMM_SELF, &sb.sb_comm, 1);
 #endif
 
-    /* Take care of alignement of sb_offset                             */
+    /* Take care of alignment of sb_offset                             */
     sb.sb_offset += sb.sb_cursor - sb.sb_addr;
     sb.sb_cursor = sb.sb_offset % sb.sb_pagesize;
     sb.sb_offset -= sb.sb_cursor;


### PR DESCRIPTION
Found via `codespell -q 3 -L bloc,childs,fo,improbe,inout,mmaped,ro`