### PR TITLE
ofi/common: release opal memory base framework

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -207,6 +207,7 @@ static int opal_common_ofi_remove_memory_monitor(void)
         fi_close(opal_common_ofi_cache_fid);
         fi_close(&opal_common_ofi_monitor->fid);
         free(opal_common_ofi_monitor);
+        mca_base_framework_close(&opal_memory_base_framework);
         opal_common_ofi_installed_memory_monitor = false;
     }
 #endif


### PR DESCRIPTION
when shutting down the memory monitoring infrastructure in ofi common.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 2d5f0fd0083114c63e6814d635bf424bd9c797a2)