### PR TITLE
v5.0.x: Remove the use of [OPAL|OMPI|OSHMEM]_MODULE_DECLSPEC

### DIFF
--- a/contrib/build-mca-comps-outside-of-tree/btl_tcp2.h
+++ b/contrib/build-mca-comps-outside-of-tree/btl_tcp2.h
@@ -98,7 +98,7 @@ struct mca_btl_tcp2_component_t {
 };
 typedef struct mca_btl_tcp2_component_t mca_btl_tcp2_component_t;
 
-OMPI_MODULE_DECLSPEC extern mca_btl_tcp2_component_t mca_btl_tcp2_component;
+OMPI_DECLSPEC extern mca_btl_tcp2_component_t mca_btl_tcp2_component;
 
 /**
  * BTL Module Interface

--- a/ompi/include/ompi_config.h
+++ b/ompi/include/ompi_config.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -44,15 +44,9 @@
 #    ifndef OMPI_DECLSPEC
 #      define OMPI_DECLSPEC            __opal_attribute_visibility__("default")
 #    endif
-#    ifndef OMPI_MODULE_DECLSPEC
-#      define OMPI_MODULE_DECLSPEC     __opal_attribute_visibility__("default")
-#    endif
 #  else
 #    ifndef OMPI_DECLSPEC
 #      define OMPI_DECLSPEC
-#    endif
-#    ifndef OMPI_MODULE_DECLSPEC
-#      define OMPI_MODULE_DECLSPEC
 #    endif
 #  endif
 

--- a/ompi/mca/coll/adapt/coll_adapt.h
+++ b/ompi/mca/coll/adapt/coll_adapt.h
@@ -133,7 +133,7 @@ struct mca_coll_adapt_module_t {
 OBJ_CLASS_DECLARATION(mca_coll_adapt_module_t);
 
 /* Global component instance */
-OMPI_MODULE_DECLSPEC extern mca_coll_adapt_component_t mca_coll_adapt_component;
+OMPI_DECLSPEC extern mca_coll_adapt_component_t mca_coll_adapt_component;
 
 /* ADAPT module functions */
 int ompi_coll_adapt_init_query(bool enable_progress_threads, bool enable_mpi_threads);

--- a/ompi/mca/coll/basic/coll_basic.h
+++ b/ompi/mca/coll/basic/coll_basic.h
@@ -39,7 +39,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-    OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+    OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
         mca_coll_basic_component;
     extern int mca_coll_basic_priority;
     extern int mca_coll_basic_crossover;

