### PR TITLE
Adding man pages to document ULFM functions 

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -539,6 +539,14 @@ OMPI_MAN3 = \
         MPI_Win_wait.3 \
         MPI_Wtick.3 \
         MPI_Wtime.3 \
+        MPIX_Comm_ack_failed.3 \
+        MPIX_Comm_agree.3 \
+        MPIX_Comm_get_failed.3 \
+        MPIX_Comm_iagree.3 \
+        MPIX_Comm_ishrink.3 \
+        MPIX_Comm_is_revoked.3 \
+        MPIX_Comm_revoke.3 \
+        MPIX_Comm_shrink.3 \
         MPIX_Query_cuda_support.3 \
         MPIX_Query_rocm_support.3 \
         OMPI_Affinity_str.3

--- a/docs/features/ulfm.rst
+++ b/docs/features/ulfm.rst
@@ -42,24 +42,28 @@ standard draft document.
   completion of an MPI operation (error code).
 * ``MPIX_ERR_PROC_FAILED_PENDING`` when a potential sender matching a
   non-blocking wildcard source receive has failed (error code).
-* ``MPIX_ERR_REVOKED`` when one of the ranks in the application has
-  invoked the ``MPI_Comm_revoke`` operation on the communicator (error
+* ``MPIX_ERR_REVOKED`` when the communicator is revoked (error
   code).
 * ``MPIX_Comm_revoke(MPI_Comm comm)`` Interrupts any communication
-  pending on the communicator at all ranks (API).
+  pending on the communicator at all ranks (API). See :ref:`MPIX_Comm_revoke`.
+* ``MPIX_Comm_is_revoked(MPI_Comm comm, int *flag)`` Test if a Communicator
+  is currently revoked (API). See :ref:`MPIX_Comm_is_revoked`.
 * ``MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm* newcomm)`` creates a new
   communicator where dead processes in comm were removed, and the
   remaining processes are renamed to cover all the gaps in the naming
-  from the original communicator (API).
+  from the original communicator (API). See :ref:`MPIX_Comm_shrink`,
+  :ref:`MPIX_Comm_ishrink`.
 * ``MPIX_Comm_agree(MPI_Comm comm, int *flag)`` performs a consensus
   (i.e. fault tolerant allreduce operation) on flag (with the
   operation bitwise AND) (API).  Absorbs all new failures, and
-  propagate the knowledge about failures among the participants.
-* ``MPIX_Comm_failure_get_acked(MPI_Comm, MPI_Group*)`` obtains the
-  group of currently acknowledged failed processes (API).
-* ``MPIX_Comm_failure_ack(MPI_Comm)`` acknowledges that the
-  application intends to ignore the effect of currently known failures
-  on wildcard receive completions and agreement return values (API).
+  propagate the knowledge about failures among the participants. see
+  :ref:`MPIX_Comm_agree`, :ref:`MPIX_Comm_iagree`.
+* ``MPIX_Comm_get_failed(MPI_Comm comm, MPI_Group* failedgrp)`` obtains the
+  group of currently failed processes (API). See :ref:`MPIX_Comm_get_failed`.
+* ``MPIX_Comm_ack_failed(MPI_Comm comm, int num_to_ack, int* num_acked)``
+  acknowledges that the application intends to ignore the effect of currently
+  known failures on wildcard receive completions and agreement return values
+  (API). See :ref:`MPIX_Comm_ack_failed`.
 
 Supported Systems
 -----------------

