### PR TITLE
osc/ucx: Add missing calls to OMPI_OSC_UCX_REQUEST_ALLOC in rget/rput error paths

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -1062,14 +1062,13 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
 
     CHECK_DYNAMIC_WIN(remote_addr, module, target, ret, true);
 
-    OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
-    assert(NULL != ucx_req);
-
     ret = ompi_osc_ucx_put(origin_addr, origin_count, origin_dt, target, target_disp,
                            target_count, target_dt, win);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
+
+    OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
 
     mca_osc_ucx_component.num_incomplete_req_ops++;
     ret = opal_common_ucx_wpmem_flush_ep_nb(mem, target, req_completion, ucx_req);
@@ -1079,6 +1078,7 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
         ret = opal_common_ucx_wpmem_fence(mem);
         if (ret != OMPI_SUCCESS) {
             OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_fence failed: %d", ret);
+            OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
             return OMPI_ERROR;
         }
 
@@ -1115,14 +1115,13 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
 
     CHECK_DYNAMIC_WIN(remote_addr, module, target, ret, true);
 
-    OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
-    assert(NULL != ucx_req);
-
     ret = ompi_osc_ucx_get(origin_addr, origin_count, origin_dt, target, target_disp,
                            target_count, target_dt, win);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
+
+    OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
 
     mca_osc_ucx_component.num_incomplete_req_ops++;
     ret = opal_common_ucx_wpmem_flush_ep_nb(mem, target, req_completion, ucx_req);
@@ -1132,6 +1131,7 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
         ret = opal_common_ucx_wpmem_fence(mem);
         if (ret != OMPI_SUCCESS) {
             OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_fence failed: %d", ret);
+            OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
             return OMPI_ERROR;
         }
 


### PR DESCRIPTION
Follow-up to https://github.com/open-mpi/ompi/pull/10642 where some of the error paths did not properly cleanup an allocated request.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>