### PR TITLE
Update installation and runtime documentation

### DIFF
--- a/docs/installing-open-mpi/configure-cli-options/index.rst
+++ b/docs/installing-open-mpi/configure-cli-options/index.rst
@@ -11,6 +11,7 @@ below.
 .. toctree::
    :maxdepth: 1
 
+   what-to-install
    conventions
    installation
    networking

--- a/docs/installing-open-mpi/configure-cli-options/what-to-install.rst
+++ b/docs/installing-open-mpi/configure-cli-options/what-to-install.rst
@@ -1,0 +1,68 @@
+Deciding what to install
+========================
+
+Open MPI's ``configure`` script will, by default, search for support
+and build every component that it can.  This is convenient, and
+helpful for a good out-of-the-box experience for many HPC
+environments.
+
+However, HPC clusters rarely change from day-to-day, and large
+clusters rarely change at all.  If you know your cluster's
+configuration, there are several steps you can take to reduce the
+Open MPI installation footprint and component selection overhead.
+These steps use a combination of build-time configuration options to
+eliminate components |mdash| thus eliminating their libraries and
+avoiding unnecessary component open/close operations |mdash| as well
+as run-time MCA parameters to specify what modules to use by default
+for most users.
+
+.. caution:: This is somewhat advanced functionality, and is only
+             recommended for users who are deeply familiar with what
+             components are actually used by Open MPI in their
+             environments.
+
+             Most users should just allow building whatever components
+             Open MPI's ``configure`` script finds.
+
+Build/install-time choices
+--------------------------
+
+One way to save memory is to avoid building components that will
+actually never be selected by the system.  Unless MCA parameters
+specify which components to open, installed components are *always*
+opened and tested as to whether or not they should be selected for
+use. If you know that a component can build on your system, but due to
+your cluster's configuration will never actually be selected, then it
+is best to simply configure Open MPI to not build that component by
+using the ``--enable-mca-no-build`` CLI option to ``configure``.
+
+For example, if you know that your system will only utilize the
+``ob1`` component of the PML framework, then you can "no build" all
+the others:
+
+.. code:: sh
+
+   # See what directories (i.e., components) exist in the PML
+   # framework
+   shell$ ls -1 ompi/mca/pml
+
+   # Do not list "base", but list all other undesired components
+   # (i.e., directories).  For example, in Open MPI v6.0.0, to build
+   # *only* the OB1 PML:
+   shell$ ./configure --enable-mca-no-build=pml-cm,pml-monitoring,pml-ubcl,pml-ucx,pml-v
+
+
+This not only reduces the size of the Open MPI libraries, but can also
+avoid unnecessary component open/selection work at run time.
+
+Run-time choices
+----------------
+
+The ``$sysconfdir/openmpi-mca-params.conf`` file in the installation
+tree (which defaults to ``$prefix/etc/openmpi-mca-params.conf``) is
+where a system administrator can set system-wide defaults for Open MPI
+:ref:`run-time MCA parameters <label-running-setting-mca-param-values>`.
+
+These values can still be overridden by end users, but the values in
+this file allow the hiding of any system-specific defaults that an
+administrator may want the majority of users to utilize.

--- a/docs/installing-open-mpi/quickstart.rst
+++ b/docs/installing-open-mpi/quickstart.rst
@@ -37,9 +37,11 @@ packages:
 .. code-block:: sh
 
    # For Homebrew
-   shell$ brew install openmpi
+   # https://formulae.brew.sh/formula/open-mpi
+   shell$ brew install open-mpi
 
    # For MacPorts
+   # https://ports.macports.org/search/?q=openmpi
    shell$ port install openmpi
 
 .. important:: Binary packages may or may not include support for

--- a/docs/man-openmpi/man1/mpirun.1.rst
+++ b/docs/man-openmpi/man1/mpirun.1.rst
@@ -267,10 +267,13 @@ To map processes:
 
 * ``--cpu-list <cpus>``: Comma-delimited list of processor IDs to
   which to bind processes [default=``NULL``].  Processor IDs are
-  interpreted as hwloc logical core IDs.
+  interpreted as `Hwloc <https://www.open-mpi.org/projects/hwloc/>`_
+  logical core IDs.
 
-  .. note:: You can run Run the hwloc ``lstopo(1)`` command to see a
-            list of available cores and their logical IDs.
+  .. note:: You can run the `Hwloc
+            <https://www.open-mpi.org/projects/hwloc/>`_ ``lstopo(1)``
+            command to see a list of available cores and their logical
+            IDs.
 
 To order processes' ranks in ``MPI_COMM_WORLD``:
 
@@ -1232,8 +1235,9 @@ All package/core slot locations are specified as logical indexes.
 
 .. note:: The Open MPI v1.6 series used physical indexes. Starting in Open MPI v5.0 only logical indexes are supported and the ``rmaps_rank_file_physical`` MCA parameter is no longer recognized.
 
-You can use tools such as Hwloc's `lstopo(1)` to find the logical
-indexes of package and cores.
+You can use tools such as `Hwloc's
+<https://www.open-mpi.org/projects/hwloc/>`_ ``lstopo(1)`` command to
+find the logical indexes of package and cores.
 
 Application Context or Executable Program?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tuning-apps/large-clusters/index.rst
+++ b/docs/tuning-apps/large-clusters/index.rst
@@ -5,6 +5,10 @@ Setting up a large cluster to run MPI applications can be challenging and
 full of many decisions.  The following sections include guidance for
 installing and tuning Open MPI on large clusters.
 
+Also see :doc:`Deciding what to install
+</installing-open-mpi/configure-cli-options/what-to-install>` for
+build-time considerations that can affect large-cluster deployments.
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
## Summary

This PR refreshes several related pieces of user-facing documentation around installing and configuring Open MPI.

- Add a new configure-options page about deciding what to install on stable HPC systems.
- Document when experienced site administrators may choose not to build components that are known not to be used.
- Include an Open MPI v6.0.0 example for building only the OB1 PML by listing the other current PML components in `--enable-mca-no-build`.
- Link the new configure guidance from the large-cluster tuning chapter.
- Correct the Homebrew package command to `brew install open-mpi` and keep the MacPorts `port install openmpi` example.
- Add package-manager reference URLs to the quickstart.
- Improve the `mpirun(1)` wording around hwloc logical IDs and `lstopo(1)`.

## Rationale

The new configure guidance is intended for stable site deployments where administrators already know which components are appropriate for their environment. It avoids overpromising performance improvements and frames `--enable-mca-no-build` as an advanced footprint and component-selection tool.

The large-cluster chapter now points readers to this build-time guidance without moving configure-specific material out of the installation chapter.

## Testing

- Rebasing and conflict resolution completed locally against current `origin/main`.
- Fixed the stale Sphinx reference from `label-run-time-tuning` to `label-running-setting-mca-param-values`.
- A full docs build was not run in this checkout.