### PR TITLE
osc/ucx: Move the ucx_mca_register/deregister to open/close

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +37,7 @@ static void _osc_ucx_init_unlock(void)
 }
 
 static int component_open(void);
+static int component_close(void);
 static int component_register(void);
 static int component_init(bool enable_progress_threads, bool enable_mpi_threads);
 static int component_finalize(void);
@@ -54,6 +56,7 @@ ompi_osc_ucx_component_t mca_osc_ucx_component = {
             MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
                                   OMPI_RELEASE_VERSION),
             .mca_open_component = component_open,
+            .mca_close_component = component_close,
             .mca_register_component_params = component_register,
         },
         .osc_data = {
@@ -112,6 +115,14 @@ ompi_osc_ucx_module_t ompi_osc_ucx_module_template = {
 };
 
 static int component_open(void) {
+    opal_common_ucx_mca_register();
+
+    return OMPI_SUCCESS;
+}
+
+static int component_close(void) {
+    opal_common_ucx_mca_deregister();
+
     return OMPI_SUCCESS;
 }
 
@@ -184,8 +195,6 @@ static int component_init(bool enable_progress_threads, bool enable_mpi_threads)
 
     mca_osc_ucx_component.enable_mpi_threads = enable_mpi_threads;
 
-    opal_common_ucx_mca_register();
-
     ret = ucp_context_init();
     if (OMPI_ERROR == ret) {
         return OMPI_ERR_NOT_AVAILABLE;
@@ -238,7 +247,7 @@ static int component_finalize(void) {
         }
         mca_osc_ucx_component.env_initialized = false;
     }
-    opal_common_ucx_mca_deregister();
+
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
 * In the scenario where UCX is built into Open MPI, but not used at runtime
   then the memory hooks infrastructure can get into a situation where it has
   an invalid function pointer resulting in a segv.
 * Move the `opal_common_ucx_mca_register` and `opal_common_ucx_mca_deregister`
   calls to the component open and close functions, just like the UCX PML.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit 1d50132f016a00aebf3cfaa4f9874cca50a5f4ab)