### PR TITLE
OSC/UCX: Adding the following optimizations (nonblocking accumulate and reusing resources)

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -165,31 +165,33 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int i, size;
     int ret = OMPI_SUCCESS;
+    ucp_ep_h *ep;
 
     if (module->epoch_type.access != START_COMPLETE_EPOCH) {
         return OMPI_ERR_RMA_SYNC;
     }
-
-    module->epoch_type.access = NONE_EPOCH;
 
     ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0/*ignore*/);
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
 
+    module->epoch_type.access = NONE_EPOCH;
+
     size = ompi_group_size(module->start_group);
     for (i = 0; i < size; i++) {
         uint64_t remote_addr = module->state_addrs[module->start_grp_ranks[i]] + OSC_UCX_STATE_COMPLETE_COUNT_OFFSET; // write to state.complete_count on remote side
 
+        OSC_UCX_GET_DEFAULT_EP(ep, module, module->start_grp_ranks[i]);
+
         ret = opal_common_ucx_wpmem_post(module->state_mem, UCP_ATOMIC_POST_OP_ADD,
                                        1, module->start_grp_ranks[i], sizeof(uint64_t),
-                                       remote_addr);
+                                       remote_addr, ep);
         if (ret != OMPI_SUCCESS) {
             OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_post failed: %d", ret);
         }
 
-        ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_EP,
-                                        module->start_grp_ranks[i]);
+        ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_EP, module->start_grp_ranks[i]);
         if (ret != OMPI_SUCCESS) {
             return ret;
         }
