### PR TITLE
Initialize opal/smsc outside of btl/sm, to enable its use without it

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -498,6 +498,10 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
 
     /* Select which MPI components to use */
 
+    if (OPAL_SUCCESS != (ret = mca_smsc_base_select())) {
+        return ompi_instance_print_error ("mca_smsc_base_select() failed", ret);
+    }
+
     if (OMPI_SUCCESS != (ret = mca_pml_base_select (OPAL_ENABLE_PROGRESS_THREADS, ompi_mpi_thread_multiple))) {
         return ompi_instance_print_error ("mca_pml_base_select() failed", ret);
     }

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -41,7 +41,6 @@
 #include "opal/mca/btl/sm/btl_sm_fbox.h"
 #include "opal/mca/btl/sm/btl_sm_fifo.h"
 #include "opal/mca/btl/sm/btl_sm_frag.h"
-#include "opal/mca/smsc/base/base.h"
 #include "opal/mca/smsc/smsc.h"
 
 #ifdef HAVE_SYS_STAT_H
@@ -333,8 +332,8 @@ mca_btl_sm_component_init(int *num_btls, bool enable_progress_threads, bool enab
     /* no fast boxes allocated initially */
     component->num_fbox_in_endpoints = 0;
 
-    rc = mca_smsc_base_select();
-    if (OPAL_SUCCESS == rc) {
+    bool have_smsc = (NULL != mca_smsc);
+    if (have_smsc) {
         mca_btl_sm.super.btl_flags |= MCA_BTL_FLAGS_RDMA;
         mca_btl_sm.super.btl_get = mca_btl_sm_get;
         mca_btl_sm.super.btl_put = mca_btl_sm_put;
@@ -356,11 +355,11 @@ mca_btl_sm_component_init(int *num_btls, bool enable_progress_threads, bool enab
             } else {
                 BTL_ERROR(("single-copy component requires registration but could not provide the "
                            "registration handle size"));
-                rc = (int) handle_size;
+                have_smsc = false;
             }
         }
     }
-    if (OPAL_SUCCESS != rc) {
+    if (!have_smsc) {
         mca_btl_sm.super.btl_flags &= ~MCA_BTL_FLAGS_RDMA;
         mca_btl_sm.super.btl_get = NULL;
         mca_btl_sm.super.btl_put = NULL;


### PR DESCRIPTION
Hello, this places the initialization call for opal/smsc in an allegedly (more) appropriate place -- I'm accepting input about the "legality" of its placement :-). Currently, the call is placed inside btl/sm, but if it is not loaded (e.g. because pml=ucx), smsc will remain uninitialized. My initial thought was that a component requiring smsc could initialize it on demand as necessary, but this might be too late for the modex to be properly sent/commited. For example, this occurs with collectives components that utilize smsc (#10342).

Fixes #10342
Signed-off-by: George Katevenis <gkatev@ics.forth.gr>