### PR TITLE
sessions: fixes for invoking some functions before init

### DIFF
--- a/ompi/mpi/c/error_class.c
+++ b/ompi/mpi/c/error_class.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,6 +40,14 @@ static const char FUNC_NAME[] = "MPI_Error_class";
 
 int MPI_Error_class(int errorcode, int *errorclass)
 {
+    int ret;
+
+    /* make sure the infrastructure is initialized */
+    ret = ompi_mpi_instance_retain ();
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
+    }
+
     if ( MPI_PARAM_CHECK ) {
         if ( ompi_mpi_errcode_is_invalid(errorcode)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
@@ -47,5 +57,7 @@ int MPI_Error_class(int errorcode, int *errorclass)
 
 
     *errorclass = ompi_mpi_errcode_get_class(errorcode);
+    ompi_mpi_instance_release ();
+
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/error_string.c
+++ b/ompi/mpi/c/error_string.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +44,15 @@ static const char FUNC_NAME[] = "MPI_Error_string";
 
 int MPI_Error_string(int errorcode, char *string, int *resultlen)
 {
+    int ret;
     char *tmpstring;
+
+    /* make sure the infrastructure is initialized */
+    ret = ompi_mpi_instance_retain ();
+    if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret,
+                                               FUNC_NAME);
+    }
 
     if ( MPI_PARAM_CHECK ) {
         if ( ompi_mpi_errcode_is_invalid(errorcode)) {
@@ -54,6 +64,8 @@ int MPI_Error_string(int errorcode, char *string, int *resultlen)
     tmpstring = ompi_mpi_errnum_get_string (errorcode);
     opal_string_copy(string, tmpstring, MPI_MAX_ERROR_STRING);
     *resultlen = (int)strlen(string);
+
+    ompi_mpi_instance_release();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/info_f2c.c
+++ b/ompi/mpi/c/info_f2c.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -65,9 +65,12 @@ MPI_Info MPI_Info_f2c(MPI_Fint info)
         return MPI_INFO_ENV;
     }
 
-    if (MPI_PARAM_CHECK) {
-        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-    }
+    /* 
+     * if the application has not created an info object yet
+     * then the size of the ompi_info_f_to_c_table is zero
+     * so this check can be done even if an info object has not
+     * previously been created.
+     */
 
     if (info_index < 0 ||
         info_index >=
@@ -75,5 +78,10 @@ MPI_Info MPI_Info_f2c(MPI_Fint info)
         return NULL;
     }
 
+    /*
+     * if we get here, then the info support infrastructure has been initialized
+     * either via a prior call to MPI_Info_create or one of the MPI initialization
+     * methods.
+     */
     return (MPI_Info)opal_pointer_array_get_item(&ompi_info_f_to_c_table, info_index);
 }

--- a/ompi/mpi/c/info_free.c
+++ b/ompi/mpi/c/info_free.c
@@ -12,6 +12,9 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
+ *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +60,6 @@ int MPI_Info_free(MPI_Info *info)
      * fashion so that there are no dangling pointers.
      */
     if (MPI_PARAM_CHECK) {
-        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == info || MPI_INFO_NULL == *info ||
             ompi_info_is_freed(*info)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO,

--- a/ompi/mpi/c/info_get_nthkey.c
+++ b/ompi/mpi/c/info_get_nthkey.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,24 +58,23 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
     int err;
 
     /*
-     * 1. Check if info is a valid handle
+     * 1. Check if info is a valid handle 
      * 2. Check if there are at least (n+1) elements
      * 3. If so, give the nth defined key
      */
+    if (NULL == info || MPI_INFO_NULL == info) {
+        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO, FUNC_NAME);
+    }
+
     if (MPI_PARAM_CHECK) {
-        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == info || MPI_INFO_NULL == info ||
-            ompi_info_is_freed(info)) {
-            return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_INFO,
-                                           FUNC_NAME);
+        if (ompi_info_is_freed(info)) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO, FUNC_NAME);
         }
         if (0 > n) {
-            return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_ARG,
-                                           FUNC_NAME);
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG, FUNC_NAME);
         }
         if (NULL == key) {
-            return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_INFO_KEY,
-                                           FUNC_NAME);
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO_KEY, FUNC_NAME);
         }
     }
 
@@ -84,8 +85,7 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
     err = ompi_info_get_nkeys(info, &nkeys);
     OMPI_ERRHANDLER_NOHANDLE_CHECK(err, err, FUNC_NAME);
     if (n > (nkeys - 1)) {
-        return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_INFO_KEY,
-                                       FUNC_NAME);
+        return OMPI_ERRHANDLER_NOHANDLE_INVOKE (MPI_ERR_INFO_KEY, FUNC_NAME);
     }
 
     /* Everything seems alright. Call the back end key copy */
@@ -96,5 +96,6 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
         opal_string_copy(key, key_str->string, MPI_MAX_INFO_KEY);
         OBJ_RELEASE(key_str);
     }
+
     OMPI_ERRHANDLER_NOHANDLE_RETURN(err, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_string.c
+++ b/ompi/mpi/c/info_get_string.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2021      Triad National Security, LLC. All rights
+ * Copyright (c) 2021-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -74,7 +74,6 @@ int MPI_Info_get_string(MPI_Info info, const char *key, int *buflen,
      * necessary structures.
      */
     if (MPI_PARAM_CHECK) {
-        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == info || MPI_INFO_NULL == info ||
             ompi_info_is_freed(info)) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_INFO,


### PR DESCRIPTION
turns out the macro used for checking init/finalize/instance count was using a different counter than that incremented when an app calls MPI_Info_create, etc. prior to MPI_Init.  so just remove its use in these functions.

related to #10794

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 7f898058cf86e343c7b57b48c313c54bd8add19b)