### PR TITLE
v4.0.x: docs: trivial typo fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ computer science researchers.
 Documentation locations
 =======================
 
-Documentation for Open can be found in the following locations:
+Documentation for Open MPI can be found in the following locations:
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit ffb6c2585d976f50db30fbf0b72b9a11480bdfff)

This is the v4.0.x PR for main PR #11006.  It is worthwhile for v4.0.x is because this typo fix will render to https://docs.open-mpi.org/en/v4.0.x/. 