### PR TITLE
v5.0.x: osc/rdma: fix iov size while unpacking result buffer

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -316,7 +316,8 @@ static inline int ompi_osc_rdma_gacc_amo (ompi_osc_rdma_module_t *module, ompi_o
     if (NULL != result_convertor) {
         /* result buffer is not necessarily contiguous. use the opal datatype engine to
          * copy the data over in this case */
-        struct iovec iov = {.iov_base = result_start, .iov_len = request->len};
+        size_t len = count * dt_size;
+        struct iovec iov = {.iov_base = result_start, .iov_len = len};
         uint32_t iov_count = 1;
         size_t size = request->len;
 


### PR DESCRIPTION
Set the iov length to target buffer size while unpacking the data to result buffer
to avoid data corruption.

Signed-off-by: Aboorva Devarajan <abodevar@in.ibm.com>

(cherry picked from commit 8803837098dd392e91a3e33aab0c8fa6349d5f5a)