### PR TITLE
Part 2 of resolving global symbol name pollution issue #10708 for OMPI v5.0.x

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -335,7 +336,7 @@ int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *dataty
     }
 
     return ompi_coll_adapt_ibcast_generic(buff, count, datatype, root, comm, request, module,
-                                          adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ibcast_algorithm),
+                                          ompi_coll_adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ibcast_algorithm),
                                           mca_coll_adapt_component.adapt_ibcast_segment_size);
 }
 

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -504,7 +505,8 @@ int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi
 
 
     return ompi_coll_adapt_ireduce_generic(sbuf, rbuf, count, dtype, op, root, comm, request, module,
-                                           adapt_module_cached_topology(module, comm, root, mca_coll_adapt_component.adapt_ireduce_algorithm),
+                                           ompi_coll_adapt_module_cached_topology(module, comm, root,
+                                        		                                            mca_coll_adapt_component.adapt_ireduce_algorithm),
                                            mca_coll_adapt_component.adapt_ireduce_segment_size);
 
 }

--- a/ompi/mca/coll/adapt/coll_adapt_module.c
+++ b/ompi/mca/coll/adapt/coll_adapt_module.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -66,8 +67,8 @@ static void adapt_module_construct(mca_coll_adapt_module_t * module)
 static void adapt_module_destruct(mca_coll_adapt_module_t * module)
 {
     if (NULL != module->topo_cache) {
-        adapt_topology_cache_item_t *item;
-        while (NULL != (item = (adapt_topology_cache_item_t*)opal_list_remove_first(module->topo_cache))) {
+        ompi_coll_adapt_topology_cache_item_t *item;
+        while (NULL != (item = (ompi_coll_adapt_topology_cache_item_t*)opal_list_remove_first(module->topo_cache))) {
             OBJ_RELEASE(item);
         }
         OBJ_RELEASE(module->topo_cache);

--- a/ompi/mca/coll/adapt/coll_adapt_topocache.c
+++ b/ompi/mca/coll/adapt/coll_adapt_topocache.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,14 +15,14 @@
 
 #include "ompi/communicator/communicator.h"
 
-static void destruct_topology_cache(adapt_topology_cache_item_t *item)
+static void destruct_topology_cache(ompi_coll_adapt_topology_cache_item_t *item)
 {
     if (NULL != item->tree) {
         ompi_coll_base_topo_destroy_tree(&item->tree);
     }
 }
 
-OBJ_CLASS_INSTANCE(adapt_topology_cache_item_t, opal_list_item_t,
+OBJ_CLASS_INSTANCE(ompi_coll_adapt_topology_cache_item_t, opal_list_item_t,
                    NULL, &destruct_topology_cache);
 
 static ompi_coll_tree_t *create_topology(
@@ -73,17 +74,17 @@ static ompi_coll_tree_t *create_topology(
     }
 }
 
-ompi_coll_tree_t* adapt_module_cached_topology(
+ompi_coll_tree_t* ompi_coll_adapt_module_cached_topology(
     mca_coll_base_module_t *module,
     struct ompi_communicator_t *comm,
     int root,
     ompi_coll_adapt_algorithm_t algorithm)
 {
     mca_coll_adapt_module_t *adapt_module = (mca_coll_adapt_module_t*)module;
-    adapt_topology_cache_item_t *item;
+    ompi_coll_adapt_topology_cache_item_t *item;
     ompi_coll_tree_t * tree;
     if (NULL != adapt_module->topo_cache) {
-        OPAL_LIST_FOREACH(item, adapt_module->topo_cache, adapt_topology_cache_item_t) {
+        OPAL_LIST_FOREACH(item, adapt_module->topo_cache, ompi_coll_adapt_topology_cache_item_t) {
             if (item->root == root && item->algorithm == algorithm) {
                 return item->tree;
             }
@@ -95,7 +96,7 @@ ompi_coll_tree_t* adapt_module_cached_topology(
     /* topology not found, create one */
     tree = create_topology(algorithm, root, comm);
 
-    item = OBJ_NEW(adapt_topology_cache_item_t);
+    item = OBJ_NEW(ompi_coll_adapt_topology_cache_item_t);
     item->tree = tree;
     item->root = root;
     item->algorithm = algorithm;

--- a/ompi/mca/coll/adapt/coll_adapt_topocache.h
+++ b/ompi/mca/coll/adapt/coll_adapt_topocache.h
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,12 +25,12 @@ typedef struct adapt_topology_cache_item_t {
     ompi_coll_tree_t *tree;
     int root;
     ompi_coll_adapt_algorithm_t algorithm;
-} adapt_topology_cache_item_t;
+} ompi_coll_adapt_topology_cache_item_t;
 
-OBJ_CLASS_DECLARATION(adapt_topology_cache_item_t);
+OBJ_CLASS_DECLARATION(ompi_coll_adapt_topology_cache_item_t);
 
 
-OMPI_DECLSPEC ompi_coll_tree_t* adapt_module_cached_topology(
+OMPI_DECLSPEC ompi_coll_tree_t* ompi_coll_adapt_module_cached_topology(
     mca_coll_base_module_t *module,
     struct ompi_communicator_t *comm,
     int root,

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  *
  * $COPYRIGHT$
@@ -132,9 +133,9 @@ typedef struct {
                                               *   containing the value on which the agreement is done */
     int                 *new_dead_array;     /**< array of header.nb_new_dead integers with the newly discovered
                                               *   processes. */
-} era_value_t;
+} ompi_coll_ftagree_era_value_t;
 
-static void  era_value_constructor (era_value_t *value)
+static void  era_value_constructor (ompi_coll_ftagree_era_value_t *value)
 {
     value->header.ret = 0;
     value->header.operand = -1;
@@ -147,7 +148,7 @@ static void  era_value_constructor (era_value_t *value)
     value->new_dead_array = NULL;
 }
 
-static void  era_value_destructor (era_value_t *value)
+static void  era_value_destructor (ompi_coll_ftagree_era_value_t *value)
 {
     if( NULL != value->bytes )
         free(value->bytes);
@@ -155,7 +156,7 @@ static void  era_value_destructor (era_value_t *value)
         free(value->new_dead_array);
 }
 
-OBJ_CLASS_INSTANCE(era_value_t, opal_object_t, era_value_constructor, era_value_destructor);
+OBJ_CLASS_INSTANCE(ompi_coll_ftagree_era_value_t, opal_object_t, era_value_constructor, era_value_destructor);
 
 typedef struct {
     era_msg_type_t      msg_type;
@@ -197,9 +198,9 @@ typedef struct {
 typedef struct {
     opal_list_item_t super;
     int32_t          rank;        /**< The rank of the descendent that provided information */
-} era_rank_item_t;
+} ompi_coll_ftagree_era_rank_item_t;
 
-OBJ_CLASS_INSTANCE(era_rank_item_t, opal_list_item_t, NULL, NULL /*print_destructor*/);
+OBJ_CLASS_INSTANCE(ompi_coll_ftagree_era_rank_item_t, opal_list_item_t, NULL, NULL /*print_destructor*/);
 
 /**
  * topology-dependent tree structure
@@ -227,9 +228,9 @@ typedef struct era_comm_agreement_specific_s {
     int           acked_ra_size;
     int          *acked_ra;
     int           ags_status;
-} era_comm_agreement_specific_t;
+} ompi_coll_ftagree_era_comm_agreement_specific_t;
 
-static void  era_agreement_comm_specific_constructor(era_comm_agreement_specific_t *comm_specific)
+static void  era_agreement_comm_specific_constructor(ompi_coll_ftagree_era_comm_agreement_specific_t *comm_specific)
 {
     comm_specific->agreed_failed_ranks = NULL;
     comm_specific->afr_size            = 0;
@@ -240,7 +241,7 @@ static void  era_agreement_comm_specific_constructor(era_comm_agreement_specific
     comm_specific->ags_status          = AGS_TREE_DIRTY | AGS_AFR_DIRTY; /**< the AGS does not exist, so it needs to be created */
 }
 
-static void  era_agreement_comm_specific_destructor(era_comm_agreement_specific_t *comm_specific)
+static void  era_agreement_comm_specific_destructor(ompi_coll_ftagree_era_comm_agreement_specific_t *comm_specific)
 {
     if( NULL != comm_specific->agreed_failed_ranks ) {
         free(comm_specific->agreed_failed_ranks );
@@ -253,12 +254,12 @@ static void  era_agreement_comm_specific_destructor(era_comm_agreement_specific_
     }
 }
 
-OBJ_CLASS_INSTANCE(era_comm_agreement_specific_t,
+OBJ_CLASS_INSTANCE(ompi_coll_ftagree_era_comm_agreement_specific_t,
                    opal_object_t,
                    era_agreement_comm_specific_constructor,
                    era_agreement_comm_specific_destructor);
 
-#define AGS(comm)  ( (era_comm_agreement_specific_t*)(comm)->agreement_specific )
+#define AGS(comm)  ( (ompi_coll_ftagree_era_comm_agreement_specific_t*)(comm)->agreement_specific )
 
 /* This mutex is used for both thread safety and to prevent recursive
  * invocation of ERA callbacks; ERA callbacks are not reentrant. Hence,
@@ -279,7 +280,7 @@ static opal_mutex_t era_mutex;
 static opal_mutex_t era_incomplete_msg_mutex;
 
 
-typedef struct era_iagree_request_s era_iagree_request_t;
+typedef struct era_iagree_request_s ompi_coll_ftagree_era_iagree_request_t;
 
 /**
  * Main structure to remember the current status of an agreement that
@@ -288,13 +289,15 @@ typedef struct era_iagree_request_s era_iagree_request_t;
 typedef struct {
     opal_object_t         super;
     era_identifier_t      agreement_id;
-    era_value_t          *current_value;
+    ompi_coll_ftagree_era_value_t          *current_value;
     era_proc_status_t     status;            /**< status of this process in that agreement. */
     uint16_t              min_passed_aid;
     ompi_communicator_t  *comm;              /**< Communicator related to that agreement. Might be NULL
                                               *   if this process has not entered the agreement yet.*/
-    era_iagree_request_t *req;               /**< Request, if this is called through an iagree */
-    era_comm_agreement_specific_t *ags;      /**< Communicator-specific agreement information, at
+    ompi_coll_ftagree_era_iagree_request_t *req;
+                                             /**< Request, if this is called through an iagree */
+    ompi_coll_ftagree_era_comm_agreement_specific_t *ags;
+                                             /**< Communicator-specific agreement information, at
                                               *   the time this agreement was started (might be different
                                               *   from comm->ags during the agreement) */
     int                   nb_acked;          /**< size of acked */
@@ -309,13 +312,13 @@ typedef struct {
                                               *   and passing over the passed agreements after the decision is taken
                                               *   is too slow */
     int                   waiting_down_from; /**< If in BROADCAST state: who is supposed to send me the info */
-} era_agreement_info_t;
+} ompi_coll_ftagree_era_agreement_info_t;
 
-static void era_build_tree_structure(era_agreement_info_t *ci);
-static int era_next_child(era_agreement_info_t *ci, int prev_child_in_comm);
-static int era_parent(era_agreement_info_t *ci);
+static void era_build_tree_structure(ompi_coll_ftagree_era_agreement_info_t *ci);
+static int era_next_child(ompi_coll_ftagree_era_agreement_info_t *ci, int prev_child_in_comm);
+static int era_parent(ompi_coll_ftagree_era_agreement_info_t *ci);
 
-static void  era_agreement_info_constructor (era_agreement_info_t *agreement_info)
+static void  era_agreement_info_constructor (ompi_coll_ftagree_era_agreement_info_t *agreement_info)
 {
     agreement_info->agreement_id.ERAID_KEY = 0;
     agreement_info->status = NOT_CONTRIBUTED | OP_NOT_DEFINED;
@@ -335,7 +338,7 @@ static void  era_agreement_info_constructor (era_agreement_info_t *agreement_inf
                          (void*)agreement_info));
 }
 
-static void  era_agreement_info_destructor (era_agreement_info_t *agreement_info)
+static void  era_agreement_info_destructor (ompi_coll_ftagree_era_agreement_info_t *agreement_info)
 {
     opal_list_item_t *li;
     while( NULL != (li = opal_list_remove_first(&agreement_info->early_requesters)) ) {
@@ -365,7 +368,7 @@ static void  era_agreement_info_destructor (era_agreement_info_t *agreement_info
     agreement_info->req = NULL;
 }
 
-OBJ_CLASS_INSTANCE(era_agreement_info_t,
+OBJ_CLASS_INSTANCE(ompi_coll_ftagree_era_agreement_info_t,
                    opal_object_t,
                    era_agreement_info_constructor,
                    era_agreement_info_destructor);
@@ -375,10 +378,10 @@ struct era_iagree_request_s {
     era_identifier_t      agreement_id;
     void                 *contrib;
     ompi_group_t        **outgroup;
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
 };
 
-OBJ_CLASS_INSTANCE(era_iagree_request_t,
+OBJ_CLASS_INSTANCE(ompi_coll_ftagree_era_iagree_request_t,
                    ompi_request_t,
                    NULL,
                    NULL);
@@ -431,22 +434,22 @@ static const char *era_msg_type_to_string(int type) {
 }
 #endif /* OPAL_ENABLE_DEBUG */
 
-static era_agreement_info_t *era_lookup_agreement_info(era_identifier_t agreement_id)
+static ompi_coll_ftagree_era_agreement_info_t *era_lookup_agreement_info(era_identifier_t agreement_id)
 {
     void *value;
 
     if( opal_hash_table_get_value_uint64(&era_ongoing_agreements,
                                          agreement_id.ERAID_KEY,
                                          &value) == OPAL_SUCCESS ) {
-        return (era_agreement_info_t *)value;
+        return (ompi_coll_ftagree_era_agreement_info_t *)value;
     } else {
         return NULL;
     }
 }
 
-static era_agreement_info_t *era_create_agreement_info(era_identifier_t agreement_id, era_value_header_t *header)
+static ompi_coll_ftagree_era_agreement_info_t *era_create_agreement_info(era_identifier_t agreement_id, era_value_header_t *header)
 {
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
     int r;
     size_t value_bytes;
 #if OPAL_ENABLE_DEBUG
@@ -455,9 +458,9 @@ static era_agreement_info_t *era_create_agreement_info(era_identifier_t agreemen
                                              agreement_id.ERAID_KEY,
                                              &value) != OPAL_SUCCESS );
 #endif /* OPAL_ENABLE_DEBUG */
-    ci = OBJ_NEW(era_agreement_info_t);
+    ci = OBJ_NEW(ompi_coll_ftagree_era_agreement_info_t);
     ci->agreement_id.ERAID_KEY = agreement_id.ERAID_KEY;
-    ci->current_value = OBJ_NEW(era_value_t);
+    ci->current_value = OBJ_NEW(ompi_coll_ftagree_era_value_t);
     memcpy(&ci->current_value->header, header, sizeof(era_value_header_t));
 
     assert( header->datatype >= 0 && header->datatype < OMPI_DATATYPE_MPI_MAX_PREDEFINED );
@@ -516,7 +519,7 @@ static void era_debug_print_group(int lvl, ompi_group_t *group, ompi_communicato
 #define era_debug_print_group(g, c, i, h) do {} while(0)
 #endif /* OPAL_ENABLE_DEBUG */
 
-static void era_update_return_value(era_agreement_info_t *ci, int nb_acked, int *acked) {
+static void era_update_return_value(ompi_coll_ftagree_era_agreement_info_t *ci, int nb_acked, int *acked) {
     ompi_group_t *ack_after_agreement_group, *tmp_sub_group;
     int r, abag_array[3];
 
@@ -667,7 +670,7 @@ static int compare_uint16_ts(const void *a, const void *b)
     return (*ia > *ib) - (*ia < *ib);
 }
 
-static void era_merge_new_dead_list(era_agreement_info_t *ci, int nb_src, int *src)
+static void era_merge_new_dead_list(ompi_coll_ftagree_era_agreement_info_t *ci, int nb_src, int *src)
 {
     int  s;
     int *dst, d, nb_dst;
@@ -728,7 +731,7 @@ static void era_merge_new_dead_list(era_agreement_info_t *ci, int nb_src, int *s
     free(merge);
 }
 
-static void era_agreement_value_set_gcrange(era_identifier_t eid, era_value_t *era_value)
+static void era_agreement_value_set_gcrange(era_identifier_t eid, ompi_coll_ftagree_era_value_t *era_value)
 {
     uint16_t *aid_list = NULL;
     uint64_t key64;
@@ -779,10 +782,10 @@ static void era_agreement_value_set_gcrange(era_identifier_t eid, era_value_t *e
 
 }
 
-static void era_update_new_dead_list(era_agreement_info_t *ci)
+static void era_update_new_dead_list(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     int *ra, s, r, t;
-    era_comm_agreement_specific_t *ags;
+    ompi_coll_ftagree_era_comm_agreement_specific_t *ags;
     ompi_communicator_t *comm;
 
     comm = ci->comm;
@@ -833,9 +836,9 @@ static void era_update_new_dead_list(era_agreement_info_t *ci)
     free(ra);
 }
 
-static void era_ci_get_clean_ags_copy(era_agreement_info_t *ci)
+static void era_ci_get_clean_ags_copy(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
-    era_comm_agreement_specific_t *old, *new;
+    ompi_coll_ftagree_era_comm_agreement_specific_t *old, *new;
 
     if( AGS(ci->comm)->ags_status & (AGS_TREE_DIRTY | AGS_AFR_DIRTY) ) {
         old = AGS(ci->comm);
@@ -846,7 +849,7 @@ static void era_ci_get_clean_ags_copy(era_agreement_info_t *ci)
              *  reuse it: create a copy for the other cis that point to it,
              *  and attach that new copy to the communicator, then update it.
              */
-            new = OBJ_NEW(era_comm_agreement_specific_t);
+            new = OBJ_NEW(ompi_coll_ftagree_era_comm_agreement_specific_t);
             if( old->afr_size > 0 ) {
                 /** old does not need to remember the agreed_failed ranks, avoid allocating memory */
                 new->agreed_failed_ranks = old->agreed_failed_ranks;
@@ -894,7 +897,7 @@ static void era_ci_get_clean_ags_copy(era_agreement_info_t *ci)
     }
 }
 
-static void era_agreement_info_set_comm(era_agreement_info_t *ci, ompi_communicator_t *comm, ompi_group_t *acked_group)
+static void era_agreement_info_set_comm(ompi_coll_ftagree_era_agreement_info_t *ci, ompi_communicator_t *comm, ompi_group_t *acked_group)
 {
     int *src_ra;
     int r, grp_size;
@@ -914,7 +917,7 @@ static void era_agreement_info_set_comm(era_agreement_info_t *ci, ompi_communica
                          ompi_comm_print_cid(comm)));
 
     if( AGS(comm) == NULL ) {
-        era_comm_agreement_specific_t *ags = OBJ_NEW(era_comm_agreement_specific_t);
+        ompi_coll_ftagree_era_comm_agreement_specific_t *ags = OBJ_NEW(ompi_coll_ftagree_era_comm_agreement_specific_t);
         comm->agreement_specific = &ags->parent;
     }
 
@@ -964,13 +967,13 @@ static void send_msg(ompi_communicator_t *comm,
                      opal_process_name_t *proc_name,
                      era_identifier_t agreement_id,
                      era_msg_type_t type,
-                     era_value_t *value,
+                     ompi_coll_ftagree_era_value_t *value,
                      int          nb_up_msg,
                      int         *ack_failed);
 
 #define ERA_TAG_AGREEMENT MCA_COLL_BASE_TAG_AGREEMENT
 
-static void era_combine_agreement_values(era_agreement_info_t *ni, era_value_t *value)
+static void era_combine_agreement_values(ompi_coll_ftagree_era_agreement_info_t *ni, ompi_coll_ftagree_era_value_t *value)
 {
     ompi_op_t *op;
     ompi_datatype_t *dt;
@@ -1157,7 +1160,7 @@ typedef struct {
     era_tree_t *tree;
 } hierarch_tree_info_t;
 
-static void era_call_tree_fn(era_agreement_info_t *ci)
+static void era_call_tree_fn(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
 #if 0
     hierarch_tree_info_t *reps, *rep_p;
@@ -1342,7 +1345,7 @@ static char *era_debug_tree(era_tree_t *tree, int tree_size)
 }
 #endif /* OPAL_ENABLE_DEBUG */
 
-static void era_build_tree_structure(era_agreement_info_t *ci)
+static void era_build_tree_structure(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     int m, n;
     int offset, next_dead_idx;
@@ -1385,7 +1388,7 @@ static void era_build_tree_structure(era_agreement_info_t *ci)
 #endif /* OPAL_ENABLE_DEBUG */
 }
 
-static int era_tree_rank_from_comm_rank(era_agreement_info_t *ci, int r_in_comm)
+static int era_tree_rank_from_comm_rank(ompi_coll_ftagree_era_agreement_info_t *ci, int r_in_comm)
 {
     int r_in_tree = r_in_comm >= ci->ags->tree_size ? ci->ags->tree_size-1 : r_in_comm;
 
@@ -1400,7 +1403,7 @@ static int era_tree_rank_from_comm_rank(era_agreement_info_t *ci, int r_in_comm)
     return r_in_tree;
 }
 
-static void era_tree_remove_node(era_agreement_info_t *ci, int r_in_tree)
+static void era_tree_remove_node(ompi_coll_ftagree_era_agreement_info_t *ci, int r_in_tree)
 {
     /** All indices are in tree */
     int p, c, s, t;
@@ -1520,7 +1523,7 @@ static void era_tree_remove_node(era_agreement_info_t *ci, int r_in_tree)
 #endif /* OPAL_ENABLE_DEBUG */
 }
 
-static int era_parent(era_agreement_info_t *ci)
+static int era_parent(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     int r_in_comm = ompi_comm_rank(ci->comm);
     int r_in_tree = era_tree_rank_from_comm_rank(ci, r_in_comm);
@@ -1538,7 +1541,7 @@ static int era_parent(era_agreement_info_t *ci)
     }
 }
 
-static int era_next_child(era_agreement_info_t *ci, int prev_child_in_comm)
+static int era_next_child(ompi_coll_ftagree_era_agreement_info_t *ci, int prev_child_in_comm)
 {
     ompi_communicator_t *comm = ci->comm;
     int prev_child_in_tree;
@@ -1603,7 +1606,7 @@ static void era_collect_passed_agreements(era_identifier_t agreement_id, uint16_
         for(r = min_aid; r <= max_aid; r++) {
             pid.ERAID_FIELDS.agreementid = r;
             if( opal_hash_table_get_value_uint64(&era_passed_agreements, pid.ERAID_KEY, &value) == OMPI_SUCCESS ) {
-                era_value_t *av = (era_value_t*)value;
+                ompi_coll_ftagree_era_value_t *av = (ompi_coll_ftagree_era_value_t*)value;
                 opal_hash_table_remove_value_uint64(&era_passed_agreements, pid.ERAID_KEY);
                 OBJ_RELEASE(av);
                 OPAL_OUTPUT_VERBOSE((17, ompi_ftmpi_output_handle,
@@ -1621,10 +1624,10 @@ static void era_collect_passed_agreements(era_identifier_t agreement_id, uint16_
     }
 }
 
-static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
+static void era_decide(ompi_coll_ftagree_era_value_t *decided_value, ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     ompi_communicator_t *comm;
-    era_rank_item_t *rl;
+    ompi_coll_ftagree_era_rank_item_t *rl;
     int r, s, dead_size;
 
     assert( 0 != ci->agreement_id.ERAID_FIELDS.agreementid );
@@ -1638,8 +1641,8 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
          * If the value was already decided, then this DOWN message
          * *must* provide the same decision: it can only be a duplicate.
          */
-        era_value_t *old_agreement_value;
-        old_agreement_value = (era_value_t*)value;
+        ompi_coll_ftagree_era_value_t *old_agreement_value;
+        old_agreement_value = (ompi_coll_ftagree_era_value_t*)value;
         assert( old_agreement_value->header.ret == decided_value->header.ret &&
                 old_agreement_value->header.nb_new_dead == decided_value->header.nb_new_dead );
     }
@@ -1751,9 +1754,9 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
 
         /** Cleanup the early_requesters list, to avoid sending unnecessary duplicate messages */
         if( opal_list_get_size(&ci->early_requesters) > 0 ) {
-            for(rl = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
-                rl != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
-                rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+            for(rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+                rl != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+                rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rl->super)) {
                 if( rl->rank == r ) {
                     opal_list_remove_item(&ci->early_requesters, &rl->super);
                     break;
@@ -1766,9 +1769,9 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
 
     /* In case we have some child we haven't detected yet */
     if( opal_list_get_size(&ci->early_requesters) > 0 ) {
-        for(rl = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
-            rl != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
-            rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+        for(rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+            rl != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+            rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rl->super)) {
             send_msg(comm, rl->rank, NULL, ci->agreement_id, MSG_DOWN, decided_value, 0, NULL);
         }
     }
@@ -1789,10 +1792,10 @@ static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
     }
 }
 
-static void era_check_status(era_agreement_info_t *ci)
+static void era_check_status(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     int r;
-    era_rank_item_t *rl;
+    ompi_coll_ftagree_era_rank_item_t *rl;
 
     OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
                          "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, current status = %s\n",
@@ -1823,9 +1826,9 @@ static void era_check_status(era_agreement_info_t *ci)
                                  ci->agreement_id.ERAID_FIELDS.epoch,
                                  ci->agreement_id.ERAID_FIELDS.agreementid,
                                  r));
-            for( rl =  (era_rank_item_t*)opal_list_get_first(&ci->gathered_info);
-                 rl != (era_rank_item_t*)opal_list_get_end(&ci->gathered_info);
-                 rl =  (era_rank_item_t*)opal_list_get_next(&rl->super) ) {
+            for( rl =  (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->gathered_info);
+                 rl != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->gathered_info);
+                 rl =  (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rl->super) ) {
                 if( rl->rank == r ) {
                     OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
                                          "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, child %d has sent its message\n",
@@ -1837,7 +1840,7 @@ static void era_check_status(era_agreement_info_t *ci)
                     break;
                 }
             }
-            if( rl == (era_rank_item_t*)opal_list_get_end(&ci->gathered_info) ) {
+            if( rl == (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->gathered_info) ) {
                 OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
                                      "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, some children have not contributed\n",
                                      OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
@@ -1880,10 +1883,10 @@ static void era_check_status(era_agreement_info_t *ci)
     }
 }
 
-static void restart_agreement_from_me(era_agreement_info_t *ci)
+static void restart_agreement_from_me(ompi_coll_ftagree_era_agreement_info_t *ci)
 {
     int r;
-    era_rank_item_t *rc;
+    ompi_coll_ftagree_era_rank_item_t *rc;
     assert( NULL != ci->comm );
     assert( 0 == opal_list_get_size(&ci->waiting_res_from) );
 
@@ -1900,7 +1903,7 @@ static void restart_agreement_from_me(era_agreement_info_t *ci)
      */
     r = -1;
     while( (r = era_next_child(ci, r)) != ompi_comm_size(ci->comm) ) {
-        rc = OBJ_NEW(era_rank_item_t);
+        rc = OBJ_NEW(ompi_coll_ftagree_era_rank_item_t);
         rc->rank = r;
         opal_list_append(&ci->waiting_res_from, &rc->super);
         send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_RESULT_REQUEST, ci->current_value,
@@ -1917,25 +1920,25 @@ static void restart_agreement_from_me(era_agreement_info_t *ci)
 /* helper to bounce recursive errors back from to the main thread opal_progress */
 typedef struct era_error_event_s {
     opal_event_t ev;
-    era_agreement_info_t* ci;
+    ompi_coll_ftagree_era_agreement_info_t* ci;
     int rank;
 } era_error_event_t;
 
-static void era_mark_process_failed(era_agreement_info_t *ci, int rank);
+static void era_mark_process_failed(ompi_coll_ftagree_era_agreement_info_t *ci, int rank);
 
 static void *era_error_event_cb(int fd, int flags, void *context) {
     era_error_event_t *event = (era_error_event_t*) context;
     int r = event->rank;
-    era_agreement_info_t* ci = event->ci;
+    ompi_coll_ftagree_era_agreement_info_t* ci = event->ci;
     free(event);
     era_mark_process_failed(ci, r);
     return NULL;
 }
 
-static void era_mark_process_failed(era_agreement_info_t *ci, int rank)
+static void era_mark_process_failed(ompi_coll_ftagree_era_agreement_info_t *ci, int rank)
 {
     int r;
-    era_rank_item_t *rl;
+    ompi_coll_ftagree_era_rank_item_t *rl;
 
     assert( ci->comm == NULL || (ci->comm->c_local_group->grp_my_rank != rank) );
 
@@ -2022,9 +2025,9 @@ static void era_mark_process_failed(era_agreement_info_t *ci, int rank)
                              ci->agreement_id.ERAID_FIELDS.agreementid));
         OBJ_RETAIN(ci);
         /* It could be one of the guys that we contacted about a restarting agreement. */
-        for(rl = (era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
-            rl != (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
-            rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+        for(rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
+            rl != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
+            rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rl->super)) {
             if(rl->rank == rank) {
                 OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
                                      "%s ftagree:agreement (ERA) Handling failure of process %d: I was waiting for the contribution of that process for Agreement (%d.%d).%d.\n",
@@ -2045,15 +2048,15 @@ static void era_mark_process_failed(era_agreement_info_t *ci, int rank)
                  */
                 r = -1;
                 while( (r = era_next_child(ci, r)) != ompi_comm_size(ci->comm) ) {
-                    for(rl = (era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
-                        rl != (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
-                        rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+                    for(rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
+                        rl != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
+                        rl = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rl->super)) {
                         if( rl->rank == r ) {
                             break;
                         }
                     }
 
-                    if( rl == (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from) ) {
+                    if( rl == (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from) ) {
                         OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
                                              "%s ftagree:agreement (ERA) Handling failure of process %d: Requesting contribution of process %d for Agreement (%d.%d).%d.\n",
                                              OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
@@ -2061,7 +2064,7 @@ static void era_mark_process_failed(era_agreement_info_t *ci, int rank)
                                              ci->agreement_id.ERAID_FIELDS.contextid,
                                              ci->agreement_id.ERAID_FIELDS.epoch,
                                              ci->agreement_id.ERAID_FIELDS.agreementid));
-                        rl = OBJ_NEW(era_rank_item_t);
+                        rl = OBJ_NEW(ompi_coll_ftagree_era_rank_item_t);
                         rl->rank = r;
                         opal_list_append(&ci->waiting_res_from, &rl->super);
                         send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_RESULT_REQUEST, ci->current_value,
@@ -2096,7 +2099,7 @@ static void send_msg(ompi_communicator_t *comm,
                      opal_process_name_t *proc_name,
                      era_identifier_t agreement_id,
                      era_msg_type_t type,
-                     era_value_t *value,
+                     ompi_coll_ftagree_era_value_t *value,
                      int          nb_ack_failed,
                      int         *ack_failed)
 {
@@ -2333,8 +2336,8 @@ static void send_msg(ompi_communicator_t *comm,
 static void result_request(era_msg_header_t *msg_header)
 {
     void *value;
-    era_value_t *old_agreement_value;
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_value_t *old_agreement_value;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
     int r;
 
     OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
@@ -2349,7 +2352,7 @@ static void result_request(era_msg_header_t *msg_header)
     if( opal_hash_table_get_value_uint64(&era_passed_agreements,
                                          msg_header->agreement_id.ERAID_KEY,
                                          &value) == OPAL_SUCCESS ) {
-        old_agreement_value = (era_value_t*)value;
+        old_agreement_value = (ompi_coll_ftagree_era_value_t*)value;
         send_msg(NULL, msg_header->src_comm_rank, &msg_header->src_proc_name, msg_header->agreement_id, MSG_DOWN, old_agreement_value, 0, NULL);
         return;
     }
@@ -2378,8 +2381,8 @@ static void result_request(era_msg_header_t *msg_header)
         send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_UP, ci->current_value,
                  ci->nb_acked, ci->acked);
     } else {
-        era_value_t success_value;
-        OBJ_CONSTRUCT(&success_value, era_value_t);
+        ompi_coll_ftagree_era_value_t success_value;
+        OBJ_CONSTRUCT(&success_value, ompi_coll_ftagree_era_value_t);
         success_value.header.ret = MPI_SUCCESS;
         success_value.header.dt_count = 0;
         success_value.header.operand  = ompi_mpi_op_band.op.o_f_to_c_index;
@@ -2412,10 +2415,10 @@ static void result_request(era_msg_header_t *msg_header)
 
 static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, int *ack_failed)
 {
-    era_agreement_info_t *ci;
-    era_rank_item_t *rank_item;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_rank_item_t *rank_item;
     void *value;
-    era_value_t *av;
+    ompi_coll_ftagree_era_value_t *av;
 
     OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
                          "%s ftagree:agreement (ERA) Received UP Message: Agreement ID = (%d.%d).%d, sender: %d/%s, msg value: %08x.%d.%d/%d\n",
@@ -2439,7 +2442,7 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
     if( opal_hash_table_get_value_uint64(&era_passed_agreements,
                                          msg_header->agreement_id.ERAID_KEY,
                                          &value) == OPAL_SUCCESS ) {
-        av = (era_value_t*)value;
+        av = (ompi_coll_ftagree_era_value_t*)value;
         send_msg(NULL, msg_header->src_comm_rank, &msg_header->src_proc_name, msg_header->agreement_id, MSG_DOWN, av,
                  0, NULL);
         return;
@@ -2479,16 +2482,16 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
                              msg_header->src_comm_rank));
 
         /** We could receive multiple messages from msg_header->src_comm_rank, because the messages are split */
-        for(rank_item = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
-            rank_item != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
-            rank_item = (era_rank_item_t*)opal_list_get_next(&rank_item->super)) {
+        for(rank_item = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+            rank_item != (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+            rank_item = (ompi_coll_ftagree_era_rank_item_t*)opal_list_get_next(&rank_item->super)) {
             if( rank_item->rank == msg_header->src_comm_rank ) {
                 return;
             }
         }
 
         /** If not, add it */
-        rank_item = OBJ_NEW(era_rank_item_t);
+        rank_item = OBJ_NEW(ompi_coll_ftagree_era_rank_item_t);
         rank_item->rank = msg_header->src_comm_rank;
         opal_list_append(&ci->early_requesters, &rank_item->super);
         return;
@@ -2500,9 +2503,9 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
      *  of another failure), but it discovered the first failure at the
      *  same time, and started sending without me requesting.
      */
-    for( rank_item = (era_rank_item_t *)opal_list_get_first( &ci->gathered_info );
-         rank_item != (era_rank_item_t *)opal_list_get_end( &ci->gathered_info );
-         rank_item = (era_rank_item_t *)opal_list_get_next( &rank_item->super ) ) {
+    for( rank_item = (ompi_coll_ftagree_era_rank_item_t *)opal_list_get_first( &ci->gathered_info );
+         rank_item != (ompi_coll_ftagree_era_rank_item_t *)opal_list_get_end( &ci->gathered_info );
+         rank_item = (ompi_coll_ftagree_era_rank_item_t *)opal_list_get_next( &rank_item->super ) ) {
         if( rank_item->rank == msg_header->src_comm_rank ) {
             /* We are not waiting from more messages, thank you */
             /* Maybe you're telling me again you want me to send? Let's check if I can't */
@@ -2511,7 +2514,7 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
         }
     }
 
-    av = OBJ_NEW(era_value_t);
+    av = OBJ_NEW(ompi_coll_ftagree_era_value_t);
     memcpy(&av->header, &msg_header->agreement_value_header, sizeof(era_value_header_t));
     /* We don't allocate the arrays of bytes and new_dead ranks: we point in the message.
      * These pointers will need to be set to NULL *before* calling RELEASE.
@@ -2531,7 +2534,7 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
     OBJ_RELEASE(av);
 
     /* We already checked above that this process did not contribute yet */
-    rank_item = OBJ_NEW(era_rank_item_t);
+    rank_item = OBJ_NEW(ompi_coll_ftagree_era_rank_item_t);
     rank_item->rank = msg_header->src_comm_rank;
     opal_list_append(&ci->gathered_info, &rank_item->super);
     OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
@@ -2544,8 +2547,8 @@ static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, 
 
 static void msg_down(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead)
 {
-    era_agreement_info_t *ci;
-    era_value_t *av;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_value_t *av;
     size_t value_bytes;
 
     OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
@@ -2580,7 +2583,7 @@ static void msg_down(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead
      */
     assert( NULL != ci->comm );
 
-    av = OBJ_NEW(era_value_t);
+    av = OBJ_NEW(ompi_coll_ftagree_era_value_t);
     memcpy(&av->header, &msg_header->agreement_value_header, sizeof(era_value_header_t));
     /* We must allocate the arrays of bytes and new_dead ranks, because era_decide is going
      * to keep that era_value_t */
@@ -2768,7 +2771,7 @@ static void era_cb_fn(struct mca_btl_base_module_t* btl,
 static void era_on_comm_rank_failure(ompi_communicator_t *comm, int rank, bool remote)
 {
     void *value, *next_value;
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
     void *node;
     uint64_t key64, key64_2;
     int rc;
@@ -2815,7 +2818,7 @@ static void era_on_comm_rank_failure(ompi_communicator_t *comm, int rank, bool r
 
             if( cid.ERAID_FIELDS.contextid == comm->c_contextid.cid_sub.u64 &&
                 cid.ERAID_FIELDS.epoch     == comm->c_epoch ) {
-                ci = (era_agreement_info_t *)value;
+                ci = (ompi_coll_ftagree_era_agreement_info_t *)value;
                 OPAL_OUTPUT_VERBOSE((6, ompi_ftmpi_output_handle,
                                      "%s ftagree:agreement (ERA) Agreement ID (%d.%d).%d, rank %d died while doing the agreement\n",
                                      OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
@@ -2875,9 +2878,9 @@ int mca_coll_ftagree_era_init(void)
 
     OBJ_CONSTRUCT( &era_iagree_requests, opal_free_list_t);
     opal_free_list_init( &era_iagree_requests,
-                         sizeof(era_iagree_request_t),
+                         sizeof(ompi_coll_ftagree_era_iagree_request_t),
                          opal_cache_line_size,
-                         OBJ_CLASS(era_iagree_request_t),
+                         OBJ_CLASS(ompi_coll_ftagree_era_iagree_request_t),
                          0, opal_cache_line_size,
                          /* initial number of elements to allocate */ 0,
                          /* maximum number of elements */ INT_MAX,
@@ -2920,8 +2923,8 @@ int mca_coll_ftagree_era_finalize(void)
     void                 *node;
     void                 *value;
     uint64_t              key64;
-    era_value_t          *av;
-    era_agreement_info_t *un_agreement;
+    ompi_coll_ftagree_era_value_t          *av;
+    ompi_coll_ftagree_era_agreement_info_t *un_agreement;
     opal_hash_table_t    *msg_table;
     era_incomplete_msg_t *inc_msg;
     int rc;
@@ -2953,7 +2956,7 @@ int mca_coll_ftagree_era_finalize(void)
                              pid.ERAID_FIELDS.epoch,
                              pid.ERAID_FIELDS.agreementid));
 #endif /* OPAL_ENABLE_DEBUG */
-        av = (era_value_t *)value;
+        av = (ompi_coll_ftagree_era_value_t *)value;
         OBJ_RELEASE(av);
     }
     OBJ_DESTRUCT( &era_passed_agreements );
@@ -2962,7 +2965,7 @@ int mca_coll_ftagree_era_finalize(void)
     for( rc = opal_hash_table_get_first_key_uint64(&era_ongoing_agreements, &key64, &value, &node);
          OPAL_SUCCESS == rc;
          rc = opal_hash_table_get_next_key_uint64(&era_ongoing_agreements, &key64, &value, node, &node) ) {
-        un_agreement = (era_agreement_info_t *)value;
+        un_agreement = (ompi_coll_ftagree_era_agreement_info_t *)value;
         opal_output(0, "%s ftagree:agreement (ERA) ERRONEOUS: Agreement ID (%d.%d).%d was started by some processor, but I never completed to it\n",
                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
                     un_agreement->agreement_id.ERAID_FIELDS.contextid,
@@ -3007,13 +3010,13 @@ static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
                                                             void *contrib,
                                                             mca_coll_base_module_t *module,
                                                             era_identifier_t *paid,
-                                                            era_agreement_info_t **pci)
+                                                            ompi_coll_ftagree_era_agreement_info_t **pci)
 {
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
     era_identifier_t agreement_id;
     void *value;
-    era_value_t agreement_value;
-    era_value_t *pa;
+    ompi_coll_ftagree_era_value_t agreement_value;
+    ompi_coll_ftagree_era_value_t *pa;
     mca_coll_ftagree_t *ag_info;
 
     ag_info = ( (mca_coll_ftagree_module_t *)module )->agreement_info;
@@ -3053,7 +3056,7 @@ static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
     }
 #endif
 
-    OBJ_CONSTRUCT(&agreement_value, era_value_t);
+    OBJ_CONSTRUCT(&agreement_value, ompi_coll_ftagree_era_value_t);
 
     agreement_value.header.ret         = 0;
     agreement_value.header.operand     = op->o_f_to_c_index;
@@ -3078,7 +3081,7 @@ static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
                     agreement_id.ERAID_FIELDS.epoch,
                     agreement_id.ERAID_FIELDS.agreementid);
         assert(0 != agreement_id.ERAID_FIELDS.agreementid);
-        pa = (era_value_t*)value;
+        pa = (ompi_coll_ftagree_era_value_t*)value;
         opal_hash_table_remove_value_uint64(&era_passed_agreements, agreement_id.ERAID_KEY);
         OBJ_RELEASE(pa);
     }
@@ -3109,10 +3112,10 @@ static int mca_coll_ftagree_era_complete_agreement(era_identifier_t agreement_id
                                                              void *contrib,
                                                              ompi_group_t **group)
 {
-    era_value_t *av;
+    ompi_coll_ftagree_era_value_t *av;
     int ret;
     int i;
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
     ompi_communicator_t *comm;
     void *value;
 
@@ -3130,7 +3133,7 @@ static int mca_coll_ftagree_era_complete_agreement(era_identifier_t agreement_id
                                            agreement_id.ERAID_KEY,
                                            &value);
     assert( OPAL_SUCCESS == ret);
-    av = (era_value_t *)value;
+    av = (ompi_coll_ftagree_era_value_t *)value;
 
     memcpy(contrib, av->bytes, ERA_VALUE_BYTES_COUNT(&av->header));
     ret = av->header.ret;
@@ -3268,7 +3271,7 @@ int mca_coll_ftagree_era_inter(void *contrib,
 
 static int era_iagree_req_free(struct ompi_request_t** rptr)
 {
-    era_iagree_request_t *req = (era_iagree_request_t *)*rptr;
+    ompi_coll_ftagree_era_iagree_request_t *req = (ompi_coll_ftagree_era_iagree_request_t *)*rptr;
 
     if( NULL != req->ci )
         req->ci->req = NULL;
@@ -3282,7 +3285,7 @@ static int era_iagree_req_free(struct ompi_request_t** rptr)
 
 static int era_iagree_req_complete_cb(struct ompi_request_t* request)
 {
-    era_iagree_request_t *req = (era_iagree_request_t *)request;
+    ompi_coll_ftagree_era_iagree_request_t *req = (ompi_coll_ftagree_era_iagree_request_t *)request;
     int rc;
 
     assert( req->ci != NULL );
@@ -3304,13 +3307,13 @@ int mca_coll_ftagree_iera_intra(void *contrib,
                                           mca_coll_base_module_t *module)
 {
     opal_free_list_item_t* item;
-    era_iagree_request_t *req;
+    ompi_coll_ftagree_era_iagree_request_t *req;
     era_identifier_t agreement_id;
-    era_agreement_info_t *ci;
+    ompi_coll_ftagree_era_agreement_info_t *ci;
 
     item = opal_free_list_get(&era_iagree_requests);
     if( NULL == item ) return OMPI_ERR_OUT_OF_RESOURCE;
-    req = (era_iagree_request_t*)item;
+    req = (ompi_coll_ftagree_era_iagree_request_t*)item;
 
     OMPI_REQUEST_INIT(&req->super, false);
     assert(MPI_UNDEFINED == req->super.req_f_to_c_index);

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -403,7 +404,7 @@ int mca_coll_han_init_query(bool enable_progress_threads, bool enable_mpi_thread
 
 mca_coll_base_module_t *mca_coll_han_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int han_request_free(ompi_request_t ** request);
+int ompi_coll_han_request_free(ompi_request_t ** request);
 
 /* Subcommunicator creation */
 int mca_coll_han_comm_create(struct ompi_communicator_t *comm, mca_coll_han_module_t * han_module);

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,7 +107,7 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
     temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_coll_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -536,7 +537,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
                 opal_output_verbose(30, mca_coll_han_component.han_output,
                                     "coll:han:allreduce_reproducible: "
                                     "fallback on %s\n",
-                                    available_components[fallback].component_name);
+                                    ompi_coll_han_available_components[fallback].component_name);
             }
             han_module->reproducible_allreduce_module = fallback_module;
             han_module->reproducible_allreduce = fallback_module->coll_allreduce;

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +34,7 @@
 const char *mca_coll_han_component_version_string =
     "Open MPI HAN collective MCA component version " OMPI_VERSION;
 
-ompi_coll_han_components available_components[COMPONENTS_COUNT] = {
+ompi_coll_han_components ompi_coll_han_available_components[COMPONENTS_COUNT] = {
     { SELF, "self",  NULL },
     { BASIC, "basic", NULL },
     { LIBNBC, "libnbc", NULL },
@@ -191,7 +192,7 @@ mca_coll_han_query_module_from_mca(mca_base_component_t* c,
     mod_id = (*module_id > (uint32_t)mod_id) ? mod_id : (int)*module_id; /* stay in range */
     mod_id = (mod_id < 0) ? 0 : mod_id;  /* in range */
 
-    *storage = available_components[mod_id].component_name;
+    *storage = ompi_coll_han_available_components[mod_id].component_name;
 
     (void) mca_base_component_var_register(c, param_name, param_doc,
                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
@@ -401,7 +402,7 @@ static int han_register(void)
                 param_desc_size += snprintf(param_desc+param_desc_size, sizeof(param_desc) - param_desc_size,
                                             "%d = %s; ",
                                             component,
-                                            available_components[component].component_name);
+                                            ompi_coll_han_available_components[component].component_name);
             }
 
             mca_base_component_var_register(c, param_name, param_desc,

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -55,7 +56,7 @@ mca_coll_han_component_name_to_id(const char* name)
     }
 
     for( int i = SELF; i < COMPONENTS_COUNT ; i++ ) {
-        if (0 == strcmp(name, available_components[i].component_name)) {
+        if (0 == strcmp(name, ompi_coll_han_available_components[i].component_name)) {
             return i;
         }
     }
@@ -250,7 +251,7 @@ get_dynamic_rule(COLLTYPE_T collective,
                         msg_size_rule->topologic_level,
                         mca_coll_han_topo_lvl_to_str(msg_size_rule->topologic_level),
                         msg_size_rule->configuration_size,
-                        msg_size_rule->msg_size, component, available_components[component].component_name);
+                        msg_size_rule->msg_size, component, ompi_coll_han_available_components[component].component_name);
 
     return msg_size_rule;
 }

--- a/ompi/mca/coll/han/coll_han_dynamic.h
+++ b/ompi/mca/coll/han/coll_han_dynamic.h
@@ -4,6 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -112,7 +113,7 @@ typedef struct {
     mca_coll_base_component_t* component;
 } ompi_coll_han_components;
 
-extern ompi_coll_han_components available_components[COMPONENTS_COUNT];
+extern ompi_coll_han_components ompi_coll_han_available_components[COMPONENTS_COUNT];
 
 /* Topologic levels */
 typedef enum TOPO_LVL {

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -4,6 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -612,7 +613,7 @@ void mca_coll_han_dump_dynamic_rules(void)
                                 "message size %d -> collective component %d (%s)\n",
                                 nb_entries, coll_id, mca_coll_base_colltype_to_str(coll_id),
                                 topo_lvl, mca_coll_han_topo_lvl_to_str(topo_lvl), conf_size,
-                                msg_size, component, available_components[component].component_name);
+                                msg_size, component, ompi_coll_han_available_components[component].component_name);
 
                     nb_entries++;
                 }

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,7 +120,7 @@ mca_coll_han_gather_intra(const void *sbuf, int scount,
     temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_coll_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -354,7 +355,7 @@ mca_coll_han_module_disable(mca_coll_base_module_t * module,
 /*
  * Free the han request
  */
-int han_request_free(ompi_request_t ** request)
+int ompi_coll_han_request_free(ompi_request_t ** request)
 {
     (*request)->req_state = OMPI_REQUEST_INVALID;
     OBJ_RELEASE(*request);

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -410,7 +411,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
                 opal_output_verbose(30, mca_coll_han_component.han_output,
                                     "coll:han:reduce_reproducible: "
                                     "fallback on %s\n",
-                                    available_components[fallback].component_name);
+                                    ompi_coll_han_available_components[fallback].component_name);
             }
             han_module->reproducible_reduce_module = fallback_module;
             han_module->reproducible_reduce = fallback_module->coll_reduce;

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -117,7 +118,7 @@ mca_coll_han_scatter_intra(const void *sbuf, int scount,
     ompi_request_t *temp_request = OBJ_NEW(ompi_request_t);
     temp_request->req_state = OMPI_REQUEST_ACTIVE;
     temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = han_request_free;
+    temp_request->req_free = ompi_coll_han_request_free;
     temp_request->req_status = (ompi_status_public_t){0};
     temp_request->req_complete = REQUEST_PENDING;
 

--- a/ompi/mca/coll/libnbc/libdict/dict.c
+++ b/ompi/mca/coll/libnbc/libdict/dict.c
@@ -13,30 +13,22 @@
 #include "dict.h"
 #include "dict_private.h"
 
-dict_malloc_func _dict_malloc = malloc;
-dict_free_func _dict_free = free;
+dict_malloc_func ompi_coll_libnbc_dict_malloc = malloc;
+dict_free_func ompi_coll_libnbc_dict_free = free;
 
-static void dict_destroy __P((dict *dct, int del));
-static void dict_itor_destroy __P((dict_itor *itor));
-static int  dict_int_cmp __P((const void *k1, const void *k2));
-static int  dict_uint_cmp __P((const void *k1, const void *k2));
-static int  dict_long_cmp __P((const void *k1, const void *k2));
-static int  dict_ulong_cmp __P((const void *k1, const void *k2));
-static int  dict_str_cmp __P((const void *k1, const void *k2));
-
-static dict_malloc_func
+static inline dict_malloc_func
 dict_set_malloc(dict_malloc_func func)
 {
-	dict_malloc_func old = _dict_malloc;
-	_dict_malloc = func ? func : malloc;
+	dict_malloc_func old = ompi_coll_libnbc_dict_malloc;
+	ompi_coll_libnbc_dict_malloc = func ? func : malloc;
 	return old;
 }
 
-static dict_free_func
+static inline dict_free_func
 dict_set_free(dict_free_func func)
 {
-	dict_free_func old = _dict_free;
-	_dict_free = func ? func : free;
+	dict_free_func old = ompi_coll_libnbc_dict_free;
+	ompi_coll_libnbc_dict_free = func ? func : free;
 	return old;
 }
 
@@ -44,7 +36,7 @@ dict_set_free(dict_free_func func)
  * In comparing, we cannot simply subtract because that might result in signed
  * overflow.
  */
-static int
+static inline int
 dict_int_cmp(const void *k1, const void *k2)
 {
 	const int *a = (int*)k1, *b = (int*)k2;
@@ -52,24 +44,24 @@ dict_int_cmp(const void *k1, const void *k2)
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-static int
-dict_uint_cmp(const void *k1, const void *k2)
+int
+ompi_coll_libnbc_dict_uint_cmp(const void *k1, const void *k2)
 {
 	const unsigned int *a = (unsigned int*)k1, *b = (unsigned int*)k2;
 
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-static int
-dict_long_cmp(const void *k1, const void *k2)
+int
+ompi_coll_libnbc_dict_long_cmp(const void *k1, const void *k2)
 {
 	const long *a = (long*)k1, *b = (long*)k2;
 
 	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
 }
 
-static int
-dict_ulong_cmp(const void *k1, const void *k2)
+int
+ompi_coll_libnbc_dict_ulong_cmp(const void *k1, const void *k2)
 {
 	const unsigned long *a = (unsigned long*)k1, *b = (unsigned long*)k2;
 
@@ -77,13 +69,13 @@ dict_ulong_cmp(const void *k1, const void *k2)
 }
 
 int
-dict_ptr_cmp(const void *k1, const void *k2)
+ompi_coll_libnbc_dict_ptr_cmp(const void *k1, const void *k2)
 {
 	return (k1 > k2) - (k1 < k2);
 }
 
-static int
-dict_str_cmp(const void *k1, const void *k2)
+int
+ompi_coll_libnbc_dict_str_cmp(const void *k1, const void *k2)
 {
 	const char *a = (char*)k1, *b = (char*)k2;
 	char p, q;
@@ -96,8 +88,8 @@ dict_str_cmp(const void *k1, const void *k2)
 	return (p > q) - (p < q);
 }
 
-static void
-dict_destroy(dict *dct, int del)
+void
+ompi_coll_libnbc_dict_destroy(dict *dct, int del)
 {
 	ASSERT(dct != NULL);
 
@@ -105,8 +97,8 @@ dict_destroy(dict *dct, int del)
 	FREE(dct);
 }
 
-static void
-dict_itor_destroy(dict_itor *itor)
+void
+ompi_coll_libnbc_dict_itor_destroy(dict_itor *itor)
 {
 	ASSERT(itor != NULL);
 

--- a/ompi/mca/coll/libnbc/libdict/dict.h
+++ b/ompi/mca/coll/libnbc/libdict/dict.h
@@ -114,7 +114,13 @@ struct dict_itor {
 #define dict_itor_set_data(i,dat,d)	(i)->_setdata((i)->_itor, (dat), (d))
 #define dict_itor_remove(i)			(i)->_remove((i)->_itor)
 
-int		dict_ptr_cmp __P((const void *k1, const void *k2));
+int ompi_coll_libnbc_dict_ptr_cmp __P((const void *k1, const void *k2));
+void ompi_coll_libnbc_dict_destroy __P((dict *dct, int del));
+void ompi_coll_libnbc_dict_itor_destroy __P((dict_itor *itor));
+int  ompi_coll_libnbc_dict_uint_cmp __P((const void *k1, const void *k2));
+int  ompi_coll_libnbc_dict_long_cmp __P((const void *k1, const void *k2));
+int  ompi_coll_libnbc_dict_ulong_cmp __P((const void *k1, const void *k2));
+int  ompi_coll_libnbc_dict_str_cmp __P((const void *k1, const void *k2));
 
 END_DECL
 

--- a/ompi/mca/coll/libnbc/libdict/dict_private.h
+++ b/ompi/mca/coll/libnbc/libdict/dict_private.h
@@ -59,10 +59,10 @@ typedef int			 (*icompare_func)	__P((void *, void *itor2));
 # define ASSERT(expr)
 #endif
 
-extern dict_malloc_func _dict_malloc;
-extern dict_free_func _dict_free;
-#define MALLOC(n)	(*_dict_malloc)(n)
-#define FREE(p)		(*_dict_free)(p)
+extern dict_malloc_func ompi_coll_libnbc_dict_malloc;
+extern dict_free_func ompi_coll_libnbc_dict_free;
+#define MALLOC(n)	(*ompi_coll_libnbc_dict_malloc)(n)
+#define FREE(p)		(*ompi_coll_libnbc_dict_free)(p)
 
 #define ABS(a)		((a) < 0 ? -(a) : +(a))
 #define MIN(a,b)	((a) < (b) ? (a) : (b))

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.c
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.c
@@ -43,6 +43,7 @@ struct hb_itor {
 
 static int rot_left __P((hb_tree *tree, hb_node *node));
 static int rot_right __P((hb_tree *tree, hb_node *node));
+static int hb_itor_search __P((hb_itor *itor, const void *key));
 static unsigned node_height __P((const hb_node *node));
 static unsigned node_mheight __P((const hb_node *node));
 static unsigned node_pathlen __P((const hb_node *node, unsigned level));
@@ -77,7 +78,7 @@ static int hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
 static void hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
 
 hb_tree *
-hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
+ompi_coll_libnbc_hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 			dict_del_func dat_del)
 {
 	hb_tree *tree;
@@ -87,16 +88,16 @@ hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 
 	tree->root = NULL;
 	tree->count = 0;
-	tree->key_cmp = key_cmp ? key_cmp : dict_ptr_cmp;
+	tree->key_cmp = key_cmp ? key_cmp : ompi_coll_libnbc_dict_ptr_cmp;
 	tree->key_del = key_del;
 	tree->dat_del = dat_del;
 
 	return tree;
 }
 
-static dict *
-hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
-			dict_del_func dat_del)
+dict *
+ompi_coll_libnbc_hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
+			     dict_del_func dat_del)
 {
 	dict *dct;
 	hb_tree *tree;
@@ -104,38 +105,38 @@ hb_dict_new(dict_cmp_func key_cmp, dict_del_func key_del,
 	if ((dct = (dict*)MALLOC(sizeof(*dct))) == NULL)
 		return NULL;
 
-	if ((tree = hb_tree_new(key_cmp, key_del, dat_del)) == NULL) {
+	if ((tree = ompi_coll_libnbc_hb_tree_new(key_cmp, key_del, dat_del)) == NULL) {
 		FREE(dct);
 		return NULL;
 	}
 
 	dct->_object = tree;
-	dct->_inew = (inew_func)hb_dict_itor_new;
-	dct->_destroy = (destroy_func)hb_tree_destroy;
-	dct->_insert = (insert_func)hb_tree_insert;
-	dct->_probe = (probe_func)hb_tree_probe;
-	dct->_search = (search_func)hb_tree_search;
-	dct->_remove = (remove_func)hb_tree_remove;
-	dct->_empty = (empty_func)hb_tree_empty;
-	dct->_walk = (walk_func)hb_tree_walk;
-	dct->_count = (count_func)hb_tree_count;
+	dct->_inew = (inew_func)ompi_coll_libnbc_hb_dict_itor_new;
+	dct->_destroy = (destroy_func)ompi_coll_libnbc_hb_tree_destroy;
+	dct->_insert = (insert_func)ompi_coll_libnbc_hb_tree_insert;
+	dct->_probe = (probe_func)ompi_coll_libnbc_hb_tree_probe;
+	dct->_search = (search_func)ompi_coll_libnbc_hb_tree_search;
+	dct->_remove = (remove_func)ompi_coll_libnbc_hb_tree_remove;
+	dct->_empty = (empty_func)ompi_coll_libnbc_hb_tree_empty;
+	dct->_walk = (walk_func)ompi_coll_libnbc_hb_tree_walk;
+	dct->_count = (count_func)ompi_coll_libnbc_hb_tree_count;
 
 	return dct;
 }
 
-static void
-hb_tree_destroy(hb_tree *tree, int del)
+void
+ompi_coll_libnbc_hb_tree_destroy(hb_tree *tree, int del)
 {
 	ASSERT(tree != NULL);
 
 	if (tree->root)
-		hb_tree_empty(tree, del);
+		ompi_coll_libnbc_hb_tree_empty(tree, del);
 
 	FREE(tree);
 }
 
-static void
-hb_tree_empty(hb_tree *tree, int del)
+void
+ompi_coll_libnbc_hb_tree_empty(hb_tree *tree, int del)
 {
 	hb_node *node, *parent;
 
@@ -173,7 +174,7 @@ hb_tree_empty(hb_tree *tree, int del)
 }
 
 void *
-hb_tree_search(hb_tree *tree, const void *key)
+ompi_coll_libnbc_hb_tree_search(hb_tree *tree, const void *key)
 {
 	int rv;
 	hb_node *node;
@@ -195,7 +196,7 @@ hb_tree_search(hb_tree *tree, const void *key)
 }
 
 int
-hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
+ompi_coll_libnbc_hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
 {
 	int rv = 0;
 	hb_node *node, *parent = NULL, *q = NULL;
@@ -261,8 +262,8 @@ hb_tree_insert(hb_tree *tree, void *key, void *dat, int overwrite)
 	return 0;
 }
 
-static int
-hb_tree_probe(hb_tree *tree, void *key, void **dat)
+int
+ompi_coll_libnbc_hb_tree_probe(hb_tree *tree, void *key, void **dat)
 {
 	int rv = 0;
 	hb_node *node, *parent = NULL, *q = NULL;
@@ -331,7 +332,7 @@ hb_tree_probe(hb_tree *tree, void *key, void **dat)
 	FREE(n)
 
 int
-hb_tree_remove(hb_tree *tree, const void *key, int del)
+ompi_coll_libnbc_hb_tree_remove(hb_tree *tree, const void *key, int del)
 {
 	int rv, left;
 	hb_node *node, *out, *parent = NULL;
@@ -427,8 +428,8 @@ higher:
 	return 0;
 }
 
-static const void *
-hb_tree_min(const hb_tree *tree)
+const void *
+ompi_coll_libnbc_hb_tree_min(const hb_tree *tree)
 {
 	const hb_node *node;
 
@@ -442,8 +443,8 @@ hb_tree_min(const hb_tree *tree)
 	return node->key;
 }
 
-static const void *
-hb_tree_max(const hb_tree *tree)
+const void *
+ompi_coll_libnbc_hb_tree_max(const hb_tree *tree)
 {
 	const hb_node *node;
 
@@ -457,8 +458,8 @@ hb_tree_max(const hb_tree *tree)
 	return node->key;
 }
 
-static void
-hb_tree_walk(hb_tree *tree, dict_vis_func visit)
+void
+ompi_coll_libnbc_hb_tree_walk(hb_tree *tree, dict_vis_func visit)
 {
 	hb_node *node;
 
@@ -471,32 +472,32 @@ hb_tree_walk(hb_tree *tree, dict_vis_func visit)
 			break;
 }
 
-static unsigned
-hb_tree_count(const hb_tree *tree)
+unsigned
+ompi_coll_libnbc_hb_tree_count(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
 	return tree->count;
 }
 
-static unsigned
-hb_tree_height(const hb_tree *tree)
+unsigned
+ompi_coll_libnbc_hb_tree_height(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
 	return tree->root ? node_height(tree->root) : 0;
 }
 
-static unsigned
-hb_tree_mheight(const hb_tree *tree)
+unsigned
+ompi_coll_libnbc_hb_tree_mheight(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
 	return tree->root ? node_mheight(tree->root) : 0;
 }
 
-static unsigned
-hb_tree_pathlen(const hb_tree *tree)
+unsigned
+ompi_coll_libnbc_hb_tree_pathlen(const hb_tree *tree)
 {
 	ASSERT(tree != NULL);
 
@@ -708,7 +709,7 @@ rot_right(hb_tree *tree, hb_node *node)
 }
 
 hb_itor *
-hb_itor_new(hb_tree *tree)
+ompi_coll_libnbc_hb_itor_new(hb_tree *tree)
 {
 	hb_itor *itor;
 
@@ -718,12 +719,12 @@ hb_itor_new(hb_tree *tree)
 		return NULL;
 
 	itor->tree = tree;
-	hb_itor_first(itor);
+	ompi_coll_libnbc_hb_itor_first(itor);
 	return itor;
 }
 
-static dict_itor *
-hb_dict_itor_new(hb_tree *tree)
+dict_itor *
+ompi_coll_libnbc_hb_dict_itor_new(hb_tree *tree)
 {
 	dict_itor *itor;
 
@@ -732,31 +733,31 @@ hb_dict_itor_new(hb_tree *tree)
 	if ((itor = (dict_itor*)MALLOC(sizeof(*itor))) == NULL)
 		return NULL;
 
-	if ((itor->_itor = hb_itor_new(tree)) == NULL) {
+	if ((itor->_itor = ompi_coll_libnbc_hb_itor_new(tree)) == NULL) {
 		FREE(itor);
 		return NULL;
 	}
 
-	itor->_destroy = (idestroy_func)hb_itor_destroy;
-	itor->_valid = (valid_func)hb_itor_valid;
-	itor->_invalid = (invalidate_func)hb_itor_invalidate;
-	itor->_next = (next_func)hb_itor_next;
-	itor->_prev = (prev_func)hb_itor_prev;
-	itor->_nextn = (nextn_func)hb_itor_nextn;
-	itor->_prevn = (prevn_func)hb_itor_prevn;
-	itor->_first = (first_func)hb_itor_first;
-	itor->_last = (last_func)hb_itor_last;
+	itor->_destroy = (idestroy_func)ompi_coll_libnbc_hb_itor_destroy;
+	itor->_valid = (valid_func)ompi_coll_libnbc_hb_itor_valid;
+	itor->_invalid = (invalidate_func)ompi_coll_libnbc_hb_itor_invalidate;
+	itor->_next = (next_func)ompi_coll_libnbc_hb_itor_next;
+	itor->_prev = (prev_func)ompi_coll_libnbc_hb_itor_prev;
+	itor->_nextn = (nextn_func)ompi_coll_libnbc_hb_itor_nextn;
+	itor->_prevn = (prevn_func)ompi_coll_libnbc_hb_itor_prevn;
+	itor->_first = (first_func)ompi_coll_libnbc_hb_itor_first;
+	itor->_last = (last_func)ompi_coll_libnbc_hb_itor_last;
 	itor->_search = (isearch_func)hb_itor_search;
-	itor->_key = (key_func)hb_itor_key;
-	itor->_data = (data_func)hb_itor_data;
-	itor->_cdata = (cdata_func)hb_itor_cdata;
-	itor->_setdata = (dataset_func)hb_itor_set_data;
+	itor->_key = (key_func)ompi_coll_libnbc_hb_itor_key;
+	itor->_data = (data_func)ompi_coll_libnbc_hb_itor_data;
+	itor->_cdata = (cdata_func)ompi_coll_libnbc_hb_itor_cdata;
+	itor->_setdata = (dataset_func)ompi_coll_libnbc_hb_itor_set_data;
 
 	return itor;
 }
 
 void
-hb_itor_destroy(hb_itor *itor)
+ompi_coll_libnbc_hb_itor_destroy(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -766,15 +767,15 @@ hb_itor_destroy(hb_itor *itor)
 #define RETVALID(itor)		return itor->node != NULL
 
 int
-hb_itor_valid(const hb_itor *itor)
+ompi_coll_libnbc_hb_itor_valid(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	RETVALID(itor);
 }
 
-static void
-hb_itor_invalidate(hb_itor *itor)
+void
+ompi_coll_libnbc_hb_itor_invalidate(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
@@ -782,37 +783,37 @@ hb_itor_invalidate(hb_itor *itor)
 }
 
 int
-hb_itor_next(hb_itor *itor)
+ompi_coll_libnbc_hb_itor_next(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	if (itor->node == NULL)
-		hb_itor_first(itor);
+		ompi_coll_libnbc_hb_itor_first(itor);
 	else
 		itor->node = node_next(itor->node);
 	RETVALID(itor);
 }
 
-static int
-hb_itor_prev(hb_itor *itor)
+int
+ompi_coll_libnbc_hb_itor_prev(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	if (itor->node == NULL)
-		hb_itor_last(itor);
+		ompi_coll_libnbc_hb_itor_last(itor);
 	else
 		itor->node = node_prev(itor->node);
 	RETVALID(itor);
 }
 
-static int
-hb_itor_nextn(hb_itor *itor, unsigned count)
+int
+ompi_coll_libnbc_hb_itor_nextn(hb_itor *itor, unsigned count)
 {
 	ASSERT(itor != NULL);
 
 	if (count) {
 		if (itor->node == NULL) {
-			hb_itor_first(itor);
+			ompi_coll_libnbc_hb_itor_first(itor);
 			count--;
 		}
 
@@ -823,14 +824,14 @@ hb_itor_nextn(hb_itor *itor, unsigned count)
 	RETVALID(itor);
 }
 
-static int
-hb_itor_prevn(hb_itor *itor, unsigned count)
+int
+ompi_coll_libnbc_hb_itor_prevn(hb_itor *itor, unsigned count)
 {
 	ASSERT(itor != NULL);
 
 	if (count) {
 		if (itor->node == NULL) {
-			hb_itor_last(itor);
+			ompi_coll_libnbc_hb_itor_last(itor);
 			count--;
 		}
 
@@ -841,8 +842,8 @@ hb_itor_prevn(hb_itor *itor, unsigned count)
 	RETVALID(itor);
 }
 
-static int
-hb_itor_first(hb_itor *itor)
+int
+ompi_coll_libnbc_hb_itor_first(hb_itor *itor)
 {
 	hb_tree *t;
 
@@ -853,8 +854,8 @@ hb_itor_first(hb_itor *itor)
 	RETVALID(itor);
 }
 
-static int
-hb_itor_last(hb_itor *itor)
+int
+ompi_coll_libnbc_hb_itor_last(hb_itor *itor)
 {
 	hb_tree *t;
 
@@ -886,31 +887,31 @@ hb_itor_search(hb_itor *itor, const void *key)
 }
 
 const void *
-hb_itor_key(const hb_itor *itor)
+ompi_coll_libnbc_hb_itor_key(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	return itor->node ? itor->node->key : NULL;
 }
 
-static void *
-hb_itor_data(hb_itor *itor)
+void *
+ompi_coll_libnbc_hb_itor_data(hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	return itor->node ? itor->node->dat : NULL;
 }
 
-static const void *
-hb_itor_cdata(const hb_itor *itor)
+const void *
+ompi_coll_libnbc_hb_itor_cdata(const hb_itor *itor)
 {
 	ASSERT(itor != NULL);
 
 	return itor->node ? itor->node->dat : NULL;
 }
 
-static int
-hb_itor_set_data(hb_itor *itor, void *dat, int del)
+int
+ompi_coll_libnbc_hb_itor_set_data(hb_itor *itor, void *dat, int del)
 {
 	ASSERT(itor != NULL);
 

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.h
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.h
@@ -18,23 +18,45 @@ BEGIN_DECL
 struct hb_tree;
 typedef struct hb_tree hb_tree;
 
-hb_tree *hb_tree_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
+hb_tree *ompi_coll_libnbc_hb_tree_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
 						  dict_del_func dat_del));
 
-int hb_tree_insert __P((hb_tree *tree, void *key, void *dat, int overwrite));
-void *hb_tree_search __P((hb_tree *tree, const void *key));
-int hb_tree_remove __P((hb_tree *tree, const void *key, int del));
+int ompi_coll_libnbc_hb_tree_insert __P((hb_tree *tree, void *key, void *dat, int overwrite));
+void *ompi_coll_libnbc_hb_tree_search __P((hb_tree *tree, const void *key));
+int ompi_coll_libnbc_hb_tree_remove __P((hb_tree *tree, const void *key, int del));
 
 struct hb_itor;
 typedef struct hb_itor hb_itor;
 
-hb_itor *hb_itor_new __P((hb_tree *tree));
-void hb_itor_destroy __P((hb_itor *tree));
+hb_itor *ompi_coll_libnbc_hb_itor_new __P((hb_tree *tree));
+void ompi_coll_libnbc_hb_itor_destroy __P((hb_itor *tree));
 
-int hb_itor_valid __P((const hb_itor *itor));
-int hb_itor_next __P((hb_itor *itor));
-const void *hb_itor_key __P((const hb_itor *itor));
-int hb_itor_remove __P((hb_itor *itor, int del));
+int ompi_coll_libnbc_hb_itor_valid __P((const hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_next __P((hb_itor *itor));
+const void *ompi_coll_libnbc_hb_itor_key __P((const hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_remove __P((hb_itor *itor, int del));
+dict *ompi_coll_libnbc_hb_dict_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
+                                                  dict_del_func dat_del));
+dict_itor *ompi_coll_libnbc_hb_dict_itor_new __P((hb_tree *tree));
+void ompi_coll_libnbc_hb_itor_invalidate __P((hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_first __P((hb_itor *itor));
+void *ompi_coll_libnbc_hb_itor_data __P((hb_itor *itor));
+const void *ompi_coll_libnbc_hb_itor_cdata __P((const hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_last __P((hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_nextn __P((hb_itor *itor, unsigned count));
+int ompi_coll_libnbc_hb_itor_prev __P((hb_itor *itor));
+int ompi_coll_libnbc_hb_itor_prevn __P((hb_itor *itor, unsigned count));
+int ompi_coll_libnbc_hb_itor_set_data __P((hb_itor *itor, void *dat, int del));
+unsigned ompi_coll_libnbc_hb_tree_count __P((const hb_tree *tree));
+void ompi_coll_libnbc_hb_tree_destroy __P((hb_tree *tree, int del));
+void ompi_coll_libnbc_hb_tree_empty __P((hb_tree *tree, int del));
+unsigned ompi_coll_libnbc_hb_tree_height __P((const hb_tree *tree));
+const void *ompi_coll_libnbc_hb_tree_max __P((const hb_tree *tree));
+unsigned ompi_coll_libnbc_hb_tree_mheight __P((const hb_tree *tree));
+const void *ompi_coll_libnbc_hb_tree_min __P((const hb_tree *tree));
+unsigned ompi_coll_libnbc_hb_tree_pathlen __P((const hb_tree *tree));
+int ompi_coll_libnbc_hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
+void ompi_coll_libnbc_hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
 
 END_DECL
 

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -5,6 +5,7 @@
  *                    Corporation.  All rights reserved.
  * Copyright (c) 2006 The Technical University of Chemnitz. All
  *                    rights reserved.
+ * Copyright (c) 2022 IBM Corporation. All rights reserved
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -568,12 +569,12 @@ static inline int NBC_Unpack(void *src, int srccount, MPI_Datatype srctype, void
 static inline void NBC_SchedCache_dictwipe(hb_tree *dict_in, int *size) {
   hb_itor *itor;
 
-  itor = hb_itor_new(dict_in);
-  for (; hb_itor_valid(itor) && (*size>NBC_SCHED_DICT_LOWER); hb_itor_next(itor)) {
-    hb_tree_remove(dict_in, hb_itor_key(itor), 0);
+  itor = ompi_coll_libnbc_hb_itor_new(dict_in);
+  for (; ompi_coll_libnbc_hb_itor_valid(itor) && (*size>NBC_SCHED_DICT_LOWER); ompi_coll_libnbc_hb_itor_next(itor)) {
+    ompi_coll_libnbc_hb_tree_remove(dict_in, ompi_coll_libnbc_hb_itor_key(itor), 0);
     *size = *size-1;
   }
-  hb_itor_destroy(itor);
+  ompi_coll_libnbc_hb_itor_destroy(itor);
 }
 
 #define NBC_IN_PLACE(sendbuf, recvbuf, inplace) \

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -11,6 +11,7 @@
  *                         reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,7 +84,7 @@ static double log10_2 = 0.;
 static int rank_world = -1;
 static int nprocs_world = 0;
 
-opal_hash_table_t *common_monitoring_translation_ht = NULL;
+opal_hash_table_t *ompi_common_monitoring_translation_ht = NULL;
 
 /* Reset all the monitoring arrays */
 static void mca_common_monitoring_reset ( void );
@@ -225,8 +226,8 @@ int mca_common_monitoring_init( void )
     mca_common_monitoring_output_stream_id =
         opal_output_open(&mca_common_monitoring_output_stream_obj);
     /* Initialize proc translation hashtable */
-    common_monitoring_translation_ht = OBJ_NEW(opal_hash_table_t);
-    opal_hash_table_init(common_monitoring_translation_ht, 2048);
+    ompi_common_monitoring_translation_ht = OBJ_NEW(opal_hash_table_t);
+    opal_hash_table_init(ompi_common_monitoring_translation_ht, 2048);
     return OMPI_SUCCESS;
 }
 
@@ -246,8 +247,8 @@ void mca_common_monitoring_finalize( void )
     free(mca_common_monitoring_output_stream_obj.lds_prefix);
     /* Free internal data structure */
     free((void *) pml_data);  /* a single allocation */
-    opal_hash_table_remove_all( common_monitoring_translation_ht );
-    OBJ_RELEASE(common_monitoring_translation_ht);
+    opal_hash_table_remove_all( ompi_common_monitoring_translation_ht );
+    OBJ_RELEASE(ompi_common_monitoring_translation_ht);
     mca_common_monitoring_coll_finalize();
     if( NULL != mca_common_monitoring_current_filename ) {
         free(mca_common_monitoring_current_filename);
@@ -484,7 +485,7 @@ int mca_common_monitoring_add_procs(struct ompi_proc_t **procs,
 
             key = *((uint64_t*)&tmp);
             /* save the rank of the process in MPI_COMM_WORLD in the hash using the proc_name as the key */
-            if( OPAL_SUCCESS != opal_hash_table_set_value_uint64(common_monitoring_translation_ht,
+            if( OPAL_SUCCESS != opal_hash_table_set_value_uint64(ompi_common_monitoring_translation_ht,
                                                                  key, (void*)(uintptr_t)peer_rank) ) {
                 return OMPI_ERR_OUT_OF_RESOURCE;  /* failed to allocate memory or growing the hash table */
             }

--- a/ompi/mca/common/monitoring/common_monitoring.h
+++ b/ompi/mca/common/monitoring/common_monitoring.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2018 Inria.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@ BEGIN_C_DECLS
 extern int mca_common_monitoring_output_stream_id;
 extern int mca_common_monitoring_enabled;
 extern int mca_common_monitoring_current_state;
-extern opal_hash_table_t *common_monitoring_translation_ht;
+extern opal_hash_table_t *ompi_common_monitoring_translation_ht;
 
 OMPI_DECLSPEC int mca_common_monitoring_init( void );
 OMPI_DECLSPEC void mca_common_monitoring_finalize( void );
@@ -88,7 +89,7 @@ static inline int mca_common_monitoring_get_world_rank(int dest, ompi_group_t *g
      * If this fails the destination is not part of my MPI_COM_WORLD
      * Lookup its name in the rank hashtable to get its MPI_COMM_WORLD rank
      */
-    int ret = opal_hash_table_get_value_uint64(common_monitoring_translation_ht,
+    int ret = opal_hash_table_get_value_uint64(ompi_common_monitoring_translation_ht,
                                                key, (void *)&rank);
 
     /* Use intermediate variable to avoid overwriting while looking up in the hashtbale. */

--- a/ompi/mca/fbtl/posix/fbtl_posix.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
 #include <aio.h>
 #endif
 
-int fbtl_posix_max_aio_active_reqs=2048;
+int ompi_fbtl_posix_max_aio_active_reqs=2048;
 
 #include "ompi/mca/fbtl/fbtl.h"
 #include "ompi/mca/fbtl/posix/fbtl_posix.h"
@@ -105,7 +106,7 @@ int mca_fbtl_posix_module_init (ompio_file_t *file) {
 #if defined (FBTL_POSIX_HAVE_AIO)
     long val = sysconf(_SC_AIO_MAX);
     if ( -1 != val ) {
-	fbtl_posix_max_aio_active_reqs = (int)val;
+	ompi_fbtl_posix_max_aio_active_reqs = (int)val;
     }
 #endif
     return OMPI_SUCCESS;

--- a/ompi/mca/fbtl/posix/fbtl_posix.h
+++ b/ompi/mca/fbtl/posix/fbtl_posix.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +47,7 @@ int mca_fbtl_posix_component_file_unquery (ompio_file_t *file);
 int mca_fbtl_posix_module_init (ompio_file_t *file);
 int mca_fbtl_posix_module_finalize (ompio_file_t *file);
 
-extern int fbtl_posix_max_aio_active_reqs;
+extern int ompi_fbtl_posix_max_aio_active_reqs;
 
 OMPI_DECLSPEC extern mca_fbtl_base_component_2_0_0_t mca_fbtl_posix_component;
 /*

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,7 +54,7 @@ ssize_t mca_fbtl_posix_ipreadv (ompio_file_t *fh,
     data->aio_req_count = fh->f_num_of_io_entries;
     data->aio_open_reqs = fh->f_num_of_io_entries;
     data->aio_req_type  = FBTL_POSIX_READ;
-    data->aio_req_chunks = fbtl_posix_max_aio_active_reqs;
+    data->aio_req_chunks = ompi_fbtl_posix_max_aio_active_reqs;
     data->aio_total_len = 0;
     data->aio_reqs = (struct aiocb *) malloc (sizeof(struct aiocb) *
                                               fh->f_num_of_io_entries);

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +53,7 @@ ssize_t  mca_fbtl_posix_ipwritev (ompio_file_t *fh,
     data->aio_req_count = fh->f_num_of_io_entries;
     data->aio_open_reqs = fh->f_num_of_io_entries;
     data->aio_req_type  = FBTL_POSIX_WRITE;
-    data->aio_req_chunks = fbtl_posix_max_aio_active_reqs;
+    data->aio_req_chunks = ompi_fbtl_posix_max_aio_active_reqs;
     data->aio_total_len = 0;
     data->aio_reqs = (struct aiocb *) malloc (sizeof(struct aiocb) *
                                               fh->f_num_of_io_entries);

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -320,10 +321,10 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         attr.context = NULL;
         if (false == ompi_mtl_base_selected_component->accelerator_support) {
             goto reg;
-        } else if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
+        } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
             attr.iface = FI_HMEM_CUDA;
             opal_accelerator.get_device(&attr.device.cuda);
-        } else if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
+        } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
             attr.iface = FI_HMEM_ROCR;
             opal_accelerator.get_device(&attr.device.cuda);
         } else {
@@ -334,7 +335,7 @@ reg:
 
         if (ret) {
             opal_show_help("help-mtl-ofi.txt", "Buffer Memory Registration Failed", true,
-                           accelerator_base_selected_component.base_version.mca_component_name,
+                           opal_accelerator_base_selected_component.base_version.mca_component_name,
                            buffer, ofi_req->length,
                            fi_strerror(-ret), ret);
             ofi_req->mr = NULL;

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -354,7 +354,7 @@ select_ofi_provider(struct fi_info *providers,
       * process id.
       */
     if (NULL != prov) {
-        prov = opal_mca_common_ofi_select_provider(prov, &ompi_process_info);
+        prov = opal_common_ofi_select_provider(prov, &ompi_process_info);
         opal_output_verbose(1, opal_common_ofi.output,
                             "%s:%d: mtl:ofi:provider:domain: %s\n",
                             __FILE__, __LINE__,

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,13 +43,6 @@
 BEGIN_C_DECLS
 
 struct mca_mtl_request_t;
-
-/* Array of send completion callback - one per send type
- * These are called internally by the library when the send
- * is completed from its perspective.
- */
-extern void (*send_completion_callbacks[])
-    (struct mca_mtl_request_t *mtl_request);
 
 struct ompi_pml_cm_t {
     mca_pml_base_module_t super;

--- a/ompi/mca/pml/cm/pml_cm_component.c
+++ b/ompi/mca/pml/cm/pml_cm_component.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +68,7 @@ mca_pml_base_component_2_1_0_t mca_pml_cm_component = {
  * These are called internally by the library when the send
  * is completed from its perspective.
  */
-void (*send_completion_callbacks[MCA_PML_BASE_SEND_SIZE])
+static void (*send_completion_callbacks[MCA_PML_BASE_SEND_SIZE])
     (struct mca_mtl_request_t *mtl_request) =
   { mca_pml_cm_send_request_completion,
     mca_pml_cm_send_request_completion,

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -344,14 +345,14 @@ int mca_pml_ob1_add_comm(ompi_communicator_t* comm)
              * the network.
              */
             if( NULL != pml_proc->frags_cant_match ) {
-                frag = check_cantmatch_for_match(pml_proc);
+                frag = ompi_pml_ob1_check_cantmatch_for_match(pml_proc);
                 if( NULL != frag ) {
                     hdr = &frag->hdr.hdr_match;
                     goto add_fragment_to_unexpected;
                 }
             }
         } else {
-            append_frag_to_ordered_list(&pml_proc->frags_cant_match, frag,
+            ompi_pml_ob1_append_frag_to_ordered_list(&pml_proc->frags_cant_match, frag,
                                         pml_proc->expected_sequence);
         }
     }

--- a/ompi/mca/pml/ob1/pml_ob1_accelerator.c
+++ b/ompi/mca/pml/ob1/pml_ob1_accelerator.c
@@ -19,6 +19,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,13 +54,13 @@ static opal_mutex_t pml_ob1_accelerator_dtoh_lock;
 
 /* Array of accelerator events to be queried for sending side and
  * receiving side. */
-opal_accelerator_event_t **accelerator_event_dtoh_array = NULL;
-opal_accelerator_event_t **accelerator_event_htod_array = NULL;
+static opal_accelerator_event_t **accelerator_event_dtoh_array = NULL;
+static opal_accelerator_event_t **accelerator_event_htod_array = NULL;
 
 /* Array of fragments currently being moved by accelerator async non-blocking
  * operations */
-struct mca_btl_base_descriptor_t **accelerator_event_dtoh_frag_array = NULL;
-struct mca_btl_base_descriptor_t **accelerator_event_htod_frag_array = NULL;
+static struct mca_btl_base_descriptor_t **accelerator_event_dtoh_frag_array = NULL;
+static struct mca_btl_base_descriptor_t **accelerator_event_htod_frag_array = NULL;
 
 /* First free/available location in accelerator_event_status_array */
 static int accelerator_event_dtoh_first_avail, accelerator_event_htod_first_avail;
@@ -71,14 +72,14 @@ static int accelerator_event_dtoh_first_used, accelerator_event_htod_first_used;
 static volatile int accelerator_event_dtoh_num_used, accelerator_event_htod_num_used;
 
 /* Size of array holding events */
-int accelerator_event_max = 400;
+static int accelerator_event_max = 400;
 static int accelerator_event_htod_most = 0;
 
 int mca_pml_ob1_record_htod_event(char *msg, struct mca_btl_base_descriptor_t *frag)
 {
     int result;
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
         return 0;
     }
 
@@ -136,7 +137,7 @@ int mca_pml_ob1_progress_one_htod_event(struct mca_btl_base_descriptor_t **frag)
 {
     int result;
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
         return 0;
     }
 
@@ -184,7 +185,7 @@ int mca_pml_ob1_accelerator_init(void)
     int result = OPAL_SUCCESS;
     int i;
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
         return 0;
     }
 
@@ -297,7 +298,7 @@ void mca_pml_ob1_accelerator_fini(void)
 {
     int i;
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
         return;
     }
 

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -170,7 +171,7 @@ extern void mca_pml_ob1_recv_frag_callback_cid( mca_btl_base_module_t *btl,
  * will be the next in sequence.
  */
 extern mca_pml_ob1_recv_frag_t*
-check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc);
+ompi_pml_ob1_check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc);
 
 /**
  * Move for all peers all pending cant_match fragments into the matching queues. This
@@ -178,9 +179,9 @@ check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc);
  */
 int mca_pml_ob1_merge_cant_match( ompi_communicator_t * ompi_comm );
 
-void append_frag_to_ordered_list(mca_pml_ob1_recv_frag_t** queue,
-                                 mca_pml_ob1_recv_frag_t* frag,
-                                 uint16_t seq);
+void ompi_pml_ob1_append_frag_to_ordered_list(mca_pml_ob1_recv_frag_t** queue,
+                                                  mca_pml_ob1_recv_frag_t* frag,
+                                                  uint16_t seq);
 
 void mca_pml_ob1_handle_cid (ompi_communicator_t *comm, int src, mca_pml_ob1_cid_hdr_t *hdr_cid);
 

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_component.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_component.c
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -183,13 +184,13 @@ static int mca_vprotocol_pessimist_component_finalize(void)
 int mca_vprotocol_pessimist_enable(bool enable) {
     if(enable) {
         int ret;
-        if((ret = vprotocol_pessimist_sender_based_init(_mmap_file_name,
+        if((ret = ompi_vprotocol_pessimist_sender_based_init(_mmap_file_name,
                                                  _sender_based_size)) != OMPI_SUCCESS)
             return ret;
     }
     else {
-        vprotocol_pessimist_sender_based_finalize();
-        vprotocol_pessimist_event_logger_disconnect(mca_vprotocol_pessimist.el_comm);
+        ompi_vprotocol_pessimist_sender_based_finalize();
+        ompi_vprotocol_pessimist_event_logger_disconnect(mca_vprotocol_pessimist.el_comm);
     }
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +20,7 @@
 #include "opal/util/printf.h"
 #include "ompi/dpm/dpm.h"
 
-int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm)
+int ompi_vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm)
 {
     int rc;
     pmix_status_t prc;
@@ -68,13 +69,13 @@ int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **
     return rc;
 }
 
-int vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm)
+int ompi_vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm)
 {
     ompi_dpm_disconnect(el_comm);
     return OMPI_SUCCESS;
 }
 
-void vprotocol_pessimist_matching_replay(int *src) {
+void ompi_vprotocol_pessimist_matching_replay(int *src) {
 #if OPAL_ENABLE_DEBUG
     vprotocol_pessimist_clock_t max = 0;
 #endif
@@ -110,7 +111,7 @@ void vprotocol_pessimist_matching_replay(int *src) {
 #endif
 }
 
-void vprotocol_pessimist_delivery_replay(size_t n, ompi_request_t **reqs,
+void ompi_vprotocol_pessimist_delivery_replay(size_t n, ompi_request_t **reqs,
                                          int *outcount, int *index,
                                          ompi_status_public_t *status) {
     mca_vprotocol_pessimist_event_t *event;

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.h
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,12 +22,12 @@ BEGIN_C_DECLS
 /** Initialize the MPI connexion with the event logger
  * @return OMPI_SUCCESS or error code
  */
-int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm);
+int ompi_vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **el_comm);
 
 /** Finalize the MPI connexion with the event logger
  * @return OMPI_SUCCESS or error code
  */
-int vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm);
+int ompi_vprotocol_pessimist_event_logger_disconnect(ompi_communicator_t *el_comm);
 
 /*******************************************************************************
   * ANY_SOURCE MATCHING
@@ -85,7 +86,7 @@ static inline void vprotocol_pessimist_matching_log_finish(ompi_request_t *req)
         vprotocol_pessimist_clock_t max_clock;                                \
         if(OPAL_UNLIKELY(ompi_comm_invalid(mca_vprotocol_pessimist.el_comm))) \
         {                                                                     \
-            rc = vprotocol_pessimist_event_logger_connect(0,                  \
+            rc = ompi_vprotocol_pessimist_event_logger_connect(0,             \
                                         &mca_vprotocol_pessimist.el_comm);    \
             if(OMPI_SUCCESS != rc)                                            \
                 OMPI_ERRHANDLER_INVOKE(mca_vprotocol_pessimist.el_comm, rc,   \
@@ -171,9 +172,9 @@ static inline void vprotocol_pessimist_event_flush(void)
  */
 #define VPROTOCOL_PESSIMIST_MATCHING_REPLAY(src) do {                         \
   if(mca_vprotocol_pessimist.replay && ((src) == MPI_ANY_SOURCE))             \
-    vprotocol_pessimist_matching_replay(&(src));                              \
+    ompi_vprotocol_pessimist_matching_replay(&(src));                         \
 } while(0)
-void vprotocol_pessimist_matching_replay(int *src);
+void ompi_vprotocol_pessimist_matching_replay(int *src);
 
 /*******************************************************************************
   * WAIT/TEST-SOME/ANY & PROBES
@@ -232,11 +233,11 @@ static inline void vprotocol_pessimist_delivery_log(ompi_request_t *req)
   * i (OUT): index(es) of the delivered request
   * status (OUT): status of the delivered request
   */
-#define VPROTOCOL_PESSIMIST_DELIVERY_REPLAY(n, reqs, outcount, i, status) do {\
-  if(mca_vprotocol_pessimist.replay)                                          \
-    vprotocol_pessimist_delivery_replay(n, reqs, outcount, i, status);        \
+#define VPROTOCOL_PESSIMIST_DELIVERY_REPLAY(n, reqs, outcount, i, status) do {   \
+  if(mca_vprotocol_pessimist.replay)                                             \
+    ompi_vprotocol_pessimist_delivery_replay(n, reqs, outcount, i, status);      \
 } while(0)
-void vprotocol_pessimist_delivery_replay(size_t, ompi_request_t **,
+void ompi_vprotocol_pessimist_delivery_replay(size_t, ompi_request_t **,
                                          int *, int *, ompi_status_public_t *);
 
 END_C_DECLS

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +81,7 @@ static void sb_mmap_free(void)
                      (void *) sb.sb_addr, strerror(errno));
 }
 
-int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
+int ompi_vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
 {
     char *path;
 #ifdef SB_USE_CONVERTOR_METHOD
@@ -107,7 +108,7 @@ int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size)
     return OMPI_SUCCESS;
 }
 
-void vprotocol_pessimist_sender_based_finalize(void)
+void ompi_vprotocol_pessimist_sender_based_finalize(void)
 {
     if(((uintptr_t) NULL) != sb.sb_addr)
         sb_mmap_free();
@@ -118,7 +119,7 @@ void vprotocol_pessimist_sender_based_finalize(void)
 /** Manage mmap floating window, allocating enough memory for the message to be
   * asynchronously copied to disk.
   */
-void vprotocol_pessimist_sender_based_alloc(size_t len)
+void ompi_vprotocol_pessimist_sender_based_alloc(size_t len)
 {
     if(((uintptr_t) NULL) != sb.sb_addr)
         sb_mmap_free();

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.h
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_sender_based.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,16 +23,16 @@ BEGIN_C_DECLS
 
 /** Prepare for using the sender based storage
   */
-int vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size);
+int ompi_vprotocol_pessimist_sender_based_init(const char *mmapfile, size_t size);
 
 /** Cleanup mmap etc
   */
-void vprotocol_pessimist_sender_based_finalize(void);
+void ompi_vprotocol_pessimist_sender_based_finalize(void);
 
 /** Manage mmap floating window, allocating enough memory for the message to be
   * asynchronously copied to disk.
   */
-void vprotocol_pessimist_sender_based_alloc(size_t len);
+void ompi_vprotocol_pessimist_sender_based_alloc(size_t len);
 
 
 /*******************************************************************************
@@ -177,7 +178,7 @@ static inline void vprotocol_pessimist_sender_based_copy_start(ompi_request_t *r
             pmlreq->req_bytes_packed +
             sizeof(vprotocol_pessimist_sender_based_header_t))
     {
-        vprotocol_pessimist_sender_based_alloc(pmlreq->req_bytes_packed);
+        ompi_vprotocol_pessimist_sender_based_alloc(pmlreq->req_bytes_packed);
     }
 
     /* Copy message header to the sender-based space */

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -235,7 +236,7 @@ opal_unpack_partial_predefined(opal_convertor_t *pConvertor, const dt_elem_desc_
      * content in the user memory. */
     /* Need to copy the modified user_data again so we can see which
      * bytes need to be converted back to their original values. */
-    if (0 != strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null")) {
+    if (0 != strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
         char resaved_data[16];
         pConvertor->cbmemcpy(resaved_data, user_data, data_length, pConvertor);
         for (size_t i = 0; i < data_length; i++) {

--- a/opal/mca/accelerator/base/accelerator_base_frame.c
+++ b/opal/mca/accelerator/base/accelerator_base_frame.c
@@ -4,6 +4,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +28,7 @@
 
 
 opal_accelerator_base_module_t opal_accelerator = {0};
-opal_accelerator_base_component_t accelerator_base_selected_component = {{0}};
+opal_accelerator_base_component_t opal_accelerator_base_selected_component = {{0}};
 
 static int opal_accelerator_base_frame_register(mca_base_register_flag_t flags)
 {

--- a/opal/mca/accelerator/base/accelerator_base_select.c
+++ b/opal/mca/accelerator/base/accelerator_base_select.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights
  * Copyright (c) 2018-2020 Triad National Security, LLC. All rights
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -125,7 +126,7 @@ int opal_accelerator_base_select(void)
         return OPAL_ERR_FATAL;
     } else if (2 >= initialized_list.opal_list_length) {
         ali = (accelerator_list_item_t *) opal_list_get_first(&initialized_list);
-        accelerator_base_selected_component = *ali->accelerator_component;
+        opal_accelerator_base_selected_component = *ali->accelerator_component;
         skip = (mca_base_component_t *) ali->accelerator_component;
         opal_accelerator = *ali->accelerator_module;
     } else {
@@ -135,7 +136,7 @@ int opal_accelerator_base_select(void)
     }
 
     opal_output_verbose(10, opal_accelerator_base_framework.framework_output, "selected %s\n",
-                        accelerator_base_selected_component.base_version.mca_component_name);
+                        opal_accelerator_base_selected_component.base_version.mca_component_name);
 
     /* This base function closes, unloads, and removes from the available list all
      * unselected components. The available list will contain only the selected component. */

--- a/opal/mca/accelerator/base/base.h
+++ b/opal/mca/accelerator/base/base.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +31,7 @@ OPAL_DECLSPEC extern mca_base_framework_t opal_accelerator_base_framework;
  */
 OPAL_DECLSPEC int opal_accelerator_base_select(void);
 
-OPAL_DECLSPEC extern opal_accelerator_base_component_t accelerator_base_selected_component;
+OPAL_DECLSPEC extern opal_accelerator_base_component_t opal_accelerator_base_selected_component;
 
 END_C_DECLS
 

--- a/opal/mca/base/mca_base_components_open.c
+++ b/opal/mca/base/mca_base_components_open.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,9 +51,9 @@ typedef struct fc_pair {
     opal_list_item_t li;
     char *framework_name;
     char *component_name;
-} fc_pair_t;
+} opal_base_fc_pair_t;
 
-OBJ_CLASS_DECLARATION(fc_pair_t);
+OBJ_CLASS_DECLARATION(opal_base_fc_pair_t);
 
 typedef enum {
     SHOW_LOAD_ERRORS_ALL,
@@ -80,7 +81,7 @@ static void fc_pair_destructor(struct fc_pair *obj)
     obj->component_name = NULL;
 }
 
-OBJ_CLASS_INSTANCE(fc_pair_t, opal_list_item_t,
+OBJ_CLASS_INSTANCE(opal_base_fc_pair_t, opal_list_item_t,
                    fc_pair_constructor,
                    fc_pair_destructor);
 
@@ -160,7 +161,7 @@ int mca_base_show_load_errors_init(void)
 
         char **split;
         int argc;
-        fc_pair_t *fcp;
+        opal_base_fc_pair_t *fcp;
         for (int i = 0; values[i] != NULL; ++i) {
             split = opal_argv_split(values[i], '/');
             if (NULL == split) {
@@ -199,7 +200,7 @@ int mca_base_show_load_errors_init(void)
                 return ret;
             }
 
-            fcp = OBJ_NEW(fc_pair_t);
+            fcp = OBJ_NEW(opal_base_fc_pair_t);
             if (NULL == fcp) {
                 ret = OPAL_ERR_OUT_OF_RESOURCE;
                 opal_show_help("help-mca-base.txt",
@@ -249,8 +250,8 @@ bool mca_base_show_load_errors(const char *framework_name,
 
     // See if the framework_name/component_name pair is found in the
     // active list.
-    fc_pair_t *item;
-    OPAL_LIST_FOREACH(item, list, fc_pair_t) {
+    opal_base_fc_pair_t *item;
+    OPAL_LIST_FOREACH(item, list, opal_base_fc_pair_t) {
         if (strcmp(framework_name, item->framework_name) == 0) {
             if (NULL == item->component_name) {
                 // If there's no component name, then we're matching

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -378,7 +378,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init(int *num_btl_modules,
              * are used to ensure that all NICs we return provide the same
              * capabilities as the initial one.
              */
-            selected_info = opal_mca_common_ofi_select_provider(info, &opal_process_info);
+            selected_info = opal_common_ofi_select_provider(info, &opal_process_info);
             rc = mca_btl_ofi_init_device(selected_info);
             if (OPAL_SUCCESS == rc) {
                 info = selected_info;

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -20,6 +20,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -319,7 +320,7 @@ static int smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl, int32_t my_s
         return rc;
     }
     /* now that res is fully populated, create the thing */
-    mca_btl_smcuda_component.sm_mpools[0] = common_sm_mpool_create(res);
+    mca_btl_smcuda_component.sm_mpools[0] = opal_btl_smcuda_common_sm_mpool_create(res);
     /* Sanity check to ensure that we found it */
     if (NULL == mca_btl_smcuda_component.sm_mpools[0]) {
         free(res);
@@ -353,7 +354,7 @@ static int smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl, int32_t my_s
     opal_output_verbose(10, opal_btl_base_framework.framework_output,
                         "btl:smcuda: CUDA cuMemHostRegister address=%p, size=%d",
                         mca_btl_smcuda_component.sm_mpool_base, (int) res->size);
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
         res = opal_accelerator.host_register(MCA_ACCELERATOR_NO_DEVICE_ID, mca_btl_smcuda_component.sm_mpool_base, res->size); 
         if (OPAL_UNLIKELY(OPAL_SUCCESS != res)) {
             /* If registering the memory fails, print a message and continue.
@@ -874,7 +875,7 @@ int mca_btl_smcuda_sendi(struct mca_btl_base_module_t *btl,
     }
     /* Initiate setting up CUDA IPC support. */
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "cuda") && (IPC_INIT == endpoint->ipcstate)
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda") && (IPC_INIT == endpoint->ipcstate)
         && mca_btl_smcuda_component.use_cuda_ipc) {
         mca_btl_smcuda_send_cuda_ipc_request(btl, endpoint);
     }
@@ -964,7 +965,7 @@ int mca_btl_smcuda_send(struct mca_btl_base_module_t *btl, struct mca_btl_base_e
         mca_btl_smcuda_component_progress();
     }
     /* Initiate setting up CUDA IPC support */
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "cuda") && (IPC_INIT == endpoint->ipcstate)
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda") && (IPC_INIT == endpoint->ipcstate)
         && mca_btl_smcuda_component.use_cuda_ipc) {
         mca_btl_smcuda_send_cuda_ipc_request(btl, endpoint);
     }

--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
@@ -1,5 +1,6 @@
 /* 
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +31,7 @@ static int accelerator_event_ipc_first_used;
 static volatile int accelerator_event_ipc_num_used;
 
 /* Size of array holding events */
-int accelerator_event_max = 400;
+static int accelerator_event_max = 400;
 static int accelerator_event_ipc_most = 0;
 static bool smcuda_accelerator_initialized = false;
 
@@ -106,7 +107,7 @@ void mca_btl_smcuda_accelerator_fini(void)
 {
     int i;
 
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "null") ||
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null") ||
         false == smcuda_accelerator_initialized) {
         return;
     }

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2011-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -175,7 +176,7 @@ static int smcuda_register(void)
         NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_smcuda_component.allocator);
 
     /* Lower priority when CUDA support is not requested */
-    if (0 == strcmp(accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
+    if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
 
         mca_btl_smcuda.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH + 1;
     } else {

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -592,7 +592,7 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
     return (uint32_t) package_ranks[process_info->my_local_rank];
 }
 
-struct fi_info *opal_mca_common_ofi_select_provider(struct fi_info *provider_list,
+struct fi_info *opal_common_ofi_select_provider(struct fi_info *provider_list,
                                                     opal_process_info_t *process_info)
 {
     struct fi_info *provider = provider_list, *current_provider = provider_list;

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -151,7 +151,7 @@ OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item);
  * balance across available NICs.
  *
  */
-OPAL_DECLSPEC struct fi_info *opal_mca_common_ofi_select_provider(struct fi_info *provider_list,
+OPAL_DECLSPEC struct fi_info *opal_common_ofi_select_provider(struct fi_info *provider_list,
                                                                   opal_process_info_t *process_info);
 
 /**

--- a/opal/mca/common/sm/common_sm_mpool.c
+++ b/opal/mca/common/sm/common_sm_mpool.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +70,7 @@ static void mca_common_sm_mpool_module_init(mca_common_sm_mpool_module_t *mpool)
     mpool->mem_node = -1;
 }
 
-mca_mpool_base_module_t *common_sm_mpool_create(mca_common_sm_mpool_resources_t *resources)
+mca_mpool_base_module_t *opal_btl_smcuda_common_sm_mpool_create(mca_common_sm_mpool_resources_t *resources)
 {
     mca_common_sm_mpool_module_t *mpool_module;
     mca_allocator_base_component_t *allocator_component;

--- a/opal/mca/common/sm/common_sm_mpool.h
+++ b/opal/mca/common/sm/common_sm_mpool.h
@@ -16,6 +16,7 @@
  *                         All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +58,7 @@ typedef struct mca_common_sm_mpool_module_t {
     int32_t mem_node;
 } mca_common_sm_mpool_module_t;
 
-OPAL_DECLSPEC mca_mpool_base_module_t *common_sm_mpool_create(mca_common_sm_mpool_resources_t *);
+OPAL_DECLSPEC mca_mpool_base_module_t *opal_btl_smcuda_common_sm_mpool_create(mca_common_sm_mpool_resources_t *);
 
 END_C_DECLS
 

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.c
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -61,7 +62,7 @@
 #include "shmem_posix_common_utils.h"
 
 /* ////////////////////////////////////////////////////////////////////////// */
-int shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
+int opal_shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
 {
     int attempt = 0, fd = -1;
 

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.h
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +43,7 @@ BEGIN_C_DECLS
  * successful shm_open.  otherwise, -1 is returned and the contents of
  * posix_file_name_buff are undefined.
  */
-OPAL_DECLSPEC extern int shmem_posix_shm_open(char *posix_file_name_buff, size_t size);
+OPAL_DECLSPEC extern int opal_shmem_posix_shm_open(char *posix_file_name_buff, size_t size);
 
 END_C_DECLS
 

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -161,7 +162,7 @@ static int posix_runtime_query(mca_base_module_t **module, int *priority, const 
                          "shmem: posix: runtime_query: NO HINT PROVIDED:"
                          "starting run-time test...\n"));
     /* shmem_posix_shm_open successfully shm_opened - we can use posix sm! */
-    if (-1 != (fd = shmem_posix_shm_open(tmp_buff, OPAL_SHMEM_POSIX_FILE_LEN_MAX - 1))) {
+    if (-1 != (fd = opal_shmem_posix_shm_open(tmp_buff, OPAL_SHMEM_POSIX_FILE_LEN_MAX - 1))) {
         /* free up allocated resources before we return */
         if (0 != shm_unlink(tmp_buff)) {
             int err = errno;

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +165,7 @@ static int segment_create(opal_shmem_ds_t *ds_buf, const char *file_name, size_t
      * buffer
      */
     if (-1
-        == (ds_buf->seg_id = shmem_posix_shm_open(ds_buf->seg_name,
+        == (ds_buf->seg_id = opal_shmem_posix_shm_open(ds_buf->seg_name,
                                                   OPAL_SHMEM_POSIX_FILE_LEN_MAX - 1))) {
         /* snaps!  something happened in posix_shm_open.  don't report anything
          * here because posix_shm_open will display all the necessary info.

--- a/opal/mca/threads/wait_sync.h
+++ b/opal/mca/threads/wait_sync.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation. All rights reserved.
  * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2021      Argonne National Laboratory.  All rights reserved.
  *
@@ -91,19 +91,19 @@ typedef struct ompi_wait_sync_t {
     }
 
 /* not static for inline "wait_sync_st" */
-OPAL_DECLSPEC extern ompi_wait_sync_t *wait_sync_list;
+OPAL_DECLSPEC extern ompi_wait_sync_t *opal_threads_base_wait_sync_list;
 
 OPAL_DECLSPEC int ompi_sync_wait_mt(ompi_wait_sync_t *sync);
 static inline int sync_wait_st(ompi_wait_sync_t *sync)
 {
-    assert(NULL == wait_sync_list);
+    assert(NULL == opal_threads_base_wait_sync_list);
     assert(NULL == sync->next);
-    wait_sync_list = sync;
+    opal_threads_base_wait_sync_list = sync;
 
     while (sync->count > 0) {
         opal_progress();
     }
-    wait_sync_list = NULL;
+    opal_threads_base_wait_sync_list = NULL;
 
     return sync->status;
 }
@@ -126,10 +126,11 @@ static inline int sync_wait_st(ompi_wait_sync_t *sync)
  * operation is a NO-OP. Otherwise it will trigger the "error condition" from
  * all registered sync.
  */
-OPAL_DECLSPEC void wait_sync_global_wakeup_st(int status);
-OPAL_DECLSPEC void wait_sync_global_wakeup_mt(int status);
+OPAL_DECLSPEC void opal_threads_base_wait_sync_global_wakeup_st(int status);
+OPAL_DECLSPEC void opal_threads_base_wait_sync_global_wakeup_mt(int status);
 #define wait_sync_global_wakeup(st) \
-    (opal_using_threads() ? wait_sync_global_wakeup_mt(st) : wait_sync_global_wakeup_st(st))
+    (opal_using_threads() ? opal_threads_base_wait_sync_global_wakeup_mt(st) : \
+    		                opal_threads_base_wait_sync_global_wakeup_st(st))
 
 /**
  * Update the status of the synchronization primitive. If an error is

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -26,6 +26,7 @@
  *                         reserved.
  * Copyright (c) 2020      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -200,7 +201,7 @@ int opal_init(int *pargc, char ***pargv)
     if (OPAL_SUCCESS == ret && OPAL_SUCCESS != (ret = opal_accelerator_base_select())) {
         return opal_init_error("opal_accelerator_base_select", ret);
     }
-    opal_finalize_register_cleanup(accelerator_base_selected_component.accelerator_finalize);
+    opal_finalize_register_cleanup(opal_accelerator_base_selected_component.accelerator_finalize);
 
     /* initialize the datatype engine */
     if (OPAL_SUCCESS != (ret = opal_datatype_init())) {


### PR DESCRIPTION
This a a cherry-pick of #10859

Rename external symbols with proper ompi_* or opal_* component prefixes

Signed-off-by: David Wootton <drwootton@us.ibm.com>
(cherry picked from commit 89191407e8534c5116903ec3ad48c219badc7f47)