### PR TITLE
Atomics: default to GCC builtin atomics and use C11 _Atomic as fall-back

### DIFF
--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -31,7 +31,11 @@ typedef volatile ssize_t opal_atomic_ssize_t;
 typedef volatile intptr_t opal_atomic_intptr_t;
 typedef volatile uintptr_t opal_atomic_uintptr_t;
 
+#if OPAL_USE_GCC_BUILTIN_ATOMICS == 0
 typedef opal_atomic_int32_t opal_atomic_lock_t;
+#else // OPAL_USE_GCC_BUILTIN_ATOMICS
+typedef volatile bool opal_atomic_lock_t;
+#endif // OPAL_USE_GCC_BUILTIN_ATOMICS
 
 enum { OPAL_ATOMIC_LOCK_UNLOCKED = 0,
        OPAL_ATOMIC_LOCK_LOCKED = 1 };


### PR DESCRIPTION
As per the discussion in https://github.com/open-mpi/ompi/pull/10492 (https://github.com/open-mpi/ompi/pull/10492#issuecomment-1189087429) we want to replace the C11 `_Atomic` variables with a custom wrapper around basic atomic types. However, this requires significant changes throughout the code base to wrap direct assignment and initialization in macros. We may not want to backport this to 5.0.x at such a late stage. Instead this PR provides some fixes for the GCC builtin atomics (`__atomic`) and makes them the default, with C11 atomics as a fallback. This can then be backported to 5.0.x before attempting the larger changes in `main`.

The underlying problem is that C11 atomics require us to annotate atomic variables with `_Atomic` that then makes direct assignment sequentially consistent, which in turn make initialization costly and defeats the purpose of the `OPAL_THREAD_*` macros that try to avoid atomic operations if possible. As an alternative, https://github.com/open-mpi/ompi/pull/10492 removes the `_Atomic` annotation of variables and adds casts to the atomic functions, which is a hack.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>