### PR TITLE
tuned: use tree instead of bruck at scale

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -487,14 +487,8 @@ int ompi_coll_tuned_barrier_intra_dec_fixed(struct ompi_communicator_t *comm,
         alg = 3;
     } else if (communicator_size < 256) {
         alg = 4;
-    } else if (communicator_size < 512) {
-        alg = 6;
-    } else if (communicator_size < 1024) {
-        alg = 4;
-    } else if (communicator_size < 4096) {
-        alg = 6;
     } else {
-        alg = 4;
+        alg = 6;
     }
 
     return ompi_coll_tuned_barrier_intra_do_this (comm, module,


### PR DESCRIPTION
The switch from `tree` to `bruck` between 512 and 1023 processes leads to unexpected latency changes in benchmarks of other collectives. We should be consistent here. There is no good reason for why bruck would perform better in that range but not beyond.

Fixes https://github.com/open-mpi/ompi/issues/11022 and https://github.com/open-mpi/ompi/issues/10947

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>