### PR TITLE
Fix the dpm to fwd IO to the spawning parent

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -1624,6 +1624,16 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
             return MPI_ERR_SPAWN;
         }
+        /* tell it to forward output to us */
+        info = OBJ_NEW(opal_info_item_t);
+        PMIX_INFO_LOAD(&info->info, PMIX_FWD_STDOUT, NULL, PMIX_BOOL);
+        opal_list_append(&job_info, &info->super);
+        info = OBJ_NEW(opal_info_item_t);
+        PMIX_INFO_LOAD(&info->info, PMIX_FWD_STDERR, NULL, PMIX_BOOL);
+        opal_list_append(&job_info, &info->super);
+        info = OBJ_NEW(opal_info_item_t);
+        PMIX_INFO_LOAD(&info->info, PMIX_FWD_STDDIAG, NULL, PMIX_BOOL);
+        opal_list_append(&job_info, &info->super);
     }
     if (NULL != hostfiles) {
         opal_argv_free(hostfiles);


### PR DESCRIPTION
When doing a comm_spawn as a singleton, you need to instruct
the "prte" DVM to forward any IO from the child job to the
singleton "parent" so it can be properly output. Otherwise,
the IO from the child job will simply be lost.

Requires update of PMIx submodule pointer to fix https://github.com/open-mpi/ompi/issues/10691
Signed-off-by: Ralph Castain <rhc@pmix.org>