### PR TITLE
Fix potential memory leak in opal_init_gethostname

### DIFF
--- a/opal/runtime/opal_init_core.c
+++ b/opal/runtime/opal_init_core.c
@@ -337,6 +337,7 @@ int opal_init_gethostname(void)
     size_t count, length = OPAL_LOCAL_MAXHOSTNAMELEN;
     int ret_val, num_tries = 0;
 
+    char *newbuf;
     char *buf = calloc(1, length);
     if (NULL == buf) {
         return OPAL_ERR_OUT_OF_RESOURCE;
@@ -407,10 +408,12 @@ int opal_init_gethostname(void)
          * the buffer and try again.
          */
         length *= 2;
-        buf = realloc(buf, length);
-        if (NULL == buf) {
+        newbuf = realloc(buf, length);
+        if (NULL == newbuf) {
+            free(buf);
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
+        buf = newbuf;
     } /* end while */
 
     /* If we got here, it means that we tried too many times and are


### PR DESCRIPTION
A clang static analysis scan reported a potential memory leak following a call to realloc in opal_get_hostname.

Fix potential memory leak in opal_get_hostname, where, if the realloc call at the bottom of the loop fails, the previously allocated memory is not freed and is leaked.

The linux realloc man page states that if realloc returns NULL then the memory pointed to by the first parameter to realloc is not freed.

This is fixed by assigning the result of realloc to a temp pointer then assigning that temp pointer to the original pointer if realloc succeeds.

Signed-off-by: David Wootton <dwootton@us.ibm.com>