### PR TITLE
Fix potential oob read in mca_coll_han_query_module_from_mca

### DIFF
--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -187,9 +187,8 @@ mca_coll_han_query_module_from_mca(mca_base_component_t* c,
 {
     char *module_name, *endptr = NULL;
 
-    int mod_id = COMPONENTS_COUNT;
+    int mod_id = COMPONENTS_COUNT-1;
     mod_id = (*module_id > (uint32_t)mod_id) ? mod_id : (int)*module_id; /* stay in range */
-    mod_id = (mod_id < 0) ? 0 : mod_id;  /* in range */
 
     *storage = available_components[mod_id].component_name;
 


### PR DESCRIPTION
Reported as CID 1516096. The `mod_id` must be one less than the `COMPONENTS_COUNT` upper bound.

I removed the second check because I don't see how `mod_id` could be negative at that point.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>