### PR TITLE
sessions: fix comm cleanup during mpi_finalize

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -326,6 +326,8 @@ static int ompi_comm_finalize (void)
         OBJ_DESTRUCT( &ompi_mpi_comm_self );
         /* Shut down MPI_COMM_WORLD */
         OBJ_DESTRUCT( &ompi_mpi_comm_world );
+
+        ompi_comm_intrinsic_init = false;
     }
 
     /* Shut down the parent communicator, if it exists */


### PR DESCRIPTION
without this patch MPI_Session_finalize fails after a call to MPI_Finalize.

Related to #10927

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 6341a8389011730924d38ee4c54852e82c98cdf2)