--- a/docs/man-openmpi/man3/MPIX_Comm_ack_failed.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_ack_failed.3.rst
@@ -1,0 +1,135 @@
+.. _mpix_comm_ack_failed:
+
+MPIX_Comm_ack_failed
+====================
+.. include_body
+
+:ref:`MPIX_Comm_get_failed` - acknowledge failed processes in a communicator.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_ack_failed(MPI_Comm comm, int num_to_ack, int *num_acked)
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_ACK_FAILED(COMM, NUM_TO_ACK, NUM_ACKED, IERROR)
+        INTEGER COMM, NUM_TO_ACK, NUM_ACKED, IERROR
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_ack_failed(comm, num_to_ack, num_acked, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        INTEGER, INTENT(IN) :: num_to_ack
+        INTEGER, INTENT(OUT) :: num_acked
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+* ``num_to_ack``: maximum number of process failures to acknowledge in *comm* (integer)
+
+OUTPUT PARAMETERS
+-----------------
+* ``num_acked``: number of acknowledged failures in *comm* (integer).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+his local operation gives the users a way to **acknowledge**
+locally notified failures on *comm*. The operation acknowledges the first
+*num_to_ack* process failures on *comm*, that is, it acknowledges the
+failure of members with a rank lower than *num_to_ack* in the group that
+would be produced by a concurrent call to :ref:`MPIX_Comm_get_failed` on
+the same *comm*.
+
+The operation also sets the value of *num_acked* to the current number of
+acknowledged process failures in *comm*, that is, a process failure has been
+acknowledged on *comm* if and only if the rank of the process is lower than
+*num_acked* in the group that would be produced by a subsequent call to
+:ref:`MPIX_Comm_get_failed` on the same *comm*.
+
+*num_acked* can be larger than *num_to_ack* when process failures have been
+acknowledged in a prior call to :ref:`MPIX_Comm_ack_failed`.
+
+EFFECT OF ACKNOWLEDGING FAILURES
+--------------------------------
+
+After an MPI process failure is acknowledged on *comm*, unmatched
+MPI_ANY_SOURCE receive operations on the same *comm* that would have raised
+an error of class MPIX_ERR_PROC_FAILED_PENDING proceed without further raising
+errors due to this acknowledged failure.
+
+Also, :ref:`MPIX_Comm_agree` on the same *comm* will not raise an error of
+class MPI_ERR_PROC_FAILED due to this acknowledged failure.
+
+USAGE PATTERNS
+--------------
+
+One may query, without side effect, for the number of currently aknowledged
+process failures *comm* by supplying 0 in *num_to_ack*.
+
+Conversely, one may unconditionally acknowledge all currently known process
+failures in *comm* by supplying the size of the group of *comm* in *num_to_ack*.
+
+Note that the number of acknowledged processes, as returned in *num_acked*,
+can be smaller or larger than the value supplied in *num_to_ack*; It is
+however never larger than the size of the group returned by a subsequent call
+to :ref:`MPIX_Comm_get_failed`.
+
+EFFECT ON COLLECTIVE OPERATIONS
+-------------------------------
+
+Calling :ref:`MPIX_Comm_ack_failed` on a communicator with failed MPI
+processes has no effect on collective operations (except for :ref:`MPIX_Comm_agree`).
+If a collective operation would raise an error due to the communicator
+containing a failed process it will continue to raise an error even after
+the failure has been acknowledged. In order to use collective operations
+between MPI processes of a communicator that contains failed MPI processes,
+users should create a new communicator (e.g., by calling :ref:`MPIX_Comm_shrink`).
+
+WHEN COMMUNICATOR IS AN INTER-COMMUNICATOR
+------------------------------------------
+
+When the communicator is an inter-communicator, the failures of members
+in both the local and the remote groups of *comm* are acknowledged.
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_get_failed` :ref:`MPIX_Comm_agree`

--- a/docs/man-openmpi/man3/MPIX_Comm_ack_failed.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_ack_failed.3.rst
@@ -121,15 +121,8 @@ in both the local and the remote groups of *comm* are acknowledged.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_get_failed` :ref:`MPIX_Comm_agree`
+   * :ref:`MPIX_Comm_get_failed`
+   * :ref:`MPIX_Comm_agree`

--- a/docs/man-openmpi/man3/MPIX_Comm_agree.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_agree.3.rst
@@ -114,7 +114,7 @@ process in *comm*, all processes raise an error of class MPIX_ERR_PROC_FAILED.
 :ref:`MPIX_Comm_agree` users can propagate and synchronize the knowledge
 of failures across all MPI processes in *comm*.
 
-::
+.. code-block:: c
 
     Comm_get_failed_consistent(MPI_Comm c, MPI_Group * g) {
         int rc; int T=1;
@@ -168,15 +168,8 @@ the local and remote groups of the inter-communicator.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_is_revoked` :ref:`MPIX_Comm_ack_failed`
+   * :ref:`MPIX_Comm_is_revoked`
+   * :ref:`MPIX_Comm_ack_failed`

--- a/docs/man-openmpi/man3/MPIX_Comm_agree.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_agree.3.rst
@@ -1,0 +1,182 @@
+.. _mpix_comm_agree:
+
+MPIX_Comm_agree
+===============
+.. include_body
+
+:ref:`MPIX_Comm_agree`, :ref:`MPIX_Comm_iagree` - Agree on a flag value
+from all live processes and distributes the result back to all live
+processes, even after process failures.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_agree(MPI_Comm comm, int *flag)
+   
+   int MPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_AGREE(COMM, FLAG, IERROR)
+        INTEGER COMM, FLAG, IERROR
+
+   MPIX_COMM_IAGREE(COMM, FLAG, REQUEST, IERROR)
+        INTEGER COMM, FLAG, REQUEST, IERROR
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_agree(comm, flag, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        INTEGER, INTENT(INOUT) :: flag
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+   MPIX_COMM_IAGREE(COMM, FLAG, REQUEST, IERROR)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        INTEGER, INTENT(INOUT), ASYNCHRONOUS :: flag
+        TYPE(MPI_Request), INTENT(OUT) :: request
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+* ``flag``: Binary flags (integer).
+
+OUTPUT PARAMETERS
+-----------------
+* ``flag``: Reduced binary flags (integer).
+* ``request``: Request (handle, non-blocking only).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+This collective communication agrees on the integer value *flag* and
+(implicitly) on the group of failed processes in *comm*.
+
+On completion, all non-failed MPI processes have agreed to set the
+output integer value of *flag* to the result of a *bitwise AND*
+operation over the contributed input values of *flag*.
+
+:ref:`MPIX_Comm_iagree` is the non-blocking variant of :ref:`MPIX_Comm_agree`.
+
+PROCESS FAILURES
+----------------
+
+When an MPI process fails before contributing to the agree operation,
+the *flag* is computed ignoring its contribution, and the operation
+raises an error of class MPIX_ERR_PROC_FAILED.
+
+When an error of class MPIX_ERR_PROC_FAILED is raised, it is consistently
+raised at all MPI processes in the group(s) of *comm*.
+
+After :ref:`MPIX_Comm_agree` raised an error of class MPIX_ERR_PROC_FAILED,
+the group produced by a subsequent call to :ref:`MPIX_Comm_get_failed` on
+*comm* contains every MPI process that didn't contribute to the
+computation of *flag*.
+
+WHEN THE COMMUNICATOR CONTAINS ACKNOWLEDGED FAILURES
+----------------------------------------------------
+
+If **all** MPI processes in the group of *comm* have acknowledged the failure
+of an MPI process (using :ref:`MPIX_Comm_ack_failed`) prior to the call to
+:ref:`MPIX_Comm_agree` (or :ref:`MPIX_Comm_iagree`), the MPIX_ERR_PROC_FAILED
+error is not raised when the output value of *flag* ignores the
+contribution of that failed process. Note that this is an uniform property:
+if a non-contributing process is found to be not-acknowledged at any live
+process in *comm*, all processes raise an error of class MPIX_ERR_PROC_FAILED.
+
+**Example 1:** Using a combination of :ref:`MPIX_Comm_ack_failed` and
+:ref:`MPIX_Comm_agree` users can propagate and synchronize the knowledge
+of failures across all MPI processes in *comm*.
+
+::
+
+    Comm_get_failed_consistent(MPI_Comm c, MPI_Group * g) {
+        int rc; int T=1;
+        int size; int num_acked;
+        MPI_Group gf;
+        int ranges[3] = {0, 0, 1};
+
+        MPI_Comm_size(c, &size);
+
+        do {
+            /* this routine is not pure: calling MPI_Comm_ack_failed
+             * affects the state of the communicator c */
+            MPIX_Comm_ack_failed(c, size, &num_acked);
+            /* we simply ignore the T value in this example */
+            rc = MPIX_Comm_agree(c, &T);
+        } while( rc != MPI_SUCCESS );
+        /* after this loop, MPIX_Comm_agree has returned MPI_SUCCESS at
+         * all processes, so all processes have Acknowledged the same set of
+         * failures. Let's get that set of failures in the g group. */
+        if( 0 == num_acked ) {
+            *g = MPI_GROUP_EMPTY;
+        }
+        else {
+            MPIX_Comm_get_failed(c, &gf);
+            ranges[1] = num_acked - 1;
+            MPI_Group_range_incl(gf, 1, ranges, g);
+            MPI_Group_free(&gf);
+        }
+    }
+
+WHEN THE COMMUNICATOR IS REVOKED
+--------------------------------
+
+This function never raises an error of class MPIX_ERR_REVOKED.
+The defined semantics of :ref:`MPIX_Comm_agree` are maintained when *comm*
+is revoked, or when the group of *comm* contains failed MPI processes.
+In particular, :ref:`MPIX_Comm_agree` is a collective operation, even
+when *comm* is revoked.
+
+WHEN COMMUNICATOR IS AN INTER-COMMUNICATOR
+------------------------------------------
+
+When the communicator is an inter-communicator, the value of *flag* is
+a *bitwise AND* operation over the values contributed by the remote
+group.
+
+When an error of class MPIX_ERR_PROC_FAILED is raised, it is consistently
+raised at all MPI processes in the group(s) of *comm*, that is, both
+the local and remote groups of the inter-communicator.
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_is_revoked` :ref:`MPIX_Comm_ack_failed`

--- a/docs/man-openmpi/man3/MPIX_Comm_get_failed.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_get_failed.3.rst
@@ -1,0 +1,105 @@
+.. _mpix_comm_get_failed:
+
+MPIX_Comm_get_failed
+====================
+.. include_body
+
+:ref:`MPIX_Comm_get_failed` - Obtain a group that lists failed processes
+in a communicator.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_get_failed(MPI_Comm comm, MPI_Group *failedgrp)
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_GET_FAILED(COMM, FAILEDGRP, IERROR)
+        INTEGER COMM, FAILEDGRP, IERROR
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_get_failed(comm, failedgrp, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+
+OUTPUT PARAMETERS
+-----------------
+* ``failedgrp``: Group (handle).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+This local operation returns the group *failedgrp* of processes from the
+communicator *comm* that are locally known to have failed.
+The *failedgrp* can be empty, that is, equal to MPI_GROUP_EMPTY.
+
+For any two groups obtained from calls to that routine at the same MPI
+process, with the same *comm*, the intersection of the largest group with
+the smallest group is MPI_IDENT to the smallest group, that is, the same
+processes have the same ranks in the two groups, up to the size of the
+smallest group.
+
+PROCESS FAILURES
+----------------
+
+MPI makes no assumption about asynchronous progress of the failure detection.
+A valid MPI implementation may choose to update the group of locally known
+failed MPI processes only when it enters a function that must raise a fault
+tolerance error.
+
+It is possible that only the calling MPI process has detected the reported
+failure. If global knowledge is necessary, MPI processes detecting failures
+should call :ref:`MPIX_Comm_revoke` to enforce an error at other ranks.
+
+WHEN COMMUNICATOR IS AN INTER-COMMUNICATOR
+------------------------------------------
+
+When the communicator is an inter-communicator, the value of *failedgrp*
+contains the members known to have failed in both the local and the remote
+groups of *comm*.
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_revoke` :ref:`MPIX_Comm_ack_failed`

--- a/docs/man-openmpi/man3/MPIX_Comm_get_failed.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_get_failed.3.rst
@@ -91,15 +91,8 @@ groups of *comm*.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_revoke` :ref:`MPIX_Comm_ack_failed`
+   * :ref:`MPIX_Comm_revoke`
+   * :ref:`MPIX_Comm_ack_failed`

--- a/docs/man-openmpi/man3/MPIX_Comm_iagree.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_iagree.3.rst
@@ -1,0 +1,8 @@
+.. _mpix_comm_iagree:
+
+MPIX_Comm_iagree
+================
+.. include_body
+
+.. include:: ../man3/MPIX_Comm_agree.3.rst
+    :start-after: .. include_body

--- a/docs/man-openmpi/man3/MPIX_Comm_is_revoked.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_is_revoked.3.rst
@@ -107,15 +107,9 @@ and complete with their normal semantics on a revoked communicator.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_revoke` :ref:`MPIX_Comm_agree` :ref:`MPIX_Comm_shrink`
+   * :ref:`MPIX_Comm_revoke`
+   * :ref:`MPIX_Comm_agree`
+   * :ref:`MPIX_Comm_shrink`

--- a/docs/man-openmpi/man3/MPIX_Comm_is_revoked.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_is_revoked.3.rst
@@ -1,0 +1,121 @@
+.. _mpix_comm_is_revoked:
+
+MPIX_Comm_is_revoked
+====================
+.. include_body
+
+:ref:`MPIX_Comm_is_revoked` - Test if a communicator is revoked.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_is_revoked(MPI_Comm comm, int *flag)
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_IS_REVOKED(COMM, FLAG, IERROR)
+        INTEGER COMM, IERROR
+        LOGICAL FLAG
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_is_revoked(comm, flag, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        LOGICAL, INTENT(OUT) :: flag
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+
+OUTPUT PARAMETERS
+-----------------
+* ``flag``: *true* if the communicator is revoked.
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Returns *flag = true* if the communicator associated with the handle
+*comm* is revoked at the calling process. It returns *flag = false*
+otherwise. The operation is local.
+
+HOW CAN A COMMUNICATOR BECOME REVOKED
+-------------------------------------
+
+A communicator can become revoked when
+
+1. the user calls the :ref:`MPIX_Comm_revoke` procedure on *comm* to revoke
+   the communicator at the local process;
+2. an MPI operation raised the error class MPIX_ERR_REVOKED because
+   another process called the :ref:`MPIX_Comm_revoke` procedure on *comm*;
+3. the communicator has the info key *mpi_error_range* set to *group* or
+   *universe*, in which case the failure of any process in, respectively,
+   the group of *comm* or the MPI universe caused an operation to raise
+   an error of class MPIX_ERR_REVOKED.
+
+REVOKE PROPAGATION AND ORDERING
+-------------------------------
+
+Note that in a multithreaded application, a thread calling
+:ref:`MPIX_Comm_is_revoked` may return *flag = true* before the operation
+that raises the first exception of class MPIX_ERR_REVOKED has completed
+in a concurrent thread.
+
+EFFECT OF A COMMUNICATOR REVOCATION
+-----------------------------------
+
+Once a communicator has been revoked at an MPI process, all subsequent
+non-local operations on that communicator (with some exceptions listed
+below), are considered local and must complete by raising an error of 
+class MPIX_ERR_REVOKED at that MPI process.
+
+OPERATIONS ON A REVOKED COMMUNICATOR
+------------------------------------
+
+The following operations never raise an error of class MPIX_ERR_REVOKED,
+and complete with their normal semantics on a revoked communicator.
+
+* :ref:`MPIX_Comm_agree`
+* :ref:`MPIX_Comm_iagree`
+* :ref:`MPIX_Comm_shrink`
+* :ref:`MPIX_Comm_ishrink`
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_revoke` :ref:`MPIX_Comm_agree` :ref:`MPIX_Comm_shrink`

--- a/docs/man-openmpi/man3/MPIX_Comm_ishrink.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_ishrink.3.rst
@@ -1,0 +1,8 @@
+.. _mpix_comm_ishrink:
+
+MPIX_Comm_ishrink
+=================
+.. include_body
+
+.. include:: ../man3/MPIX_Comm_shrink.3.rst
+    :start-after: .. include_body

--- a/docs/man-openmpi/man3/MPIX_Comm_revoke.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_revoke.3.rst
@@ -1,0 +1,98 @@
+.. _mpix_comm_revoke:
+
+MPIX_Comm_revoke
+================
+.. include_body
+
+:ref:`MPIX_Comm_revoke` - Revoke a communicator, causing errors to be
+raised, at all ranks, for non-local operations on the communicator.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_revoke(MPI_Comm comm)
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_REVOKE(COMM, IERROR)
+        INTEGER COMM, IERROR
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_revoke(comm, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+
+OUTPUT PARAMETERS
+-----------------
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+This function marks the communicator *comm* as revoked at all MPI processes
+in the groups (local and remote) associated with the communicator *comm*.
+This function is not collective and therefore does not have a matching call
+on remote MPI processes.
+
+The documentation for :ref:`MPIX_Comm_is_revoked` details the conditions
+for when a communicator becomes revoked locally, and what semantics apply
+on a revoked communicator. In summary, when a communicator is revoked,
+non-local operation raise an exception of class MPIX_ERR_REVOKED,
+except for select fault-tolerant operations.
+
+PROPAGATION OF THE REVOKED STATE AND ORDERING
+---------------------------------------------
+
+The implementation propagates the revoked state in a fault-tolerant manner;
+thus, the communicator becomes revoked at all non-failed MPI processes
+belonging to *comm* despite failed processes.
+
+There is no particular ordering between the revocation call at another
+process and the completion of operations at a local process, for example,
+a receive operation can raise an error of class MPIX_ERR_REVOKED, even if
+the send operation procedure is called before the revoke procedure at the
+sender.
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_is_revoked` :ref:`MPIX_Comm_agree` :ref:`MPIX_Comm_shrink`

--- a/docs/man-openmpi/man3/MPIX_Comm_revoke.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_revoke.3.rst
@@ -84,15 +84,9 @@ sender.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_is_revoked` :ref:`MPIX_Comm_agree` :ref:`MPIX_Comm_shrink`
+   * :ref:`MPIX_Comm_is_revoked`
+   * :ref:`MPIX_Comm_agree`
+   * :ref:`MPIX_Comm_shrink`

--- a/docs/man-openmpi/man3/MPIX_Comm_shrink.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_shrink.3.rst
@@ -111,15 +111,7 @@ MPI operations on *newcomm*.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 .. seealso::
-    :ref:`MPIX_Comm_is_revoked`
+   * :ref:`MPIX_Comm_is_revoked`

--- a/docs/man-openmpi/man3/MPIX_Comm_shrink.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Comm_shrink.3.rst
@@ -1,0 +1,125 @@
+.. _mpix_comm_shrink:
+
+MPIX_Comm_shrink
+================
+.. include_body
+
+:ref:`MPIX_Comm_shrink`, :ref:`MPIX_Comm_ishrink` - Create a new communicator
+that includes all processes from the parent communicator that have not failed.
+
+This is part of the User Level Fault Mitigation :ref:`ULFM extension <ulfm-label>`.
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <mpi-ext.h>
+
+   int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm)
+   
+   int MPIX_Comm_ishrink(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   USE MPI_EXT
+   ! or the older form: INCLUDE 'mpif.h'
+
+   MPIX_COMM_SHRINK(COMM, NEWCOMM, IERROR)
+        INTEGER COMM, NEWCOMM, IERROR
+
+   MPIX_COMM_ISHRINK(COMM, NEWCOMM, REQUEST, IERROR)
+        INTEGER COMM, NEWCOMM, REQUEST, IERROR
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   USE mpi_ext_f08
+
+   MPIX_Comm_shrink(comm, newcomm, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+   MPIX_Comm_ishrink(comm, newcomm, request, ierror)
+        TYPE(MPI_Comm), INTENT(IN) :: comm
+        TYPE(MPI_Comm), INTENT(OUT), ASYNCHRONOUS :: newcomm
+        TYPE(MPI_Request), INTENT(OUT) :: request
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETERS
+----------------
+* ``comm``: Communicator (handle).
+
+OUTPUT PARAMETERS
+-----------------
+* ``newcomm``: Communicator (handle).
+* ``request``: Request (handle, non-blocking only).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+This collective operation creates a new intra- or intercommunicator
+*newcomm* from the intra- or intercommunicator *comm*, respectively, by
+excluding the group of failed MPI processes as shrinkd upon during the
+operation.
+
+The groups of *newcomm* must include every MPI process that returns from
+:ref:`MPIX_Comm_shrink`, and it must exclude every MPI process whose failure
+caused an operation on *comm* to raise an MPI error of class
+MPIX_ERR_PROC_FAILED or MPIX_ERR_PROC_FAILED_PENDING at a member of the
+groups of *newcomm*, before that member initiated the shrink operation.
+
+Said otherwise, this procedure is semantically equivalent to an
+:ref:`MPI_Comm_split` operation that would succeed despite failures, where
+members of the groups of *newcomm* participate with the same color and a key
+equal to their rank in *comm*.
+
+:ref:`MPIX_Comm_ishrink` is the non-blocking variant of :ref:`MPIX_Comm_shrink`.
+Note that, as with :ref:`MPI_Comm_idup`, it is erroneous to use *newcomm*
+before *request* has completed.
+
+WHEN THE COMMUNICATOR IS REVOKED OR CONTAINS FAILED PROCESSES
+-------------------------------------------------------------
+
+This function never raises an error of classes MPIX_ERR_REVOKED or
+MPIX_ERR_PROC_FAILED. The defined semantics of :ref:`MPIX_Comm_shrink` and
+:ref:`MPIX_Comm_ishrink` are maintained when *comm* is revoked, or when the
+group of *comm* contains failed MPI processes. In particular,
+:ref:`MPIX_Comm_shrink` and :ref:`MPIX_Comm_ishrink` are collective operations,
+even when *comm* is revoked.
+
+The implementation will strive to detect all failures during the shrink
+operation, but in certain circumpstances, the group of *newcomm* may still
+contain failed MPI processes, whose failure will be detected in subsequent
+MPI operations on *newcomm*.
+
+ERRORS
+------
+
+Almost all MPI routines return an error value; C routines as the value
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for
+I/O function errors. The error handler may be changed with
+:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
+may be used to cause error values to be returned. Note that MPI does not
+guarantee that an MPI program can continue past an error.
+
+.. seealso::
+    :ref:`MPIX_Comm_is_revoked`

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -471,6 +471,14 @@ MPI API manual pages (section 3)
    MPI_Win_wait.3.rst
    MPI_Wtick.3.rst
    MPI_Wtime.3.rst
+   MPIX_Comm_ack_failed.3.rst
+   MPIX_Comm_agree.3.rst
+   MPIX_Comm_get_failed.3.rst
+   MPIX_Comm_iagree.3.rst
+   MPIX_Comm_ishrink.3.rst
+   MPIX_Comm_is_revoked.3.rst
+   MPIX_Comm_revoke.3.rst
+   MPIX_Comm_shrink.3.rst
    MPIX_Query_cuda_support.3.rst
    MPIX_Query_rocm_support.3.rst
    OMPI_Affinity_str.3.rst


### PR DESCRIPTION
Adding man pages that document ULFM functions.

The function are documented in the form that assumes pending PRs #10507 #9925 are merged prior. 
