### PR TITLE
oshmem: Fix segment reset

### DIFF
--- a/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
@@ -88,7 +88,6 @@ shmem_ds_reset(map_segment_t *ds_buf)
     ds_buf->mkeys_cache = NULL;
     ds_buf->mkeys = NULL;
     ds_buf->alloc_hints = 0;
-    ds_buf->context = NULL;
     ds_buf->allocator = NULL;
 }
 


### PR DESCRIPTION
Do not clear pointer to segment context in shmem_ds_reset, as it can be used by the following segment_unlink call
(which results in incorrect memory access)

Signed-off-by: Mikhail Brinskii <mikhailb@nvidia.com>