### PR TITLE
Part 3 of resolving global symbol name pollution #10708 for V5.0.x

### DIFF
--- a/3rd-party/treematch/IntConstantInitializedVector.c
+++ b/3rd-party/treematch/IntConstantInitializedVector.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "IntConstantInitializedVector.h"
 
-int intCIV_isInitialized(int_CIVector * v, int i)
+int tm_intCIV_isInitialized(int_CIVector * v, int i)
 {
   if(v->top == 0)
     return 0;
@@ -14,7 +14,7 @@ int intCIV_isInitialized(int_CIVector * v, int i)
 
 
 
-void intCIV_init(int_CIVector * v, int size, int init_value)
+void tm_intCIV_init(int_CIVector * v, int size, int init_value)
 {
   v->init_value = init_value;
   v->size = size;
@@ -24,20 +24,20 @@ void intCIV_init(int_CIVector * v, int size, int init_value)
   v->vec = malloc(sizeof(int)*size);
 }
 
-void intCIV_exit(int_CIVector * v)
+static inline void intCIV_exit(int_CIVector * v)
 {
   free(v->to);
   free(v->from);
   free(v->vec);
  }
 
-int intCIV_set(int_CIVector * v, int i, int val)
+int tm_intCIV_set(int_CIVector * v, int i, int val)
 {
   if(v == NULL)
     return -1;
   if(i < 0 || i >= v->size)
     return -1;
-  if(!intCIV_isInitialized(v,i))
+  if(!tm_intCIV_isInitialized(v,i))
     {
       v->from[i] = v->top;
       v->to[v->top] = i;
@@ -47,13 +47,13 @@ int intCIV_set(int_CIVector * v, int i, int val)
   return 0;  
 }
 
-int intCIV_get(int_CIVector * v, int i)
+int tm_intCIV_get(int_CIVector * v, int i)
 {
   if(v == NULL)
     return -1;
   if(i < 0 || i >= v->size)
     return -1;
-  if(intCIV_isInitialized(v,i))
+  if(tm_intCIV_isInitialized(v,i))
     return v->vec[i];
   return v->init_value;
 }

--- a/3rd-party/treematch/IntConstantInitializedVector.h
+++ b/3rd-party/treematch/IntConstantInitializedVector.h
@@ -1,15 +1,16 @@
 #ifndef INTEGER_CONSTANT_INITIALIZED_VECTOR
 #define INTEGER_CONSTANT_INITIALIZED_VECTOR
 
+#include "ompi_config.h"
+
 typedef struct int_CIVector_
 {
   int init_value, size, top, *to, *from, *vec;
 } int_CIVector;
 
-int intCIV_isInitialized(int_CIVector * v, int i);
-void intCIV_init(int_CIVector * v, int size, int init_value);
-void intCIV_exit(int_CIVector * v);
-int intCIV_set(int_CIVector * v, int i, int val);
-int intCIV_get(int_CIVector * v, int i);
+OMPI_HIDDEN int tm_intCIV_isInitialized(int_CIVector * v, int i);
+OMPI_HIDDEN void tm_intCIV_init(int_CIVector * v, int size, int init_value);
+OMPI_HIDDEN int tm_intCIV_set(int_CIVector * v, int i, int val);
+OMPI_HIDDEN int tm_intCIV_get(int_CIVector * v, int i);
 
 #endif /*INTEGER_CONSTANT_INITIALIZED_VECTOR*/

--- a/3rd-party/treematch/PriorityQueue.c
+++ b/3rd-party/treematch/PriorityQueue.c
@@ -21,7 +21,7 @@ int PQ_init(PriorityQueue * const q, int size)
   q->elements = malloc(sizeof(QueueElement *) * size);
   for(i=0; i < size; i++)
     q->elements[i]=NULL;
-  return fiboTreeInit((FiboTree *)q, compFunc);
+  return tm_fiboTreeInit((FiboTree *)q, compFunc);
 }
 
 void PQ_exit(PriorityQueue * const q)
@@ -35,7 +35,7 @@ void PQ_exit(PriorityQueue * const q)
     }
   if(q->elements != NULL)
     free(q->elements);
-  fiboTreeExit((FiboTree *)q);
+  tm_fiboTreeExit((FiboTree *)q);
 }
 void PQ_free(PriorityQueue * const q)
 {
@@ -45,7 +45,7 @@ void PQ_free(PriorityQueue * const q)
       if(q->elements[i] != NULL)
 	free(q->elements[i]);
     }
-  fiboTreeFree((FiboTree *)q);
+  tm_fiboTreeFree((FiboTree *)q);
 }
 
 int PQ_isEmpty(PriorityQueue * const q)
@@ -68,7 +68,7 @@ void PQ_insertElement(PriorityQueue * const q, QueueElement * const e)
 }
 void PQ_deleteElement(PriorityQueue * const q, QueueElement * const e)
 {
-  fiboTreeDel((FiboTree *)q, (FiboNode *)(e));
+  tm_fiboTreeDel((FiboTree *)q, (FiboNode *)(e));
   q->elements[e->value] = NULL;
   e->isInQueue = 0;
 }
