### PR TITLE
OFI/MTL: bypass HMEM mem reg for CXI provider

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019-2021 Triad National Security, LLC. All rights
+ * Copyright (c) 2019-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  *                         reserved.
@@ -306,7 +306,7 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         return OMPI_SUCCESS;
     }
 
-    if (convertor->flags & CONVERTOR_ACCELERATOR) {
+    if ((convertor->flags & CONVERTOR_ACCELERATOR) && ompi_mtl_ofi.hmem_needs_reg) {
         /* Register buffer */
         int ret;
         struct fi_mr_attr attr = {0};

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -777,6 +777,19 @@ select_prov:
         *accelerator_support = false;
     } else {
         *accelerator_support = true;
+        ompi_mtl_ofi.hmem_needs_reg = true;
+        /*
+         * Workaround for the fact that the CXI provider actually doesn't need for accelerator memory to be registered
+         * for local buffers, but if one does do so using fi_mr_regattr, one actually needs to manage the
+         * requested_key field in the fi_mr_attr attr argument, and the OFI MTL doesn't track which requested_keys
+         * have already been registered. So just set a flag to disable local registration.  Note the OFI BTL doesn't
+         * have a problem here since it uses fi_mr_regattr only within the context of an rcache, and manages the
+         * requested_key field in this way.
+         */
+         if (!strncasecmp(prov->fabric_attr->prov_name, "cxi", 3)) {
+             ompi_mtl_ofi.hmem_needs_reg = false;
+         }
+
     }
 
     /**

--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved
  *
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022 Triad National Security, LLC. All rights
+ *                    reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,6 +99,7 @@ typedef struct mca_mtl_ofi_module_t {
 
     bool is_initialized;
     bool has_posted_initial_buffer;
+    bool hmem_needs_reg;
 
 } mca_mtl_ofi_module_t;
 


### PR DESCRIPTION
The code in the OFI MTL to register acclerator memory doesn't work well with providers like CXI which require the libfabric consumer to specify the requested_key field in the fi_mr_attr arg to fi_mr_regattr.  As it turns out there's a simpe workaround though with this provider as it actually doesn't need accelerator memory to be registered for FI_MSG/FI_TAGGED type transfers.

This patch restores support for transfers to/from accelerator memory using the OFI MTL on SS11 (CXI provider).

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit a74f31df1cab9fd98790f722de38b34c1fc344f0)