### PR TITLE
java: catch exceptions if we fail to load mpi_java

### DIFF
--- a/ompi/mpi/java/java/MPI.java
+++ b/ompi/mpi/java/java/MPI.java
@@ -204,7 +204,15 @@ public final class MPI
 
 	static
 	{
-		System.loadLibrary("mpi_java");
+		try
+		{
+			System.loadLibrary("mpi_java") ;
+		}
+		catch (UnsatisfiedLinkError e)
+		{
+			System.err.println("mpi java lib failed to load: " + e  + "\n") ;
+			System.exit(1) ;
+		}
 
 		DATATYPE_NULL = new Datatype();
 


### PR DESCRIPTION
library.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 54042fc5f457639927eb69404c4daaf14f3c6838)