### PR TITLE
smsc/cma: Add a check for CAP_SYS_PTRACE between processes

### DIFF
--- a/config/opal_check_cma.m4
+++ b/config/opal_check_cma.m4
@@ -4,7 +4,7 @@
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
+# Copyright (c) 2010-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2013-2016 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
@@ -129,6 +129,25 @@ static void do_check (pid_t pid, int *in, int *out)
     fi
 
     OPAL_VAR_SCOPE_POP
+
+    # Testing CAP_SYS_PTRACE between two processes with kcmp
+    AC_CHECK_HEADERS([linux/kcmp.h])
+    AC_CHECK_HEADERS([sys/syscall.h])
+    AC_MSG_CHECKING([if kcmp works])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <linux/kcmp.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+                                       ]], [[
+syscall(SYS_kcmp, 123, 456, KCMP_VM, 0, 0);
+                                           ]])],
+                      [AC_MSG_RESULT([yes])
+                       opal_check_cma_kcmp_happy=1],
+                      [AC_MSG_RESULT([no])
+                       opal_check_cma_kcmp_happy=0])
+    AC_DEFINE_UNQUOTED([OPAL_CMA_KCMP_AVAIL],
+                       [$opal_check_cma_kcmp_happy],
+                       [If kcmp is available])
 
     AS_IF([test $opal_check_cma_happy -eq 1],
           [opal_check_cma_msg=yes],


### PR DESCRIPTION
 * If you run in an environment (e.g., container) where the `CAP_SYS_PTRACE`
   capability is not provided then the two processes will not be able to
   use `process_vm_readv`/`process_vm_writev` even if all of the other
   checks currently in the code pass.
   The result is errors when trying to call one of these two functions
   which is difficult for the called (i.e., `btl/sm`) to recover from.
 * Use the `kcmp` system call as a proxy for the `process_vm_readv`/`process_vm_writev`
   functions. `kcmp` is a lightweight check in the kernel and is sufficient
   to detect if the two processes have the necessary capabilities.
 * Refs
   * Capabilities : https://man7.org/linux/man-pages/man7/capabilities.7.html
   * `kcmp` : https://man7.org/linux/man-pages/man2/kcmp.2.html