@@ -204,6 +206,7 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
 
 int ompi_osc_ucx_post(struct ompi_group_t *group, int mpi_assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
+    ucp_ep_h *ep;
     int ret = OMPI_SUCCESS;
 
     if (module->epoch_type.exposure != NONE_EPOCH) {
@@ -243,12 +246,12 @@ int ompi_osc_ucx_post(struct ompi_group_t *group, int mpi_assert, struct ompi_wi
             uint64_t remote_addr = module->state_addrs[ranks_in_win_grp[i]] + OSC_UCX_STATE_POST_INDEX_OFFSET; // write to state.post_index on remote side
             uint64_t curr_idx = 0, result = 0;
 
-
+            OSC_UCX_GET_DEFAULT_EP(ep, module, ranks_in_win_grp[i]);
 
             /* do fop first to get an post index */
             ret = opal_common_ucx_wpmem_fetch(module->state_mem, UCP_ATOMIC_FETCH_OP_FADD,
                                             1, ranks_in_win_grp[i], &result,
-                                            sizeof(result), remote_addr);
+                                            sizeof(result), remote_addr, ep);
 
             if (ret != OMPI_SUCCESS) {
                 ret = OMPI_ERROR;
@@ -265,7 +268,7 @@ int ompi_osc_ucx_post(struct ompi_group_t *group, int mpi_assert, struct ompi_wi
                 result =  myrank + 1;
                 ret = opal_common_ucx_wpmem_cmpswp(module->state_mem, 0, result,
                                                  ranks_in_win_grp[i], &result, sizeof(result),
-                                                 remote_addr);
+                                                 remote_addr, ep);
 
                 if (ret != OMPI_SUCCESS) {
                     ret = OMPI_ERROR;

--- a/ompi/mca/osc/ucx/osc_ucx_request.c
+++ b/ompi/mca/osc/ucx/osc_ucx_request.c
@@ -24,9 +24,9 @@ static int request_cancel(struct ompi_request_t *request, int complete)
 
 static int request_free(struct ompi_request_t **ompi_req)
 {
-    ompi_osc_ucx_request_t *request = (ompi_osc_ucx_request_t*) *ompi_req;
+    ompi_osc_ucx_generic_request_t *request = (ompi_osc_ucx_generic_request_t*) *ompi_req;
 
-    if (true != (bool)(request->super.req_complete)) {
+    if (true != (bool)(request->super.super.req_complete)) {
         return MPI_ERR_REQUEST;
     }
 
@@ -37,20 +37,15 @@ static int request_free(struct ompi_request_t **ompi_req)
     return OMPI_SUCCESS;
 }
 
-static void request_construct(ompi_osc_ucx_request_t *request)
+static void request_construct(ompi_osc_ucx_generic_request_t *request)
 {
-    request->super.req_type = OMPI_REQUEST_WIN;
-    request->super.req_status._cancelled = 0;
-    request->super.req_free = request_free;
-    request->super.req_cancel = request_cancel;
+    request->super.super.req_type = OMPI_REQUEST_WIN;
+    request->super.super.req_status._cancelled = 0;
+    request->super.super.req_free = request_free;
+    request->super.super.req_cancel = request_cancel;
 }
 
-void req_completion(void *request) {
-    ompi_osc_ucx_request_t *req = (ompi_osc_ucx_request_t *)request;
-    ompi_request_complete(&(req->super), true);
-    mca_osc_ucx_component.num_incomplete_req_ops--;
-    assert(mca_osc_ucx_component.num_incomplete_req_ops >= 0);
-}
-
-OBJ_CLASS_INSTANCE(ompi_osc_ucx_request_t, ompi_request_t,
+OBJ_CLASS_INSTANCE(ompi_osc_ucx_generic_request_t, ompi_request_t,
+                   request_construct, NULL);
+OBJ_CLASS_INSTANCE(ompi_osc_ucx_accumulate_request_t, ompi_request_t,
                    request_construct, NULL);

--- a/ompi/mca/osc/ucx/osc_ucx_request.h
+++ b/ompi/mca/osc/ucx/osc_ucx_request.h
@@ -16,38 +16,132 @@
 
 #include "ompi/request/request.h"
 
+
+enum req_type {
+    ACCUMULATE_REQ,
+    RPUT_REQ,
+    RGET_REQ
+};
+
+enum acc_rma_type {
+    NONE,
+    ACCUMULATE,
+    GET_ACCUMULATE,
+    ANY
+};
+
+enum acc_phases {
+    ACC_INIT,
+    ACC_GET_RESULTS_DATA,
+    ACC_GET_STAGE_DATA,
+    ACC_PUT_TARGET_DATA,
+    ACC_FINALIZE
+};
+
 typedef struct ompi_osc_ucx_request {
     ompi_request_t super;
+    int request_type;
+    ompi_osc_ucx_module_t *module;
 } ompi_osc_ucx_request_t;
 
+typedef struct ompi_osc_ucx_generic_request {
+    ompi_osc_ucx_request_t super;
+} ompi_osc_ucx_generic_request_t;
+
+typedef struct ompi_osc_ucx_accumulate_request {
+    ompi_osc_ucx_request_t super;
+    struct ompi_op_t *op;
+    int phase;
+    int acc_type;
+    bool lock_acquired;
+    int target;
+    struct ompi_win_t *win;
+    const void *origin_addr;
+    int origin_count;
+    struct ompi_datatype_t *origin_dt;
+    void *stage_addr;
+    int stage_count;
+    struct ompi_datatype_t *stage_dt;
+    struct ompi_datatype_t *target_dt;
+    int target_disp;
+    int target_count;
+    void *free_ptr;
+} ompi_osc_ucx_accumulate_request_t;
+
 OBJ_CLASS_DECLARATION(ompi_osc_ucx_request_t);
+OBJ_CLASS_DECLARATION(ompi_osc_ucx_generic_request_t);
+OBJ_CLASS_DECLARATION(ompi_osc_ucx_accumulate_request_t);
 
-#define OMPI_OSC_UCX_REQUEST_ALLOC(win, req)                            \
-    do {                                                                \
-        opal_free_list_item_t *item;                                    \
-        do {                                                            \
-            item = opal_free_list_get(&mca_osc_ucx_component.requests); \
-            if (item == NULL) {                                         \
-                if (mca_osc_ucx_component.num_incomplete_req_ops > 0) { \
-                    opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool); \
-                }                                                       \
-            }                                                           \
-        } while (item == NULL);                                         \
-        req = (ompi_osc_ucx_request_t*) item;                           \
-        OMPI_REQUEST_INIT(&req->super, false);                          \
-        req->super.req_mpi_object.win = win;                            \
-        req->super.req_complete = false;                                \
-        req->super.req_state = OMPI_REQUEST_ACTIVE;                     \
-        req->super.req_status.MPI_ERROR = MPI_SUCCESS;                  \
+#define OMPI_OSC_UCX_GENERIC_REQUEST_ALLOC(win, req, _req_type)                         \
+    do {                                                                                \
+        opal_free_list_item_t *item;                                                    \
+        do {                                                                            \
+            item = opal_free_list_get(&mca_osc_ucx_component.requests);                 \
+            if (item == NULL) {                                                         \
+                if (module->ctx->num_incomplete_req_ops > 0) {                          \
+                    opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);        \
+                }                                                                       \
+            }                                                                           \
+        } while (item == NULL);                                                         \
+        req = (ompi_osc_ucx_generic_request_t*) item;                                   \
+        OMPI_REQUEST_INIT(&req->super.super, false);                                          \
+        req->super.super.req_mpi_object.win = win;                                            \
+        req->super.super.req_complete = false;                                                \
+        req->super.super.req_state = OMPI_REQUEST_ACTIVE;                                     \
+        req->super.super.req_status.MPI_ERROR = MPI_SUCCESS;                                  \
+        req->super.module = NULL;                                                             \
+        req->super.request_type = _req_type;                                                  \
     } while (0)
 
-#define OMPI_OSC_UCX_REQUEST_RETURN(req)                                \
-    do {                                                                \
-        OMPI_REQUEST_FINI(&req->super);                                 \
-        opal_free_list_return (&mca_osc_ucx_component.requests,         \
-                               (opal_free_list_item_t*) req);           \
+#define OMPI_OSC_UCX_ACCUMULATE_REQUEST_ALLOC(win, req)                                 \
+    do {                                                                                \
+        opal_free_list_item_t *item;                                                    \
+        do {                                                                            \
+            item = opal_free_list_get(&mca_osc_ucx_component.accumulate_requests);      \
+            if (item == NULL) {                                                         \
+                if (module->ctx->num_incomplete_req_ops > 0) {                          \
+                    opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);        \
+                }                                                                       \
+            }                                                                           \
+        } while (item == NULL);                                                         \
+        req = (ompi_osc_ucx_accumulate_request_t*) item;                                \
+        OMPI_REQUEST_INIT(&req->super.super, false);                                          \
+        req->super.super.req_mpi_object.win = win;                                            \
+        req->super.super.req_complete = false;                                                \
+        req->super.super.req_state = OMPI_REQUEST_ACTIVE;                                     \
+        req->super.super.req_status.MPI_ERROR = MPI_SUCCESS;                                  \
+        req->super.module = NULL;                                                             \
+        req->super.request_type = ACCUMULATE_REQ;                                             \
+        req->acc_type = NONE;                                                   \
+        req->op = MPI_NO_OP;                                                    \
+        req->phase = ACC_INIT;                                                  \
+        req->target = -1;                                                       \
+        req->lock_acquired = false;                                             \
+        req->win = NULL;                                                        \
+        req->origin_addr = NULL;                                                \
+        req->origin_count = 0;                                                  \
+        req->origin_dt = NULL;                                                  \
+        req->stage_addr = NULL;                                                 \
+        req->stage_count = 0;                                                   \
+        req->stage_dt = NULL;                                                   \
+        req->target_dt = NULL;                                                  \
+        req->target_count = 0;                                                  \
+        req->target_disp = 0;                                                   \
+        req->free_ptr = NULL;                                                   \
     } while (0)
 
-void req_completion(void *request);
+#define OMPI_OSC_UCX_REQUEST_RETURN(req)                                                \
+    do {                                                                                \
+        OMPI_REQUEST_FINI(&req->super.super);                                           \
+        if (req->super.request_type == ACCUMULATE_REQ) {                                \
+            opal_free_list_return (&mca_osc_ucx_component.accumulate_requests,          \
+                                   (opal_free_list_item_t*) req);                       \
+        } else {                                                                        \
+            opal_free_list_return (&mca_osc_ucx_component.requests,                     \
+                                   (opal_free_list_item_t*) req);                       \
+        }                                                                               \
+    } while (0)
+
+void ompi_osc_ucx_req_completion(void *request);
 
 #endif /* OMPI_OSC_UCX_REQUEST_H */

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -9,7 +9,7 @@
 #include "opal/memoryhooks/memory.h"
 #include "opal/util/proc.h"
 #include "opal/util/sys_limits.h"
-
+#include "opal/util/sys_limits.h"
 #include <ucm/api/ucm.h>
 
 /*******************************************************************************
@@ -31,6 +31,8 @@ __thread FILE *tls_pf = NULL;
 __thread int initialized = 0;
 #endif
 
+bool opal_common_ucx_thread_enabled = false;
+
 static _ctx_record_t *_tlocal_add_ctx_rec(opal_common_ucx_ctx_t *ctx);
 static inline _ctx_record_t *_tlocal_get_ctx_rec(opal_tsd_tracked_key_t tls_key);
 static void _tlocal_ctx_rec_cleanup(_ctx_record_t *ctx_rec);
@@ -48,13 +50,18 @@ static opal_common_ucx_winfo_t *_winfo_create(opal_common_ucx_wpool_t *wpool)
     ucs_status_t status;
     opal_common_ucx_winfo_t *winfo = NULL;
 
-    memset(&worker_params, 0, sizeof(worker_params));
-    worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-    worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
-    status = ucp_worker_create(wpool->ucp_ctx, &worker_params, &worker);
-    if (UCS_OK != status) {
-        MCA_COMMON_UCX_ERROR("ucp_worker_create failed: %d", status);
-        goto exit;
+    if (opal_common_ucx_thread_enabled || wpool->dflt_winfo == NULL) {
+        memset(&worker_params, 0, sizeof(worker_params));
+        worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+        worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        status = ucp_worker_create(wpool->ucp_ctx, &worker_params, &worker);
+        if (UCS_OK != status) {
+            MCA_COMMON_UCX_ERROR("ucp_worker_create failed: %d", status);
+            goto exit;
+        }
+    } else {
+        /* Single threaded application can reuse the default worker */
+        worker = wpool->dflt_winfo->worker;
     }
 
     winfo = OBJ_NEW(opal_common_ucx_winfo_t);
@@ -70,6 +77,7 @@ static opal_common_ucx_winfo_t *_winfo_create(opal_common_ucx_wpool_t *wpool)
     winfo->inflight_ops = NULL;
     winfo->global_inflight_ops = 0;
     winfo->inflight_req = UCS_OK;
+    winfo->is_dflt_winfo = false;
 
     return winfo;
 
@@ -90,11 +98,13 @@ static void _winfo_destructor(opal_common_ucx_winfo_t *winfo)
 
     if (winfo->comm_size != 0) {
         size_t i;
-        for (i = 0; i < winfo->comm_size; i++) {
-            if (NULL != winfo->endpoints[i]) {
-                ucp_ep_destroy(winfo->endpoints[i]);
+        if (opal_common_ucx_thread_enabled) {
+            for (i = 0; i < winfo->comm_size; i++) {
+                if (NULL != winfo->endpoints[i]) {
+                    ucp_ep_destroy(winfo->endpoints[i]);
+                }
+                assert(winfo->inflight_ops[i] == 0);
             }
-            assert(winfo->inflight_ops[i] == 0);
         }
         free(winfo->endpoints);
         free(winfo->inflight_ops);
@@ -103,7 +113,10 @@ static void _winfo_destructor(opal_common_ucx_winfo_t *winfo)
     winfo->comm_size = 0;
 
     OBJ_DESTRUCT(&winfo->mutex);
-    ucp_worker_destroy(winfo->worker);
+    if (opal_common_ucx_thread_enabled || winfo->is_dflt_winfo) {
+        ucp_worker_destroy(winfo->worker);
+    }
+
 }
 
 /* -----------------------------------------------------------------------------
@@ -145,12 +158,15 @@ OPAL_DECLSPEC int opal_common_ucx_wpool_init(opal_common_ucx_wpool_t *wpool)
     OBJ_CONSTRUCT(&wpool->idle_workers, opal_list_t);
     OBJ_CONSTRUCT(&wpool->active_workers, opal_list_t);
 
+    wpool->dflt_winfo = NULL;
+
     winfo = _winfo_create(wpool);
     if (NULL == winfo) {
         MCA_COMMON_UCX_ERROR("Failed to create receive worker");
         rc = OPAL_ERROR;
         goto err_worker_create;
     }
+    winfo->is_dflt_winfo = true;
     wpool->dflt_winfo = winfo;
     OBJ_RETAIN(wpool->dflt_winfo);
 
@@ -332,7 +348,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpctx_create(opal_common_ucx_wpool_t *wpool, i
     opal_common_ucx_ctx_t *ctx = calloc(1, sizeof(*ctx));
     int ret = OPAL_SUCCESS;
 
-    OBJ_CONSTRUCT(&ctx->mutex, opal_mutex_t);
+    OBJ_CONSTRUCT(&ctx->mutex, opal_recursive_mutex_t);
     OBJ_CONSTRUCT(&ctx->ctx_records, opal_list_t);
 
     ctx->wpool = wpool;
@@ -340,6 +356,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpctx_create(opal_common_ucx_wpool_t *wpool, i
 
     ctx->recv_worker_addrs = NULL;
     ctx->recv_worker_displs = NULL;
+    ctx->num_incomplete_req_ops = 0;
     ret = exchange_func(wpool->recv_waddr, wpool->recv_waddr_len, &ctx->recv_worker_addrs,
                         &ctx->recv_worker_displs, exchange_metadata);
     if (ret != OPAL_SUCCESS) {
@@ -404,6 +421,7 @@ int opal_common_ucx_wpmem_create(opal_common_ucx_ctx_t *ctx, void **mem_base, si
     mem->ctx = ctx;
     mem->mem_addrs = NULL;
     mem->mem_displs = NULL;
+    mem->skip_periodic_flush = false;
 
     OBJ_CONSTRUCT(&mem->mutex, opal_mutex_t);
 
@@ -693,7 +711,7 @@ static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int targ
 }
 
 /* Get the TLS in case of slow path (not everything has been yet initialized */
-OPAL_DECLSPEC int opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target)
+OPAL_DECLSPEC int opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target, ucp_ep_h *dflt_ep)
 {
     _ctx_record_t *ctx_rec = NULL;
     _mem_record_t *mem_rec = NULL;
@@ -712,9 +730,20 @@ OPAL_DECLSPEC int opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *me
 
     /* Obtain the endpoint */
     if (OPAL_UNLIKELY(NULL == winfo->endpoints[target])) {
-        rc = _tlocal_ctx_connect(ctx_rec, target);
-        if (rc != OPAL_SUCCESS) {
-            return rc;
+        if (opal_common_ucx_thread_enabled || (dflt_ep == NULL) ||
+                (*dflt_ep == NULL)) {
+            rc = _tlocal_ctx_connect(ctx_rec, target);
+            if (rc != OPAL_SUCCESS) {
+                return rc;
+            }
+            if (!opal_common_ucx_thread_enabled && (dflt_ep != NULL) &&
+                    (*dflt_ep == NULL)) {
+                /* set the proc ep */
+                *dflt_ep = winfo->endpoints[target];
+            }
+        } else {
+            /* reuse the previously created ep */
+            winfo->endpoints[target] = *dflt_ep;
         }
     }
     ep = winfo->endpoints[target];
@@ -784,8 +813,8 @@ OPAL_DECLSPEC int opal_common_ucx_winfo_flush(opal_common_ucx_winfo_t *winfo, in
     return rc;
 }
 
-OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
-                                              opal_common_ucx_flush_scope_t scope, int target)
+static inline int ctx_flush(opal_common_ucx_ctx_t *ctx,
+                                opal_common_ucx_flush_scope_t scope, int target)
 {
     _ctx_record_t *ctx_rec;
     int rc = OPAL_SUCCESS;
@@ -821,7 +850,39 @@ OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
             break;
         }
     }
+
     opal_mutex_unlock(&ctx->mutex);
+
+    return rc;
+}
+
+OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
+                                    opal_common_ucx_flush_scope_t scope, int target)
+{
+    int rc = OPAL_SUCCESS;
+    int spin = 0;
+
+    if (NULL == ctx) {
+        return OPAL_SUCCESS;
+    }
+
+    rc = ctx_flush(ctx, scope, target);
+    if (rc != OPAL_SUCCESS) {
+        return rc;
+    }
+
+    /* progress the nonblocking operations */
+    while (ctx->num_incomplete_req_ops != 0) {
+        spin++;
+        rc = ctx_flush(ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+        if (rc != OPAL_SUCCESS) {
+            return rc;
+        }
+        if (spin == opal_common_ucx.progress_iterations) {
+            opal_progress();
+            spin = 0;
+        }
+    }
 
     return rc;
 }
@@ -830,7 +891,7 @@ OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
 OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem,
                                                     int target,
                                                     opal_common_ucx_user_req_handler_t user_req_cb,
-                                                    void *user_req_ptr)
+                                                    void *user_req_ptr, ucp_ep_h *dflt_ep)
 {
 #if HAVE_DECL_UCP_EP_FLUSH_NB
     int rc = OPAL_SUCCESS;
@@ -842,7 +903,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem
         return OPAL_SUCCESS;
     }
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("tlocal_fetch failed: %d", rc);
         return rc;
@@ -868,7 +929,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem
 
 }
 
