### PR TITLE
Fix potential memory leak in opal/mca/base/mca_base_var_enum.c for v5.0.x

### DIFF
--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * $COPYRIGHT$
  *
@@ -373,6 +373,7 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
 
     new_enum->super.enum_name = strdup(name);
     if (NULL == new_enum->super.enum_name) {
+        OBJ_RELEASE(new_enum);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 


### PR DESCRIPTION
A clang static analysis run flagged a potential memory leak in mca_base_var_enum_create_flag
if a call to strdup fails. I added an OBJ_RELEASE macro to free that memory.

This is a cherry-pick from #10894 

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit e4ee02a255b007a7265fd6c619c4556289966f6e)