### PR TITLE
Fix resource leak reported by coverity scan report CID 1515756

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -110,6 +110,7 @@ static void setup_mca_prefixes(void)
     char *env_str = opal_argv_join(tmp, ',');
     opal_setenv("OMPI_MCA_PREFIXES", env_str, true,
                 &environ);
+    free(env_str);
 
     opal_argv_free(tmp);
 }


### PR DESCRIPTION
Free env_str after use by opal_setenv. The opal_setenv function will copy the value as does the original setenv.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>