### PR TITLE
opal_check_cuda.m4: Add AC_ARG_WITH for libdir option

### DIFF
--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -50,6 +50,9 @@ AC_ARG_WITH([cuda],
             [AS_HELP_STRING([--with-cuda(=DIR)],
             [Build cuda support, optionally adding DIR/include])])
 AC_MSG_CHECKING([if --with-cuda is set])
+AC_ARG_WITH([cuda-libdir],
+            [AS_HELP_STRING([--with-cuda-libdir=DIR],
+                            [Search for CUDA libraries in DIR])])
 
 # Note that CUDA support is off by default.  To turn it on, the user has to
 # request it.  The user can just ask for --with-cuda and it that case we


### PR DESCRIPTION
Without this, using --with-cuda-libdir will output a warning as follows that does not impact functionality but is misleading.

configure: WARNING: unrecognized options: --with-cuda-libdir

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit c95fa2c38c88b31be247bd0bcb2811a281b3a2aa)