### PR TITLE
build: fix bashisms in configure

### DIFF
--- a/ompi/mca/op/avx/configure.m4
+++ b/ompi/mca/op/avx/configure.m4
@@ -315,15 +315,15 @@ AC_DEFUN([MCA_ompi_op_avx_CONFIG],[
                        [$op_sse3_support],
                        [SSE3 supported in the current build])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_avx512_support],
-                   [test "$op_avx512_support" == "1"])
+                   [test "$op_avx512_support" = "1"])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_avx2_support],
-                   [test "$op_avx2_support" == "1"])
+                   [test "$op_avx2_support" = "1"])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_avx_support],
-                   [test "$op_avx_support" == "1"])
+                   [test "$op_avx_support" = "1"])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_sse41_support],
-                   [test "$op_sse41_support" == "1"])
+                   [test "$op_sse41_support" = "1"])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_sse3_support],
-                   [test "$op_sse3_support" == "1"])
+                   [test "$op_sse3_support" = "1"])
     AC_SUBST(MCA_BUILD_OP_AVX512_FLAGS)
     AC_SUBST(MCA_BUILD_OP_AVX2_FLAGS)
     AC_SUBST(MCA_BUILD_OP_AVX_FLAGS)

--- a/opal/mca/memory/patcher/configure.m4
+++ b/opal/mca/memory/patcher/configure.m4
@@ -51,7 +51,7 @@ AC_DEFUN([MCA_opal_memory_patcher_CONFIG],[
     # Per the above logic, memory patcher no longer supports MacOS/Darwin,
     # so we no longer support Darwin-specific logic for intercept_mmap.
     # See issue #6853: mmap infinite recurse in opal/mca/memory/patcher
-    AS_IF([test "$opal_memory_patcher_happy" == "yes"], [
+    AS_IF([test "$opal_memory_patcher_happy" = "yes"], [
         AC_CHECK_FUNCS([__curbrk])
         AC_CHECK_HEADERS([linux/mman.h sys/syscall.h])
         AC_CHECK_DECLS([__syscall], [], [], [#include <sys/syscall.h>])


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>