### PR TITLE
v5.0.x OSC/UCX: Fix the opal_progress call condition inside flush

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -294,7 +294,7 @@ static inline int opal_common_ucx_wait_request_mt(ucs_status_ptr_t request, cons
                 break;
             }
             ctr--;
-        } while (ctr > 0 && ret > 0 && status == UCS_INPROGRESS);
+        } while (ctr > 0 && ret == 0 && status == UCS_INPROGRESS);
         opal_mutex_unlock(&winfo->mutex);
         if (!ctr) {
             opal_progress();


### PR DESCRIPTION
v5.0.x OSC/UCX: Fix the opal_progress call condition inside flush

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
(cherry picked from commit e2cf80bfe574911b9147e1f3d1b33bea6e7a6dac)