### PR TITLE
Fix uninitialized pointer reported by coverity scan report CID 1516636

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -276,8 +276,7 @@ static inline int get_dynamic_win_info(uint64_t remote_addr,
      * dynamic lock */
     ret = ompi_osc_ucx_dynamic_lock(module, target);
     if (ret != OPAL_SUCCESS) {
-        ret = OMPI_ERROR;
-        goto cleanup;
+        return OMPI_ERROR;
     }
 
     temp_buf = calloc(remote_state_len, 1);

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -281,6 +281,10 @@ static inline int get_dynamic_win_info(uint64_t remote_addr,
     }
 
     temp_buf = calloc(remote_state_len, 1);
+    if (NULL == temp_buf) {
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
     ret = opal_common_ucx_wpmem_putget(module->state_mem, OPAL_COMMON_UCX_GET, target,
                                        (void *)((intptr_t)temp_buf),
                                        remote_state_len, remote_state_addr, ep);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -5,6 +5,8 @@
  *                         reserved.
  *
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -933,7 +935,7 @@ int ompi_osc_ucx_dynamic_lock(ompi_osc_ucx_module_t *module, int target) {
                                         TARGET_LOCK_UNLOCKED, TARGET_LOCK_EXCLUSIVE,
                                         target, &result_value, sizeof(result_value),
                                         remote_addr, ep);
-        if (ret != OMPI_SUCCESS) {
+        if (ret != OPAL_SUCCESS) {
             OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_cmpswp failed: %d", ret);
             return OMPI_ERROR;
         }
@@ -955,7 +957,7 @@ int ompi_osc_ucx_dynamic_unlock(ompi_osc_ucx_module_t *module, int target) {
     int ret = OMPI_SUCCESS;
 
     ret = opal_common_ucx_wpmem_fence(module->mem);
-    if (ret != OMPI_SUCCESS) {
+    if (ret != OPAL_SUCCESS) {
         OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_fence failed: %d", ret);
         return OMPI_ERROR;
     }

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -928,7 +928,7 @@ int ompi_osc_ucx_dynamic_lock(ompi_osc_ucx_module_t *module, int target) {
     uint64_t remote_addr = (module->state_addrs)[target] + OSC_UCX_STATE_DYNAMIC_LOCK_OFFSET;
     ucp_ep_h *ep;
     OSC_UCX_GET_DEFAULT_EP(ep, module, target);
-    int ret = OMPI_SUCCESS;
+    int ret = OPAL_SUCCESS;
 
     for (;;) {
         ret = opal_common_ucx_wpmem_cmpswp(module->state_mem,
@@ -946,7 +946,7 @@ int ompi_osc_ucx_dynamic_lock(ompi_osc_ucx_module_t *module, int target) {
         opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);
     }
 
-    return ret;
+    return OMPI_SUCCESS;
 }
 
 int ompi_osc_ucx_dynamic_unlock(ompi_osc_ucx_module_t *module, int target) {
@@ -954,7 +954,7 @@ int ompi_osc_ucx_dynamic_unlock(ompi_osc_ucx_module_t *module, int target) {
     uint64_t remote_addr = (module->state_addrs)[target] + OSC_UCX_STATE_DYNAMIC_LOCK_OFFSET;
     ucp_ep_h *ep;
     OSC_UCX_GET_DEFAULT_EP(ep, module, target);
-    int ret = OMPI_SUCCESS;
+    int ret = OPAL_SUCCESS;
 
     ret = opal_common_ucx_wpmem_fence(module->mem);
     if (ret != OPAL_SUCCESS) {
@@ -966,8 +966,11 @@ int ompi_osc_ucx_dynamic_unlock(ompi_osc_ucx_module_t *module, int target) {
                                     UCP_ATOMIC_FETCH_OP_SWAP, TARGET_LOCK_UNLOCKED,
                                     target, &result_value, sizeof(result_value),
                                     remote_addr, ep);
+    if (OPAL_SUCCESS != ret) {
+        return OMPI_ERROR;
+    }
     assert(result_value == TARGET_LOCK_EXCLUSIVE);
-    return ret;
+    return OMPI_SUCCESS;
 }
 
 int ompi_osc_ucx_win_attach(struct ompi_win_t *win, void *base, size_t len) {


### PR DESCRIPTION
The temp_buf pointer may be used uninitialized by the code path introduced in 1ea6fb9a672766352bb858601d0fd363a700ad16. Fix this by initializing the temp_buf pointer to NULL.
Also make sure, that the later calloc call is successful; otherwise report an OMPI_ERR_OUT_OF_RESOURCE error.

Update: Along this several issues with type mismatches of returned error codes mixing OPAL and OMPI error codes came up that are addressed, too.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>