### PR TITLE
process set query: if pmix_query_info_nb returns error

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -1047,6 +1047,7 @@ static void ompi_instance_refresh_pmix_psets (const char *key)
                                                  ompi_instance_get_num_psets_complete,
                                                  (void*)&lock))) {
        opal_mutex_unlock (&instance_lock);
+       return;
     }
 
     OPAL_PMIX_WAIT_THREAD(&lock);


### PR DESCRIPTION
don't wait for call back to be run as it will not be per section 5.4.4 of PMIx 4.1 standard.

related to #10749

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 0b125a38bb7bbd311a6b66b92b70637fcdba649e)