### PR TITLE
v5.0.x: Consolidate "contributing to Open MPI" docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,85 +5,14 @@ Open MPI!
 
 ![You're awesome!](https://www.open-mpi.org/images/youre-awesome.jpg)
 
-General information about contributing to the Open MPI project can be found at the [Contributing to Open MPI webpage](https://www.open-mpi.org/community/contribute/).
-The instructions below are specifically for opening issues and pull requests against Open MPI.
+General information about contributing to the Open MPI project can be
+found at the [Contributing to Open MPI
+webpage](https://docs.open-mpi.org/en/main/contributing.html).
 
-## Content
+In short: Open MPI is hosted on GitHub, and we gladly accept pull
+requests.  The instructions below are specifically for opening issues
+and pull requests against Open MPI.
 
-We love getting contributions from anyone.  But keep in mind that Open
-MPI is used in production environments all around the world.
-
-If you're contributing a small bug fix, awesome!
-
-If you're contributing a large new piece of functionality, that will
-be best viewed if you — or someone, anyone — is also stepping up to
-help maintain that functionality over time.  We love new ideas and new
-features, but we do need to be realistic in what we can reliably test
-and deliver to our users.
-
-## Contributor's Declaration
-
-In order to ensure that we can keep distributing Open MPI under our
-[open source license](/LICENSE), we need to ensure that all
-contributions are compatible with that license.
-
-To that end, we require that all Git commits contributed to Open MPI
-have a "Signed-off-by" token indicating that the commit author agrees
-with [Open MPI's Contributor's
-Declaration](https://github.com/open-mpi/ompi/wiki/Administrative-rules#contributors-declaration).
-
-If you have not already done so, please ensure that:
-
-1. Every commit contains exactly the "Signed-off-by" token.  You can
-add this token via `git commit -s`.
-1. The email address after "Signed-off-by" must match the Git commit
-email address.
-
-## **Did you find a bug?**
-
-* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/open-mpi/ompi/issues).
-
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/open-mpi/ompi/issues/new).
-
-* For more detailed information on submitting a bug report and creating an issue, visit our [Bug Tracking webpage](https://www.open-mpi.org/community/help/bugs.php).
-
-## **Did you write a patch that fixes a bug?**
-
-* Open a new GitHub pull request with the patch.
-
-* Ensure the PR description clearly describes the problem and solution. If there is an existing GitHub issue open describing this bug, please include it in the description so we can close it.
-
-* Before submitting, please read the [Contributing to the Open MPI Project FAQ](https://www.open-mpi.org/faq/?category=contributing) web page, and the [SubmittingPullRequests](https://github.com/open-mpi/ompi/wiki/SubmittingPullRequests) wiki page.  In particular, note that all Git commits contributed to Open MPI require a "Signed-off-by" line.
-
-## **Do you intend to add a new feature or change an existing one?**
-
-* Suggest your change on the [devel mail list](https://www.open-mpi.org/community/lists/ompi.php) and start writing code.  The [developer level technical information on the internals of Open MPI](https://www.open-mpi.org/faq/?category=developers) may also be useful for large scale features.
-
-* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
-
-## **Do you have questions about the source code?**
-
-* First checkout the [developer level technical information on the internals of Open MPI](https://www.open-mpi.org/faq/?category=developers).  A paper describing the [multi-component architecture](https://www.open-mpi.org/papers/ics-2004/ics-2004.pdf)  of Open MPI may also be helpful.  The [devel mail list](https://www.open-mpi.org/community/lists/ompi.php) is a good place to post questions about the source code as well.
-
-## Style
-
-There are a small number of style rules for Open MPI:
-
-1. For all code:
-    * 4 space tabs.  No more, no less.
-    * No tab characters *at all*.  2 indentations are 8 spaces — not a tab.
-    * m4 code is a bit weird in terms of indentation: we don't have a
-      good, consistent indentation style in our existing code.  But
-      still: no tab characters at all.
-1. For C code:
-    * We prefer if all blocks are enclosed in `{}` (even 1-line
-      blocks).
-    * We prefer that if you are testing equality with a constant, put
-      the constant on the *left* of the `==`.  E.g., `if (NULL ==
-      ptr)`.
-    * If there are no parameters to a C function, declare it with
-      `(void)` (vs. `()`).
-
-That's about it.  Thank you!
-
-— The Open MPI Team
+Please see the [Contributing
+guidelines](https://docs.open-mpi.org/en/main/contributing.html) for
+more details on how to contribute to Open MPI.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,78 +6,157 @@ There are many ways to contribute.  Here are a few:
 #. Subscribe to `the mailing lists
    <https://www.open-mpi.org/community/lists/ompi.php>`_ and become
    active in the discussions.
-#. Obtain `a Git clone <https://www.open-mpi.org/source/>`_ of Open
+
+#. Obtain `a Git clone <https://github.com/open-mpi/ompi/>`_ of Open
    MPI's code base and start looking through the code.
 
    .. note:: Be sure to see the :doc:`Developers guide
-             </developers/index>` for technical details about the code
-             base and how to build it).
+             </developers/index>` for technical details about the
+             code base and how to build it).
 
-#. Write your own components and contribute them back to the main code
+#. Report bug fixes to the main code base.
+
+   * First, ensure the bug was not already reported by searching
+     `existing      GitHub Issues
+     <https://github.com/open-mpi/ompi/issues>`_.
+   * If you're unable to find an open issue addressing the problem,
+     `open a new one <https://github.com/open-mpi/ompi/issues/new>`_.
+
+#. Submit bug fixes to the main code base.
+
+   * Awesome!  Open a new GitHub pull request with the patch.
+   * Ensure the PR description clearly describes the problem and
+     solution. If there is an existing GitHub issue open describing
+     this bug, please include it in the description so we can track
+     them together.
+   * Be sure to see the :ref:`Open source contributions
+     <contributing-open-source-label>` section, below.
+
+#. Submit feature enhancements and/or new components to the main code
    base.
-#. Contribute bug fixes and feature enhancements to the main code
-   base.
+
+   * Awesome!  We love new ideas!
+   * You might want to suggest your change on the `devel mail list
+     <https://www.open-mpi.org/community/lists/ompi.php>`_ before you
+     start writing code.  The `developer level technical information
+     on the internals of Open MPI
+     <https://www.open-mpi.org/faq/?category=developers>`_ may also be
+     useful for large scale features.
+   * If you're contributing a large new piece of functionality, that
+     will be best viewed if you |mdash| or someone, anyone |mdash| is
+     also stepping up to help maintain that functionality over time.
+     We love new ideas and new features, but we do need to be
+     realistic in what we can reliably test and deliver to our users.
+   * Be sure to see the :ref:`Open source contributions
+     <contributing-open-source-label>` section, below.
+
 #. Provide testing resources:
 
    #. For Github Pull Request Continuous Integration (CI)
    #. For nightly snapshot builds and testing
-
 
 .. _contributing-open-source-label:
 
 Open source contributions
 -------------------------
 
-All code contributions are submitted as pull requests on the `Open MPI
-GitHub repository <https://github.com/open-mpi/ompi/>`_.
+All code contributions are submitted as pull requests on the `Open
+MPI GitHub repository <https://github.com/open-mpi/ompi/>`_.
 
-We need to have an established intellectual property pedigree of the
+.. important:: All commits must include a ``Signed-off-by:`` line,
+               indicating the submitter's agreement to the :ref:`Open
+               MPI Contributor's Declaration
+               <contributing-contributors-declaration-label>`.
+
+.. _contributing-contributors-declaration-label:
+
+Contributor's Declaration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to ensure that we can keep distributing Open MPI under our
+:doc:`open source license </license/index>`, we need to ensure that
+all contributions are compatible with that license.  Put differently:
+we need to have an established intellectual property pedigree of the
 code in Open MPI.  This means being able to ensure that all code
 included in Open MPI is free, open source, and able to be distributed
 under :doc:`the BSD license </license/index>`.
 
 Open MPI has therefore adopted requirements based on the signed-off-by
-process as described in the `Submitting patches
-<https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin>`_
-section of the Linux kernel documentation. Each proposed contribution
-to the Open MPI code base must include the text "Signed-off-by:"
-followed by the contributor's name and email address. This is a
-developer's certification that he or she has the right to submit the
-patch for inclusion into the project, and indicates agreement to the
-Developer's Certificate of Origin:
+process as described in Section 11 of the Linux kernel document on
+`Submitting Patches
+<https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin>`_.
+Each proposed contribution to the Open MPI code base must include the
+text ``Signed-off-by:`` followed by the contributor's name and email
+address. This is a developer's certification that he or she has the
+right to submit the patch for inclusion into the project, and
+indicates agreement to the Developer's Certificate of Origin:
 
-   By making a contribution to this project, I certify that:
+    By making a contribution to this project, I certify that:
 
-   #. The contribution was created in whole or in part by me and I
-      have the right to submit it under the Open MPI open source
-      license; or
+    #. The contribution was created in whole or in part by me and I
+       have the right to submit it under the :doc:`Open MPI open
+       source license </license/index>`; or
 
-   #. The contribution is based upon previous work that, to the best
-      of my knowledge, is covered under an appropriate open source
-      license and I have the right under that license to submit that
-      work with modifications, whether created in whole or in part by
-      me, under the Open MPI open source license (unless I am
-      permitted to submit under a different license); or
+    #. The contribution is based upon previous work that, to the best
+       of my knowledge, is covered under an appropriate open source
+       license and I have the right under that license to submit that
+       work with modifications, whether created in whole or in part by
+       me, under the :doc:`Open MPI open source license
+       </license/index/>` (unless I am permitted to submit under a
+       different license); or
 
-   #. The contribution was provided directly to me by some other
-      person who certified (1) or (2) and I have not modified it.
+    #. The contribution was provided directly to me by some other
+       person who certified (1) or (2) and I have not modified it.
 
-   #. I understand and agree that this project and the contribution
-      are public and that a record of the contribution (including all
-      personal information I submit with it, including my sign-off) is
-      maintained indefinitely and may be redistributed consistent with
-      this project and the open source license(s) involved.
+    #. I understand and agree that this project and the contribution
+       are public and that a record of the contribution (including all
+       personal information I submit with it, including my sign-off)
+       is maintained indefinitely and may be redistributed consistent
+       with this project and the open source license(s) involved.
 
-Proposed contributions failing to include the "Signed-off-by:"
+Proposed contributions failing to include the ``Signed-off-by:``
 certification will not be accepted into any Open MPI code
 repository. The community reserves the right to revert any commit
 inadvertently made without the required certification.
 
-This policy prevents a situation where intellectual property gets into
-the Open MPI code base and then someone later claims that we owe them
-money for it.  Open MPI is a free, open source code base.  We intend
-it to remain that way.
+.. note:: This policy prevents a situation where intellectual property
+          gets into the Open MPI code base and then someone later
+          claims that we owe them money for it.  Open MPI is a free,
+          open source code base.  We intend it to remain that way.
 
+If you have not already done so, please ensure that *every* commit in
+your pull request contains the ``Signed-off-by:`` line.
+
+.. admonition:: Pro tip
+   :class: tip
+
+   You can use the ``-s`` flag to the ``git commit`` command (i.e.,
+   ``git commit -s ...``) to automatically add the appropriate
+   ``Signed-off-by:`` line to your commit message.
+
+Code style
+^^^^^^^^^^
+
+There are a small number of style rules for Open MPI:
+
+#. For all code:
+
+   * 4 space tabs.  No more, no less.
+   * No tab characters **at all**.  2 indentations are 8 spaces
+     |mdash| not a tab.
+   * m4 code is a bit weird in terms of indentation: we don't have a
+     good, consistent indentation style in our existing code.  But
+     still: no tab characters at all.
+
+#. For C code:
+
+   * We prefer if all blocks are enclosed in ``{}`` (even 1-line
+     blocks).
+   * We prefer that if you are testing equality with a constant, put
+     the constant on the **left** of the ``==``.  E.g., ``if (NULL ==
+     ptr)``.
+   * If there are no parameters to a C function, declare it with
+     ``(void)`` (vs. ``()``).
 
 Closed source contributions
 ---------------------------
@@ -89,9 +168,8 @@ from us.  Such is the reality of software development in today's
 global economy.
 
 As such, it is perfectly acceptable to make non-free / non-open-source
-contributions to Open MPI.
-
-We obviously cannot accept such contributions into the main code base,
-but you are free to distribute plugins, enhancements, etc. as you see
-fit.  Indeed, the :doc:`the BSD license </license/index>` is extremely
-liberal in its redistribution provisions.
+contributions to Open MPI.  We obviously cannot accept such
+contributions into the main code base, but you are free to distribute
+plugins, enhancements, etc. as you see fit.  Indeed, the :doc:`the BSD
+license </license/index>` is extremely liberal in its redistribution
+provisions.

--- a/docs/developers/rst-for-markdown-expats.rst
+++ b/docs/developers/rst-for-markdown-expats.rst
@@ -98,16 +98,16 @@ Chapter and section delimiters
     .. code-block:: rst
 
        Subsection 1: hello world
-       -------------------------
+       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. code-block:: rst
 
        Subsubsection 1: hello world
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ++++++++++++++++++++++++++++
 
     Meaning: underlines made of ``=`` denotes chapters, underlines
-    made of ``-`` denotes sections, underlines made of ``-`` denotes
-    subsections, and underlines made of ``^`` denote subsubsections.
+    made of ``-`` denotes sections, underlines made of ``^`` denotes
+    subsections, and underlines made of ``+`` denote subsubsections.
 
 Multi-line code/fixed-width font
 --------------------------------


### PR DESCRIPTION
Consolidate most of the content from .github/CONTRIBUTING.md into docs/contributing.rst.

This PR is also paired with two others to further consolidate everything into docs/contributing.rst:

1. A wiki update to consolidate the contribution text to docs/contributing.rst.
2. An ompi-www PR (https://github.com/open-mpi/ompi-www/pull/429) to consolidate the contribution pages on the web site to docs/contributing.rst.

There's also a 2nd, minor commit on this PR that fixes up the sub/subsubsection annotations in the developer's documentation.