### PR TITLE
Fix typos in config subdirectory

### DIFF
--- a/config/extract-3rd-party-configure.pl
+++ b/config/extract-3rd-party-configure.pl
@@ -120,7 +120,7 @@ sub process_m4($)
     #  AC_ARG_WITH (package, help-string, [action-if-given], [action-if-not-given])
     my @conf_keywords = ("AC_ARG_ENABLE", "AC_ARG_WITH");
 
-    # stack with funciton parameters: '(', ')'
+    # stack with function parameters: '(', ')'
     my @the_stack = ();
     # push(@the_stack) / pop(@the_stack) / scalar(@the_stack)
     my $arg_num = 0;
@@ -151,7 +151,7 @@ sub process_m4($)
                         last;
                     }
 
-                    # Skip any option that contains a variable substition
+                    # Skip any option that contains a variable substitution
                     if ( $option_name =~ /\$/ ) {
                         if( !$list_only && !$quiet_arg) {
                             print "# Warning: Skipped (embedded variable): $option_name\n";

--- a/config/oac_check_package.m4
+++ b/config/oac_check_package.m4
@@ -53,7 +53,7 @@ dnl      in the specified path.
 dnl   4. We try to find the specified header and function with no change
 dnl      in CPPFLAGS or LDFLAGS and adding the specified libraries to LIBS.
 dnl
-dnl It is the resposibility of the caller to register arguments of the form
+dnl It is the responsibility of the caller to register arguments of the form
 dnl with-<package name>, with-<package name>-libdir, and with-package name>-incdir.
 dnl All three are optional, nothing will break if the caller doesn't specify them
 dnl (and indeed, if the package being searched for isn't libnl3, it's likely the
@@ -63,7 +63,7 @@ dnl By default, OAC_CHECK_PACKAGE will use <package name> for the module name to
 dnl to pkg-config, meaning there is a <package name>.pc in the filesystem.  If a
 dnl different module name should be used, add a macro to the M4 environment named
 dnl <package name>_pkgconfig_module with the value of the pkgconfig module name
-dnl to use.  For exmaple, if the libevent module name is libevent_core, you could
+dnl to use.  For example, if the libevent module name is libevent_core, you could
 dnl specify:
 dnl
 dnl    m4_define([libevent_pkgconfig_module], [libevent_core])
@@ -326,7 +326,7 @@ dnl Rarely, packages change linking or in some other way make it
 dnl difficult to determine all the correct arguments for
 dnl OAC_CHECK_PACKAGE in one try.  The TM interface is a good example
 dnl of this, which has changed the name of the library (or its
-dnl dependencies) throughtout the years.  Because OAC_CHECK_PACKAGE
+dnl dependencies) throughout the years.  Because OAC_CHECK_PACKAGE
 dnl makes heavy use of caching (yay!), it is generally not useful to
 dnl call OAC_CHECK_PACKAGE multiple times with the same package name,
 dnl but different arguments.  This macro may be expanded between calls
@@ -621,7 +621,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC_PREFIX], [
                   AS_IF([test $? -eq 0],
                         [check_package_generic_prefix_happy=1
                          $2_LDFLAGS="-L${check_package_libdir}"
-                         AC_MSG_RESULT([foound])],
+                         AC_MSG_RESULT([found])],
                         [AC_MSG_RESULT([not found])])],
                  [check_package_generic_prefix_lib=0
                   check_package_generic_prefix_lib64=0

--- a/config/ompi_find_mpi_aint_count_offset.m4
+++ b/config/ompi_find_mpi_aint_count_offset.m4
@@ -95,7 +95,7 @@ AC_DEFUN([_OMPI_FIND_MPI_COUNT_TYPE], [
     # memory space, the scheme we use below may not work.  ...but such
     # systems are pretty rare today.
 
-    MPI_COUNT_TYPE=unknonwn
+    MPI_COUNT_TYPE=unknown
     AC_MSG_CHECKING([for type of MPI_Count])
     if test $ac_cv_sizeof_long_long -le $ac_cv_sizeof_size_t && \
        test $ac_cv_sizeof_long_long -ge $MPI_AINT_SIZE; then

--- a/config/ompi_fortran_check.m4
+++ b/config/ompi_fortran_check.m4
@@ -32,7 +32,7 @@ dnl
 # - alignment
 # - associated C type
 #
-# types to search is a comma-seperated list of values
+# types to search is a comma-separated list of values
 AC_DEFUN([OMPI_FORTRAN_CHECK], [
     OPAL_VAR_SCOPE_PUSH([ofc_have_type ofc_type_size ofc_type_alignment ofc_c_type ofc_expected_size])
 

--- a/config/ompi_fortran_find_module_include_flag.m4
+++ b/config/ompi_fortran_find_module_include_flag.m4
@@ -54,7 +54,7 @@ EOF
         cd ..
 
         #
-        # Now try to compile a simple program usinng that module, iterating
+        # Now try to compile a simple program using that module, iterating
         # through the possible flags that the compiler might use
         #
 

--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -81,7 +81,7 @@ AC_DEFUN([OMPI_SETUP_FC],[
 
     # OS X before 10.3 (deployment target) does not allow undefined common
     # symbols in shared libraries.  Because we can't figure out how to
-    # implement MPI_STATUSES_IGNORE and friends wihtout common symbols, on
+    # implement MPI_STATUSES_IGNORE and friends without common symbols, on
     # OS X we can't build the F90 bindings as a shared library.
     OMPI_FORTRAN_EXTRA_SHARED_LIBRARY_FLAGS=
     AS_IF([test $ompi_fc_happy -eq 1],

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -301,7 +301,7 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     #
     # ...and you can't have a "use..." statement before that (to get
     # the Fortran/C interop C_INTxx_T KIND values).  So figure out
-    # those KIND values here and just substitue them in via
+    # those KIND values here and just substitute them in via
     # AC_DEFINE's.  Kinda gross, but there you are.  :-\
     OMPI_FORTRAN_GET_KIND_VALUE([C_INT16_T], 4, [OMPI_FORTRAN_C_INT16_T_KIND])
     OMPI_FORTRAN_GET_KIND_VALUE([C_INT32_T], 9, [OMPI_FORTRAN_C_INT32_T_KIND])

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -30,7 +30,7 @@ dnl Check for / configure PRRTE package.  Prefer finding an external
 dnl PRRTE, build our internal one if required.  If we can not find an
 dnl external PRRTE and the internal one fails to configure, abort.
 dnl
-dnl This macro wil change the environment in the following way:
+dnl This macro will change the environment in the following way:
 dnl
 dnl A Makefile conditional OMPI_WANT_PRRTE will be defined based on the
 dnl results of the build.
@@ -62,7 +62,7 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
                                            [prrte_setup_internal_happy=0])])
 
          # if we have a pmix package and configure did not complete
-         # successfullly (or wasn't started), then disable make dist.
+         # successfully (or wasn't started), then disable make dist.
          AS_IF([test $prrte_setup_internal_happy != 1],
                [OPAL_MAKEDIST_DISABLE="$OPAL_MAKEDIST_DISABLE PRRTE"])])
 

--- a/config/opal_case_sensitive_fs_setup.m4
+++ b/config/opal_case_sensitive_fs_setup.m4
@@ -64,7 +64,7 @@ AC_ARG_WITH([cs_fs],
             [AS_HELP_STRING([--with-cs-fs],
                            [Destination FS is case sensitive (default: set to value of the build FS's case sensitivity)])])
 
-dnl Stupid emacs syntax hilighting: '
+dnl Stupid emacs syntax highlighting: '
 
 if test "$with_cs_fs" = "yes"; then
     OPAL_WANT_CS_FS=1

--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -39,7 +39,7 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
 
     # need at least version 0x0000000b
     AS_IF([test "$opal_check_knem_happy" = "yes"],
-          [AC_CACHE_CHECK([for recent vesion of knem ABI],
+          [AC_CACHE_CHECK([for recent version of knem ABI],
               [opal_check_knem_cv_abi_version],
               [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
 #include <knem_io.h>

--- a/config/opal_config_3rdparty.m4
+++ b/config/opal_config_3rdparty.m4
@@ -33,7 +33,7 @@ dnl If m4_ifdef(internal support) does not evaluate to true (ie, at
 dnl autogen time), the references to internal in the help strings will
 dnl be removed and internal will not be a supported option.
 dnl
-dnl If m4_ifval(ddisbaled ok) does not evaluete to true (ie, at autogen
+dnl If m4_ifval(ddisbaled ok) does not evaluate to true (ie, at autogen
 dnl time), then --without-pkg will not be a valid configure option and
 dnl will raise an error.
 dnl

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -588,7 +588,7 @@ dnl   - OPAL_USE_GCC_BUILTIN_ATOMICS - 1 if atomics implementation
 dnl         should use GCC built-in style atomics
 dnl   - OPAL_USE_ASM_ATOMICS - 1 if atomics implementation should
 dnl         use inline assembly (using GCC-style inline assembly)
-dnl        for atomics implementaiton
+dnl        for atomics implementation
 dnl
 dnl #################################################################
 AC_DEFUN([OPAL_CONFIG_ASM],[
@@ -678,7 +678,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
 
             powerpc-*|powerpc64-*|powerpcle-*|powerpc64le-*|rs6000-*|ppc-*)
                 AS_IF([test "$ac_cv_sizeof_long" = "8"],
-                      [atomics_found="PowerPC asssembly"])
+                      [atomics_found="PowerPC assembly"])
             ;;
             esac
 

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -136,7 +136,7 @@ AC_DEFUN([_OPAL_CONFIG_LIBEVENT_EXTERNAL], [
               [opal_libevent_cv_threads_enabled="yes"],
               [opal_libevent_cv_threads_enabled="no"])])
            AS_IF([test "${opal_libevent_cv_threads_enabled}" = "no"],
-                 [AC_MSG_WARN([Open MPI rquires libevent to be compiled with thread support enabled])
+                 [AC_MSG_WARN([Open MPI requires libevent to be compiled with thread support enabled])
                   opal_libevent_external_support="no"])])
 
     AS_IF([test "$opal_libevent_external_support" = "yes"],

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -116,7 +116,7 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
                 OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS openpmix"])
 
          # if we have a pmix package and configure did not complete
-         # successfullly (or wasn't started), then disable make dist.
+         # successfully (or wasn't started), then disable make dist.
          AS_IF([test $internal_pmix_happy != 1],
                [OPAL_MAKEDIST_DISABLE="$OPAL_MAKEDIST_DISABLE PMIX"])])
 

--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -523,7 +523,7 @@ OPAL_WITH_OPTION_MIN_MAX_VALUE(info_val,        256,  32, 1024)
 # Min length according to _POSIX_HOST_NAME_MAX=255 (4*HOST_NAME_MAX)
 OPAL_WITH_OPTION_MIN_MAX_VALUE(port_name,      1024, 255, 2048)
 
-# Min length accroding to MPI-2.1, p. 418
+# Min length according to MPI-2.1, p. 418
 OPAL_WITH_OPTION_MIN_MAX_VALUE(datarep_string,  128,  64,  256)
 
 OPAL_WITH_OPTION_MIN_MAX_VALUE(pset_name_len,  512,  512, 4096)

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -395,7 +395,7 @@ dnl #######################################################################
 # variable, it is appended to variable.
 #
 # If an argument in new_argument begins with a -l and is already in
-# variable, the existing occurances of the argument are removed from
+# variable, the existing occurrences of the argument are removed from
 # variable and the argument is appended to variable.  This behavior
 # is most useful in LIBS, where ordering matters and being rightmost
 # is usually the right behavior.
@@ -456,7 +456,7 @@ AC_DEFUN([OPAL_WHICH],[
     # executable, return the absolute path of that value in $2.
     # Otherwise, $2 is unchanged.
 
-    # 3. opal_prog contains no /.  Search the PATH for an excutable
+    # 3. opal_prog contains no /.  Search the PATH for an executable
     # with the appropriate name.  If found, return the absolute path
     # in $2.  Otherwise, $2 is unchanged.
 

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -81,7 +81,7 @@ AC_DEFUN([OPAL_MCA],[
                         supported) is to build all components as DSOs.
                         Enabling a component as static disables it
                         building as a DSO.  The default is to build all
-                        components staticly.])])
+                        components statically.])])
     AC_ARG_ENABLE([mca-direct],
         [AS_HELP_STRING([--enable-mca-direct=LIST],
                        [Comma-separated list of type-component pairs that
@@ -153,7 +153,7 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
             AS_VAR_COPY([var_value], [$var_name])
 
             if test -n "$var_value" ; then
-                AC_MSG_ERROR([enable-mca-direct can only enable a single component per framwork: specified both ${type}-${var_value} and ${type}-${comp}.])
+                AC_MSG_ERROR([enable-mca-direct can only enable a single component per framework: specified both ${type}-${var_value} and ${type}-${comp}.])
             fi
 
             AS_VAR_SET([$var_name], AS_TR_SH([${comp}]))

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -183,7 +183,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
         # following lines and update the warning when we require a C11 compiler.
         # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
         # AC_MSG_ERROR([Aborting.])
-        # From Open MPI 1.7 on we require a C99 compiant compiler
+        # From Open MPI 1.7 on we require a C99 compliant compiler
         dnl with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
         m4_version_prereq([2.70],
             [],
@@ -428,7 +428,7 @@ AC_DEFUN([_OPAL_START_SETUP_CC],[
 
 
 AC_DEFUN([_OPAL_PROG_CC],[
-    dnl It is really easy to accidently call AC_PROG_CC implicitly through
+    dnl It is really easy to accidentally call AC_PROG_CC implicitly through
     dnl some other test run before OPAL_SETUP_CC.  Try to make that harder.
     m4_provide_if([AC_PROG_CC],
                   [m4_fatal([AC_PROG_CC called before OPAL_SETUP_CC])])

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -317,7 +317,7 @@ AC_DEFUN([RPATHIFY_FC_LDFLAGS],[RPATHIFY_LDFLAGS_INTERNAL([$1], [rpath_fc_args])
 # and pkg-config files:
 #
 # 1) --enable-shared --disable-static (today's default): Any
-#    application linking against libmpi will be a dynamicly linked
+#    application linking against libmpi will be a dynamically linked
 #    application
 # 2) --enable-shared --enable-static: An application linking against
 #    libmpi will dynamically link against libmpi unless -static (or

--- a/config/opal_subdir_env.m4
+++ b/config/opal_subdir_env.m4
@@ -17,7 +17,7 @@ dnl That is, if a precious variable (say CPPFLAGS) was set on the
 dnl configure command line or in the environment at the start of
 dnl configure, it will be reset to that stored value.  Otherwise, it
 dnl will be unset.  The current state is recorded so that it can be
-dnl restored with OPAL_SUBDIR_ENV_RESTORE.  Useful for wrapping calles
+dnl restored with OPAL_SUBDIR_ENV_RESTORE.  Useful for wrapping calls
 dnl to subconfigure scripts.
 AC_DEFUN([OPAL_SUBDIR_ENV_CLEAN], [
     for temp_var in $ac_precious_vars; do

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -39,7 +39,7 @@ dnl
 # OPAL_SUMMARY_ADD([Resource Type], [Component Name], [], [$results])
 # and then unset $results to avoid namespace pollution.  This will
 # work properly with the current behavior, but would result in odd
-# errors if we delayed evaulation.
+# errors if we delayed evaluation.
 #
 # As a historical note, the third argument has never been used in
 # OPAL_SUMMARY_ADD and its meaning is unclear.  Preferred behavior is


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rd-party,./docs/news -L bloc,chello,childs,connexion,fo,improbe,inout,iput,mmaped,msdos,ro,scoll,sentinal,siz,upto,warmup`

Signed-off-by: luz paz <luzpaz@github.com>
