### PR TITLE
singleton: reduce chattiness under slurm

### DIFF
--- a/ompi/runtime/help-mpi-runtime.txt
+++ b/ompi/runtime/help-mpi-runtime.txt
@@ -120,5 +120,5 @@ that either you are operating in a PMIx-enabled environment, or use "mpirun"
 to execute the job.
 #
 [no-pmix-but]
-No PMIx server was reachable, but a PMI1/2 or SLURM environment was detected.
-Open MPI will start %d singletons
+No PMIx server was reachable, but a PMI1/2 was detected.
+If srun is being used to launch application,  %d singletons will be started.


### PR DESCRIPTION
The changes to address issue #10286 had the side effect of adding some unexpected output in the case an application is being launched in singleton mode and happens to be within a slurm allocation.

This patch is more selecive in the environment variables checked to determine whether or not a process was launched under srun vs just being a process that happens to be running within a slurm allocation.

Related to #11034

Signed-off-by: Howard Pritchard <howardp@lanl.gov>

better solution

Signed-off-by: Howard Pritchard <howardp@lanl.gov>