### PR TITLE
v4.0.x: Do not invoke the errorhandler on MPI_SUCCESS.

### DIFF
--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -77,7 +77,7 @@ int MPI_Start(MPI_Request *request)
         ret = (*request)->req_start(1, request);
 
         OPAL_CR_EXIT_LIBRARY();
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_REQUEST, FUNC_NAME);
+        OMPI_ERRHANDLER_NOHANDLE_RETURN(ret, ret, FUNC_NAME);
 
     case OMPI_REQUEST_NOOP:
         /**


### PR DESCRIPTION
Use OMPI_ERRHANDLER_NOHANDLE_RETURN instead of INVOKE.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 8bf82fca2581cce028dda509a5554c3604f3e268)