### PR TITLE
sessions: switch to mpi_size for info key

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1374,7 +1374,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub;
 /*
  * Predefined info keys
  */
-#define MPI_INFO_KEY_SESSION_PSET_SIZE  "size"
+#define MPI_INFO_KEY_SESSION_PSET_SIZE  "mpi_size"
 
 /*
  * MPI API


### PR DESCRIPTION
per the key defined in the MPI 4.0 standard for number
of processes in a process set.

related to #10576

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 23000defa32e3de327a147cc4b652dcd666065c0)