### PR TITLE
v5.0.x OSC/UCX: Fix coverity issues and missing extend var in nb acc

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -49,12 +49,12 @@ OMPI_DECLSPEC extern ompi_osc_ucx_component_t mca_osc_ucx_component;
 
 #define OSC_UCX_INCREMENT_OUTSTANDING_NB_OPS(_module)                               \
     do {                                                                            \
-        opal_atomic_add_fetch_size_t(&_module->ctx->num_incomplete_req_ops, 1);     \
+        opal_atomic_add_fetch_64(&_module->ctx->num_incomplete_req_ops, 1);         \
     } while(0);
 
 #define OSC_UCX_DECREMENT_OUTSTANDING_NB_OPS(_module)                               \
     do {                                                                            \
-        opal_atomic_add_fetch_size_t(&_module->ctx->num_incomplete_req_ops, -1);    \
+        opal_atomic_add_fetch_64(&_module->ctx->num_incomplete_req_ops, -1);        \
     } while(0);
 
 typedef enum ompi_osc_ucx_epoch {

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -874,7 +874,7 @@ OPAL_DECLSPEC int opal_common_ucx_ctx_flush(opal_common_ucx_ctx_t *ctx,
     }
 
     /* progress the nonblocking operations */
-    while (ctx->num_incomplete_req_ops != 0) {
+    while (ctx->num_incomplete_req_ops > 0) {
         spin++;
         rc = ctx_flush(ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
         if (rc != OPAL_SUCCESS) {

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -88,7 +88,7 @@ typedef struct {
     char *recv_worker_addrs;
     int *recv_worker_displs;
     size_t comm_size;
-    opal_atomic_size_t num_incomplete_req_ops;
+    opal_atomic_int64_t num_incomplete_req_ops;
 } opal_common_ucx_ctx_t;
 
 /* Worker Pool memory (wpmem) is an object that represents a remotely accessible


### PR DESCRIPTION

v5.0.x OSC/UCX: Fix coverity issues and missing extend var in nb acc
Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit fb23119592387354640ec425c313367bdef41dcd)