### PR TITLE
MPI-4: Issue warning when MPI_Cancel called for non blocking send request, MPI_Isend, etc

### DIFF
--- a/ompi/mca/pml/base/pml_base_sendreq.h
+++ b/ompi/mca/pml/base/pml_base_sendreq.h
@@ -67,6 +67,19 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
  * is done in the send request start routine.
  */
 
+#if MPI_VERSION >= 4
+/*
+ * Deprecation of MPI_Cancel for non blocking sends in MPI 4.0 and later
+ * is handled by adding a callback for the cancel request.
+ */
+#define MCA_PML_BASE_SEND_CANCEL_CALLBACK(req)                              \
+    if (NULL == (req)->req_base.req_ompi.req_cancel) {                      \
+        (req)->req_base.req_ompi.req_cancel = mca_pml_cancel_send_callback; \
+    }
+#else
+#define MCA_PML_BASE_SEND_CANCEL_CALLBACK(req)
+#endif
+
 #define MCA_PML_BASE_SEND_REQUEST_INIT( request,                          \
                                         addr,                             \
                                         count,                            \
@@ -95,6 +108,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
       (request)->req_base.req_pml_complete = false;                       \
       (request)->req_base.req_free_called = false;                        \
       (request)->req_base.req_ompi.req_status._cancelled = 0;             \
+      MCA_PML_BASE_SEND_CANCEL_CALLBACK(request)                          \
       (request)->req_bytes_packed = 0;                                    \
                                                                           \
       /* initialize datatype convertor for this request */                \

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -30,6 +30,11 @@
 #include "ompi/peruse/peruse-internal.h"
 #include "ompi/runtime/ompi_spc.h"
 
+#if MPI_VERSION >= 4
+extern int ompi_pml_base_deprecation_warn_level;
+extern ompi_request_t ompi_request_empty_send;
+#endif
+
 /**
  * Single usage request. As we allow recursive calls (as an
  * example from the request completion callback), we cannot rely
@@ -181,6 +186,12 @@ int mca_pml_ob1_isend(const void *buf,
             /* NTH: it is legal to return ompi_request_empty since the only valid
              * field in a send completion status is whether or not the send was
              * cancelled (which it can't be at this point anyway). */
+#if MPI_VERSION >= 4
+            if (OPAL_UNLIKELY(ompi_pml_base_deprecation_warn_level != 3)) {
+                *request = &ompi_request_empty_send;
+                return OMPI_SUCCESS;
+            }
+#endif
             *request = &ompi_request_empty;
             return OMPI_SUCCESS;
         }

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -125,8 +125,16 @@ static int mca_pml_ob1_send_request_free(struct ompi_request_t** request)
     return OMPI_SUCCESS;
 }
 
+#if MPI_VERSION >= 4
+extern int mca_pml_cancel_send_callback(struct ompi_request_t* request, int complete);
+#endif
+
 static int mca_pml_ob1_send_request_cancel(struct ompi_request_t* request, int complete)
 {
+#if MPI_VERSION >= 4
+    mca_pml_cancel_send_callback(request, complete);
+#endif
+
 #if OPAL_ENABLE_FT_MPI
     ompi_communicator_t* comm = request->req_mpi_object.comm;
     mca_pml_ob1_send_request_t* pml_req = (mca_pml_ob1_send_request_t*)request;

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
@@ -358,6 +358,9 @@ int mca_pml_ucx_init(int enable_mpi_threads)
     /* Create a completed request to be returned from isend */
     OBJ_CONSTRUCT(&ompi_pml_ucx.completed_send_req, ompi_request_t);
     mca_pml_ucx_completed_request_init(&ompi_pml_ucx.completed_send_req);
+#if MPI_VERSION >= 4
+    ompi_pml_ucx.completed_send_req.req_cancel = mca_pml_cancel_send_callback;
+#endif
 
     opal_progress_register(mca_pml_ucx_progress);
 
@@ -924,6 +927,11 @@ int mca_pml_ucx_isend(const void *buf, size_t count, ompi_datatype_t *datatype,
     } else if (!UCS_PTR_IS_ERR(req)) {
         PML_UCX_VERBOSE(8, "got request %p", (void*)req);
         req->req_mpi_object.comm = comm;
+#if MPI_VERSION >= 4
+        if (mca_pml_ucx_request_cancel == req->req_cancel) {
+            req->req_cancel      = mca_pml_ucx_request_cancel_send;
+        }
+#endif
         *request                 = req;
         return OMPI_SUCCESS;
     } else {

--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,6 +15,7 @@
 #include "ompi/mca/pml/base/pml_base_bsend.h"
 #include "ompi/message/message.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/request/request.h"
 #include <inttypes.h>
 
 
@@ -29,11 +31,19 @@ static int mca_pml_ucx_request_free(ompi_request_t **rptr)
     return OMPI_SUCCESS;
 }
 
-static int mca_pml_ucx_request_cancel(ompi_request_t *req, int flag)
+int mca_pml_ucx_request_cancel(ompi_request_t *req, int flag)
 {
     ucp_request_cancel(ompi_pml_ucx.ucp_worker, req);
     return OMPI_SUCCESS;
 }
+
+#if MPI_VERSION >= 4
+int mca_pml_ucx_request_cancel_send(ompi_request_t *req, int flag)
+{
+    mca_pml_cancel_send_callback(req, flag);
+    return mca_pml_ucx_request_cancel(req, flag);
+}
+#endif
 
 __opal_attribute_always_inline__ static inline void
 mca_pml_ucx_send_completion_internal(void *request, ucs_status_t status)

--- a/ompi/mca/pml/ucx/pml_ucx_request.h
+++ b/ompi/mca/pml/ucx/pml_ucx_request.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2016-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,6 +145,11 @@ void mca_pml_ucx_completed_request_init(ompi_request_t *ompi_req);
 void mca_pml_ucx_request_init(void *request);
 
 void mca_pml_ucx_request_cleanup(void *request);
+
+int mca_pml_ucx_request_cancel(ompi_request_t *req, int flag);
+#if MPI_VERSION >= 4
+int mca_pml_ucx_request_cancel_send(ompi_request_t *req, int flag);
+#endif
 
 
 static inline void mca_pml_ucx_request_reset(ompi_request_t *req)

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -383,6 +383,10 @@ OMPI_DECLSPEC extern ompi_predefined_request_t        *ompi_request_null_addr;
 OMPI_DECLSPEC extern ompi_request_t         ompi_request_empty;
 OMPI_DECLSPEC extern ompi_status_public_t   ompi_status_empty;
 OMPI_DECLSPEC extern ompi_request_fns_t     ompi_request_functions;
+#if MPI_VERSION >= 4
+OMPI_DECLSPEC extern ompi_request_t         ompi_request_empty_send;
+extern int mca_pml_cancel_send_callback(struct ompi_request_t *request, int flag);
+#endif
 
 /**
  * Initialize the MPI_Request subsystem; invoked during MPI_INIT.


### PR DESCRIPTION
Issue a deprecation warning when MPI_Cancel is called referencing a request created by a point to point non-blocking send, such as MPI_Isend.

The warning is issued only when MPI version is >= 4

This change only applies to the ob1 and UCX components since I don't have systems to test anything else.

The message is controlled on a per-task basis by a new MCA option, --mca pml_base_warn_deprecated {once | always | never}

Signed-off-by: David Wootton [dwootton@us.ibm.com](mailto:dwootton@us.ibm.com)