### PR TITLE
Part 1 of resolving global symbol name pollution issue #10708

### DIFF
--- a/ompi/mca/coll/libnbc/libdict/dict.c
+++ b/ompi/mca/coll/libnbc/libdict/dict.c
@@ -3,6 +3,7 @@
  *
  * Implementation of generic dictionary routines.
  * Copyright (C) 2001-2004 Farooq Mela.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  *
  * $Id: dict.c,v 1.7 2001/11/25 06:00:49 farooq Exp farooq $
  */
@@ -15,7 +16,15 @@
 dict_malloc_func _dict_malloc = malloc;
 dict_free_func _dict_free = free;
 
-dict_malloc_func
+static void dict_destroy __P((dict *dct, int del));
+static void dict_itor_destroy __P((dict_itor *itor));
+static int  dict_int_cmp __P((const void *k1, const void *k2));
+static int  dict_uint_cmp __P((const void *k1, const void *k2));
+static int  dict_long_cmp __P((const void *k1, const void *k2));
+static int  dict_ulong_cmp __P((const void *k1, const void *k2));
+static int  dict_str_cmp __P((const void *k1, const void *k2));
+
+static dict_malloc_func
 dict_set_malloc(dict_malloc_func func)
 {
 	dict_malloc_func old = _dict_malloc;
@@ -23,7 +32,7 @@ dict_set_malloc(dict_malloc_func func)
 	return old;
 }
 
