### PR TITLE
Fix possible memory leak in ompi_dpm_dyn_finalize

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -1779,6 +1779,7 @@ int ompi_dpm_dyn_finalize(void)
         }
 
         disconnect_waitall(ompi_comm_num_dyncomm, objs);
+        cleanup_dpm_disconnect_objs(objs, ompi_comm_num_dyncomm);
     }
 
     return OMPI_SUCCESS;
@@ -1896,8 +1897,6 @@ static int disconnect_waitall (int count, ompi_dpm_disconnect_obj **objs)
     /* force all non-blocking all-to-alls to finish */
     ret = ompi_request_wait_all(2*totalcount, reqs, MPI_STATUSES_IGNORE);
 
-    /* Finally, free everything */
-    cleanup_dpm_disconnect_objs(objs, count);
     free(reqs);
 
     return ret;


### PR DESCRIPTION
A clang static analysis run flagged a potential memory leak in ompi_dpm_dyn_finalize, where the leak of the obj array was flagged at the return at the end of the function.

dompi_dpm_dyn_finalize calls disconnect_waitall just before returning, but disconnect_waitall only frees the obj array and the objects in the array by calling cleanup_dpm_disconnect_objs only if disconnect_waitall was successful.

I moved the call to cleanup_dpm_disconnect_objs into ompi_dpm_dyn_finalize, just after the disconnect_waitall call.

This is a chery-pick from #10987 

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 2359a057523640b4c2ef05cd4c73826173330beb)