### PR TITLE
autogen.pl: tweak a regexp to handle more cases

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1409,7 +1409,7 @@ if (-f ".gitmodules") {
     open(IN, "git submodule status|")
         || die "Can't run \"git submodule status\"";
     while (<IN>) {
-        $_ =~ m/^(.).{40} ([^ ]+) /;
+        $_ =~ m/^(.)[0-9a-f]{40}\s+(\S+)/;
         my $status = $1;
         my $path   = $2;
 


### PR DESCRIPTION
The output of `git submodule status` will be of the following form:

```
Xgit_hash submodule_path [(git_ref)]
```

* `X` is either a space, `+`, or `-`
* `git_hash` is 40 hex digits
* `submodule_path` is the path in the repo where the submodule is located
* `(git_ref)` is optional, and will not be there if the submodule is missing (which the previous regexp did not handle).

This commit tightens up the regexp to be a bit more robust and handle the case where the git_ref token is not present.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>