-dict_free_func
+static dict_free_func
 dict_set_free(dict_free_func func)
 {
 	dict_free_func old = _dict_free;
@@ -35,7 +44,7 @@ dict_set_free(dict_free_func func)
  * In comparing, we cannot simply subtract because that might result in signed
  * overflow.
  */
-int
+static int
 dict_int_cmp(const void *k1, const void *k2)
 {
 	const int *a = (int*)k1, *b = (int*)k2;
@@ -43,7 +52,7 @@ dict_int_cmp(const void *k1, const void *k2)
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-int
+static int
 dict_uint_cmp(const void *k1, const void *k2)
 {
 	const unsigned int *a = (unsigned int*)k1, *b = (unsigned int*)k2;
@@ -51,7 +60,7 @@ dict_uint_cmp(const void *k1, const void *k2)
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-int
+static int
 dict_long_cmp(const void *k1, const void *k2)
 {
 	const long *a = (long*)k1, *b = (long*)k2;
@@ -59,7 +68,7 @@ dict_long_cmp(const void *k1, const void *k2)
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-int
+static int
 dict_ulong_cmp(const void *k1, const void *k2)
 {
 	const unsigned long *a = (unsigned long*)k1, *b = (unsigned long*)k2;
@@ -73,7 +82,7 @@ dict_ptr_cmp(const void *k1, const void *k2)
 	return (k1 > k2) - (k1 < k2);
 }
 
-int
+static int
 dict_str_cmp(const void *k1, const void *k2)
 {
 	const char *a = (char*)k1, *b = (char*)k2;
@@ -87,7 +96,7 @@ dict_str_cmp(const void *k1, const void *k2)
 	return (p > q) - (p < q);
 }
 
-void
+static void
 dict_destroy(dict *dct, int del)
 {
 	ASSERT(dct != NULL);
@@ -96,7 +105,7 @@ dict_destroy(dict *dct, int del)
 	FREE(dct);
 }
 
-void
+static void
 dict_itor_destroy(dict_itor *itor)
 {
 	ASSERT(itor != NULL);

--- a/ompi/mca/coll/libnbc/libdict/dict.h
+++ b/ompi/mca/coll/libnbc/libdict/dict.h
@@ -3,6 +3,7 @@
  *
  * Interface for generic access to dictionary library.
  * Copyright (C) 2001-2004 Farooq Mela.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  *
  * $Id: dict.h,v 1.6 2001/11/14 05:21:10 farooq Exp farooq $
  */
@@ -46,9 +47,6 @@ BEGIN_DECL
 typedef void *(*dict_malloc_func)(size_t);
 typedef void  (*dict_free_func)(void *);
 
-dict_malloc_func	dict_set_malloc		__P((dict_malloc_func func));
-dict_free_func		dict_set_free		__P((dict_free_func func));
-
 typedef int			(*dict_cmp_func)	__P((const void *, const void *));
 typedef void		(*dict_del_func)	__P((void *));
 typedef int			(*dict_vis_func)	__P((const void *, void *));
@@ -78,7 +76,6 @@ struct dict {
 #define dict_walk(dct,f)		(dct)->_walk((dct)->_object, (f))
 #define dict_count(dct)			(dct)->_count((dct)->_object)
 #define dict_empty(dct,d)		(dct)->_empty((dct)->_object, (d))
-void dict_destroy __P((dict *dct, int del));
 #define dict_itor_new(dct)		(dct)->_inew((dct)->_object)
 
 struct dict_itor {
@@ -116,14 +113,8 @@ struct dict_itor {
 #define dict_itor_cdata(i)			(i)->_cdata((i)->_itor)
 #define dict_itor_set_data(i,dat,d)	(i)->_setdata((i)->_itor, (dat), (d))
 #define dict_itor_remove(i)			(i)->_remove((i)->_itor)
-void dict_itor_destroy __P((dict_itor *itor));
 
-int		dict_int_cmp __P((const void *k1, const void *k2));
-int		dict_uint_cmp __P((const void *k1, const void *k2));
-int		dict_long_cmp __P((const void *k1, const void *k2));
-int		dict_ulong_cmp __P((const void *k1, const void *k2));
 int		dict_ptr_cmp __P((const void *k1, const void *k2));
-int		dict_str_cmp __P((const void *k1, const void *k2));
 
 END_DECL
 

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.h
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.h
@@ -3,6 +3,7 @@
  *
  * Interface for height balanced tree.
  * Copyright (C) 2001 Farooq Mela.
+ * Copyright (c) 2022 IBM Corporation.  All rights reserved.
  *
  * $Id: hb_tree.h,v 1.2 2001/09/10 06:46:41 farooq Exp $
  */
@@ -19,43 +20,20 @@ typedef struct hb_tree hb_tree;
 
 hb_tree *hb_tree_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
 						  dict_del_func dat_del));
-dict	*hb_dict_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
-						  dict_del_func dat_del));
-void	 hb_tree_destroy __P((hb_tree *tree, int del));
 
 int hb_tree_insert __P((hb_tree *tree, void *key, void *dat, int overwrite));
-int hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
 void *hb_tree_search __P((hb_tree *tree, const void *key));
 int hb_tree_remove __P((hb_tree *tree, const void *key, int del));
-void hb_tree_empty __P((hb_tree *tree, int del));
-void hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
-unsigned hb_tree_count __P((const hb_tree *tree));
-unsigned hb_tree_height __P((const hb_tree *tree));
-unsigned hb_tree_mheight __P((const hb_tree *tree));
-unsigned hb_tree_pathlen __P((const hb_tree *tree));
-const void *hb_tree_min __P((const hb_tree *tree));
-const void *hb_tree_max __P((const hb_tree *tree));
 
 struct hb_itor;
 typedef struct hb_itor hb_itor;
 
 hb_itor *hb_itor_new __P((hb_tree *tree));
-dict_itor *hb_dict_itor_new __P((hb_tree *tree));
 void hb_itor_destroy __P((hb_itor *tree));
 
 int hb_itor_valid __P((const hb_itor *itor));
-void hb_itor_invalidate __P((hb_itor *itor));
 int hb_itor_next __P((hb_itor *itor));
-int hb_itor_prev __P((hb_itor *itor));
-int hb_itor_nextn __P((hb_itor *itor, unsigned count));
-int hb_itor_prevn __P((hb_itor *itor, unsigned count));
-int hb_itor_first __P((hb_itor *itor));
-int hb_itor_last __P((hb_itor *itor));
-int hb_itor_search __P((hb_itor *itor, const void *key));
 const void *hb_itor_key __P((const hb_itor *itor));
-void *hb_itor_data __P((hb_itor *itor));
-const void *hb_itor_cdata __P((const hb_itor *itor));
-int hb_itor_set_data __P((hb_itor *itor, void *dat, int del));
 int hb_itor_remove __P((hb_itor *itor, int del));
 
 END_DECL

--- a/opal/mca/smsc/base/base.h
+++ b/opal/mca/smsc/base/base.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,8 +15,6 @@
 #include "opal/mca/smsc/smsc.h"
 
 extern mca_base_framework_t opal_smsc_base_framework;
-extern mca_smsc_component_t *selected_component;
-extern mca_smsc_module_t *selected_module;
 
 int mca_smsc_base_select(void);
 void mca_smsc_base_register_default_params(mca_smsc_component_t *component, int default_priority);

--- a/opal/mca/smsc/base/smsc_base_frame.c
+++ b/opal/mca/smsc/base/smsc_base_frame.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
  */
 #include "opal/mca/smsc/base/static-components.h"
 
-mca_smsc_component_t *selected_component = NULL;
+static mca_smsc_component_t *selected_component = NULL;
 mca_smsc_module_t *mca_smsc = NULL;
 
 /*


### PR DESCRIPTION
This pull request is part 1 of solving issue #10708.

Public symbols in the ompi and opal subdirectories that were public scope have been made static within the single file that uses them.

Any declarations for those symbols in header files were moved to the source file where the symbol was defined, to eliminate warning messages issued complaining about symbols defined but not used.

Signed-off-by: David Wootton <dwootton@us.ibm.com>