### PR TITLE
cmd_line: fix "ompi_info --help"

### DIFF
--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
@@ -217,7 +217,7 @@ int opal_cmd_line_make_opt3(opal_cmd_line_t *cmd, char short_name, const char *s
 
     e.ocl_description = desc;
 
-    e.ocl_otype = OPAL_CMD_LINE_OTYPE_NULL;
+    e.ocl_otype = OPAL_CMD_LINE_OTYPE_GENERAL;
 
     return make_opt(cmd, &e);
 }
@@ -689,17 +689,6 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
                 free(desc);
             }
         }
-    }
-    if (otype == OPAL_CMD_LINE_OTYPE_NULL || otype == OPAL_CMD_LINE_OTYPE_GENERAL) {
-        char *argument_line
-            = "\nFor additional mpirun arguments, run 'mpirun --help <category>'\n\nThe following "
-              "categories exist: general (Defaults to this option), debug,\n    output, input, "
-              "mapping, ranking, binding, devel (arguments useful to OMPI\n    Developers), "
-              "compatibility (arguments supported for backwards compatibility),\n    launch "
-              "(arguments to modify launch options), and dvm (Distributed Virtual\n    Machine "
-              "arguments).";
-
-        opal_argv_append(&argc, &argv, argument_line);
     }
     if (NULL != argv) {
         ret = opal_argv_join(argv, '\n');

--- a/opal/util/cmd_line.h
+++ b/opal/util/cmd_line.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -182,7 +182,10 @@ typedef enum opal_cmd_line_type_t opal_cmd_line_type_t;
  * mpirun --help output.
  */
 enum opal_cmd_line_otype_t {
-    OPAL_CMD_LINE_OTYPE_GENERAL,
+    OPAL_CMD_LINE_OTYPE_GENERAL, /* This type is shown via --help by
+                                    default (i.e., if no arg is
+                                    specified to narrow the help
+                                    scope) */
     OPAL_CMD_LINE_OTYPE_DEBUG,
     OPAL_CMD_LINE_OTYPE_OUTPUT,
     OPAL_CMD_LINE_OTYPE_INPUT,


### PR DESCRIPTION
cmd_line.c was previously given some mpirun-specific functionality, ignoring the fact that it is used by other executables (in this case, ompi_info).  This commit removes an mpirun-specific output message when generating the help message from an ompi_cmd_line_t (since Open MPI's mpirun doesn't even use opal_cmd_line_t any more) and also changes the default for all cmd_line options to be of type OPAL_CMD_LINE_OTYPE_GENERAL (instead of OPAL_CMD_LINE_OTYPE_NULL) so that "<cmd> --help" (with no argument) will, by default, show that option's description/help message.

Thanks to George Katevenis (@gkatev) for pointing out the issue and suggesting a fix.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@gkatev In digging into #10842, I opted to just make all options created by `_opt3` be of type `OTYPE_GENERAL` (instead of `OTYPE_NULL`) in order to preserve the difference between "this help content is shown by default" vs. "this help content is shown when *all* help is specifically requested".