-
+/* TODO Replace the input with opal_common_ucx_ctx_t */
 OPAL_DECLSPEC int opal_common_ucx_wpmem_fence(opal_common_ucx_wpmem_t *mem)
 {
     ucs_status_t status = UCS_OK;

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -58,6 +58,8 @@ typedef struct {
     opal_list_t active_workers;
 } opal_common_ucx_wpool_t;
 
+extern bool opal_common_ucx_thread_enabled;
+
 /* Worker Pool Context (wpctx) is an object that is comprised of a set of UCP
  * workers that are considered as one logical communication entity.
  * One UCP worker per "active" thread is used.
@@ -86,6 +88,7 @@ typedef struct {
     char *recv_worker_addrs;
     int *recv_worker_displs;
     size_t comm_size;
+    opal_atomic_size_t num_incomplete_req_ops;
 } opal_common_ucx_ctx_t;
 
 /* Worker Pool memory (wpmem) is an object that represents a remotely accessible
@@ -105,6 +108,7 @@ typedef struct {
     ucp_mem_h memh;
     char *mem_addrs;
     int *mem_displs;
+    bool skip_periodic_flush;
 
     /* TLS item that allows each thread to
      * store endpoints and rkey arrays
@@ -127,6 +131,7 @@ struct opal_common_ucx_winfo {
     short *inflight_ops;
     short global_inflight_ops;
     ucs_status_ptr_t inflight_req;
+    bool is_dflt_winfo;
 };
 OBJ_CLASS_DECLARATION(opal_common_ucx_winfo_t);
 
@@ -178,7 +183,6 @@ OBJ_CLASS_DECLARATION(_mem_record_t);
 
 typedef int (*opal_common_ucx_exchange_func_t)(void *my_info, size_t my_info_len, char **recv_info,
                                                int **disps, void *metadata);
-
 /* Manage Worker Pool (wpool) */
 OPAL_DECLSPEC opal_common_ucx_wpool_t *opal_common_ucx_wpool_allocate(void);
 OPAL_DECLSPEC void opal_common_ucx_wpool_free(opal_common_ucx_wpool_t *wpool);
@@ -198,10 +202,11 @@ OPAL_DECLSPEC void opal_common_ucx_req_init(void *request);
 OPAL_DECLSPEC void opal_common_ucx_req_completion(void *request, ucs_status_t status);
 
 /* Managing thread local storage */
-OPAL_DECLSPEC int opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target);
+OPAL_DECLSPEC int opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target, ucp_ep_h *_dflt_ep);
 static inline int opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
                                                ucp_ep_h *_ep, ucp_rkey_h *_rkey,
