### PR TITLE
mtl: Fix datatype offsetting

### DIFF
--- a/ompi/mca/mtl/base/mtl_base_datatype.h
+++ b/ompi/mca/mtl/base/mtl_base_datatype.h
@@ -46,7 +46,7 @@ ompi_mtl_datatype_pack(struct opal_convertor_t *convertor,
 						  convertor->count) &&
         !(convertor->flags & CONVERTOR_ACCELERATOR)) {
 	    *free_after = false;
-	    *buffer = convertor->pBaseBuf;
+	    *buffer = convertor->pBaseBuf + convertor->bConverted + convertor->pDesc->true_lb;
 	    *buffer_len = convertor->local_size;
 	    return OPAL_SUCCESS;
     }

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -374,7 +374,7 @@ mca_pml_cm_send(const void *buf,
                 MCA_PML_CM_SWITCH_ACCELERATOR_CONVERTOR_OFF(flags, datatype, count);
                 convertor.flags      |= flags;
                 /* Sets CONVERTOR_ACCELERATOR flag if device buffer */
-                opal_convertor_prepare_for_send(&convertor, &datatype->super, count, (unsigned char *)buf + datatype->super.true_lb);
+                opal_convertor_prepare_for_send(&convertor, &datatype->super, count, (unsigned char *)buf);
     } else
 #endif
 	{


### PR DESCRIPTION
The convertor packing code will automatically add
datatype offsets. However, the MTL avoids entering the convertor in some cases and thus was required to add an offset somewhere. The original location -
mca_pml_cm_send() - was causing a problem with accelerator buffers as it would add the offset before sending it to the opal_convertor_pack function, doubling the offset.

The correct place to add the datatype offset was modified to be in the ompi_mtl_datatype_pack() function which appropriately mirrors the opal_convertor_pack() offset behavior.

Signed-off-by: William Zhang <wilzhang@amazon.com>