### PR TITLE
v4.1.x: docs: update 5.0.0 doc locations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,11 @@ Documentation for Open can be found in the following locations:
      - Documentation location
 
    * - v5.0.0 and later
-     - Open MPI documentation has consolidated and moved to
+     - Web: https://docs.open-mpi.org/
 
-       https://docs.open-mpi.org/.
+       Tarball: ``docs/_build/html/index.html``
+
+       Installed: ``$prefix/share/doc/openmpi/html/index.html``
 
    * - v4.1.x and earlier
      - See the `legacy Open MPI FAQ <https://www.open-mpi.org/faq/>`_


### PR DESCRIPTION
Note on the front page that the v5.0.0 docs are on the public web site, in the tarball, and installed locally.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit f33d3d4d9a2a093ef2572ac3307a54f804d9f335)