### PR TITLE
threads: configury updates for argo and qthreads

### DIFF
--- a/opal/mca/threads/argobots/configure.m4
+++ b/opal/mca/threads/argobots/configure.m4
@@ -14,7 +14,7 @@
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
-# Copyright (c) 2019      Triad National Security, LLC. All rights
+# Copyright (c) 2019-2022 Triad National Security, LLC. All rights
 #                         Reserved.
 # Copyright (c) 2021      Argonne National Laboratory.  All rights reserved.
 # $COPYRIGHT$
@@ -56,14 +56,9 @@ AC_DEFUN([OPAL_CONFIG_ARGOBOTS_THREADS],[
 
     AS_IF([test $opal_argo_happy = yes && test $opal_argo11_happy = no],
           [AC_MSG_ERROR([Open MPI requires Argobots 1.1 or newer.])])
-    AS_IF([test $opal_argo_happy = yes && test $opal_argo11_happy = yes && test -n "$opal_argo_dir"],
-          [OPAL_ARGO_INCLUDE_PATH="$opal_argo_dir/include/"],
-          [OPAL_ARGO_INCLUDE_PATH=""])
 
     AS_IF([test $opal_argo_happy = yes],
-          [AC_CONFIG_FILES([opal/mca/threads/argobots/threads_argobots.h])
-           AC_SUBST([OPAL_ARGO_INCLUDE_PATH])
-           AC_SUBST([opal_argo_CPPFLAGS])
+          [ AC_SUBST([opal_argo_CPPFLAGS])
            AC_SUBST([opal_argo_LDFLAGS])
            AC_SUBST([opal_argo_LIBS])
            TPKG_CFLAGS="$opal_argo_CPPFLAGS"
@@ -74,7 +69,7 @@ AC_DEFUN([OPAL_CONFIG_ARGOBOTS_THREADS],[
            TPKG_LDFLAGS="$opal_argo_LDFLAGS"
            TPKG_LIBS="$opal_argo_LIBS"])
 
-    CPPFLAGS=$opal_check_argo_save_CPPFLAGS
+    CPPFLAGS="${opal_check_argo_save_CPPFLAGS} ${opal_argo_CPPFLAGS}"
     LDFLAGS=$opal_check_argo_save_LDFLAGS
     LIBS=$opal_check_argo_save_LIBS
 

--- a/opal/mca/threads/argobots/threads_argobots.h
+++ b/opal/mca/threads/argobots/threads_argobots.h
@@ -26,7 +26,7 @@
 #ifndef OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_H
 #define OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_H
 
-#include "@OPAL_ARGO_INCLUDE_PATH@abt.h"
+#include "abt.h"
 
 static inline void opal_threads_argobots_ensure_init(void)
 {

--- a/opal/mca/threads/qthreads/configure.m4
+++ b/opal/mca/threads/qthreads/configure.m4
@@ -13,7 +13,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2019      Triad National Security, LLC. All rights
+# Copyright (c) 2019-2022 Triad National Security, LLC. All rights
 #                         reserved.
 #
 # $COPYRIGHT$
@@ -45,10 +45,6 @@ AC_DEFUN([OPAL_CONFIG_QTHREADS],[
                       [opal_qthreads_happy=yes],
                       [opal_qthreads_happy=no])
 
-    AS_IF([test $opal_qthreads_happy = yes && test -n "$opal_qthreads_dir"],
-          [OPAL_QTHREADS_INCLUDE_PATH="$opal_qthreads_dir/include/"],
-          [OPAL_QTHREADS_INCLUDE_PATH=""])
-
     AS_IF([test $opal_qthreads_happy = yes],
           [TPKG_CFLAGS="$opal_qthreads_CPPFLAGS"
            TPKG_FCFLAGS="$opal_qthreads_CPPFLAGS"
@@ -58,13 +54,11 @@ AC_DEFUN([OPAL_CONFIG_QTHREADS],[
            TPKG_LDFLAGS="$opal_qthreads_LDFLAGS"
            TPKG_LIBS="$opal_qthreads_LIBS"])
 
-    AC_CONFIG_FILES([opal/mca/threads/qthreads/threads_qthreads.h])
-    AC_SUBST([OPAL_QTHREADS_INCLUDE_PATH])
     AC_SUBST([opal_qthreads_CPPFLAGS])
     AC_SUBST([opal_qthreads_LDFLAGS])
     AC_SUBST([opal_qthreads_LIBS])
 
-    CPPFLAGS=$opal_check_qthreads_save_CPPFLAGS
+    CPPFLAGS="${opal_check_argo_save_CPPFLAGS} ${opal_qthreads_CPPFLAGS}"
     LDFLAGS=$opal_check_qthreads_save_LDFLAGS
     LIBS=$opal_check_qthreads_save_LIBS
 

--- a/opal/mca/threads/qthreads/threads_qthreads.h
+++ b/opal/mca/threads/qthreads/threads_qthreads.h
@@ -26,8 +26,8 @@
 #ifndef OPAL_MCA_THREADS_QTHREADS_THREADS_QTHREADS_H
 #define OPAL_MCA_THREADS_QTHREADS_THREADS_QTHREADS_H 1
 
-#include "@OPAL_QTHREADS_INCLUDE_PATH@qthread.h"
-#include "@OPAL_QTHREADS_INCLUDE_PATH@qthread/tls.h"
+#include "qthread.h"
+#include "qthread/tls.h"
 
 static inline void opal_threads_ensure_init_qthreads(void)
 {


### PR DESCRIPTION
The OAC_CHECK_PACKAGE macro doesn't have quite the same
functionality as the origina ?OPAL_CHECK_PACKAGE? macro,
so add some sed magic to get the path we need for
argo/qthread related header files.

related to #10459

Signed-off-by: Howard Pritchard <howardp@lanl.gov>