### PR TITLE
mtl/ofi: Fix FI_HMEM bit check

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -738,7 +738,7 @@ no_hmem:
 
     if (FI_ENODATA == -ret) {
         /* Attempt selecting a provider without FI_HMEM hints */
-        if (hints->caps |= FI_HMEM) {
+        if (hints->caps & FI_HMEM) {
             hints->caps &= ~FI_HMEM;
             hints->domain_attr->mr_mode &= ~FI_MR_HMEM;
             goto no_hmem;


### PR DESCRIPTION
Instead of checking the bit, previously set the bit. This was not the intended behavior.

Signed-off-by: William Zhang <wilzhang@amazon.com>