-                                               opal_common_ucx_winfo_t **_winfo)
+                                               opal_common_ucx_winfo_t **_winfo,
+                                               ucp_ep_h *_dflt_ep)
 {
     _mem_record_t *mem_rec = NULL;
     int is_ready;
@@ -215,7 +220,7 @@ static inline int opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int
     is_ready = mem_rec && (mem_rec->winfo->endpoints[target]) && (NULL != mem_rec->rkeys[target]);
     MCA_COMMON_UCX_ASSERT((NULL == mem_rec) || (NULL != mem_rec->winfo));
     if (OPAL_UNLIKELY(!is_ready)) {
-        rc = opal_common_ucx_tlocal_fetch_spath(mem, target);
+        rc = opal_common_ucx_tlocal_fetch_spath(mem, target, _dflt_ep);
         if (OPAL_SUCCESS != rc) {
             return rc;
         }
@@ -246,11 +251,12 @@ OPAL_DECLSPEC int opal_common_ucx_wpmem_create(opal_common_ucx_ctx_t *ctx, void 
 OPAL_DECLSPEC void opal_common_ucx_wpmem_free(opal_common_ucx_wpmem_t *mem);
 
 OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
-                                              opal_common_ucx_flush_scope_t scope, int target);
+                                              opal_common_ucx_flush_scope_t scope,
+                                              int target);
 OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem,
                                                     int target,
                                                     opal_common_ucx_user_req_handler_t user_req_cb,
-                                                    void *user_req_ptr);
+                                                    void *user_req_ptr, ucp_ep_h *_dflt_ep);
 OPAL_DECLSPEC int opal_common_ucx_wpmem_fence(opal_common_ucx_wpmem_t *mem);
 
 OPAL_DECLSPEC int opal_common_ucx_winfo_flush(opal_common_ucx_winfo_t *winfo, int target,
@@ -309,6 +315,8 @@ static inline int _periodical_flush_nb(opal_common_ucx_wpmem_t *mem, opal_common
 {
     int rc = OPAL_SUCCESS;
 
+    if (mem->skip_periodic_flush) return OPAL_SUCCESS;
+
     if (OPAL_UNLIKELY(winfo->inflight_ops[target] >= MCA_COMMON_UCX_PER_TARGET_OPS_THRESHOLD)
         || OPAL_UNLIKELY(winfo->global_inflight_ops >= MCA_COMMON_UCX_GLOBAL_OPS_THRESHOLD)) {
         opal_common_ucx_flush_scope_t scope;
@@ -349,7 +357,7 @@ static inline int _periodical_flush_nb(opal_common_ucx_wpmem_t *mem, opal_common
 
 static inline int opal_common_ucx_wpmem_putget(opal_common_ucx_wpmem_t *mem,
                                                opal_common_ucx_op_t op, int target, void *buffer,
-                                               size_t len, uint64_t rem_addr)
+                                               size_t len, uint64_t rem_addr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep;
     ucp_rkey_h rkey;
@@ -358,7 +366,7 @@ static inline int opal_common_ucx_wpmem_putget(opal_common_ucx_wpmem_t *mem,
     int rc = OPAL_SUCCESS;
     char *called_func = "";
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_VERBOSE(1, "tlocal_fetch failed: %d", rc);
         return rc;
@@ -401,7 +409,7 @@ out:
 
 static inline int opal_common_ucx_wpmem_cmpswp(opal_common_ucx_wpmem_t *mem, uint64_t compare,
                                                uint64_t value, int target, void *buffer, size_t len,
-                                               uint64_t rem_addr)
+                                               uint64_t rem_addr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep;
     ucp_rkey_h rkey;
@@ -409,7 +417,7 @@ static inline int opal_common_ucx_wpmem_cmpswp(opal_common_ucx_wpmem_t *mem, uin
     ucs_status_t status;
     int rc = OPAL_SUCCESS;
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("opal_common_ucx_tlocal_fetch failed: %d", rc);
         return rc;
@@ -440,7 +448,7 @@ static inline int opal_common_ucx_wpmem_cmpswp_nb(opal_common_ucx_wpmem_t *mem, 
                                                   uint64_t value, int target, void *buffer,
                                                   size_t len, uint64_t rem_addr,
                                                   opal_common_ucx_user_req_handler_t user_req_cb,
-                                                  void *user_req_ptr)
+                                                  void *user_req_ptr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep;
     ucp_rkey_h rkey;
@@ -448,7 +456,7 @@ static inline int opal_common_ucx_wpmem_cmpswp_nb(opal_common_ucx_wpmem_t *mem, 
     opal_common_ucx_request_t *req;
     int rc = OPAL_SUCCESS;
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("opal_common_ucx_tlocal_fetch failed: %d", rc);
         return rc;
@@ -482,7 +490,7 @@ static inline int opal_common_ucx_wpmem_cmpswp_nb(opal_common_ucx_wpmem_t *mem, 
 
 static inline int opal_common_ucx_wpmem_post(opal_common_ucx_wpmem_t *mem,
                                              ucp_atomic_post_op_t opcode, uint64_t value,
-                                             int target, size_t len, uint64_t rem_addr)
+                                             int target, size_t len, uint64_t rem_addr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep;
     ucp_rkey_h rkey;
@@ -490,7 +498,7 @@ static inline int opal_common_ucx_wpmem_post(opal_common_ucx_wpmem_t *mem,
     ucs_status_t status;
     int rc = OPAL_SUCCESS;
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("tlocal_fetch failed: %d", rc);
         return rc;
@@ -518,7 +526,7 @@ out:
 static inline int opal_common_ucx_wpmem_fetch(opal_common_ucx_wpmem_t *mem,
                                               ucp_atomic_fetch_op_t opcode, uint64_t value,
                                               int target, void *buffer, size_t len,
-                                              uint64_t rem_addr)
+                                              uint64_t rem_addr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep = NULL;
     ucp_rkey_h rkey = NULL;
@@ -526,7 +534,7 @@ static inline int opal_common_ucx_wpmem_fetch(opal_common_ucx_wpmem_t *mem,
     ucs_status_t status;
     int rc = OPAL_SUCCESS;
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("tlocal_fetch failed: %d", rc);
         return rc;
@@ -558,7 +566,7 @@ static inline int opal_common_ucx_wpmem_fetch_nb(opal_common_ucx_wpmem_t *mem,
                                                  int target, void *buffer, size_t len,
                                                  uint64_t rem_addr,
                                                  opal_common_ucx_user_req_handler_t user_req_cb,
-                                                 void *user_req_ptr)
+                                                 void *user_req_ptr, ucp_ep_h *dflt_ep)
 {
     ucp_ep_h ep = NULL;
     ucp_rkey_h rkey = NULL;
@@ -566,7 +574,7 @@ static inline int opal_common_ucx_wpmem_fetch_nb(opal_common_ucx_wpmem_t *mem,
     int rc = OPAL_SUCCESS;
     opal_common_ucx_request_t *req;
 
-    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo, dflt_ep);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         MCA_COMMON_UCX_ERROR("tlocal_fetch failed: %d", rc);
         return rc;


### PR DESCRIPTION
Adding the following optimizations: 1) Reuse the same workers/eps in
single-threaded applications, this is helpful if an application
creates many windows, therefore, we avoid the unnecessary overheads  and 2) adding the truly nonblocking
MPI_Accumulate/Get_Accumulate.

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
Co-authored-by: Joseph Schuchart <schuchart@icl.utk.edu>