### PR TITLE
 Update man pages to clarify MPI-4 error handlers for v5.0.x

### DIFF
--- a/docs/man-openmpi/man3/ERRORS.rst
+++ b/docs/man-openmpi/man3/ERRORS.rst
@@ -1,0 +1,53 @@
+Almost all MPI routines return an error value; C routines as the return result
+of the function and Fortran routines in the last argument.
+
+Before the error value is returned, the current MPI error handler associated
+with the communication object (e.g., communicator, window, file) is called.
+If no communication object is associated with the MPI call, then the call is
+considered attached to MPI_COMM_SELF and will call the associated MPI error
+handler. When MPI_COMM_SELF is not initialized (i.e., before
+MPI_INIT / MPI_INIT_THREAD, after MPI_FINALIZE, or when using the Sessions
+Model exclusively) the error raises the initial error handler. The initial
+error handler can be changed by calling MPI_COMM_SET_ERRHANDLER on
+MPI_COMM_SELF when using the World model, or the mpi_initial_errhandler CLI
+argument to mpiexec or info key to MPI_COMM_SPAWN[_MULTIPLE].
+If no other appropriate error handler has been set, then the MPI_ERRORS_RETURN
+error handler is called for MPI I/O functions and the MPI_ERRORS_ABORT error
+handler is called for all other MPI functions.
+
+In the sessions model, the error handler can be set during MPI_Session_init.
+
+Open MPI includes three predefined error handlers that can be used::
+
+ MPI_ERRORS_ARE_FATAL: Causes the program to abort all connected MPI processes.
+ MPI_ERRORS_ABORT:     An error handler that can be invoked on a communicator,
+                       window, file, or session. When called on a communicator, it
+                       acts as if MPI_ABORT was called on that communicator. If
+                       called on a window or file, acts as if MPI_ABORT was called
+                       on a communicator containing the group of processes in the
+                       corresponding window or file. If called on a session,
+                       aborts only the local process.
+ MPI_ERRORS_RETURN:    Returns an error code to the application.
+
+MPI applications can also implement their own error handlers.
+
+Custom MPI error handlers can be created by calling:
+:ref:`MPI_Comm_create_errhandler(3) <MPI_Comm_create_errhandler>`
+:ref:`MPI_File_create_errhandler(3) <MPI_File_create_errhandler>`
+:ref:`MPI_Session_create_errhandler(3) <MPI_Session_create_errhandler>`
+:ref:`MPI_Win_create_errhandler(3) <MPI_Win_create_errhandler>`
+
+Predefined and custom error handlers can be set by calling:
+:ref:`MPI_Comm_set_errhandler(3) <MPI_Comm_set_errhandler>`
+:ref:`MPI_File_set_errhandler(3) <MPI_File_set_errhandler>`
+:ref:`MPI_Session_set_errhandler(3) <MPI_Session_set_errhandler>`
+:ref:`MPI_Win_set_errhandler(3) <MPI_Win_set_errhandler>`
+
+Note that MPI does not guarantee that an MPI program can continue past
+an error.
+
+See the MPI man page for a full list of MPI error codes.
+
+See the Error Handling section of the MPI-|mpi_standard_version| standard for
+more information.
+

--- a/docs/man-openmpi/man3/MPIX_Query_cuda_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_cuda_support.3.rst
@@ -65,7 +65,7 @@ application with older versions of Open MPI or other MPI
 implementations that do not have this function.
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 .. code-block:: c

--- a/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
+++ b/docs/man-openmpi/man3/MPIX_Query_rocm_support.3.rst
@@ -65,7 +65,7 @@ application with older versions of Open MPI or other MPI
 implementations that do not have this function.
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 .. code-block:: c

--- a/docs/man-openmpi/man3/MPI_Abort.3.rst
+++ b/docs/man-openmpi/man3/MPI_Abort.3.rst
@@ -74,13 +74,4 @@ Note: All associated processes are sent a SIGTERM.
 
 ERRORS
 ------
-
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Accumulate.3.rst
+++ b/docs/man-openmpi/man3/MPI_Accumulate.3.rst
@@ -169,16 +169,7 @@ arguments in the call to the :ref:`MPI_Accumulate` function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Put` :ref:`MPI_Get_accumulate` :ref:`MPI_Reduce`

--- a/docs/man-openmpi/man3/MPI_Add_error_class.3.rst
+++ b/docs/man-openmpi/man3/MPI_Add_error_class.3.rst
@@ -80,16 +80,7 @@ The value returned is always greater than or equal to MPI_ERR_LASTCODE.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Add_error_code` :ref:`MPI_Add_error_string` :ref:`MPI_Error_class` :ref:`MPI_Error_string`

--- a/docs/man-openmpi/man3/MPI_Add_error_code.3.rst
+++ b/docs/man-openmpi/man3/MPI_Add_error_code.3.rst
@@ -75,16 +75,7 @@ The value returned is always greater than or equal to MPI_ERR_LASTCODE.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Add_error_class` :ref:`MPI_Error_class`

--- a/docs/man-openmpi/man3/MPI_Add_error_string.3.rst
+++ b/docs/man-openmpi/man3/MPI_Add_error_string.3.rst
@@ -72,16 +72,7 @@ code or class with a value not greater than MPI_LAST_ERRCODE).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Add_error_class` :ref:`MPI_Add_error_code` :ref:`MPI_Error_class` :ref:`MPI_Error_string`

--- a/docs/man-openmpi/man3/MPI_Address.3.rst
+++ b/docs/man-openmpi/man3/MPI_Address.3.rst
@@ -89,16 +89,7 @@ variables guarantees portability to such machines as well.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Get_address`

--- a/docs/man-openmpi/man3/MPI_Allgather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgather.3.rst
@@ -199,16 +199,7 @@ in the second group. You can move data in only one direction by giving
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Allgatherv` :ref:`MPI_Gather`

--- a/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
@@ -186,16 +186,7 @@ operation must exhibit symmetric, full-duplex behavior.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Gatherv` :ref:`MPI_Allgather`

--- a/docs/man-openmpi/man3/MPI_Alloc_mem.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alloc_mem.3.rst
@@ -112,16 +112,7 @@ User's Guide and are supported by many Fortran compilers. For example,
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Free_mem`

--- a/docs/man-openmpi/man3/MPI_Allreduce.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allreduce.3.rst
@@ -209,12 +209,4 @@ MPI_ERRORS_RETURN , then no error may be indicated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Alltoall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoall.3.rst
@@ -193,16 +193,7 @@ functionality to allow the exchange of data with different datatypes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alltoallv` :ref:`MPI_Alltoallw`

--- a/docs/man-openmpi/man3/MPI_Alltoallv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoallv.3.rst
@@ -213,16 +213,7 @@ where these offsets are measured in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alltoall` :ref:`MPI_Alltoallw`

--- a/docs/man-openmpi/man3/MPI_Alltoallw.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoallw.3.rst
@@ -217,16 +217,7 @@ this to :ref:`MPI_Alltoallv`, where these offsets are measured in units of
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alltoall` :ref:`MPI_Alltoallv`

--- a/docs/man-openmpi/man3/MPI_Attr_delete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Attr_delete.3.rst
@@ -75,16 +75,7 @@ being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_delete_attr`

--- a/docs/man-openmpi/man3/MPI_Attr_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Attr_get.3.rst
@@ -64,16 +64,7 @@ an erroneous key value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_get_attr`

--- a/docs/man-openmpi/man3/MPI_Attr_put.3.rst
+++ b/docs/man-openmpi/man3/MPI_Attr_put.3.rst
@@ -80,16 +80,7 @@ the corresponding keyval was created) will be called.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_set_attr`

--- a/docs/man-openmpi/man3/MPI_Barrier.3.rst
+++ b/docs/man-openmpi/man3/MPI_Barrier.3.rst
@@ -84,14 +84,6 @@ have entered the barrier.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Bcast`

--- a/docs/man-openmpi/man3/MPI_Barrier.3.rst
+++ b/docs/man-openmpi/man3/MPI_Barrier.3.rst
@@ -8,7 +8,7 @@ MPI_Barrier
 :ref:`MPI_Barrier`, :ref:`MPI_Ibarrier` - Synchronization between MPI processes in a
 group
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -55,19 +55,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT (OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 An MPI barrier completes after all groups members have entered the
@@ -81,7 +81,7 @@ performed across all processes in both groups. All processes in the
 first group may exit the barrier when all processes in the second group
 have entered the barrier.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bcast.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bcast.3.rst
@@ -127,14 +127,4 @@ This function does not support the in-place option.
 
 ERRORS
 ------
-
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend.3.rst
@@ -97,14 +97,4 @@ delivered.)
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value;
-C routines as the value of the function and Fortran routines in the last
-argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend.3.rst
@@ -7,7 +7,7 @@ MPI_Bsend
 
 :ref:`MPI_Bsend` - Basic send with user-specified buffering.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(IN) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of send buffer (choice).
@@ -55,17 +55,17 @@ Input Parameters
 -  ``tag`` : Message tag (integer).
 -  ``comm`` : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Bsend` performs a buffered-mode, blocking send.
 
-Notes
+NOTES
 -----
 
 This send is provided as a convenience function; it allows the user to
@@ -94,7 +94,7 @@ In C, you can force the messages to be delivered by
 ``MPI_Buffer_detach`` will not complete until all buffered messages are
 delivered.)
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
@@ -76,15 +76,6 @@ initiated by the function :ref:`MPI_Start`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Send_init` :ref:`MPI_Start`

--- a/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bsend_init.3.rst
@@ -7,7 +7,7 @@ MPI_Bsend_init
 
 :ref:`MPI_Bsend_init` - Builds a handle for a buffered send.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,7 +48,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  buf : Initial address of send buffer (choice).
@@ -58,13 +58,13 @@ Input Parameters
 -  tag : Message tag (integer).
 -  comm : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  request : Communication request (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Creates a persistent communication request for a buffered mode send, and
@@ -73,7 +73,7 @@ binds to it all the arguments of a send operation.
 A communication (send or receive) that uses a persistent request is
 initiated by the function :ref:`MPI_Start`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
@@ -86,15 +86,6 @@ Fortran.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Buffer_detach`

--- a/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_attach.3.rst
@@ -7,7 +7,7 @@ MPI_Buffer_attach
 
 :ref:`MPI_Buffer_attach` - Attaches a user-defined buffer for sending.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,25 +43,25 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: size
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  buf : Initial buffer address (choice).
 -  size : Buffer size, in bytes (integer).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Provides to MPI a buffer in the user's memory to be used for buffering
 outgoing messages. The buffer is used only by messages sent in buffered
 mode. Only one buffer can be attached to a process at a time.
 
-Notes
+NOTES
 -----
 
 The size given should be the sum of the sizes of all outstanding Bsends
@@ -83,7 +83,7 @@ MPI_BSEND_OVERHEAD gives the maximum amount of buffer space that may be
 used by the Bsend routines. This value is in mpi.h for C and mpif.h for
 Fortran.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
