### PR TITLE
Update MCA mutexes to use the qthreads ULT backend

### DIFF
--- a/opal/mca/threads/argobots/threads_argobots_mutex.h
+++ b/opal/mca/threads/argobots/threads_argobots_mutex.h
@@ -84,9 +84,8 @@ static inline int opal_thread_internal_mutex_trylock(opal_thread_internal_mutex_
         opal_output(0, "opal_thread_internal_mutex_trylock()");
 #endif
         return 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 static inline void opal_thread_internal_mutex_unlock(opal_thread_internal_mutex_t *p_mutex)

--- a/opal/mca/threads/argobots/threads_argobots_mutex.h
+++ b/opal/mca/threads/argobots/threads_argobots_mutex.h
@@ -19,6 +19,7 @@
  *                         reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2021      Argonne National Laboratory.  All rights reserved.
+ * Copyright (c) 2022      Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,6 +40,7 @@
 #include "opal/mca/threads/argobots/threads_argobots.h"
 #include "opal/mca/threads/mutex.h"
 #include "opal/util/output.h"
+#include "opal/util/show_help.h"
 
 BEGIN_C_DECLS
 
@@ -66,7 +68,7 @@ static inline void opal_thread_internal_mutex_lock(opal_thread_internal_mutex_t 
 #if OPAL_ENABLE_DEBUG
     int ret = ABT_mutex_lock(mutex);
     if (ABT_SUCCESS != ret) {
-        opal_output(0, "opal_thread_internal_mutex_lock()");
+        opal_show_help("help-opal-threads.txt", "mutex lock failed", true);
     }
 #else
     ABT_mutex_lock(mutex);
@@ -81,7 +83,7 @@ static inline int opal_thread_internal_mutex_trylock(opal_thread_internal_mutex_
         return 1;
     } else if (ABT_SUCCESS != ret) {
 #if OPAL_ENABLE_DEBUG
-        opal_output(0, "opal_thread_internal_mutex_trylock()");
+        opal_show_help("help-opal-threads.txt", "mutex trylock failed", true);
 #endif
         return 1;
     }
@@ -94,7 +96,7 @@ static inline void opal_thread_internal_mutex_unlock(opal_thread_internal_mutex_
 #if OPAL_ENABLE_DEBUG
     int ret = ABT_mutex_unlock(mutex);
     if (ABT_SUCCESS != ret) {
-        opal_output(0, "opal_thread_internal_mutex_unlock()");
+        opal_show_help("help-opal-threads.txt", "mutex unlock failed", true);
     }
 #else
     ABT_mutex_unlock(mutex);

--- a/opal/mca/threads/base/help-opal-threads.txt
+++ b/opal/mca/threads/base/help-opal-threads.txt
@@ -1,0 +1,22 @@
+# -*- text -*-
+#
+# Copyright (c) 2022      Sandia National Laboratories.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI's OPAL thread MCA.
+#
+[mutex init failed]
+A mutex initialization has failed.
+
+[mutex lock failed]
+A mutex acquire (mutex lock) has failed.
+
+[mutex unlock failed]
+A mutex release (mutex unlock) has failed.
+
+[mutex trylock failed]
+A try to acquire a mutex (mutex trylock) has failed.

--- a/opal/mca/threads/pthreads/threads_pthreads_mutex.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_mutex.h
@@ -48,7 +48,7 @@
 
 #include "opal/class/opal_object.h"
 #include "opal/constants.h"
-#include "opal/util/output.h"
+#include "opal/util/show_help.h"
 
 BEGIN_C_DECLS
 
@@ -110,7 +110,7 @@ static inline void opal_thread_internal_mutex_lock(opal_thread_internal_mutex_t 
 #if OPAL_ENABLE_DEBUG
     int ret = pthread_mutex_lock(p_mutex);
     if (EDEADLK == ret) {
-        opal_output(0, "opal_thread_internal_mutex_lock() %d", ret);
+        opal_show_help("help-opal-threads.txt", "mutex lock failed", true);
     }
     assert(0 == ret);
 #else

--- a/opal/mca/threads/qthreads/threads_qthreads_mutex.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_mutex.h
@@ -39,7 +39,7 @@
 #include "opal/constants.h"
 #include "opal/mca/threads/qthreads/threads_qthreads.h"
 #include "opal/sys/atomic.h"
-#include "opal/util/output.h"
+#include "opal/util/show_help.h"
 
 BEGIN_C_DECLS
 
@@ -55,7 +55,7 @@ static inline int opal_thread_internal_mutex_init(opal_thread_internal_mutex_t *
     #if OPAL_ENABLE_DEBUG
     int ret = qthread_spinlock_init(p_mutex,recursive);
     if (QTHREAD_SUCCESS != ret) {
-        opal_output(0, "opal_thread_internal_mutex_init()");
+        opal_show_help("help-opal-threads.txt", "mutex init failed", true);
     }
     #else
     qthread_spinlock_init(p_mutex,recursive);
@@ -69,7 +69,7 @@ static inline void opal_thread_internal_mutex_lock(opal_thread_internal_mutex_t 
     #if OPAL_ENABLE_DEBUG
     int ret = qthread_spinlock_lock(p_mutex);
     if (QTHREAD_SUCCESS != ret) {
-        opal_output(0, "opal_thread_internal_mutex_lock()");
+        opal_show_help("help-opal-threads.txt", "mutex lock failed", true);
     }
     #else
     qthread_spinlock_lock(p_mutex);
@@ -84,7 +84,7 @@ static inline int opal_thread_internal_mutex_trylock(opal_thread_internal_mutex_
         return 1;
     } else if (QTHREAD_SUCCESS != ret) {
 #if OPAL_ENABLE_DEBUG
-        opal_output(0, "opal_thread_internal_mutex_trylock()");
+        opal_show_help("help-opal-threads.txt", "mutex trylock failed", true);
 #endif
         return 1;
     } 
@@ -98,7 +98,7 @@ static inline void opal_thread_internal_mutex_unlock(opal_thread_internal_mutex_
     #if OPAL_ENABLE_DEBUG
     ret = qthread_spinlock_unlock(p_mutex);
     if (QTHREAD_SUCCESS != ret) {
-        opal_output(0, "opal_thread_internal_mutex_unlock()");
+        opal_show_help("help-opal-threads.txt", "mutex unlock failed", true);
     }
     #else
     qthread_spinlock_unlock(p_mutex);

--- a/opal/mca/threads/qthreads/threads_qthreads_mutex.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_mutex.h
@@ -20,6 +20,7 @@
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2021      Argonne National Laboratory.  All rights reserved.
+ * Copyright (c) 2022      Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,46 +43,66 @@
 
 BEGIN_C_DECLS
 
-typedef opal_atomic_lock_t opal_thread_internal_mutex_t;
+typedef qthread_spinlock_t opal_thread_internal_mutex_t;
 
-#define OPAL_THREAD_INTERNAL_MUTEX_INITIALIZER           OPAL_ATOMIC_LOCK_INIT
-#define OPAL_THREAD_INTERNAL_RECURSIVE_MUTEX_INITIALIZER OPAL_ATOMIC_LOCK_INIT
+#define OPAL_THREAD_INTERNAL_MUTEX_INITIALIZER           QTHREAD_MUTEX_INITIALIZER
+#define OPAL_THREAD_INTERNAL_RECURSIVE_MUTEX_INITIALIZER QTHREAD_RECURSIVE_MUTEX_INITIALIZER
 
 static inline int opal_thread_internal_mutex_init(opal_thread_internal_mutex_t *p_mutex,
                                                   bool recursive)
 {
-    opal_atomic_lock_init(p_mutex, 0);
+    opal_threads_ensure_init_qthreads();
+    #if OPAL_ENABLE_DEBUG
+    int ret = qthread_spinlock_init(p_mutex,recursive);
+    if (QTHREAD_SUCCESS != ret) {
+        opal_output(0, "opal_thread_internal_mutex_init()");
+    }
+    #else
+    qthread_spinlock_init(p_mutex,recursive);
+    #endif
     return OPAL_SUCCESS;
 }
 
 static inline void opal_thread_internal_mutex_lock(opal_thread_internal_mutex_t *p_mutex)
 {
     opal_threads_ensure_init_qthreads();
-
-    int ret = opal_atomic_trylock(p_mutex);
-    while (0 != ret) {
-        qthread_yield();
-        ret = opal_atomic_trylock(p_mutex);
+    #if OPAL_ENABLE_DEBUG
+    int ret = qthread_spinlock_lock(p_mutex);
+    if (QTHREAD_SUCCESS != ret) {
+        opal_output(0, "opal_thread_internal_mutex_lock()");
     }
+    #else
+    qthread_spinlock_lock(p_mutex);
+    #endif
 }
 
 static inline int opal_thread_internal_mutex_trylock(opal_thread_internal_mutex_t *p_mutex)
 {
     opal_threads_ensure_init_qthreads();
-
-    int ret = opal_atomic_trylock(p_mutex);
-    if (0 != ret) {
-        /* Yield to avoid a deadlock. */
-        qthread_yield();
-    }
-    return ret;
+    int ret = qthread_spinlock_trylock(p_mutex);
+    if (QTHREAD_OPFAIL == ret) {
+        return 1;
+    } else if (QTHREAD_SUCCESS != ret) {
+#if OPAL_ENABLE_DEBUG
+        opal_output(0, "opal_thread_internal_mutex_trylock()");
+#endif
+        return 1;
+    } 
+    return 0;
 }
 
 static inline void opal_thread_internal_mutex_unlock(opal_thread_internal_mutex_t *p_mutex)
 {
     opal_threads_ensure_init_qthreads();
-
-    opal_atomic_unlock(p_mutex);
+    int ret; 
+    #if OPAL_ENABLE_DEBUG
+    ret = qthread_spinlock_unlock(p_mutex);
+    if (QTHREAD_SUCCESS != ret) {
+        opal_output(0, "opal_thread_internal_mutex_unlock()");
+    }
+    #else
+    qthread_spinlock_unlock(p_mutex);
+    #endif
     /* For fairness of locking. */
     qthread_yield();
 }
@@ -97,19 +118,19 @@ typedef struct opal_thread_cond_waiter_t {
 } opal_thread_cond_waiter_t;
 
 typedef struct {
-    opal_atomic_lock_t m_lock;
+    opal_thread_internal_mutex_t m_lock;
     opal_thread_cond_waiter_t *m_waiter_head;
     opal_thread_cond_waiter_t *m_waiter_tail;
 } opal_thread_internal_cond_t;
 
 #define OPAL_THREAD_INTERNAL_COND_INITIALIZER                                          \
     {                                                                                  \
-        .m_lock = OPAL_ATOMIC_LOCK_INIT, .m_waiter_head = NULL, .m_waiter_tail = NULL, \
+        .m_lock = QTHREAD_MUTEX_INITIALIZER, .m_waiter_head = NULL, .m_waiter_tail = NULL, \
     }
 
 static inline int opal_thread_internal_cond_init(opal_thread_internal_cond_t *p_cond)
 {
-    opal_atomic_lock_init(&p_cond->m_lock, 0);
+    qthread_spinlock_init(&p_cond->m_lock, false /* is_recursive */);
     p_cond->m_waiter_head = NULL;
     p_cond->m_waiter_tail = NULL;
     return OPAL_SUCCESS;
@@ -121,7 +142,7 @@ static inline void opal_thread_internal_cond_wait(opal_thread_internal_cond_t *p
     opal_threads_ensure_init_qthreads();
     /* This thread is taking "lock", so only this thread can access this
      * condition variable.  */
-    opal_atomic_lock(&p_cond->m_lock);
+    qthread_spinlock_lock(&p_cond->m_lock);
     opal_thread_cond_waiter_t waiter = {0, NULL};
     if (NULL == p_cond->m_waiter_head) {
         p_cond->m_waiter_tail = &waiter;
@@ -129,16 +150,15 @@ static inline void opal_thread_internal_cond_wait(opal_thread_internal_cond_t *p
         p_cond->m_waiter_head->m_prev = &waiter;
     }
     p_cond->m_waiter_head = &waiter;
-    opal_atomic_unlock(&p_cond->m_lock);
-
-    while (1) {
+    qthread_spinlock_unlock(&p_cond->m_lock);
+    while (1) {       
         opal_thread_internal_mutex_unlock(p_mutex);
         qthread_yield();
         opal_thread_internal_mutex_lock(p_mutex);
         /* Check if someone woke me up. */
-        opal_atomic_lock(&p_cond->m_lock);
+        qthread_spinlock_lock(&p_cond->m_lock);
         int signaled = waiter.m_signaled;
-        opal_atomic_unlock(&p_cond->m_lock);
+        qthread_spinlock_unlock(&p_cond->m_lock);
         if (1 == signaled) {
             break;
         }
@@ -148,7 +168,7 @@ static inline void opal_thread_internal_cond_wait(opal_thread_internal_cond_t *p
 
 static inline void opal_thread_internal_cond_broadcast(opal_thread_internal_cond_t *p_cond)
 {
-    opal_atomic_lock(&p_cond->m_lock);
+    qthread_spinlock_lock(&p_cond->m_lock);
     while (NULL != p_cond->m_waiter_tail) {
         opal_thread_cond_waiter_t *p_cur_tail = p_cond->m_waiter_tail;
         p_cond->m_waiter_tail = p_cur_tail->m_prev;
@@ -157,12 +177,12 @@ static inline void opal_thread_internal_cond_broadcast(opal_thread_internal_cond
     }
     /* No waiters. */
     p_cond->m_waiter_head = NULL;
-    opal_atomic_unlock(&p_cond->m_lock);
+    qthread_spinlock_unlock(&p_cond->m_lock);
 }
 
 static inline void opal_thread_internal_cond_signal(opal_thread_internal_cond_t *p_cond)
 {
-    opal_atomic_lock(&p_cond->m_lock);
+    qthread_spinlock_lock(&p_cond->m_lock);
     if (NULL != p_cond->m_waiter_tail) {
         opal_thread_cond_waiter_t *p_cur_tail = p_cond->m_waiter_tail;
         p_cond->m_waiter_tail = p_cur_tail->m_prev;
@@ -172,7 +192,7 @@ static inline void opal_thread_internal_cond_signal(opal_thread_internal_cond_t 
             p_cond->m_waiter_head = NULL;
         }
     }
-    opal_atomic_unlock(&p_cond->m_lock);
+    qthread_spinlock_unlock(&p_cond->m_lock);
 }
 
 static inline void opal_thread_internal_cond_destroy(opal_thread_internal_cond_t *p_cond)


### PR DESCRIPTION
- This replaces the use of opal atomics with the use of qthread's atomics in the opal/thread MCA if ompi is configured with qthreads. 
- This resolves the deadlock reported originating from expecting recursive locks to work (https://github.com/open-mpi/ompi/issues/10459).
- Requires Qthreads version >=1.18 as we added support for recursive locks in that version. I will issue a PR for the configury changes to version check.

Signed-off-by: Jan Ciesko <jciesko@sandia.gov>