### PR TITLE
ofi/common: use verbosity level to control

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -554,11 +554,13 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
     }
 #endif
 
-    // Get the local peers
+    // Get the local peers - note there may not always be local peers,e.g. .singleton launch case
     OPAL_MODEX_RECV_VALUE(rc, PMIX_LOCAL_PEERS, &pname, &local_peers, PMIX_STRING);
     if (PMIX_SUCCESS != rc || NULL == local_peers) {
         // We can't find package_rank, fall back to procid
-        opal_show_help("help-common-ofi.txt", "package_rank failed", true);
+        if (10 <= opal_common_ofi_verbose_level) {
+            opal_show_help("help-common-ofi.txt", "package_rank failed", true, 10);
+        }
         return (uint32_t) process_info->myprocid.rank;
     }
     peers = opal_argv_split(local_peers, ',');


### PR DESCRIPTION
informational message about process/ofi dev selection. Also fix help output.

related to #11034

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit d642af133b782b857218975056a9afac8801dcc1)