### PR TITLE
Fix potential oob read in mca_coll_han_query_module_from_mca [5.0.x]

### DIFF
--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -188,9 +188,8 @@ mca_coll_han_query_module_from_mca(mca_base_component_t* c,
 {
     char *module_name, *endptr = NULL;
 
-    int mod_id = COMPONENTS_COUNT;
+    int mod_id = COMPONENTS_COUNT-1;
     mod_id = (*module_id > (uint32_t)mod_id) ? mod_id : (int)*module_id; /* stay in range */
-    mod_id = (mod_id < 0) ? 0 : mod_id;  /* in range */
 
     *storage = ompi_coll_han_available_components[mod_id].component_name;
 


### PR DESCRIPTION
Reported as CID 1516096.

Backport of https://github.com/open-mpi/ompi/pull/10964/commits to 5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 6b2887955f2be60a378021abbedc2526554eda01)