### PR TITLE
opal/accelerator: Rename malloc/free functions

### DIFF
--- a/ompi/mca/mtl/base/mtl_base_datatype.h
+++ b/ompi/mca/mtl/base/mtl_base_datatype.h
@@ -68,7 +68,7 @@ ompi_mtl_datatype_pack(struct opal_convertor_t *convertor,
             iov.iov_base = malloc(*buffer_len);
         /* The remaining case is if this is an accelerator buffer and we have accelerator support and we need buffers. We will need to do an accelerator malloc*/
         } else {
-            opal_accelerator.malloc(MCA_ACCELERATOR_NO_DEVICE_ID, &iov.iov_base, *buffer_len);
+            opal_accelerator.mem_alloc(MCA_ACCELERATOR_NO_DEVICE_ID, &iov.iov_base, *buffer_len);
         }
 
         if (NULL == iov.iov_base) return OMPI_ERR_OUT_OF_RESOURCE;
@@ -103,7 +103,7 @@ ompi_mtl_datatype_recv_buf(struct opal_convertor_t *convertor,
             *buffer = malloc(*buffer_len);
         /* The remaining case is if this is an accelerator buffer and we have accelerator support and we need buffers. Wwe will need to do an accelerator malloc*/
         } else {
-            opal_accelerator.malloc(MCA_ACCELERATOR_NO_DEVICE_ID, buffer, *buffer_len);
+            opal_accelerator.mem_alloc(MCA_ACCELERATOR_NO_DEVICE_ID, buffer, *buffer_len);
         }
 
         if (NULL == *buffer) return OMPI_ERR_OUT_OF_RESOURCE;
