### PR TITLE
SHMEM/BASE: added missing initializers

### DIFF
--- a/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
@@ -76,8 +76,7 @@ char * oshmem_get_unique_file_name(uint64_t pe)
 }
 
 
-void
-shmem_ds_reset(map_segment_t *ds_buf)
+void shmem_ds_reset(map_segment_t *ds_buf)
 {
     MAP_SEGMENT_RESET_FLAGS(ds_buf);
     ds_buf->seg_id = MAP_SEGMENT_SHM_INVALID;
@@ -85,5 +84,10 @@ shmem_ds_reset(map_segment_t *ds_buf)
     ds_buf->super.va_end = 0;
     ds_buf->seg_size = 0;
     ds_buf->type = MAP_SEGMENT_UNKNOWN;
+    ds_buf->mkeys_cache = NULL;
+    ds_buf->mkeys = NULL;
+    ds_buf->alloc_hints = 0;
+    ds_buf->context = NULL;
+    ds_buf->allocator = NULL;
 }
 


### PR DESCRIPTION
CREATING a DRAFT version of #10814 to test the IBM CI with.  It _SHOULD_ be working now.

- there were missing initializers in shmem segment which caused incorrect memory access
- added missing initializers

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>