### PR TITLE
v5.0.x: Initialize opal/smsc outside of btl/sm, to enable its use without it

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -493,6 +493,10 @@ static int ompi_mpi_instance_init_common (void)
 
     /* Select which MPI components to use */
 
+    if (OPAL_SUCCESS != (ret = mca_smsc_base_select())) {
+        return ompi_instance_print_error ("mca_smsc_base_select() failed", ret);
+    }
+
     if (OMPI_SUCCESS != (ret = mca_pml_base_select (OPAL_ENABLE_PROGRESS_THREADS, ompi_mpi_thread_multiple))) {
         return ompi_instance_print_error ("mca_pml_base_select() failed", ret);
     }

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -40,7 +40,6 @@
 #include "opal/mca/btl/sm/btl_sm_fbox.h"
 #include "opal/mca/btl/sm/btl_sm_fifo.h"
 #include "opal/mca/btl/sm/btl_sm_frag.h"
-#include "opal/mca/smsc/base/base.h"
 #include "opal/mca/smsc/smsc.h"
 
 #ifdef HAVE_SYS_STAT_H
@@ -332,8 +331,8 @@ mca_btl_sm_component_init(int *num_btls, bool enable_progress_threads, bool enab
     /* no fast boxes allocated initially */
     component->num_fbox_in_endpoints = 0;
 
-    rc = mca_smsc_base_select();
-    if (OPAL_SUCCESS == rc) {
+    bool have_smsc = (NULL != mca_smsc);
+    if (have_smsc) {
         mca_btl_sm.super.btl_flags |= MCA_BTL_FLAGS_RDMA;
         mca_btl_sm.super.btl_get = mca_btl_sm_get;
         mca_btl_sm.super.btl_put = mca_btl_sm_put;
@@ -355,11 +354,11 @@ mca_btl_sm_component_init(int *num_btls, bool enable_progress_threads, bool enab
             } else {
                 BTL_ERROR(("single-copy component requires registration but could not provide the "
                            "registration handle size"));
-                rc = (int) handle_size;
+                have_smsc = false;
             }
         }
     }
-    if (OPAL_SUCCESS != rc) {
+    if (!have_smsc) {
         mca_btl_sm.super.btl_flags &= ~MCA_BTL_FLAGS_RDMA;
         mca_btl_sm.super.btl_get = NULL;
         mca_btl_sm.super.btl_put = NULL;


### PR DESCRIPTION
#10897 for v5.0.x
Signed-off-by: George Katevenis <gkatev@ics.forth.gr>

@awlauria 