### PR TITLE
Change top level heading in man pages to upper case for consistencyin Open MPI man pages.

### DIFF
--- a/docs/man-openmpi/man3/MPIX_Query_cuda_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_cuda_support.3.rst
@@ -65,7 +65,7 @@ application with older versions of Open MPI or other MPI
 implementations that do not have this function.
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 .. code-block:: c

--- a/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
@@ -65,7 +65,7 @@ application with older versions of Open MPI or other MPI
 implementations that do not have this function.
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 .. code-block:: c

--- a/docs/man-openmpi/man3/MPI_Barrier.3.rst
+++ b/docs/man-openmpi/man3/MPI_Barrier.3.rst
@@ -8,7 +8,7 @@ MPI_Barrier
 :ref:`MPI_Barrier`, :ref:`MPI_Ibarrier` - Synchronization between MPI processes in a
 group
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -55,19 +55,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT (OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 An MPI barrier completes after all groups members have entered the
@@ -81,7 +81,7 @@ performed across all processes in both groups. All processes in the
 first group may exit the barrier when all processes in the second group
 have entered the barrier.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend.3.rst
@@ -7,7 +7,7 @@ MPI_Bsend
 
 :ref:`MPI_Bsend` - Basic send with user-specified buffering.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(IN) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of send buffer (choice).
@@ -55,17 +55,17 @@ Input Parameters
 -  ``tag`` : Message tag (integer).
 -  ``comm`` : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Bsend` performs a buffered-mode, blocking send.
 
-Notes
+NOTES
 -----
 
 This send is provided as a convenience function; it allows the user to
@@ -94,7 +94,7 @@ In C, you can force the messages to be delivered by
 ``MPI_Buffer_detach`` will not complete until all buffered messages are
 delivered.)
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
@@ -7,7 +7,7 @@ MPI_Bsend_init
 
 :ref:`MPI_Bsend_init` - Builds a handle for a buffered send.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,7 +48,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  buf : Initial address of send buffer (choice).
@@ -58,13 +58,13 @@ Input Parameters
 -  tag : Message tag (integer).
 -  comm : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  request : Communication request (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Creates a persistent communication request for a buffered mode send, and
@@ -73,7 +73,7 @@ binds to it all the arguments of a send operation.
 A communication (send or receive) that uses a persistent request is
 initiated by the function :ref:`MPI_Start`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
@@ -7,7 +7,7 @@ MPI_Buffer_attach
 
 :ref:`MPI_Buffer_attach` - Attaches a user-defined buffer for sending.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,25 +43,25 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: size
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  buf : Initial buffer address (choice).
 -  size : Buffer size, in bytes (integer).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Provides to MPI a buffer in the user's memory to be used for buffering
 outgoing messages. The buffer is used only by messages sent in buffered
 mode. Only one buffer can be attached to a process at a time.
 
-Notes
+NOTES
 -----
 
 The size given should be the sum of the sizes of all outstanding Bsends
@@ -83,7 +83,7 @@ MPI_BSEND_OVERHEAD gives the maximum amount of buffer space that may be
 used by the Bsend routines. This value is in mpi.h for C and mpif.h for
 Fortran.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
@@ -8,7 +8,7 @@ MPI_Buffer_detach
 :ref:`MPI_Buffer_detach` - Removes an existing buffer (for use in in :ref:`MPI_Bsend`,
 etc.)
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,14 +45,14 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: size
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  buf : Initial buffer address (choice).
 -  size : Buffer size, in bytes (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Detach the buffer currently associated with MPI. The call returns the
@@ -69,7 +69,7 @@ MPI_Buffer_detach( &buff, &size); /* Buffer size reduced to zero */
 MPI_Buffer_attach( buff, size); /* Buffer of 10000 bytes available again
 \*/
 
-Notes
+NOTES
 -----
 
 The reason that :ref:`MPI_Buffer_detach` returns the address and size of the
@@ -97,7 +97,7 @@ differently: A pointer to the buffer is passed to :ref:`MPI_Buffer_attach`; the
 address of the pointer is passed to :ref:`MPI_Buffer_detach`, so that this call
 can return the pointer value.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cancel.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cancel.3.rst
@@ -7,7 +7,7 @@ MPI_Cancel
 
 :ref:`MPI_Cancel` - Cancels a communication request.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,17 +41,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(IN) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  request : Communication request (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The :ref:`MPI_Cancel` operation allows pending communications to be canceled.
@@ -99,7 +99,7 @@ If the operation has been canceled, then information to that effect will
 be returned in the status argument of the operation that completes the
 communication.
 
-Notes
+NOTES
 -----
 
 The primary expected use of :ref:`MPI_Cancel` is in multi-buffering schemes,
@@ -107,7 +107,7 @@ where speculative MPI_Irecvs are made. When the computation completes,
 some of these requests may remain; using :ref:`MPI_Cancel` allows the user to
 cancel these unsatisfied requests.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_coords
 :ref:`MPI_Cart_coords` - Determines process coords in Cartesian topology
 given rank in group.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: coords(maxdims)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm`` : Communicator with Cartesian structure (handle).
@@ -53,7 +53,7 @@ Input Parameters
 -  ``maxdims`` : Length of vector coords in the calling program
    (integer). Length of vector coords in the calling program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``coords`` : Integer array (of size ndims,which was defined by
@@ -61,13 +61,13 @@ Output Parameters
    specified process (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_coords` provides a mapping of ``rank``\ s to Cartesian
 coordinates.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_create.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_create
 :ref:`MPI_Cart_create` - Makes a new communicator to which Cartesian
 topology information has been attached.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -49,7 +49,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: comm_cart
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm_old`` : Input communicator (handle).
@@ -61,13 +61,13 @@ Input Parameters
 -  ``reorder`` : Ranking may be reordered (true) or not (false)
    (logical).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``comm_cart`` : Communicator with new Cartesian topology (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_create` returns a handle to a new communicator to which the
@@ -80,7 +80,7 @@ smaller than the size of the group of comm, then some processes are
 returned MPI_COMM_NULL, in analogy to :ref:`MPI_Comm_split`. The call
 is erroneous if it specifies a grid that is larger than the group size.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_get.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_get
 :ref:`MPI_Cart_get` - Retrieves Cartesian topology information associated with
 a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,14 +47,14 @@ Fortran 2008 Syntax
        LOGICAL, INTENT(OUT) :: periods(maxdims)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
 -  maxdims : Length of vectors dims, periods, and coords in the calling
    program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  dims : Number of processes for each Cartesian dimension (array of
@@ -65,14 +65,14 @@ Output Parameters
    of integers).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The functions :ref:`MPI_Cartdim_get` and :ref:`MPI_Cart_get` return the Cartesian
 topology information that was associated with a communicator by
 :ref:`MPI_Cart_create`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_map.3.rst
@@ -7,7 +7,7 @@ MPI_Cart_map
 
 :ref:`MPI_Cart_map` - Maps process to Cartesian topology information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,7 +46,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: newrank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Input communicator (handle).
@@ -56,14 +56,14 @@ Input Parameters
 -  periods : Logical array of size ndims specifying the periodicity
    specification in each coordinate direction.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newrank : Reordered rank of the calling process; MPI_UNDEFINED if
    calling process does not belong to grid (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_map` and :ref:`MPI_Graph_map` can be used to implement all other
@@ -74,7 +74,7 @@ capability other than that provided by MPI. :ref:`MPI_Cart_map` computes an
 possible implementation of this function is to always return the rank of
 the calling process, that is, not to perform any reordering.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_rank
 :ref:`MPI_Cart_rank` - Determines process rank in communicator given Cartesian
 location.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: rank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
@@ -52,13 +52,13 @@ Input Parameters
    :ref:`MPI_Cart_create` call) specifying the Cartesian coordinates of a
    process.
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  rank : Rank of specified process (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 For a process group with Cartesian structure, the function :ref:`MPI_Cart_rank`
@@ -69,7 +69,7 @@ true, if the coordinate, coords(i), is out of range, that is, coords(i)
 coords(i) < dims(i) automatically. Out-of-range coordinates are
 erroneous for nonperiodic dimensions.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_shift
 :ref:`MPI_Cart_shift` - Returns the shifted source and destination ranks,
 given a shift direction and amount.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: rank_source, rank_dest
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm`` : Communicator with Cartesian structure (handle).
@@ -55,14 +55,14 @@ Input Parameters
 -  ``disp`` : Displacement ( > 0: upward shift, < 0: downward shift)
    (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``rank_source`` : Rank of source process (integer).
 -  ``rank_dest`` : Rank of destination process (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 If the process topology is a Cartesian structure, an :ref:`MPI_Sendrecv`
@@ -107,7 +107,7 @@ column) by i steps.
        CALL MPI_SENDRECV_REPLACE(A, 1, MPI_REAL, dest, 0, source, 0, comm, status,
                                  ierr)
 
-Note
+NOTE
 ----
 
 In Fortran, the dimension indicated by DIRECTION = i has DIMS(i+1)
@@ -115,7 +115,7 @@ nodes, where DIMS is the array that was used to create the grid. In C,
 the dimension indicated by direction = i is the dimension specified by
 dims[i].
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_sub
 :ref:`MPI_Cart_sub` - Partitions a communicator into subgroups, which form
 lower-dimensional Cartesian subgrids.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
@@ -53,14 +53,14 @@ Input Parameters
    dimension is kept in the subgrid (true) or is dropped (false)
    (logical vector).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  comm_new : Communicator containing the subgrid that includes the
    calling process (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 If a Cartesian topology has been created with :ref:`MPI_Cart_create`, the
@@ -83,7 +83,7 @@ to MPI_Cart_sub(comm, remain_dims, comm_new) will create six
 nonoverlapping communicators, each with four processes, in a
 one-dimensional Cartesian topology.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
@@ -8,7 +8,7 @@ MPI_Cartdim_get
 :ref:`MPI_Cartdim_get` - Retrieves Cartesian topology information associated
 with a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,24 +43,24 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: ndims
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator with Cartesian structure (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ndims : Number of dimensions of the Cartesian structure (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cartdim_get` returns the number of dimensions of the Cartesian
 structure.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Close_port.3.rst
+++ b/docs/man-openmpi/man3/MPI_Close_port.3.rst
@@ -7,7 +7,7 @@ MPI_Close_port
 
 :ref:`MPI_Close_port` - Releases the specified network address.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,23 +42,23 @@ Fortran 2008 Syntax
        CHARACTER(LEN=*), INTENT(IN) :: port_name
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``port_name`` : A port (string).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Close_port` releases the network address represented by
 ``port_name``.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_accept
 
 :ref:`MPI_Comm_accept` - Establishes communication with a client.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,7 +46,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  port_name : Port name (string, used only on *root*).
@@ -55,13 +55,13 @@ Input Parameters
 -  root : Rank in *comm* of root node (integer).
 -  comm : Intracommunicator over which call is collective (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Intercommunicator with client as remote group (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_accept` establishes communication with a client. It is
@@ -71,7 +71,7 @@ client has connected with the :ref:`MPI_Comm_accept` function using the
 :ref:`MPI_Comm_connect` function. The port_name must have been established
 through a call to :ref:`MPI_Open_port` on the root.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_call_errhandler
 :ref:`MPI_Comm_call_errhandler` - Passes the supplied error code to the error
 handler assigned to a communicator
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: errorcode
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : communicator with error handler (handle).
 -  errorcode : error code (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function invokes the error handler assigned to the communicator
@@ -62,14 +62,14 @@ comm with the supplied error code errorcode. If the error handler was
 successfully called, the process is not aborted, and the error handler
 returns, this function returns MPI_SUCCESS.
 
-Notes
+NOTES
 -----
 
 Users should note that the default error handler is
 MPI_ERRORS_ARE_FATAL. Thus, calling this function will abort the
 processes in comm if the default error handler has not been changed.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_compare
 
 :ref:`MPI_Comm_compare` - Compares two communicators.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,19 +42,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: result
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm1`` : Comm1 (handle).
 -  ``comm2`` : Comm2 (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``result`` : Result of comparison (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 MPI_IDENT ``result``\ s if and only if ``comm1`` and ``comm2`` are
@@ -64,7 +64,7 @@ constituents and rank order; these communicators differ only by context.
 MPI_SIMILAR results of the group members of both communicators are
 the same but the rank order differs. MPI_UNEQUAL results otherwise.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_connect
 
 :ref:`MPI_Comm_connect` - Establishes communication with a server.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  port_name : Port name (string, used only on *root*).
@@ -56,13 +56,13 @@ Input Parameters
 -  root : Rank in *comm* of root node (integer).
 -  comm : Intracommunicator over which call is collective (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Intercommunicator with client as remote group (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_connect` establishes communication with a server specified by
@@ -79,7 +79,7 @@ connection attempt from being satisfied. The port_name parameter is the
 address of the server. It must be the same as the name returned by
 :ref:`MPI_Open_port` on the server.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create
 
 :ref:`MPI_Comm_create` - Creates a new communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  group : Group, which is a subset of the group of comm (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function creates a new communicator newcomm with communication
@@ -69,7 +69,7 @@ with a non-empty group, then all processes in that group must call the
 function with the same group as argument, that is: the same processes in
 the same order. Otherwise the call is erroneous.
 
-Notes
+NOTES
 -----
 
 :ref:`MPI_Comm_create` provides a means of making a subset of processes for the
@@ -79,7 +79,7 @@ calls to :ref:`MPI_Comm_create` (or other communicator constructors) to further
 subdivide a computation into parallel sub-computations. A more general
 service is provided by :ref:`MPI_Comm_split`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_create_errhandler
 :ref:`MPI_Comm_create_errhandler` - Creates an error handler that can be
 attached to communicators.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -54,18 +54,18 @@ MPI_Comm_errhandler_function and ``MPI::Comm::Errhandler_function``,
 respectively. Open MPI supports both names (indeed, the \_fn names are
 typedefs to the \_function names).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``function`` : User-defined error handling procedure (function).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``errhandler`` : MPI error handler (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_errhandler` creates an error handler that can be
@@ -88,7 +88,7 @@ deprecated. In Fortran, the user routine should be of this form:
    SUBROUTINE COMM_ERRHANDLER_FUNCTION(COMM, ERROR_CODE, ...)
       INTEGER COMM, ERROR_CODE
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_create_from_group
 :ref:`MPI_Comm_create_from_group` - Creates a new communicator from a group and
 stringtag
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handler)
@@ -56,13 +56,13 @@ Input Parameters
 -  errhandler : error handler to be attached to the new
    intra-communicator (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_from_group` is similar to :ref:`MPI_Comm_create_group`, except
@@ -82,7 +82,7 @@ operations by providing different stringtag arguments. The stringtag
 shall not exceed MPI_MAX_STRINGTAG_LEN characters in length. For C, this
 includes space for a null terminating character.
 
-Notes
+NOTES
 -----
 
 The errhandler argument specifies an error handler to be attached to the
@@ -91,7 +91,7 @@ possibly MPI implementation dependent, which indicate desired
 characteristics and guide communicator creation. MPI_MAX_STRINGTAG_LEN
 shall have a value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create_group
 
 :ref:`MPI_Comm_create_group` - Creates a new communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,20 +44,20 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator (handle).
 -  group : Group, which is a subset of the group of comm (handle).
 -  tag : Tag (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_group` is similar to :ref:`MPI_Comm_create`; however,
@@ -79,7 +79,7 @@ associated group. If the calling process is not a member of group, e.g.,
 group is MPI_GROUP_EMPTY, then the call is a local operation and
 MPI_COMM_NULL is returned as newcomm.
 
-Notes
+NOTES
 -----
 
 :ref:`MPI_Comm_create_group` provides a means of making a subset of processes
@@ -90,7 +90,7 @@ communicator constructors) to further subdivide a computation into
 parallel sub-computations. A more general service is provided by
 :ref:`MPI_Comm_split`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create_keyval
 
 :ref:`MPI_Comm_create_keyval` - Generates a new attribute key.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -52,7 +52,7 @@ Fortran 2008 Syntax
        INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) :: extra_state
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm_copy_attr_fn`` : Copy callback function for ``comm_keyval``
@@ -61,13 +61,13 @@ Input Parameters
    ``comm_keyval`` (function).
 -  ``extra_state`` : Extra state for callback functions.
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``comm_keyval`` : Key value for future access (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function replaces :ref:`MPI_Keyval_create`, the use of which is
@@ -112,7 +112,7 @@ names are deprecated. The two Fortran callback functions are:
 
        INTEGER(KIND=MPI_ADDRESS_KIND) ATTRIBUTE_VAL, EXTRA_STATE
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ^^^^^^^^^^^^^^^^
 
 The MPI standard prescribes portable Fortran syntax for the
@@ -126,7 +126,7 @@ the non-portable syntax
 where ``MPI_ADDRESS_KIND`` is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_delete_attr
 :ref:`MPI_Comm_delete_attr` - Deletes attribute value associated with a
 key.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,22 +43,22 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: comm_keyval
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  ``comm`` : Communicator from which the attribute is deleted (handle).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``comm_keyval`` : Key value (integer).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_delete_attr` deletes an attribute from cache by key. This
@@ -74,7 +74,7 @@ function is the same as :ref:`MPI_Attr_delete` but is needed to match the
 ``comm``\ unicator-specific functions introduced in the MPI-2 standard.
 The use of :ref:`MPI_Attr_delete` is deprecated.
 
-Notes
+NOTES
 -----
 
 Note that it is not defined by the MPI standard what happens if the
@@ -83,7 +83,7 @@ not valid for ``delete_fn`` callbacks (or any of their children) to add
 or delete attributes on the same object on which the ``delete_fn``
 callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_disconnect
 :ref:`MPI_Comm_disconnect` - Deallocates communicator object and sets handle to
 MPI_COMM_NULL.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,17 +42,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(INOUT) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  comm : Communicator (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_disconnect` waits for all pending communication on comm to
@@ -66,7 +66,7 @@ has the same action as :ref:`MPI_Comm_free`, except that it waits for pending
 communication to finish internally and enables the guarantee about the
 behavior of disconnected processes.
 
-Notes
+NOTES
 -----
 
 To disconnect two processes you may need to call :ref:`MPI_Comm_disconnect`,
@@ -75,7 +75,7 @@ between the two processes. Note that it may be necessary to disconnect
 several communicators (or to free several windows or files) before two
 processes are completely independent.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_dup
 :ref:`MPI_Comm_dup` - Duplicates an existing communicator with all its cached
 information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Copy of comm (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_dup` duplicates the existing communicator comm with associated
@@ -65,7 +65,7 @@ delete the attribute from the new communicator. Returns in newcomm a new
 communicator with the same group, any copied cached information, but a
 new context (see Section 5.7.1 of the MPI-1 Standard, "Functionality").
 
-Notes
+NOTES
 -----
 
 This operation is used to provide a parallel library call with a
@@ -83,7 +83,7 @@ invokes other MPI functions. In Open MPI, it is not valid for attribute
 copy callbacks (or any of their children) to add or delete attributes on
 the same object on which the attribute copy callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_dup_with_info
 :ref:`MPI_Comm_dup_with_info` - Duplicates an existing communicator using
 provided info.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  info : Info argument (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Copy of comm (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_dup_with_info` acts exactly like :ref:`MPI_Comm_dup` except that the
@@ -65,7 +65,7 @@ newcomm. The hints provided by the argument info are associated with the
 output communicator newcomm instead. See :ref:`MPI_Comm_set_info` for the
 list of recognized info keys.
 
-Notes
+NOTES
 -----
 
 This operation is used to provide a parallel library call with a
@@ -83,7 +83,7 @@ invokes other MPI functions. In Open MPI, it is not valid for attribute
 copy callbacks (or any of their children) to add or delete attributes on
 the same object on which the attribute copy callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
@@ -8,7 +8,7 @@ MPI_File_write_ordered
 :ref:`MPI_File_write_ordered` - Writes a file at a location specified by a
 shared file pointer (blocking, collective).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -50,7 +50,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``fh`` : File handle (handle).
@@ -58,13 +58,13 @@ Input Parameters
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (Status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered` is a collective routine. This routine must be
@@ -81,7 +81,7 @@ number of ``datatype`` elements written in ``status``. The shared file
 pointer is updated by the amounts of data requested by all processes of
 the group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
@@ -9,7 +9,7 @@ MPI_File_write_ordered_begin
 by a shared file pointer; beginning part of a split collective routine
 (nonblocking).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,24 +48,24 @@ Fortran 2008 Syntax
        TYPE(MPI_Datatype), INTENT(IN) :: datatype
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of buffer (choice).
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered_begin` is the beginning part of a split
@@ -81,7 +81,7 @@ position at which the shared file pointer would be after all processes
 whose ranks within the group are less than that of this process had
 written their data.
 
-Notes
+NOTES
 -----
 
 All the nonblocking collective routines for data access are "split" into
@@ -89,7 +89,7 @@ two routines, each with \_begin or \_end as a suffix. These split
 collective routines are subject to the semantic rules described in
 Section 9.4.5 of the MPI-2 standard.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
@@ -9,7 +9,7 @@ MPI_File_write_ordered_end
 by a shared file pointer; ending part of a split collective routine
 (blocking).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,23 +47,23 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``buf`` : Initial address of buffer (choice).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered_end` is the ending part of a split collective
@@ -72,7 +72,7 @@ associated with the file handle ``fh``. :ref:`MPI_File_write_ordered_end`
 returns the number of elements written into the file associated with
 ``fh`` in ``status``.
 
-Notes
+NOTES
 -----
 
 All the nonblocking collective routines for data access are "split" into
@@ -80,7 +80,7 @@ two routines, each with \_begin or \_end as a suffix. These split
 collective routines are subject to the semantic rules described in
 Section 9.4.5 of the MPI-2 standard.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
@@ -8,7 +8,7 @@ MPI_File_write_shared
 :ref:`MPI_File_write_shared` - Writes a file using the shared file pointer
 (blocking, noncollective).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,32 +48,32 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of buffer (choice).
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_shared` is a blocking routine that uses the shared
 file pointer to write files. The order of serialization is not
 deterministic for this noncollective routine.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalize.3.rst
@@ -7,7 +7,7 @@ MPI_Finalize
 
 :ref:`MPI_Finalize` - Terminates MPI execution environment.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -40,12 +40,12 @@ Fortran 2008 Syntax
    MPI_Finalize(ierror)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine cleans up all MPI states. Once this routine is called, no
@@ -64,7 +64,7 @@ were spawned, accepted, or connected, then this means it is collective
 over MPI_COMM_WORLD. Otherwise, it is collective over the union of all
 processes that have been and continue to be connected.
 
-Notes
+NOTES
 -----
 
 All processes must call this routine before exiting. All processes will
@@ -95,7 +95,7 @@ other parts of MPI are affected. Calling :ref:`MPI_Finalized` will thus return
 "false" in any of these callback functions. Once you have done this with
 MPI_COMM_SELF, the results of :ref:`MPI_Finalize` are not specified.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Finalized.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalized.3.rst
@@ -7,7 +7,7 @@ MPI_Finalized
 
 :ref:`MPI_Finalized` - Checks whether MPI has been finalized
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,13 +42,13 @@ Fortran 2008 Syntax
        LOGICAL, INTENT(OUT) :: flag
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  flag : True if MPI was finalized, and false otherwise (logical).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine may be used to determine whether MPI has been finalized. It
@@ -56,7 +56,7 @@ is one of a small number of routines that may be called before MPI is
 initialized and after MPI has been finalized (:ref:`MPI_Initialized` is
 another).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Free_mem.3.rst
+++ b/docs/man-openmpi/man3/MPI_Free_mem.3.rst
@@ -7,7 +7,7 @@ MPI_Free_mem
 
 :ref:`MPI_Free_mem` - Frees memory that has been allocated using :ref:`MPI_Alloc_mem`.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,23 +42,23 @@ Fortran 2008 Syntax
        TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: base
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  base : Initial address of memory segment allocated by :ref:`MPI_Alloc_mem`
    (choice).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Free_mem` frees memory that has been allocated by :ref:`MPI_Alloc_mem`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Gather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gather.3.rst
@@ -93,7 +93,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  sendbuf : Starting address of send buffer (choice).
@@ -107,7 +107,7 @@ Input Parameters
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  recvbuf : Address of receive buffer (choice, significant only at
@@ -115,7 +115,7 @@ Output Parameters
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Each process (root process included) sends the contents of its send
@@ -216,7 +216,7 @@ root argument. The send buffer argument of the processes in the first
 group must be consistent with the receive buffer argument of the root
 process in the second group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Gatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gatherv.3.rst
@@ -8,7 +8,7 @@ MPI_Gatherv
 :ref:`MPI_Gatherv`, :ref:`MPI_Igatherv`, :ref:`MPI_Gatherv_init` - Gathers varying amounts of
 data from all processes to the root process
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -95,7 +95,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  sendbuf : Starting address of send buffer (choice).
@@ -113,7 +113,7 @@ Input Parameters
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  recvbuf : Address of receive buffer (choice, significant only at
@@ -121,7 +121,7 @@ Output Parameters
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Gatherv` extends the functionality of :ref:`MPI_Gather` by allowing a
@@ -298,7 +298,7 @@ root argument. The send buffer argument of the processes in the first
 group must be consistent with the receive buffer argument of the root
 process in the second group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get.3.rst
@@ -7,7 +7,7 @@ MPI_Get
 
 :ref:`MPI_Get`, :ref:`MPI_Rget` - Copies data from the target memory to the origin.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -75,7 +75,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  origin_addr : Initial address of origin buffer (choice).
@@ -90,13 +90,13 @@ Input Parameters
 -  target datatype : datatype of each entry in target buffer (handle)
 -  win : window object used for communication (handle)
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  request : :ref:`MPI_Rget`: RMA request
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get` copies data from the target memory to the origin, similar to
@@ -113,7 +113,7 @@ of an :ref:`MPI_Rget` operation indicates that the data is available in the
 origin buffer. If origin_addr points to memory attached to a window,
 then the data becomes available in the private copy of this window.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the TARGET_DISP
@@ -125,7 +125,7 @@ fortran INTEGERMPI_ADDRESS_KIND TARGET_DISP
 where MPI_ADDRESS_KIND is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
@@ -9,7 +9,7 @@ MPI_Get_accumulate
 origin buffer with that of a target buffer and returns the target buffer
 value.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -89,7 +89,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  origin_addr : Initial address of buffer (choice).
@@ -108,13 +108,13 @@ Input Parameters
 -  op : Reduce operation (handle).
 -  win : Window object (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  :ref:`MPI_Rget_accumulate`: RMA request
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_accumulate` is a function used for one-sided MPI communication
@@ -155,7 +155,7 @@ indicates that the data is available in the result buffer and the origin
 buffer is free to be updated. It does not indicate that the operation
 has been completed at the target window.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the TARGET_DISP
@@ -167,7 +167,7 @@ fortran INTEGERMPI_ADDRESS_KIND TARGET_DISP
 where MPI_ADDRESS_KIND is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Notes
+NOTES
 -----
 
 The generic functionality of :ref:`MPI_Get_accumulate` might limit the
@@ -185,7 +185,7 @@ accumulate functions, the target displacement argument is such that
 accesses to the window are properly aligned according to the data type
 arguments in the call to the :ref:`MPI_Get_accumulate` function.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_address.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_address.3.rst
@@ -7,7 +7,7 @@ MPI_Get_address
 
 :ref:`MPI_Get_address` - Gets the address of a location in memory.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,18 +44,18 @@ Fortran 2008 Syntax
        INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(OUT) :: address
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``location`` : Location in caller memory (choice).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``address`` : Address of location (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_address` returns the byte ``address`` of a location in
@@ -73,7 +73,7 @@ Example: Using :ref:`MPI_Get_address` for an array.
    ! The value of DIFF is 909*sizeofreal; the values of I1 and I2 are
    ! implementation dependent.
 
-Notes
+NOTES
 -----
 
 Current Fortran MPI codes will run unmodified and will port to any
@@ -84,7 +84,7 @@ new functions. This provides compatibility with C and avoids errors on
 (slightly) rewritten to port to old Fortran 77 environments that do not
 support KIND declarations.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_count.3.rst
@@ -7,7 +7,7 @@ MPI_Get_count
 
 :ref:`MPI_Get_count` - Gets the number of top-level elements received.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: count
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  status : Return status of receive operation (status).
 -  datatype : Datatype of each receive buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  count : Number of received elements (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Returns the number of entries received. (We count entries, each of type
@@ -71,7 +71,7 @@ A message might be received without counting the number of elements it
 contains, and the count value is often not needed. Also, this allows the
 same function to be used after a call to :ref:`MPI_Probe`.
 
-Notes
+NOTES
 -----
 
 If the size of the datatype is zero, this routine will return a count of
@@ -79,7 +79,7 @@ zero. If the amount of data in status is not an exact multiple of the
 size of datatype (so that count would not be integral), a count of
 MPI_UNDEFINED is returned instead.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_elements.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_elements.3.rst
@@ -8,7 +8,7 @@ MPI_Get_elements
 :ref:`MPI_Get_elements`, :ref:`MPI_Get_elements_x` - Returns the number of basic
 elements in a data type.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -59,18 +59,18 @@ Fortran 2008 Syntax
        INTEGER(KIND = MPI_COUNT_KIND), INTENT(OUT) :: count
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  status : Return status of receive operation (status).
 -  datatype : Datatype used by receive operation (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_elements` and :ref:`MPI_Get_elements_x` behave different from
@@ -109,12 +109,12 @@ number of elements in the probed message. Note that the two functions
 :ref:`MPI_Get_count` and :ref:`MPI_Get_elements` return the same values when they are
 used with primitive data types.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the COUNT

--- a/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
@@ -8,7 +8,7 @@ MPI_Get_library_version
 :ref:`MPI_Get_library_version` - Returns a string of the current Open MPI
 version
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: resultlen
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  version : A string containing the Open MPI version (string).
@@ -52,7 +52,7 @@ Output Parameters
    (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine returns a string representing the version of the MPI
@@ -66,7 +66,7 @@ version[resultlen]. The resultlen cannot be larger than
 the right with blank characters. The resultlen cannot be larger than
 MPI_MAX_LIBRARY_VERSION_STRING.
 
-Note
+NOTE
 ----
 
 The version string that is passed must be at least
@@ -75,7 +75,7 @@ MPI_MAX_LIBRARY_VERSION_STRING characters long.
 :ref:`MPI_Get_library_version` is one of the few functions that can be called
 before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
@@ -7,7 +7,7 @@ MPI_Get_processor_name
 
 :ref:`MPI_Get_processor_name` - Gets the name of the processor.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,7 +43,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: resultlen
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``name`` : A unique specifier for the actual (as opposed to virtual)
@@ -51,7 +51,7 @@ Output Parameters
 -  ``resultlen`` : Length (in characters) of result returned in name.
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine returns the ``name`` of the processor on which it was
@@ -63,7 +63,7 @@ that is at least MPI_MAX_PROCESSOR_NAME characters long.
 The number of characters actually written is returned in the output
 argument, ``resultlen``.
 
-Notes
+NOTES
 -----
 
 The user must provide at least MPI_MAX_PROCESSOR_NAME space to write
@@ -71,7 +71,7 @@ the processor ``name``; processor ``name``\ s can be this long. The user
 should examine the output argument, ``resultlen``, to determine the
 actual length of the ``name``.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_version.3.rst
@@ -8,7 +8,7 @@ MPI_Get_version
 :ref:`MPI_Get_version` - Returns the version of the standard corresponding
 to the current implementation.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,7 +42,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: version, subversion
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``version`` : The major version number of the corresponding standard
@@ -51,19 +51,19 @@ Output Parameters
    standard (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Since Open MPI is MPI-|mpi_standard_version|.|mpi_standard_subversion| compliant, this function will return a
 ``version`` value of |mpi_standard_version| and a subversion value of |mpi_standard_subversion| for this release.
 
-Note
+NOTE
 ----
 
 :ref:`MPI_Get_version` is one of the few functions that can be called
 before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_create.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_create
 :ref:`MPI_Graph_create` - Makes a new communicator to which topology
 information has been attached.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -50,7 +50,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: comm_graph
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm_old : Input communicator without topology (handle).
@@ -59,13 +59,13 @@ Input Parameters
 -  edges : Array of integers describing graph edges (see below).
 -  reorder : Ranking may be reordered (true) or not (false) (logical).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  comm_graph : Communicator with graph topology added (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Graph_create` returns a handle to a new communicator to which the
@@ -121,7 +121,7 @@ neighbors of node zero is stored in edges(j), for 1 <= j <= index(1) and
 the list of neighbors of node i, i > 0, is stored in edges(j), index(i)
 + 1 <= j <= index(i + 1).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_get.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_get
 :ref:`MPI_Graph_get` - Retrieves graph topology information associated with a
 communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,14 +46,14 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: index(maxindex), edges(maxedges)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with graph structure (handle).
 -  maxindex : Length of vector index in the calling program (integer).
 -  maxedges : Length of vector edges in the calling program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  index : Array of integers containing the graph structure (for details
@@ -61,7 +61,7 @@ Output Parameters
 -  edges : Array of integers containing the graph structure.
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Functions :ref:`MPI_Graphdims_get` and :ref:`MPI_Graph_get` retrieve the
@@ -71,7 +71,7 @@ graph-topology information that was associated with a communicator by
 The information provided by :ref:`MPI_Graphdims_get` can be used to dimension
 the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_map.3.rst
@@ -7,7 +7,7 @@ MPI_Graph_map
 
 :ref:`MPI_Graph_map` - Maps process to graph topology information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: newrank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Input communicator (handle).
@@ -53,14 +53,14 @@ Input Parameters
    :ref:`MPI_Graph_create`.
 -  edges : Integer array specifying the graph structure.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newrank : Reordered rank of the calling process; MPI_UNDEFINED if the
    calling process does not belong to graph (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_map` and :ref:`MPI_Graph_map` can be used to implement all other
@@ -68,7 +68,7 @@ topology functions. In general they will not be called by the user
 directly, unless he or she is creating additional virtual topology
 capability other than that provided by MPI.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_neighbors_count
 :ref:`MPI_Graph_neighbors_count` - Returns the number of neighbors of a node
 associated with a graph topology.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,26 +45,26 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: nneighbors
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with graph topology (handle).
 -  rank : Rank of process in group of comm (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  nneighbors : Number of neighbors of specified process (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Graph_neighbors_count` and :ref:`MPI_Graph_neighbors` provide adjacency
 information for a general, graph topology. :ref:`MPI_Graph_neighbors_count`
 returns the number of neighbors for the process signified by rank.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
@@ -8,7 +8,7 @@ MPI_Graphdims_get
 :ref:`MPI_Graphdims_get` - Retrieves graph topology information associated with
 a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: nnodes, nedges
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator for group with graph structure (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  nnodes : Number of nodes in graph (integer).
 -  nedges : Number of edges in graph (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Functions :ref:`MPI_Graphdims_get` and :ref:`MPI_Graph_get` retrieve the
@@ -65,7 +65,7 @@ graph-topology information that was associated with a communicator by
 The information provided by :ref:`MPI_Graphdims_get` can be used to dimension
 the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
@@ -8,7 +8,7 @@ MPI_Grequest_complete
 :ref:`MPI_Grequest_complete` - Reports that a generalized request is
 complete.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,17 +42,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(IN) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``request`` : Generalized request (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Grequest_complete` informs MPI that the operations represented by
@@ -76,7 +76,7 @@ regardless of the state of other processes (the operation has acquired
 side-effects. The user should guarantee these same properties for newly
 defined operations.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
@@ -8,7 +8,7 @@ MPI_Grequest_start
 :ref:`MPI_Grequest_start` - Starts a generalized request and returns a
 handle to it in ``request``.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -53,7 +53,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``query_fn`` : Callback function invoked when request status is
@@ -64,13 +64,13 @@ Input Parameters
    (function).
 -  ``extra_state`` : Extra state.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``request`` : Generalized request (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Grequest_start` starts a generalized ``request`` and returns a
@@ -175,7 +175,7 @@ MPI passes to the callback function complete=true if
 ``MPI_Grequest_complete`` has already been called on the request, and
 complete=false otherwise.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the
@@ -189,7 +189,7 @@ the non-portable syntax
 where ``MPI_ADDRESS_KIND`` is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_compare.3.rst
@@ -7,7 +7,7 @@ MPI_Group_compare
 
 :ref:`MPI_Group_compare` - Compares two groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,13 +43,13 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: result
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``group1`` : First group (handle).
 -  ``group2`` : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``result`` : Integer which is MPI_IDENT if the order and members of
@@ -57,7 +57,7 @@ Output Parameters
    same, and MPI_UNEQUAL otherwise.
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 MPI_IDENT results if the group members and group order is exactly
@@ -66,7 +66,7 @@ the same in both groups. This happens for instance if ``group1`` and
 members are the same but the order is different. MPI_UNEQUAL results
 otherwise.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_difference.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_difference.3.rst
@@ -7,7 +7,7 @@ MPI_Group_difference
 
 :ref:`MPI_Group_difference` - Makes a group from the difference of two groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group1 : First group (handle).
 -  group2 : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : Difference group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The set-like operations are defined as follows:
@@ -74,7 +74,7 @@ intersection are commutative, but both are associative.
 
 The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_excl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_excl.3.rst
@@ -8,7 +8,7 @@ MPI_Group_excl
 :ref:`MPI_Group_excl` - Produces a group by reordering an existing group and
 taking only unlisted members.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,21 +45,21 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handle).
 -  n : Number of elements in array ranks (integer).
 -  ranks : Array of integer ranks in group not to appear in newgroup.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from above, preserving the order defined
    by group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_excl` creates a group of processes newgroup that
@@ -69,14 +69,14 @@ the ordering in group. Each of the n elements of ranks must be a valid
 rank in group and all elements must be distinct; otherwise, the call is
 erroneous. If n = 0, then newgroup is identical to group.
 
-Note
+NOTE
 ----
 
 Currently, each of the ranks to exclude must be a valid rank in the
 group and all elements must be distinct or the function is erroneous.
 This restriction is per the draft.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_free.3.rst
@@ -7,7 +7,7 @@ MPI_Group_free
 
 :ref:`MPI_Group_free` - Frees a group.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,29 +41,29 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(INOUT) :: group
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``group`` : Group (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This operation marks a ``group`` object for deallocation. The handle
 ``group`` is set to MPI_GROUP_NULL by the call. Any ongoing
 operation using this ``group`` will complete normally.
 
-Note
+NOTE
 ----
 
 On return, ``group`` is set to MPI_GROUP_NULL.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
@@ -8,7 +8,7 @@ MPI_Group_from_session_pset
 :ref:`MPI_Group_from_session_pset` - Creates a group using a provided session
 handle and process set.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,21 +45,21 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : Session (handle).
 -  pset_name : name of process set to use to create the new group
    (string)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from supplied session and process set
    (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_from_session_pset` creates a group newgroup using
@@ -68,13 +68,13 @@ be one returned from an invocation of :ref:`MPI_Session_get_nth_pset` using the
 supplied session handle. If the pset_name does not exist, MPI_GROUP_NULL
 will be returned in the newgroup argument.
 
-Note
+NOTE
 ----
 
 As with other group constructors, :ref:`MPI_Group_from_session_pset` is a local
 function.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_incl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_incl.3.rst
@@ -8,7 +8,7 @@ MPI_Group_incl
 :ref:`MPI_Group_incl` - Produces a group by reordering an existing group and
 taking only listed members.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handle).
@@ -54,14 +54,14 @@ Input Parameters
 -  ranks : Ranks of processes in group to appear in newgroup (array of
    integers).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from above, in the order defined by
    ranks (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_incl` creates a group group_out that consists of
@@ -72,13 +72,13 @@ elements must be distinct, or else the program is erroneous. If n = 0,
 then group_out is MPI_GROUP_EMPTY. This function can, for instance, be
 used to reorder the elements of a group.
 
-Note
+NOTE
 ----
 
 This implementation does not currently check to ensure that there are no
 duplicates in the list of ranks.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
@@ -8,7 +8,7 @@ MPI_Group_intersection
 :ref:`MPI_Group_intersection` - Produces a group at the intersection of two
 existing groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group1 : First group (handle).
 -  group2 : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : Intersection group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The set-like operations are defined as follows:
@@ -75,7 +75,7 @@ intersection are commutative, but both are associative.
 
 The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
@@ -56,7 +56,7 @@ DESCRIPTION
 
 :ref:`MPI_Info_create_env` creates a new info object with the same construction as :ref:`MPI_INFO_ENV` as created during :ref:`MPI_Init` or :ref:`MPI_Init_thread` when the same arguments are used.
 
-Note
+NOTE
 ----
 
 :ref:`MPI_Info_create_env` is one of the few functions that can be called

--- a/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
+++ b/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
@@ -8,7 +8,7 @@ MPI_Intercomm_create_from_groups
 :ref:`MPI_Intercomm_create_from_groups` - Creates a new inter-communicator from
 a local and remote group and stringtag
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,7 +48,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newintercomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  local_group : Local group (handler)
@@ -61,13 +61,13 @@ Input Parameters
 -  errhandler : error handler to be attached to the new
    inter-communicator (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newintercomm : New inter-communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Intercomm_create_from_groups` creates an inter-communicator. Unlike
@@ -87,7 +87,7 @@ event that MPI_GROUP_EMPTY is supplied as the local_group or
 remote_group1 or both, then the call is a local operation and
 MPI_COMM_NULL is returned as the newintercomm.
 
-Notes
+NOTES
 -----
 
 The errhandler argument specifies an error handler to be attached to the
@@ -96,7 +96,7 @@ possibly MPI implementation dependent, which indicate desired
 characteristics and guide communicator creation. MPI_MAX_STRINGTAG_LEN
 shall have a value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Session_call_errhandler
 :ref:`MPI_Session_call_errhandler` - Passes the supplied error code to the error
 handler assigned to a session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: errorcode
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  session : session with error handler (handle).
 -  errorcode : error code (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function invokes the error handler assigned to the session
@@ -62,14 +62,14 @@ session with the supplied error code errorcode. If the error handler was
 successfully called, the process is not aborted, and the error handler
 returns, this function returns MPI_SUCCESS.
 
-Notes
+NOTES
 -----
 
 Users should note that the default error handler is
 MPI_ERRORS_ARE_FATAL. Thus, calling this function will abort the
 processes in session if the default error handler has not been changed.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Session_create_errhandler
 :ref:`MPI_Session_create_errhandler` - Creates an error handler that can be
 attached to sessions
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,18 +45,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``function`` : User-defined error handling procedure (function).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``errhandler`` : MPI error handler (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_create_errhandler` creates an error handler that can be
@@ -79,7 +79,7 @@ Fortran, the user routine should be of this form:
    SUBROUTINE SESSION_ERRHANDLER_FUNCTION(SESSION, ERROR_CODE, ...)
       INTEGER SESSION, ERROR_CODE
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
@@ -7,7 +7,7 @@ MPI_Session_finalize
 
 :ref:`MPI_Session_finalize` - releases all MPI state associated with a session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,17 +41,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(IN) :: session
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session to be finalized (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_finalize` releases all MPI state associated with the supplied
@@ -59,7 +59,7 @@ session. Every instantiated session must be finalized using
 :ref:`MPI_Session_finalize`. The handle session is set to MPI_SESSION_NULL by
 the call.
 
-Notes
+NOTES
 -----
 
 Before an MPI process invokes :ref:`MPI_Session_finalize`, the process must
@@ -78,7 +78,7 @@ later, :ref:`MPI_Session_finalize` may be synchronizing on the group associated
 with a communicator that is only freed (with MPI_Comm_free) rather than
 disconnected (with MPI_Comm_disconnect).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_info
 :ref:`MPI_Session_get_info` - Returns an info object containing the hints of an
 MPI Session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,18 +42,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(IN) :: session
        TYPE(MPI_Info), INTENT(OUT) :: info_used
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  info_used: info object (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_info` returns a new info object containing the hints of
@@ -66,12 +66,12 @@ hints that were set by the implementation. If no such hints exist, a
 handle to a newly created info object is returned that contains no
 key/value pair.
 
-Notes
+NOTES
 -----
 
 The user is responsible for freeing info_used via :ref:`MPI_Info_free`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
@@ -7,7 +7,7 @@ MPI_Session_get_nth_pset
 
 :ref:`MPI_Session_get_nth_pset` - Query runtime for name of the nth process set
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,25 +46,25 @@ Fortran 2008 Syntax
        CHARACTER(LEN=*), INTENT(OUT) :: pset_name
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  info: info object (handle)
 -  n: index of the desired process set name (integer)
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  pset_len: length of the pset_name argument (integer)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  pset_name : name of the nth process set (string)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_nth_pset` returns the name of the nth process set in the
@@ -78,14 +78,14 @@ C, pset_len includes the required space for the null terminator. In C,
 this function returns a null terminated string in all cases where the
 pset_len input value is greater than 0.
 
-Notes
+NOTES
 -----
 
 Process set names have an implementation-defined maximum length of
 MPI_MAX_PSET_NAME_LEN characters. MPI_MAX_PSET_NAME_LEN shall have a
 value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_num_psets
 :ref:`MPI_Session_get_num_psets` - Query runtime for number of available
 process sets
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: npset_names
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  info: info object (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  npset_names : number of available process sets (non-negtive integer)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_num_psets` is used to query the runtime for the number of
@@ -68,7 +68,7 @@ change the index of a particular process set name, or to change the name
 of the process set at a particular index, or to delete a process set
 name once it has been added.
 
-Notes
+NOTES
 -----
 
 When a process set becomes invalid, for example, when some processes
@@ -78,7 +78,7 @@ example, creating an MPI_Group from such a process set might succeed
 because it is a local operation, but creating an MPI_Comm from that
 group and attempting collective communication may raise an error.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_pset_info
 :ref:`MPI_Session_get_pset_info` - Returns an info object containing properties
 of a specific process set
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,19 +45,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Info), INTENT(OUT) :: info
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  pset_name : name of process set (string)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  info: info object (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_pset_info` is used to query properties of a specific
@@ -66,13 +66,13 @@ info object query functions. One key/value pair must be defined,
 "mpi_size". The value of the "mpi_size" key specifies the number of MPI
 processes in the process set.
 
-Notes
+NOTES
 -----
 
 The user is responsible for freeing the returned info object via
 :ref:`MPI_Info_free`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_init.3.rst
@@ -7,7 +7,7 @@ MPI_Session_init
 
 :ref:`MPI_Session_init` - Creates a new session handle
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,20 +43,20 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(OUT) :: session
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  info : info object (handle)
 -  errhandler : error handler to be attached to the returned session
    (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  session : New session (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_init` is used to instantiate an MPI Session. The returned
@@ -65,7 +65,7 @@ characteristics of the job within which the process is running, as well
 as other system resources. An application can make multiple calls to
 :ref:`MPI_Session_init` and the related :ref:`MPI_Session_finalize` routine.
 
-Notes
+NOTES
 -----
 
 The info argument is used to request MPI functionality requirements and
@@ -74,7 +74,7 @@ possible MPI implementation specific capabilities.
 The errhandler argument specifies an error handler to invoke in the
 event that the Session instantiation call encounters an error.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
+++ b/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
@@ -87,7 +87,7 @@ What processors exist.
    can see (which is *usually* all processors in the system).
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 **Example 1:** Print out processes binding using resource string format.


### PR DESCRIPTION
Most man page source files in the docs/man-openmpi/man3 sub directory have top levels headings such as SYNTAX, ERRORS, NOTES, etc. Some have these headings, but in mixed case.

This pull request changes top level headings to upper case for consistency within the set of man pages, and because other sets of man pages like libc man pages and some other GNU man pages use upper case for top level section headings.

Signed-off-by: David Wootton <dwootton@us.ibm.com>