### PR TITLE
sharedfp/sm: convert output to use verbosity levels

### DIFF
--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
@@ -126,30 +126,30 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_lockedfile_component_file
     fd = open(filename, O_RDWR | O_CREAT, 0644);
 
     if ( -1 == fd ){
-        opal_output(ompi_sharedfp_base_framework.framework_output,
+        opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 		    "mca_sharedfp_lockedfile_component_file_query: error opening file %s %s", filename, strerror(errno));
         has_file_lock_support=false;
     }
     else{
         err = fcntl(fd, F_SETLKW, &lock);
-	opal_output(ompi_sharedfp_base_framework.framework_output,
+        opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 		    "mca_sharedfp_lockedfile_component_file_query: returned err=%d, for fd=%d\n",err,fd);
 
         if (err) {
-            opal_output(ompi_sharedfp_base_framework.framework_output,
+            opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 			"mca_sharedfp_lockedfile_component_file_query: Failed to set a file lock on %s %s\n", filename, strerror(errno) );
-            opal_output(ompi_sharedfp_base_framework.framework_output,
+            opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 			"err=%d, errno=%d, EOPNOTSUPP=%d, EINVAL=%d, ENOSYS=%d, EACCES=%d, EAGAIN=%d, EBADF=%d\n",
                         err, errno, EOPNOTSUPP, EINVAL, ENOSYS, EACCES, EAGAIN, EBADF);
 
             if (errno == EACCES || errno == EAGAIN) {
-                opal_output(ompi_sharedfp_base_framework.framework_output,
+                opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 			    "errno=EACCES || EAGAIN, Already locked by another process\n");
             }
 
         }
         else {
-	    opal_output(ompi_sharedfp_base_framework.framework_output,
+            opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 			"mca_sharedfp_lockedfile_component_file_query: fcntl claims success in setting a file lock on %s\n", filename );
 
             has_file_lock_support=true;
@@ -166,7 +166,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_lockedfile_component_file
     *priority = 0;
     /*module can not run!, return NULL to indicate that we are unable to run*/
 
-    opal_output(ompi_sharedfp_base_framework.framework_output,
+    opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
 		"mca_sharedfp_lockedfile_component_file_query: Can not run!, file locking not supported\n");
     return NULL;
 }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -90,7 +90,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(o
     for (i = 0; i < size; ++i) {
         proc = ompi_group_peer_lookup(group,i);
         if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)){
-            opal_output(ompi_sharedfp_base_framework.framework_output,
+            opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
                         "mca_sharedfp_sm_component_file_query: Disqualifying myself: (%d/%s) "
                         "not all processes are on the same node.",
                         comm->c_contextid, comm->c_name);
@@ -113,7 +113,9 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(o
                      S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     if ( sm_fd == -1){
         /*error opening file*/
-        opal_output(0,"mca_sharedfp_sm_component_file_query: Error, unable to open file for mmap: %s\n",sm_filename);
+        opal_output_verbose(10, ompi_sharedfp_base_framework.framework_output,
+		    "mca_sharedfp_sm_component_file_query: Error, unable to open file "
+		    "for mmap: %s\n",sm_filename);
         free(sm_filename);
         return NULL;
     }


### PR DESCRIPTION
Avoid cluttering the output of users by converting some 'error' messages that are not necessarily fatal to the job from an opal_output to opal_output_verbose.

Fixes Issue #10971

Fixed the same issue in sharedfp/lockedfile as well.

Note: sharedfp/individual does not have the problem, since all opal_output calls are wrapped in if(sharedfp_sm_individual_verbose) statements.

Signed-off-by: Edgar Gabriel <Edgar.Gabriel@amd.com>
(cherry picked from commit a6d64a98f0e9f35a8dc3b3f19009ee02da4250c4)