### PR TITLE
v5.0.x: io/romio341: fix support for GCC 4.8 compilers

### DIFF
--- a/ompi/mca/io/romio341/configure.m4
+++ b/ompi/mca/io/romio341/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015-2021 Research Organization for Information Science
+# Copyright (c) 2015-2022 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
@@ -99,14 +99,21 @@ AC_DEFUN([MCA_ompi_io_romio341_CONFIG],[
                           . 3rd-party/romio341/localdefs
                           io_romio341_LIBS="$LIBS"
                           LIBS="$io_romio341_save_LIBS"
-                          OPAL_3RDPARTY_SUBDIRS="$OPAL_3RDPARTY_SUBDIRS romio341"
                           OPAL_3RDPARTY_DIST_SUBDIRS="$OPAL_3RDPARTY_DIST_SUBDIRS romio341"
 
-                          echo "ROMIO distribution configured successfully"
-                          $1],
+                          AC_MSG_NOTICE([ROMIO distribution configured successfully])],
                          [AS_IF([test "$enable_io_romio" = "yes"],
                                 [AC_MSG_ERROR([ROMIO distribution did not configure successfully])],
-                                [AC_MSG_WARN([ROMIO distribution did not configure successfully])])
-                          $2])])])
+                                [AC_MSG_WARN([ROMIO distribution did not configure successfully])])])
+
+                   AS_IF([test "$io_romio341_happy" = "1"],
+                         [AC_CHECK_HEADERS([stdatomic.h],
+                                           [OPAL_3RDPARTY_SUBDIRS="$OPAL_3RDPARTY_SUBDIRS romio341"],
+                                           [AC_MSG_WARN([3rd party ROMIO cannot be built, disqualifying the io/romio341 component])
+                                            io_romio341_happy=0])])
+
+                   AS_IF([test "$io_romio341_happy" = "1"],
+                         [$1],
+                         [$2])])])
     OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
ROMIO 3.4.1 requires <stdatomic.h>, but this is not checked by the embedded configure, causing a failure at compilation time if the compiler (such as GCC 4.8 provided by RHEL7 like distros).

Explicitly check for <stdatomic.h> and disable the io/romio341 component and the third party ROMIO if not available.

Refs. open-mpi/ompi#11088

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit c2ac975bdc57fd86f988e54ad442d3c6412b625b)