### PR TITLE
Fix compilation of x86-64-asm atomic backend

### DIFF
--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -208,7 +208,7 @@ static inline int64_t opal_atomic_fetch_sub_64(opal_atomic_int64_t *v, int64_t i
     return ret;
 }
 
-static inline int64_t opal_atomic_fetch_sub_64(opal_atomic_int64_t *v, int64_t i)
+static inline int64_t opal_atomic_sub_fetch_64(opal_atomic_int64_t *v, int64_t i)
 {
     return opal_atomic_sub_fetch_64(v, i) - i;
 }
@@ -231,7 +231,7 @@ static inline int64_t opal_atomic_fetch_sub_64(opal_atomic_int64_t *v, int64_t i
             do {                                                                                   \
                 oldval = *addr;                                                                    \
                 newval = oldval operation value;                                                   \
-            } while (!opal_atomic_compare_exchange_strong_##bits(addr, &oldval, newval);           \
+            } while (!opal_atomic_compare_exchange_strong_##bits(addr, &oldval, newval));          \
                                                                                                    \
             return newval;                                                                         \
         }
@@ -244,7 +244,7 @@ OPAL_ATOMIC_DEFINE_OP(int64_t, 64, &, and)
 OPAL_ATOMIC_DEFINE_OP(int64_t, 64, |, or)
 OPAL_ATOMIC_DEFINE_OP(int64_t, 64, ^, xor)
 
-#include "opal/sys/atomic_math_minmax_impl.h"
-#include "opal/sys/atomic_math_size_t_impl.h"
+#include "opal/sys/atomic_impl_minmax_math.h"
+#include "opal/sys/atomic_impl_size_t_math.h"
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */


### PR DESCRIPTION
https://github.com/open-mpi/ompi/issues/10797 showed that the x86-64 asm atomic backend is broken. This PR fixes that backend so that it at least compiles. It's not a fix for #10797 though. 

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>