### PR TITLE
Revert "Start: check return value of request start function"

### DIFF
--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -77,7 +77,7 @@ int MPI_Start(MPI_Request *request)
         ret = (*request)->req_start(1, request);
 
         OPAL_CR_EXIT_LIBRARY();
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_REQUEST, FUNC_NAME);
+        return ret;
 
     case OMPI_REQUEST_NOOP:
         /**


### PR DESCRIPTION
This check was missing for many years, which didn't seem to
cause any harm. Back-porting is not straightforward.

This reverts commit 350284603d1fc8f50e7642ea508d701d7fb5fc8f which was part of https://github.com/open-mpi/ompi/pull/10553 and broke the branch.

bot:notacherrypick

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>