### PR TITLE
config/opal_check_os_flavors.m4: fix -Wimplicit-int in OPAL_CHECK_OS_...

### DIFF
--- a/config/opal_check_os_flavors.m4
+++ b/config/opal_check_os_flavors.m4
@@ -22,7 +22,7 @@ AC_DEFUN([OPAL_CHECK_OS_FLAVOR_SPECIFIC],
     AC_MSG_CHECKING([$1])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
      [[#ifndef $1
-      error: this is not $1
+      #this is not $1, error
       #endif
      ]])],
                       [opal_found_$2=yes],


### PR DESCRIPTION
…FLAVOR_SPECIFIC

Clang 16 makes -Wimplicit-intan error by default.

This one is harmless but it's very noisy, especially because it's used
a bunch in subconfigures. These warnings becoming errors can, especially in configure,
lead to miscompiled or misconfigured software, so distributions are starting
to look for instances of them in config.log, etc.

In this case, an error is supposed to fire (because it's checking platform
name) but it's easier to use the preprocessor directive '#error' so that
we don't trigger a -Wimplicit-int warning/error instead.

Fixes errors like:
```
error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Werror,-Wimplicit-int]
```

For more information, see LWN.net [0] or LLVM's Discourse [1], Gentoo's wiki [2]
or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
[2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Signed-off-by: Sam James <sam@gentoo.org>