### PR TITLE
[4.1.x] GCC atomics: acquire thread-fence was busted until GCC 8.1.0

### DIFF
--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -52,7 +52,7 @@
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 
 
-#if (OPAL_ASSEMBLY_ARCH == OPAL_X86_64) && defined (__GNUC__) && !defined(__llvm) && (__GNUC__ < 6)
+#if defined(PLATFORM_ARCH_X86_64) && defined(PLATFORM_COMPILER_GNU) && __GNUC__ < 8
     /* work around a bug in older gcc versions where ACQUIRE seems to get
      * treated as a no-op instead */
 #define OPAL_BUSTED_ATOMIC_MB 1


### PR DESCRIPTION
GCC's acquire thread-fence was busted until GCC 8.1.0 (similar for C11). Check [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,selection:(endColumn:19,endLineNumber:7,positionColumn:19,positionLineNumber:7,selectionStartColumn:19,selectionStartLineNumber:7,startColumn:19,startLineNumber:7),source:'%23include+%3Cstdint.h%3E%0A%23include+%3Cstdbool.h%3E%0A%0Aint+x+%3D+1%3B%0A%0Avoid+foo(int+*var)+%7B%0A++while+(*var+%3D%3D+x)%0A++++__atomic_thread_fence(__ATOMIC_ACQUIRE)%3B%0A%7D%0A'),l:'5',n:'0',o:'C+source+%231',t:'0')),k:41.63105651274704,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:cg74,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,libs:!(),options:'-O2',selection:(endColumn:18,endLineNumber:8,positionColumn:18,positionLineNumber:8,selectionStartColumn:18,selectionStartLineNumber:8,startColumn:18,startLineNumber:8),source:1,tree:'1'),l:'5',n:'0',o:'x86-64+gcc+7.4+(C,+Editor+%231,+Compiler+%231)',t:'0')),k:27.832350140228634,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:cg81,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:2,lang:___c,libs:!(),options:'-O2',selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1,tree:'1'),l:'5',n:'0',o:'x86-64+gcc+8.1+(C,+Editor+%231,+Compiler+%232)',t:'0'),(h:output,i:(editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+gcc+7.4+(Compiler+%231)',t:'0')),k:30.536593347024322,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) for an example compiled with GCC 7 and 8. Notice that the load of x is optimized out of the loop when compiling with GCC 7. We had previously updated the version of the busted GCC for the C11 atomics (https://github.com/open-mpi/ompi/pull/10118).

Partial cherry-pick of https://github.com/open-mpi/ompi/pull/10721 to 4.1.x. 