### PR TITLE
opal/convertor: Use regular memcpy when detecting Unified memory

### DIFF
--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -48,7 +48,7 @@
 static void *opal_convertor_accelerator_memcpy(void *dest, const void *src, size_t size, opal_convertor_t *convertor)
 {
     int res;
-    if (!(convertor->flags & CONVERTOR_ACCELERATOR)) {
+    if (!(convertor->flags & CONVERTOR_ACCELERATOR) || (convertor->flags & CONVERTOR_ACCELERATOR_UNIFIED)) {
         return MEMCPY(dest, src, size);
     }
 


### PR DESCRIPTION
During some testing, cuMemcpyAsync was failing on managed memory. Unified memory is able to accept regular memcpy so switch to that instead.

Signed-off-by: William Zhang <wilzhang@amazon.com>