### PR TITLE
v5.0.x: Fix typos in ompi/ subdirectory

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -1333,7 +1333,7 @@ static int set_value(ompi_attribute_type_t type, void *object,
     ret = opal_hash_table_set_value_uint32(*attr_hash, key, new_attr);
 
     /* Increase the reference count of the object, only if there was no
-       old atribute/no old entry in the object's key hash */
+       old attribute/no old entry in the object's key hash */
     if (OMPI_SUCCESS == ret && !had_old) {
         OBJ_RETAIN(keyval);
     }

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -52,7 +52,7 @@
  *
  * MPI_HOST is set to MPI_PROC_NULL (per MPI-1, see 7.1.1, p192).
  *
- * MPI_IO is set to MPI_ANY_SOURCE.  We may need to revist this.
+ * MPI_IO is set to MPI_ANY_SOURCE.  We may need to revisit this.
  *
  * MPI_WTIME_IS_GLOBAL is set to 0 (a conservative answer).
  *
@@ -78,7 +78,7 @@
  * integer-valued attributes, *BUT* at least the MPI_WIN_SIZE is an
  * MPI_Aint, so in terms of consistency, both should be the same --
  * hence, we treat them as MPI-2 Fortran integer-valued attributes.
- * All three of these atrributes have NULL_COPY_FN copy functions; it
+ * All three of these attributes have NULL_COPY_FN copy functions; it
  * doesn't make sense to copy them to new windows (because they're
  * values specific and unique to each window) -- especially when
  * WIN_CREATE will explicitly set them on new windows anyway.

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -2049,7 +2049,7 @@ int ompi_comm_get_rprocs (ompi_communicator_t *local_comm, ompi_communicator_t *
         PMIX_DATA_BUFFER_RELEASE(sbuf);
     }
 