@@ -8,7 +8,7 @@ MPI_Buffer_detach
 :ref:`MPI_Buffer_detach` - Removes an existing buffer (for use in in :ref:`MPI_Bsend`,
 etc.)
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,14 +45,14 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: size
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  buf : Initial buffer address (choice).
 -  size : Buffer size, in bytes (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Detach the buffer currently associated with MPI. The call returns the
@@ -69,7 +69,7 @@ MPI_Buffer_detach( &buff, &size); /* Buffer size reduced to zero */
 MPI_Buffer_attach( buff, size); /* Buffer of 10000 bytes available again
 \*/
 
-Notes
+NOTES
 -----
 
 The reason that :ref:`MPI_Buffer_detach` returns the address and size of the
@@ -97,7 +97,7 @@ differently: A pointer to the buffer is passed to :ref:`MPI_Buffer_attach`; the
 address of the pointer is passed to :ref:`MPI_Buffer_detach`, so that this call
 can return the pointer value.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Buffer_detach.3.rst
@@ -100,15 +100,6 @@ can return the pointer value.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Buffer_attach`

--- a/docs/man-openmpi/man3/MPI_Cancel.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cancel.3.rst
@@ -110,14 +110,6 @@ cancel these unsatisfied requests.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Probe`

--- a/docs/man-openmpi/man3/MPI_Cancel.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cancel.3.rst
@@ -7,7 +7,7 @@ MPI_Cancel
 
 :ref:`MPI_Cancel` - Cancels a communication request.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,17 +41,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(IN) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  request : Communication request (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The :ref:`MPI_Cancel` operation allows pending communications to be canceled.
@@ -99,7 +99,7 @@ If the operation has been canceled, then information to that effect will
 be returned in the status argument of the operation that completes the
 communication.
 
-Notes
+NOTES
 -----
 
 The primary expected use of :ref:`MPI_Cancel` is in multi-buffering schemes,
@@ -107,7 +107,7 @@ where speculative MPI_Irecvs are made. When the computation completes,
 some of these requests may remain; using :ref:`MPI_Cancel` allows the user to
 cancel these unsatisfied requests.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_coords
 :ref:`MPI_Cart_coords` - Determines process coords in Cartesian topology
 given rank in group.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: coords(maxdims)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm`` : Communicator with Cartesian structure (handle).
@@ -53,7 +53,7 @@ Input Parameters
 -  ``maxdims`` : Length of vector coords in the calling program
    (integer). Length of vector coords in the calling program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``coords`` : Integer array (of size ndims,which was defined by
@@ -61,13 +61,13 @@ Output Parameters
    specified process (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_coords` provides a mapping of ``rank``\ s to Cartesian
 coordinates.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_coords.3.rst
@@ -70,12 +70,4 @@ coordinates.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_create.3.rst
@@ -83,12 +83,4 @@ is erroneous if it specifies a grid that is larger than the group size.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_create.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_create
 :ref:`MPI_Cart_create` - Makes a new communicator to which Cartesian
 topology information has been attached.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -49,7 +49,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: comm_cart
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm_old`` : Input communicator (handle).
@@ -61,13 +61,13 @@ Input Parameters
 -  ``reorder`` : Ranking may be reordered (true) or not (false)
    (logical).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``comm_cart`` : Communicator with new Cartesian topology (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_create` returns a handle to a new communicator to which the
@@ -80,7 +80,7 @@ smaller than the size of the group of comm, then some processes are
 returned MPI_COMM_NULL, in analogy to :ref:`MPI_Comm_split`. The call
 is erroneous if it specifies a grid that is larger than the group size.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_get.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_get
 :ref:`MPI_Cart_get` - Retrieves Cartesian topology information associated with
 a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,14 +47,14 @@ Fortran 2008 Syntax
        LOGICAL, INTENT(OUT) :: periods(maxdims)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
 -  maxdims : Length of vectors dims, periods, and coords in the calling
    program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  dims : Number of processes for each Cartesian dimension (array of
@@ -65,14 +65,14 @@ Output Parameters
    of integers).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The functions :ref:`MPI_Cartdim_get` and :ref:`MPI_Cart_get` return the Cartesian
 topology information that was associated with a communicator by
 :ref:`MPI_Cart_create`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_get.3.rst
@@ -75,14 +75,6 @@ topology information that was associated with a communicator by
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Cartdim_get`

--- a/docs/man-openmpi/man3/MPI_Cart_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_map.3.rst
@@ -77,14 +77,6 @@ the calling process, that is, not to perform any reordering.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Graph_map`

--- a/docs/man-openmpi/man3/MPI_Cart_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_map.3.rst
@@ -7,7 +7,7 @@ MPI_Cart_map
 
 :ref:`MPI_Cart_map` - Maps process to Cartesian topology information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,7 +46,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: newrank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Input communicator (handle).
@@ -56,14 +56,14 @@ Input Parameters
 -  periods : Logical array of size ndims specifying the periodicity
    specification in each coordinate direction.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newrank : Reordered rank of the calling process; MPI_UNDEFINED if
    calling process does not belong to grid (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_map` and :ref:`MPI_Graph_map` can be used to implement all other
@@ -74,7 +74,7 @@ capability other than that provided by MPI. :ref:`MPI_Cart_map` computes an
 possible implementation of this function is to always return the rank of
 the calling process, that is, not to perform any reordering.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_rank
 :ref:`MPI_Cart_rank` - Determines process rank in communicator given Cartesian
 location.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: rank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
@@ -52,13 +52,13 @@ Input Parameters
    :ref:`MPI_Cart_create` call) specifying the Cartesian coordinates of a
    process.
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  rank : Rank of specified process (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 For a process group with Cartesian structure, the function :ref:`MPI_Cart_rank`
@@ -69,7 +69,7 @@ true, if the coordinate, coords(i), is out of range, that is, coords(i)
 coords(i) < dims(i) automatically. Out-of-range coordinates are
 erroneous for nonperiodic dimensions.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_rank.3.rst
@@ -72,14 +72,6 @@ erroneous for nonperiodic dimensions.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
@@ -118,13 +118,4 @@ dims[i].
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_shift.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_shift
 :ref:`MPI_Cart_shift` - Returns the shifted source and destination ranks,
 given a shift direction and amount.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: rank_source, rank_dest
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm`` : Communicator with Cartesian structure (handle).
@@ -55,14 +55,14 @@ Input Parameters
 -  ``disp`` : Displacement ( > 0: upward shift, < 0: downward shift)
    (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``rank_source`` : Rank of source process (integer).
 -  ``rank_dest`` : Rank of destination process (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 If the process topology is a Cartesian structure, an :ref:`MPI_Sendrecv`
@@ -107,7 +107,7 @@ column) by i steps.
        CALL MPI_SENDRECV_REPLACE(A, 1, MPI_REAL, dest, 0, source, 0, comm, status,
                                  ierr)
 
-Note
+NOTE
 ----
 
 In Fortran, the dimension indicated by DIRECTION = i has DIMS(i+1)
@@ -115,7 +115,7 @@ nodes, where DIMS is the array that was used to create the grid. In C,
 the dimension indicated by direction = i is the dimension specified by
 dims[i].
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
@@ -86,14 +86,6 @@ one-dimensional Cartesian topology.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cart_sub.3.rst
@@ -8,7 +8,7 @@ MPI_Cart_sub
 :ref:`MPI_Cart_sub` - Partitions a communicator into subgroups, which form
 lower-dimensional Cartesian subgrids.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with Cartesian structure (handle).
@@ -53,14 +53,14 @@ Input Parameters
    dimension is kept in the subgrid (true) or is dropped (false)
    (logical vector).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  comm_new : Communicator containing the subgrid that includes the
    calling process (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 If a Cartesian topology has been created with :ref:`MPI_Cart_create`, the
@@ -83,7 +83,7 @@ to MPI_Cart_sub(comm, remain_dims, comm_new) will create six
 nonoverlapping communicators, each with four processes, in a
 one-dimensional Cartesian topology.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
@@ -8,7 +8,7 @@ MPI_Cartdim_get
 :ref:`MPI_Cartdim_get` - Retrieves Cartesian topology information associated
 with a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,24 +43,24 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: ndims
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator with Cartesian structure (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ndims : Number of dimensions of the Cartesian structure (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cartdim_get` returns the number of dimensions of the Cartesian
 structure.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Cartdim_get.3.rst
@@ -63,14 +63,6 @@ structure.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Cart_get`

--- a/docs/man-openmpi/man3/MPI_Close_port.3.rst
+++ b/docs/man-openmpi/man3/MPI_Close_port.3.rst
@@ -61,12 +61,4 @@ Description
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Close_port.3.rst
+++ b/docs/man-openmpi/man3/MPI_Close_port.3.rst
@@ -7,7 +7,7 @@ MPI_Close_port
 
 :ref:`MPI_Close_port` - Releases the specified network address.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,23 +42,23 @@ Fortran 2008 Syntax
        CHARACTER(LEN=*), INTENT(IN) :: port_name
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``port_name`` : A port (string).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Close_port` releases the network address represented by
 ``port_name``.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
@@ -74,14 +74,6 @@ through a call to :ref:`MPI_Open_port` on the root.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. See the MPI man page for a full list of MPI
-error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_connect`

--- a/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_accept.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_accept
 
 :ref:`MPI_Comm_accept` - Establishes communication with a client.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,7 +46,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  port_name : Port name (string, used only on *root*).
@@ -55,13 +55,13 @@ Input Parameters
 -  root : Rank in *comm* of root node (integer).
 -  comm : Intracommunicator over which call is collective (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Intercommunicator with client as remote group (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_accept` establishes communication with a client. It is
@@ -71,7 +71,7 @@ client has connected with the :ref:`MPI_Comm_accept` function using the
 :ref:`MPI_Comm_connect` function. The port_name must have been established
 through a call to :ref:`MPI_Open_port` on the root.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
@@ -72,9 +72,6 @@ processes in comm if the default error handler has not been changed.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. See the MPI
-man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_create_errhandler`

--- a/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_call_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_call_errhandler
 :ref:`MPI_Comm_call_errhandler` - Passes the supplied error code to the error
 handler assigned to a communicator
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: errorcode
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : communicator with error handler (handle).
 -  errorcode : error code (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function invokes the error handler assigned to the communicator
@@ -62,14 +62,14 @@ comm with the supplied error code errorcode. If the error handler was
 successfully called, the process is not aborted, and the error handler
 returns, this function returns MPI_SUCCESS.
 
-Notes
+NOTES
 -----
 
 Users should note that the default error handler is
 MPI_ERRORS_ARE_FATAL. Thus, calling this function will abort the
 processes in comm if the default error handler has not been changed.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_compare
 
 :ref:`MPI_Comm_compare` - Compares two communicators.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,19 +42,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: result
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm1`` : Comm1 (handle).
 -  ``comm2`` : Comm2 (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``result`` : Result of comparison (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 MPI_IDENT ``result``\ s if and only if ``comm1`` and ``comm2`` are
@@ -64,7 +64,7 @@ constituents and rank order; these communicators differ only by context.
 MPI_SIMILAR results of the group members of both communicators are
 the same but the rank order differs. MPI_UNEQUAL results otherwise.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_compare.3.rst
@@ -67,12 +67,4 @@ the same but the rank order differs. MPI_UNEQUAL results otherwise.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
@@ -82,15 +82,6 @@ address of the server. It must be the same as the name returned by
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error. See the MPI man page for a full
-list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_accept`

--- a/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_connect.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_connect
 
 :ref:`MPI_Comm_connect` - Establishes communication with a server.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  port_name : Port name (string, used only on *root*).
@@ -56,13 +56,13 @@ Input Parameters
 -  root : Rank in *comm* of root node (integer).
 -  comm : Intracommunicator over which call is collective (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Intercommunicator with client as remote group (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_connect` establishes communication with a server specified by
@@ -79,7 +79,7 @@ connection attempt from being satisfied. The port_name parameter is the
 address of the server. It must be the same as the name returned by
 :ref:`MPI_Open_port` on the server.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create
 
 :ref:`MPI_Comm_create` - Creates a new communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  group : Group, which is a subset of the group of comm (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function creates a new communicator newcomm with communication
@@ -69,7 +69,7 @@ with a non-empty group, then all processes in that group must call the
 function with the same group as argument, that is: the same processes in
 the same order. Otherwise the call is erroneous.
 
-Notes
+NOTES
 -----
 
 :ref:`MPI_Comm_create` provides a means of making a subset of processes for the
@@ -79,7 +79,7 @@ calls to :ref:`MPI_Comm_create` (or other communicator constructors) to further
 subdivide a computation into parallel sub-computations. A more general
 service is provided by :ref:`MPI_Comm_split`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create.3.rst
@@ -82,14 +82,6 @@ service is provided by :ref:`MPI_Comm_split`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_split`

--- a/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_create_errhandler
 :ref:`MPI_Comm_create_errhandler` - Creates an error handler that can be
 attached to communicators.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -54,18 +54,18 @@ MPI_Comm_errhandler_function and ``MPI::Comm::Errhandler_function``,
 respectively. Open MPI supports both names (indeed, the \_fn names are
 typedefs to the \_function names).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``function`` : User-defined error handling procedure (function).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``errhandler`` : MPI error handler (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_errhandler` creates an error handler that can be
@@ -88,7 +88,7 @@ deprecated. In Fortran, the user routine should be of this form:
    SUBROUTINE COMM_ERRHANDLER_FUNCTION(COMM, ERROR_CODE, ...)
       INTEGER COMM, ERROR_CODE
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_errhandler.3.rst
@@ -91,12 +91,4 @@ deprecated. In Fortran, the user routine should be of this form:
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the ``function`` and Fortran routines in the last argument. Before
-the error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O
-``function`` errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
@@ -94,14 +94,6 @@ shall have a value of at least 63.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_create_group`

--- a/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_from_group.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_create_from_group
 :ref:`MPI_Comm_create_from_group` - Creates a new communicator from a group and
 stringtag
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,7 +47,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handler)
@@ -56,13 +56,13 @@ Input Parameters
 -  errhandler : error handler to be attached to the new
    intra-communicator (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_from_group` is similar to :ref:`MPI_Comm_create_group`, except
@@ -82,7 +82,7 @@ operations by providing different stringtag arguments. The stringtag
 shall not exceed MPI_MAX_STRINGTAG_LEN characters in length. For C, this
 includes space for a null terminating character.
 
-Notes
+NOTES
 -----
 
 The errhandler argument specifies an error handler to be attached to the
@@ -91,7 +91,7 @@ possibly MPI implementation dependent, which indicate desired
 characteristics and guide communicator creation. MPI_MAX_STRINGTAG_LEN
 shall have a value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create_group
 
 :ref:`MPI_Comm_create_group` - Creates a new communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,20 +44,20 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator (handle).
 -  group : Group, which is a subset of the group of comm (handle).
 -  tag : Tag (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : New communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_create_group` is similar to :ref:`MPI_Comm_create`; however,
@@ -79,7 +79,7 @@ associated group. If the calling process is not a member of group, e.g.,
 group is MPI_GROUP_EMPTY, then the call is a local operation and
 MPI_COMM_NULL is returned as newcomm.
 
-Notes
+NOTES
 -----
 
 :ref:`MPI_Comm_create_group` provides a means of making a subset of processes
@@ -90,7 +90,7 @@ communicator constructors) to further subdivide a computation into
 parallel sub-computations. A more general service is provided by
 :ref:`MPI_Comm_split`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_group.3.rst
@@ -93,14 +93,6 @@ parallel sub-computations. A more general service is provided by
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_create`

--- a/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
@@ -7,7 +7,7 @@ MPI_Comm_create_keyval
 
 :ref:`MPI_Comm_create_keyval` - Generates a new attribute key.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -52,7 +52,7 @@ Fortran 2008 Syntax
        INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) :: extra_state
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``comm_copy_attr_fn`` : Copy callback function for ``comm_keyval``
@@ -61,13 +61,13 @@ Input Parameters
    ``comm_keyval`` (function).
 -  ``extra_state`` : Extra state for callback functions.
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``comm_keyval`` : Key value for future access (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function replaces :ref:`MPI_Keyval_create`, the use of which is
@@ -112,7 +112,7 @@ names are deprecated. The two Fortran callback functions are:
 
        INTEGER(KIND=MPI_ADDRESS_KIND) ATTRIBUTE_VAL, EXTRA_STATE
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ^^^^^^^^^^^^^^^^
 
 The MPI standard prescribes portable Fortran syntax for the
@@ -126,7 +126,7 @@ the non-portable syntax
 where ``MPI_ADDRESS_KIND`` is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_create_keyval.3.rst
@@ -129,15 +129,6 @@ length of the declared integer in bytes.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error. See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI`

--- a/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_delete_attr
 :ref:`MPI_Comm_delete_attr` - Deletes attribute value associated with a
 key.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,22 +43,22 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: comm_keyval
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  ``comm`` : Communicator from which the attribute is deleted (handle).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``comm_keyval`` : Key value (integer).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_delete_attr` deletes an attribute from cache by key. This
@@ -74,7 +74,7 @@ function is the same as :ref:`MPI_Attr_delete` but is needed to match the
 ``comm``\ unicator-specific functions introduced in the MPI-2 standard.
 The use of :ref:`MPI_Attr_delete` is deprecated.
 
-Notes
+NOTES
 -----
 
 Note that it is not defined by the MPI standard what happens if the
@@ -83,7 +83,7 @@ not valid for ``delete_fn`` callbacks (or any of their children) to add
 or delete attributes on the same object on which the ``delete_fn``
 callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_delete_attr.3.rst
@@ -86,12 +86,4 @@ callback is being invoked.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
@@ -78,14 +78,6 @@ processes are completely independent.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_connect`

--- a/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_disconnect.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_disconnect
 :ref:`MPI_Comm_disconnect` - Deallocates communicator object and sets handle to
 MPI_COMM_NULL.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,17 +42,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(INOUT) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  comm : Communicator (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_disconnect` waits for all pending communication on comm to
@@ -66,7 +66,7 @@ has the same action as :ref:`MPI_Comm_free`, except that it waits for pending
 communication to finish internally and enables the guarantee about the
 behavior of disconnected processes.
 
-Notes
+NOTES
 -----
 
 To disconnect two processes you may need to call :ref:`MPI_Comm_disconnect`,
@@ -75,7 +75,7 @@ between the two processes. Note that it may be necessary to disconnect
 several communicators (or to free several windows or files) before two
 processes are completely independent.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_dup
 :ref:`MPI_Comm_dup` - Duplicates an existing communicator with all its cached
 information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Copy of comm (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_dup` duplicates the existing communicator comm with associated
@@ -65,7 +65,7 @@ delete the attribute from the new communicator. Returns in newcomm a new
 communicator with the same group, any copied cached information, but a
 new context (see Section 5.7.1 of the MPI-1 Standard, "Functionality").
 
-Notes
+NOTES
 -----
 
 This operation is used to provide a parallel library call with a
@@ -83,7 +83,7 @@ invokes other MPI functions. In Open MPI, it is not valid for attribute
 copy callbacks (or any of their children) to add or delete attributes on
 the same object on which the attribute copy callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup.3.rst
@@ -86,14 +86,6 @@ the same object on which the attribute copy callback is being invoked.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_dup_with_info`

--- a/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
@@ -8,7 +8,7 @@ MPI_Comm_dup_with_info
 :ref:`MPI_Comm_dup_with_info` - Duplicates an existing communicator using
 provided info.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newcomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator (handle).
 -  info : Info argument (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newcomm : Copy of comm (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Comm_dup_with_info` acts exactly like :ref:`MPI_Comm_dup` except that the
@@ -65,7 +65,7 @@ newcomm. The hints provided by the argument info are associated with the
 output communicator newcomm instead. See :ref:`MPI_Comm_set_info` for the
 list of recognized info keys.
 
-Notes
+NOTES
 -----
 
 This operation is used to provide a parallel library call with a
@@ -83,7 +83,7 @@ invokes other MPI functions. In Open MPI, it is not valid for attribute
 copy callbacks (or any of their children) to add or delete attributes on
 the same object on which the attribute copy callback is being invoked.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_dup_with_info.3.rst
@@ -86,14 +86,6 @@ the same object on which the attribute copy callback is being invoked.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_dup`

--- a/docs/man-openmpi/man3/MPI_Comm_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_free.3.rst
@@ -78,16 +78,7 @@ being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_delete_attr`

--- a/docs/man-openmpi/man3/MPI_Comm_free_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_free_keyval.3.rst
@@ -80,13 +80,4 @@ Key values are global (they can be used with any and all communicators).
 
 ERRORS
 ------
-
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_get_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_get_attr.3.rst
@@ -94,12 +94,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_get_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_get_errhandler.3.rst
@@ -68,14 +68,4 @@ use of which is deprecated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_get_info.3.rst
@@ -69,16 +69,7 @@ responsible for freeing info_used via :ref:`MPI_Info_free`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_get_info` :ref:`MPI_Info_free`

--- a/docs/man-openmpi/man3/MPI_Comm_get_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_get_name.3.rst
@@ -98,13 +98,4 @@ present information in a less cryptic manner.
 
 ERRORS
 ------
-
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_get_parent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_get_parent.3.rst
@@ -81,16 +81,7 @@ communicator is not useful.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_spawn` :ref:`MPI_Comm_spawn_multiple`

--- a/docs/man-openmpi/man3/MPI_Comm_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_group.3.rst
@@ -66,12 +66,4 @@ To return the remote group, use the :ref:`MPI_Comm_remote_group` function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_idup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_idup.3.rst
@@ -101,16 +101,7 @@ callback is being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_dup` :ref:`MPI_Comm_dup_with_info`

--- a/docs/man-openmpi/man3/MPI_Comm_idup_with_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_idup_with_info.3.rst
@@ -104,16 +104,7 @@ callback is being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_dup` :ref:`MPI_Comm_idup` :ref:`MPI_Comm_dup_with_info`

--- a/docs/man-openmpi/man3/MPI_Comm_join.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_join.3.rst
@@ -91,18 +91,7 @@ mechanisms.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    socket(3SOCKET) :ref:`MPI_Comm_create` :ref:`MPI_Comm_group`

--- a/docs/man-openmpi/man3/MPI_Comm_rank.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_rank.3.rst
@@ -74,16 +74,7 @@ the various processes of a communicator.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_group` :ref:`MPI_Comm_size` :ref:`MPI_Comm_compare`

--- a/docs/man-openmpi/man3/MPI_Comm_remote_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_remote_group.3.rst
@@ -69,16 +69,7 @@ The intercommunicator accessors (:ref:`MPI_Comm_test_inter`,
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_test_inter` :ref:`MPI_Comm_remote_size` :ref:`MPI_Intercomm_create`

--- a/docs/man-openmpi/man3/MPI_Comm_remote_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_remote_size.3.rst
@@ -69,16 +69,7 @@ The intercommunicator accessors (:ref:`MPI_Comm_test_inter`,
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_test_inter` :ref:`MPI_Comm_remote_group` :ref:`MPI_Intercomm_create`

--- a/docs/man-openmpi/man3/MPI_Comm_set_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_set_attr.3.rst
@@ -111,12 +111,4 @@ the corresponding keyval was created) will be called.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_set_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_set_errhandler.3.rst
@@ -69,12 +69,4 @@ identical to :ref:`MPI_Errhandler_set`, the use of which is deprecated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Comm_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_set_info.3.rst
@@ -92,16 +92,7 @@ were performed by the receiver.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_get_info` :ref:`MPI_Info_create` :ref:`MPI_Info_set` :ref:`MPI_Info_free`

--- a/docs/man-openmpi/man3/MPI_Comm_set_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_set_name.3.rst
@@ -97,16 +97,7 @@ will always succeed.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_get_name`

--- a/docs/man-openmpi/man3/MPI_Comm_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_size.3.rst
@@ -84,16 +84,7 @@ MPI_COMM_NULL is not considered a valid argument to this function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_group` :ref:`MPI_Comm_rank` :ref:`MPI_Comm_compare`

--- a/docs/man-openmpi/man3/MPI_Comm_spawn.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_spawn.3.rst
@@ -272,16 +272,7 @@ intercommunicator can be used immediately).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_spawn_multiple` :ref:`MPI_Comm_get_parent` mpirun(1)

--- a/docs/man-openmpi/man3/MPI_Comm_spawn_multiple.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_spawn_multiple.3.rst
@@ -270,16 +270,7 @@ of calling :ref:`MPI_Comm_spawn` several times.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_spawn` :ref:`MPI_Comm_get_parent` mpirun(1)

--- a/docs/man-openmpi/man3/MPI_Comm_split.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split.3.rst
@@ -122,16 +122,7 @@ the processes in the new communicator.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create` :ref:`MPI_Intercomm_create` :ref:`MPI_Comm_dup` :ref:`MPI_Comm_free`

--- a/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
@@ -144,16 +144,7 @@ macro.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create` :ref:`MPI_Intercomm_create` :ref:`MPI_Comm_dup` :ref:`MPI_Comm_free`

--- a/docs/man-openmpi/man3/MPI_Comm_test_inter.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_test_inter.3.rst
@@ -97,16 +97,7 @@ The intercommunicator accessors (:ref:`MPI_Comm_test_inter`,
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_remote_group` :ref:`MPI_Comm_remote_size` :ref:`MPI_Intercomm_create`

--- a/docs/man-openmpi/man3/MPI_Compare_and_swap.3.rst
+++ b/docs/man-openmpi/man3/MPI_Compare_and_swap.3.rst
@@ -114,13 +114,4 @@ arguments in the call to the :ref:`MPI_Compare_and_swap` function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Dims_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dims_create.3.rst
@@ -105,12 +105,4 @@ order. Array dims is suitable for use as input to routine
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Dist_graph_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_create.3.rst
@@ -136,16 +136,7 @@ section 2.5.4.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Dist_graph_create_adjacent` :ref:`MPI_Dist_graph_neighbors`

--- a/docs/man-openmpi/man3/MPI_Dist_graph_create_adjacent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_create_adjacent.3.rst
@@ -125,16 +125,7 @@ See MPI-3 section 2.5.4.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Dist_graph_create` :ref:`MPI_Dist_graph_neighbors`

--- a/docs/man-openmpi/man3/MPI_Dist_graph_neighbors.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_neighbors.3.rst
@@ -85,16 +85,7 @@ process with the same rank in comm_old in the creation call.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Dist_graph_neighbors_count`

--- a/docs/man-openmpi/man3/MPI_Dist_graph_neighbors_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Dist_graph_neighbors_count.3.rst
@@ -74,16 +74,7 @@ destinations for the calling process.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Dist_graph_neighbors`

--- a/docs/man-openmpi/man3/MPI_Errhandler_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Errhandler_create.3.rst
@@ -85,16 +85,7 @@ that use it are freed.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create_errhandler` :ref:`MPI_Comm_get_errhandler`

--- a/docs/man-openmpi/man3/MPI_Errhandler_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Errhandler_free.3.rst
@@ -65,16 +65,7 @@ deallocated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create_errhandler` :ref:`MPI_Comm_get_errhandler`

--- a/docs/man-openmpi/man3/MPI_Errhandler_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Errhandler_get.3.rst
@@ -61,16 +61,7 @@ error handler.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create_errhandler` :ref:`MPI_Comm_get_errhandler`

--- a/docs/man-openmpi/man3/MPI_Errhandler_set.3.rst
+++ b/docs/man-openmpi/man3/MPI_Errhandler_set.3.rst
@@ -57,16 +57,7 @@ with the communicator.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_create_errhandler` :ref:`MPI_Comm_get_errhandler`

--- a/docs/man-openmpi/man3/MPI_Error_class.3.rst
+++ b/docs/man-openmpi/man3/MPI_Error_class.3.rst
@@ -65,16 +65,7 @@ onto itself.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Error_string`

--- a/docs/man-openmpi/man3/MPI_Error_string.3.rst
+++ b/docs/man-openmpi/man3/MPI_Error_string.3.rst
@@ -72,16 +72,7 @@ argument, resultlen.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Error_class`

--- a/docs/man-openmpi/man3/MPI_Exscan.3.rst
+++ b/docs/man-openmpi/man3/MPI_Exscan.3.rst
@@ -169,18 +169,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Op_create` :ref:`MPI_Reduce` :ref:`MPI_Scan`

--- a/docs/man-openmpi/man3/MPI_Fetch_and_op.3.rst
+++ b/docs/man-openmpi/man3/MPI_Fetch_and_op.3.rst
@@ -124,17 +124,7 @@ arguments in the call to the :ref:`MPI_Fetch_and_op` function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Get_accumulate` :ref:`MPI_Reduce`

--- a/docs/man-openmpi/man3/MPI_File_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_call_errhandler.3.rst
@@ -71,11 +71,7 @@ files is MPI_ERRORS_RETURN.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_File_create_errhandler` :ref:`MPI_File_set_errhandler`

--- a/docs/man-openmpi/man3/MPI_File_close.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_close.3.rst
@@ -66,12 +66,4 @@ with *fh* have completed before calling :ref:`MPI_File_close`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_create_errhandler.3.rst
@@ -95,12 +95,4 @@ In the Fortran language, the user routine should be of the form:
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_delete.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_delete.3.rst
@@ -70,12 +70,4 @@ delete the file with :ref:`MPI_File_delete` if some process has it open, but
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_amode.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_amode.3.rst
@@ -67,12 +67,4 @@ the open file *fh.*
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_atomicity.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_atomicity.3.rst
@@ -70,12 +70,4 @@ enabled; if *flag* is *false,* nonatomic mode is currently enabled.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_byte_offset.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_byte_offset.3.rst
@@ -90,12 +90,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_errhandler.3.rst
@@ -66,12 +66,4 @@ currently associated with file *file*.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_group.3.rst
@@ -69,12 +69,4 @@ used to open the file associated with *fh.* The group is returned in
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_info.3.rst
@@ -142,12 +142,4 @@ The following hints can be used as values for the *info_used* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_position.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_position.3.rst
@@ -84,12 +84,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_position_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_position_shared.3.rst
@@ -84,12 +84,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_size.3.rst
@@ -85,16 +85,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_File_preallocate`

--- a/docs/man-openmpi/man3/MPI_File_get_type_extent.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_type_extent.3.rst
@@ -107,12 +107,4 @@ corresponding to displacements in memory.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_get_view.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_view.3.rst
@@ -95,12 +95,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iread.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iread.3.rst
@@ -85,12 +85,4 @@ mode was specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iread_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iread_all.3.rst
@@ -85,12 +85,4 @@ MPI_MODE_SEQUENTIAL mode was specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iread_at.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iread_at.3.rst
@@ -102,12 +102,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iread_at_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iread_at_all.3.rst
@@ -103,12 +103,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iread_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iread_shared.3.rst
@@ -82,12 +82,4 @@ processors.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iwrite.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iwrite.3.rst
@@ -87,12 +87,4 @@ specified when the file was open.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iwrite_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iwrite_all.3.rst
@@ -87,12 +87,4 @@ specified when the file was open.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iwrite_at.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iwrite_at.3.rst
@@ -107,12 +107,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iwrite_at_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iwrite_at_all.3.rst
@@ -108,12 +108,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_iwrite_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_iwrite_shared.3.rst
@@ -80,12 +80,4 @@ methods of synchronization to impose a particular order.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_open.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_open.3.rst
@@ -190,12 +190,4 @@ The following hints can be used as values for the *info* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_preallocate.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_preallocate.3.rst
@@ -116,12 +116,4 @@ or by performing a read or write to certain bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read.3.rst
@@ -84,12 +84,4 @@ specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_all.3.rst
@@ -84,12 +84,4 @@ specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_all_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_all_begin.3.rst
@@ -90,12 +90,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_all_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_all_end.3.rst
@@ -85,12 +85,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_at.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_at.3.rst
@@ -102,12 +102,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_at_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_at_all.3.rst
@@ -103,12 +103,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_at_all_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_at_all_begin.3.rst
@@ -107,12 +107,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_at_all_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_at_all_end.3.rst
@@ -84,12 +84,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_ordered.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_ordered.3.rst
@@ -86,12 +86,4 @@ data requested by all processes of the group.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_ordered_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_ordered_begin.3.rst
@@ -94,12 +94,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_ordered_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_ordered_end.3.rst
@@ -89,12 +89,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_read_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_read_shared.3.rst
@@ -80,12 +80,4 @@ for this noncollective routine.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_seek.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_seek.3.rst
@@ -97,12 +97,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_seek_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_seek_shared.3.rst
@@ -104,12 +104,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_set_atomicity.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_atomicity.3.rst
@@ -74,12 +74,4 @@ SMP. For more information, see the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_set_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_errhandler.3.rst
@@ -70,12 +70,4 @@ a predefined error handler or an error handler created by a call to
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_info.3.rst
@@ -140,12 +140,4 @@ The following hints can be used as values for the *info* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_set_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_size.3.rst
@@ -99,12 +99,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_set_view.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_view.3.rst
@@ -180,12 +180,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_sync.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_sync.3.rst
@@ -72,12 +72,4 @@ erroneous.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write.3.rst
@@ -88,12 +88,4 @@ specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_all.3.rst
@@ -84,12 +84,4 @@ specified when the file was opened.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_all_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_all_begin.3.rst
@@ -90,12 +90,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_all_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_all_end.3.rst
@@ -88,12 +88,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_at.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_at.3.rst
@@ -103,16 +103,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_File_iwrite_at` :ref:`MPI_File_write_at_all` :ref:`MPI_File_write_at_all_begin`

--- a/docs/man-openmpi/man3/MPI_File_write_at_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_at_all.3.rst
@@ -103,12 +103,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_at_all_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_at_all_begin.3.rst
@@ -108,12 +108,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_at_all_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_at_all_end.3.rst
@@ -86,12 +86,4 @@ Section 9.4.5 of the MPI-2 standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
@@ -8,7 +8,7 @@ MPI_File_write_ordered
 :ref:`MPI_File_write_ordered` - Writes a file at a location specified by a
 shared file pointer (blocking, collective).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -50,7 +50,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``fh`` : File handle (handle).
@@ -58,13 +58,13 @@ Input Parameters
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (Status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered` is a collective routine. This routine must be
@@ -81,7 +81,7 @@ number of ``datatype`` elements written in ``status``. The shared file
 pointer is updated by the amounts of data requested by all processes of
 the group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered.3.rst
@@ -84,12 +84,4 @@ the group.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that
-MPI does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
@@ -92,12 +92,4 @@ Section 9.4.5 of the MPI-2 standard.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that
-MPI does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_begin.3.rst
@@ -9,7 +9,7 @@ MPI_File_write_ordered_begin
 by a shared file pointer; beginning part of a split collective routine
 (nonblocking).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,24 +48,24 @@ Fortran 2008 Syntax
        TYPE(MPI_Datatype), INTENT(IN) :: datatype
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of buffer (choice).
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered_begin` is the beginning part of a split
@@ -81,7 +81,7 @@ position at which the shared file pointer would be after all processes
 whose ranks within the group are less than that of this process had
 written their data.
 
-Notes
+NOTES
 -----
 
 All the nonblocking collective routines for data access are "split" into
@@ -89,7 +89,7 @@ two routines, each with \_begin or \_end as a suffix. These split
 collective routines are subject to the semantic rules described in
 Section 9.4.5 of the MPI-2 standard.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
@@ -9,7 +9,7 @@ MPI_File_write_ordered_end
 by a shared file pointer; ending part of a split collective routine
 (blocking).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -47,23 +47,23 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``buf`` : Initial address of buffer (choice).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_ordered_end` is the ending part of a split collective
@@ -72,7 +72,7 @@ associated with the file handle ``fh``. :ref:`MPI_File_write_ordered_end`
 returns the number of elements written into the file associated with
 ``fh`` in ``status``.
 
-Notes
+NOTES
 -----
 
 All the nonblocking collective routines for data access are "split" into
@@ -80,7 +80,7 @@ two routines, each with \_begin or \_end as a suffix. These split
 collective routines are subject to the semantic rules described in
 Section 9.4.5 of the MPI-2 standard.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_ordered_end.3.rst
@@ -83,12 +83,4 @@ Section 9.4.5 of the MPI-2 standard.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that
-MPI does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
@@ -8,7 +8,7 @@ MPI_File_write_shared
 :ref:`MPI_File_write_shared` - Writes a file using the shared file pointer
 (blocking, noncollective).
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,32 +48,32 @@ Fortran 2008 Syntax
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``fh`` : File handle (handle).
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``buf`` : Initial address of buffer (choice).
 -  ``count`` : Number of elements in buffer (integer).
 -  ``datatype`` : Data type of each buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``status`` : Status object (status).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_File_write_shared` is a blocking routine that uses the shared
 file pointer to write files. The order of serialization is not
 deterministic for this noncollective routine.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_write_shared.3.rst
@@ -76,12 +76,4 @@ deterministic for this noncollective routine.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that
-MPI does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalize.3.rst
@@ -7,7 +7,7 @@ MPI_Finalize
 
 :ref:`MPI_Finalize` - Terminates MPI execution environment.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -40,12 +40,12 @@ Fortran 2008 Syntax
    MPI_Finalize(ierror)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine cleans up all MPI states. Once this routine is called, no
@@ -64,7 +64,7 @@ were spawned, accepted, or connected, then this means it is collective
 over MPI_COMM_WORLD. Otherwise, it is collective over the union of all
 processes that have been and continue to be connected.
 
-Notes
+NOTES
 -----
 
 All processes must call this routine before exiting. All processes will
@@ -95,7 +95,7 @@ other parts of MPI are affected. Calling :ref:`MPI_Finalized` will thus return
 "false" in any of these callback functions. Once you have done this with
 MPI_COMM_SELF, the results of :ref:`MPI_Finalize` are not specified.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalize.3.rst
@@ -98,15 +98,6 @@ MPI_COMM_SELF, the results of :ref:`MPI_Finalize` are not specified.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Init`

--- a/docs/man-openmpi/man3/MPI_Finalized.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalized.3.rst
@@ -59,14 +59,6 @@ another).
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Init`

--- a/docs/man-openmpi/man3/MPI_Finalized.3.rst
+++ b/docs/man-openmpi/man3/MPI_Finalized.3.rst
@@ -7,7 +7,7 @@ MPI_Finalized
 
 :ref:`MPI_Finalized` - Checks whether MPI has been finalized
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,13 +42,13 @@ Fortran 2008 Syntax
        LOGICAL, INTENT(OUT) :: flag
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  flag : True if MPI was finalized, and false otherwise (logical).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine may be used to determine whether MPI has been finalized. It
@@ -56,7 +56,7 @@ is one of a small number of routines that may be called before MPI is
 initialized and after MPI has been finalized (:ref:`MPI_Initialized` is
 another).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Free_mem.3.rst
+++ b/docs/man-openmpi/man3/MPI_Free_mem.3.rst
@@ -61,15 +61,6 @@ Description
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Alloc_mem`

--- a/docs/man-openmpi/man3/MPI_Free_mem.3.rst
+++ b/docs/man-openmpi/man3/MPI_Free_mem.3.rst
@@ -7,7 +7,7 @@ MPI_Free_mem
 
 :ref:`MPI_Free_mem` - Frees memory that has been allocated using :ref:`MPI_Alloc_mem`.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,23 +42,23 @@ Fortran 2008 Syntax
        TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: base
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  base : Initial address of memory segment allocated by :ref:`MPI_Alloc_mem`
    (choice).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Free_mem` frees memory that has been allocated by :ref:`MPI_Alloc_mem`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Gather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gather.3.rst
@@ -219,15 +219,6 @@ process in the second group.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error. See the MPI man page for a full
-list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Gatherv`

--- a/docs/man-openmpi/man3/MPI_Gather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gather.3.rst
@@ -93,7 +93,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  sendbuf : Starting address of send buffer (choice).
@@ -107,7 +107,7 @@ Input Parameters
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  recvbuf : Address of receive buffer (choice, significant only at
@@ -115,7 +115,7 @@ Output Parameters
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Each process (root process included) sends the contents of its send
@@ -216,7 +216,7 @@ root argument. The send buffer argument of the processes in the first
 group must be consistent with the receive buffer argument of the root
 process in the second group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Gatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gatherv.3.rst
@@ -301,15 +301,6 @@ process in the second group.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Gather`

--- a/docs/man-openmpi/man3/MPI_Gatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gatherv.3.rst
@@ -8,7 +8,7 @@ MPI_Gatherv
 :ref:`MPI_Gatherv`, :ref:`MPI_Igatherv`, :ref:`MPI_Gatherv_init` - Gathers varying amounts of
 data from all processes to the root process
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -95,7 +95,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  sendbuf : Starting address of send buffer (choice).
@@ -113,7 +113,7 @@ Input Parameters
 -  comm : Communicator (handle).
 -  info : Info (handle, persistent only).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  recvbuf : Address of receive buffer (choice, significant only at
@@ -121,7 +121,7 @@ Output Parameters
 -  request : Request (handle, non-blocking only).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Gatherv` extends the functionality of :ref:`MPI_Gather` by allowing a
@@ -298,7 +298,7 @@ root argument. The send buffer argument of the processes in the first
 group must be consistent with the receive buffer argument of the root
 process in the second group.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get.3.rst
@@ -128,15 +128,6 @@ length of the declared integer in bytes.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Put`

--- a/docs/man-openmpi/man3/MPI_Get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get.3.rst
@@ -7,7 +7,7 @@ MPI_Get
 
 :ref:`MPI_Get`, :ref:`MPI_Rget` - Copies data from the target memory to the origin.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -75,7 +75,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  origin_addr : Initial address of origin buffer (choice).
@@ -90,13 +90,13 @@ Input Parameters
 -  target datatype : datatype of each entry in target buffer (handle)
 -  win : window object used for communication (handle)
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  request : :ref:`MPI_Rget`: RMA request
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get` copies data from the target memory to the origin, similar to
@@ -113,7 +113,7 @@ of an :ref:`MPI_Rget` operation indicates that the data is available in the
 origin buffer. If origin_addr points to memory attached to a window,
 then the data becomes available in the private copy of this window.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the TARGET_DISP
@@ -125,7 +125,7 @@ fortran INTEGERMPI_ADDRESS_KIND TARGET_DISP
 where MPI_ADDRESS_KIND is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
@@ -188,15 +188,6 @@ arguments in the call to the :ref:`MPI_Get_accumulate` function.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Put` :ref:`MPI_Reduce`

--- a/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_accumulate.3.rst
@@ -9,7 +9,7 @@ MPI_Get_accumulate
 origin buffer with that of a target buffer and returns the target buffer
 value.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -89,7 +89,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  origin_addr : Initial address of buffer (choice).
@@ -108,13 +108,13 @@ Input Parameters
 -  op : Reduce operation (handle).
 -  win : Window object (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  :ref:`MPI_Rget_accumulate`: RMA request
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_accumulate` is a function used for one-sided MPI communication
@@ -155,7 +155,7 @@ indicates that the data is available in the result buffer and the origin
 buffer is free to be updated. It does not indicate that the operation
 has been completed at the target window.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the TARGET_DISP
@@ -167,7 +167,7 @@ fortran INTEGERMPI_ADDRESS_KIND TARGET_DISP
 where MPI_ADDRESS_KIND is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Notes
+NOTES
 -----
 
 The generic functionality of :ref:`MPI_Get_accumulate` might limit the
@@ -185,7 +185,7 @@ accumulate functions, the target displacement argument is such that
 accesses to the window are properly aligned according to the data type
 arguments in the call to the :ref:`MPI_Get_accumulate` function.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_address.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_address.3.rst
@@ -87,13 +87,4 @@ support KIND declarations.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_address.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_address.3.rst
@@ -7,7 +7,7 @@ MPI_Get_address
 
 :ref:`MPI_Get_address` - Gets the address of a location in memory.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,18 +44,18 @@ Fortran 2008 Syntax
        INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(OUT) :: address
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``location`` : Location in caller memory (choice).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``address`` : Address of location (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_address` returns the byte ``address`` of a location in
@@ -73,7 +73,7 @@ Example: Using :ref:`MPI_Get_address` for an array.
    ! The value of DIFF is 909*sizeofreal; the values of I1 and I2 are
    ! implementation dependent.
 
-Notes
+NOTES
 -----
 
 Current Fortran MPI codes will run unmodified and will port to any
@@ -84,7 +84,7 @@ new functions. This provides compatibility with C and avoids errors on
 (slightly) rewritten to port to old Fortran 77 environments that do not
 support KIND declarations.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_count.3.rst
@@ -82,18 +82,9 @@ MPI_UNDEFINED is returned instead.
 Errors
 ------
 
+.. include:: ./ERRORS.rst
+
 If the value to be returned is larger than can fit into the count
 parameter, an MPI_ERR_TRUNCATE error is raised.
-
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
 
 .. seealso:: :ref:`MPI_Get_elements`

--- a/docs/man-openmpi/man3/MPI_Get_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_count.3.rst
@@ -7,7 +7,7 @@ MPI_Get_count
 
 :ref:`MPI_Get_count` - Gets the number of top-level elements received.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: count
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  status : Return status of receive operation (status).
 -  datatype : Datatype of each receive buffer element (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  count : Number of received elements (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Returns the number of entries received. (We count entries, each of type
@@ -71,7 +71,7 @@ A message might be received without counting the number of elements it
 contains, and the count value is often not needed. Also, this allows the
 same function to be used after a call to :ref:`MPI_Probe`.
 
-Notes
+NOTES
 -----
 
 If the size of the datatype is zero, this routine will return a count of
@@ -79,7 +79,7 @@ zero. If the amount of data in status is not an exact multiple of the
 size of datatype (so that count would not be integral), a count of
 MPI_UNDEFINED is returned instead.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_elements.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_elements.3.rst
@@ -112,15 +112,7 @@ used with primitive data types.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 Fortran 77 Notes
 ----------------

--- a/docs/man-openmpi/man3/MPI_Get_elements.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_elements.3.rst
@@ -8,7 +8,7 @@ MPI_Get_elements
 :ref:`MPI_Get_elements`, :ref:`MPI_Get_elements_x` - Returns the number of basic
 elements in a data type.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -59,18 +59,18 @@ Fortran 2008 Syntax
        INTEGER(KIND = MPI_COUNT_KIND), INTENT(OUT) :: count
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  status : Return status of receive operation (status).
 -  datatype : Datatype used by receive operation (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Get_elements` and :ref:`MPI_Get_elements_x` behave different from
@@ -109,12 +109,12 @@ number of elements in the probed message. Note that the two functions
 :ref:`MPI_Get_count` and :ref:`MPI_Get_elements` return the same values when they are
 used with primitive data types.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the COUNT

--- a/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
@@ -8,7 +8,7 @@ MPI_Get_library_version
 :ref:`MPI_Get_library_version` - Returns a string of the current Open MPI
 version
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: resultlen
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  version : A string containing the Open MPI version (string).
@@ -52,7 +52,7 @@ Output Parameters
    (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine returns a string representing the version of the MPI
@@ -66,7 +66,7 @@ version[resultlen]. The resultlen cannot be larger than
 the right with blank characters. The resultlen cannot be larger than
 MPI_MAX_LIBRARY_VERSION_STRING.
 
-Note
+NOTE
 ----
 
 The version string that is passed must be at least
@@ -75,7 +75,7 @@ MPI_MAX_LIBRARY_VERSION_STRING characters long.
 :ref:`MPI_Get_library_version` is one of the few functions that can be called
 before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_library_version.3.rst
@@ -78,15 +78,6 @@ before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Get_version`

--- a/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
@@ -74,13 +74,4 @@ actual length of the ``name``.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
@@ -7,7 +7,7 @@ MPI_Get_processor_name
 
 :ref:`MPI_Get_processor_name` - Gets the name of the processor.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,7 +43,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: resultlen
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``name`` : A unique specifier for the actual (as opposed to virtual)
@@ -51,7 +51,7 @@ Output Parameters
 -  ``resultlen`` : Length (in characters) of result returned in name.
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This routine returns the ``name`` of the processor on which it was
@@ -63,7 +63,7 @@ that is at least MPI_MAX_PROCESSOR_NAME characters long.
 The number of characters actually written is returned in the output
 argument, ``resultlen``.
 
-Notes
+NOTES
 -----
 
 The user must provide at least MPI_MAX_PROCESSOR_NAME space to write
@@ -71,7 +71,7 @@ the processor ``name``; processor ``name``\ s can be this long. The user
 should examine the output argument, ``resultlen``, to determine the
 actual length of the ``name``.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_version.3.rst
@@ -8,7 +8,7 @@ MPI_Get_version
 :ref:`MPI_Get_version` - Returns the version of the standard corresponding
 to the current implementation.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,7 +42,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: version, subversion
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``version`` : The major version number of the corresponding standard
@@ -51,19 +51,19 @@ Output Parameters
    standard (integer).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Since Open MPI is MPI-|mpi_standard_version|.|mpi_standard_subversion| compliant, this function will return a
 ``version`` value of |mpi_standard_version| and a subversion value of |mpi_standard_subversion| for this release.
 
-Note
+NOTE
 ----
 
 :ref:`MPI_Get_version` is one of the few functions that can be called
 before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Get_version.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_version.3.rst
@@ -66,13 +66,4 @@ before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_create.3.rst
@@ -124,15 +124,6 @@ the list of neighbors of node i, i > 0, is stored in edges(j), index(i)
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Graph_get`

--- a/docs/man-openmpi/man3/MPI_Graph_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_create.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_create
 :ref:`MPI_Graph_create` - Makes a new communicator to which topology
 information has been attached.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -50,7 +50,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: comm_graph
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm_old : Input communicator without topology (handle).
@@ -59,13 +59,13 @@ Input Parameters
 -  edges : Array of integers describing graph edges (see below).
 -  reorder : Ranking may be reordered (true) or not (false) (logical).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  comm_graph : Communicator with graph topology added (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Graph_create` returns a handle to a new communicator to which the
@@ -121,7 +121,7 @@ neighbors of node zero is stored in edges(j), for 1 <= j <= index(1) and
 the list of neighbors of node i, i > 0, is stored in edges(j), index(i)
 + 1 <= j <= index(i + 1).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_get.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_get
 :ref:`MPI_Graph_get` - Retrieves graph topology information associated with a
 communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,14 +46,14 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: index(maxindex), edges(maxedges)
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with graph structure (handle).
 -  maxindex : Length of vector index in the calling program (integer).
 -  maxedges : Length of vector edges in the calling program (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  index : Array of integers containing the graph structure (for details
@@ -61,7 +61,7 @@ Output Parameters
 -  edges : Array of integers containing the graph structure.
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Functions :ref:`MPI_Graphdims_get` and :ref:`MPI_Graph_get` retrieve the
@@ -71,7 +71,7 @@ graph-topology information that was associated with a communicator by
 The information provided by :ref:`MPI_Graphdims_get` can be used to dimension
 the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_get.3.rst
@@ -74,15 +74,6 @@ the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Graph_create`

--- a/docs/man-openmpi/man3/MPI_Graph_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_map.3.rst
@@ -71,15 +71,6 @@ capability other than that provided by MPI.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Cart_map`

--- a/docs/man-openmpi/man3/MPI_Graph_map.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_map.3.rst
@@ -7,7 +7,7 @@ MPI_Graph_map
 
 :ref:`MPI_Graph_map` - Maps process to graph topology information.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,7 +44,7 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: newrank
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Input communicator (handle).
@@ -53,14 +53,14 @@ Input Parameters
    :ref:`MPI_Graph_create`.
 -  edges : Integer array specifying the graph structure.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newrank : Reordered rank of the calling process; MPI_UNDEFINED if the
    calling process does not belong to graph (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Cart_map` and :ref:`MPI_Graph_map` can be used to implement all other
@@ -68,7 +68,7 @@ topology functions. In general they will not be called by the user
 directly, unless he or she is creating additional virtual topology
 capability other than that provided by MPI.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_neighbors.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_neighbors.3.rst
@@ -108,16 +108,7 @@ and performs an appropriate permutation for each.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Graph_neighbors_count`

--- a/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
@@ -8,7 +8,7 @@ MPI_Graph_neighbors_count
 :ref:`MPI_Graph_neighbors_count` - Returns the number of neighbors of a node
 associated with a graph topology.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,26 +45,26 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: nneighbors
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  comm : Communicator with graph topology (handle).
 -  rank : Rank of process in group of comm (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  nneighbors : Number of neighbors of specified process (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Graph_neighbors_count` and :ref:`MPI_Graph_neighbors` provide adjacency
 information for a general, graph topology. :ref:`MPI_Graph_neighbors_count`
 returns the number of neighbors for the process signified by rank.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graph_neighbors_count.3.rst
@@ -67,15 +67,6 @@ returns the number of neighbors for the process signified by rank.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Graph_neighbors`

--- a/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
@@ -8,7 +8,7 @@ MPI_Graphdims_get
 :ref:`MPI_Graphdims_get` - Retrieves graph topology information associated with
 a communicator.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: nnodes, nedges
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  comm : Communicator for group with graph structure (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  nnodes : Number of nodes in graph (integer).
 -  nedges : Number of edges in graph (integer).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 Functions :ref:`MPI_Graphdims_get` and :ref:`MPI_Graph_get` retrieve the
@@ -65,7 +65,7 @@ graph-topology information that was associated with a communicator by
 The information provided by :ref:`MPI_Graphdims_get` can be used to dimension
 the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Graphdims_get.3.rst
@@ -68,15 +68,6 @@ the vectors index and edges correctly for a call to :ref:`MPI_Graph_get`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Graph_create`

--- a/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
@@ -79,13 +79,4 @@ defined operations.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_complete.3.rst
@@ -8,7 +8,7 @@ MPI_Grequest_complete
 :ref:`MPI_Grequest_complete` - Reports that a generalized request is
 complete.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,17 +42,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(IN) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``request`` : Generalized request (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Grequest_complete` informs MPI that the operations represented by
@@ -76,7 +76,7 @@ regardless of the state of other processes (the operation has acquired
 side-effects. The user should guarantee these same properties for newly
 defined operations.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
@@ -8,7 +8,7 @@ MPI_Grequest_start
 :ref:`MPI_Grequest_start` - Starts a generalized request and returns a
 handle to it in ``request``.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -53,7 +53,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``query_fn`` : Callback function invoked when request status is
@@ -64,13 +64,13 @@ Input Parameters
    (function).
 -  ``extra_state`` : Extra state.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``request`` : Generalized request (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Grequest_start` starts a generalized ``request`` and returns a
@@ -175,7 +175,7 @@ MPI passes to the callback function complete=true if
 ``MPI_Grequest_complete`` has already been called on the request, and
 complete=false otherwise.
 
-Fortran 77 Notes
+FORTRAN 77 NOTES
 ----------------
 
 The MPI standard prescribes portable Fortran syntax for the
@@ -189,7 +189,7 @@ the non-portable syntax
 where ``MPI_ADDRESS_KIND`` is a constant defined in mpif.h and gives the
 length of the declared integer in bytes.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Grequest_start.3.rst
@@ -192,16 +192,7 @@ length of the declared integer in bytes.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst
 
 All callback functions return an error code. The code is passed back and
 dealt with as appropriate for the error code by the MPI function that
@@ -219,5 +210,3 @@ error code returned by the corresponding invocation of its ``free_fn``
 callback function. However, if the MPI function was passed
 MPI_STATUSES_IGNORE, then the individual error codes returned by
 each callback function will be lost.
-
-See the MPI man page for a full list of MPI error codes.

--- a/docs/man-openmpi/man3/MPI_Group_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_compare.3.rst
@@ -7,7 +7,7 @@ MPI_Group_compare
 
 :ref:`MPI_Group_compare` - Compares two groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,13 +43,13 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: result
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  ``group1`` : First group (handle).
 -  ``group2`` : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``result`` : Integer which is MPI_IDENT if the order and members of
@@ -57,7 +57,7 @@ Output Parameters
    same, and MPI_UNEQUAL otherwise.
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 MPI_IDENT results if the group members and group order is exactly
@@ -66,7 +66,7 @@ the same in both groups. This happens for instance if ``group1`` and
 members are the same but the order is different. MPI_UNEQUAL results
 otherwise.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_compare.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_compare.3.rst
@@ -69,13 +69,4 @@ otherwise.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_difference.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_difference.3.rst
@@ -77,15 +77,6 @@ The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Group_free`

--- a/docs/man-openmpi/man3/MPI_Group_difference.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_difference.3.rst
@@ -7,7 +7,7 @@ MPI_Group_difference
 
 :ref:`MPI_Group_difference` - Makes a group from the difference of two groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,19 +43,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group1 : First group (handle).
 -  group2 : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : Difference group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The set-like operations are defined as follows:
@@ -74,7 +74,7 @@ intersection are commutative, but both are associative.
 
 The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_excl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_excl.3.rst
@@ -79,15 +79,6 @@ This restriction is per the draft.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Group_range_excl`

--- a/docs/man-openmpi/man3/MPI_Group_excl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_excl.3.rst
@@ -8,7 +8,7 @@ MPI_Group_excl
 :ref:`MPI_Group_excl` - Produces a group by reordering an existing group and
 taking only unlisted members.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,21 +45,21 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handle).
 -  n : Number of elements in array ranks (integer).
 -  ranks : Array of integer ranks in group not to appear in newgroup.
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from above, preserving the order defined
    by group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_excl` creates a group of processes newgroup that
@@ -69,14 +69,14 @@ the ordering in group. Each of the n elements of ranks must be a valid
 rank in group and all elements must be distinct; otherwise, the call is
 erroneous. If n = 0, then newgroup is identical to group.
 
-Note
+NOTE
 ----
 
 Currently, each of the ranks to exclude must be a valid rank in the
 group and all elements must be distinct or the function is erroneous.
 This restriction is per the draft.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_free.3.rst
@@ -7,7 +7,7 @@ MPI_Group_free
 
 :ref:`MPI_Group_free` - Frees a group.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,29 +41,29 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(INOUT) :: group
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ----------------------
 
 -  ``group`` : Group (handle).
 
-Output Parameter
+OUTPUT PARAMETER
 ----------------
 
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This operation marks a ``group`` object for deallocation. The handle
 ``group`` is set to MPI_GROUP_NULL by the call. Any ongoing
 operation using this ``group`` will complete normally.
 
-Note
+NOTE
 ----
 
 On return, ``group`` is set to MPI_GROUP_NULL.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_free.3.rst
@@ -66,13 +66,4 @@ On return, ``group`` is set to MPI_GROUP_NULL.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
@@ -8,7 +8,7 @@ MPI_Group_from_session_pset
 :ref:`MPI_Group_from_session_pset` - Creates a group using a provided session
 handle and process set.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,21 +45,21 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : Session (handle).
 -  pset_name : name of process set to use to create the new group
    (string)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from supplied session and process set
    (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_from_session_pset` creates a group newgroup using
@@ -68,13 +68,13 @@ be one returned from an invocation of :ref:`MPI_Session_get_nth_pset` using the
 supplied session handle. If the pset_name does not exist, MPI_GROUP_NULL
 will be returned in the newgroup argument.
 
-Note
+NOTE
 ----
 
 As with other group constructors, :ref:`MPI_Group_from_session_pset` is a local
 function.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_from_session_pset.3.rst
@@ -77,16 +77,6 @@ function.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Group_incl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_incl.3.rst
@@ -8,7 +8,7 @@ MPI_Group_incl
 :ref:`MPI_Group_incl` - Produces a group by reordering an existing group and
 taking only listed members.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,7 +45,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group : Group (handle).
@@ -54,14 +54,14 @@ Input Parameters
 -  ranks : Ranks of processes in group to appear in newgroup (array of
    integers).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : New group derived from above, in the order defined by
    ranks (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The function :ref:`MPI_Group_incl` creates a group group_out that consists of
@@ -72,13 +72,13 @@ elements must be distinct, or else the program is erroneous. If n = 0,
 then group_out is MPI_GROUP_EMPTY. This function can, for instance, be
 used to reorder the elements of a group.
 
-Note
+NOTE
 ----
 
 This implementation does not currently check to ensure that there are no
 duplicates in the list of ranks.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_incl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_incl.3.rst
@@ -81,15 +81,6 @@ duplicates in the list of ranks.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Group_compare`

--- a/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
@@ -78,15 +78,6 @@ The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Group_free`

--- a/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_intersection.3.rst
@@ -8,7 +8,7 @@ MPI_Group_intersection
 :ref:`MPI_Group_intersection` - Produces a group at the intersection of two
 existing groups.
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Group), INTENT(OUT) :: newgroup
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  group1 : First group (handle).
 -  group2 : Second group (handle).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newgroup : Intersection group (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 The set-like operations are defined as follows:
@@ -75,7 +75,7 @@ intersection are commutative, but both are associative.
 
 The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_range_excl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_range_excl.3.rst
@@ -77,16 +77,7 @@ passing the resulting array of ranks and other arguments to
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Group_excl` :ref:`MPI_Group_free`

--- a/docs/man-openmpi/man3/MPI_Group_range_incl.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_range_incl.3.rst
@@ -104,16 +104,7 @@ ranges to include are valid ranks in the group.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Group_incl` :ref:`MPI_Group_free`

--- a/docs/man-openmpi/man3/MPI_Group_rank.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_rank.3.rst
@@ -67,12 +67,4 @@ MPI_UNDEFINED is returned.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_size.3.rst
@@ -66,12 +66,4 @@ the other hand, a call with group = MPI_GROUP_NULL is erroneous.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_translate_ranks.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_translate_ranks.3.rst
@@ -74,12 +74,4 @@ want to know their ranks in a subset of that group.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Group_union.3.rst
+++ b/docs/man-openmpi/man3/MPI_Group_union.3.rst
@@ -79,16 +79,7 @@ The new group can be empty, that is, equal to MPI_GROUP_EMPTY.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Group_free`

--- a/docs/man-openmpi/man3/MPI_Ibsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Ibsend.3.rst
@@ -82,16 +82,7 @@ completes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Test` :ref:`MPI_Wait`

--- a/docs/man-openmpi/man3/MPI_Improbe.3.rst
+++ b/docs/man-openmpi/man3/MPI_Improbe.3.rst
@@ -90,16 +90,7 @@ and can be received by passing the *message* handle to the :ref:`MPI_Mrecv` or
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Mprobe` :ref:`MPI_Probe` :ref:`MPI_Iprobe` :ref:`MPI_Mrecv` :ref:`MPI_Imrecv` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Imrecv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Imrecv.3.rst
@@ -94,16 +94,7 @@ matched -- and possible received -- before this :ref:`MPI_Imrecv` is canceled).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Mprobe` :ref:`MPI_Improbe` :ref:`MPI_Probe` :ref:`MPI_Iprobe` :ref:`MPI_Imrecv` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Info_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_create.3.rst
@@ -60,16 +60,7 @@ contains no key/value pairs.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_free` :ref:`MPI_Info_get` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
@@ -65,16 +65,7 @@ before :ref:`MPI_Init` and after :ref:`MPI_Finalize`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_free` :ref:`MPI_Info_get` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_create_env.3.rst
@@ -56,7 +56,7 @@ DESCRIPTION
 
 :ref:`MPI_Info_create_env` creates a new info object with the same construction as :ref:`MPI_INFO_ENV` as created during :ref:`MPI_Init` or :ref:`MPI_Init_thread` when the same arguments are used.
 
-Note
+NOTE
 ----
 
 :ref:`MPI_Info_create_env` is one of the few functions that can be called

--- a/docs/man-openmpi/man3/MPI_Info_delete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_delete.3.rst
@@ -69,16 +69,7 @@ defined in *info*, the call raises an error of class MPI_ERR_INFO_NOKEY.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_dup` :ref:`MPI_Info_free` :ref:`MPI_Info_get` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Info_dup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_dup.3.rst
@@ -65,16 +65,7 @@ with the same (key,value) pairs and the same ordering of keys.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_delete` :ref:`MPI_Info_free` :ref:`MPI_Info_get` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Info_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_free.3.rst
@@ -62,16 +62,7 @@ DESCRIPTION
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_get` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Info_get.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_get.3.rst
@@ -81,16 +81,7 @@ If *key* is larger than MPI_MAX_INFO_KEY, the call is erroneous.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_free`

--- a/docs/man-openmpi/man3/MPI_Info_get_nkeys.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_get_nkeys.3.rst
@@ -66,16 +66,7 @@ DESCRIPTION
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_get` :ref:`MPI_Info_get_nthkey` :ref:`MPI_Info_get_valuelen`

--- a/docs/man-openmpi/man3/MPI_Info_get_nthkey.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_get_nthkey.3.rst
@@ -71,16 +71,7 @@ not modified with :ref:`MPI_Info_set` or :ref:`MPI_Info_delete`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_get` :ref:`MPI_Info_get_nkeys` :ref:`MPI_Info_get_valuelen`

--- a/docs/man-openmpi/man3/MPI_Info_get_string.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_get_string.3.rst
@@ -87,16 +87,7 @@ If *key* is larger than MPI_MAX_INFO_KEY, the call is erroneous.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_free`

--- a/docs/man-openmpi/man3/MPI_Info_get_valuelen.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_get_valuelen.3.rst
@@ -78,16 +78,7 @@ If *key* is larger than MPI_MAX_INFO_KEY, the call is erroneous.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_get` :ref:`MPI_Info_get_nkeys` :ref:`MPI_Info_get_nthkey`

--- a/docs/man-openmpi/man3/MPI_Info_set.3.rst
+++ b/docs/man-openmpi/man3/MPI_Info_set.3.rst
@@ -74,16 +74,7 @@ or MPI_ERR_INFO_VALUE is raised, respectively.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Info_create` :ref:`MPI_Info_delete` :ref:`MPI_Info_dup` :ref:`MPI_Info_free` :ref:`MPI_Info_set`

--- a/docs/man-openmpi/man3/MPI_Init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Init.3.rst
@@ -92,18 +92,7 @@ input, or writing to standard output.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Init_thread` :ref:`MPI_Initialized` :ref:`MPI_Finalize` :ref:`MPI_Finalized`

--- a/docs/man-openmpi/man3/MPI_Init_thread.3.rst
+++ b/docs/man-openmpi/man3/MPI_Init_thread.3.rst
@@ -147,16 +147,7 @@ as compared to when using MPI_THREAD_SINGLE, for example.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Init` :ref:`MPI_Initialized` :ref:`MPI_Finalize` :ref:`MPI_Finalized`

--- a/docs/man-openmpi/man3/MPI_Initialized.3.rst
+++ b/docs/man-openmpi/man3/MPI_Initialized.3.rst
@@ -62,16 +62,7 @@ initialized and after MPI has been finalized (:ref:`MPI_Finalized` is another).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Init` :ref:`MPI_Init_thread` :ref:`MPI_Finalize` :ref:`MPI_Finalized`

--- a/docs/man-openmpi/man3/MPI_Intercomm_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Intercomm_create.3.rst
@@ -102,16 +102,7 @@ the groups are not disjoint.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Intercomm_merge` :ref:`MPI_Comm_free` :ref:`MPI_Comm_remote_group`

--- a/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
+++ b/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
@@ -99,14 +99,6 @@ shall have a value of at least 63.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`;
-the predefined error handler MPI_ERRORS_RETURN may be used to cause
-error values to be returned. Note that MPI does not guarantee that an
-MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Comm_create_from_group`

--- a/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
+++ b/docs/man-openmpi/man3/MPI_Intercomm_create_from_groups.3.rst
@@ -8,7 +8,7 @@ MPI_Intercomm_create_from_groups
 :ref:`MPI_Intercomm_create_from_groups` - Creates a new inter-communicator from
 a local and remote group and stringtag
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -48,7 +48,7 @@ Fortran 2008 Syntax
        TYPE(MPI_Comm), INTENT(OUT) :: newintercomm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  local_group : Local group (handler)
@@ -61,13 +61,13 @@ Input Parameters
 -  errhandler : error handler to be attached to the new
    inter-communicator (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  newintercomm : New inter-communicator (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Intercomm_create_from_groups` creates an inter-communicator. Unlike
@@ -87,7 +87,7 @@ event that MPI_GROUP_EMPTY is supplied as the local_group or
 remote_group1 or both, then the call is a local operation and
 MPI_COMM_NULL is returned as the newintercomm.
 
-Notes
+NOTES
 -----
 
 The errhandler argument specifies an error handler to be attached to the
@@ -96,7 +96,7 @@ possibly MPI implementation dependent, which indicate desired
 characteristics and guide communicator creation. MPI_MAX_STRINGTAG_LEN
 shall have a value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Intercomm_merge.3.rst
+++ b/docs/man-openmpi/man3/MPI_Intercomm_merge.3.rst
@@ -76,16 +76,7 @@ blocking and collective within the union of the two groups.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Intercomm_create` :ref:`MPI_Comm_free`

--- a/docs/man-openmpi/man3/MPI_Iprobe.3.rst
+++ b/docs/man-openmpi/man3/MPI_Iprobe.3.rst
@@ -116,16 +116,7 @@ that actually returns true for the same message for both threads.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Probe` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Irecv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Irecv.3.rst
@@ -87,16 +87,7 @@ this function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Recv` :ref:`MPI_Probe` :ref:`MPI_Test` :ref:`MPI_Testany` :ref:`MPI_Wait` :ref:`MPI_Waitany`

--- a/docs/man-openmpi/man3/MPI_Irsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Irsend.3.rst
@@ -82,16 +82,7 @@ completes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Rsend`

--- a/docs/man-openmpi/man3/MPI_Is_thread_main.3.rst
+++ b/docs/man-openmpi/man3/MPI_Is_thread_main.3.rst
@@ -62,18 +62,7 @@ MPI_Init_thread).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Init` :ref:`MPI_Init_thread`

--- a/docs/man-openmpi/man3/MPI_Isend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Isend.3.rst
@@ -86,16 +86,7 @@ this function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Send` :ref:`MPI_Wait` :ref:`MPI_Waitany` :ref:`MPI_Test` :ref:`MPI_Testany`

--- a/docs/man-openmpi/man3/MPI_Isendrecv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Isendrecv.3.rst
@@ -108,16 +108,7 @@ request returned by this function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Isendrecv_replace` :ref:`MPI_Sendrecv` :ref:`MPI_Sendrecv_replace`

--- a/docs/man-openmpi/man3/MPI_Isendrecv_replace.3.rst
+++ b/docs/man-openmpi/man3/MPI_Isendrecv_replace.3.rst
@@ -105,16 +105,7 @@ request returned by this function.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Isendrecv` :ref:`MPI_Sendrecv` :ref:`MPI_Sendrecv_replace`

--- a/docs/man-openmpi/man3/MPI_Issend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Issend.3.rst
@@ -84,16 +84,7 @@ completes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Ssend`

--- a/docs/man-openmpi/man3/MPI_Keyval_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Keyval_create.3.rst
@@ -153,16 +153,7 @@ of key values.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Keyval_free` :ref:`MPI_Comm_create_keyval`

--- a/docs/man-openmpi/man3/MPI_Keyval_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Keyval_free.3.rst
@@ -67,16 +67,7 @@ Key values are global (they can be used with any and all communicators).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Keyval_create` :ref:`MPI_Comm_free_keyval`

--- a/docs/man-openmpi/man3/MPI_Lookup_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Lookup_name.3.rst
@@ -121,18 +121,7 @@ For a more detailed description of scoping rules, please see the
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Publish_name` :ref:`MPI_Open_port`

--- a/docs/man-openmpi/man3/MPI_Mprobe.3.rst
+++ b/docs/man-openmpi/man3/MPI_Mprobe.3.rst
@@ -86,16 +86,7 @@ message can then be received by passing the *message* handle to the
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Improbe` :ref:`MPI_Probe` :ref:`MPI_Iprobe` :ref:`MPI_Mrecv` :ref:`MPI_Imrecv` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Mrecv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Mrecv.3.rst
@@ -79,16 +79,7 @@ from MPI_PROC_NULL was issued.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Mprobe` :ref:`MPI_Improbe` :ref:`MPI_Probe` :ref:`MPI_Iprobe` :ref:`MPI_Imrecv` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Neighbor_allgather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_allgather.3.rst
@@ -165,16 +165,7 @@ operation.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Neighbor_allgatherv` :ref:`MPI_Cart_create` MPI_Garph_create

--- a/docs/man-openmpi/man3/MPI_Neighbor_allgatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_allgatherv.3.rst
@@ -174,16 +174,7 @@ operation.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Neighbor_allgather` :ref:`MPI_Cart_create` :ref:`MPI_Graph_create`

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoall.3.rst
@@ -208,16 +208,7 @@ allow the exchange of data with different datatypes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Neighbor_alltoallv` :ref:`MPI_Neighbor_alltoallw` :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoallv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoallv.3.rst
@@ -224,16 +224,7 @@ The offsets of *sdispls* and *rdispls* are measured in units of
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Neighbor_alltoall` :ref:`MPI_Neighbor_alltoallw` :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoallw.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoallw.3.rst
@@ -211,16 +211,7 @@ units of *sendtype* and *recvtype*, respectively.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Neighbor_alltoall` :ref:`MPI_Neighbor_alltoallv` :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Op_commutative.3.rst
+++ b/docs/man-openmpi/man3/MPI_Op_commutative.3.rst
@@ -65,16 +65,7 @@ Reduction operations can be queried for their commutativity.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Op_create`

--- a/docs/man-openmpi/man3/MPI_Op_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Op_create.3.rst
@@ -214,16 +214,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Reduce` :ref:`MPI_Reduce_scatter` :ref:`MPI_Allreduce` :ref:`MPI_Scan` :ref:`MPI_Op_free`

--- a/docs/man-openmpi/man3/MPI_Op_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Op_free.3.rst
@@ -63,16 +63,7 @@ to MPI_OP_NULL.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Op_create` :ref:`MPI_Reduce` :ref:`MPI_Allreduce` :ref:`MPI_Reduce_scatter` :ref:`MPI_Scan`

--- a/docs/man-openmpi/man3/MPI_Open_port.3.rst
+++ b/docs/man-openmpi/man3/MPI_Open_port.3.rst
@@ -79,16 +79,7 @@ None.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Comm_accept` :ref:`MPI_Comm_connect`

--- a/docs/man-openmpi/man3/MPI_Pack.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pack.3.rst
@@ -116,16 +116,7 @@ subsequently used for sending the packed message.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Unpack` :ref:`MPI_Pack_size`

--- a/docs/man-openmpi/man3/MPI_Pack_external.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pack_external.3.rst
@@ -176,18 +176,7 @@ of related unpack calls.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external_size` :ref:`MPI_Send` :ref:`MPI_Unpack_external` sscanf(3C)

--- a/docs/man-openmpi/man3/MPI_Pack_external_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pack_external_size.3.rst
@@ -90,18 +90,7 @@ for future extensibility.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external` :ref:`MPI_Unpack_external`

--- a/docs/man-openmpi/man3/MPI_Pack_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pack_size.3.rst
@@ -79,16 +79,7 @@ take more space).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack` :ref:`MPI_Unpack`

--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -61,16 +61,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pready_list` :ref:`MPI_Pready_range` :ref:`MPI_Parrived`

--- a/docs/man-openmpi/man3/MPI_Pready.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready.3.rst
@@ -59,16 +59,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pready_list` :ref:`MPI_Pready_range` :ref:`MPI_Parrived`

--- a/docs/man-openmpi/man3/MPI_Pready_list.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready_list.3.rst
@@ -61,16 +61,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pready` :ref:`MPI_Pready_range` :ref:`MPI_Parrived`

--- a/docs/man-openmpi/man3/MPI_Pready_range.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready_range.3.rst
@@ -60,16 +60,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pready` :ref:`MPI_Pready_list` :ref:`MPI_Parrived`

--- a/docs/man-openmpi/man3/MPI_Precv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Precv_init.3.rst
@@ -69,16 +69,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 NOTE
 ----

--- a/docs/man-openmpi/man3/MPI_Probe.3.rst
+++ b/docs/man-openmpi/man3/MPI_Probe.3.rst
@@ -141,16 +141,7 @@ that is distinct from the message probed by the preceding call to
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Iprobe` :ref:`MPI_Cancel`

--- a/docs/man-openmpi/man3/MPI_Psend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Psend_init.3.rst
@@ -69,16 +69,7 @@ OUTPUT PARAMETERS
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 NOTE
 ----

--- a/docs/man-openmpi/man3/MPI_Publish_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Publish_name.3.rst
@@ -154,18 +154,7 @@ communication with it.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Lookup_name` :ref:`MPI_Open_port`

--- a/docs/man-openmpi/man3/MPI_Put.3.rst
+++ b/docs/man-openmpi/man3/MPI_Put.3.rst
@@ -181,16 +181,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Get` :ref:`MPI_Rget` :ref:`MPI_Accumulate` :ref:`MPI_Win_flush` :ref:`MPI_Win_flush_all`

--- a/docs/man-openmpi/man3/MPI_Query_thread.3.rst
+++ b/docs/man-openmpi/man3/MPI_Query_thread.3.rst
@@ -86,18 +86,7 @@ is MPI_THREAD_MULTIPLE.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Init` :ref:`MPI_Init_thread`

--- a/docs/man-openmpi/man3/MPI_Recv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Recv.3.rst
@@ -144,16 +144,7 @@ special value for the *status* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Irecv` :ref:`MPI_Probe`

--- a/docs/man-openmpi/man3/MPI_Recv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Recv_init.3.rst
@@ -86,16 +86,7 @@ initiated by the function :ref:`MPI_Start` or :ref:`MPI_Startall`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Rsend_init` :ref:`MPI_Send_init` MPI_Sssend_init :ref:`MPI_Start`

--- a/docs/man-openmpi/man3/MPI_Reduce.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce.3.rst
@@ -550,16 +550,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Allreduce` :ref:`MPI_Reduce_scatter` :ref:`MPI_Scan` :ref:`MPI_Op_create` :ref:`MPI_Op_free`

--- a/docs/man-openmpi/man3/MPI_Reduce_local.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce_local.3.rst
@@ -318,16 +318,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Allreduce` :ref:`MPI_Reduce` :ref:`MPI_Reduce_scatter` :ref:`MPI_Scan` :ref:`MPI_Op_create`

--- a/docs/man-openmpi/man3/MPI_Reduce_scatter.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce_scatter.3.rst
@@ -163,12 +163,4 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Reduce_scatter_block.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce_scatter_block.3.rst
@@ -166,16 +166,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Reduce_scatter`

--- a/docs/man-openmpi/man3/MPI_Register_datarep.3.rst
+++ b/docs/man-openmpi/man3/MPI_Register_datarep.3.rst
@@ -118,12 +118,4 @@ Error classes are found in mpi.h (for C) and mpif.h (for Fortran).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. For MPI I/O function errors, the default error handler is set to
-MPI_ERRORS_RETURN. The error handler may be changed with
-:ref:`MPI_File_set_errhandler`; the predefined error handler
-MPI_ERRORS_ARE_FATAL may be used to make I/O errors fatal. Note that MPI
-does not guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Request_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Request_free.3.rst
@@ -118,16 +118,7 @@ can not use the request in a wait or test routine (e.g., :ref:`MPI_Wait` ).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include ../ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Isend` :ref:`MPI_Irecv` :ref:`MPI_Issend` :ref:`MPI_Ibsend` :ref:`MPI_Irsend` :ref:`MPI_Recv_init`

--- a/docs/man-openmpi/man3/MPI_Request_get_status.3.rst
+++ b/docs/man-openmpi/man3/MPI_Request_get_status.3.rst
@@ -75,12 +75,4 @@ special value for the *status* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Rsend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Rsend.3.rst
@@ -74,12 +74,4 @@ the ready send is called.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Rsend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Rsend_init.3.rst
@@ -79,16 +79,7 @@ initiated by the function :ref:`MPI_Start`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Send_init` MPI_Sssend_init :ref:`MPI_Recv_init` :ref:`MPI_Start`

--- a/docs/man-openmpi/man3/MPI_Scan.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scan.3.rst
@@ -238,18 +238,7 @@ collective routines return the same error value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Exscan` :ref:`MPI_Op_create` :ref:`MPI_Reduce`

--- a/docs/man-openmpi/man3/MPI_Scatter.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scatter.3.rst
@@ -208,16 +208,7 @@ processes in the second group.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Scatterv` :ref:`MPI_Gather` :ref:`MPI_Gatherv`

--- a/docs/man-openmpi/man3/MPI_Scatterv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scatterv.3.rst
@@ -253,16 +253,7 @@ processes in the second group.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Gather` :ref:`MPI_Gatherv` :ref:`MPI_Scatter`

--- a/docs/man-openmpi/man3/MPI_Send.3.rst
+++ b/docs/man-openmpi/man3/MPI_Send.3.rst
@@ -80,16 +80,7 @@ refer to the MPI-1 Standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Isend` :ref:`MPI_Bsend` :ref:`MPI_Recv`

--- a/docs/man-openmpi/man3/MPI_Send_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Send_init.3.rst
@@ -80,16 +80,7 @@ initiated by the function :ref:`MPI_Start` or :ref:`MPI_Startall`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Ssend_init` :ref:`MPI_Rsend_init` :ref:`MPI_Recv_init` :ref:`MPI_Start`

--- a/docs/man-openmpi/man3/MPI_Sendrecv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Sendrecv.3.rst
@@ -114,16 +114,7 @@ special value for the *status* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Sendrecv_replace`

--- a/docs/man-openmpi/man3/MPI_Sendrecv_replace.3.rst
+++ b/docs/man-openmpi/man3/MPI_Sendrecv_replace.3.rst
@@ -110,16 +110,7 @@ one to execute the receive, followed by a join of these two threads.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Sendrecv`

--- a/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
@@ -72,9 +72,6 @@ processes in session if the default error handler has not been changed.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. See the MPI
-man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_create_errhandler`

--- a/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_call_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Session_call_errhandler
 :ref:`MPI_Session_call_errhandler` - Passes the supplied error code to the error
 handler assigned to a session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,18 +43,18 @@ Fortran 2008 Syntax
        INTEGER, INTENT(IN) :: errorcode
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  session : session with error handler (handle).
 -  errorcode : error code (integer).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 This function invokes the error handler assigned to the session
@@ -62,14 +62,14 @@ session with the supplied error code errorcode. If the error handler was
 successfully called, the process is not aborted, and the error handler
 returns, this function returns MPI_SUCCESS.
 
-Notes
+NOTES
 -----
 
 Users should note that the default error handler is
 MPI_ERRORS_ARE_FATAL. Thus, calling this function will abort the
 processes in session if the default error handler has not been changed.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
@@ -82,12 +82,4 @@ Fortran, the user routine should be of this form:
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the ``function`` and Fortran routines in the last argument. Before
-the error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O
-``function`` errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned.
-Note that MPI does not guarantee that an MPI program can continue past
-an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_create_errhandler.3.rst
@@ -8,7 +8,7 @@ MPI_Session_create_errhandler
 :ref:`MPI_Session_create_errhandler` - Creates an error handler that can be
 attached to sessions
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,18 +45,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameter
+INPUT PARAMETER
 ---------------
 
 -  ``function`` : User-defined error handling procedure (function).
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  ``errhandler`` : MPI error handler (handle).
 -  ``IERROR`` : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_create_errhandler` creates an error handler that can be
@@ -79,7 +79,7 @@ Fortran, the user routine should be of this form:
    SUBROUTINE SESSION_ERRHANDLER_FUNCTION(SESSION, ERROR_CODE, ...)
       INTEGER SESSION, ERROR_CODE
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
@@ -81,15 +81,6 @@ disconnected (with MPI_Comm_disconnect).
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_finalize.3.rst
@@ -7,7 +7,7 @@ MPI_Session_finalize
 
 :ref:`MPI_Session_finalize` - releases all MPI state associated with a session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -41,17 +41,17 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(IN) :: session
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session to be finalized (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_finalize` releases all MPI state associated with the supplied
@@ -59,7 +59,7 @@ session. Every instantiated session must be finalized using
 :ref:`MPI_Session_finalize`. The handle session is set to MPI_SESSION_NULL by
 the call.
 
-Notes
+NOTES
 -----
 
 Before an MPI process invokes :ref:`MPI_Session_finalize`, the process must
@@ -78,7 +78,7 @@ later, :ref:`MPI_Session_finalize` may be synchronizing on the group associated
 with a communicator that is only freed (with MPI_Comm_free) rather than
 disconnected (with MPI_Comm_disconnect).
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_errhandler.3.rst
@@ -67,14 +67,4 @@ with a session.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Session_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
@@ -74,15 +74,6 @@ The user is responsible for freeing info_used via :ref:`MPI_Info_free`.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_info.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_info
 :ref:`MPI_Session_get_info` - Returns an info object containing the hints of an
 MPI Session
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -42,18 +42,18 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(IN) :: session
        TYPE(MPI_Info), INTENT(OUT) :: info_used
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  info_used: info object (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_info` returns a new info object containing the hints of
@@ -66,12 +66,12 @@ hints that were set by the implementation. If no such hints exist, a
 handle to a newly created info object is returned that contains no
 key/value pair.
 
-Notes
+NOTES
 -----
 
 The user is responsible for freeing info_used via :ref:`MPI_Info_free`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
@@ -7,7 +7,7 @@ MPI_Session_get_nth_pset
 
 :ref:`MPI_Session_get_nth_pset` - Query runtime for name of the nth process set
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -46,25 +46,25 @@ Fortran 2008 Syntax
        CHARACTER(LEN=*), INTENT(OUT) :: pset_name
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  info: info object (handle)
 -  n: index of the desired process set name (integer)
 
-Input/Output Parameter
+INPUT/OUTPUT PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^^
 
 -  pset_len: length of the pset_name argument (integer)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  pset_name : name of the nth process set (string)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_nth_pset` returns the name of the nth process set in the
@@ -78,14 +78,14 @@ C, pset_len includes the required space for the null terminator. In C,
 this function returns a null terminated string in all cases where the
 pset_len input value is greater than 0.
 
-Notes
+NOTES
 -----
 
 Process set names have an implementation-defined maximum length of
 MPI_MAX_PSET_NAME_LEN characters. MPI_MAX_PSET_NAME_LEN shall have a
 value of at least 63.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_nth_pset.3.rst
@@ -88,15 +88,6 @@ value of at least 63.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_num_psets
 :ref:`MPI_Session_get_num_psets` - Query runtime for number of available
 process sets
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -44,19 +44,19 @@ Fortran 2008 Syntax
        INTEGER, INTENT(OUT) :: npset_names
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  info: info object (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  npset_names : number of available process sets (non-negtive integer)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_num_psets` is used to query the runtime for the number of
@@ -68,7 +68,7 @@ change the index of a particular process set name, or to change the name
 of the process set at a particular index, or to delete a process set
 name once it has been added.
 
-Notes
+NOTES
 -----
 
 When a process set becomes invalid, for example, when some processes
@@ -78,7 +78,7 @@ example, creating an MPI_Group from such a process set might succeed
 because it is a local operation, but creating an MPI_Comm from that
 group and attempting collective communication may raise an error.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_num_psets.3.rst
@@ -81,15 +81,6 @@ group and attempting collective communication may raise an error.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
@@ -8,7 +8,7 @@ MPI_Session_get_pset_info
 :ref:`MPI_Session_get_pset_info` - Returns an info object containing properties
 of a specific process set
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -45,19 +45,19 @@ Fortran 2008 Syntax
        TYPE(MPI_Info), INTENT(OUT) :: info
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  session : session (handle)
 -  pset_name : name of process set (string)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  info: info object (handle)
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_get_pset_info` is used to query properties of a specific
@@ -66,13 +66,13 @@ info object query functions. One key/value pair must be defined,
 "mpi_size". The value of the "mpi_size" key specifies the number of MPI
 processes in the process set.
 
-Notes
+NOTES
 -----
 
 The user is responsible for freeing the returned info object via
 :ref:`MPI_Info_free`.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_get_pset_info.3.rst
@@ -75,15 +75,6 @@ The user is responsible for freeing the returned info object via
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with
-MPI_Session_set_errhandler; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_init`

--- a/docs/man-openmpi/man3/MPI_Session_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_init.3.rst
@@ -7,7 +7,7 @@ MPI_Session_init
 
 :ref:`MPI_Session_init` - Creates a new session handle
 
-Syntax
+SYNTAX
 ------
 
 C Syntax
@@ -43,20 +43,20 @@ Fortran 2008 Syntax
        TYPE(MPI_Session), INTENT(OUT) :: session
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-Input Parameters
+INPUT PARAMETERS
 ----------------
 
 -  info : info object (handle)
 -  errhandler : error handler to be attached to the returned session
    (handle)
 
-Output Parameters
+OUTPUT PARAMETERS
 -----------------
 
 -  session : New session (handle).
 -  IERROR : Fortran only: Error status (integer).
 
-Description
+DESCRIPTION
 -----------
 
 :ref:`MPI_Session_init` is used to instantiate an MPI Session. The returned
@@ -65,7 +65,7 @@ characteristics of the job within which the process is running, as well
 as other system resources. An application can make multiple calls to
 :ref:`MPI_Session_init` and the related :ref:`MPI_Session_finalize` routine.
 
-Notes
+NOTES
 -----
 
 The info argument is used to request MPI functionality requirements and
@@ -74,7 +74,7 @@ possible MPI implementation specific capabilities.
 The errhandler argument specifies an error handler to invoke in the
 event that the Session instantiation call encounters an error.
 
-Errors
+ERRORS
 ------
 
 .. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Session_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_init.3.rst
@@ -77,13 +77,6 @@ event that the Session instantiation call encounters an error.
 Errors
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument. Before the
-error value is returned, the current MPI error handler is called. By
-default, this error handler aborts the MPI job, except for I/O function
-errors. The predefined error handler MPI_ERRORS_RETURN may be used to
-cause error values to be returned. Note that MPI does not guarantee that
-an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso:: :ref:`MPI_Session_get_num_psets` MPI_Session_group_from_pset

--- a/docs/man-openmpi/man3/MPI_Session_set_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_set_errhandler.3.rst
@@ -68,12 +68,4 @@ handler created by a call to :ref:`MPI_Session_create_errhandler`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Session_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Sizeof.3.rst
+++ b/docs/man-openmpi/man3/MPI_Sizeof.3.rst
@@ -65,14 +65,4 @@ This function is not available in C because it is not necessary.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Ssend.3.rst
+++ b/docs/man-openmpi/man3/MPI_Ssend.3.rst
@@ -73,12 +73,4 @@ Standard for more detailed information about such sends.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Ssend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Ssend_init.3.rst
@@ -79,16 +79,7 @@ initiated by the function :ref:`MPI_Start`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Send_init` :ref:`MPI_Rsend_init` :ref:`MPI_Recv_init` :ref:`MPI_Start`

--- a/docs/man-openmpi/man3/MPI_Start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Start.3.rst
@@ -83,16 +83,7 @@ call to :ref:`MPI_Ibsend`; and so on.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Rsend_init` :ref:`MPI_Send_init` MPI_Sssend_init

--- a/docs/man-openmpi/man3/MPI_Startall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Startall.3.rst
@@ -102,16 +102,7 @@ receive operation and, likewise, a receive operation initiated with
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Bsend_init` :ref:`MPI_Rsend_init` :ref:`MPI_Send_init` :ref:`MPI_Ssend_init` :ref:`MPI_Recv_init`

--- a/docs/man-openmpi/man3/MPI_Status_set_cancelled.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_cancelled.3.rst
@@ -85,12 +85,4 @@ unpredictable results and is strongly discouraged.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_set_elements.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_elements.3.rst
@@ -102,16 +102,7 @@ unpredictable results and is strongly discouraged.*
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 FORTRAN 77 NOTES
 ----------------

--- a/docs/man-openmpi/man3/MPI_Test.3.rst
+++ b/docs/man-openmpi/man3/MPI_Test.3.rst
@@ -99,17 +99,7 @@ event-driven thread scheduler can be emulated with periodic calls to
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`, :ref:`MPI_File_set_errhandler`, or
-:ref:`MPI_Win_set_errhandler` (depending on the type of MPI handle that
-generated the request); the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 Note that per MPI-1 section 3.2.5, MPI errors on requests passed to
 :ref:`MPI_TEST` do not set the status.MPI_ERROR field in the returned status.

--- a/docs/man-openmpi/man3/MPI_Test_cancelled.3.rst
+++ b/docs/man-openmpi/man3/MPI_Test_cancelled.3.rst
@@ -77,12 +77,4 @@ exceptionally.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Testall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Testall.3.rst
@@ -99,6 +99,8 @@ modified.
 ERRORS
 ------
 
+.. include:: ./ERRORS.rst
+
 For each invocation of :ref:`MPI_Testall`, if one or more requests generate an
 MPI error, only the *first* MPI request that caused an error will be
 passed to its corresponding error handler. No other error handlers will
@@ -106,14 +108,6 @@ be invoked (even if multiple requests generated errors). However, *all*
 requests that generate an error will have a relevant error code set in
 the corresponding status.MPI_ERROR field (unless MPI_STATUSES_IGNORE was
 used).
-
-The default error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`,
-:ref:`MPI_File_set_errhandler`, or :ref:`MPI_Win_set_errhandler` (depending on the
-type of MPI handle that generated the MPI request); the predefined error
-handler MPI_ERRORS_RETURN may be used to cause error values to be
-returned. Note that MPI does not guarantee that an MPI program can
-continue past an error.
 
 If the invoked error handler allows :ref:`MPI_Testall` to return to the caller,
 the value MPI_ERR_IN_STATUS will be returned in the C and Fortran

--- a/docs/man-openmpi/man3/MPI_Testany.3.rst
+++ b/docs/man-openmpi/man3/MPI_Testany.3.rst
@@ -99,17 +99,7 @@ special value for the *status* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`, :ref:`MPI_File_set_errhandler`, or
-:ref:`MPI_Win_set_errhandler` (depending on the type of MPI handle that
-generated the request); the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 Note that per MPI-1 section 3.2.5, MPI errors on requests passed to
 :ref:`MPI_TESTANY` do not set the status.MPI_ERROR field in the returned
@@ -117,7 +107,6 @@ status. The error code is passed to the back-end error handler and may
 be passed back to the caller through the return value of :ref:`MPI_TESTANY` if
 the back-end error handler returns it. The pre-defined MPI error handler
 MPI_ERRORS_RETURN exhibits this behavior, for example.
-
 
 .. seealso::
    :ref:`MPI_Comm_set_errhandler` :ref:`MPI_File_set_errhandler` :ref:`MPI_Test` :ref:`MPI_Testall`

--- a/docs/man-openmpi/man3/MPI_Testsome.3.rst
+++ b/docs/man-openmpi/man3/MPI_Testsome.3.rst
@@ -122,6 +122,8 @@ another client always sneak in first.
 ERRORS
 ------
 
+.. include:: ./ERRORS.rst
+
 For each invocation of :ref:`MPI_Testsome`, if one or more requests generate an
 MPI error, only the *first* MPI request that caused an error will be
 passed to its corresponding error handler. No other error handlers will
@@ -130,18 +132,9 @@ requests that generate an error will have a relevant error code set in
 the corresponding status.MPI_ERROR field (unless MPI_STATUSES_IGNORE was
 used).
 
-The default error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`,
-:ref:`MPI_File_set_errhandler`, or :ref:`MPI_Win_set_errhandler` (depending on the
-type of MPI handle that generated the MPI request); the predefined error
-handler MPI_ERRORS_RETURN may be used to cause error values to be
-returned. Note that MPI does not guarantee that an MPI program can
-continue past an error.
-
 If the invoked error handler allows :ref:`MPI_Testsome` to return to the
 caller, the value MPI_ERR_IN_STATUS will be returned in the C and
 Fortran bindings.
-
 
 .. seealso::
    :ref:`MPI_Comm_set_errhandler` :ref:`MPI_File_set_errhandler` :ref:`MPI_Test` :ref:`MPI_Testall`

--- a/docs/man-openmpi/man3/MPI_Topo_test.3.rst
+++ b/docs/man-openmpi/man3/MPI_Topo_test.3.rst
@@ -77,16 +77,7 @@ The output value *top_type* is one of the following:
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Graph_create` :ref:`MPI_Cart_create`

--- a/docs/man-openmpi/man3/MPI_Type_commit.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_commit.3.rst
@@ -80,12 +80,4 @@ equivalent to a no-op.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_contiguous.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_contiguous.3.rst
@@ -103,12 +103,4 @@ MPI-1 Standard.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_create_darray.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_darray.3.rst
@@ -161,12 +161,4 @@ provided in MPI-1.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_create_f90_complex.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_f90_complex.3.rst
@@ -124,18 +124,7 @@ the only way to obtain a matching MPI datatype is to use the functions
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external` :ref:`MPI_Sizeof` :ref:`MPI_Type_match_size` :ref:`MPI_Unpack_external`

--- a/docs/man-openmpi/man3/MPI_Type_create_f90_integer.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_f90_integer.3.rst
@@ -117,18 +117,7 @@ to obtain a matching MPI datatype is to use the functions :ref:`MPI_Sizeof` and
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external` :ref:`MPI_Sizeof` :ref:`MPI_Type_match_size` :ref:`MPI_Unpack_external`

--- a/docs/man-openmpi/man3/MPI_Type_create_f90_real.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_f90_real.3.rst
@@ -123,18 +123,7 @@ the only way to obtain a matching MPI datatype is to use the functions
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external` :ref:`MPI_Sizeof` :ref:`MPI_Type_match_size` :ref:`MPI_Unpack_external`

--- a/docs/man-openmpi/man3/MPI_Type_create_hvector.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_hvector.3.rst
@@ -94,16 +94,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_hvector` :ref:`MPI_Type_vector`

--- a/docs/man-openmpi/man3/MPI_Type_create_indexed_block.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_indexed_block.3.rst
@@ -94,16 +94,7 @@ while :ref:`MPI_Type_create_hindexed_block` takes displacements in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_indexed`

--- a/docs/man-openmpi/man3/MPI_Type_create_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_keyval.3.rst
@@ -136,16 +136,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_free_keyval`

--- a/docs/man-openmpi/man3/MPI_Type_create_resized.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_resized.3.rst
@@ -101,16 +101,7 @@ MPI-1 functions :ref:`MPI_Type_extent` and :ref:`MPI_Type_lb`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_extent`

--- a/docs/man-openmpi/man3/MPI_Type_create_struct.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_struct.3.rst
@@ -95,16 +95,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_struct` :ref:`MPI_Type_create_hindexed`

--- a/docs/man-openmpi/man3/MPI_Type_create_subarray.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_create_subarray.3.rst
@@ -152,13 +152,4 @@ then the entry in array of starts for that dimension is *n*-1.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler(3) <mpi_comm_set_errhandler>`; the
-predefined error handler MPI_ERRORS_RETURN may be used to cause error
-values to be returned. Note that MPI does not guarantee that an MPI
-program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_delete_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_delete_attr.3.rst
@@ -80,12 +80,4 @@ being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_dup.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_dup.3.rst
@@ -83,16 +83,7 @@ callback is being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_keyval`

--- a/docs/man-openmpi/man3/MPI_Type_extent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_extent.3.rst
@@ -89,16 +89,7 @@ extent(Typemap) to the next multiple of max(i) k(i).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_extent`

--- a/docs/man-openmpi/man3/MPI_Type_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_free.3.rst
@@ -69,12 +69,4 @@ arguments to derived datatype constructors are passed by value.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_free_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_free_keyval.3.rst
@@ -60,16 +60,7 @@ DESCRIPTION
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_keyval`

--- a/docs/man-openmpi/man3/MPI_Type_get_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_attr.3.rst
@@ -87,16 +87,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_set_attr`

--- a/docs/man-openmpi/man3/MPI_Type_get_contents.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_contents.3.rst
@@ -139,16 +139,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_envelope`

--- a/docs/man-openmpi/man3/MPI_Type_get_envelope.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_envelope.3.rst
@@ -115,16 +115,7 @@ obtained from the call :ref:`MPI_Type_get_contents`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_contents`

--- a/docs/man-openmpi/man3/MPI_Type_get_extent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_extent.3.rst
@@ -115,12 +115,4 @@ mpif.h and give the length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_get_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_name.3.rst
@@ -69,16 +69,7 @@ MPI data type.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_set_name`

--- a/docs/man-openmpi/man3/MPI_Type_get_true_extent.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_get_true_extent.3.rst
@@ -119,12 +119,4 @@ mpif.h and give the length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Type_hindexed.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_hindexed.3.rst
@@ -86,16 +86,7 @@ array_of_displacements argument. The newly created datatype has
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_hindexed` :ref:`MPI_Type_indexed`

--- a/docs/man-openmpi/man3/MPI_Type_hvector.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_hvector.3.rst
@@ -87,16 +87,7 @@ has a type map with count \* bl \* n entries:
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_hvector` :ref:`MPI_Type_vector`

--- a/docs/man-openmpi/man3/MPI_Type_indexed.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_indexed.3.rst
@@ -154,16 +154,7 @@ specified in bytes, rather than in multiples of the *oldtype* extent.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_hindexed`

--- a/docs/man-openmpi/man3/MPI_Type_lb.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_lb.3.rst
@@ -96,16 +96,7 @@ extent(Typemap) to the next multiple of max(i) k(i).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_extent`

--- a/docs/man-openmpi/man3/MPI_Type_match_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_match_size.3.rst
@@ -80,18 +80,7 @@ It is erroneous to specify a size not supported by the compiler.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Sizeof` :ref:`MPI_Type_get_extent`

--- a/docs/man-openmpi/man3/MPI_Type_set_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_set_attr.3.rst
@@ -87,16 +87,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_attr`

--- a/docs/man-openmpi/man3/MPI_Type_set_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_set_name.3.rst
@@ -69,16 +69,7 @@ type.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_name`

--- a/docs/man-openmpi/man3/MPI_Type_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_size.3.rst
@@ -80,16 +80,7 @@ hold the output value), it is set to MPI_UNDEFINED.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 FORTRAN 77 NOTES
 ----------------

--- a/docs/man-openmpi/man3/MPI_Type_struct.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_struct.3.rst
@@ -128,16 +128,7 @@ be used for the structure foo:
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_struct` :ref:`MPI_Type_create_hindexed`

--- a/docs/man-openmpi/man3/MPI_Type_ub.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_ub.3.rst
@@ -101,16 +101,7 @@ extent(Typemap) to the next multiple of max(i) k(i).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_get_extent`

--- a/docs/man-openmpi/man3/MPI_Type_vector.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_vector.3.rst
@@ -128,16 +128,7 @@ to MPI_Type_vector(1, count, n, oldtype, newtype), n arbitrary.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Type_create_hvector` :ref:`MPI_Type_hvector`

--- a/docs/man-openmpi/man3/MPI_Unpack.3.rst
+++ b/docs/man-openmpi/man3/MPI_Unpack.3.rst
@@ -149,16 +149,7 @@ a unit, by a sequence of related unpack calls.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack` :ref:`MPI_Pack_size`

--- a/docs/man-openmpi/man3/MPI_Unpack_external.3.rst
+++ b/docs/man-openmpi/man3/MPI_Unpack_external.3.rst
@@ -154,18 +154,7 @@ of related unpack calls.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Pack_external` :ref:`MPI_Pack_external_size` :ref:`MPI_Recv` sscanf(3C)

--- a/docs/man-openmpi/man3/MPI_Unpublish_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Unpublish_name.3.rst
@@ -117,18 +117,7 @@ For a more detailed description of scoping rules, please see the
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Publish_name` :ref:`MPI_Lookup_name` :ref:`MPI_Open_port`

--- a/docs/man-openmpi/man3/MPI_Wait.3.rst
+++ b/docs/man-openmpi/man3/MPI_Wait.3.rst
@@ -111,17 +111,7 @@ Example: Simple usage of nonblocking operations and :ref:`MPI_Wait`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`, :ref:`MPI_File_set_errhandler`, or
-:ref:`MPI_Win_set_errhandler` (depending on the type of MPI handle that
-generated the request); the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst 
 
 Note that per MPI-1 section 3.2.5, MPI errors on requests passed to
 :ref:`MPI_WAIT` do not set the status.MPI_ERROR field in the returned status.

--- a/docs/man-openmpi/man3/MPI_Waitall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Waitall.3.rst
@@ -99,6 +99,8 @@ MPI_STATUSES_IGNORE can be used as a special value for the
 ERRORS
 ------
 
+.. include:: ./ERRORS.rst
+
 For each invocation of :ref:`MPI_Waitall`, if one or more requests generate an
 MPI error, only the *first* MPI request that caused an error will be
 passed to its corresponding error handler. No other error handlers will
@@ -106,14 +108,6 @@ be invoked (even if multiple requests generated errors). However, *all*
 requests that generate an error will have a relevant error code set in
 the corresponding status.MPI_ERROR field (unless MPI_STATUSES_IGNORE was
 used).
-
-The default error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`,
-:ref:`MPI_File_set_errhandler`, or :ref:`MPI_Win_set_errhandler` (depending on the
-type of MPI handle that generated the MPI request); the predefined error
-handler MPI_ERRORS_RETURN may be used to cause error values to be
-returned. Note that MPI does not guarantee that an MPI program can
-continue past an error.
 
 If the invoked error handler allows :ref:`MPI_Waitall` to return to the caller,
 the value MPI_ERR_IN_STATUS will be returned in the C and Fortran

--- a/docs/man-openmpi/man3/MPI_Waitany.3.rst
+++ b/docs/man-openmpi/man3/MPI_Waitany.3.rst
@@ -110,17 +110,7 @@ special value for the *status* argument.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`, :ref:`MPI_File_set_errhandler`, or
-:ref:`MPI_Win_set_errhandler` (depending on the type of MPI handle that
-generated the request); the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst
 
 Note that per MPI-1 section 3.2.5, MPI errors on requests passed to
 :ref:`MPI_WAITANY` do not set the status.MPI_ERROR field in the returned

--- a/docs/man-openmpi/man3/MPI_Waitsome.3.rst
+++ b/docs/man-openmpi/man3/MPI_Waitsome.3.rst
@@ -140,6 +140,8 @@ range 1 to incount for Fortran.
 ERRORS
 ------
 
+.. include:: ./ERRORS.rst
+
 For each invocation of :ref:`MPI_Waitsome`, if one or more requests generate an
 MPI error, only the *first* MPI request that caused an error will be
 passed to its corresponding error handler. No other error handlers will
@@ -147,14 +149,6 @@ be invoked (even if multiple requests generated errors). However, *all*
 requests that generate an error will have a relevant error code set in
 the corresponding status.MPI_ERROR field (unless MPI_STATUSES_IGNORE was
 used).
-
-The default error handler aborts the MPI job, except for I/O function
-errors. The error handler may be changed with :ref:`MPI_Comm_set_errhandler`,
-:ref:`MPI_File_set_errhandler`, or :ref:`MPI_Win_set_errhandler` (depending on the
-type of MPI handle that generated the MPI request); the predefined error
-handler MPI_ERRORS_RETURN may be used to cause error values to be
-returned. Note that MPI does not guarantee that an MPI program can
-continue past an error.
 
 If the invoked error handler allows :ref:`MPI_Waitsome` to return to the
 caller, the value MPI_ERR_IN_STATUS will be returned in the C and

--- a/docs/man-openmpi/man3/MPI_Win_allocate.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_allocate.3.rst
@@ -118,16 +118,7 @@ type.*
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alloc_mem` :ref:`MPI_Free_mem` :ref:`MPI_Win_create` :ref:`MPI_Win_allocate_shared`

--- a/docs/man-openmpi/man3/MPI_Win_allocate_shared.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_allocate_shared.3.rst
@@ -138,16 +138,7 @@ type.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alloc_mem` :ref:`MPI_Free_mem` :ref:`MPI_Win_allocate` :ref:`MPI_Win_create`

--- a/docs/man-openmpi/man3/MPI_Win_attach.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_attach.3.rst
@@ -102,12 +102,4 @@ and so on).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_call_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_call_errhandler.3.rst
@@ -77,11 +77,7 @@ window.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-See the MPI man page for a full list of MPI error codes.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_create_errhandler` :ref:`MPI_Win_set_errhandler`

--- a/docs/man-openmpi/man3/MPI_Win_complete.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_complete.3.rst
@@ -66,16 +66,7 @@ not have completed at the target when it has completed at the origin.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_start`

--- a/docs/man-openmpi/man3/MPI_Win_create.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_create.3.rst
@@ -156,16 +156,7 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alloc_mem` :ref:`MPI_Free_mem` :ref:`MPI_Win_allocate` :ref:`MPI_Win_allocate_shared`

--- a/docs/man-openmpi/man3/MPI_Win_create_dynamic.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_create_dynamic.3.rst
@@ -111,16 +111,7 @@ correct offset calculations with proper type handling.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_attach` :ref:`MPI_Win_detach` :ref:`MPI_Get_address`

--- a/docs/man-openmpi/man3/MPI_Win_create_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_create_errhandler.3.rst
@@ -90,12 +90,4 @@ In Fortran, the user routine should be of the form:
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_create_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_create_keyval.3.rst
@@ -133,12 +133,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_delete_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_delete_attr.3.rst
@@ -71,12 +71,4 @@ being invoked.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_fence.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_fence.3.rst
@@ -113,16 +113,7 @@ or accumulate that are synchronized with fence calls.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_create` :ref:`MPI_Win_start` :ref:`MPI_Win_post` :ref:`MPI_Win_complete` :ref:`MPI_Win_wait`

--- a/docs/man-openmpi/man3/MPI_Win_flush.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_flush.3.rst
@@ -80,17 +80,7 @@ Can only be called from within a passive target epoch.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_flush_local` :ref:`MPI_Win_lock` :ref:`MPI_Win_lock_all`

--- a/docs/man-openmpi/man3/MPI_Win_flush_local.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_flush_local.3.rst
@@ -81,17 +81,7 @@ Can only be called from within a passive target epoch.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_flush` :ref:`MPI_Win_lock` :ref:`MPI_Win_lock_all`

--- a/docs/man-openmpi/man3/MPI_Win_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_free.3.rst
@@ -76,16 +76,7 @@ call will be freed when calling :ref:`MPI_Win_free`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_create` :ref:`MPI_Win_allocate` :ref:`MPI_Win_allocate_shared`

--- a/docs/man-openmpi/man3/MPI_Win_free_keyval.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_free_keyval.3.rst
@@ -56,12 +56,4 @@ OUTPUT PARAMETER
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_get_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_get_attr.3.rst
@@ -86,12 +86,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_get_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_get_errhandler.3.rst
@@ -66,12 +66,4 @@ with a window.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_get_group.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_get_group.3.rst
@@ -67,12 +67,4 @@ in *group*.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_get_info.3.rst
@@ -69,16 +69,7 @@ info_used via :ref:`MPI_Info_free`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_set_info` :ref:`MPI_Win_free`

--- a/docs/man-openmpi/man3/MPI_Win_get_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_get_name.3.rst
@@ -65,12 +65,4 @@ DESCRIPTION
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_lock.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_lock.3.rst
@@ -97,16 +97,7 @@ failing to notice that the peer MPI job has terminated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_unlock` :ref:`MPI_Win_lock_all`

--- a/docs/man-openmpi/man3/MPI_Win_lock_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_lock_all.3.rst
@@ -98,16 +98,7 @@ call, failing to notice that the peer MPI job has terminated.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_unlock_all` :ref:`MPI_Win_lock`

--- a/docs/man-openmpi/man3/MPI_Win_post.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_post.3.rst
@@ -88,16 +88,7 @@ MPI_MODE_NOPUT
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_start` :ref:`MPI_Win_wait`

--- a/docs/man-openmpi/man3/MPI_Win_set_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_set_attr.3.rst
@@ -83,12 +83,4 @@ length of the declared integer in bytes.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_set_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_set_errhandler.3.rst
@@ -69,12 +69,4 @@ handler created by a call to :ref:`MPI_Win_create_errhandler`.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_set_info.3.rst
@@ -68,16 +68,7 @@ the same value in each process's *info* object.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_get_info` :ref:`MPI_Info_create` :ref:`MPI_Info_set` :ref:`MPI_Info_free`

--- a/docs/man-openmpi/man3/MPI_Win_set_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_set_name.3.rst
@@ -66,12 +66,4 @@ DESCRIPTION
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_shared_query.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_shared_query.3.rst
@@ -95,16 +95,7 @@ pointer to a pointer of arbitrary type (e.g. *void \*\**).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Alloc_mem` :ref:`MPI_Win_allocate_shared`

--- a/docs/man-openmpi/man3/MPI_Win_start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_start.3.rst
@@ -81,16 +81,7 @@ MPI_MODE_NOCHECK
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_post` :ref:`MPI_Win_complete`

--- a/docs/man-openmpi/man3/MPI_Win_sync.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_sync.3.rst
@@ -67,13 +67,4 @@ epoch or complete any pending MPI RMA operations).
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler
-MPI_ERRORS_RETURN may be used to cause error values to be returned. Note
-that MPI does not guarantee that an MPI program can continue past an
-error.
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Win_test.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_test.3.rst
@@ -74,16 +74,7 @@ window is posted anew.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_post` :ref:`MPI_Win_wait`

--- a/docs/man-openmpi/man3/MPI_Win_unlock.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_unlock.3.rst
@@ -76,16 +76,7 @@ protected by an exclusive lock to the same window.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_lock` :ref:`MPI_Win_unlock_all`

--- a/docs/man-openmpi/man3/MPI_Win_unlock_all.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_unlock_all.3.rst
@@ -74,16 +74,7 @@ protected by an exclusive lock to the same window.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Comm_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_lock_all` :ref:`MPI_Win_unlock`

--- a/docs/man-openmpi/man3/MPI_Win_wait.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_wait.3.rst
@@ -71,16 +71,7 @@ target window.
 ERRORS
 ------
 
-Almost all MPI routines return an error value; C routines as the value
-of the function and Fortran routines in the last argument.
-
-Before the error value is returned, the current MPI error handler is
-called. By default, this error handler aborts the MPI job, except for
-I/O function errors. The error handler may be changed with
-:ref:`MPI_Win_set_errhandler`; the predefined error handler MPI_ERRORS_RETURN
-may be used to cause error values to be returned. Note that MPI does not
-guarantee that an MPI program can continue past an error.
-
+.. include:: ./ERRORS.rst
 
 .. seealso::
    :ref:`MPI_Win_post`

--- a/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
+++ b/docs/man-openmpi/man3/OMPI_Affinity_str.3.rst
@@ -87,7 +87,7 @@ What processors exist.
    can see (which is *usually* all processors in the system).
 
 
-Examples
+EXAMPLES
 ^^^^^^^^
 
 **Example 1:** Print out processes binding using resource string format.


### PR DESCRIPTION
Update MPI function man pages to describe MPI runtime error handling as specified by the MPI-4 standard.

Update MPI function pages to consistently use upper case headings for each major section.

This pull request is a cherry-pick of #11015 and #11077 from the ompi main branch