### PR TITLE
git-commit-checks: comment on PR with error(s) (cherry pick to v5.0.x)

### DIFF
--- a/.github/workflows/git-commit-checks.yml
+++ b/.github/workflows/git-commit-checks.yml
@@ -1,7 +1,11 @@
 name: GitHub Action CI
 
+# We're using pull_request_target here instead of just pull_request so that the
+# action runs in the context of the base of the pull request, rather than in the
+# context of the merge commit. For more detail about the differences, see:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 on:
-    pull_request:
+    pull_request_target:
         # We don't need this to be run on all types of PR behavior
         # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
         types:
@@ -32,3 +36,4 @@ jobs:
             run: $GITHUB_WORKSPACE/.github/workflows/git-commit-checks.py
             env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                PR_NUM: ${{ github.event.number }}


### PR DESCRIPTION
This adds comments onto the pull request containing what caused the commit checks to fail, if any, and suggests fixes to the user. If no errors are raised, no comment is made.

GitHub says there's a limit of 65536 characters on comments. If the bot's comment is over that limit, it will truncate the comment to fit, and add a message explaining where the remaining errors can be found. Unfortunately, the GitHub API doesn't seem to provide a job's unique ID for linking to a job run (this is different than an action run: ".../runs/..." vs ".../actions/runs/...", respectively), so we can't directly link to the error messages printed to the console. Additionally, to create this link, two new environment variables are used: GITHUB_RUN_ID and GITHUB_SERVER_URL.

Because we need the PR object twice, check_github_pr_description() was also changed to have the PR object passed into it; the PR object is gotten with a new function, get_github_pr().

The GitHub action configuration was changed to run on pull_request_target, instead of pull_request. This allows the action to be run in the context of the base of the PR, rather than in the context of the merge commit. Therefore, the action is run even if the PR has merge conflicts. Because of how the branch contexts are different between pull_request and pull_request_target, other parts of the Python script had to change to reflect these differences.

Signed-off-by: Joe Downs <joe@dwns.dev>
(cherry picked from commit 4b0ce7e5e1a1b7429e22ea861d6d84ecb478fb90)