### PR TITLE
github-labeler.yaml: update permissions/security

### DIFF
--- a/.github/workflows/github-labeler.yaml
+++ b/.github/workflows/github-labeler.yaml
@@ -13,8 +13,12 @@ on:
           - opened
           - edited
 
+permissions: {} # none
+
 jobs:
     ci:
+        permissions:
+          pull-requests: write
         name: Label Bot
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
This PR adds explicit [permissions
section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
to workflows. This is a security best practice because by default
workflows run with [extended set of
permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
(except from `on: pull_request` [from external
forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By
specifying any permission explicitly all others are set to none. By
using the principle of least privilege the damage a compromised
workflow can do (because of an
[injection](https://securitylab.github.com/research/github-actions-untrusted-input/)
or compromised third party tool or action) is restricted.

It is recommended to have [most strict permissions on the top
level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
and grant write permissions on [job
level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
case by case.

Signed-off-by: sashashura <93376818+sashashura@users.noreply.github.com>
(cherry picked from commit 5bf0b021380ffb115f302ed470c6a2e3db100d8b)