### PR TITLE
v5.0.x: fortran/ignore-tkr: fix typos in PMPI_* symbols

### DIFF
--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
@@ -1,6 +1,6 @@
 ! -*- fortran -*-
 !
-! Copyright (c) 2020      Research Organization for Information Science
+! Copyright (c) 2020-2022 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
 ! $COPYRIGHT$
 !
@@ -31,8 +31,8 @@
 #define MPI_Alltoallw_init PMPI_Alltoallw_init
 #define MPI_Barrier PMPI_Barrier
 #define MPI_Barrier_init PMPI_Barrier_init
-#define MPI_Bcast PPMPI_Bcast
-#define MPI_Bcast_init PPMPI_Bcast_init
+#define MPI_Bcast PMPI_Bcast
+#define MPI_Bcast_init PMPI_Bcast_init
 #define MPI_Bsend PMPI_Bsend
 #define MPI_Bsend_init PMPI_Bsend_init
 #define MPI_Buffer_attach PMPI_Buffer_attach


### PR DESCRIPTION
 - PPMPI_Bcast -> PMPI_Bcast
 - PPMPI_Bcast_init -> PMPI_Bcast_init

Thanks Felix Uhl for reporting this

Refs. open-mpi/ompi#10674

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit a4504c48c444e99053b156b9e4efdead5d81f16d)