### PR TITLE
lanl/ci: fix trailing clutter

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -20,7 +20,7 @@ build:intel:
     - make -j 8 install
     - make check
     - export PATH=$PWD/install_test/bin:$PATH
-    - cd examples 
+    - cd examples
     - make
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
@@ -93,7 +93,7 @@ build:gnu:
     - make -j 8 install
     - make check
     - export PATH=$PWD/install_test/bin:$PATH
-    - cd examples 
+    - cd examples
     - make
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
@@ -123,7 +123,7 @@ build:cce:
     - make -j 8 install
     - make check
     - export PATH=$PWD/install_test/bin:$PATH
-    - cd examples»
+    - cd examples
     - make
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"


### PR DESCRIPTION
that was messing up the gitlab ci brain

Signed-off-by: Howard Pritchard <howardp@lanl.gov>