### PR TITLE
build: Use shell function for OPAL_VAR_SCOPE

### DIFF
--- a/config/ompi_fortran_check_f08_assumed_rank.m4
+++ b/config/ompi_fortran_check_f08_assumed_rank.m4
@@ -39,7 +39,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_F08_ASSUMED_RANK], [
 ###################################
 
 AC_DEFUN([_OMPI_FORTRAN_CHECK_F08_ASSUMED_RANK], [
-    OPAL_VAR_SCOPE_PUSH([happy])
+    OPAL_VAR_SCOPE_PUSH([f08_assumed_rank_happy])
 
     # If we were called here, it means that the value was not cached,
     # so we need to check several different things.  Since CACHE_CHECK
@@ -50,9 +50,9 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_F08_ASSUMED_RANK], [
     # Check for the F08 type(*),dimension(..) syntax
     OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB([!], [TYPE(*), DIMENSION(..)],
                                       [TYPE(*), DIMENSION(..)],
-                                      [happy=yes], [happy=no])
+                                      [f08_assumed_rank_happy=yes], [f08_assumed_rank_happy=no])
 
-    AS_VAR_SET(fortran_f08_assumed_rank, [$happy]);
+    AS_VAR_SET(fortran_f08_assumed_rank, [$f08_assumed_rank_happy]);
 
     # Now put the original CACHE_CHECK MSG_CHECKING back so that it can
     # output the MSG_RESULT.

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -23,7 +23,7 @@ dnl $HEADER$
 # Does this compiler support (void*)-like functionality for MPI choice
 # buffers?  If so, which flavor?
 AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
-    OPAL_VAR_SCOPE_PUSH([result happy type predecl])
+    OPAL_VAR_SCOPE_PUSH([result ignore_tkr_happy type predecl])
 
     OMPI_FORTRAN_IGNORE_TKR_PREDECL=
     OMPI_FORTRAN_IGNORE_TKR_TYPE=
@@ -41,11 +41,11 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
     AS_VAR_COPY([result], [fortran_ignore_tkr_data])
 
     # Parse the result
-    happy=`echo $result | cut -d: -f1`
+    ignore_tkr_happy=`echo $result | cut -d: -f1`
     type=`echo $result | cut -d: -f2`
     predecl=`echo $result | cut -d: -f3-`
 
-    AS_IF([test $happy -eq 1],
+    AS_IF([test $ignore_tkr_happy -eq 1],
           [OMPI_FORTRAN_IGNORE_TKR_PREDECL=$predecl
            OMPI_FORTRAN_IGNORE_TKR_TYPE=$type
            $1],
@@ -58,7 +58,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
 ################
 
 AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
-    OPAL_VAR_SCOPE_PUSH([happy ompi_fortran_ignore_tkr_predecl ompi_fortran_ignore_tkr_type])
+    OPAL_VAR_SCOPE_PUSH([internal_ignore_tkr_happy ompi_fortran_ignore_tkr_predecl ompi_fortran_ignore_tkr_type])
 
     # If we were called here, it means that the value was not cached,
     # so we need to check several different things.  Since CACHE_CHECK
@@ -74,43 +74,43 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
     OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
          [!], [type(*)],
          [TYPE(*), DIMENSION(*)],
-         [happy=1], [happy=0])
+         [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])
 
     # GCC compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK ::], [type(*), dimension(*)],
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Intel compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!DEC\$ ATTRIBUTES NO_ARG_CHECK ::], [real, dimension(*)],
               [!DEC\$ ATTRIBUTES NO_ARG_CHECK],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Solaris Studio compilers
     # Note that due to a compiler bug, we have been advised by Oracle to
     # use the "character(*)" type
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!\$PRAGMA IGNORE_TKR], [character(*)],
               [!\$PRAGMA IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Cray compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!DIR\$ IGNORE_TKR], [real, dimension(*)],
               [!DIR\$ IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # IBM compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!IBM* IGNORE_TKR], [real, dimension(*)],
               [!IBM* IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
 
     AS_VAR_SET(fortran_ignore_tkr_data,
-               [${happy}:${ompi_fortran_ignore_tkr_type}:${ompi_fortran_ignore_tkr_predecl}])
+               [${internal_ignore_tkr_happy}:${ompi_fortran_ignore_tkr_type}:${ompi_fortran_ignore_tkr_predecl}])
 
     # Now put the original CACHE_CHECK MSG_CHECKING back so that it can
     # output the MSG_RESULT.

--- a/config/ompi_fortran_check_real16_c_equiv.m4
+++ b/config/ompi_fortran_check_real16_c_equiv.m4
@@ -24,8 +24,7 @@ dnl
 # OMPI_FORTRAN_CHECK_REAL16_C_EQUIV
 # ----------------------------------------------------
 AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
-    unset happy
-    OPAL_VAR_SCOPE_PUSH([happy define_value msg CFLAGS_save])
+    OPAL_VAR_SCOPE_PUSH([fortran_real16_happy define_value msg CFLAGS_save])
     AS_VAR_PUSHDEF([real16_matches_c_var], [ompi_cv_real16_c_equiv])
 
     # We have to do this as a cache check for cross-compilation platforms
@@ -42,15 +41,15 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                 OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([$OMPI_FORTRAN_REAL16_C_TYPE], [L])
                 # If that didn't work, see if we have a compiler-specific
                 # type that might work
-                AS_IF([test "$happy" = "no"],
-                      [AC_MSG_RESULT([$happy])
+                AS_IF([test "$fortran_real16_happy" = "no"],
+                      [AC_MSG_RESULT([$fortran_real16_happy])
                        # Intel compiler has a special type that should work
                        AS_IF([test "$opal_cv_c_compiler_vendor" = "intel"],
                              [AC_MSG_CHECKING([if intel compiler _Quad == REAL*16])
                               CFLAGS_save="$CFLAGS"
                               OPAL_FLAGS_APPEND_UNIQ([CFLAGS], ["-Qoption,cpp,--extended_float_types"])
                               OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([_Quad], [q])
-                              AS_IF([test "$happy" = "yes"],
+                              AS_IF([test "$fortran_real16_happy" = "yes"],
                                     [OMPI_FORTRAN_REAL16_C_TYPE="_Quad"
                                      AC_MSG_RESULT([works!])],
                                     [CFLAGS="$CFLAGS_save"
@@ -59,7 +58,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                        AS_IF([test "$opal_cv_c_compiler_vendor" = "gnu" && test "$ac_cv_type___float128" = "yes"],
                              [AC_MSG_CHECKING([if gnu compiler __float128 == REAL*16])
                               OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([__float128], [q])
-                              AS_IF([test "$happy" = "yes"],
+                              AS_IF([test "$fortran_real16_happy" = "yes"],
                                     [OMPI_FORTRAN_REAL16_C_TYPE="__float128"
                                      AC_MSG_RESULT([works!])],
                                     [AC_MSG_RESULT([does not work])])
@@ -68,7 +67,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                        # AC_CACHE_CHECK will automatically AC_MSG_RESULT
                        AC_MSG_CHECKING([for C type matching bit representation of REAL*16])
                       ])
-                AS_VAR_SET(real16_matches_c_var, [$happy])
+                AS_VAR_SET(real16_matches_c_var, [$fortran_real16_happy])
                ],[
                 # No fortran bindings or no REAL*16
                 AS_IF([test "$OMPI_TRY_FORTRAN_BINDINGS" = "$OMPI_FORTRAN_NO_BINDINGS"],
@@ -134,15 +133,15 @@ EOF
     # Compile and link
     OPAL_LOG_COMMAND([$CC $CFLAGS -I. -c conftest_c.c],
         [OPAL_LOG_COMMAND([$FC $FCFLAGS conftest_f.f conftest_c.o -o conftest $LDFLAGS $LIBS],
-            [happy="yes"], [happy="no"])], [happy="no"])
-    AS_IF([test "$happy" = "no"],
+            [fortran_real16_happy="yes"], [fortran_real16_happy="no"])], [fortran_real16_happy="no"])
+    AS_IF([test "$fortran_real16_happy" = "no"],
         [AC_MSG_RESULT([Could not determine if REAL*16 bit-matches C type])],
         # If it worked so far, try running to see what we get
-        [AS_IF([test "$happy" = "yes" && test "$cross_compiling" = "yes"],
+        [AS_IF([test "$fortran_real16_happy" = "yes" && test "$cross_compiling" = "yes"],
              [AC_MSG_RESULT([Error!])
               AC_MSG_ERROR([Can not determine if REAL*16 bit-matches C if cross compiling])],
              [OPAL_LOG_COMMAND([./conftest],
-                 [happy=`cat conftestval`],
+                 [fortran_real16_happy=`cat conftestval`],
                  [AC_MSG_RESULT([Error!])
                   AC_MSG_ERROR([Could not determine if REAL*16 bit-matches C type])
                  ])

--- a/config/ompi_fortran_get_alignment.m4
+++ b/config/ompi_fortran_get_alignment.m4
@@ -55,8 +55,7 @@ dnl
 # OMPI_FORTRAN_GET_ALIGNMENT(type, shell variable to set)
 # ----------------------------------------------------
 AC_DEFUN([OMPI_FORTRAN_GET_ALIGNMENT],[
-    unset happy
-    OPAL_VAR_SCOPE_PUSH([happy ompi_conftest_h])
+    OPAL_VAR_SCOPE_PUSH([fortran_get_alignment_happy ompi_conftest_h])
     # Use of m4_translit suggested by Eric Blake:
     # http://lists.gnu.org/archive/html/bug-autoconf/2010-10/msg00016.html
     AS_VAR_PUSHDEF([type_var],
@@ -112,9 +111,11 @@ EOF
 
         OPAL_LOG_COMMAND([$CC $CFLAGS -I. -c conftest.c],
             [OPAL_LOG_COMMAND([$FC $FCFLAGS conftestf.f conftest.o -o conftest $LDFLAGS $LIBS],
-                [happy="yes"], [happy="no"])], [happy="no"])
+                [fortran_get_alignment_happy="yes"],
+                [fortran_get_alignment_happy="no"])],
+            [fortran_get_alignment_happy="no"])
 
-        if test "$happy" = "no" ; then
+        if test "$fortran_get_alignment_happy" = "no" ; then
             AC_MSG_RESULT([Error!])
             AC_MSG_ERROR([Could not determine alignment of $1])
         fi


### PR DESCRIPTION
Move the logic for OPAL_VAR_SCOPE_PUSH and OPAL_VAR_SCOPE_POP into shell functions that are called by OPAL_VAR_SCOPE_PUSH and OPAL_VAR_SCOPE_POP.  This patch reduces the size of configure by over 30% on MacOS by eliminating the repitition in stamping out the check loop.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>