### PR TITLE
Abort configure if static component depends on dso common

### DIFF
--- a/config/oac_literal.m4
+++ b/config/oac_literal.m4
@@ -1,0 +1,17 @@
+dnl -*- autoconf -*-
+dnl
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+
+dnl OAC_ASSERT_LITERAL: Assert if first argument is not an Autoconf literal
+dnl
+dnl 1 -> Variable which must be a literal
+dnl 2 -> Argument reference string (usually an integer argument number)
+dnl
+dnl Assert that the first argument is a literal (in the Autoconf sense
+dnl of the word) Second argument is the argument number (ie, a bare
+dnl number) to make the error message easier to parse.
+AC_DEFUN([OAC_ASSERT_LITERAL],
+[AS_LITERAL_IF([$1], [], [m4_fatal([argument $2 ($1) must be a literal])])])dnl

--- a/config/opal_check_compiler_version.m4
+++ b/config/opal_check_compiler_version.m4
@@ -27,8 +27,7 @@ AC_DEFUN([OPAL_CHECK_COMPILER_VERSION_ID],
 
 
 AC_DEFUN([OPAL_CHECK_COMPILER], [
-    AS_LITERAL_IF([$1], [],
-                  [m4_fatal([OPAL_CHECK_COMPILER argument must be a literal])])
+    OAC_ASSERT_LITERAL([$1], [1])dnl
     lower=m4_tolower([$1])
     AC_CACHE_CHECK([for compiler $lower], [opal_cv_compiler_$1],
     [

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -1033,3 +1033,29 @@ AC_DEFUN([OPAL_MCA_MAKE_DIR_LIST],[
     done
     AC_SUBST($1)
 ])
+
+
+# OPAL_MCA_CHECK_DEPENDENCY(check project, check framework, check component,
+#                           dependent project, dependent framework, dependent component)
+# --------------------------------------------------------------------------
+# Enforce that the check component does not introduce a dependency from its
+# project library (ie libmpi.so or libopen-pal.so) to another component
+# (ie, a common_*.so).  This can happen if the check component is set to
+# build static and the common library is set to build dso.  If this situation
+# is detected, print an error and abort configure.
+AC_DEFUN([OPAL_MCA_CHECK_DEPENDENCY],
+[
+    OPAL_VAR_SCOPE_PUSH([component_compile_mode dependency_compile_mode])
+
+    MCA_COMPONENT_COMPILE_MODE([$1], [$2], [$3], [component_compile_mode])
+    MCA_COMPONENT_COMPILE_MODE([$4], [$5], [$6], [dependency_compile_mode])
+
+    AS_IF([test "${component_compile_mode}" = "static" -a "${dependency_compile_mode}" = "dso"],
+         [AC_MSG_ERROR([Component $2:$3 is set to build as a
+static component, but its dependency $5:$6 is set to build as
+a dynamic component.  This configuration is not supported.  Please
+either build $5:$6 as a static component or build $2:$3 as a dynamic
+component.])])
+
+    OPAL_VAR_SCOPE_POP
+])

--- a/ompi/mca/coll/han/Makefile.am
+++ b/ompi/mca/coll/han/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2018-2020 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,9 +41,6 @@ component_install += mca_coll_han.la
 else
 component_noinst += libmca_coll_han.la
 endif
-
-# See ompi/mca/btl/sm/Makefile.am for an explanation of
-# libmca_common_sm.la.
 
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)

--- a/ompi/mca/coll/sm/configure.m4
+++ b/ompi/mca/coll/sm/configure.m4
@@ -1,0 +1,17 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AC_DEFUN([MCA_ompi_coll_sm_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/coll/sm/Makefile])
+
+    OPAL_MCA_CHECK_DEPENDENCY([ompi], [coll], [sm], [opal], [common], [sm])
+
+    $1
+])dnl

--- a/ompi/mca/mtl/ofi/configure.m4
+++ b/ompi/mca/mtl/ofi/configure.m4
@@ -49,6 +49,9 @@ AC_DEFUN([MCA_ompi_mtl_ofi_CONFIG],[
                                             [mtl_ofi_happy=0])])])
 
     AS_IF([test ${mtl_ofi_happy} -eq 1],
+          [OPAL_MCA_CHECK_DEPENDENCY([opal], [btl], [ofi], [opal], [common], [ofi])])
+
+    AS_IF([test ${mtl_ofi_happy} -eq 1],
           [$1],
           [AS_IF([test -n "${with_ofi}" -a "${with_ofi}" != "no"],
                  [AC_MSG_WARN([OFI libfabric support requested (via --with-ofi or --with-libfabric), but not found.])

--- a/ompi/mca/osc/ucx/configure.m4
+++ b/ompi/mca/osc/ucx/configure.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,6 +25,9 @@ AC_DEFUN([MCA_ompi_osc_ucx_CONFIG],[
     OMPI_CHECK_UCX([osc_ucx],
                    [osc_ucx_happy="yes"],
                    [osc_ucx_happy="no"])
+
+    AS_IF([test "${osc_ucx_happy}" = "yes"],
+          [OPAL_MCA_CHECK_DEPENDENCY([ompi], [osc], [ucx], [opal], [common], [ucx])])
 
     AS_IF([test "$osc_ucx_happy" = "yes"],
           [$1],

--- a/ompi/mca/pml/ucx/configure.m4
+++ b/ompi/mca/pml/ucx/configure.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,6 +19,9 @@ AC_DEFUN([MCA_ompi_pml_ucx_CONFIG], [
     OMPI_CHECK_UCX([pml_ucx],
                    [pml_ucx_happy="yes"],
                    [pml_ucx_happy="no"])
+
+    AS_IF([test "${pml_ucx_happy}" = "yes"],
+          [OPAL_MCA_CHECK_DEPENDENCY([ompi], [pml], [ucx], [opal], [common], [ucx])])
 
     AS_IF([test "$pml_ucx_happy" = "yes"],
           [$1],

--- a/opal/mca/btl/ofi/configure.m4
+++ b/opal/mca/btl/ofi/configure.m4
@@ -15,7 +15,6 @@
 # Copyright (c) 2011-2018 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2018      Intel, inc. All rights reserved
-#
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
@@ -44,6 +43,9 @@ AC_DEFUN([MCA_opal_btl_ofi_CONFIG],[
            AC_CHECK_DECL([FI_MR_VIRT_ADDR], [], [btl_ofi_happy=0],
                          [#include <rdma/fabric.h>])
            CPPFLAGS=${CPPFLAGS_save}])
+
+    AS_IF([test ${btl_ofi_happy} -eq 1],
+          [OPAL_MCA_CHECK_DEPENDENCY([opal], [btl], [ofi], [opal], [common], [ofi])])
 
     AS_IF([test ${btl_ofi_happy} -eq 1],
           [$1],

--- a/opal/mca/btl/smcuda/configure.m4
+++ b/opal/mca/btl/smcuda/configure.m4
@@ -5,6 +5,7 @@
 #                         reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,7 +24,7 @@ AC_DEFUN([MCA_opal_btl_smcuda_CONFIG],[
 
     # Only build if CUDA support is available
     AS_IF([test "x$CUDA_SUPPORT" = "x1"],
-          [$1],
+          [$1
+           OPAL_MCA_CHECK_DEPENDENCY([opal], [btl], [smcuda], [opal], [common], [sm])],
           [$2])
-
 ])dnl


### PR DESCRIPTION
Another take on fixing https://github.com/open-mpi/ompi/issues/9451 (original attempt https://github.com/open-mpi/ompi/pull/10710).  This avoids running the evaluation logic for build type multiple times, and hides all the logic in a central place.