@@ -93,12 +93,12 @@ void PQ_delete(PriorityQueue * const q, int val)
 
 QueueElement * PQ_findMaxElement(PriorityQueue * const q)
 {
-  QueueElement * e = (QueueElement *)(fiboTreeMin((FiboTree *)q));
+  QueueElement * e = (QueueElement *)(tm_fiboTreeMin((FiboTree *)q));
   return e;
 }
 QueueElement * PQ_deleteMaxElement(PriorityQueue * const q)
 {
-  QueueElement * e = (QueueElement *)(fiboTreeMin((FiboTree *)q));
+  QueueElement * e = (QueueElement *)(tm_fiboTreeMin((FiboTree *)q));
   if(e != NULL)
     {
       PQ_deleteElement(q, e);

--- a/3rd-party/treematch/fibo.c
+++ b/3rd-party/treematch/fibo.c
@@ -28,6 +28,7 @@
 ** 
 ** The fact that you are presently reading this means that you have had
 ** knowledge of the CeCILL-B license and that you accept its terms.
+**
 */
 /************************************************************/
 /**                                                        **/
@@ -69,6 +70,8 @@
 #define memFree                     free
 #endif /* memAlloc */
 
+static FiboNode *fiboTreeConsolidate (FiboTree * const);
+
 /*********************************************/
 /*                                           */
 /* These routines deal with Fibonacci trees. */
@@ -83,7 +86,7 @@
 */
 
 int
-fiboTreeInit (
+tm_fiboTreeInit (
 FiboTree * const            treeptr,
 int                      (* cmpfptr) (const FiboNode * const, const FiboNode * const))
 {
@@ -106,7 +109,7 @@ int                      (* cmpfptr) (const FiboNode * const, const FiboNode * c
 */
 
 void
-fiboTreeExit (
+tm_fiboTreeExit (
 FiboTree * const            treeptr)
 {
   if (treeptr->degrtab != NULL)
@@ -122,7 +125,7 @@ FiboTree * const            treeptr)
 */
 
 void
-fiboTreeFree (
+tm_fiboTreeFree (
 FiboTree * const            treeptr)
 {
   treeptr->rootdat.linkdat.prevptr =              /* Link root node to itself */
@@ -138,7 +141,7 @@ FiboTree * const            treeptr)
 ** - NULL   : Fibonacci tree is empty.
 */
 
-FiboNode *
+static FiboNode *
 fiboTreeConsolidate (
 FiboTree * const            treeptr)
 {
@@ -229,7 +232,7 @@ FiboTree * const            treeptr)
 #ifndef fiboTreeMin
 
 FiboNode *
-fiboTreeMin (
+tm_fiboTreeMin (
 FiboTree * const            treeptr)
 {
   FiboNode *            bestptr;
@@ -279,7 +282,7 @@ FiboNode * const            nodeptr)
 #ifndef fiboTreeDel
 
 void
-fiboTreeDel (
+tm_fiboTreeDel (
 FiboTree * const            treeptr,
 FiboNode * const            nodeptr)
 {

--- a/3rd-party/treematch/fibo.h
+++ b/3rd-party/treematch/fibo.h
@@ -28,6 +28,7 @@
 ** 
 ** The fact that you are presently reading this means that you have had
 ** knowledge of the CeCILL-B license and that you accept its terms.
+** 
 */
 /************************************************************/
 /**                                                        **/
@@ -55,6 +56,8 @@
 /**                  implementations do.                   **/
 /**                                                        **/
 /************************************************************/
+
+#include "ompi_config.h"
 
 /*
 **  The type and structure definitions.
@@ -184,19 +187,18 @@ typedef struct FiboTree_ {
 #define static
 #endif
 
-int                         fiboTreeInit        (FiboTree * const, int (*) (const FiboNode * const, const FiboNode * const));
-void                        fiboTreeExit        (FiboTree * const);
-void                        fiboTreeFree        (FiboTree * const);
-FiboNode *                  fiboTreeConsolidate (FiboTree * const);
+OMPI_HIDDEN int             tm_fiboTreeInit        (FiboTree * const, int (*) (const FiboNode * const, const FiboNode * const));
+OMPI_HIDDEN void            tm_fiboTreeExit        (FiboTree * const);
+OMPI_HIDDEN void            tm_fiboTreeFree        (FiboTree * const);
 #ifndef fiboTreeAdd
 void                        fiboTreeAdd         (FiboTree * const, FiboNode * const);
 #endif /* fiboTreeAdd */
 #ifndef fiboTreeDel
-void                        fiboTreeDel         (FiboTree * const, FiboNode * const);
+OMPI_HIDDEN void            tm_fiboTreeDel (FiboTree * const, FiboNode * const);
 #endif /* fiboTreeDel */
-#ifndef fiboTreeMin
-FiboNode *                  fiboTreeMin         (FiboTree * const);
-#endif /* fiboTreeMin */
+#ifndef treematch_fiboTreeMin
+OMPI_HIDDEN FiboNode *      tm_fiboTreeMin         (FiboTree * const);
+#endif /* treematch_fiboTreeMin */
 #ifdef FIBO_DEBUG
 int                         fiboTreeCheck       (const FiboTree * const);
 static int                  fiboTreeCheck2      (const FiboNode * const);

--- a/3rd-party/treematch/k-partitioning.c
+++ b/3rd-party/treematch/k-partitioning.c
@@ -4,19 +4,19 @@
 #include "tm_mt.h"
 #include "tm_verbose.h"
 
-void memory_allocation(PriorityQueue ** Q, PriorityQueue ** Qinst, double *** D, int n, int k);
-void initialization(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int k, int * const deficit, int * const surplus);
-void algo(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n,  int * const deficit, int * const surplus);
-double nextGain(PriorityQueue * const Qpart, PriorityQueue * const Q, int * const deficit, int * const surplus);
-void balancing(int n, int deficit, int surplus, double ** const D, int * const part);
-void destruction(PriorityQueue * Qpart, PriorityQueue * Q, PriorityQueue * Qinst, double ** D, int n, int k);
+static void memory_allocation(PriorityQueue ** Q, PriorityQueue ** Qinst, double *** D, int n, int k);
+static void initialization(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int k, int * const deficit, int * const surplus);
+static void algo(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n,  int * const deficit, int * const surplus);
+static double nextGain(PriorityQueue * const Qpart, PriorityQueue * const Q, int * const deficit, int * const surplus);
+static void balancing(int n, int deficit, int surplus, double ** const D, int * const part);
+static void destruction(PriorityQueue * Qpart, PriorityQueue * Q, PriorityQueue * Qinst, double ** D, int n, int k);
 
-void allocate_vertex2(int u, int *res, double **comm, int n, int *size, int max_size);
-double eval_cost2(int *,int,double **);
-int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *constraints, int nb_constraints);
-int*  build_p_vector(double **comm, int n, int k, int greedy_trials, int * constraints, int nb_constraints);
+static void allocate_vertex2(int u, int *res, double **comm, int n, int *size, int max_size);
+static double eval_cost2(int *,int,double **);
+static int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *constraints, int nb_constraints);
+static int*  build_p_vector(double **comm, int n, int k, int greedy_trials, int * constraints, int nb_constraints);
 
-int* kPartitioning(double ** comm, int n, int k, int * constraints, int nb_constraints, int greedy_trials)
+int* tm_kPartitioning(double ** comm, int n, int k, int * constraints, int nb_constraints, int greedy_trials)
 {
   /* ##### declarations & allocations ##### */
 
@@ -48,7 +48,7 @@ int* kPartitioning(double ** comm, int n, int k, int * constraints, int nb_const
   return part;
 }
 
-void memory_allocation(PriorityQueue ** Q, PriorityQueue ** Qinst, double *** D, int n, int k)
+static void memory_allocation(PriorityQueue ** Q, PriorityQueue ** Qinst, double *** D, int n, int k)
 {
   int i;
   *Q = calloc(k, sizeof(PriorityQueue)); /*one Q for each partition*/
@@ -58,7 +58,7 @@ void memory_allocation(PriorityQueue ** Q, PriorityQueue ** Qinst, double *** D,
     (*D)[i] = calloc(k, sizeof(double));
 }
 
-void initialization(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int k, int * const deficit, int * const surplus)
+static void initialization(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int k, int * const deficit, int * const surplus)
 {
   int i,j;
 
@@ -103,7 +103,7 @@ void initialization(int * const part, double ** const matrice, PriorityQueue * c
   *surplus = *deficit = 0;
 }
 
-void algo(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int * const deficit, int * const surplus)
+static void algo(int * const part, double ** const matrice, PriorityQueue * const Qpart, PriorityQueue * const Q, PriorityQueue * const Qinst, double ** const D, int n, int * const deficit, int * const surplus)
 {
   int p,u,v,j;
   double d;
@@ -149,7 +149,7 @@ void algo(int * const part, double ** const matrice, PriorityQueue * const Qpart
   PQ_adjustKey(Qpart, part[u], d); /*we update the new highest possible gain in u's subset*/
 }
 
-double nextGain(PriorityQueue * const Qpart, PriorityQueue * const Q, int * const deficit, int * const surplus)
+static double nextGain(PriorityQueue * const Qpart, PriorityQueue * const Q, int * const deficit, int * const surplus)
 {
   double res;
   if(*deficit == *surplus) /*if the current partition is balanced*/
@@ -159,7 +159,7 @@ double nextGain(PriorityQueue * const Qpart, PriorityQueue * const Q, int * cons
   return res;
 }
 
-void balancing(int n, int deficit, int surplus, double ** const D, int * const part)
+static void balancing(int n, int deficit, int surplus, double ** const D, int * const part)
 {
   if(surplus != deficit) /*if the current partition is not balanced*/
     {
@@ -176,7 +176,7 @@ void balancing(int n, int deficit, int surplus, double ** const D, int * const p
     }
 }
 
-void destruction(PriorityQueue * Qpart, PriorityQueue * Q, PriorityQueue * Qinst, double ** D, int n, int k)
+static void destruction(PriorityQueue * Qpart, PriorityQueue * Q, PriorityQueue * Qinst, double ** D, int n, int k)
 {
   int i;
   PQ_exit(Qpart);
@@ -195,7 +195,7 @@ void destruction(PriorityQueue * Qpart, PriorityQueue * Q, PriorityQueue * Qinst
 }
 
 
-int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *constraints, int nb_constraints)
+static int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *constraints, int nb_constraints)
 {
   int *res = NULL, *best_res=NULL, *size = NULL;
   int i,j,nb_trials;
@@ -229,7 +229,7 @@ int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *const
       /* find a vertex not already partitionned*/
       do{
 	/* call the mersenne twister PRNG of tm_mt.c*/
-	j =  genrand_int32() % n;
+	j =  tm_genrand_int32() % n;
       } while ( res[j] != -1 );
       /* allocate and update size of partition*/
       res[j] = i;
@@ -261,7 +261,7 @@ int  *kpartition_greedy2(int k, double **comm, int n, int nb_try_max, int *const
   return best_res;
 }
 
-void allocate_vertex2(int u, int *res, double **comm, int n, int *size, int max_size)
+static void allocate_vertex2(int u, int *res, double **comm, int n, int *size, int max_size)
 {
   int i,best_part = -1;
   double cost, best_cost = -1;
@@ -285,7 +285,7 @@ void allocate_vertex2(int u, int *res, double **comm, int n, int *size, int max_
   size[best_part]++;
 }
 
-double eval_cost2(int *partition, int n, double **comm)
+static double eval_cost2(int *partition, int n, double **comm)
 {
   double cost = 0;
   int i,j;
@@ -298,7 +298,7 @@ double eval_cost2(int *partition, int n, double **comm)
   return cost;
 }
 
-int* build_p_vector(double **comm, int n, int k, int greedy_trials, int * constraints, int nb_constraints)
+static int* build_p_vector(double **comm, int n, int k, int greedy_trials, int * constraints, int nb_constraints)
 {
   int * part = NULL;
   if(greedy_trials>0) /*if greedy_trials > 0 then we use kpartition_greedy with greedy_trials trials*/

--- a/3rd-party/treematch/k-partitioning.h
+++ b/3rd-party/treematch/k-partitioning.h
@@ -1,6 +1,8 @@
 #ifndef K_PARTITIONING
 #define K_PARTITIONING
 
+#include "ompi_config.h"
+
 #include "PriorityQueue.h"
 
 /*
@@ -14,7 +16,7 @@
           - 0 : cyclic distribution of vertices
 	  - > 0 : use of kpartition_greedy with greedy_trials number of trials 
  */
-             
-int* kPartitioning(double ** comm, int n, int k, int * const constraints, int nb_constraints, int greedy_trials);
+
+OMPI_HIDDEN int* tm_kPartitioning(double ** comm, int n, int k, int * const constraints, int nb_constraints, int greedy_trials);
 
 #endif /*K_PARTITIONING*/

--- a/3rd-party/treematch/tm_bucket.c
+++ b/3rd-party/treematch/tm_bucket.c
@@ -33,27 +33,28 @@ static int verbose_level = ERROR;
 
 static bucket_list_t global_bl = {0};
 
-int tab_cmp(const void*,const void*);
-int old_bucket_id(int,int,bucket_list_t);
-int bucket_id(int,int,bucket_list_t);
-void display_bucket(bucket_t *);
-void check_bucket(bucket_t *,double **,double, double);
-void display_pivots(bucket_list_t);
-void display_bucket_list(bucket_list_t);
-void add_to_bucket(int,int,int,bucket_list_t);
-void dfs(int,int,int,double *,double *,int,int);
-void built_pivot_tree(bucket_list_t);
-void fill_buckets(bucket_list_t);
-int is_power_of_2(int);
-void partial_sort(bucket_list_t *,double **,int);
-void next_bucket_elem(bucket_list_t,int *,int *);
-int add_edge_3(tm_tree_t *,tm_tree_t *,int,int,int *);
-void free_bucket(bucket_t *);
-void free_tab_bucket(bucket_t **,int);
-void free_bucket_list(bucket_list_t);
-void partial_update_val (int nb_args, void **args, int thread_id);
-double bucket_grouping(tm_affinity_mat_t *,tm_tree_t *, tm_tree_t *, int ,int);
-int tab_cmp(const void* x1,const void* x2)
+static int tab_cmp(const void*,const void*);
+static int old_bucket_id(int,int,bucket_list_t);
+static int bucket_id(int,int,bucket_list_t);
+static void display_bucket(bucket_t *);
+static void check_bucket(bucket_t *,double **,double, double);
+static void display_pivots(bucket_list_t);
+static void display_bucket_list(bucket_list_t);
+static void add_to_bucket(int,int,int,bucket_list_t);
+static void dfs(int,int,int,double *,double *,int,int);
+static void built_pivot_tree(bucket_list_t);
+static void fill_buckets(bucket_list_t);
+static int is_power_of_2(int);
+static void partial_sort(bucket_list_t *,double **,int);
+static void next_bucket_elem(bucket_list_t,int *,int *);
+static int add_edge_3(tm_tree_t *,tm_tree_t *,int,int,int *);
+static void free_bucket(bucket_t *);
+static void free_tab_bucket(bucket_t **,int);
+static void free_bucket_list(bucket_list_t);
+static void partial_update_val (int nb_args, void **args, int thread_id);
+double tm_bucket_grouping(tm_affinity_mat_t *,tm_tree_t *, tm_tree_t *, int ,int);
+
+static int tab_cmp(const void* x1,const void* x2)
 {
   int *e1 = NULL,*e2 = NULL,i1,i2,j1,j2;
   double **tab = NULL;
@@ -82,7 +83,7 @@ int tab_cmp(const void* x1,const void* x2)
 }
 
 
-int old_bucket_id(int i,int j,bucket_list_t bucket_list)
+static inline int old_bucket_id(int i,int j,bucket_list_t bucket_list)
 {
   double *pivot = NULL,val;
   int n,sup,inf,p;
@@ -111,7 +112,7 @@ int old_bucket_id(int i,int j,bucket_list_t bucket_list)
   return sup;
 }
 
-int bucket_id(int i,int j,bucket_list_t bucket_list)
+static int bucket_id(int i,int j,bucket_list_t bucket_list)
 {
   double *pivot_tree = NULL,val;
   int p,k;
@@ -131,14 +132,14 @@ int bucket_id(int i,int j,bucket_list_t bucket_list)
   return (int)pivot_tree[p];
 }
 
-void  display_bucket(bucket_t *b)
+static void  display_bucket(bucket_t *b)
 {
   printf("\tb.bucket=%p\n",(void *)b->bucket);
   printf("\tb.bucket_len=%d\n",(int)b->bucket_len);
   printf("\tb.nb_elem=%d\n",(int)b->nb_elem);
 }
 
-void check_bucket(bucket_t *b,double **tab,double inf, double sup)
+static void check_bucket(bucket_t *b,double **tab,double inf, double sup)
 {
   int i,j,k;
   for( k = 0 ; k < b->nb_elem ; k++ ){
@@ -152,7 +153,7 @@ void check_bucket(bucket_t *b,double **tab,double inf, double sup)
   }
 }
 
-void display_pivots(bucket_list_t bucket_list)
+static void display_pivots(bucket_list_t bucket_list)
 {
   int i;
   for( i = 0 ; i < bucket_list->nb_buckets-1 ; i++)
@@ -160,7 +161,7 @@ void display_pivots(bucket_list_t bucket_list)
   printf("\n");
 }
 
-void display_bucket_list(bucket_list_t bucket_list)
+static inline void display_bucket_list(bucket_list_t bucket_list)
 {
   int i;
   double inf,sup;
@@ -184,7 +185,7 @@ void display_bucket_list(bucket_list_t bucket_list)
 
 }
 
-void add_to_bucket(int id,int i,int j,bucket_list_t bucket_list)
+static void add_to_bucket(int id,int i,int j,bucket_list_t bucket_list)
 {
   bucket_t *bucket = NULL;
   int N,n,size;
@@ -222,7 +223,7 @@ void add_to_bucket(int id,int i,int j,bucket_list_t bucket_list)
  /* exit(-1); */
 }
 
-void dfs(int i,int inf,int sup,double *pivot,double *pivot_tree,int depth,int max_depth)
+static void dfs(int i,int inf,int sup,double *pivot,double *pivot_tree,int depth,int max_depth)
 {
   int p;
   if( depth == max_depth )
@@ -235,7 +236,7 @@ void dfs(int i,int inf,int sup,double *pivot,double *pivot_tree,int depth,int ma
   dfs(2*i+1,p+1,sup,pivot,pivot_tree,depth+1,max_depth);
 }
 
-void  built_pivot_tree(bucket_list_t bucket_list)
+static void  built_pivot_tree(bucket_list_t bucket_list)
 {
   double *pivot_tree = NULL,*pivot = NULL;
   int n,i,k;
@@ -261,7 +262,7 @@ void  built_pivot_tree(bucket_list_t bucket_list)
   }
 }
 
-void fill_buckets(bucket_list_t bucket_list)
+static void fill_buckets(bucket_list_t bucket_list)
 {
   int N,i,j,id;
 
@@ -274,7 +275,7 @@ void fill_buckets(bucket_list_t bucket_list)
     }
 }
 
-int is_power_of_2(int val)
+static int is_power_of_2(int val)
 {
   int n = 1;
   do{
@@ -286,7 +287,7 @@ int is_power_of_2(int val)
 }
 
 
-void partial_sort(bucket_list_t *bl,double **tab,int N)
+static void partial_sort(bucket_list_t *bl,double **tab,int N)
 {
   double *pivot = NULL;
   int *sample = NULL;
@@ -325,11 +326,11 @@ void partial_sort(bucket_list_t *bl,double **tab,int N)
   sample = (int*)MALLOC(2*sizeof(int)*n);
 
   for( k =  0 ; k < n ; k++ ){
-    i = genrand_int32()%(N-2)+1;
+    i = tm_genrand_int32()%(N-2)+1;
     if( i == N-2 )
       j = N-1;
     else
-      j = genrand_int32()%(N-i-2)+i+1;
+      j = tm_genrand_int32()%(N-i-2)+i+1;
     if(verbose_level >= DEBUG)
       printf("i=%d, j=%d\n",i,j);
     assert( i != j );
@@ -386,7 +387,7 @@ void partial_sort(bucket_list_t *bl,double **tab,int N)
   *bl = bucket_list;
 }
 
-void next_bucket_elem(bucket_list_t bucket_list,int *i,int *j)
+static void next_bucket_elem(bucket_list_t bucket_list,int *i,int *j)
 {
   bucket_t *bucket = bucket_list->bucket_tab[bucket_list->cur_bucket];
 
@@ -415,7 +416,7 @@ void next_bucket_elem(bucket_list_t bucket_list,int *i,int *j)
 }
 
 
-int add_edge_3(tm_tree_t *tab_node, tm_tree_t *parent,int i,int j,int *nb_groups)
+static int add_edge_3(tm_tree_t *tab_node, tm_tree_t *parent,int i,int j,int *nb_groups)
 {
   /* printf("%d <-> %d ?\n",tab_node[i].id,tab_node[j].id); */
   if((!tab_node[i].parent) && (!tab_node[j].parent)){
@@ -464,7 +465,7 @@ int add_edge_3(tm_tree_t *tab_node, tm_tree_t *parent,int i,int j,int *nb_groups
   return 0;
 }
 
-int try_add_edge(tm_tree_t *tab_node, tm_tree_t *parent,int arity,int i,int j,int *nb_groups)
+int tm_try_add_edge(tm_tree_t *tab_node, tm_tree_t *parent,int arity,int i,int j,int *nb_groups)
 {
   assert( i != j );
 
@@ -492,13 +493,13 @@ int try_add_edge(tm_tree_t *tab_node, tm_tree_t *parent,int arity,int i,int j,in
   }
 }
 
-void free_bucket(bucket_t *bucket)
+static void free_bucket(bucket_t *bucket)
 {
   FREE(bucket->bucket);
   FREE(bucket);
 }
 
-void free_tab_bucket(bucket_t **bucket_tab,int N)
+static void free_tab_bucket(bucket_t **bucket_tab,int N)
 {
   int i;
   for( i = 0 ; i < N ; i++ )
@@ -506,7 +507,7 @@ void free_tab_bucket(bucket_t **bucket_tab,int N)
   FREE(bucket_tab);
 }
 
-void free_bucket_list(bucket_list_t bucket_list)
+static void free_bucket_list(bucket_list_t bucket_list)
 {
   /* Do not free the tab field it is used elsewhere */
   free_tab_bucket(bucket_list->bucket_tab,bucket_list->nb_buckets);
@@ -515,7 +516,7 @@ void free_bucket_list(bucket_list_t bucket_list)
   FREE(bucket_list);
 }
 
-void partial_update_val (int nb_args, void **args, int thread_id){
+static void partial_update_val (int nb_args, void **args, int thread_id){
   int inf = *(int*)args[0];
   int sup = *(int*)args[1];
   tm_affinity_mat_t *aff_mat = (tm_affinity_mat_t*)args[2];
@@ -530,12 +531,12 @@ void partial_update_val (int nb_args, void **args, int thread_id){
   }
 
   for( l = inf ; l < sup ; l++ ){
-      update_val(aff_mat,&new_tab_node[l]);
+      tm_update_val(aff_mat,&new_tab_node[l]);
       *res += new_tab_node[l].val;
     }
 }
 
-double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t *new_tab_node,
+double tm_bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t *new_tab_node,
 		     int arity,int M)
 {
   bucket_list_t bucket_list;
@@ -576,7 +577,7 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
 	printf("elem[%d][%d]=%f ",i,j,mat[i][j]);
       gr1_1 += TOC;
       TIC;
-      if(try_add_edge(tab_node,&new_tab_node[l],arity,i,j,&nb_groups)){
+      if(tm_try_add_edge(tab_node,&new_tab_node[l],arity,i,j,&nb_groups)){
 	l++;
       }
       gr1_2 += TOC;
@@ -584,7 +585,7 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
   }else{
     while( l < M ){
       next_bucket_elem(bucket_list,&i,&j);
-      if(try_add_edge(tab_node,&new_tab_node[l],arity,i,j,&nb_groups)){
+      if(tm_try_add_edge(tab_node,&new_tab_node[l],arity,i,j,&nb_groups)){
 	l++;
       }
     }
@@ -600,7 +601,7 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
   TIC;
   while( nb_groups < M ){
     next_bucket_elem(bucket_list,&i,&j);
-    try_add_edge(tab_node,NULL,arity,i,j,&nb_groups);
+    tm_try_add_edge(tab_node,NULL,arity,i,j,&nb_groups);
   }
 
   gr2=TOC;
@@ -621,7 +622,7 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
     int *sup;
     double *tab_val;
 
-    nb_threads = get_nb_threads();
+    nb_threads = tm_get_nb_threads();
     works = (work_t**)MALLOC(sizeof(work_t*)*nb_threads);
     inf = (int*)MALLOC(sizeof(int)*nb_threads);
     sup = (int*)MALLOC(sizeof(int)*nb_threads);
@@ -637,18 +638,18 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
       args[3]=(void*)new_tab_node;
       args[4]=(void*)(tab_val+id);
 
-      works[id]= create_work(5,args,partial_update_val);
+      works[id]= tm_create_work(5,args,partial_update_val);
       if(verbose_level >= DEBUG)
 	printf("Executing %p\n",(void *)works[id]);
 
-      submit_work( works[id], id);
+      tm_submit_work( works[id], id);
     }
 
     for(id=0;id<nb_threads;id++){
-      wait_work_completion(works[id]);
+      tm_wait_work_completion(works[id]);
       val+=tab_val[id];
       FREE(works[id]->args);
-      destroy_work(works[id]);
+      tm_destroy_work(works[id]);
     }
 
 
@@ -659,7 +660,7 @@ double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t
   }else{
     for( l = 0 ; l < M ; l++ ){
 
-      update_val(aff_mat,&new_tab_node[l]);
+      tm_update_val(aff_mat,&new_tab_node[l]);
       val += new_tab_node[l].val;
     }
   }

--- a/3rd-party/treematch/tm_bucket.h
+++ b/3rd-party/treematch/tm_bucket.h
@@ -1,6 +1,8 @@
 #ifndef __BUCKET_H__
 #define __BUCKET_H__
 
+#include "ompi_config.h"
+
 typedef struct{
   int i;
   int j;
@@ -28,8 +30,8 @@ typedef struct{
 
 typedef _bucket_list_t *bucket_list_t;
 
-double bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t *new_tab_node, 
+OMPI_HIDDEN double tm_bucket_grouping(tm_affinity_mat_t *aff_mat,tm_tree_t *tab_node, tm_tree_t *new_tab_node, 
 		       int arity,int M);
-int try_add_edge(tm_tree_t *tab_node, tm_tree_t *parent,int arity,int i,int j,int *nb_groups);
+OMPI_HIDDEN int tm_try_add_edge(tm_tree_t *tab_node, tm_tree_t *parent,int arity,int i,int j,int *nb_groups);
 #endif
 

--- a/3rd-party/treematch/tm_kpartitioning.h
+++ b/3rd-party/treematch/tm_kpartitioning.h
@@ -1,3 +1,5 @@
+#include "ompi_config.h"
+
 typedef struct _com_mat_t{
   double **comm; 
   int n;  /*comm is of size n by n the other element are zeroes*/
@@ -5,5 +7,5 @@ typedef struct _com_mat_t{
 } com_mat_t;
 
 
-int  *kpartition(int, com_mat_t*, int, int *, int);
-tm_tree_t * kpartition_build_tree_from_topology(tm_topology_t *topology,double **com_mat,int N, int *constraints, int nb_constraints, double *obj_weight, double *com_speed);
+OMPI_HIDDEN int  *tm_kpartition(int, com_mat_t*, int, int *, int);
+OMPI_HIDDEN tm_tree_t * tm_kpartition_build_tree_from_topology(tm_topology_t *topology,double **com_mat,int N, int *constraints, int nb_constraints, double *obj_weight, double *com_speed);

--- a/3rd-party/treematch/tm_malloc.c
+++ b/3rd-party/treematch/tm_malloc.c
@@ -10,7 +10,7 @@
 #include "tm_mt.h"
 
 
-#define MIN(a,b) ((a)<(b)?(a):(b))
+#define TM_MIN(a,b) ((a)<(b)?(a):(b))
 
 #define EXTRA_BYTE 100
 
@@ -102,10 +102,10 @@ void init_extra_data(void){
   if(done)
     return;
 
-  init_genrand(0);
+  tm_init_genrand(0);
 
   for( i = 0 ; i < EXTRA_BYTE; i++)
-    extra_data[i] = (char) genrand_int32() % 256;
+    extra_data[i] = (char) tm_genrand_int32() % 256;
 
   done = 1;
 }
@@ -182,7 +182,7 @@ void *tm_realloc(void *old_ptr, size_t size, char *file, int line){
     byte *original_ptr = ((byte *)old_ptr) - EXTRA_BYTE;
     size_t old_ptr_size = retreive_size(original_ptr);
 
-    memcpy(ptr + EXTRA_BYTE, old_ptr, MIN(old_ptr_size - 2 * EXTRA_BYTE, size));
+    memcpy(ptr + EXTRA_BYTE, old_ptr, TM_MIN(old_ptr_size - 2 * EXTRA_BYTE, size));
 
     if((bcmp(original_ptr ,extra_data, EXTRA_BYTE)) && ((tm_get_verbose_level()>=ERROR))){
       fprintf(stderr,"Realloc: cannot find special string ***before*** %p!\n", (void *)original_ptr);

--- a/3rd-party/treematch/tm_malloc.h
+++ b/3rd-party/treematch/tm_malloc.h
@@ -2,11 +2,13 @@
 #define _TM_MALLOC_H_
 
 #include <stdlib.h>
-void *tm_malloc(size_t size, char *, int);
-void *tm_calloc(size_t count, size_t size, char *, int);
-void *tm_realloc(void *ptr, size_t size, char *, int);
-void tm_free(void *ptr);
-void tm_mem_check(void);
+#include "ompi_config.h"
+
+OMPI_HIDDEN void *tm_malloc(size_t size, char *, int);
+OMPI_HIDDEN void *tm_calloc(size_t count, size_t size, char *, int);
+OMPI_HIDDEN void *tm_realloc(void *ptr, size_t size, char *, int);
+OMPI_HIDDEN void tm_free(void *ptr);
+OMPI_HIDDEN void tm_mem_check(void);
 
 /* for debugging malloc */
 /* #define __DEBUG_TM_MALLOC__ */

--- a/3rd-party/treematch/tm_mapping.h
+++ b/3rd-party/treematch/tm_mapping.h
@@ -4,24 +4,19 @@
 #include "tm_topology.h"
 #include "tm_timings.h"
 #include "tm_verbose.h"
+#include "ompi_config.h"
 
-tm_affinity_mat_t * new_affinity_mat(double **mat, double *sum_row, int order, long int nnz);
-void   build_synthetic_proc_id(tm_topology_t *topology);
-tm_topology_t  *build_synthetic_topology(int *arity, int nb_levels, int *core_numbering, int nb_core_per_nodes);
-int compute_nb_leaves_from_level(int depth,tm_topology_t *topology);
-void depth_first(tm_tree_t *comm_tree, int *proc_list,int *i);
-int  fill_tab(int **new_tab,int *tab, int n, int start, int max_val, int shift);
-long int  init_mat(char *filename,int N, double **mat, double *sum_row);
-void map_topology(tm_topology_t *topology,tm_tree_t *comm_tree, int level,
+OMPI_HIDDEN tm_affinity_mat_t * tm_new_affinity_mat(double **mat, double *sum_row, int order, long int nnz);
+OMPI_HIDDEN tm_topology_t  *build_synthetic_topology(int *arity, int nb_levels, int *core_numbering, int nb_core_per_nodes);
+OMPI_HIDDEN int tm_compute_nb_leaves_from_level(int depth,tm_topology_t *topology);
+OMPI_HIDDEN int  tm_fill_tab(int **new_tab,int *tab, int n, int start, int max_val, int shift);
+OMPI_HIDDEN void tm_map_topology(tm_topology_t *topology,tm_tree_t *comm_tree, int level,
 		  int *sigma, int nb_processes, int **k, int nb_compute_units);
-int nb_leaves(tm_tree_t *comm_tree);
-int nb_lines(char *filename);
-int nb_processing_units(tm_topology_t *topology);
-void print_1D_tab(int *tab,int N);
-tm_solution_t * tm_compute_mapping(tm_topology_t *topology,tm_tree_t *comm_tree);
-void tm_free_affinity_mat(tm_affinity_mat_t *aff_mat);
-tm_affinity_mat_t *tm_load_aff_mat(char *filename);
-void update_comm_speed(double **comm_speed,int old_size,int new_size);
+OMPI_HIDDEN int tm_nb_processing_units(tm_topology_t *topology);
+OMPI_HIDDEN void tm_print_1D_tab(int *tab,int N);
+OMPI_HIDDEN tm_solution_t * tm_compute_mapping(tm_topology_t *topology,tm_tree_t *comm_tree);
+OMPI_HIDDEN void tm_free_affinity_mat(tm_affinity_mat_t *aff_mat);
+OMPI_HIDDEN tm_affinity_mat_t *tm_load_aff_mat(char *filename);
 
 /* use to split a constaint into subconstraint according the tree*/
 typedef struct{

--- a/3rd-party/treematch/tm_mt.c
+++ b/3rd-party/treematch/tm_mt.c
@@ -50,6 +50,8 @@
 
 #include "tm_mt.h"
 
+#include "ompi_config.h"
+
 /* Period parameters */
 #define N 624
 #define M 397
@@ -59,6 +61,13 @@
 
 static unsigned long x[N];      /* the array for the state vector  */
 static unsigned long *p0, *p1, *pm;
+
+OMPI_HIDDEN long tm_genrand_int31(void);
+OMPI_HIDDEN double tm_genrand_real1(void);
+OMPI_HIDDEN double tm_genrand_real2(void);
+OMPI_HIDDEN double tm_genrand_real3(void);
+OMPI_HIDDEN double tm_genrand_res53(void);
+OMPI_HIDDEN void init_by_array(unsigned long init_key[], int key_length);
 
 /*
    initialize with a seed
@@ -71,7 +80,7 @@ static unsigned long *p0, *p1, *pm;
    2002-01-09 modified by Makoto Matsumoto
 */
 void
-init_genrand(unsigned long s)
+tm_init_genrand(unsigned long s)
 {
   int i;
 
@@ -99,7 +108,7 @@ init_by_array(unsigned long init_key[], int key_length)
 {
   int i, j, k;
 
-  init_genrand(19650218UL);
+  tm_init_genrand(19650218UL);
   i = 1;
   j = 0;
   for (k = (N > key_length ? N : key_length); k; --k) {
@@ -128,13 +137,13 @@ init_by_array(unsigned long init_key[], int key_length)
 
 /* generates a random number on the interval [0,0xffffffff] */
 unsigned long
-genrand_int32(void)
+tm_genrand_int32(void)
 {
   unsigned long y;
 
   if (!p0) {
     /* Default seed */
-    init_genrand(5489UL);
+    tm_init_genrand(5489UL);
   }
   /* Twisted feedback */
   y = *p0 = *pm++ ^ (((*p0 & UPPER_MASK) | (*p1 & LOWER_MASK)) >> 1)
@@ -156,40 +165,40 @@ genrand_int32(void)
 
 /* generates a random number on the interval [0,0x7fffffff] */
 long
-genrand_int31(void)
+tm_genrand_int31(void)
 {
-  return (long) (genrand_int32() >> 1);
+  return (long) (tm_genrand_int32() >> 1);
 }
 
 /* generates a random number on the real interval [0,1] */
 double
-genrand_real1(void)
+tm_genrand_real1(void)
 {
-  return genrand_int32() * (1.0 / 4294967295.0);
+  return tm_genrand_int32() * (1.0 / 4294967295.0);
   /* divided by 2^32-1 */
 }
 
 /* generates a random number on the real interval [0,1) */
 double
-genrand_real2(void)
+tm_genrand_real2(void)
 {
-  return genrand_int32() * (1.0 / 4294967296.0);
+  return tm_genrand_int32() * (1.0 / 4294967296.0);
   /* divided by 2^32 */
 }
 
 /* generates a random number on the real interval (0,1) */
 double
-genrand_real3(void)
+tm_genrand_real3(void)
 {
-  return (((double) genrand_int32()) + 0.5) * (1.0 / 4294967296.0);
+  return (((double) tm_genrand_int32()) + 0.5) * (1.0 / 4294967296.0);
   /* divided by 2^32 */
 }
 
 /* generates a 53-bit random number on the real interval [0,1) */
 double
-genrand_res53(void)
+tm_genrand_res53(void)
 {
-  unsigned long a = genrand_int32() >> 5, b = genrand_int32() >> 6;
+  unsigned long a = tm_genrand_int32() >> 5, b = tm_genrand_int32() >> 6;
 
   return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0);
 }

--- a/3rd-party/treematch/tm_mt.h
+++ b/3rd-party/treematch/tm_mt.h
@@ -1,10 +1,6 @@
-void init_genrand(unsigned long s);
-void init_by_array(unsigned long init_key[], int key_length);
+#include "ompi_config.h"
+
+OMPI_HIDDEN void tm_init_genrand(unsigned long s);
 
 /* generates a random number on the interval [0,0x7fffffff] */
-unsigned long genrand_int32(void); 
-long genrand_int31(void);
-double genrand_real1(void);
-double genrand_real2(void);
-double genrand_real3(void);
-double genrand_res53(void);
+OMPI_HIDDEN unsigned long tm_genrand_int32(void);

--- a/3rd-party/treematch/tm_solution.c
+++ b/3rd-party/treematch/tm_solution.c
@@ -11,24 +11,25 @@ typedef struct {
 
 
 
-void tm_free_solution(tm_solution_t *sol);
-int distance(tm_topology_t *topology,int i, int j);
-double display_sol_sum_com(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma);
-  double display_sol(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma, tm_metric_t metric);
-double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol,
+OMPI_HIDDEN void tm_free_solution(tm_solution_t *sol);
+static int distance(tm_topology_t *topology,int i, int j);
+static double display_sol_sum_com(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma);
+static double display_sol(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma, tm_metric_t metric);
+OMPI_HIDDEN double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol,
 			   tm_metric_t metric);
-void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
-int in_tab(int *tab, int n, int val);
-void map_Packed(tm_topology_t *topology, int N, int *sigma);
-void map_RR(tm_topology_t * topology, int N, int *sigma);
-int hash_asc(const void* x1,const void* x2);
-int *generate_random_sol(tm_topology_t *topology,int N, int seed);
-double eval_sol(int *sol,int N,double **comm, double **arch);
-void exchange(int *sol,int i,int j);
-double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, double **arch);
-void select_max(int *l,int *m,double **gain,int N,int *state);
-void compute_gain(int *sol,int N,double **gain,double **comm, double **arch);
-void map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch);
+OMPI_HIDDEN void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
+OMPI_HIDDEN int tm_in_tab(int *tab, int n, int val);
+OMPI_HIDDEN void tm_map_Packed(tm_topology_t *topology, int N, int *sigma);
+OMPI_HIDDEN void tm_map_RR(tm_topology_t * topology, int N, int *sigma);
+static int hash_asc(const void* x1,const void* x2);
+static int *generate_random_sol(tm_topology_t *topology,int N, int seed);
+static double eval_sol(int *sol,int N,double **comm, double **arch);
+static void exchange(int *sol,int i,int j);
+static double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, double **arch);
+static void select_max(int *l,int *m,double **gain,int N,int *state);
+static void compute_gain(int *sol,int N,double **gain,double **comm, double **arch);
+OMPI_HIDDEN void tm_map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch);
+static void compute_gain(int *sol,int N,double **gain,double **comm, double **arch);
 
 
 void tm_free_solution(tm_solution_t *sol){
@@ -54,7 +55,7 @@ void tm_free_solution(tm_solution_t *sol){
    for which node i and j are still in the same subtree. This is done
    by iteratively dividing their numbering by the arity of the levels
 */
-int distance(tm_topology_t *topology,int i, int j)
+static int distance(tm_topology_t *topology,int i, int j)
 {
   int level = 0;
   int arity;
@@ -84,7 +85,7 @@ int distance(tm_topology_t *topology,int i, int j)
   return level;
 }
 
-double display_sol_sum_com(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma)
+static double display_sol_sum_com(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma)
 {
   double a,c,sol;
   int i,j;
@@ -186,7 +187,7 @@ static double display_sol_hop_byte(tm_topology_t *topology, tm_affinity_mat_t *a
 
 
 
-double display_sol(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma, tm_metric_t metric){
+static double display_sol(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma, tm_metric_t metric){
   switch (metric){
   case TM_METRIC_SUM_COM:
     return display_sol_sum_com(topology, aff_mat, sigma);
@@ -212,7 +213,7 @@ double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, 
 
   if(tm_get_verbose_level() >= DEBUG){
     printf("k: \n");
-    for( i = 0 ; i < nb_processing_units(topology) ; i++ ){
+    for( i = 0 ; i < tm_nb_processing_units(topology) ; i++ ){
       if(k[i][0] != -1){
 	printf("\tProcessing unit %d: ",i);
 	for (j = 0 ; j<topology->oversub_fact; j++){
@@ -236,11 +237,11 @@ void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff
 
   sigma = (int*)MALLOC(sizeof(int)*N);
 
-  map_Packed(topology, N, sigma);
+  tm_map_Packed(topology, N, sigma);
   printf("Packed: ");
   display_sol(topology, aff_mat, sigma, metric);
 
-  map_RR(topology, N, sigma);
+  tm_map_RR(topology, N, sigma);
   printf("RR: ");
   display_sol(topology, aff_mat, sigma, metric);
 
@@ -272,7 +273,7 @@ void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff
 }
 
 
-int in_tab(int *tab, int n, int val){
+int tm_in_tab(int *tab, int n, int val){
   int i;
   for( i = 0; i < n ; i++)
     if(tab[i] == val)
@@ -281,7 +282,7 @@ int in_tab(int *tab, int n, int val){
   return 0;
 }
 
-void map_Packed(tm_topology_t *topology, int N, int *sigma)
+void tm_map_Packed(tm_topology_t *topology, int N, int *sigma)
 {
   size_t i;
   int j = 0,depth;
@@ -291,7 +292,7 @@ void map_Packed(tm_topology_t *topology, int N, int *sigma)
 
   for( i = 0 ; i < topology->nb_nodes[depth] ; i++){
     /* printf ("%d -> %d\n",objs[i]->os_index,i); */
-    if((!topology->constraints) || (in_tab(topology->constraints, topology->nb_constraints, topology->node_id[i]))){
+    if((!topology->constraints) || (tm_in_tab(topology->constraints, topology->nb_constraints, topology->node_id[i]))){
       if(vl >= DEBUG)
 	printf ("%lu: %d -> %d\n", i, j, topology->node_id[i]);
       sigma[j++]=topology->node_id[i];
@@ -301,7 +302,7 @@ void map_Packed(tm_topology_t *topology, int N, int *sigma)
   }
 }
 
-void map_RR(tm_topology_t *topology, int N,int *sigma)
+void tm_map_RR(tm_topology_t *topology, int N,int *sigma)
 {
   int i;
   int vl = tm_get_verbose_level();
@@ -316,7 +317,7 @@ void map_RR(tm_topology_t *topology, int N,int *sigma)
   }
 }
 
-int hash_asc(const void* x1,const void* x2)
+static int hash_asc(const void* x1,const void* x2)
 {
   hash_t *e1 = NULL,*e2 = NULL;
 
@@ -327,7 +328,7 @@ int hash_asc(const void* x1,const void* x2)
 }
 
 
-int *generate_random_sol(tm_topology_t *topology,int N, int seed)
+static int *generate_random_sol(tm_topology_t *topology,int N, int seed)
 {
   hash_t *hash_tab = NULL;
   int *sol = NULL;
@@ -339,11 +340,11 @@ int *generate_random_sol(tm_topology_t *topology,int N, int seed)
   hash_tab = (hash_t*)MALLOC(sizeof(hash_t)*N);
   sol = (int*)MALLOC(sizeof(int)*N);
 
-  init_genrand(seed);
+  tm_init_genrand(seed);
 
   for( i = 0 ; i < N ; i++ ){
     hash_tab[i].val = nodes_id[i];
-    hash_tab[i].key = genrand_int32();
+    hash_tab[i].key = tm_genrand_int32();
   }
 
   qsort(hash_tab,N,sizeof(hash_t),hash_asc);
@@ -355,7 +356,7 @@ int *generate_random_sol(tm_topology_t *topology,int N, int seed)
 }
 
 
-double eval_sol(int *sol,int N,double **comm, double **arch)
+static double eval_sol(int *sol,int N,double **comm, double **arch)
 {
   double a,c,res;
   int i,j;
@@ -371,7 +372,7 @@ double eval_sol(int *sol,int N,double **comm, double **arch)
   return res;
 }
 
-void exchange(int *sol,int i,int j)
+static void exchange(int *sol,int i,int j)
 {
   int tmp;
   tmp = sol[i];
@@ -379,7 +380,7 @@ void exchange(int *sol,int i,int j)
   sol[j] = tmp;
 }
 
-double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, double **arch)
+static double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, double **arch)
 {
   double eval2;
   if( l == m )
@@ -391,7 +392,7 @@ double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, doub
   return eval1-eval2;
 }
 
-void select_max(int *l,int *m,double **gain,int N,int *state)
+static void select_max(int *l,int *m,double **gain,int N,int *state)
 {
   double max;
   int i,j;
@@ -411,7 +412,7 @@ void select_max(int *l,int *m,double **gain,int N,int *state)
 }
 
 
-void compute_gain(int *sol,int N,double **gain,double **comm, double **arch)
+static void compute_gain(int *sol,int N,double **gain,double **comm, double **arch)
 {
   double eval1;
   int i,j;
@@ -429,7 +430,7 @@ parallel process placement toolset for smp clusters and multiclusters. In
 Gregory K. Egan and Yoichi Muraoka, editors, ICS, pages 353-360. ACM, 2006.
  */
 
-void map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch)
+void tm_map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch)
 {
   int *sol = NULL;
   int *state = NULL;

--- a/3rd-party/treematch/tm_solution.h
+++ b/3rd-party/treematch/tm_solution.h
@@ -1,26 +1,16 @@
 #ifndef TM_SOLUION_H
 #define TM_SOLUION_H
 
+#include "ompi_config.h"
 #include "treematch.h"
 
-void tm_free_solution(tm_solution_t *sol);
-int distance(tm_topology_t *topology,int i, int j);
-double display_sol_sum_com(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma);
-  double display_sol(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, int *sigma, tm_metric_t metric);
-double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol,
-			   tm_metric_t metric);
-void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
-int in_tab(int *tab, int n, int val);
-void map_Packed(tm_topology_t *topology, int N, int *sigma);
-void map_RR(tm_topology_t *topology, int N, int *sigma);
-int hash_asc(const void* x1,const void* x2);
-int *generate_random_sol(tm_topology_t *topology,int N, int seed);
-double eval_sol(int *sol,int N,double **comm, double **arch);
-void exchange(int *sol,int i,int j);
-double gain_exchange(int *sol,int l,int m,double eval1,int N,double **comm, double **arch);
-void select_max(int *l,int *m,double **gain,int N,int *state);
-void compute_gain(int *sol,int N,double **gain,double **comm, double **arch);
-void map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch);
+OMPI_HIDDEN void tm_free_solution(tm_solution_t *sol);
+OMPI_HIDDEN double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol, tm_metric_t metric);
+OMPI_HIDDEN void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
+int tm_in_tab(int *tab, int n, int val);
+OMPI_HIDDEN void tm_map_Packed(tm_topology_t *topology, int N, int *sigma);
+OMPI_HIDDEN void tm_map_RR(tm_topology_t *topology, int N, int *sigma);
+OMPI_HIDDEN void tm_map_MPIPP(tm_topology_t *topology,int nb_seed,int N,int *sigma,double **comm, double **arch);
 
 
 #endif

--- a/3rd-party/treematch/tm_thread_pool.h
+++ b/3rd-party/treematch/tm_thread_pool.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <hwloc.h>
+#include "ompi_config.h"
 
 
 typedef struct _work_t{
@@ -35,13 +36,13 @@ typedef struct _thread_pool_t{
   hwloc_topology_t topology;
 }thread_pool_t;
 
-int get_nb_threads(void);
-int submit_work(work_t *work, int thread_id);
-void wait_work_completion(work_t *work);
-void terminate_thread_pool(void);
-work_t *create_work(int nb_args, void **args, void (int, void **, int));
-int test_main(void);
-void destroy_work(work_t *work);
+OMPI_HIDDEN int tm_get_nb_threads(void);
+OMPI_HIDDEN int tm_submit_work(work_t *work, int thread_id);
+OMPI_HIDDEN void tm_wait_work_completion(work_t *work);
+OMPI_HIDDEN void tm_terminate_thread_pool(void);
+OMPI_HIDDEN work_t *tm_create_work(int nb_args, void **args, void (int, void **, int));
+OMPI_HIDDEN int tm_test_main(void);
+OMPI_HIDDEN void tm_destroy_work(work_t *work);
 
 
 

--- a/3rd-party/treematch/tm_timings.c
+++ b/3rd-party/treematch/tm_timings.c
@@ -3,7 +3,7 @@
 static CLOCK_T time_tab[MAX_CLOCK];
 static int clock_num = -1;
 
-void get_time(void)
+void tm_get_time(void)
 {
   clock_num++;
 
@@ -13,7 +13,7 @@ void get_time(void)
   CLOCK(time_tab[clock_num]);
 }
 
-double time_diff(void)
+double tm_time_diff(void)
 {
   CLOCK_T t2,t1;
 

--- a/3rd-party/treematch/tm_timings.h
+++ b/3rd-party/treematch/tm_timings.h
@@ -2,6 +2,8 @@
 #define TIMINGS_H
 #include <stdio.h>
 
+#include "ompi_config.h"
+
 #ifndef _WIN32
 #include <sys/time.h>
 #else
@@ -36,11 +38,11 @@ typedef struct _timeb CLOCK_T;
 
 #endif
 
-double time_diff(void);
-void get_time(void);
+OMPI_HIDDEN double tm_time_diff(void);
+OMPI_HIDDEN void tm_get_time(void);
 
-#define TIC get_time()
-#define TOC time_diff()
+#define TIC tm_get_time()
+#define TOC tm_time_diff()
 
 #endif /*TIMINGS_H*/
 

--- a/3rd-party/treematch/tm_topology.c
+++ b/3rd-party/treematch/tm_topology.c
@@ -8,26 +8,27 @@
 
 
 tm_topology_t* tm_get_local_topo_with_hwloc(void);
-tm_topology_t* hwloc_to_tm(char *filename);
-int int_cmp_inc(const void* x1,const void* x2);
-void optimize_arity(int **arity, double **cost, int *nb_levels,int n);
-int symetric(hwloc_topology_t topology);
-tm_topology_t * tgt_to_tm(char *filename);
-void tm_display_arity(tm_topology_t *topology);
-void tm_display_topology(tm_topology_t *topology);
-void tm_free_topology(tm_topology_t *topology);
-tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
-void tm_optimize_topology(tm_topology_t **topology);
-int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology_t *topology);
-int topo_nb_proc(hwloc_topology_t topology,int N);
-void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels);
-void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_constraints);
-void topology_cost_cpy(tm_topology_t *topology,double **cost);
-void topology_numbering_cpy(tm_topology_t *topology,int **numbering,int *nb_nodes);
-double ** topology_to_arch(hwloc_topology_t topology);
-void   build_synthetic_proc_id(tm_topology_t *topology);
+static tm_topology_t* hwloc_to_tm(char *filename);
+OMPI_HIDDEN int tm_int_cmp_inc(const void* x1,const void* x2);
+static void optimize_arity(int **arity, double **cost, int *nb_levels,int n);
+static int symetric(hwloc_topology_t topology);
+static tm_topology_t * tgt_to_tm(char *filename);
+OMPI_HIDDEN void tm_display_arity(tm_topology_t *topology);
+OMPI_HIDDEN void tm_display_topology(tm_topology_t *topology);
+OMPI_HIDDEN void tm_free_topology(tm_topology_t *topology);
+OMPI_HIDDEN tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
+OMPI_HIDDEN void tm_optimize_topology(tm_topology_t **topology);
+OMPI_HIDDEN int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology_t *topology);
+static int topo_nb_proc(hwloc_topology_t topology,int N);
+static void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels);
+static void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_constraints);
+static void topology_cost_cpy(tm_topology_t *topology,double **cost);
+static void topology_numbering_cpy(tm_topology_t *topology,int **numbering,int *nb_nodes);
+static double ** topology_to_arch(hwloc_topology_t topology);
+static void   build_synthetic_proc_id(tm_topology_t *topology);
 tm_topology_t  *tm_build_synthetic_topology(int *arity, double *cost, int nb_levels, int *core_numbering, int nb_core_per_nodes);
-void            tm_set_numbering(tm_numbering_t new_val); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
+OMPI_HIDDEN void tm_set_numbering(tm_numbering_t new_val); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
+void   build_synthetic_proc_id(tm_topology_t *topology);
 
 
 #define LINE_SIZE (1000000)
@@ -46,7 +47,7 @@ tm_numbering_t  tm_get_numbering(){
 
 
 /* transform a tgt scotch file into a topology file*/
-tm_topology_t * tgt_to_tm(char *filename)
+static tm_topology_t * tgt_to_tm(char *filename)
 {
   tm_topology_t *topology = NULL;
   FILE *pf = NULL;
@@ -122,12 +123,12 @@ tm_topology_t * tgt_to_tm(char *filename)
 
 
 
-int nb_processing_units(tm_topology_t *topology)
+int tm_nb_processing_units(tm_topology_t *topology)
 {
   return topology->nb_proc_units;
 }
 
-int topo_nb_proc(hwloc_topology_t topology,int N)
+static inline int topo_nb_proc(hwloc_topology_t topology,int N)
 {
   hwloc_obj_t *objs = NULL;
   int nb_proc;
@@ -158,7 +159,7 @@ static double link_cost(int depth)
   */
 }
 
-double ** topology_to_arch(hwloc_topology_t topology)
+static inline double ** topology_to_arch(hwloc_topology_t topology)
 {
   int nb_proc,i,j;
   hwloc_obj_t obj_proc1,obj_proc2,obj_res;
@@ -185,7 +186,7 @@ double ** topology_to_arch(hwloc_topology_t topology)
   return arch;
 }
 
-int symetric(hwloc_topology_t topology)
+static int symetric(hwloc_topology_t topology)
 {
    int depth,i,topodepth = hwloc_topology_get_depth(topology);
    unsigned int arity;
@@ -247,7 +248,7 @@ static void build_process_tab_id(tm_topology_t *topology,  hwloc_obj_t *objs, ch
 }
 
 
-tm_topology_t* hwloc_to_tm(char *filename)
+static tm_topology_t* hwloc_to_tm(char *filename)
 {
   hwloc_topology_t topology;
   tm_topology_t *res = NULL;
@@ -485,7 +486,7 @@ void tm_display_arity(tm_topology_t *topology){
   printf("\n");
 }
 
-int int_cmp_inc(const void* x1,const void* x2)
+int tm_int_cmp_inc(const void* x1,const void* x2)
 {
   return *((int *)x1) < *((int *)x2) ? -1 : 1;
 }
@@ -496,7 +497,7 @@ static int topo_check_constraints(tm_topology_t *topology){
   int i;
   int depth = topology->nb_levels-1;
   for (i=0;i<n;i++){
-    if(!in_tab(topology->node_id, topology->nb_nodes[depth], topology->constraints[i])){
+    if(!tm_in_tab(topology->node_id, topology->nb_nodes[depth], topology->constraints[i])){
       if(tm_get_verbose_level() >= CRITICAL){
 	fprintf(stderr,"Error! Incompatible constraint with the topology: rank %d in the constraints is not a valid id of any nodes of the topology.\n",topology->constraints[i]);
       }
@@ -585,13 +586,13 @@ int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology
     exit(-1);
   }
 
-  qsort(tab,n,sizeof(int),int_cmp_inc);
+  qsort(tab,n,sizeof(int),tm_int_cmp_inc);
 
   return tm_topology_set_binding_constraints_cpy(tab, n, topology, 0);
 }
 
 
-void topology_numbering_cpy(tm_topology_t *topology,int **numbering_loc,int *nb_nodes)
+static void topology_numbering_cpy(tm_topology_t *topology,int **numbering_loc,int *nb_nodes)
 {
   int nb_levels;
   unsigned int vl = tm_get_verbose_level();
@@ -604,14 +605,14 @@ void topology_numbering_cpy(tm_topology_t *topology,int **numbering_loc,int *nb_
   memcpy(*numbering_loc,topology->node_id,sizeof(int)*(*nb_nodes));
 }
 
-void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels)
+static void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels)
 {
   *nb_levels = topology->nb_levels;
   *arity = (int*)MALLOC(sizeof(int)*(*nb_levels));
   memcpy(*arity,topology->arity,sizeof(int)*(*nb_levels));
 }
 
-void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_constraints)
+static void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_constraints)
 {
   *nb_constraints = topology->nb_constraints;
   if(topology->constraints){
@@ -622,13 +623,13 @@ void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_
   }
 }
 
-void topology_cost_cpy(tm_topology_t *topology,double **cost)
+static void topology_cost_cpy(tm_topology_t *topology,double **cost)
 {
   *cost = (double*)MALLOC(sizeof(double)*(topology->nb_levels));
   memcpy(*cost,topology->cost,sizeof(double)*(topology->nb_levels));
 }
 
-void optimize_arity(int **arity, double **cost, int *nb_levels,int n)
+static void optimize_arity(int **arity, double **cost, int *nb_levels,int n)
 {
   int a,i;
   int *new_arity = NULL;
@@ -827,7 +828,7 @@ tm_topology_t  *tm_build_synthetic_topology(int *arity, double *cost, int nb_lev
 }
 
 
-void   build_synthetic_proc_id(tm_topology_t *topology)
+static void   build_synthetic_proc_id(tm_topology_t *topology)
 {
   int i;
   size_t j,n = 1;

--- a/3rd-party/treematch/tm_topology.h
+++ b/3rd-party/treematch/tm_topology.h
@@ -2,22 +2,16 @@
 #include "tm_tree.h"
 
 tm_topology_t* get_local_topo_with_hwloc(void);
-tm_topology_t* hwloc_to_tm(char *filename);
-int int_cmp_inc(const void* x1,const void* x2);
-void optimize_arity(int **arity, double **cost, int *nb_levels,int n);
-int symetric(hwloc_topology_t topology);
-tm_topology_t * tgt_to_tm(char *filename);
-void tm_display_arity(tm_topology_t *topology);
-void tm_display_topology(tm_topology_t *topology);
-void tm_free_topology(tm_topology_t *topology);
-tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
-void tm_optimize_topology(tm_topology_t **topology);
-int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology_t *topology);
-int topo_nb_proc(hwloc_topology_t topology,int N);
+OMPI_HIDDEN int tm_int_cmp_inc(const void* x1,const void* x2);
+OMPI_HIDDEN void tm_display_arity(tm_topology_t *topology);
+OMPI_HIDDEN void tm_display_topology(tm_topology_t *topology);
+OMPI_HIDDEN void tm_free_topology(tm_topology_t *topology);
+OMPI_HIDDEN tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
+OMPI_HIDDEN void tm_optimize_topology(tm_topology_t **topology);
+OMPI_HIDDEN int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology_t *topology);
 void topology_arity(tm_topology_t *topology,int **arity,int *nb_levels);
 void topology_constraints(tm_topology_t *topology,int **constraints,int *nb_constraints);
 void topology_cost(tm_topology_t *topology,double **cost);
 void topology_numbering(tm_topology_t *topology,int **numbering,int *nb_nodes);
-double ** topology_to_arch(hwloc_topology_t topology);
-int nb_processing_units(tm_topology_t *topology);
+OMPI_HIDDEN int tm_nb_processing_units(tm_topology_t *topology);
 

--- a/3rd-party/treematch/tm_tree.h
+++ b/3rd-party/treematch/tm_tree.h
@@ -3,9 +3,9 @@
 #include <stdlib.h>
 #include "treematch.h"
 
-void update_val(tm_affinity_mat_t *aff_mat,tm_tree_t *parent);
-void display_tab(double **tab,int N);
-void set_node(tm_tree_t *node,tm_tree_t ** child, int arity,tm_tree_t *parent,
+OMPI_HIDDEN void tm_update_val(tm_affinity_mat_t *aff_mat,tm_tree_t *parent);
+OMPI_HIDDEN void tm_display_tab(double **tab,int N);
+OMPI_HIDDEN void tm_set_node(tm_tree_t *node,tm_tree_t ** child, int arity,tm_tree_t *parent,
 	      int id,double val,tm_tree_t *tab_child,int depth);
 
 

--- a/3rd-party/treematch/tm_verbose.h
+++ b/3rd-party/treematch/tm_verbose.h
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "ompi_config.h"
 
 #define NONE     0
 /* output in stderr*/
@@ -12,11 +13,11 @@
 
 
 /* return 0 on errror and  1 on success */
-int          tm_open_verbose_file(char *filename);
-int          tm_close_verbose_file(void);
-void         tm_set_verbose_level(unsigned int level);
-unsigned int tm_get_verbose_level(void);
-FILE *       tm_get_verbose_output(void);
+OMPI_HIDDEN int          tm_open_verbose_file(char *filename);
+OMPI_HIDDEN int          tm_close_verbose_file(void);
+OMPI_HIDDEN void         tm_set_verbose_level(unsigned int level);
+OMPI_HIDDEN unsigned int tm_get_verbose_level(void);
+OMPI_HIDDEN FILE *       tm_get_verbose_output(void);
 
 #define tm_verbose_printf(level, ...) level <= tm_get_verbose_level()?fprintf(tm_get_verbose_output(),__VA_ARGS__):0
 

--- a/3rd-party/treematch/treematch.h
+++ b/3rd-party/treematch/treematch.h
@@ -4,6 +4,7 @@
 /* size_t definition */
 #include <stddef.h>
 #include "tm_verbose.h"
+#include "ompi_config.h"
 
 /********* TreeMatch Public Enum **********/
 
@@ -105,10 +106,10 @@ typedef struct {
 
 /************ TreeMatch Public API ************/
 /* construct topology from local one using hwloc */
-tm_topology_t* tm_get_local_topology_with_hwloc(void);
+OMPI_HIDDEN tm_topology_t* tm_get_local_topology_with_hwloc(void);
 
 /* Aletrnatively, load XML or TGT topology */
-tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
+OMPI_HIDDEN tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
 /*
    Alternatively, build a synthetic balanced topology.
 
@@ -136,74 +137,74 @@ tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_ty
    topology = tm_build_synthetic_topology(arity,cost,5,cn,2);
 
  */
-tm_topology_t  *tm_build_synthetic_topology(int *arity, double *cost, int nb_levels, int *core_numbering, int nb_core_per_nodes);
+OMPI_HIDDEN tm_topology_t  *tm_build_synthetic_topology(int *arity, double *cost, int nb_levels, int *core_numbering, int nb_core_per_nodes);
 /* load affinity matrix */
-tm_affinity_mat_t *tm_load_aff_mat(char *com_filename);
+OMPI_HIDDEN tm_affinity_mat_t *tm_load_aff_mat(char *com_filename);
 /*
    Alternativelly, build the affinity matrix from a array of array of matrix of size order by order
    For performance reason mat is not copied.
 */
-tm_affinity_mat_t * tm_build_affinity_mat(double **mat, int order);
+OMPI_HIDDEN tm_affinity_mat_t * tm_build_affinity_mat(double **mat, int order);
 /* Add constraints to toplogy
    Return 1 on success and 0  if the constari,ts id are not compatible withe nodes id */
-int tm_topology_add_binding_constraints(char *bind_filename, tm_topology_t *topology);
+OMPI_HIDDEN int tm_topology_add_binding_constraints(char *bind_filename, tm_topology_t *topology);
 /* Alternatively, set the constraints from an array.
    Return 1 on success and 0  if the constari,ts id are not compatible withe nodes id
 
    The array constraints is copied inside tm_topology_set_binding_constraints
 
 */
-int tm_topology_set_binding_constraints(int *constraints, int nb_constraints, tm_topology_t *topology);
+OMPI_HIDDEN int tm_topology_set_binding_constraints(int *constraints, int nb_constraints, tm_topology_t *topology);
 /* display arity of the topology */
-void  tm_display_arity(tm_topology_t *topology);
+OMPI_HIDDEN void  tm_display_arity(tm_topology_t *topology);
 /* display the full topology */
-void  tm_display_topology(tm_topology_t *topology);
+OMPI_HIDDEN void  tm_display_topology(tm_topology_t *topology);
 /* Optimize the topology by decomposing arities */
-void tm_optimize_topology(tm_topology_t **topology);
+OMPI_HIDDEN void tm_optimize_topology(tm_topology_t **topology);
 /* Manage oversubscribing */
-void tm_enable_oversubscribing(tm_topology_t *topology, unsigned int oversub_fact);
+OMPI_HIDDEN void tm_enable_oversubscribing(tm_topology_t *topology, unsigned int oversub_fact);
 /* core of the treematch: compute the solution tree */
-tm_tree_t *tm_build_tree_from_topology(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, double *obj_weight, double *com_speed);
+OMPI_HIDDEN tm_tree_t *tm_build_tree_from_topology(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, double *obj_weight, double *com_speed);
 /* compute the mapping according to the tree and the core numbering*/
-tm_solution_t *tm_compute_mapping(tm_topology_t *topology, tm_tree_t *comm_tree);
+OMPI_HIDDEN tm_solution_t *tm_compute_mapping(tm_topology_t *topology, tm_tree_t *comm_tree);
 /* display the solution*/
-double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol, tm_metric_t metric);
+OMPI_HIDDEN double tm_display_solution(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_solution_t *sol, tm_metric_t metric);
 /* display RR, packed, MPIPP*/
-void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
+OMPI_HIDDEN void tm_display_other_heuristics(tm_topology_t *topology, tm_affinity_mat_t *aff_mat, tm_metric_t metric);
 /* free TM strutures*/
-void tm_free_topology(tm_topology_t *topology);
-void tm_free_tree(tm_tree_t *comm_tree);
-void tm_free_solution(tm_solution_t *sol);
-void tm_free_affinity_mat(tm_affinity_mat_t *aff_mat);
+OMPI_HIDDEN void tm_free_topology(tm_topology_t *topology);
+OMPI_HIDDEN void tm_free_tree(tm_tree_t *comm_tree);
+OMPI_HIDDEN void tm_free_solution(tm_solution_t *sol);
+OMPI_HIDDEN void tm_free_affinity_mat(tm_affinity_mat_t *aff_mat);
 /* manage verbosity of TM*/
 void tm_set_verbose_level(unsigned int level);
 unsigned int  tm_get_verbose_level(void);
 /* finalize treematch :check memory if necessary, and free internal variables (thread pool)*/
-void tm_finalize(void);
+OMPI_HIDDEN void tm_finalize(void);
 
 /*
 Ask for exhaustive search: may be very long
    new_val == 0 : no exhuative search
    new_val != 0 : exhuative search
 */
-void tm_set_exhaustive_search_flag(int new_val);
-int tm_get_exhaustive_search_flag(void);
+OMPI_HIDDEN void tm_set_exhaustive_search_flag(int new_val);
+OMPI_HIDDEN int tm_get_exhaustive_search_flag(void);
 
 /*
 Ask for greedy k-partitionning even if scotch is available
    new_val == 0 : no greedy k-partitionning
    new_val != 0 : greedy k-partitionning
 */
-void tm_set_greedy_flag(int new_val);
-int tm_get_greedy_flag(void);
+OMPI_HIDDEN void tm_set_greedy_flag(int new_val);
+OMPI_HIDDEN int tm_get_greedy_flag(void);
 
 
 /* Setting the maximum number of threads you want to use in parallel parts of TreeMatch */
-void tm_set_max_nb_threads(unsigned int val);
+OMPI_HIDDEN void tm_set_max_nb_threads(unsigned int val);
 
 /* managing the usage of physical vs. logical core numbering when using hwloc/xml files */
-void            tm_set_numbering(tm_numbering_t new_val); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
-tm_numbering_t  tm_get_numbering(void); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
+OMPI_HIDDEN void tm_set_numbering(tm_numbering_t new_val); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
+OMPI_HIDDEN tm_numbering_t  tm_get_numbering(void); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
 
 #include "tm_malloc.h"
 

--- a/ompi/include/ompi_config.h
+++ b/ompi/include/ompi_config.h
@@ -44,10 +44,17 @@
 #    ifndef OMPI_DECLSPEC
 #      define OMPI_DECLSPEC            __opal_attribute_visibility__("default")
 #    endif
+#    ifndef OMPI_HIDDEN
+#      define OMPI_HIDDEN              __opal_attribute_visibility__("hidden")
+#    endif
 #  else
 #    ifndef OMPI_DECLSPEC
 #      define OMPI_DECLSPEC
 #    endif
+#    ifndef OMPI_HIDDEN
+#      define OMPI_HIDDEN
+#    endif
 #  endif
+
 
 #endif


### PR DESCRIPTION
This is a cherry-pick of #10863 to the V5.0.x branch for issue #10708

This pull request handles renaming external symbols in 3rdparty/treematch so they are prefixed with tm_

Signed-off-by: David Wootton <drwootton@us.ibm.com>
(cherry picked from commit 2a95bb9c7b521a6405eb2dc3ee63ba8c2c3f5a54)