### PR TITLE
v5.0.x: mpirun: set OMPI_MCA_PREFIXES env var

### DIFF
--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,6 +22,11 @@ mpirun_SOURCES = \
 
 mpirun_LDADD = \
 	$(top_builddir)/opal/libopen-pal_core.la
+
+mpirun_CPPFLAGS = \
+    -DMCA_oshmem_FRAMEWORKS="\"$(MCA_oshmem_FRAMEWORKS)\"" \
+    -DMCA_ompi_FRAMEWORKS="\"$(MCA_ompi_FRAMEWORKS)\"" \
+    -DMCA_opal_FRAMEWORKS="\"$(MCA_opal_FRAMEWORKS)\""
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f mpiexec$(EXEEXT); $(LN_S) mpirun$(EXEEXT) mpiexec$(EXEEXT))


### PR DESCRIPTION
The OMPI_MCA_PREFIXES env variable is used to pass the list of MCA variable prefixes to prterun, so that the PRRTE schizo/ompi component can know which variables passed via `--mca foo bar` belong to Open MPI and which belong to something else.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 7454a5e81a6b76a6b2a645479e9c1623a3798df1)

This is the v5.0.x PR corresponding to `main` PR #10836