### PR TITLE
Move MPI Standard version to VERSION file

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -19,6 +19,10 @@ major=5
 minor=1
 release=0
 
+# MPI Standard Compliance Level
+mpi_standard_version=3
+mpi_standard_subversion=1
+
 # OMPI required dependency versions.
 # List in x.y.z format.
 pmix_min_version=4.1.2

--- a/config/opal_get_version.m4
+++ b/config/opal_get_version.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
 dnl Copyright (c) 2014-2020 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
+dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -97,5 +98,29 @@ m4_define([OPAL_GET_VERSION],[
 
         m4_ifdef([AC_MSG_RESULT],
                  [AC_MSG_RESULT([$$2_REPO_REV])])
+    fi
+])
+
+# OPAL_GET_MPI_STANDARD_VERSION(version_file)
+# -----------------------------------------------
+# parse version_file for MPI Standard version information, setting
+# the following shell variables:
+#
+#  MPI_VERSION
+#  MPI_SUBVERSION
+m4_define([OPAL_GET_MPI_STANDARD_VERSION],[
+    dnl quote eval to suppress macro expansion with non-GNU m4
+    if test -f "$1"; then
+        srcdir=`dirname $1`
+        mpi_standard_vers=`sed -n "
+        t clear
+        : clear
+        s/^mpi_standard_version/MPI_VERSION/
+        s/^mpi_standard_subversion/MPI_SUBVERSION/
+        t print
+        b
+        : print
+        p" < "$1"`
+        [eval] "$mpi_standard_vers"
     fi
 ])

--- a/config/opal_save_version.m4
+++ b/config/opal_save_version.m4
@@ -11,6 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -61,4 +62,23 @@ AC_DEFUN([OPAL_SAVE_VERSION], [
         [Release date of ]$2)
 
     AC_CONFIG_FILES([$4])
+])dnl
+
+# OPAL_SAVE_MPI_STANDARD_VERSION(version_file)
+# ----------------------------------------------
+# creates version information for project from version_file, using
+# OPAL_GET_MPI_STANDARD_VERSION().
+AC_DEFUN([OPAL_SAVE_MPI_STANDARD_VERSION], [
+    OPAL_GET_MPI_STANDARD_VERSION([$1])
+
+    AC_SUBST([MPI_VERSION])
+    AC_SUBST([MPI_SUBVERSION])
+
+    AC_DEFINE_UNQUOTED([MPI_VERSION], [$MPI_VERSION],
+                       [MPI Standard Major version number])
+    AC_DEFINE_UNQUOTED([MPI_SUBVERSION], [$MPI_SUBVERSION],
+                       [MPI Standard Minor version number])
+
+    AC_MSG_CHECKING([MPI Standard version])
+    AC_MSG_RESULT([$MPI_VERSION.$MPI_SUBVERSION])
 ])dnl

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -6,6 +6,7 @@ dnl Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -92,6 +93,7 @@ AC_DEFUN([OPAL_SUMMARY_PRINT],[
 Open MPI configuration:
 -----------------------
 Version: $OMPI_MAJOR_VERSION.$OMPI_MINOR_VERSION.$OMPI_RELEASE_VERSION$OMPI_GREEK_VERSION
+MPI Standard Version: $MPI_VERSION.$MPI_SUBVERSION
 EOF
 
     if test "$project_ompi_amc" = "true" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2022 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
-# Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
@@ -141,7 +141,8 @@ opal_show_subtitle "Checking versions"
 
 m4_ifdef([project_ompi],
          [OPAL_SAVE_VERSION([OMPI], [Open MPI], [$srcdir/VERSION],
-                            [ompi/include/ompi/version.h])])
+                            [ompi/include/ompi/version.h])
+          OPAL_SAVE_MPI_STANDARD_VERSION([$srcdir/VERSION])])
 
 m4_ifdef([project_oshmem],
          [OPAL_SAVE_VERSION([OSHMEM], [Open SHMEM],

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -199,6 +199,12 @@
 #undef OMPI_MINOR_VERSION
 #undef OMPI_RELEASE_VERSION
 
+/*
+ * MPI version
+ */
+#undef MPI_VERSION
+#undef MPI_SUBVERSION
+
 /* A  type that allows us to have sentinel type values that are still
    valid */
 #undef ompi_fortran_bogus_type_t
@@ -248,12 +254,6 @@
  * Just in case you need it.  :-)
  */
 #define OPEN_MPI 1
-
-/*
- * MPI version
- */
-#define MPI_VERSION 3
-#define MPI_SUBVERSION 1
 
 
 /*

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -71,6 +71,30 @@ sub write_file {
 
 #----------------------------------------------------------------------------
 
+# Read a value for a specified key from the file specified.
+
+sub read_value_from_file {
+    my ($filename, $key) = @_;
+    my $value;
+
+    open(FILE_IN, $filename) || die "Couldn't open $filename";
+    while(my $line = <FILE_IN>) {
+        if( $line =~ /^$key=(.+)/ ) {
+            $value = $1;
+            last;
+        }
+    }
+    close(FILE_IN);
+
+    if(!defined($value)) {
+        die "Did not find the string \"$key\" in the file $filename"
+    }
+
+    return $value;
+}
+
+#----------------------------------------------------------------------------
+
 print "creating Fortran header files (with common constants)...\n";
 
 # Find the OMPI topdir.  It is likely the pwd.
@@ -216,8 +240,8 @@ $io_handles->{MPI_FILE_NULL} = 0;
 
 my $constants;
 
-$constants->{MPI_VERSION} = 3;
-$constants->{MPI_SUBVERSION} = 1;
+$constants->{MPI_VERSION} = read_value_from_file("$topdir/VERSION", "mpi_standard_version");
+$constants->{MPI_SUBVERSION} = read_value_from_file("$topdir/VERSION", "mpi_standard_subversion");
 
 $constants->{MPI_ANY_SOURCE} = -1;
 $constants->{MPI_ANY_TAG} = -1;


### PR DESCRIPTION
 * This puts the MPI standard major and minor version in the scope
   of the Makefiles so we can leverage this information when deciding
   build time options for non-C portions of the code (portions that
   do not look at `mpi.h`) - such as Fortran and Perl.