--- a/ompi/mca/coll/cuda/coll_cuda.h
+++ b/ompi/mca/coll/cuda/coll_cuda.h
@@ -94,7 +94,7 @@ typedef struct mca_coll_cuda_component_t {
 
 /* Globally exported variables */
 
-OMPI_MODULE_DECLSPEC extern mca_coll_cuda_component_t mca_coll_cuda_component;
+OMPI_DECLSPEC extern mca_coll_cuda_component_t mca_coll_cuda_component;
 
 END_C_DECLS
 

--- a/ompi/mca/coll/demo/coll_demo.h
+++ b/ompi/mca/coll/demo/coll_demo.h
@@ -30,7 +30,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_demo_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_demo_component;
     extern int mca_coll_demo_priority;
     extern int mca_coll_demo_verbose;
 

--- a/ompi/mca/coll/ftagree/coll_ftagree.h
+++ b/ompi/mca/coll/ftagree/coll_ftagree.h
@@ -32,7 +32,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
 mca_coll_ftagree_component;
 extern int mca_coll_ftagree_priority;
 

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -394,7 +394,7 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 /**
  * Global component instance
  */
-OMPI_MODULE_DECLSPEC extern mca_coll_han_component_t mca_coll_han_component;
+OMPI_DECLSPEC extern mca_coll_han_component_t mca_coll_han_component;
 
 /*
  * coll module functions

--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -100,7 +100,7 @@ struct mca_coll_hcoll_component_t {
 };
 typedef struct mca_coll_hcoll_component_t mca_coll_hcoll_component_t;
 
-OMPI_MODULE_DECLSPEC extern mca_coll_hcoll_component_t mca_coll_hcoll_component;
+OMPI_DECLSPEC extern mca_coll_hcoll_component_t mca_coll_hcoll_component;
 
 
 

--- a/ompi/mca/coll/inter/coll_inter.h
+++ b/ompi/mca/coll/inter/coll_inter.h
@@ -37,7 +37,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_inter_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_inter_component;
 extern int mca_coll_inter_priority_param;
 extern int mca_coll_inter_verbose_param;
 

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -88,7 +88,7 @@ struct ompi_coll_libnbc_component_t {
 typedef struct ompi_coll_libnbc_component_t ompi_coll_libnbc_component_t;
 
 /* Globally exported variables */
-OMPI_MODULE_DECLSPEC extern ompi_coll_libnbc_component_t mca_coll_libnbc_component;
+OMPI_DECLSPEC extern ompi_coll_libnbc_component_t mca_coll_libnbc_component;
 
 struct ompi_coll_libnbc_module_t {
     mca_coll_base_module_t super;

--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -73,7 +73,7 @@ struct mca_coll_portals4_component_t {
 
 };
 typedef struct mca_coll_portals4_component_t mca_coll_portals4_component_t;
-OMPI_MODULE_DECLSPEC extern mca_coll_portals4_component_t mca_coll_portals4_component;
+OMPI_DECLSPEC extern mca_coll_portals4_component_t mca_coll_portals4_component;
 
 
 /*

--- a/ompi/mca/coll/self/coll_self.h
+++ b/ompi/mca/coll/self/coll_self.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_self_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_self_component;
 extern int ompi_coll_self_priority;
 
 /*

--- a/ompi/mca/coll/sm/coll_sm.h
+++ b/ompi/mca/coll/sm/coll_sm.h
@@ -201,7 +201,7 @@ BEGIN_C_DECLS
     /**
      * Global component instance
      */
-    OMPI_MODULE_DECLSPEC extern mca_coll_sm_component_t mca_coll_sm_component;
+    OMPI_DECLSPEC extern mca_coll_sm_component_t mca_coll_sm_component;
 
     /*
      * coll module functions

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -151,7 +151,7 @@ typedef struct mca_coll_sync_component_t {
 
 /* Globally exported variables */
 
-OMPI_MODULE_DECLSPEC extern mca_coll_sync_component_t mca_coll_sync_component;
+OMPI_DECLSPEC extern mca_coll_sync_component_t mca_coll_sync_component;
 
 /* Macro used in most of the collectives */
 

--- a/ompi/mca/coll/tuned/coll_tuned.h
+++ b/ompi/mca/coll/tuned/coll_tuned.h
@@ -204,7 +204,7 @@ typedef struct mca_coll_tuned_component_t mca_coll_tuned_component_t;
 /**
  * Global component instance
  */
-OMPI_MODULE_DECLSPEC extern mca_coll_tuned_component_t mca_coll_tuned_component;
+OMPI_DECLSPEC extern mca_coll_tuned_component_t mca_coll_tuned_component;
 
 struct mca_coll_tuned_module_t {
     mca_coll_base_module_t super;

--- a/ompi/mca/coll/ucc/coll_ucc.h
+++ b/ompi/mca/coll/ucc/coll_ucc.h
@@ -58,7 +58,7 @@ struct mca_coll_ucc_component_t {
 };
 typedef struct mca_coll_ucc_component_t mca_coll_ucc_component_t;
 
-OMPI_MODULE_DECLSPEC extern mca_coll_ucc_component_t mca_coll_ucc_component;
+OMPI_DECLSPEC extern mca_coll_ucc_component_t mca_coll_ucc_component;
 
 /**
  * UCC enabled communicator

--- a/ompi/mca/fbtl/ime/fbtl_ime.h
+++ b/ompi/mca/fbtl/ime/fbtl_ime.h
@@ -44,7 +44,7 @@ int mca_fbtl_ime_component_file_unquery (ompio_file_t *file);
 int mca_fbtl_ime_module_init (ompio_file_t *file);
 int mca_fbtl_ime_module_finalize (ompio_file_t *file);
 
-OMPI_MODULE_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_ime_component;
+OMPI_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_ime_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fbtl/posix/fbtl_posix.h
+++ b/ompi/mca/fbtl/posix/fbtl_posix.h
@@ -48,7 +48,7 @@ int mca_fbtl_posix_module_finalize (ompio_file_t *file);
 
 extern int fbtl_posix_max_aio_active_reqs;
 
-OMPI_MODULE_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_posix_component;
+OMPI_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_posix_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fbtl/pvfs2/fbtl_pvfs2.h
+++ b/ompi/mca/fbtl/pvfs2/fbtl_pvfs2.h
@@ -52,7 +52,7 @@ int mca_fbtl_pvfs2_component_file_unquery (ompio_file_t *file);
 int mca_fbtl_pvfs2_module_init (ompio_file_t *file);
 int mca_fbtl_pvfs2_module_finalize (ompio_file_t *file);
 
-OMPI_MODULE_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_pvfs2_component;
+OMPI_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_pvfs2_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
 
 extern int mca_fcoll_dynamic_priority;
 
-OMPI_MODULE_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_component;
 
 /* API functions */
 

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
@@ -40,7 +40,7 @@ BEGIN_C_DECLS
 extern int mca_fcoll_dynamic_gen2_priority;
 extern int mca_fcoll_dynamic_gen2_num_groups;
 
-OMPI_MODULE_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_gen2_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_gen2_component;
 
 /* API functions */
 

--- a/ompi/mca/fcoll/individual/fcoll_individual.h
+++ b/ompi/mca/fcoll/individual/fcoll_individual.h
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
 
 extern int mca_fcoll_individual_priority;
 
-OMPI_MODULE_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_individual_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_individual_component;
 
 /* API functions */
 

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
@@ -42,7 +42,7 @@ extern int mca_fcoll_vulcan_num_groups;
 extern int mca_fcoll_vulcan_write_chunksize;
 extern int mca_fcoll_vulcan_async_io;
 
-OMPI_MODULE_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_vulcan_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_vulcan_component;
 
 /* API functions */
 

--- a/ompi/mca/fs/gpfs/fs_gpfs.h
+++ b/ompi/mca/fs/gpfs/fs_gpfs.h
@@ -40,7 +40,7 @@ int mca_fs_gpfs_component_file_unquery(ompio_file_t *file);
 
 int mca_fs_gpfs_module_init(ompio_file_t *file);
 int mca_fs_gpfs_module_finalize(ompio_file_t *file);
-OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
+OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
 
 /*
  * ******************************************************************

--- a/ompi/mca/fs/ime/fs_ime.h
+++ b/ompi/mca/fs/ime/fs_ime.h
@@ -37,7 +37,7 @@ int mca_fs_ime_module_finalize (ompio_file_t *file);
 
 int mca_fs_ime_native_fini(void);
 
-OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_ime_component;
+OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_ime_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fs/lustre/fs_lustre.h
+++ b/ompi/mca/fs/lustre/fs_lustre.h
@@ -51,7 +51,7 @@ int mca_fs_lustre_component_file_unquery (ompio_file_t *file);
 int mca_fs_lustre_module_init (ompio_file_t *file);
 int mca_fs_lustre_module_finalize (ompio_file_t *file);
 
-OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_lustre_component;
+OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_lustre_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.h
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.h
@@ -63,7 +63,7 @@ int mca_fs_pvfs2_component_file_unquery (ompio_file_t *file);
 int mca_fs_pvfs2_module_init (ompio_file_t *file);
 int mca_fs_pvfs2_module_finalize (ompio_file_t *file);
 
-OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_pvfs2_component;
+OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_pvfs2_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/fs/ufs/fs_ufs.h
+++ b/ompi/mca/fs/ufs/fs_ufs.h
@@ -47,7 +47,7 @@ int mca_fs_ufs_component_file_unquery (ompio_file_t *file);
 int mca_fs_ufs_module_init (ompio_file_t *file);
 int mca_fs_ufs_module_finalize (ompio_file_t *file);
 
-OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_ufs_component;
+OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_ufs_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/hook/comm_method/hook_comm_method.h
+++ b/ompi/mca/hook/comm_method/hook_comm_method.h
@@ -18,7 +18,7 @@
 
 BEGIN_C_DECLS
 
-OMPI_MODULE_DECLSPEC extern ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component;
+OMPI_DECLSPEC extern ompi_hook_base_component_1_0_0_t mca_hook_comm_method_component;
 
 extern int mca_hook_comm_method_verbose;
 extern int mca_hook_comm_method_output;

--- a/ompi/mca/hook/demo/hook_demo.h
+++ b/ompi/mca/hook/demo/hook_demo.h
@@ -20,7 +20,7 @@
 
 BEGIN_C_DECLS
 
-OMPI_MODULE_DECLSPEC extern const ompi_hook_base_component_1_0_0_t mca_hook_demo_component;
+OMPI_DECLSPEC extern const ompi_hook_base_component_1_0_0_t mca_hook_demo_component;
 
 void ompi_hook_demo_mpi_initialized_top(int *flag);
 void ompi_hook_demo_mpi_initialized_bottom(int *flag);

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -45,7 +45,7 @@ static mca_mtl_base_module_t*
 ompi_mtl_portals4_component_init(bool enable_progress_threads,
                                  bool enable_mpi_threads);
 
-OMPI_MODULE_DECLSPEC extern mca_mtl_base_component_2_0_0_t mca_mtl_portals4_component;
+OMPI_DECLSPEC extern mca_mtl_base_component_2_0_0_t mca_mtl_portals4_component;
 
 mca_mtl_base_component_2_0_0_t mca_mtl_portals4_component = {
 

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -317,7 +317,7 @@ struct ompi_osc_rdma_module_t {
     opal_atomic_int32_t pending_ops;
 };
 typedef struct ompi_osc_rdma_module_t ompi_osc_rdma_module_t;
-OMPI_MODULE_DECLSPEC extern ompi_osc_rdma_component_t mca_osc_rdma_component;
+OMPI_DECLSPEC extern ompi_osc_rdma_component_t mca_osc_rdma_component;
 
 #define GET_MODULE(win) ((ompi_osc_rdma_module_t*) win->w_osc_module)
 

--- a/ompi/mca/part/persist/part_persist_component.h
+++ b/ompi/mca/part/persist/part_persist_component.h
@@ -26,7 +26,7 @@ BEGIN_C_DECLS
 /*
  * PART module functions.
  */
-OMPI_MODULE_DECLSPEC extern mca_part_base_component_4_0_0_t mca_part_rma_component;
+OMPI_DECLSPEC extern mca_part_base_component_4_0_0_t mca_part_rma_component;
 
 END_C_DECLS
 

--- a/ompi/mca/pml/cm/pml_cm_component.h
+++ b/ompi/mca/pml/cm/pml_cm_component.h
@@ -25,7 +25,7 @@ BEGIN_C_DECLS
 /*
  * PML module functions.
  */
-OMPI_MODULE_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_cm_component;
+OMPI_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_cm_component;
 
 END_C_DECLS
 

--- a/ompi/mca/pml/ob1/pml_ob1_component.h
+++ b/ompi/mca/pml/ob1/pml_ob1_component.h
@@ -27,7 +27,7 @@ BEGIN_C_DECLS
 /*
  * PML module functions.
  */
-OMPI_MODULE_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_ob1_component;
+OMPI_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_ob1_component;
 
 END_C_DECLS
 

--- a/ompi/mca/pml/v/pml_v.h
+++ b/ompi/mca/pml/v/pml_v.h
@@ -19,7 +19,7 @@
 
 BEGIN_C_DECLS
 
-OMPI_MODULE_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_v_component;
+OMPI_DECLSPEC extern mca_pml_base_component_2_1_0_t mca_pml_v_component;
 
 END_C_DECLS
 

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.h
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.h
@@ -44,7 +44,7 @@ extern int mca_sharedfp_individual_priority;
 extern int mca_sharedfp_individual_verbose;
 extern int mca_sharedfp_individual_usage_counter;
 
-OMPI_MODULE_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_individual_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_individual_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
@@ -43,7 +43,7 @@ int mca_sharedfp_lockedfile_module_finalize (ompio_file_t *file);
 extern int mca_sharedfp_lockedfile_priority;
 extern int mca_sharedfp_lockedfile_verbose;
 
-OMPI_MODULE_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_lockedfile_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_lockedfile_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.h
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.h
@@ -44,7 +44,7 @@ int mca_sharedfp_sm_module_finalize (ompio_file_t *file);
 extern int mca_sharedfp_sm_priority;
 extern int mca_sharedfp_sm_verbose;
 
-OMPI_MODULE_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_sm_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_sm_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/topo/basic/topo_basic.h
+++ b/ompi/mca/topo/basic/topo_basic.h
@@ -24,7 +24,7 @@ BEGIN_C_DECLS
 
 typedef mca_topo_base_component_2_2_0_t mca_topo_basic_component_t;
 /* Public component instance */
-OMPI_MODULE_DECLSPEC extern mca_topo_basic_component_t
+OMPI_DECLSPEC extern mca_topo_basic_component_t
     mca_topo_basic_component;
 
 END_C_DECLS

--- a/ompi/mca/topo/example/topo_example.h
+++ b/ompi/mca/topo/example/topo_example.h
@@ -42,7 +42,7 @@ BEGIN_C_DECLS
 /*
  * Public component instance
  */
-OMPI_MODULE_DECLSPEC extern mca_topo_base_component_2_2_0_t
+OMPI_DECLSPEC extern mca_topo_base_component_2_2_0_t
     mca_topo_example_component;
 
 /*

--- a/ompi/mca/topo/treematch/topo_treematch.h
+++ b/ompi/mca/topo/treematch/topo_treematch.h
@@ -45,7 +45,7 @@ typedef struct mca_topo_treematch_component_2_2_0_t {
     int reorder_mode;
 } mca_topo_treematch_component_2_2_0_t;
 
-OMPI_MODULE_DECLSPEC extern mca_topo_treematch_component_2_2_0_t
+OMPI_DECLSPEC extern mca_topo_treematch_component_2_2_0_t
     mca_topo_treematch_component;
 
 /*

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -249,10 +249,8 @@
 
 #if OPAL_C_HAVE_VISIBILITY
 #    define OPAL_DECLSPEC        __opal_attribute_visibility__("default")
-#    define OPAL_MODULE_DECLSPEC __opal_attribute_visibility__("default")
 #else
 #    define OPAL_DECLSPEC
-#    define OPAL_MODULE_DECLSPEC
 #endif
 
 #if !defined(__STDC_LIMIT_MACROS) && (defined(c_plusplus) || defined(__cplusplus))

--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -171,7 +171,7 @@ struct mca_btl_ofi_component_t {
 };
 typedef struct mca_btl_ofi_component_t mca_btl_ofi_component_t;
 
-OPAL_MODULE_DECLSPEC extern mca_btl_ofi_component_t mca_btl_ofi_component;
+OPAL_DECLSPEC extern mca_btl_ofi_component_t mca_btl_ofi_component;
 
 struct mca_btl_base_registration_handle_t {
     uint64_t rkey;

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -243,7 +243,7 @@ struct mca_btl_base_registration_handle_t {
 /*
  * global structures
  */
-OPAL_MODULE_DECLSPEC extern mca_btl_portals4_component_t mca_btl_portals4_component;
+OPAL_DECLSPEC extern mca_btl_portals4_component_t mca_btl_portals4_component;
 extern mca_btl_portals4_module_t mca_btl_portals4_module;
 
 /**

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -47,7 +47,7 @@ static mca_btl_base_module_t **mca_btl_portals4_component_init(int *num_btls,
                                                                bool enable_mpi_threads);
 int mca_btl_portals4_component_progress(void);
 
-OPAL_MODULE_DECLSPEC extern mca_btl_portals4_component_t mca_btl_portals4_component;
+OPAL_DECLSPEC extern mca_btl_portals4_component_t mca_btl_portals4_component;
 
 mca_btl_portals4_component_t mca_btl_portals4_component = {{
     /* First, the mca_base_module_t struct containing meta

--- a/opal/mca/btl/self/btl_self.h
+++ b/opal/mca/btl/self/btl_self.h
@@ -51,7 +51,7 @@ struct mca_btl_self_component_t {
     opal_free_list_t self_frags_rdma;  /**< free list of self second */
 };
 typedef struct mca_btl_self_component_t mca_btl_self_component_t;
-OPAL_MODULE_DECLSPEC extern mca_btl_self_component_t mca_btl_self_component;
+OPAL_DECLSPEC extern mca_btl_self_component_t mca_btl_self_component;
 
 extern mca_btl_base_module_t mca_btl_self;
 

--- a/opal/mca/btl/sm/btl_sm.h
+++ b/opal/mca/btl/sm/btl_sm.h
@@ -71,8 +71,8 @@ BEGIN_C_DECLS
 
 struct sm_fifo_t;
 
-OPAL_MODULE_DECLSPEC extern mca_btl_sm_component_t mca_btl_sm_component;
-OPAL_MODULE_DECLSPEC extern mca_btl_sm_t mca_btl_sm;
+OPAL_DECLSPEC extern mca_btl_sm_component_t mca_btl_sm_component;
+OPAL_DECLSPEC extern mca_btl_sm_t mca_btl_sm;
 
 /* number of peers on the node (not including self) */
 #define MCA_BTL_SM_NUM_LOCAL_PEERS opal_process_info.num_local_peers

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -208,7 +208,7 @@ struct mca_btl_smcuda_component_t {
     char *allocator;
 };
 typedef struct mca_btl_smcuda_component_t mca_btl_smcuda_component_t;
-OPAL_MODULE_DECLSPEC extern mca_btl_smcuda_component_t mca_btl_smcuda_component;
+OPAL_DECLSPEC extern mca_btl_smcuda_component_t mca_btl_smcuda_component;
 
 /**
  * SM BTL Interface
@@ -220,7 +220,7 @@ struct mca_btl_smcuda_t {
     mca_rcache_base_module_t *rcache;
 };
 typedef struct mca_btl_smcuda_t mca_btl_smcuda_t;
-OPAL_MODULE_DECLSPEC extern mca_btl_smcuda_t mca_btl_smcuda;
+OPAL_DECLSPEC extern mca_btl_smcuda_t mca_btl_smcuda;
 
 struct btl_smcuda_pending_send_item_t {
     opal_free_list_item_t super;

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -148,7 +148,7 @@ struct mca_btl_tcp_component_t {
 };
 typedef struct mca_btl_tcp_component_t mca_btl_tcp_component_t;
 
-OPAL_MODULE_DECLSPEC extern mca_btl_tcp_component_t mca_btl_tcp_component;
+OPAL_DECLSPEC extern mca_btl_tcp_component_t mca_btl_tcp_component;
 
 /**
  * BTL Module Interface

--- a/opal/mca/btl/template/btl_template.h
+++ b/opal/mca/btl/template/btl_template.h
@@ -77,7 +77,7 @@ struct mca_btl_template_component_t {
 };
 typedef struct mca_btl_template_component_t mca_btl_template_component_t;
 
-OPAL_MODULE_DECLSPEC extern mca_btl_template_component_t mca_btl_template_component;
+OPAL_DECLSPEC extern mca_btl_template_component_t mca_btl_template_component;
 
 /**
  * BTL Module Interface

--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -156,7 +156,7 @@ struct mca_btl_uct_component_t {
 };
 typedef struct mca_btl_uct_component_t mca_btl_uct_component_t;
 
-OPAL_MODULE_DECLSPEC extern mca_btl_uct_component_t mca_btl_uct_component;
+OPAL_DECLSPEC extern mca_btl_uct_component_t mca_btl_uct_component;
 
 struct mca_btl_base_registration_handle_t {
     /** The packed memory handle. The size of this field is defined by UCT. */

--- a/opal/mca/btl/ugni/btl_ugni.h
+++ b/opal/mca/btl/ugni/btl_ugni.h
@@ -298,8 +298,8 @@ typedef struct mca_btl_ugni_component_t {
 
 /* Global structures */
 
-OPAL_MODULE_DECLSPEC extern mca_btl_ugni_component_t mca_btl_ugni_component;
-OPAL_MODULE_DECLSPEC extern mca_btl_ugni_module_t mca_btl_ugni_module;
+OPAL_DECLSPEC extern mca_btl_ugni_component_t mca_btl_ugni_component;
+OPAL_DECLSPEC extern mca_btl_ugni_module_t mca_btl_ugni_module;
 
 static inline uint32_t mca_btl_ugni_ep_get_device_index(mca_btl_ugni_module_t *ugni_module)
 {

--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -241,7 +241,7 @@ typedef struct opal_btl_usnic_component_t {
     opal_event_base_t *opal_evbase;
 } opal_btl_usnic_component_t;
 
-OPAL_MODULE_DECLSPEC extern opal_btl_usnic_component_t mca_btl_usnic_component;
+OPAL_DECLSPEC extern opal_btl_usnic_component_t mca_btl_usnic_component;
 
 typedef mca_btl_base_recv_reg_t opal_btl_usnic_recv_reg_t;
 

--- a/opal/mca/mpool/memkind/mpool_memkind.h
+++ b/opal/mca/mpool/memkind/mpool_memkind.h
@@ -74,7 +74,7 @@ struct mca_mpool_memkind_component_t {
 };
 
 typedef struct mca_mpool_memkind_component_t mca_mpool_memkind_component_t;
-OPAL_MODULE_DECLSPEC extern mca_mpool_memkind_component_t mca_mpool_memkind_component;
+OPAL_DECLSPEC extern mca_mpool_memkind_component_t mca_mpool_memkind_component;
 
 /**
  *  Initializes the mpool module.

--- a/opal/mca/shmem/mmap/shmem_mmap.h
+++ b/opal/mca/shmem/mmap/shmem_mmap.h
@@ -43,7 +43,7 @@ typedef struct opal_shmem_mmap_component_t {
     int priority;
 } opal_shmem_mmap_component_t;
 
-OPAL_MODULE_DECLSPEC extern opal_shmem_mmap_component_t mca_shmem_mmap_component;
+OPAL_DECLSPEC extern opal_shmem_mmap_component_t mca_shmem_mmap_component;
 
 typedef struct opal_shmem_mmap_module_t {
     opal_shmem_base_module_t super;

--- a/opal/mca/shmem/posix/shmem_posix.h
+++ b/opal/mca/shmem/posix/shmem_posix.h
@@ -54,7 +54,7 @@ typedef struct opal_shmem_posix_component_t {
     int priority;
 } opal_shmem_posix_component_t;
 
-OPAL_MODULE_DECLSPEC extern opal_shmem_posix_component_t mca_shmem_posix_component;
+OPAL_DECLSPEC extern opal_shmem_posix_component_t mca_shmem_posix_component;
 
 typedef struct opal_shmem_posix_module_t {
     opal_shmem_base_module_t super;

--- a/opal/mca/shmem/sysv/shmem_sysv.h
+++ b/opal/mca/shmem/sysv/shmem_sysv.h
@@ -39,7 +39,7 @@ typedef struct opal_shmem_sysv_component_t {
     int priority;
 } opal_shmem_sysv_component_t;
 
-OPAL_MODULE_DECLSPEC extern opal_shmem_sysv_component_t mca_shmem_sysv_component;
+OPAL_DECLSPEC extern opal_shmem_sysv_component_t mca_shmem_sysv_component;
 
 typedef struct opal_shmem_sysv_module_t {
     opal_shmem_base_module_t super;

--- a/oshmem/include/oshmem_config.h
+++ b/oshmem/include/oshmem_config.h
@@ -2,7 +2,7 @@
  *
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -22,46 +22,14 @@
 
 #define OSHMEM_IDENT_STRING OPAL_IDENT_STRING
 
-#if defined(__WINDOWS__)
-
-#  if defined(_USRDLL)    /* building shared libraries (.DLL) */
-#    if defined(OSHMEM_EXPORTS)
-#      define OSHMEM_DECLSPEC        __declspec(dllexport)
-#      define OSHMEM_MODULE_DECLSPEC
-#    else
-#      define OSHMEM_DECLSPEC        __declspec(dllimport)
-#      if defined(OSHMEM_MODULE_EXPORTS)
-#        define OSHMEM_MODULE_DECLSPEC __declspec(dllexport)
-#      else
-#        define OSHMEM_MODULE_DECLSPEC __declspec(dllimport)
-#      endif  /* defined(OSHMEM_MODULE_EXPORTS) */
-#    endif  /* defined(OSHMEM_EXPORTS) */
-#  else          /* building static library */
-#    if defined(OSHMEM_IMPORTS)
-#      define OSHMEM_DECLSPEC        __declspec(dllimport)
-#    else
-#      define OSHMEM_DECLSPEC
-#    endif  /* defined(OSHMEM_IMPORTS) */
-#    define OSHMEM_MODULE_DECLSPEC
-#  endif  /* defined(_USRDLL) */
-
-#else
-
 #  if OPAL_C_HAVE_VISIBILITY
 #    ifndef OSHMEM_DECLSPEC
 #      define OSHMEM_DECLSPEC            __opal_attribute_visibility__("default")
-#    endif
-#    ifndef OSHMEM_MODULE_DECLSPEC
-#      define OSHMEM_MODULE_DECLSPEC     __opal_attribute_visibility__("default")
 #    endif
 #  else
 #    ifndef OSHMEM_DECLSPEC
 #      define OSHMEM_DECLSPEC
 #    endif
-#    ifndef OSHMEM_MODULE_DECLSPEC
-#      define OSHMEM_MODULE_DECLSPEC
-#    endif
 #  endif
-#endif  /* defined(__WINDOWS__) */
 
 #endif

--- a/oshmem/mca/atomic/basic/atomic_basic.h
+++ b/oshmem/mca/atomic/basic/atomic_basic.h
@@ -23,7 +23,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OSHMEM_MODULE_DECLSPEC extern mca_atomic_base_component_1_0_0_t
+OSHMEM_DECLSPEC extern mca_atomic_base_component_1_0_0_t
 mca_atomic_basic_component;
 
 OSHMEM_DECLSPEC void atomic_basic_lock(shmem_ctx_t ctx, int pe);

--- a/oshmem/mca/atomic/ucx/atomic_ucx.h
+++ b/oshmem/mca/atomic/ucx/atomic_ucx.h
@@ -26,7 +26,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OSHMEM_MODULE_DECLSPEC extern mca_atomic_base_component_1_0_0_t
+OSHMEM_DECLSPEC extern mca_atomic_base_component_1_0_0_t
 mca_atomic_ucx_component;
 
 /* this component works with spml:ucx only */

--- a/oshmem/mca/memheap/buddy/memheap_buddy_component.h
+++ b/oshmem/mca/memheap/buddy/memheap_buddy_component.h
@@ -19,7 +19,7 @@ BEGIN_C_DECLS
 /*
  * MEMHEAP module functions.
  */
-OSHMEM_MODULE_DECLSPEC extern mca_memheap_base_component_2_0_0_t mca_memheap_buddy_component;
+OSHMEM_DECLSPEC extern mca_memheap_base_component_2_0_0_t mca_memheap_buddy_component;
 
 END_C_DECLS
 

--- a/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc_component.h
+++ b/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc_component.h
@@ -19,7 +19,7 @@ BEGIN_C_DECLS
 /*
  * MEMHEAP module functions.
  */
-OSHMEM_MODULE_DECLSPEC extern mca_memheap_base_component_2_0_0_t mca_memheap_ptmalloc_component;
+OSHMEM_DECLSPEC extern mca_memheap_base_component_2_0_0_t mca_memheap_ptmalloc_component;
 
 END_C_DECLS
 

--- a/oshmem/mca/scoll/basic/scoll_basic.h
+++ b/oshmem/mca/scoll/basic/scoll_basic.h
@@ -32,7 +32,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OSHMEM_MODULE_DECLSPEC extern mca_scoll_base_component_1_0_0_t
+OSHMEM_DECLSPEC extern mca_scoll_base_component_1_0_0_t
 mca_scoll_basic_component;
 
 extern int mca_scoll_basic_priority_param;

--- a/oshmem/mca/scoll/mpi/scoll_mpi.h
+++ b/oshmem/mca/scoll/mpi/scoll_mpi.h
@@ -49,7 +49,7 @@ struct mca_scoll_mpi_component_t {
 };
 typedef struct mca_scoll_mpi_component_t mca_scoll_mpi_component_t;
 
-OMPI_MODULE_DECLSPEC extern mca_scoll_mpi_component_t mca_scoll_mpi_component;
+OMPI_DECLSPEC extern mca_scoll_mpi_component_t mca_scoll_mpi_component;
 
 
 /**

--- a/oshmem/mca/scoll/ucc/scoll_ucc.h
+++ b/oshmem/mca/scoll/ucc/scoll_ucc.h
@@ -51,7 +51,7 @@ struct mca_scoll_ucc_component_t {
 };
 typedef struct mca_scoll_ucc_component_t mca_scoll_ucc_component_t;
 
-OMPI_MODULE_DECLSPEC extern mca_scoll_ucc_component_t mca_scoll_ucc_component;
+OMPI_DECLSPEC extern mca_scoll_ucc_component_t mca_scoll_ucc_component;
 
 /**
  * UCC enabled team

--- a/oshmem/mca/spml/ucx/spml_ucx_component.h
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.h
@@ -19,7 +19,7 @@ BEGIN_C_DECLS
 /*
  * SPML module functions.
  */
-OSHMEM_MODULE_DECLSPEC extern mca_spml_base_component_2_0_0_t mca_spml_ucx_component;
+OSHMEM_DECLSPEC extern mca_spml_base_component_2_0_0_t mca_spml_ucx_component;
 END_C_DECLS
 
 #endif

--- a/oshmem/mca/sshmem/mmap/sshmem_mmap.h
+++ b/oshmem/mca/sshmem/mmap/sshmem_mmap.h
@@ -29,7 +29,7 @@ typedef struct mca_sshmem_mmap_component_t {
     int is_start_addr_fixed;
 } mca_sshmem_mmap_component_t;
 
-OSHMEM_MODULE_DECLSPEC extern mca_sshmem_mmap_component_t
+OSHMEM_DECLSPEC extern mca_sshmem_mmap_component_t
 mca_sshmem_mmap_component;
 
 typedef struct mca_sshmem_mmap_module_t {

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv.h
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv.h
@@ -30,7 +30,7 @@ typedef struct mca_sshmem_sysv_component_t {
     int use_hp;
 } mca_sshmem_sysv_component_t;
 
-OSHMEM_MODULE_DECLSPEC extern mca_sshmem_sysv_component_t
+OSHMEM_DECLSPEC extern mca_sshmem_sysv_component_t
 mca_sshmem_sysv_component;
 
 typedef struct mca_sshmem_sysv_module_t {
@@ -38,7 +38,7 @@ typedef struct mca_sshmem_sysv_module_t {
 } mca_sshmem_sysv_module_t;
 extern mca_sshmem_sysv_module_t mca_sshmem_sysv_module;
 
-OSHMEM_MODULE_DECLSPEC extern size_t sshmem_sysv_gethugepagesize(void);
+OSHMEM_DECLSPEC extern size_t sshmem_sysv_gethugepagesize(void);
 
 END_C_DECLS
 

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx.h
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx.h
@@ -31,7 +31,7 @@ typedef struct mca_sshmem_ucx_component_t {
     int priority;
 } mca_sshmem_ucx_component_t;
 
-OSHMEM_MODULE_DECLSPEC extern mca_sshmem_ucx_component_t
+OSHMEM_DECLSPEC extern mca_sshmem_ucx_component_t
 mca_sshmem_ucx_component;
 
 typedef struct mca_sshmem_ucx_segment_context {


### PR DESCRIPTION
In native Microsoft Windows builds, there is difference in how MCA component struct symbols need to be exported compared to other symbols.  The "MODULE_DECLSPEC" macros were for exporting MCA component struct symbols, and "DECLSPEC" macros were for all exporting all other symbols.

In other operating systems, there's no difference in how these two types of symbols are exported.

Once Open MPI stopped supporting native Microsoft Windows builds, there was no need to preserve the difference.  This commit therefore does the following:

- Removes all definitions of the "MODULE_DECLSPEC" macros
- Converts all uses of the "MODULE_DECLSPEC" macros to "DECLSPEC"
- Removes stale Microsoft Windows declarations in oshmem_config.h

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 17a1f97565fb17e418b928677f72388393a64865)

This is the v5.0.x PR for #10774