### PR TITLE
MPI_Parrived: fix type of C binding param

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1855,7 +1855,7 @@ OMPI_DECLSPEC  int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatyp
                             void *outbuf, int outsize, int *position, MPI_Comm comm);
 OMPI_DECLSPEC  int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm,
                                  int *size);
-OMPI_DECLSPEC  int MPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
+OMPI_DECLSPEC  int MPI_Parrived(MPI_Request request, int partition, int *flag);
 OMPI_DECLSPEC  int MPI_Pcontrol(const int level, ...);
 OMPI_DECLSPEC  int MPI_Pready(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int MPI_Pready_range(int partition_low, int partition_high,
@@ -2557,7 +2557,7 @@ OMPI_DECLSPEC  int PMPI_Pready(int partitions, MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Pready_range(int partition_low, int partition_high,
                                     MPI_Request request);
 OMPI_DECLSPEC  int PMPI_Pready_list(int length, int partition_list[], MPI_Request request);
-OMPI_DECLSPEC  int PMPI_Parrived(MPI_Request request, MPI_Count partition, int *flag);
+OMPI_DECLSPEC  int PMPI_Parrived(MPI_Request request, int partition, int *flag);
 OMPI_DECLSPEC  int PMPI_Is_thread_main(int *flag);
 OMPI_DECLSPEC  int PMPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
 OMPI_DECLSPEC  MPI_Fint PMPI_Message_c2f(MPI_Message message);

--- a/ompi/mpi/c/parrived.c
+++ b/ompi/mpi/c/parrived.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -43,7 +43,7 @@
 static const char FUNC_NAME[] = "MPI_Parrived";
 
 
-int MPI_Parrived(MPI_Request request, MPI_Count partition,  int *flag)
+int MPI_Parrived(MPI_Request request, int partition,  int *flag)
 {
     int rc;
 


### PR DESCRIPTION
Fix "partition": it should be an "int", not "MPI_Count".

Thanks to @jprotze for raising the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #10826