### PR TITLE
MCA/PML/UCX: Enabled multi_send_nb option by default.

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -85,7 +85,7 @@ static int mca_pml_ucx_component_register(void)
 
     ompi_pml_ucx.op_attr_nonblocking = 0;
 #if HAVE_DECL_UCP_OP_ATTR_FLAG_MULTI_SEND
-    multi_send_op_attr_enable        = 0;
+    multi_send_op_attr_enable        = 1;
     (void) mca_base_component_var_register(&mca_pml_ucx_component.pmlm_version, "multi_send_nb",
                                            "Enable passing multi-send optimization flag for nonblocking operations",
                                            MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,


### PR DESCRIPTION
Changed default value for multi_send_nb option.
Enabled option has a positive impact on underlying protocol selection in UCX.

Cherry-picked https://github.com/open-mpi/ompi/commit/42895fe6c3eeed103c0342403ddd39ca6369d533