### PR TITLE
Fix/avoid intrinsics collisions

### DIFF
--- a/ompi/mca/coll/cuda/coll_cuda.h
+++ b/ompi/mca/coll/cuda/coll_cuda.h
@@ -97,8 +97,8 @@ static inline int mca_coll_cuda_check_buf(void *addr)
 static inline void *mca_coll_cuda_memcpy(void *dest, const void *src, size_t size)
 {
     int res;
-    res = opal_accelerator.memcpy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
-                                  dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
+    res = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
+                                    dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
     if (res != 0) {
         opal_output(0, "CUDA: Error in cuMemcpy: res=%d, dest=%p, src=%p, size=%d", res, dest, src,
                     (int) size);

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -52,7 +52,7 @@ static void *opal_convertor_accelerator_memcpy(void *dest, const void *src, size
         return MEMCPY(dest, src, size);
     }
 
-    res = opal_accelerator.memcpy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
+    res = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
                                   dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
     if (OPAL_SUCCESS != res) {
         opal_output(0, "Error in accelerator memcpy");

--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -58,7 +58,7 @@
 static void *opal_datatype_accelerator_memcpy(void *dest, const void *src, size_t size)
 {
     int res;
-    res = opal_accelerator.memcpy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
+    res = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
                                   dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
     if (OPAL_SUCCESS != res) {
         opal_output(0, "Error in accelerator memcpy");
@@ -70,8 +70,8 @@ static void *opal_datatype_accelerator_memcpy(void *dest, const void *src, size_
 static void *opal_datatype_accelerator_memmove(void *dest, const void *src, size_t size)
 {
     int res;
-    res = opal_accelerator.memmove(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
-                                   dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
+    res = opal_accelerator.mem_move(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
+                                    dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
     if (OPAL_SUCCESS != res) {
         opal_output(0, "Error in accelerator memmove");
         abort();

--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -386,9 +386,9 @@ typedef struct {
     opal_accelerator_base_module_record_event_fn_t record_event;
     opal_accelerator_base_module_query_event_fn_t query_event;
 
-    opal_accelerator_base_module_memcpy_async_fn_t memcpy_async;
-    opal_accelerator_base_module_memcpy_fn_t memcpy;
-    opal_accelerator_base_module_memmove_fn_t memmove;
+    opal_accelerator_base_module_memcpy_async_fn_t mem_copy_async;
+    opal_accelerator_base_module_memcpy_fn_t mem_copy;
+    opal_accelerator_base_module_memmove_fn_t mem_move;
 
     opal_accelerator_base_module_mem_alloc_fn_t mem_alloc;
     opal_accelerator_base_module_mem_release_fn_t mem_release;

--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
@@ -209,8 +209,8 @@ int mca_btl_smcuda_memcpy(void *dst, void *src, size_t amount, char *msg,
         }
     }
 
-    result = opal_accelerator.memcpy_async(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
-                                           dst, src, amount, ipc_stream, MCA_ACCELERATOR_TRANSFER_UNSPEC);
+    result = opal_accelerator.mem_copy_async(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
+                                             dst, src, amount, ipc_stream, MCA_ACCELERATOR_TRANSFER_UNSPEC);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != result)) {
         opal_output_verbose(1, mca_btl_smcuda_component.cuda_ipc_output, "smcuda: memcpy async failed: %d",
                             result);

--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -540,7 +540,7 @@ static bool mca_rcache_accelerator_previously_freed_memory(mca_rcache_base_regis
     int res;
     opal_accelerator_buffer_id_t buf_id;
     unsigned char *dbuf = reg->base;
-    opal_accelerator.get_buffer_id(MCA_ACCELERATOR_NO_DEVICE_ID, dbuf, &buf_id);
+    res = opal_accelerator.get_buffer_id(MCA_ACCELERATOR_NO_DEVICE_ID, dbuf, &buf_id);
     if (OPAL_UNLIKELY(res != OPAL_SUCCESS)) {
         return true;
     }


### PR DESCRIPTION
memcpy and memove (among others intrinsics) cannot be used a members of structs.