### PR TITLE
mtl/ofi: set initial value variables in ompi_mtl_ofi_component_init()

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -604,8 +604,8 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     struct fi_info *providers = NULL;
     struct fi_info *prov = NULL;
     struct fi_info *prov_cq_data = NULL;
-    void *ep_name;
-    size_t namelen;
+    void *ep_name = NULL;
+    size_t namelen = 0;
     int universe_size;
     char *univ_size_str;
 


### PR DESCRIPTION
This patch set initial value of "ep_name" and "namelen" in function ompi_mtl_ofi_component_init().

This is because free() is applied to "ep_name" on error handling path, and uninitialized "ep_name" can cause trouble.

Signed-off-by: Wei Zhang <wzam@amazon.com>