### PR TITLE
coll/basic: Fix clang warnings

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_reduce.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -145,6 +146,9 @@ mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
         }
         sbuf = inplace_temp - gap;
         err = ompi_datatype_copy_content_same_ddt(dtype, count, (char*)sbuf, (char*)rbuf);
+        if (MPI_SUCCESS != err) {
+            goto cleanup_and_return;
+        }
     }
     snd_buffer = (char*)sbuf;
 

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,11 +105,12 @@ mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcou
     if (rank == root) {
         span = opal_datatype_span(&dtype->super, totalcounts, &gap);
 
-        tmpbuf = (char *) malloc(span);
-        tmpbuf2 = (char *) malloc(span);
-        if (NULL == tmpbuf || NULL == tmpbuf2) {
+        tmpbuf = (char *) malloc(2*span);
+        if (NULL == tmpbuf) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
+        tmpbuf2 = tmpbuf + span;
+
         lbuf = tmpbuf - gap;
         buf = tmpbuf2 - gap;
 

--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -93,6 +93,9 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
             if (scounts[i] > 0 && MPI_IN_PLACE != rbuf) {
                 err = ompi_datatype_sndrcv(ptmp, scounts[i], sdtype, rbuf, rcount,
                                       rdtype);
+                if (MPI_SUCCESS != err) {
+                    return err;
+                }
             }
         } else {
             /* Only send if there is something to send */


### PR DESCRIPTION
 * Possible memory leak of tmp variable
 * `err` variable not checked or used