### PR TITLE
ofi-common-dso: allow this only if other ofi comps

### DIFF
--- a/ompi/mca/mtl/ofi/configure.m4
+++ b/ompi/mca/mtl/ofi/configure.m4
@@ -24,9 +24,14 @@ AC_DEFUN([MCA_ompi_mtl_ofi_POST_CONFIG], [
 #                    [action-if-cant-compile])
 # ------------------------------------------------
 AC_DEFUN([MCA_ompi_mtl_ofi_CONFIG],[
-    OPAL_VAR_SCOPE_PUSH([mtl_ofi_happy])
+    OPAL_VAR_SCOPE_PUSH([mtl_ofi_happy common_ofi_compile_mode mtl_ofi_compile_mode])
 
     AC_CONFIG_FILES([ompi/mca/mtl/ofi/Makefile])
+
+    MCA_COMPONENT_COMPILE_MODE("opal", "common", "ofi", common_ofi_compile_mode)
+    MCA_COMPONENT_COMPILE_MODE("ompi", "mtl", "ofi", mtl_ofi_compile_mode)
+    AS_IF([test ${common_ofi_compile_mode} = "dso" && test ${mtl_ofi_compile_mode} = "static"],
+          [AC_MSG_ERROR([mtl-ofi must be included on the --enable-mca-dso list if common-ofi is on this list])])
 
     OPAL_CHECK_OFI([mtl_ofi],
                    [mtl_ofi_happy=1],

--- a/opal/mca/btl/ofi/configure.m4
+++ b/opal/mca/btl/ofi/configure.m4
@@ -31,9 +31,14 @@
 # support, otherwise executes action-if-not-found
 
 AC_DEFUN([MCA_opal_btl_ofi_CONFIG],[
-    OPAL_VAR_SCOPE_PUSH([btl_ofi_happy CPPFLAGS_save])
+    OPAL_VAR_SCOPE_PUSH([btl_ofi_happy CPPFLAGS_save common_ofi_compile_mode btl_ofi_compile_mode])
 
     AC_CONFIG_FILES([opal/mca/btl/ofi/Makefile])
+
+    MCA_COMPONENT_COMPILE_MODE("opal", "common", "ofi", common_ofi_compile_mode)
+    MCA_COMPONENT_COMPILE_MODE("opal", "btl", "ofi", btl_ofi_compile_mode)
+    AS_IF([test ${common_ofi_compile_mode} = "dso" && test ${btl_ofi_compile_mode} = "static"],
+          [AC_MSG_ERROR([ofi-btl must be included on the --enable-mca-dso list if common-ofi is on this list])])
 
     # Check for OFI
     OPAL_CHECK_OFI([btl_ofi], [btl_ofi_happy=1], [btl_ofi_happy=0])


### PR DESCRIPTION
are also on the enable-dso-mca list

with this patch, if one configures with --enable-mca-dso=common-ofi

but not also ofi-btl or/and ofi-mtl they get a configure failure with
this sort of message:

configure: error: ofi-btl must be included on the --enable-mca-dso list if common-ofi is on this list

related to #9451

Signed-off-by: Howard Pritchard <howardp@lanl.gov>