@@ -132,7 +132,7 @@ ompi_mtl_datatype_unpack(struct opal_convertor_t *convertor,
         opal_convertor_unpack(convertor, &iov, &iov_count, &buffer_len);
         /* If it's an accelerator buffer and we have accelerator support, we will need to free the accelerator buffer */
         if (is_accelerator && true == ompi_mtl_base_selected_component->accelerator_support) {
-            opal_accelerator.free(MCA_ACCELERATOR_NO_DEVICE_ID, buffer);
+            opal_accelerator.mem_release(MCA_ACCELERATOR_NO_DEVICE_ID, buffer);
         /* If it's not an accelerator buffer or we don't have accelerator support, we will need to free the host buffer */
         } else {
             free(buffer);

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -382,7 +382,7 @@ int ompi_mtl_ofi_deregister_and_free_buffer(ompi_mtl_ofi_request_t *ofi_req) {
             free(ofi_req->buffer);
         /* The buffer must be an accelerator buffer */
         } else {
-            ret = opal_accelerator.free(MCA_ACCELERATOR_NO_DEVICE_ID, ofi_req->buffer);
+            ret = opal_accelerator.mem_release(MCA_ACCELERATOR_NO_DEVICE_ID, ofi_req->buffer);
         }
     }
     ofi_req->buffer = NULL;

--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -274,12 +274,12 @@ typedef int (*opal_accelerator_base_module_memmove_fn_t)(
  *
  * @return                   OPAL_SUCCESS or error status on failure
  */
-typedef int (*opal_accelerator_base_module_malloc_fn_t)(
+typedef int (*opal_accelerator_base_module_mem_alloc_fn_t)(
     int dev_id, void **ptr, size_t size);
 
 /**
  * Frees the memory space pointed to by ptr which has been returned by
- * a previous call to an opal_accelerator_base_module_malloc_fn_t().
+ * a previous call to an opal_accelerator_base_module_mem_alloc_fn_t().
  * If the function is called on a ptr that has already been freed,
  * undefined behavior occurs. If ptr is NULL, no operation is performed,
  * and the function returns OPAL_SUCCESS.
@@ -290,7 +290,7 @@ typedef int (*opal_accelerator_base_module_malloc_fn_t)(
  *
  * @return                   OPAL_SUCCESS or error status on failure
  */
-typedef int (*opal_accelerator_base_module_free_fn_t)(
+typedef int (*opal_accelerator_base_module_mem_release_fn_t)(
     int dev_id, void *ptr);
 
 /**
@@ -375,8 +375,8 @@ typedef struct {
     opal_accelerator_base_module_memcpy_fn_t memcpy;
     opal_accelerator_base_module_memmove_fn_t memmove;
 
-    opal_accelerator_base_module_malloc_fn_t malloc;
-    opal_accelerator_base_module_free_fn_t free;
+    opal_accelerator_base_module_mem_alloc_fn_t mem_alloc;
+    opal_accelerator_base_module_mem_release_fn_t mem_release;
     opal_accelerator_base_module_get_address_range_fn_t get_address_range;
 
     opal_accelerator_base_module_host_register_fn_t host_register;

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -36,8 +36,8 @@ static int accelerator_cuda_memcpy(int dest_dev_id, int src_dev_id, void *dest, 
                             size_t size, opal_accelerator_transfer_type_t type);
 static int accelerator_cuda_memmove(int dest_dev_id, int src_dev_id, void *dest, const void *src, size_t size,
                              opal_accelerator_transfer_type_t type);
-static int accelerator_cuda_malloc(int dev_id, void **ptr, size_t size);
-static int accelerator_cuda_free(int dev_id, void *ptr);
+static int accelerator_cuda_mem_alloc(int dev_id, void **ptr, size_t size);
+static int accelerator_cuda_mem_release(int dev_id, void *ptr);
 static int accelerator_cuda_get_address_range(int dev_id, const void *ptr, void **base,
                                               size_t *size);
 
@@ -60,8 +60,8 @@ opal_accelerator_base_module_t opal_accelerator_cuda_module =
     accelerator_cuda_memcpy_async,
     accelerator_cuda_memcpy,
     accelerator_cuda_memmove,
-    accelerator_cuda_malloc,
-    accelerator_cuda_free,
+    accelerator_cuda_mem_alloc,
+    accelerator_cuda_mem_release,
     accelerator_cuda_get_address_range,
 
     accelerator_cuda_host_register,
@@ -417,7 +417,7 @@ static int accelerator_cuda_memmove(int dest_dev_id, int src_dev_id, void *dest,
     return OPAL_SUCCESS;
 }
 
-static int accelerator_cuda_malloc(int dev_id, void **ptr, size_t size)
+static int accelerator_cuda_mem_alloc(int dev_id, void **ptr, size_t size)
 {
     CUresult result;
 
@@ -436,7 +436,7 @@ static int accelerator_cuda_malloc(int dev_id, void **ptr, size_t size)
     return 0;
 }
 
-static int accelerator_cuda_free(int dev_id, void *ptr)
+static int accelerator_cuda_mem_release(int dev_id, void *ptr)
 {
     CUresult result;
     if (NULL != ptr) {

--- a/opal/mca/accelerator/null/accelerator_null_component.c
+++ b/opal/mca/accelerator/null/accelerator_null_component.c
@@ -51,8 +51,8 @@ static int accelerator_null_memcpy(int dest_dev_id, int src_dev_id, void *dest, 
 static int accelerator_null_memmove(int dest_dev_id, int src_dev_id, void *dest, const void *src, size_t size,
                                     opal_accelerator_transfer_type_t type);
 
-static int accelerator_null_malloc(int dev_id, void **ptr, size_t size);
-static int accelerator_null_free(int dev_id, void *ptr);
+static int accelerator_null_mem_alloc(int dev_id, void **ptr, size_t size);
+static int accelerator_null_mem_release(int dev_id, void *ptr);
 static int accelerator_null_get_address_range(int dev_id, const void *ptr, void **base, size_t *size);
 
 static int accelerator_null_host_register(int dev_id, void *ptr, size_t size);
@@ -112,8 +112,8 @@ opal_accelerator_base_module_t opal_accelerator_null_module =
     accelerator_null_memcpy_async,
     accelerator_null_memcpy,
     accelerator_null_memmove,
-    accelerator_null_malloc,
-    accelerator_null_free,
+    accelerator_null_mem_alloc,
+    accelerator_null_mem_release,
     accelerator_null_get_address_range,
 
     accelerator_null_host_register,
@@ -198,13 +198,13 @@ static int accelerator_null_memmove(int dest_dev_id, int src_dev_id, void *dest,
     return OPAL_SUCCESS;
 }
 
-static int accelerator_null_malloc(int dev_id, void **ptr, size_t size)
+static int accelerator_null_mem_alloc(int dev_id, void **ptr, size_t size)
 {
     *ptr = malloc(size);
     return OPAL_SUCCESS;
 }
 
-static int accelerator_null_free(int dev_id, void *ptr)
+static int accelerator_null_mem_release(int dev_id, void *ptr)
 {
     free(ptr);
     return OPAL_SUCCESS;

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -26,8 +26,8 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
                             size_t size, opal_accelerator_transfer_type_t type);
 static int mca_accelerator_rocm_memmove(int dest_dev_id, int src_dev_id, void *dest, const void *src, size_t size,
                                         opal_accelerator_transfer_type_t type);
-static int mca_accelerator_rocm_malloc(int dev_id, void **ptr, size_t size);
-static int mca_accelerator_rocm_free(int dev_id, void *ptr);
+static int mca_accelerator_rocm_mem_alloc(int dev_id, void **ptr, size_t size);
+static int mca_accelerator_rocm_mem_release(int dev_id, void *ptr);
 static int mca_accelerator_rocm_get_address_range(int dev_id, const void *ptr, void **base,
                                                   size_t *size);
 
@@ -51,8 +51,8 @@ opal_accelerator_base_module_t opal_accelerator_rocm_module =
     mca_accelerator_rocm_memcpy_async,
     mca_accelerator_rocm_memcpy,
     mca_accelerator_rocm_memmove,
-    mca_accelerator_rocm_malloc,
-    mca_accelerator_rocm_free,
+    mca_accelerator_rocm_mem_alloc,
+    mca_accelerator_rocm_mem_release,
     mca_accelerator_rocm_get_address_range,
 
     mca_accelerator_rocm_host_register,
@@ -364,7 +364,7 @@ static int mca_accelerator_rocm_memmove(int dest_dev_id, int src_dev_id, void *d
     return OPAL_SUCCESS;
 }
 
-static int mca_accelerator_rocm_malloc(int dev_id, void **ptr, size_t size)
+static int mca_accelerator_rocm_mem_alloc(int dev_id, void **ptr, size_t size)
 {
     if (NULL == ptr || size <= 0) {
         return OPAL_ERR_BAD_PARAM;
@@ -380,7 +380,7 @@ static int mca_accelerator_rocm_malloc(int dev_id, void **ptr, size_t size)
     return OPAL_SUCCESS;
 }
 
-static int mca_accelerator_rocm_free(int dev_id, void *ptr)
+static int mca_accelerator_rocm_mem_release(int dev_id, void *ptr)
 {
     if (NULL == ptr) {
         return OPAL_ERR_BAD_PARAM;


### PR DESCRIPTION
with --enable-mem-debug, malloc and free are macro'd to opal_malloc and opal_free.

Signed-off-by: William Zhang <wilzhang@amazon.com>