### PR TITLE
Fix memory leak in ompi_report_comm_methods by removing redundant malloc, fixes Coverity CID 1515837

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -525,11 +525,6 @@ ompi_report_comm_methods(int called_from_location)
 
 // Each host leader fills in a "numhosts" sized array method[] of
 // how it communicates with each peer.
-    // Use a bitmap to keep track of which communication methods are used
-    n = ((comm_method_string_conversion.n + 7) / 8) * sizeof(unsigned char);
-    methods_used = malloc(n);
-    memset(methods_used, 0, n);
-
     for (i=0; i<nleaderranks; ++i) {
         method[i] = comm_method(leader_comm, i);
 


### PR DESCRIPTION
Fixed a memory leak in ompi_report_comm_methods where the bitmap used to track which UCX transport strings were used
in building the report generated when the --mca hook_comm_method_display option was specified.

Storage for the bitmap was allocated twice, with no use between the first and second allocations, so the first allocation is removed.

This fixes Coverity CID 1515837

This is a cherry-pick of #10935 for ompi v5.0.x

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 5c2813987e45a684766697e900496920fcd21bb1)