### PR TITLE
Fix fallback to C11 atomics if GCC builtin is unavailable

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -658,7 +658,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     # C11 atomics, but have not apparently found a build we are happy
     # with.  In the future, this should be changed to a check for a
     # particular Intel version.
-    AS_IF([test "$atomics_found" = "no" -a "$enable_c11_atomics" == "yes" -a "$opal_cv_c11_supported" = "yes" -a "$opal_cv_c_compiler_vendor" != "intel"],
+    AS_IF([test "$atomics_found" = "no" -a "$enable_c11_atomics" != "no" -a "$opal_cv_c11_supported" = "yes" -a "$opal_cv_c_compiler_vendor" != "intel"],
           [AC_MSG_NOTICE([Using C11 atomics])
            OPAL_CHECK_C11_CSWAP_INT128
            want_c11_atomics=1


### PR DESCRIPTION
Fixes #10797 by correctly falling back to C11 atomics if GCC builtin is not available. Before this PR, C11 atomics would be skipped unless explicitly requested.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>