-    /* broadcast name list to all proceses in local_comm */
+    /* broadcast name list to all processes in local_comm */
     rc = local_comm->c_coll->coll_bcast( recvbuf, rlen, MPI_BYTE,
                                         local_leader, local_comm,
                                         local_comm->c_coll->coll_bcast_module);

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -725,7 +725,7 @@ static int ompi_comm_activate_complete (ompi_communicator_t **newcomm, ompi_comm
     /**
      * Check to see if this process is in the new communicator.
      *
-     * Specifically, this function is invoked by all proceses in the
+     * Specifically, this function is invoked by all processes in the
      * old communicator, regardless of whether they are in the new
      * communicator or not.  This is because it is far simpler to use
      * MPI collective functions on the old communicator to determine
@@ -736,7 +736,7 @@ static int ompi_comm_activate_complete (ompi_communicator_t **newcomm, ompi_comm
      *
      * That being said, only processes in the new communicator need to
      * select a coll module for the new communicator.  More
-     * specifically, proceses who are not in the new communicator
+     * specifically, processes who are not in the new communicator
      * should *not* select a coll module -- for example,
      * ompi_comm_rank(newcomm) returns MPI_UNDEFINED for processes who
      * are not in the new communicator.  This can cause errors in the

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -84,7 +84,7 @@ OBJ_CLASS_INSTANCE(ompi_communicator_t, opal_infosubscriber_t,
                    ompi_comm_destruct);
 
 /* This is the counter for the number of communicators, which contain
-   process with more than one jobid. This counter is a usefull
+   process with more than one jobid. This counter is a useful
    shortcut for finalize and abort. */
 int ompi_comm_num_dyncomm=0;
 
@@ -231,7 +231,7 @@ int ompi_comm_init_mpi3 (void)
     ompi_attr_get_ref();
 
     /* We have to create a hash (although it is legal to leave this
-       filed NULL -- the attribute accessor functions will intepret
+       filed NULL -- the attribute accessor functions will interpret
        this as "there are no attributes cached on this object")
        because MPI_COMM_WORLD has some predefined attributes. */
     ompi_attr_hash_init(&ompi_mpi_comm_world.comm.c_keyhash);

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -273,7 +273,7 @@ struct ompi_communicator_t {
                to a child*/
     int c_id_start_index; /* the starting index of the block of cids
                  allocated to this communicator*/
-    uint32_t c_epoch;  /* Identifier used to differenciate between two communicators
+    uint32_t c_epoch;  /* Identifier used to differentiate between two communicators
                           using the same c_contextid (not at the same time, obviously) */
 
     ompi_group_t        *c_local_group;
@@ -346,7 +346,7 @@ struct ompi_communicator_t {
 typedef struct ompi_communicator_t ompi_communicator_t;
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  *
  * The following ompi_predefined_xxx_t structure is used to maintain
  * backwards binary compatibility for MPI applications compiled
@@ -395,7 +395,7 @@ typedef struct ompi_communicator_t ompi_communicator_t;
  *
  * - union of struct and padding - Similar to current implementation
  *   except using a union for the parent.  This worked except in cases
- *   where the compilers did not support C99 union static initalizers.
+ *   where the compilers did not support C99 union static initializers.
  *   It would have been a pain to convert a bunch of the code to use
  *   non-static initializers (e.g., MPI datatypes).
  */
@@ -452,7 +452,7 @@ OMPI_DECLSPEC extern ompi_predefined_communicator_t ompi_mpi_comm_null;
 
 /*
  * These variables are for the MPI F03 bindings (F03 must bind Fortran
- * varaiables to symbols; it cannot bind Fortran variables to the
+ * variables to symbols; it cannot bind Fortran variables to the
  * address of a C variable).
  */
 OMPI_DECLSPEC extern ompi_predefined_communicator_t *ompi_mpi_comm_world_addr;
@@ -480,7 +480,7 @@ OMPI_DECLSPEC extern ompi_predefined_communicator_t *ompi_mpi_comm_null_addr;
  * ompi_comm_invalid() as originally coded -- per the MPI-1
  * definition, where MPI_COMM_NULL is an invalid communicator.
  * The MPI_Comm_c2f() function, therefore, calls
- * ompi_comm_invalid() but also explictily checks to see if the
+ * ompi_comm_invalid() but also explicitly checks to see if the
  * handle is MPI_COMM_NULL.
  */
 static inline int ompi_comm_invalid (const ompi_communicator_t* comm)
@@ -1072,7 +1072,7 @@ int ompi_comm_determine_first ( ompi_communicator_t *intercomm,
                                 int high );
 
 /**
- * This is a routine determining wether the local or the
+ * This is a routine determining whether the local or the
  * remote group will be first in the new intra-comm.
  * It does not communicate to exchange the "high" values; used in Agree
  */

--- a/ompi/communicator/ft/comm_ft_reliable_bcast.c
+++ b/ompi/communicator/ft/comm_ft_reliable_bcast.c
@@ -170,7 +170,7 @@ static void ompi_comm_rbcast_bml_recv_cb(
     msg = (ompi_comm_rbcast_message_t*) descriptor->des_segments->seg_addr.pval;
 
     OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
-                         "%s %s: Info: Recieved rbcast tag for communicator with CID %3d:%d",
+                         "%s %s: Info: Received rbcast tag for communicator with CID %3d:%d",
                          OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch));
 
     /* Find the target comm */
@@ -190,7 +190,7 @@ static void ompi_comm_rbcast_bml_recv_cb(
     /* Check if this is a delayed rbcast for an old communicator whose CID has been reused */
     if(OPAL_UNLIKELY( comm->c_epoch != msg->epoch )) {
         OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
-                             "%s %s: Info: Received a late rbcast order for the communicator with CID %3d:%d when is is now at epoch %d - ignoring, nothing to do",
+                             "%s %s: Info: Received a late rbcast order for the communicator with CID %3d:%d when it is now at epoch %d - ignoring, nothing to do",
                              OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch, comm->c_epoch));
         return;
     }
@@ -204,7 +204,7 @@ static void ompi_comm_rbcast_bml_recv_cb(
         }
     }
     else {
-        /* During finalize, we loosly synchronize so it may happen 
+        /* During finalize, we loosely synchronize so it may happen 
          * that we keep receiving messages after we deregistered the type.
          * Any other time, this is indicative of a problem.
          */

--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -91,7 +91,7 @@ typedef struct ompi_datatype_t ompi_datatype_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_datatype_t);
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See opal/communicator/communicator.h comments with struct opal_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -423,7 +423,7 @@ OMPI_DECLSPEC int ompi_datatype_pack_external_size( const char datarep[], int in
  * converted to (1,larger_datatype).  This comes up in pack/unpack if
  * the datatype is [int4b,empty4b] for example.  With that datatype the
  * (count,datatype) path has to loop over the count processing each
- * occurrance of the datatype, but a larger type created via
+ * occurrence of the datatype, but a larger type created via
  * MPI_Type_contiguous(count,datatype,) will have a single description
  * entry describing the whole vector and go through pack/unpack much
  * faster.

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -365,8 +365,8 @@ int32_t ompi_datatype_copy_args( const ompi_datatype_t* source_data,
 {
     ompi_datatype_args_t* pArgs = (ompi_datatype_args_t*)source_data->args;
 
-    /* Increase the reference count of the datatype enveloppe. This
-     * prevent us from making extra copies for the enveloppe (which is mostly
+    /* Increase the reference count of the datatype envelope. This
+     * prevent us from making extra copies for the envelope (which is mostly
      * a read only memory).
      */
     if( NULL != pArgs ) {
@@ -391,7 +391,7 @@ int32_t ompi_datatype_release_args( ompi_datatype_t* pData )
     OPAL_THREAD_ADD_FETCH32(&pArgs->ref_count, -1);
     if( 0 == pArgs->ref_count ) {
         /* There are some duplicated datatypes around that have a pointer to this
-         * args. We will release them only when the last datatype will dissapear.
+         * args. We will release them only when the last datatype will disappear.
          */
         for( i = 0; i < pArgs->cd; i++ ) {
             if( !(ompi_datatype_is_predefined(pArgs->d[i])) ) {
@@ -448,7 +448,7 @@ static inline int __ompi_datatype_pack_description( ompi_datatype_t* datatype,
     position = (int*)next_packed;
     next_packed += sizeof(int) * args->cd;
 
-    /* copy the aray of counts (32 bits aligned) */
+    /* copy the array of counts (32 bits aligned) */
     memcpy( next_packed, args->i, sizeof(int) * args->ci );
     next_packed += args->ci * sizeof(int);
 

--- a/ompi/datatype/ompi_datatype_external.c
+++ b/ompi/datatype/ompi_datatype_external.c
@@ -57,7 +57,7 @@ int ompi_datatype_pack_external(const char datarep[], const void *inbuf, int inc
         return MPI_ERR_TRUNCATE;
     }
 
-    /* Prepare the iovec with all informations */
+    /* Prepare the iovec with all information */
     invec.iov_base = (char*) outbuf + (*position);
     invec.iov_len = size;
 
@@ -97,7 +97,7 @@ int ompi_datatype_unpack_external (const char datarep[], const void *inbuf, MPI_
         return MPI_ERR_TRUNCATE;
     }
 
-    /* Prepare the iovec with all informations */
+    /* Prepare the iovec with all information */
     outvec.iov_base = (char*) inbuf + (*position);
     outvec.iov_len = size;
 

--- a/ompi/datatype/ompi_datatype_internal.h
+++ b/ompi/datatype/ompi_datatype_internal.h
@@ -455,7 +455,7 @@ extern const ompi_datatype_t* ompi_datatype_basicDatatypes[OMPI_DATATYPE_MPI_MAX
 /*
  * Initialization for these types is deferred until runtime.
  *
- * Using this macro implies that at this point not all informations needed
+ * Using this macro implies that at this point not all information needed
  * to fill up the datatype are known. We fill them with zeros and then later
  * when the datatype engine will be initialized we complete with the
  * correct information. This macro should be used for all composed types.

--- a/ompi/debuggers/MPI_Handles_interface.txt
+++ b/ompi/debuggers/MPI_Handles_interface.txt
@@ -507,7 +507,7 @@ create their own requests.
   - Whether the underlying object has been "freed" by the MPI
     implementation (i.e., made inactive, and would have actually been
     freed if not running under a debugger)
-  - Peer process(es) invovled with the request (if available)
+  - Peer process(es) involved with the request (if available)
   - If pt2pt, communicator associated with the request
   - If file, file associated with the request
   - If pt2pt or file, whether the data transfer has started yet
@@ -570,7 +570,7 @@ C++: MPI::Status
 
 A user-accessible struct that contains information about a completed
 communication.  The MPI status is a little different from other MPI
-handles in that it is the object itselt; not a handle to an underlying
+handles in that it is the object itself; not a handle to an underlying
 MPI status.  For example, if a point-to-point communication was
 started with a wildcard receive, the status will contain information
 about the peer to whom the communication completed.  There are no

--- a/ompi/debuggers/dlopen_test.c
+++ b/ompi/debuggers/dlopen_test.c
@@ -117,7 +117,7 @@ static int do_test(void)
     /* If we're using libltdl, it will find the .la file and may
        discover that it needs to open the actual file in the .libs
        directory.  If we're not using libltdl, then we won't know
-       about the magic .la file / .libs directory.  Hueristic: if we
+       about the magic .la file / .libs directory.  Heuristic: if we
        get here, manually prefix the filename with .libs/ and try
        again. */
     char *rel_filename;

--- a/ompi/debuggers/mpihandles_interface.h
+++ b/ompi/debuggers/mpihandles_interface.h
@@ -153,7 +153,7 @@ struct mpidbg_process_t {
     int mpi_comm_world_rank;
 };
 /* ==> JMS Should we just use mqs_process_location instead?  George
-   thinks that this is unncessary -- perhaps due to the fact that we
+   thinks that this is unnecessary -- perhaps due to the fact that we
    could use mqs_process_location...?  Need to get some feedback from
    others on this one.  Need to check Euro PVM/MPI '06 paper... */
 
@@ -503,8 +503,8 @@ extern char mpidbg_dll_is_big_endian;
    the DLL. */
 extern char mpidbg_dll_bitness;
 
-/* Global variable *in the DLL* describing the DLL's capabilties with
-   regards to communicators.  This value is valid after a successfull
+/* Global variable *in the DLL* describing the DLL's capabilities with
+   regards to communicators.  This value is valid after a successful
    call to mpidbg_init_per_process(). */
 extern enum mpidbg_comm_capabilities_t mpidbg_comm_capabilities;
 
@@ -515,12 +515,12 @@ extern enum mpidbg_comm_capabilities_t mpidbg_comm_capabilities;
    be able to map this name to a valid handle.  MPI implementations
    not requiring this mapping can either have a NULL value for this
    variable or have a single entry that has a NULL string value.  This
-   variable is not valid until after a successfull call to
+   variable is not valid until after a successful call to
    mpidbg_init_per_process().  */
 extern struct mpidbg_name_map_t *mpidbg_comm_name_map;
 
-/* Global variable *in the DLL* describing the DLL's capabilties with
-   regards to error handlers.  This value is valid after a successfull
+/* Global variable *in the DLL* describing the DLL's capabilities with
+   regards to error handlers.  This value is valid after a successful
    call to mpidbg_init_per_process(). */
 extern enum mpidbg_errhandler_capabilities_t mpidbg_errhandler_capabilities;
 

--- a/ompi/debuggers/ompi_common_dll.c
+++ b/ompi/debuggers/ompi_common_dll.c
@@ -505,7 +505,7 @@ int ompi_fill_in_type_info(mqs_image *image, char **message)
         }
     }
 
-    /* All the types are here. Let's succesfully return. */
+    /* All the types are here. Let's successfully return. */
     *message = NULL;
     return mqs_ok;
 

--- a/ompi/debuggers/ompi_debuggers.c
+++ b/ompi/debuggers/ompi_debuggers.c
@@ -58,7 +58,7 @@
  * information on optimized build, and as a result we are unable to access
  * the fields structure (i.e. to get their displacement). This file is
  * included in the optimized build just to provide us with this missing
- * informations. Therefore, it always have to be compiled with the -g flag,
+ * information. Therefore, it always have to be compiled with the -g flag,
  * otherwise the type information will be missing and the parallel
  * debuggers will be unable to initialize the Open MPI debug library.
  */

--- a/ompi/debuggers/ompi_mpihandles_dll.c
+++ b/ompi/debuggers/ompi_mpihandles_dll.c
@@ -286,7 +286,7 @@ int mpidbg_init_per_image(mqs_image *image, const mqs_image_callbacks *icb,
     handle_types->hi_cxx_win =
         mqs_find_type(image, "MPI::Win", mqs_lang_cplus);
 
-    /* Tell the debuger what capabilities we have */
+    /* Tell the debugger what capabilities we have */
     mpidbg_comm_capabilities =
         MPIDBG_COMM_CAP_BASIC |
         MPIDBG_COMM_CAP_STRING_NAMES |

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -79,7 +79,7 @@
 
 /* Notice to developers!!!!
  * The following include files with _dbg.h suffixes contains definitions
- * that are shared between the debuggger plugins and the OMPI code base.
+ * that are shared between the debugger plugins and the OMPI code base.
  * This is done instead of including the non-_dbg suffixed files because
  * of the different way compilers may handle extern definitions. The
  * particular case that is causing problems is when there is an extern

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -2065,7 +2065,7 @@ static int start_dvm(char **hostfiles, char **dash_host)
         set_handler_default(SIGCHLD);
 
         /* Unblock all signals, for many of the same reasons that
-         we set the default handlers, above.  This is noticable
+         we set the default handlers, above.  This is noticeable
          on Linux where the event library blocks SIGTERM, but we
          don't want that blocked by the prted (or, more
          specifically, we don't want it to be blocked by the

--- a/ompi/dpm/help-dpm.txt
+++ b/ompi/dpm/help-dpm.txt
@@ -48,7 +48,7 @@ We are not able to proceed. Please correct your application.
 #
 [execv-error]
 
-The singleton application was not able to find an executabe in your
+The singleton application was not able to find an executable in your
 PATH or in the directory where PRTE was initially installed, and
 therefore cannot continue.
 

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -189,7 +189,7 @@ int ompi_mpi_errcode_init (void)
     CONSTRUCT_ERRCODE( ompi_err_conversion, MPI_ERR_CONVERSION, "MPI_ERR_CONVERSION: error in data conversion" );
     CONSTRUCT_ERRCODE( ompi_err_disp, MPI_ERR_DISP, "MPI_ERR_DISP: invalid displacement" );
     CONSTRUCT_ERRCODE( ompi_err_dup_datarep, MPI_ERR_DUP_DATAREP, "MPI_ERR_DUP_DATAREP: error duplicating data representation" );
-    CONSTRUCT_ERRCODE( ompi_err_file_exists, MPI_ERR_FILE_EXISTS, "MPI_ERR_FILE_EXISTS: file exists alreay" );
+    CONSTRUCT_ERRCODE( ompi_err_file_exists, MPI_ERR_FILE_EXISTS, "MPI_ERR_FILE_EXISTS: file exists already" );
     CONSTRUCT_ERRCODE( ompi_err_file_in_use, MPI_ERR_FILE_IN_USE, "MPI_ERR_FILE_IN_USE: file already in use" );
     CONSTRUCT_ERRCODE( ompi_err_file, MPI_ERR_FILE, "MPI_ERR_FILE: invalid file" );
     CONSTRUCT_ERRCODE( ompi_err_info_key, MPI_ERR_INFO_KEY, "MPI_ERR_INFO_KEY: invalid key argument for info object" );

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -420,7 +420,7 @@ int ompi_errhandler_proc_failed_internal(ompi_proc_t* ompi_proc, int status, boo
      * forward through errors in collectives" as this is less intrusive to the
      * code base.) */
     if( forward ) {
-        /* TODO: this to become redundand when pmix has rbcast */
+        /* TODO: this to become redundant when pmix has rbcast */
         ompi_comm_failure_propagate(&ompi_mpi_comm_world.comm, ompi_proc, status);
         /* Let pmix know: flush modex information, propagate to connect/accept
          * jobs; we will tell our local daemon, and it will do the proper thing */

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -121,7 +121,7 @@ struct ompi_errhandler_t {
 typedef struct ompi_errhandler_t ompi_errhandler_t;
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */

--- a/ompi/etc/Makefile.am
+++ b/ompi/etc/Makefile.am
@@ -47,7 +47,7 @@ install-data-local:
 
 # Only remove if exactly the same as what in our tree
 # NOTE TO READER: Bourne shell if ... fi evaluates the body if
-#    the return of the evaluted command is 0 (as opposed to non-zero
+#    the return of the evaluated command is 0 (as opposed to non-zero
 #    as used by everyone else)
 uninstall-local:
 	@ p="$(ompi_config_files)"; \

--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -69,7 +69,7 @@ OBJ_CLASS_INSTANCE(ompi_file_t,
 
 
 /*
- * Initialize file handling bookeeping
+ * Initialize file handling bookkeeping
  */
 int ompi_file_init(void)
 {

--- a/ompi/file/file.h
+++ b/ompi/file/file.h
@@ -101,7 +101,7 @@ struct ompi_file_t {
 typedef struct ompi_file_t ompi_file_t;
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -136,7 +136,7 @@ int ompi_file_init(void);
 
 /**
  * Back-end to MPI_FILE_OPEN: create a file handle, select an io
- * component to use, and have that componet open the file.
+ * component to use, and have that component open the file.
  *
  * @param comm Communicator
  * @param filename String filename

--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -202,7 +202,7 @@ int ompi_group_incl(ompi_group_t* group, int n, const int *ranks, ompi_group_t *
         len[2] = ompi_group_calc_sporadic ( n ,ranks );
         len[3] = ompi_group_calc_bmap     ( n , group->grp_proc_count ,ranks );
 
-        /* determin minimum length */
+        /* determine minimum length */
         method = ompi_group_minloc ( len, 4 );
     }
 #endif

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -109,7 +109,7 @@ typedef struct ompi_group_t ompi_group_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_group_t);
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -344,7 +344,7 @@ int ompi_group_calc_bmap ( int n, int orig_size , const int *ranks );
 int ompi_group_minloc (int list[], int length);
 
 /**
- * @brief Helper function for retreiving the proc of a group member in a dense group
+ * @brief Helper function for retrieving the proc of a group member in a dense group
  *
  * This function exists to handle the translation of sentinel group members to real
  * ompi_proc_t's. If a sentinel value is found and allocate is true then this function

--- a/ompi/group/group_bitmap.c
+++ b/ompi/group/group_bitmap.c
@@ -54,13 +54,13 @@ int ompi_group_translate_ranks_bmap ( ompi_group_t *parent_group,
             m = ranks1[j];
             count = 0;
             tmp = ( 1 << (m % BSIZE) );
-            /* check if the bit that correponds to the parent rank is set in the bitmap */
+            /* check if the bit that corresponds to the parent rank is set in the bitmap */
             if ( tmp == (child_group->sparse_data.grp_bitmap.grp_bitmap_array[(int)(m/BSIZE)]
                          & (1 << (m % BSIZE)))) {
                 /*
                  * add up how many bits are set, till we get to the bit of parent
                  * rank that we want. The rank in the child will be the sum of the bits
-                 * that are set on the way till we get to the correponding bit
+                 * that are set on the way till we get to the corresponding bit
                  */
                 for (i=0 ; i<=(int)(m/BSIZE) ; i++) {
                     for (k=0 ; k<BSIZE ; k++) {
@@ -131,7 +131,7 @@ int ompi_group_div_ceil (int num, int den)
 /*
  * This functions is to check that all ranks in the included list of ranks
  * are monotonically increasing. If not, the bitmap format can not be used
- * since we won't be able to translate the ranks corrently since the algorithms
+ * since we won't be able to translate the ranks correctly since the algorithms
  * assume that the ranks are in order in the bitmap list.
  */
 static bool check_ranks (int n, const int *ranks) {

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -334,7 +334,7 @@ static void ompi_group_construct(ompi_group_t *new_group)
 
     /* Note that we do *NOT* increase the refcount on all the included
        procs here because that is handled at a different level (e.g.,
-       the proc counts are not decreased during the desstructor,
+       the proc counts are not decreased during the destructor,
        either). */
 
     /* assign entry in fortran <-> c translation array */

--- a/ompi/group/group_plist.c
+++ b/ompi/group/group_plist.c
@@ -197,7 +197,7 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
 int ompi_group_difference(ompi_group_t* group1, ompi_group_t* group2,
                           ompi_group_t **new_group) {
 
-    /* local varibles */
+    /* local variables */
     int new_group_size, overlap_count, rc;
     ompi_group_t *new_group_pointer;
     ompi_proc_t *proc1_pointer;

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -819,7 +819,7 @@ enum {
 /* If not building or configured --enable-mpi1-compatibility, then
  * we don't want these datatypes, instead we define MPI_COMBINER_*_INTEGER
  * to our Static Assert message if the compiler supports
- * that staticly assert with a nice message.
+ * that static assert with a nice message.
  */
 #    if (OMPI_REMOVED_USE_STATIC_ASSERT)
 #        define MPI_COMBINER_HVECTOR_INTEGER THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_COMBINER_HVECTOR_INTEGER, MPI_COMBINER_HVECTOR);
@@ -1196,7 +1196,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub;
 /* If not building or configured --enable-mpi1-compatibility, then
  * we don't want these datatypes, instead we define MPI_UB and
  * MPI_LB to our Static Assert message if the compiler supports
- * that staticly assert with a nice message.
+ * that static assert with a nice message.
  */
 #    if (OMPI_REMOVED_USE_STATIC_ASSERT)
 #        define MPI_UB THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_UB, MPI_Type_create_resized);

--- a/ompi/include/mpif-sentinels.h
+++ b/ompi/include/mpif-sentinels.h
@@ -36,7 +36,7 @@
 !     MPI_IN_PLACE has the same rationale as MPI_BOTTOM.
       integer MPI_IN_PLACE
 !     Making MPI_ARGV_NULL be the same type as the parameter that is
-!     exepected in the F90 binding for MPI_COMM_SPAWN means that we
+!     expected in the F90 binding for MPI_COMM_SPAWN means that we
 !     don't need another interface for MPI_COMM_SPAWN.
       character MPI_ARGV_NULL(1)
 !     Ditto for MPI_ARGVS_NULL / MPI_COMM_SPAWN_MULTIPLE.

--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -55,7 +55,7 @@ static inline int memchecker_convertor_call (int (*f)(void *, size_t), opal_conv
         /*  We have a contiguous type. */
         f( (void *)pConvertor->pBaseBuf , pConvertor->local_size);
     } else {
-        /* Now we got a noncontigous data. */
+        /* Now we got a non-contiguous data. */
         uint32_t elem_pos = 0, i;
         ptrdiff_t  stack_disp  = 0;
         dt_elem_desc_t*  description = pConvertor->use_desc->desc;
@@ -109,7 +109,7 @@ static inline int memchecker_call (int (*f)(void *, size_t), const void * addr,
         /*  We have a contiguous type. */
         f( (void*)((char *)addr+datatype->super.true_lb), datatype->super.size * count );
     } else {
-        /* Now we got a noncontigous type. */
+        /* Now we got a non-contiguous type. */
         uint32_t         elem_pos = 0, i;
         ptrdiff_t        stack_disp  = 0;
         dt_elem_desc_t*  description = datatype->super.opt_desc.desc;

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -55,7 +55,7 @@ struct ompi_info_t {
 typedef struct ompi_info_t ompi_info_t;
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -376,7 +376,7 @@ static int ompi_mpi_instance_init_common (void)
            default is specified before forcing "all" in case that is not what
            the user desires. Note that we do *NOT* set this value as an
            environment variable, just so that it won't be inherited by
-           any spawned processes and potentially cause unintented
+           any spawned processes and potentially cause unintended
            side-effects with launching RTE tools... */
         mca_base_var_set_value(ret, allvalue, 4, MCA_BASE_VAR_SOURCE_DEFAULT, NULL);
     }
@@ -474,7 +474,7 @@ static int ompi_mpi_instance_init_common (void)
     }
 
     /* Initialize the op framework. This has to be done *after*
-       ddt_init, but befor mca_coll_base_open, since some collective
+       ddt_init, but before mca_coll_base_open, since some collective
        modules (e.g., the hierarchical coll component) may need ops in
        their query function. */
     if (OMPI_SUCCESS != (ret = ompi_op_base_find_available (OPAL_ENABLE_PROGRESS_THREADS, ompi_mpi_thread_multiple))) {
@@ -791,7 +791,7 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
 
     *instance = &ompi_mpi_instance_null.instance;
 
-    /* If thread support was enabled, then setup OPAL to allow for them by deault. This must be done
+    /* If thread support was enabled, then setup OPAL to allow for them by default. This must be done
      * early to prevent a race condition that can occur with orte_init(). */
     if (ts_level == MPI_THREAD_MULTIPLE) {
         opal_set_using_threads(true);

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -98,7 +98,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
     if( tree->tree_nextsize > 0 ) {
         ptrdiff_t real_segment_size;
 
-        /* handle non existant recv buffer (i.e. its NULL) and
+        /* handle non existent recv buffer (i.e. its NULL) and
            protect the recv buffer on non-root nodes */
         accumbuf = (char*)recvbuf;
         if( (NULL == accumbuf) || (root != rank) ) {

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -42,7 +42,7 @@ static int fileline = 1;
 
 /*
  * File parsing function. Allocated memory depending on the number of rules.
- * This functions expects a file formatted as describbed in coll_han_dynamic_file.h.
+ * This functions expects a file formatted as described in coll_han_dynamic_file.h.
  * The configuration is then used by coll/han component to determine which module to
  * use at each topological level.
  */

--- a/ompi/mca/coll/tuned/coll_tuned_module.c
+++ b/ompi/mca/coll/tuned/coll_tuned_module.c
@@ -129,7 +129,7 @@ ompi_coll_tuned_forced_getvalues( enum COLLTYPE type,
 
     /**
      * Set the selected algorithm to 0 by default. Later on we can check this against 0
-     * to see if it was setted explicitly (if we suppose that setting it to 0 enable the
+     * to see if it was set explicitly (if we suppose that setting it to 0 enable the
      * default behavior) or not.
      */
     mca_base_var_get_value(mca_params->algorithm_param_index, &tmp, NULL, NULL);

--- a/ompi/mca/fbtl/ime/fbtl_ime_blocking_op.c
+++ b/ompi/mca/fbtl/ime/fbtl_ime_blocking_op.c
@@ -74,7 +74,7 @@ static ssize_t mca_fbtl_ime_blocking_op(ompio_file_t *fh, int io_op)
            - OR the next iovec is not "contiguous"
            - OR we exceeded the advised number of iovecs for IME
            Then: pwritev/preadv shall be called,
-                 and the iovec array resetted */
+                 and the iovec array reset */
         if (i+1 == fh->f_num_of_io_entries ||
             ((OMPI_MPI_OFFSET_TYPE)(intptr_t)fh->f_io_array[i].offset +
              (ptrdiff_t)fh->f_io_array[i].length) !=

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -463,7 +463,7 @@ mca_pml_ob1_copy_frag_completion( mca_btl_base_module_t* btl,
     mca_bml_base_btl_t* bml_btl = (mca_bml_base_btl_t*) des->des_context;
 
     des->des_cbfunc = mca_pml_ob1_frag_completion;
-    /* Reset the BTL onwership flag as the BTL can free it after completion. */
+    /* Reset the BTL ownership flag as the BTL can free it after completion. */
     des->des_flags |= MCA_BTL_DES_FLAGS_BTL_OWNERSHIP;
     OPAL_OUTPUT((-1, "copy_frag_completion FRAG frag=%p", (void *)des));
     /* Currently, we cannot support a failure in the send.  In the blocking

--- a/ompi/mca/topo/example/topo_example.h
+++ b/ompi/mca/topo/example/topo_example.h
@@ -26,7 +26,7 @@
 
 /*
  * ******************************************************************
- * ******** functions which provide MCA interface comppliance *******
+ * ******** functions which provide MCA interface compliance ********
  * ******************************************************************
  * These functions are:
  *       - mca_topo_example_module_open

--- a/ompi/mca/topo/treematch/topo_treematch.h
+++ b/ompi/mca/topo/treematch/topo_treematch.h
@@ -23,7 +23,7 @@
 
 /*
  * ******************************************************************
- * ******** functions which provide MCA interface comppliance *******
+ * ******** functions which provide MCA interface compliance ********
  * ******************************************************************
  * These functions are:
  *       - mca_topo_treematch_module_open

--- a/ompi/message/message.h
+++ b/ompi/message/message.h
@@ -36,7 +36,7 @@ typedef struct ompi_message_t ompi_message_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_message_t);
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */

--- a/ompi/mpi/c/accumulate.c
+++ b/ompi/mpi/c/accumulate.c
@@ -92,7 +92,7 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origi
                     /* ACCUMULATE, unlike REDUCE, can use with derived
                        datatypes with predefinied operations, with some
                        restrictions outlined in MPI-3:11.3.4.  The derived
-                       datatype must be composed entierly from one predefined
+                       datatype must be composed entirely from one predefined
                        datatype (so you can do all the construction you want,
                        but at the bottom, you can only use one datatype, say,
                        MPI_INT).  If the datatype at the target isn't

--- a/ompi/mpi/c/bindings.h
+++ b/ompi/mpi/c/bindings.h
@@ -34,10 +34,10 @@ BEGIN_C_DECLS
    doesn't work to simply list all of the pragmas in a top-level
    header file. */
 
-/* These macros have to be used to check the corectness of the datatype depending on the
+/* These macros have to be used to check the correctness of the datatype depending on the
  * operations that we have to do with them. They can be used on all functions, not only
  * on the top level MPI functions, as they does not trigger the error handler. Is the user
- * responsability to do it.
+ * responsibility to do it.
  */
 #define OMPI_CHECK_DATATYPE_FOR_SEND( RC, DDT, COUNT )                  \
     do {                                                                \

--- a/ompi/mpi/c/comm_join.c
+++ b/ompi/mpi/c/comm_join.c
@@ -181,7 +181,7 @@ static int ompi_socket_send (int fd, char *buf, int len )
             }
 #endif
             else {
-                /* Another error occured */
+                /* Another error occurred */
                 fprintf (stderr,"ompi_socket_send: error while writing to socket"
                          " error:%s", strerror (errno) );
                 return MPI_ERR_OTHER;
@@ -230,7 +230,7 @@ static int ompi_socket_recv (int fd, char *buf, int len )
             }
 #endif
             else {
-                /* Another error occured */
+                /* Another error occurred */
                 fprintf (stderr,"ompi_socket_recv: error while reading from socket"
                          " error:%s", strerror (errno) );
                 return MPI_ERR_OTHER;

--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -231,12 +231,12 @@ getfactors(int num, int *nfactors, int **factors) {
     *factors = (int *) malloc((unsigned) size * sizeof(int));
 
     i = 0;
-    /* determine all occurences of factor 2 */
+    /* determine all occurrences of factor 2 */
     while((num % 2) == 0) {
         num /= 2;
         (*factors)[i++] = 2;
     }
-    /* determine all occurences of uneven prime numbers up to sqrt(num) */
+    /* determine all occurrences of uneven prime numbers up to sqrt(num) */
     d = 3;
     for(d = 3; (num > 1) && (d <= sqrtnum); d += 2) {
         while((num % d) == 0) {

--- a/ompi/mpi/c/file_close.c
+++ b/ompi/mpi/c/file_close.c
@@ -53,7 +53,7 @@ int MPI_File_close(MPI_File *fh)
     }
 
     /* Release the MPI_File; the destructor releases the component,
-       zeroes out fiels, etc. */
+       zeroes out fields, etc. */
 
     rc = ompi_file_close(fh);
     OMPI_ERRHANDLER_RETURN(rc, *fh, rc, FUNC_NAME);

--- a/ompi/mpi/c/get_accumulate.c
+++ b/ompi/mpi/c/get_accumulate.c
@@ -99,7 +99,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype o
                     /* GET_ACCUMULATE, unlike REDUCE, can use with derived
                        datatypes with predefinied operations, with some
                        restrictions outlined in MPI-3:11.3.4.  The derived
-                       datatype must be composed entierly from one predefined
+                       datatype must be composed entirely from one predefined
                        datatype (so you can do all the construction you want,
                        but at the bottom, you can only use one datatype, say,
                        MPI_INT).  If the datatype at the target isn't

--- a/ompi/mpi/c/imrecv.c
+++ b/ompi/mpi/c/imrecv.c
@@ -69,7 +69,7 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype type,
 #if OPAL_ENABLE_FT_MPI
     /*
      * The message and associated request will be checked by the PML, and
-     * handled approprately. So no need to check here.
+     * handled appropriately. So no need to check here.
      */
 #endif
 

--- a/ompi/mpi/c/info_set.c
+++ b/ompi/mpi/c/info_set.c
@@ -59,8 +59,8 @@ static const char FUNC_NAME[] = "MPI_Info_set";
  *   @retval MPI_ERR_NO_MEM
  *
  *   MPI_Info_set adds the (key,value) pair to info, and overrides
- *   the value if for the same key a previsou value was set. key and
- *   value must be NULL terminated strings in C. In Fortan, leading
+ *   the value if for the same key a previous value was set. key and
+ *   value must be NULL terminated strings in C. In Fortran, leading
  *   and trailing spaces in key and value are stripped. If either
  *   key or value is greater than the allowed maxima, MPI_ERR_INFO_KEY
  *   and MPI_ERR_INFO_VALUE are raised

--- a/ompi/mpi/c/ireduce_scatter.c
+++ b/ompi/mpi/c/ireduce_scatter.c
@@ -67,7 +67,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcounts[rank], datatype);
 

--- a/ompi/mpi/c/ireduce_scatter_block.c
+++ b/ompi/mpi/c/ireduce_scatter_block.c
@@ -57,7 +57,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcount, datatype);
 

--- a/ompi/mpi/c/isend.c
+++ b/ompi/mpi/c/isend.c
@@ -94,7 +94,7 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype type, int dest,
     /*
      * today's MPI standard mandates the send buffer remains accessible during the send operation
      * hence memchecker cannot mark buf as non accessible, but it might mark buf as read-only in
-     * order to trap end user errors. Unfortunatly valgrind does not support marking buffers as read-only,
+     * order to trap end user errors. Unfortunately valgrind does not support marking buffers as read-only,
      * so there is pretty much nothing we can do here.
      */
 

--- a/ompi/mpi/c/mrecv.c
+++ b/ompi/mpi/c/mrecv.c
@@ -77,7 +77,7 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype type,
 #if OPAL_ENABLE_FT_MPI
     /*
      * The message and associated request will be checked by the PML, and
-     * handled approprately. SO no need to check here.
+     * handled appropriately. SO no need to check here.
      */
 #endif
 

--- a/ompi/mpi/c/pack.c
+++ b/ompi/mpi/c/pack.c
@@ -103,7 +103,7 @@ int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
     }
 
-    /* Prepare the iovec with all informations */
+    /* Prepare the iovec with all information */
     invec.iov_base = (char*) outbuf + (*position);
     invec.iov_len = size;
 

--- a/ompi/mpi/c/raccumulate.c
+++ b/ompi/mpi/c/raccumulate.c
@@ -93,7 +93,7 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype orig
                     /* RACCUMULATE, unlike REDUCE, can use with derived
                        datatypes with predefinied operations, with some
                        restrictions outlined in MPI-3:11.3.4.  The derived
-                       datatype must be composed entierly from one predefined
+                       datatype must be composed entirely from one predefined
                        datatype (so you can do all the construction you want,
                        but at the bottom, you can only use one datatype, say,
                        MPI_INT).  If the datatype at the target isn't

--- a/ompi/mpi/c/reduce_scatter.c
+++ b/ompi/mpi/c/reduce_scatter.c
@@ -65,7 +65,7 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcounts[rank], datatype);
 

--- a/ompi/mpi/c/reduce_scatter_block.c
+++ b/ompi/mpi/c/reduce_scatter_block.c
@@ -55,7 +55,7 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcount, datatype);
 

--- a/ompi/mpi/c/reduce_scatter_block_init.c
+++ b/ompi/mpi/c/reduce_scatter_block_init.c
@@ -57,7 +57,7 @@ int MPI_Reduce_scatter_block_init(const void *sendbuf, void *recvbuf, int recvco
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcount, datatype);
 

--- a/ompi/mpi/c/reduce_scatter_init.c
+++ b/ompi/mpi/c/reduce_scatter_init.c
@@ -68,7 +68,7 @@ int MPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvco
         memchecker_comm(comm);
         memchecker_datatype(datatype);
 
-        /* check receive buffer of current proccess, whether it's addressable. */
+        /* check receive buffer of current process, whether it's addressable. */
         memchecker_call(&opal_memchecker_base_isaddressable, recvbuf,
                         recvcounts[rank], datatype);
 

--- a/ompi/mpi/c/rget_accumulate.c
+++ b/ompi/mpi/c/rget_accumulate.c
@@ -100,7 +100,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype 
                     /* RGET_ACCUMULATE, unlike REDUCE, can use with derived
                        datatypes with predefinied operations, with some
                        restrictions outlined in MPI-3:11.3.4.  The derived
-                       datatype must be composed entierly from one predefined
+                       datatype must be composed entirely from one predefined
                        datatype (so you can do all the construction you want,
                        but at the bottom, you can only use one datatype, say,
                        MPI_INT).  If the datatype at the target isn't

--- a/ompi/mpi/c/sendrecv.c
+++ b/ompi/mpi/c/sendrecv.c
@@ -97,7 +97,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             /* If this is a PROC_FAILED error, we still need to proceed with
              * the receive, so that we do not propagate errors to the sender in
              * the case src != dst, and only dst is dead. In this case the 
-             * recv is garanteed to complete (either in error if the source is 
+             * recv is guaranteed to complete (either in error if the source is 
              * dead, or successfully if the source is live). */
             if (OPAL_UNLIKELY(MPI_ERR_PROC_FAILED != rc))
             /* if intentionally spills outside ifdef */

--- a/ompi/mpi/c/session_finalize.c
+++ b/ompi/mpi/c/session_finalize.c
@@ -40,6 +40,6 @@ int MPI_Session_finalize (MPI_Session *session)
     }
 
     rc = ompi_mpi_instance_finalize (session);
-    /* if an error occured raise it on the null session */
+    /* if an error occurred raise it on the null session */
     OMPI_ERRHANDLER_RETURN (rc, MPI_SESSION_NULL, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/session_init.c
+++ b/ompi/mpi/c/session_init.c
@@ -55,6 +55,6 @@ int MPI_Session_init (MPI_Info info, MPI_Errhandler errhandler, MPI_Session *ses
     }
 
     rc = ompi_mpi_instance_init (ts_level, &info->super, errhandler, session);
-    /* if an error occured raise it on the null session */
+    /* if an error occurred raise it on the null session */
     OMPI_ERRHANDLER_RETURN (rc, MPI_SESSION_NULL, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -62,7 +62,7 @@ int MPI_Start(MPI_Request *request)
      * Per definition of the handling of persistent request in the
      * MPI standard 3.1 page 78 line 19: we must have the following
      * sequence CREATE (START COMPLETE)* FREE. The upper level is
-     * responsible for handling any concurency. The PML must handle
+     * responsible for handling any concurrency. The PML must handle
      * this case, as it is the only one knowing if the request can
      * be reused or not (it is PML completed or not?).
      */

--- a/ompi/mpi/c/unpack.c
+++ b/ompi/mpi/c/unpack.c
@@ -107,7 +107,7 @@ int MPI_Unpack(const void *inbuf, int insize, int *position,
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
         }
 
-        /* Prepare the iovec with all informations */
+        /* Prepare the iovec with all information */
         outvec.iov_base = (char*) inbuf + (*position);
         outvec.iov_len = size;
 

--- a/ompi/mpi/fortran/base/datarep.h
+++ b/ompi/mpi/fortran/base/datarep.h
@@ -59,7 +59,7 @@ typedef void (ompi_mpi2_fortran_datarep_extent_fn_t)
 
 /**
  * Macro for declaring each of the 5 back-end Fortran functions for
- * MPI_CONVERSION_FN_NULL.  We need the 4 fortran compiler convetions
+ * MPI_CONVERSION_FN_NULL.  We need the 4 fortran compiler conversions
  * and 1 for the "real" back-end function (even though these functions
  * are never invoked -- they're only used as sentinel values -- it's
  * simpler to use the same kind of code structure that we use for the

--- a/ompi/mpi/fortran/base/fint_2_int.h
+++ b/ompi/mpi/fortran/base/fint_2_int.h
@@ -96,7 +96,7 @@
   #define OMPI_SINGLE_INT_2_FINT(in) \
     *(in) = OMPI_ARRAY_NAME_CONVERT(in)
 
-  /* This is for OUT/IN-OUT parametes. Does back assignment and free */
+  /* This is for OUT/IN-OUT parameters. Does back assignment and free */
   #define OMPI_ARRAY_INT_2_FINT(in, n) \
     do { \
       int converted_n = (int)(n); \

--- a/ompi/mpi/fortran/base/fortran_base_strings.h
+++ b/ompi/mpi/fortran/base/fortran_base_strings.h
@@ -69,7 +69,7 @@ BEGIN_C_DECLS
      * @retval OMPI_SUCCESS upon success
      * @retval OMPI_ERROR upon error
      *
-     * This function is intented to be used in the MPI F77 bindings to
+     * This function is intended to be used in the MPI F77 bindings to
      * convert arrays of fortran strings to argv-style arrays of C
      * strings.  The argv array will be allocated and returned; it is
      * the caller's responsibility to invoke opal_argv_free() to free
@@ -115,9 +115,9 @@ BEGIN_C_DECLS
      * @param count Dimension of the array of argvs
      * @param array Array of fortran argv
      * @param len Length of Fortran array
-     * @param argv Returned C arrray of argvs
+     * @param argv Returned C array of argvs
      *
-     * This function is intented to be used in the MPI F77 bindings to
+     * This function is intended to be used in the MPI F77 bindings to
      * convert arrays of fortran strings to argv-style arrays of C
      * strings.  The argv array will be allocated and returned; it is
      * the caller's responsibility to invoke opal_argv_free() to free

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -233,7 +233,7 @@ sub output_file {
 ! Specifically: we need support for the INTERFACE keyword,
 ! ISO_FORTRAN_ENV, and the STORAGE_SIZE() intrinsic on all types.
 ! Apparently, this compiler does not support both of those things, so
-! this file will be (effecitvely) blank (i.e., we didn't bother
+! this file will be (effectively) blank (i.e., we didn't bother
 ! generating the necessary stuff for MPI_SIZEOF because the compiler
 ! doesn't support
 ! it).

--- a/ompi/mpi/fortran/use-mpi-f08/base/buffer_detach.c
+++ b/ompi/mpi/fortran/use-mpi-f08/base/buffer_detach.c
@@ -28,7 +28,7 @@
 /*
  * This function implemented in this file is only called from Fortran,
  * so we never bothered to put a prototype for it in any C header
- * file.  To avoid compiler warnings about no protoype, we prototype
+ * file.  To avoid compiler warnings about no prototype, we prototype
  * it here.
  */
 OMPI_DECLSPEC void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size,

--- a/ompi/mpi/java/c/mpi_Comm.c
+++ b/ompi/mpi/java/c/mpi_Comm.c
@@ -933,7 +933,7 @@ JNIEXPORT jlong JNICALL Java_mpi_Comm_iGather(
     if(rootOrInter || sPtr == MPI_IN_PLACE)
     {
         /*
-         * In principle need the "id == root" check here and elsewere for
+         * In principle need the "id == root" check here and elsewhere for
          * correctness, in case arguments that are not supposed to be
          * significant except on root are legitimately passed in as `null',
          * say.  Shouldn't produce null pointer exception.

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -1271,7 +1271,7 @@ void ompi_java_releasePtrArray(JNIEnv *env, jlongArray array,
  * code execution returns to Java code, an exception is immediately
  * thrown.  Since an exception has occurred somewhere in the C code,
  * the object that is returned from C may not be valid.  This is not
- * an issue, however, as the assignment opperation will not be
+ * an issue, however, as the assignment operation will not be
  * executed.  The results of this method need not be checked if the
  * only following code cleans up memory and then returns to Java.
  * If existing objects are changed after a call to this method, the

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -906,7 +906,7 @@ public class Comm implements Freeable, Cloneable
 	 * Java binding of the MPI operation {@code MPI_PACK}.
 	 * <p>
 	 * The return value is the output value of {@code position} - the
-	 * inital value incremented by the number of bytes written.
+	 * initial value incremented by the number of bytes written.
 	 * @param inbuf    input buffer
 	 * @param incount  number of items in input buffer
 	 * @param type     datatype of each item in input buffer
@@ -944,7 +944,7 @@ public class Comm implements Freeable, Cloneable
 	 * Java binding of the MPI operation {@code MPI_UNPACK}.
 	 * <p>
 	 * The return value is the output value of {@code position} - the
-	 * inital value incremented by the number of bytes read.
+	 * initial value incremented by the number of bytes read.
 	 * @param inbuf    input buffer
 	 * @param position initial position in input buffer
 	 * @param outbuf   output buffer
@@ -1150,7 +1150,7 @@ public class Comm implements Freeable, Cloneable
 
 	private native int getTopology(long comm) throws MPIException;
 
-	// Enviromental Management
+	// Environmental Management
 
 	/**
 	 * Abort MPI.

--- a/ompi/mpi/java/java/GraphComm.java
+++ b/ompi/mpi/java/java/GraphComm.java
@@ -135,7 +135,7 @@ public final class GraphComm extends Intracomm
 	 * <p>The number of nodes and number of edges can be extracted
 	 * from the sizes of the {@code index} and {@code edges} fields
 	 * of the returned object.
-	 * @return object defining node degress and edges of graph
+	 * @return object defining node degrees and edges of graph
 	 * @throws MPIException Signals that an MPI error of some sort has occurred.
 	 */
 	public GraphParms getDims() throws MPIException

--- a/ompi/mpi/java/java/Message.java
+++ b/ompi/mpi/java/java/Message.java
@@ -111,7 +111,7 @@ public final class Message
 	/**
 	 * Java binding of {@code MPI_MRECV}.
 	 * @param buf   receive buffer
-	 * @param count number of elements in receve buffer
+	 * @param count number of elements in receive buffer
 	 * @param type  datatype of each receive buffer element
 	 * @return status object
 	 * @throws MPIException Signals that an MPI error of some sort has occurred.
@@ -142,7 +142,7 @@ public final class Message
 	/**
 	 * Java binding of {@code MPI_IMRECV}.
 	 * @param buf   receive buffer
-	 * @param count number of elements in receve buffer
+	 * @param count number of elements in receive buffer
 	 * @param type  datatype of each receive buffer element
 	 * @return request object
 	 * @throws MPIException Signals that an MPI error of some sort has occurred.

--- a/ompi/mpi/java/java/Status.java
+++ b/ompi/mpi/java/java/Status.java
@@ -95,7 +95,7 @@ public final class Status
 	/**
 	 * Tests if the communication was cancelled.
 	 * <p>Java binding of the MPI operation {@code MPI_TEST_CANCELLED}.
-	 * @return true if the operation was succesfully cancelled, false otherwise
+	 * @return true if the operation was successfully cancelled, false otherwise
 	 * @throws MPIException Signals that an MPI error of some sort has occurred.
 	 */
 	public boolean isCancelled() throws MPIException

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -48,7 +48,7 @@ int MPI_T_init_thread (int required, int *provided)
             break;
         }
 
-        /* call opal_init_util to intialize the MCA system */
+        /* call opal_init_util to initialize the MCA system */
         rc = opal_init_util (NULL, NULL);
         if (OPAL_SUCCESS != rc) {
             rc = MPI_T_ERR_INVALID;

--- a/ompi/mpiext/example/README.md
+++ b/ompi/mpiext/example/README.md
@@ -132,7 +132,7 @@ As such, `ompi/mpiext/EXTENSION_NAME/Makefile.am` is not traversed
 during a normal top-level `make all` target.  This `Makefile.am`
 exists for two reasons, however:
 
-1. For the conveneince of the developer, so that you can issue normal
+1. For the convenience of the developer, so that you can issue normal
    `make` commands at the top of your extension tree (e.g., `make all`
    will still build all bindings in an extension).
 1. During a top-level `make dist`, extension directories *are*

--- a/ompi/mpiext/ftmpi/c/profile/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/profile/Makefile.am
@@ -12,7 +12,7 @@
 
 # If OMPI_BUILD_MPI_PROFILING is enabled when we want our generated MPI_* symbols
 # to be replaced by PMPI_*.
-# In this directory, we definately need it to be 1.
+# In this directory, we definitely need it to be 1.
 AM_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=1
 
 noinst_LTLIBRARIES = libpmpiext_ftmpi_c.la

--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -388,7 +388,7 @@ ompi_op_t *ompi_op_create_user(bool commute,
 
     /* Set the user-defined callback function.  The "fort_fn" member
        is part of a union, so it doesn't matter if this is a C or
-       Fortan callback; we'll call the right flavor (per o_flags) at
+       Fortran callback; we'll call the right flavor (per o_flags) at
        invocation time. */
     new_op->o_func.fort_fn = func;
 

--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -176,7 +176,7 @@ typedef struct ompi_op_t ompi_op_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_op_t);
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -358,7 +358,7 @@ ompi_op_t *ompi_op_create_user(bool commute,
                                ompi_op_fortran_handler_fn_t func);
 
 /**
- * Mark an MPI_Op as holding a Java calback function, and cache that
+ * Mark an MPI_Op as holding a Java callback function, and cache that
  * function in the MPI_Op.
  */
 OMPI_DECLSPEC void ompi_op_set_java_callback(ompi_op_t *op,  void *jnienv,

--- a/ompi/patterns/comm/allgather.c
+++ b/ompi/patterns/comm/allgather.c
@@ -49,7 +49,7 @@ OMPI_DECLSPEC int ompi_comm_allgather_pml(void *src_buf, void *dest_buf, int cou
     ompi_request_t *requests[4];
 
     /* get size of data needed - same layout as user data, so that
-     *   we can apply the reudction routines directly on these buffers
+     *   we can apply the reduction routines directly on these buffers
      */
     rc = ompi_datatype_type_size(dtype, &dt_size);
     if( OMPI_SUCCESS != rc ) {
@@ -165,7 +165,7 @@ OMPI_DECLSPEC int ompi_comm_allgather_pml(void *src_buf, void *dest_buf, int cou
                  */
                 extra_end=n_extra_nodes-1;
             }
-            /* get the number of ranks whos data is to be grabbed */
+            /* get the number of ranks whose data is to be grabbed */
             n_extra=extra_end-extra_start+1;
 
             recv_iov[1].iov_base=(char *)dest_buf+
@@ -210,7 +210,7 @@ OMPI_DECLSPEC int ompi_comm_allgather_pml(void *src_buf, void *dest_buf, int cou
                  */
                 extra_end=n_extra_nodes-1;
             }
-            /* get the number of ranks whos data is to be grabbed */
+            /* get the number of ranks whose data is to be grabbed */
             n_extra=extra_end-extra_start+1;
 
             send_iov[1].iov_base=(char *)dest_buf+

--- a/ompi/patterns/comm/allreduce.c
+++ b/ompi/patterns/comm/allreduce.c
@@ -28,7 +28,7 @@
 #include "commpatterns.h"
 
 /**
- * All-reduce for contigous primitive types
+ * All-reduce for contiguous primitive types
  */
 OMPI_DECLSPEC int ompi_comm_allreduce_pml(void *sbuf, void *rbuf, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
@@ -46,7 +46,7 @@ OMPI_DECLSPEC int ompi_comm_allreduce_pml(void *sbuf, void *rbuf, int count,
     char *sbuf_current, *rbuf_current;
 
     /* get size of data needed - same layout as user data, so that
-     *   we can apply the reudction routines directly on these buffers
+     *   we can apply the reduction routines directly on these buffers
      */
     rc = opal_datatype_type_size((opal_datatype_t *)dtype, &dt_size);
     if( OMPI_SUCCESS != rc ) {
@@ -153,7 +153,7 @@ OMPI_DECLSPEC int ompi_comm_allreduce_pml(void *sbuf, void *rbuf, int count,
 
             /* change pointer to scratch buffer - this was we can send data
             ** that we have summed w/o a memory copy, and receive data into the
-            ** other buffer, w/o fear of over writting data that has not yet
+            ** other buffer, w/o fear of over writing data that has not yet
             ** completed being send
             */
             recv_buffer^=1;

--- a/ompi/patterns/net/allreduce.c
+++ b/ompi/patterns/net/allreduce.c
@@ -77,7 +77,7 @@ Error:
 }
 
 /**
- * All-reduce for contigous primitive types
+ * All-reduce for contiguous primitive types
  */
 static
 comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
@@ -104,7 +104,7 @@ comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
     int data_type;
 
     /* get size of data needed - same layout as user data, so that
-     *   we can apply the reudction routines directly on these buffers
+     *   we can apply the reduction routines directly on these buffers
      */
     rc=opal_datatype_type_size(dtype, &dt_size);
     if( OMPI_SUCCESS != rc ) {
@@ -112,7 +112,7 @@ comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
     }
     message_extent=dt_extent*count;
 
-    /* lenght of control and data regions */
+    /* length of control and data regions */
     len_data_buffer=sm_module->data_memory_per_proc_per_segment;
 
     /* number of data types copies that the scratch buffer can hold */
@@ -138,7 +138,7 @@ comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
             item != opal_list_get_end(peers) ;
             item = opal_list_get_next(peers)) {
         if(ompi_proc_local()==(ompi_proc_t *)item){
-            /* this is the pointer to my proc strucuture */
+            /* this is the pointer to my proc structure */
             break;
         }
         my_rank++;
@@ -227,7 +227,7 @@ comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
 
             /* change pointer to scratch buffer - this was we can send data
             ** that we have summed w/o a memory copy, and receive data into the
-            ** other buffer, w/o fear of over writting data that has not yet
+            ** other buffer, w/o fear of over writing data that has not yet
             ** completed being send
             */
             recv_buffer^=1;

--- a/ompi/patterns/net/netpatterns.h
+++ b/ompi/patterns/net/netpatterns.h
@@ -91,7 +91,7 @@ struct netpatterns_tree_node_t {
     int n_children;
     /* parent rank within the group */
     int parent_rank;
-    /* chidren ranks within the group */
+    /* children ranks within the group */
     int *children_ranks;
 };
 typedef struct netpatterns_tree_node_t netpatterns_tree_node_t;
@@ -113,7 +113,7 @@ struct netpatterns_narray_knomial_tree_node_t {
     int n_children;
     /* parent rank within the group */
     int parent_rank;
-    /* chidren ranks within the group */
+    /* children ranks within the group */
     int *children_ranks;
     /* Total number of ranks on this specific level */
     int level_size;

--- a/ompi/patterns/net/netpatterns_knomial_tree.c
+++ b/ompi/patterns/net/netpatterns_knomial_tree.c
@@ -76,7 +76,7 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_allgather_tree_node(
         cnt *= tree_order;
         n_levels++;
     }
-    /* this is the actual number of recusive k-ing steps
+    /* this is the actual number of recursive k-ing steps
      * we will perform, the last step may not be a full
      * step depending on the outcome of the next conditional
      */
@@ -214,7 +214,7 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_allgather_tree_node(
         }
 
     }
-    /* intialize the payload array
+    /* initialize the payload array
        This is the money struct, just need to initialize this with
        the subgroup information */
     /*
@@ -324,7 +324,7 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_allgather_tree_node(
                             /* how much I am to send to this peer on this level */
                             exchange_node->payload_info[i][j].s_len = prev_data[node_rank];
                             /*fprintf(stderr,"exchange_node->payload_info[%d][%d].s_len %d\n",i,j,prev_data[node_rank]);*/
-                            /*fprintf(stderr,"I am rank %d receiveing %d bytes from rank %d at level %d\n",node_rank,
+                            /*fprintf(stderr,"I am rank %d receiving %d bytes from rank %d at level %d\n",node_rank,
                                                                         prev_data[exchange_node->reindex_map[peer]],
                                                                         exchange_node->reindex_map[peer], i+1);*/
                             /*fprintf(stderr,"I am rank %d sending %d bytes to rank %d at level %d\n",node_rank,prev_data[myid],
@@ -791,7 +791,7 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_n_tree_node(int num_
         NETPATTERNS_VERBOSE(("extra_source#%d = %d", 0, node_rank & (cnt - 1)));
     }
 
-    /* Ishai: To be compatable with the old structure - should be remoived later */
+    /* Ishai: To be compatible with the old structure - should be removed later */
     if (1 == exchange_node->n_extra_sources) {
         exchange_node->rank_extra_source = exchange_node->rank_extra_sources_array[0];
     } else {

--- a/ompi/patterns/net/netpatterns_knomial_tree.h
+++ b/ompi/patterns/net/netpatterns_knomial_tree.h
@@ -39,7 +39,7 @@ struct netpatterns_pair_exchange_node_t {
     /* number of nodes this node will exchange data with */
     int n_exchanges;
 
-    /* ranks of nodes involved in data exchnge */
+    /* ranks of nodes involved in data exchange */
     int *rank_exchanges;
 
     /* number of extra sources of data - outside largest power of 2 in
@@ -82,7 +82,7 @@ struct netpatterns_k_exchange_node_t {
     int n_exchanges;
     /* total number of exchanges that I actually participate in */
     int n_actual_exchanges;
-    /* ranks of nodes involved in data exchnge */
+    /* ranks of nodes involved in data exchange */
     int **rank_exchanges;
     /* number of extra sources of data - outside largest power of 2 in
      *  this group */

--- a/ompi/patterns/net/netpatterns_multinomial_tree.c
+++ b/ompi/patterns/net/netpatterns_multinomial_tree.c
@@ -49,7 +49,7 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_multinomial_tree(int tree_order, int nu
     result=num_nodes;
     /* cnt - number of ranks in given level */
     cnt=1;
-    /*  cummulative count of ranks */
+    /*  cumulative count of ranks */
     while( 0 < result ) {
         result-=cnt;
         cnt*=tree_order;

--- a/ompi/patterns/net/netpatterns_nary_tree.c
+++ b/ompi/patterns/net/netpatterns_nary_tree.c
@@ -63,7 +63,7 @@ int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_node
     result=my_rank;
     /* cnt - number of ranks in given level */
     cnt=1;
-    /*  cummulative count of ranks */
+    /*  cumulative count of ranks */
     while( 0 <= result ) {
         result-=cnt;
         cnt*=tree_order;
@@ -80,7 +80,7 @@ int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_node
         cnt=1;
         cum_cnt=0;
         for (lvl = 0 ; lvl < my_level_in_tree ; lvl ++ ) {
-            /* cummulative count up to this level */
+            /* cumulative count up to this level */
             cum_cnt+=cnt;
             /* number of ranks in this level */
             cnt*=tree_order;
@@ -95,7 +95,7 @@ int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_node
     result=num_nodes;
     /* cnt - number of ranks in given level */
     cnt=1;
-    /*  cummulative count of ranks */
+    /*  cumulative count of ranks */
     while( 0 < result ) {
         result-=cnt;
         cnt*=tree_order;
@@ -204,7 +204,7 @@ int ompi_netpatterns_setup_narray_knomial_tree(
     result=my_rank;
     /* cnt - number of ranks in given level */
     cnt=1;
-    /*  cummulative count of ranks */
+    /*  cumulative count of ranks */
     while( 0 <= result ) {
         result-=cnt;
         cnt*=tree_order;
@@ -221,7 +221,7 @@ int ompi_netpatterns_setup_narray_knomial_tree(
         cnt=1;
         cum_cnt=0;
         for (lvl = 0 ; lvl < my_level_in_tree ; lvl ++ ) {
-            /* cummulative count up to this level */
+            /* cumulative count up to this level */
             cum_cnt+=cnt;
             /* number of ranks in this level */
             cnt*=tree_order;
@@ -248,7 +248,7 @@ int ompi_netpatterns_setup_narray_knomial_tree(
     result=num_nodes;
     /* cnt - number of ranks in given level */
     cnt=1;
-    /*  cummulative count of ranks */
+    /*  cumulative count of ranks */
     while( 0 < result ) {
         result-=cnt;
         cnt*=tree_order;

--- a/ompi/peruse/peruse.h
+++ b/ompi/peruse/peruse.h
@@ -36,7 +36,7 @@ typedef int (peruse_comm_callback_f)(peruse_event_h event_h,
 
 /* PERUSE constants */
 enum {
-    PERUSE_SUCCESS = 0,       /* Success *//* XXX Devation from 1.11 */
+    PERUSE_SUCCESS = 0,       /* Success *//* XXX Deviation from 1.11 */
     PERUSE_ERR_INIT,          /* PERUSE initialization failure */
     PERUSE_ERR_GENERIC,       /* Generic unspecified error */
     PERUSE_ERR_MALLOC,        /* Memory-related error */
@@ -49,7 +49,7 @@ enum {
 };
 
 enum {
-    PERUSE_EVENT_INVALID = -1, /* Must differ in value from PERUSE_SUCCESS. Devation from 1.11 */
+    PERUSE_EVENT_INVALID = -1, /* Must differ in value from PERUSE_SUCCESS. Deviation from 1.11 */
 
     /* Point-to-point request events */
     PERUSE_COMM_REQ_ACTIVATE,
@@ -80,13 +80,13 @@ enum {
 
 /* Scope of message queues */
 enum {
-    PERUSE_PER_COMM=0,                  /* XXX Devation from 1.11 */
+    PERUSE_PER_COMM=0,                  /* XXX Deviation from 1.11 */
     PERUSE_GLOBAL
 };
 
 /* Operation values */
 enum {
-    PERUSE_SEND=0,                      /* XXX Devation from 1.11 */
+    PERUSE_SEND=0,                      /* XXX Deviation from 1.11 */
     PERUSE_RECV
 };
 

--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -352,7 +352,7 @@ int ompi_proc_complete_init(void)
      * are already in the hash table
      */
     if (ompi_process_info.num_procs < ompi_add_procs_cutoff) {
-        /* sinse ompi_proc_for_name is locking internally -
+        /* since ompi_proc_for_name is locking internally -
          * we need to release lock here
          */
         opal_mutex_unlock (&ompi_proc_lock);

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -355,7 +355,7 @@ OMPI_DECLSPEC int ompi_proc_unpack(pmix_data_buffer_t *buf,
  *
  * Refresh the Open MPI process subsystem. This function will update
  * the list of proc instances in the current MPI_COMM_WORLD with
- * data from the run-time environemnt.
+ * data from the run-time environment.
  *
  * @note This is primarily used when restarting a process and thus
  * need to update the jobid and node name.

--- a/ompi/request/grequest.c
+++ b/ompi/request/grequest.c
@@ -86,7 +86,7 @@ static void ompi_grequest_construct(ompi_grequest_t* greq)
  *
  * 1. Call to MPI_GREQUEST_COMPLETE and then a corresponding call to
  * some flavor of MPI_TEST* or MPI_WAIT*.  This will both complete the
- * requests and destroy the coresponding MPI generalized request
+ * requests and destroy the corresponding MPI generalized request
  * object.
  *
  * 2. Call MPI_REQUEST_FREE and then (!) -- with some other
@@ -111,7 +111,7 @@ static void ompi_grequest_construct(ompi_grequest_t* greq)
  * TEST* / WAIT* notified the user as such, and this function is also
  * invoked by REQUEST_FREE).  Hence, these two functions will *always*
  * be invoked, but the order in which they are invoked is up to the
- * user.  So this is a perfect opprotunity for the OBJ_* reference
+ * user.  So this is a perfect opportunity for the OBJ_* reference
  * count system.  When we create an ompi_grequest_t in
  * ompi_grequest_start(), we both OBJ_NEW and OBJ_RETAIN it so that
  * its reference count goes to 0.  Then in ompi_grequest_complete()

--- a/ompi/request/req_ft.c
+++ b/ompi/request/req_ft.c
@@ -173,14 +173,14 @@ bool ompi_request_is_failed_fn(ompi_request_t *req)
             MCA_PML_CALL(dump(req->req_mpi_object.comm, ompi_ftmpi_output_handle));
         }
 #endif /* OPAL_ENABLE_DEBUG */
-        /* Cancel and force completion immmediately
+        /* Cancel and force completion immediately
          * However, for Revoked and Collective error we can't complete
          * with an error before the buffer is unpinned (i.e. the request gets
          * wire cancelled).
          */
         ompi_request_cancel(req);
         req->req_status._cancelled = cancelled; /* This request is not user cancelled here, it is completed in error */
-        return REQUEST_COMPLETE(req); /* If this request is not complete yet, it is stil ok and needs more spinning */
+        return REQUEST_COMPLETE(req); /* If this request is not complete yet, it is still ok and needs more spinning */
     }
     return (MPI_SUCCESS != req->req_status.MPI_ERROR);
 }

--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -50,7 +50,7 @@ int ompi_request_default_wait(
 #endif /* OPAL_ENABLE_FT_MPI */
 
     /* return status.  If it's a generalized request, we *have* to
-       invoke the query_fn, even if the user procided STATUS_IGNORE.
+       invoke the query_fn, even if the user provided STATUS_IGNORE.
        MPI-2:8.2. */
     if (OMPI_REQUEST_GEN == req->req_type) {
         ompi_grequest_invoke_query(req, &req->req_status);
@@ -316,7 +316,7 @@ recheck:
             if( OPAL_UNLIKELY(0 < failed) ) {
                 /* if we have failed requests we skipped the waiting on the sync. Thus,
                  * some of the requests might not be properly completed, in which case
-                 * we must detach all requests from the sync. However, if we can succesfully
+                 * we must detach all requests from the sync. However, if we can successfully
                  * mark the request as pending then it is neither failed nor complete, and
                  * we must stop altering it.
                  */
@@ -501,7 +501,7 @@ int ompi_request_default_wait_some(size_t count,
 
     if(num_requests_null_inactive == count) {
         *outcount = MPI_UNDEFINED;
-        /* nobody will signall us */
+        /* nobody will signal us */
         WAIT_SYNC_RELEASE_NOWAIT(&sync);
         return rc;
     }

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -129,7 +129,7 @@ struct ompi_request_t {
     opal_free_list_item_t super;                /**< Base type */
     ompi_request_type_t req_type;               /**< Enum indicating the type of the request */
     ompi_status_public_t req_status;            /**< Completion status */
-    volatile void *req_complete;                /**< Flag indicating wether request has completed */
+    volatile void *req_complete;                /**< Flag indicating whether request has completed */
     volatile ompi_request_state_t req_state;    /**< enum indicate state of the request */
     bool req_persistent;                        /**< flag indicating if the this is a persistent request */
     int req_f_to_c_index;                       /**< Index in Fortran <-> C translation array */
@@ -148,7 +148,7 @@ typedef struct ompi_request_t ompi_request_t;
 
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -195,7 +195,7 @@ typedef struct ompi_predefined_request_t ompi_predefined_request_t;
  * This function should be called only from the MPI layer. It should
  * never be called from the PML. It take care of the upper level clean-up.
  * When the user call MPI_Request_free we should release all MPI level
- * ressources, so we have to call this function too.
+ * resources, so we have to call this function too.
  */
 #define OMPI_REQUEST_FINI(request)                                      \
 do {                                                                    \
@@ -266,7 +266,7 @@ typedef int (*ompi_request_test_any_fn_t)(size_t count,
  *
  * @param count (IN)      Number of requests
  * @param requests (IN)   Array of requests
- * @param completed (OUT) Flag indicating wether all requests completed.
+ * @param completed (OUT) Flag indicating whether all requests completed.
  * @param statuses (OUT)  Array of completion statuses.
  * @return                OMPI_SUCCESS or failure status.
  *

--- a/ompi/runtime/mpiruntime.h
+++ b/ompi/runtime/mpiruntime.h
@@ -90,7 +90,7 @@ typedef enum {
 
 /*
  * These variables are for the MPI F03 bindings (F03 must bind Fortran
- * varaiables to symbols; it cannot bind Fortran variables to the
+ * variables to symbols; it cannot bind Fortran variables to the
  * address of a C variable).
  */
 
@@ -151,7 +151,7 @@ OMPI_DECLSPEC extern struct ompi_status_public_t *ompi_mpi_statuses_ignore_addr;
     MPI_FINALIZE. */
 OMPI_DECLSPEC extern opal_list_t ompi_registered_datareps;
 
-/** In ompi_mpi_init: the lists of Fortran 90 mathing datatypes.
+/** In ompi_mpi_init: the lists of Fortran 90 matching datatypes.
  * We need these lists and hashtables in order to satisfy the new
  * requirements introduced in MPI 2-1 Sect. 10.2.5,
  * MPI_TYPE_CREATE_F90_xxxx, page 295, line 47.
@@ -184,12 +184,12 @@ void ompi_mpi_thread_level(int requested, int *provided);
  * @returns MPI_SUCCESS if successful
  * @returns Error code if unsuccessful
  *
- * Intialize all support code needed for MPI applications.  This
+ * Initialize all support code needed for MPI applications.  This
  * function should only be called by MPI applications (including
  * singletons).  If this function is called, ompi_init() and
  * ompi_rte_init() should *not* be called.
  *
- * It is permissable to pass in (0, NULL) for (argc, argv).
+ * It is permissible to pass in (0, NULL) for (argc, argv).
  */
 int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
                   bool reinit_ok);

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -106,7 +106,7 @@
 #ifdef HAVE___MALLOC_INITIALIZE_HOOK
 #include "opal/mca/memory/base/base.h"
 /* So this sucks, but with OPAL in its own library that is brought in
-   implicity from libmpi, there are times when the malloc initialize
+   implicitly from libmpi, there are times when the malloc initialize
    hook in the memory component doesn't work.  So we have to do it
    from here, since any MPI code is going to call MPI_Init... */
 OPAL_DECLSPEC void (*__malloc_initialize_hook) (void) =
@@ -135,7 +135,7 @@ opal_thread_t *ompi_mpi_main_thread = NULL;
 
 /*
  * These variables are for the MPI F08 bindings (F08 must bind Fortran
- * varaiables to symbols; it cannot bind Fortran variables to the
+ * variables to symbols; it cannot bind Fortran variables to the
  * address of a C variable).
  */
 
@@ -257,7 +257,7 @@ MPI_Fint *MPI_F08_STATUSES_IGNORE = NULL;
    in a linker warning).  FWIW, if you initialize these variables in
    functions (i.e., not at the instantiation in the global scope), the
    linker somehow "figures it all out" (w.r.t. different alignments
-   between fortan common blocks and the corresponding C variables) and
+   between fortran common blocks and the corresponding C variables) and
    no linker warnings occur.
 
    Note that the rationale for the types of each of these variables is

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -54,7 +54,7 @@
  *
  * As a deviation from the norm, ompi_mpi_param_check is also
  * extern'ed in src/mpi/interface/c/bindings.h because it is already
- * included in all MPI function imlementation files
+ * included in all MPI function implementation files
  *
  * The values below are the default values.
  */
@@ -206,7 +206,7 @@ int ompi_mpi_register_params(void)
     /* Whether or not to print all MCA parameters in MPI_INIT */
     ompi_mpi_show_mca_params_string = NULL;
     (void) mca_base_var_register("ompi", "mpi", NULL, "show_mca_params",
-                                 "Whether to show all MCA parameter values during MPI_INIT or not (good for reproducability of MPI jobs "
+                                 "Whether to show all MCA parameter values during MPI_INIT or not (good for reproducibility of MPI jobs "
                                  "for debug purposes). Accepted values are all, default, file, api, and enviro - or a comma "
                                  "delimited combination of them",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
@@ -249,7 +249,7 @@ int ompi_mpi_register_params(void)
     /* File to use when dumping the parameters */
     (void) mca_base_var_register("ompi", "mpi", NULL, "show_mca_params_file",
                                  "If mpi_show_mca_params is true, setting this string to a valid filename tells "
-                                 OMPI_IDENT_STRING " to dump all the MCA parameter values into a file suitable for reading via the mca_param_files parameter (good for reproducability of MPI jobs)",
+                                 OMPI_IDENT_STRING " to dump all the MCA parameter values into a file suitable for reading via the mca_param_files parameter (good for reproducibility of MPI jobs)",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                  OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY,

--- a/ompi/runtime/ompi_spc.c
+++ b/ompi/runtime/ompi_spc.c
@@ -395,7 +395,7 @@ static void ompi_spc_dump(void)
     ompi_spc_comm->c_coll->coll_barrier(ompi_spc_comm, ompi_spc_comm->c_coll->coll_barrier_module);
 }
 
-/* Frees any dynamically alocated OMPI SPC data structures */
+/* Frees any dynamically allocated OMPI SPC data structures */
 void ompi_spc_fini(void)
 {
     if (ompi_mpi_spc_dump_enabled) {

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -63,7 +63,7 @@ OMPI_DECLSPEC extern bool ompi_mpi_param_check;
  * handles that are still allocated during MPI_FINALIZE.
  *
  * This is good debugging for user applications to find out if they
- * are inadvertantly orphaning MPI handles.
+ * are inadvertently orphaning MPI handles.
  */
 OMPI_DECLSPEC extern bool ompi_debug_show_handle_leaks;
 
@@ -73,7 +73,7 @@ OMPI_DECLSPEC extern bool ompi_debug_show_handle_leaks;
  * freed via MPI_FREE_MEM will be displayed during MPI_FINALIZE.
  *
  * This is good debugging for user applications to find out if they
- * are inadvertantly orphaning MPI "special" memory.
+ * are inadvertently orphaning MPI "special" memory.
  */
 OMPI_DECLSPEC extern int ompi_debug_show_mpi_alloc_mem_leaks;
 
@@ -84,7 +84,7 @@ OMPI_DECLSPEC extern int ompi_debug_show_mpi_alloc_mem_leaks;
  * attempt to use them will result in an MPI error.
  *
  * This is good debugging for user applications to find out if they
- * are inadvertantly using MPI handles after they have been freed.
+ * are inadvertently using MPI handles after they have been freed.
  */
 OMPI_DECLSPEC extern bool ompi_debug_no_free_handles;
 
@@ -178,7 +178,7 @@ OMPI_DECLSPEC extern char * ompi_mpi_spc_attach_string;
 OMPI_DECLSPEC extern bool ompi_mpi_spc_dump_enabled;
 
 /**
- * Timeout for calls to PMIx_Connect(defaut 0, no timeout)
+ * Timeout for calls to PMIx_Connect(default 0, no timeout)
  */
 OMPI_DECLSPEC extern uint32_t ompi_pmix_connect_timeout;
 

--- a/ompi/tools/ompi_info/ompi_info.1in
+++ b/ompi/tools/ompi_info/ompi_info.1in
@@ -114,7 +114,7 @@ Show version of Open MPI.
 .\" **************************
 .SH LEVELS
 Open MPI has many, many run-time tunable parameters (called "MCA
-parameters"), and usually only a handfull of them are useful to a
+parameters"), and usually only a handful of them are useful to a
 given user.
 .
 .

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -117,7 +117,7 @@ typedef struct ompi_win_t ompi_win_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_win_t);
 
 /**
- * Padded struct to maintain back compatibiltiy.
+ * Padded struct to maintain back compatibility.
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
@@ -149,8 +149,8 @@ OMPI_DECLSPEC int ompi_win_get_name(ompi_win_t *win, char *win_name, int *length
 
 OMPI_DECLSPEC int ompi_win_group(ompi_win_t *win, ompi_group_t **group);
 
-/* Note that the defintion of an "invalid" window is closely related
-   to the defintion of an "invalid" communicator.  See a big comment
+/* Note that the definition of an "invalid" window is closely related
+   to the definition of an "invalid" communicator.  See a big comment
    in ompi/communicator/communicator.h about this. */
 static inline int ompi_win_invalid(ompi_win_t *win) {
     if (NULL == win ||


### PR DESCRIPTION
Found via: codespell -q 3 -S ./3rd-party,./docs/news -L bloc,chello,childs,connexion,fo,improbe,inout,iput,mmaped,msdos,ro,scoll,sentinal,upto

Signed-off-by: luz paz <luzpaz@github.com>

fix typo introduced by previous commit

Signed-off-by: luz paz <luzpaz@github.com>
(cherry picked from commit d88da19a23883eceb0df69956b977c6bb1aba97a)

FYI @luzpaz 