### PR TITLE
osc/ucx: Fix bugs with dynamic windows

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -82,7 +82,7 @@ typedef struct ompi_osc_ucx_epoch_type {
 #define OSC_UCX_STATE_COMPLETE_COUNT_OFFSET (sizeof(uint64_t) * 3)
 #define OSC_UCX_STATE_POST_INDEX_OFFSET (sizeof(uint64_t) * 4)
 #define OSC_UCX_STATE_POST_STATE_OFFSET (sizeof(uint64_t) * 5)
-#define OSC_UCX_STATE_DYNAMIC_LOCK_OFFSET (sizeof(uint64_t) * 6)
+#define OSC_UCX_STATE_DYNAMIC_LOCK_OFFSET (sizeof(uint64_t) * (5 + OMPI_OSC_UCX_POST_PEER_MAX))
 #define OSC_UCX_STATE_DYNAMIC_WIN_CNT_OFFSET (sizeof(uint64_t) * (6 + OMPI_OSC_UCX_POST_PEER_MAX))
 
 typedef struct ompi_osc_dynamic_win_info {
@@ -105,6 +105,7 @@ typedef struct ompi_osc_ucx_state {
     volatile uint64_t complete_count; /* # msgs received from complete processes */
     volatile uint64_t post_index;
     volatile uint64_t post_state[OMPI_OSC_UCX_POST_PEER_MAX];
+    volatile uint64_t dynamic_lock;
     volatile uint64_t dynamic_win_count;
     volatile ompi_osc_dynamic_win_info_t dynamic_wins[OMPI_OSC_UCX_ATTACH_MAX];
 } ompi_osc_ucx_state_t;

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -358,7 +358,9 @@ cleanup:
     free(temp_buf);
 
     /* unlock the dynamic lock */
-    return ompi_osc_ucx_dynamic_unlock(module, target);
+    ompi_osc_ucx_dynamic_unlock(module, target);
+
+    return ret;
 }
 
 static inline

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -843,7 +843,6 @@ static inline int ompi_osc_ucx_acc_rputget(void *stage_addr, int stage_count,
     ompi_osc_ucx_accumulate_request_t *ucx_req = NULL;
     bool sync_check;
     int ret = OMPI_SUCCESS;
-    CHECK_DYNAMIC_WIN(remote_addr, module, target, ret);
 
     if (acc_type != NONE) {
         OMPI_OSC_UCX_ACCUMULATE_REQUEST_ALLOC(win, ucx_req);
@@ -1394,8 +1393,6 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
         return ret;
     }
 
-    CHECK_DYNAMIC_WIN(remote_addr, module, target, ret);
-
     ret = ompi_osc_ucx_put(origin_addr, origin_count, origin_dt, target, target_disp,
                            target_count, target_dt, win);
     if (ret != OMPI_SUCCESS) {
@@ -1449,8 +1446,6 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
     if (ret != OMPI_SUCCESS) {
         return ret;
     }
-
-    CHECK_DYNAMIC_WIN(remote_addr, module, target, ret);
 
     ret = ompi_osc_ucx_get(origin_addr, origin_count, origin_dt, target, target_disp,
                            target_count, target_dt, win);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -838,6 +838,7 @@ select_unlock:
     module->state.complete_count = 0;
     module->state.req_flag = 0;
     module->state.acc_lock = TARGET_LOCK_UNLOCKED;
+    module->state.dynamic_lock = TARGET_LOCK_UNLOCKED;
     module->state.dynamic_win_count = 0;
     for (i = 0; i < OMPI_OSC_UCX_ATTACH_MAX; i++) {
         module->local_dynamic_win_info[i].refcnt = 0;


### PR DESCRIPTION
This PR contains three small bug fixes for dynamic windows in osc/ucx.

The first two fixes are for bugs introduced in this PR https://github.com/open-mpi/ompi/pull/10709 :
- The `get_dynamic_win_info()` function always returned `OMPI_SUCCESS` even if it caused an error in the middle, which hid the next error below
- `OSC_UCX_STATE_DYNAMIC_LOCK_OFFSET` was introduced but no actual `dynamic_lock` member was added, which resulted in corrupted `dynamic_win_count` value

The third issue is independent of the above PR, but it causes an error when we call `MPI_Rget` or `MPI_Rput` for dynamic windows.
As the `remote_addr` value for rget/rput was wrong, the dynamic window check always failed with rget/rput.
I fixed this issue by simply removing dynamic window check for rget/rput, because the request is eventually forwarded to `ompi_osc_ucx_get/put`, which correctly checks dynamic window status anyway.