### PR TITLE
Make GCC atomics the default atomic implementation [5.0.x]

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -658,7 +658,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     # C11 atomics, but have not apparently found a build we are happy
     # with.  In the future, this should be changed to a check for a
     # particular Intel version.
-    AS_IF([test "$atomics_found" = "no" -a "$enable_c11_atomics" == "yes" -a "$opal_cv_c11_supported" = "yes" -a "$opal_cv_c_compiler_vendor" != "intel"],
+    AS_IF([test "$atomics_found" = "no" -a "$enable_c11_atomics" != "no" -a "$opal_cv_c11_supported" = "yes" -a "$opal_cv_c_compiler_vendor" != "intel"],
           [AC_MSG_NOTICE([Using C11 atomics])
            OPAL_CHECK_C11_CSWAP_INT128
            want_c11_atomics=1


### PR DESCRIPTION
Access to C11 _Atomic variables incurs sequential memory ordering, which compiles to atomic operations and in many cases is not desired (initialization, non-multi-threaded runs). This change makes GCC atomics the default and uses C11 atomics as a fallback.

This is a backport of https://github.com/open-mpi/ompi/pull/10724 to v5.0.x and includes the follow-up fix in https://github.com/open-mpi/ompi/pull/10819 for https://github.com/open-mpi/ompi/issues/10797.

Signed-off-by: Joseph Schuchart [schuchart@icl.utk.edu](mailto:schuchart@icl.utk.edu)