### PR TITLE
    pml/cm: Fix call convertor_prepare_for_send to use the right pointer

### DIFF
--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -375,17 +375,12 @@ mca_pml_cm_send(const void *buf,
 		convertor.flags      = ompi_mpi_local_convertor->flags;
 		convertor.master     = ompi_mpi_local_convertor->master;
 
-		convertor.local_size = count * datatype->super.size;
-		convertor.pBaseBuf   = (unsigned char*)buf + datatype->super.true_lb;
-		convertor.count      = count;
-		convertor.pDesc      = &datatype->super;
-
-        /* Switches off device detection if
-           MTL set MCA_MTL_BASE_FLAG_ACCELERATOR_INIT_DISABLE during init */
-        MCA_PML_CM_SWITCH_ACCELERATOR_CONVERTOR_OFF(flags, datatype, count);
-        convertor.flags      |= flags;
-        /* Sets CONVERTOR_ACCELERATOR flag if device buffer */
-        opal_convertor_prepare_for_send( &convertor, &datatype->super, count, buf );
+                /* Switches off device detection if
+                   MTL set MCA_MTL_BASE_FLAG_ACCELERATOR_INIT_DISABLE during init */
+                MCA_PML_CM_SWITCH_ACCELERATOR_CONVERTOR_OFF(flags, datatype, count);
+                convertor.flags      |= flags;
+                /* Sets CONVERTOR_ACCELERATOR flag if device buffer */
+                opal_convertor_prepare_for_send(&convertor, &datatype->super, count, (unsigned char *)buf + datatype->super.true_lb);
     } else
 #endif
 	{


### PR DESCRIPTION
…vertor_accelerator_init

The original desire was to do device buffer checking. However, this call did much more than that and caused a change in behavior which lead to data invalidation.

Signed-off-by: William Zhang <wilzhang@amazon.com>