### PR TITLE
v5.0.x: mpirun: Fix crash when project disabled

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -77,6 +77,9 @@ static void append_prefixes(char ***out, const char *in)
 
     char **tokenized;
     tokenized = opal_argv_split(in, ' ');
+    if (NULL == tokenized) {
+        return;
+    }
 
     int count = opal_argv_count(*out);
     for (int i = 0; tokenized[i] != NULL; ++i) {


### PR DESCRIPTION
Fix a crash when a project is disabled (or has no frameworks). opal_argv_split() will return NULL if the input string is an empty string, which will happen when the project is disabled. Handle that case explicitly.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 09f5b16e72a74406a7cc31d7db97530979ede3fa)