### PR TITLE
mtl/ofi: fix convertor on ofi_req

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -1059,6 +1059,7 @@ ompi_mtl_ofi_isend_generic(struct mca_mtl_base_module_t *mtl,
     ofi_req->length = length;
     ofi_req->status.MPI_ERROR = OMPI_SUCCESS;
     ofi_req->completion_count = 1;
+    ofi_req->convertor = convertor;
 
     if (OPAL_UNLIKELY(length > endpoint->mtl_ofi_module->max_msg_size)) {
         opal_show_help("help-mtl-ofi.txt",


### PR DESCRIPTION
There was one instances in isend_generic where the convertor field on the ofi request was not set correctly. This commit fixes this.

Signed-off-by: Edgar Gabriel <Edgar.Gabriel@amd.com>