### PR TITLE
docs: fix typo

### DIFF
--- a/docs/developers/sphinx.rst
+++ b/docs/developers/sphinx.rst
@@ -182,8 +182,8 @@ they rendered in HTML).
 Checking Sphinx HTML links
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``linkcheck`` ``make`` target will invoke Sphinx's functionality
-to check all the external links in the documentation::
+``make linkcheck`` will invoke Sphinx's functionality to check all the
+external links in the documentation:
 
 .. code:: sh
 


### PR DESCRIPTION
Fix a ("::") typo that caused a code block to render incorrectly. Also make the surrounding text a little cleaner.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>