### PR TITLE
mpi4: fix init check for a few more functions

### DIFF
--- a/ompi/mpi/c/errhandler_c2f.c
+++ b/ompi/mpi/c/errhandler_c2f.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +35,7 @@
 #define MPI_Errhandler_c2f PMPI_Errhandler_c2f
 #endif
 
-static const char FUNC_NAME[] = "MPI_Errhandler_c2f";
+static const char FUNC_NAME[] __opal_attribute_unused__ = "MPI_Errhandler_c2f";
 
 
 MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler)
@@ -41,8 +43,6 @@ MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler)
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {
-    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-
 	/* mapping an invalid handle to a null handle */
     if (NULL == errhandler) {
         return OMPI_INT_2_FINT(-1);

--- a/ompi/mpi/c/errhandler_free.c
+++ b/ompi/mpi/c/errhandler_free.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +34,7 @@
 #define MPI_Errhandler_free PMPI_Errhandler_free
 #endif
 
-static const char FUNC_NAME[] = "MPI_Errhandler_free";
+static const char FUNC_NAME[] __opal_attribute_unused__ = "MPI_Errhandler_free";
 
 
 int MPI_Errhandler_free(MPI_Errhandler *errhandler)
@@ -40,7 +42,6 @@ int MPI_Errhandler_free(MPI_Errhandler *errhandler)
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {
-    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     /* Raise an MPI exception if we got NULL or if we got an intrinsic
        *and* the reference count is 1 (meaning that this FREE would
        actually free the underlying intrinsic object).  This is ugly

--- a/ompi/mpi/c/session_call_errhandler.c
+++ b/ompi/mpi/c/session_call_errhandler.c
@@ -36,7 +36,7 @@
 #endif
 
 
-static const char FUNC_NAME[] = "MPI_Session_call_errhandler";
+static const char FUNC_NAME[] __opal_attribute_unused__ = "MPI_Session_call_errhandler";
 
 
 int MPI_Session_call_errhandler(MPI_Session session, int errorcode)
@@ -44,7 +44,6 @@ int MPI_Session_call_errhandler(MPI_Session session, int errorcode)
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {
-    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     if (ompi_instance_invalid(session)) {
         if (NULL != session) {
             return OMPI_ERRHANDLER_INVOKE(session, MPI_ERR_SESSION, FUNC_NAME);


### PR DESCRIPTION
MPI_Errhandler_c2f
MPI_Errhandler_free
MPI_Session_call_errhandler

are on the list of functions that can be invoked before mpi is initialized (via mpi_init or session_init) and after finalize.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 92d9194ebda467f8040b6ef3fbca200def36fb57)