### PR TITLE
MPI 4: Add MPI_COMM_TYPE_HW_UNGUIDED and MPI_COMM_TYPE_HW_GUIDED

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -19,7 +19,7 @@
  * Copyright (c) 2015      University of Houston. All rights reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2021-2022 Google, LLC. All rights reserved.
  * Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights
@@ -852,7 +852,9 @@ enum {
   OMPI_COMM_TYPE_BOARD,
   OMPI_COMM_TYPE_HOST,
   OMPI_COMM_TYPE_CU,
-  OMPI_COMM_TYPE_CLUSTER
+  OMPI_COMM_TYPE_CLUSTER,
+  MPI_COMM_TYPE_HW_UNGUIDED,
+  MPI_COMM_TYPE_HW_GUIDED
 };
 #define OMPI_COMM_TYPE_NODE MPI_COMM_TYPE_SHARED
 

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -7,6 +7,7 @@
 # Copyright (c) 2020      The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -395,6 +396,8 @@ $constants->{OMPI_COMM_TYPE_BOARD} = 8;
 $constants->{OMPI_COMM_TYPE_HOST} = 9;
 $constants->{OMPI_COMM_TYPE_CU} = 10;
 $constants->{OMPI_COMM_TYPE_CLUSTER} = 11;
+$constants->{MPI_COMM_TYPE_HW_UNGUIDED} = 12;
+$constants->{MPI_COMM_TYPE_HW_GUIDED} = 13;
 
 #----------------------------------------------------------------------------
 


### PR DESCRIPTION
 * Fixes #9197
 * `MPI_COMM_TYPE_HW_GUIDED` supports all of the existing `OMPI_COMM_TYPE_`
   options.
 * `MPI_COMM_TYPE_HW_UNGUIDED` is recognized, but not supported so it returns
   `MPI_COMM_NULL` indidicating that the MPI library cannot split the
   communicator any further.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>