### PR TITLE
add accelerator and part frameworks to mca lists

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -96,14 +96,15 @@ static void ompi_instance_destruct(ompi_instance_t *instance)
 
 OBJ_CLASS_INSTANCE(ompi_instance_t, opal_infosubscriber_t, ompi_instance_construct, ompi_instance_destruct);
 
-/* NTH: frameworks needed by MPI */
+/* OMPI MCA frameworks needed by MPI.  New frameworks need to be added to this list */
 static mca_base_framework_t *ompi_framework_dependencies[] = {
     &ompi_hook_base_framework, &ompi_op_base_framework,
     &opal_allocator_base_framework, &opal_rcache_base_framework, &opal_mpool_base_framework, &opal_smsc_base_framework,
     &ompi_bml_base_framework, &ompi_pml_base_framework, &ompi_coll_base_framework,
-    &ompi_osc_base_framework, NULL,
+    &ompi_osc_base_framework, &ompi_part_base_framework, NULL,
 };
 
+/* OMPI MCA frameworks that can be opened multiple times need to be added to this list */
 static mca_base_framework_t *ompi_lazy_frameworks[] = {
     &ompi_io_base_framework, &ompi_topo_base_framework, NULL,
 };
@@ -642,11 +643,7 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
         return ompi_instance_print_error ("ompi_win_init() failed", ret);
     }
 
-    /* initialize partcomm */
-    if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_part_base_framework, 0))) {
-        return ompi_instance_print_error ("mca_part_base_select() failed", ret);
-    }
-
+    /* select partcomm */
     if (OMPI_SUCCESS != (ret = mca_part_base_select (true, true))) {
         return ompi_instance_print_error ("mca_part_base_select() failed", ret);
     }

--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
@@ -35,6 +35,8 @@ static int accelerator_event_max = 400;
 static int accelerator_event_ipc_most = 0;
 static bool smcuda_accelerator_initialized = false;
 
+static void mca_btl_smcuda_accelerator_fini(void);
+
 int mca_btl_smcuda_accelerator_init(void)
 {
     int rc = OPAL_SUCCESS;
@@ -79,6 +81,7 @@ int mca_btl_smcuda_accelerator_init(void)
         goto cleanup_and_error;
     }
 
+    opal_finalize_register_cleanup(mca_btl_smcuda_accelerator_fini);
     smcuda_accelerator_initialized = true;
 
 cleanup_and_error:
@@ -103,7 +106,7 @@ cleanup_and_error:
     return rc;
 }
 
-void mca_btl_smcuda_accelerator_fini(void)
+static void mca_btl_smcuda_accelerator_fini(void)
 {
     int i;
 

--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.h
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.h
@@ -17,7 +17,6 @@
 #include "opal/mca/btl/btl.h"
 
 OPAL_DECLSPEC int mca_btl_smcuda_accelerator_init(void);
-OPAL_DECLSPEC void mca_btl_smcuda_accelerator_fini(void);
 OPAL_DECLSPEC int mca_btl_smcuda_progress_one_ipc_event(struct mca_btl_base_descriptor_t **frag);
 OPAL_DECLSPEC int mca_btl_smcuda_memcpy(void *dst, void *src, size_t amount, char *msg,
                            struct mca_btl_base_descriptor_t *frag);

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -18,6 +18,8 @@
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,6 +70,7 @@ static int mca_btl_smcuda_component_close(void);
 static int smcuda_register(void);
 static mca_btl_base_module_t **
 mca_btl_smcuda_component_init(int *num_btls, bool enable_progress_threads, bool enable_mpi_threads);
+static void mca_btl_smcuda_component_fini(void);
 
 typedef enum {
     MCA_BTL_SM_RNDV_MOD_SM = 0,
@@ -260,6 +263,9 @@ static int mca_btl_smcuda_component_open(void)
     OBJ_CONSTRUCT(&mca_btl_smcuda_component.sm_frags_max, opal_free_list_t);
     OBJ_CONSTRUCT(&mca_btl_smcuda_component.sm_frags_user, opal_free_list_t);
     OBJ_CONSTRUCT(&mca_btl_smcuda_component.pending_send_fl, opal_free_list_t);
+
+    opal_finalize_register_cleanup(mca_btl_smcuda_component_fini);
+
     return OPAL_SUCCESS;
 }
 
@@ -269,7 +275,12 @@ static int mca_btl_smcuda_component_open(void)
 
 static int mca_btl_smcuda_component_close(void)
 {
-    int return_value = OPAL_SUCCESS;
+    return OPAL_SUCCESS;
+}
+
+static void mca_btl_smcuda_component_fini(void)
+{
+    int rc;
 
     OBJ_DESTRUCT(&mca_btl_smcuda_component.sm_lock);
     /**
@@ -282,11 +293,11 @@ static int mca_btl_smcuda_component_close(void)
 
     /* unmap the shared memory control structure */
     if (mca_btl_smcuda_component.sm_seg != NULL) {
-        return_value = mca_common_sm_fini(mca_btl_smcuda_component.sm_seg);
-        if (OPAL_SUCCESS != return_value) {
-            return_value = OPAL_ERROR;
+        rc = mca_common_sm_fini(mca_btl_smcuda_component.sm_seg);
+        if (OPAL_SUCCESS != rc) {
+            rc = OPAL_ERROR;
             opal_output(0, " mca_common_sm_fini failed\n");
-            goto CLEANUP;
+            return;
         }
 
         /* unlink file, so that it will be deleted when all references
@@ -311,12 +322,8 @@ static int mca_btl_smcuda_component_close(void)
     }
 #endif
 
-CLEANUP:
-
-    mca_btl_smcuda_accelerator_fini();
-
     /* return */
-    return return_value;
+    return;
 }
 
 /*


### PR DESCRIPTION
This patch adds part framework to the list of ompi frameworks opened when the core of open mpi initialized and
closed when the ref cnt on the ompi core drops back to zero.

Likewise, the accelerator framework is added to the opal frameworks list.

Add some verbiage that will hopefully show where to add new frameworks in the opal/ompi initialization procedures.

Related to #10938

Signed-off-by: Howard Pritchard <howardp@lanl.gov>