### PR TITLE
opal_list: fix a bug in opal_list_insert()

### DIFF
--- a/opal/class/opal_list.c
+++ b/opal/class/opal_list.c
@@ -135,9 +135,9 @@ bool opal_list_insert(opal_list_t *list, opal_list_item_t *item, long long idx)
         assert(1 == item->opal_list_item_refcount);
         item->opal_list_item_belong_to = list;
 #endif
+        list->opal_list_length++;
     }
 
-    list->opal_list_length++;
     return true;
 }
 


### PR DESCRIPTION
related to #11058 

Fix the bug that calls to `opal_list_insert()` with `idx=0` will make `list->opal_list_length` increase twice.

Signed-off-by: Jinyuan Wang [wangjingyuan@mail.nwpu.edu.cn](wangjingyuan@mail.nwpu.edu.cn)