### PR TITLE
Implement warning for use of MPI_Sizeof in MPI 4.0 compliant OpenMPI

### DIFF
--- a/ompi/include/Makefile.am
+++ b/ompi/include/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2014-2021 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -91,7 +92,9 @@ mpif-sizeof.h:
 	    --iso_real16=$(OMPI_FORTRAN_HAVE_ISO_FORTRAN_ENV_REAL16) \
 	    --real16=$(OMPI_HAVE_FORTRAN_REAL16) \
 	    --complex4=$(OMPI_HAVE_FORTRAN_COMPLEX4) \
-	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32)
+	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32) \
+	    --mpi_version=$(MPI_VERSION) \
+	    --request_deprecate=$(OMPI_FORTRAN_HAVE_ATTR_DEPRECATED)
 
 #
 # mpif-c-constants-decl.h, among other files, is generated based on some

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -3,6 +3,7 @@
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015-2021 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Script to generate the overloaded MPI_SIZEOF interfaces and
@@ -39,6 +40,8 @@ my $mpi_complex4;
 my $mpi_complex32;
 my $pmpi_arg;
 my $help_arg = 0;
+my $request_deprecate = 0;
+my $mpi_version = 0;
 
 &Getopt::Long::Configure("bundling");
 my $ok = Getopt::Long::GetOptions("complex32=i" => \$mpi_complex32,
@@ -53,6 +56,8 @@ my $ok = Getopt::Long::GetOptions("complex32=i" => \$mpi_complex32,
                                   "real16=i" => \$mpi_real16,
                                   "real2=i" => \$mpi_real2,
                                   "iso_real16=i" => \$mpi_iso_real16,
+                                  "request_deprecate=i" => \$request_deprecate,
+                                  "mpi_version=i" => \$mpi_version,
                                   "help|h" => \$help_arg);
 
 die "Must specify header and/or impl filenames to output"
@@ -106,7 +111,13 @@ ${indent}  INTEGER$optional_ierror_param, INTENT(OUT) :: ierror";
     $subr->{start} = $start;
     $subr->{middle} = "${indent}  size = storage_size(x) / 8
 ${indent}  ${optional_ierror_statement}ierror = 0";
-    $subr->{end} = "${indent}END SUBROUTINE ^PREFIX^$sub_name^RANK^";
+    if (($mpi_version >= 4) && ($request_deprecate == 1)) {
+        $subr->{end} = "!GCC\$ ATTRIBUTES DEPRECATED :: ^PREFIX^$sub_name^RANK^\n";
+    }
+    else {
+        $subr->{end} = "";
+    }
+    $subr->{end} .= "${indent}END SUBROUTINE ^PREFIX^$sub_name^RANK^";
 
     # Save it in the overall hash
     $subs->{$sub_name} = $subr;

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2019      Triad National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -79,7 +80,9 @@ sizeof_f08.h:
 	    --iso_real16=$(OMPI_FORTRAN_HAVE_ISO_FORTRAN_ENV_REAL16) \
 	    --real16=$(OMPI_HAVE_FORTRAN_REAL16) \
 	    --complex4=$(OMPI_HAVE_FORTRAN_COMPLEX4) \
-	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32)
+	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32) \
+	    --mpi_version=$(MPI_VERSION) \
+	    --request_deprecate=$(OMPI_FORTRAN_HAVE_ATTR_DEPRECATED)
 
 sizeof_f08.f90: $(top_builddir)/config.status
 sizeof_f08.f90: $(sizeof_pl)

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -6,6 +6,7 @@
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -105,7 +106,9 @@ mpi-ignore-tkr-sizeof.h:
 	    --iso_real16=$(OMPI_FORTRAN_HAVE_ISO_FORTRAN_ENV_REAL16) \
 	    --real16=$(OMPI_HAVE_FORTRAN_REAL16) \
 	    --complex4=$(OMPI_HAVE_FORTRAN_COMPLEX4) \
-	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32)
+	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32) \
+	    --mpi_version=$(MPI_VERSION) \
+	    --request_deprecate=$(OMPI_FORTRAN_HAVE_ATTR_DEPRECATED)
 
 mpi-ignore-tkr-sizeof.f90: $(top_builddir)/config.status
 mpi-ignore-tkr-sizeof.f90: $(sizeof_pl)

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -15,7 +15,7 @@
 #                         reserved.
 # Copyright (c) 2014-2021 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -136,7 +136,9 @@ mpi-tkr-sizeof.h:
 	    --iso_real16=$(OMPI_FORTRAN_HAVE_ISO_FORTRAN_ENV_REAL16) \
 	    --real16=$(OMPI_HAVE_FORTRAN_REAL16) \
 	    --complex4=$(OMPI_HAVE_FORTRAN_COMPLEX4) \
-	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32)
+	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32) \
+	    --mpi_version=$(MPI_VERSION) \
+	    --request_deprecate=$(OMPI_FORTRAN_HAVE_ATTR_DEPRECATED)
 
 mpi-tkr-sizeof.f90: $(top_builddir)/config.status
 mpi-tkr-sizeof.f90: $(sizeof_pl)


### PR DESCRIPTION
Implement a compilation time warning message stating that use of MPI_Sizeof is deprecated if a Fortran application calls MPI_Sizeof, and the installed OpenMPI is compliant with the MPI standard 4.0 or later.

This warning will only be generated if OpenMPI is built with MPI 4.0 compliance, the compiler it was built with was gfortran, and the gfortran compiler level is 11.0.0 or greater.

The '!gcc$ attributes deprecated' directive that results in this warning diagnostic is not recognized by earlier gfortran compilers and is not recognized by other compilers.

This fixes issue #9206

Signed-off-by: David Wootton <dwootton@us.ibm.com>