### PR TITLE
Fix debugger attach during MPI_Init

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -1088,7 +1088,7 @@ void ompi_rte_breakpoint(char *name)
     u32ptr = &u32;
     pname.jobid = opal_process_info.my_name.jobid;
     pname.vpid = OPAL_VPID_WILDCARD;
-    OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, "PMIX_DEBUG_STOP_IN_APP",
+    OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_DEBUG_STOP_IN_APP,
                                    &pname, &u32ptr, PMIX_PROC_RANK);
     if (PMIX_SUCCESS != rc) {
         /* if not, just return */


### PR DESCRIPTION
Correct the attribute being sought to detect debugger launch - you cannot quote the name of the PMIx attribute as it is the string representation of that name that is used inside PMIx, and not the attribute name itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>