### PR TITLE
Fix undefined file offset in mca_io_ompio_file_seek.

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -443,7 +443,8 @@ int mca_io_ompio_file_seek (ompi_file_t *fh,
 {
     int ret = OMPI_SUCCESS;
     mca_common_ompio_data_t *data;
-    OMPI_MPI_OFFSET_TYPE offset, temp_offset, temp_offset2;
+    OMPI_MPI_OFFSET_TYPE offset, temp_offset2;
+    OMPI_MPI_OFFSET_TYPE temp_offset = 0;
 
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 


### PR DESCRIPTION
Clang static analysis flagged a garbage or undefined value in mca_io_ompio_file_seek in io_ompio_file_open.c in the MPI_SEEK_END case, following the call to  mca_io_ompio_file_get_eof_offset at line 472.

The temp_offset variable is not initialized at it's definition. Then it is not set in  mca_io_ompio_file_get_eof_offset if fh->f_view_size is <= 0.

mca_common_ompio_set_explicit_offset also checks if fh->f_view_size is > zero and does not update anything if the value is <= 0.

However, temp_offset is added to temp_offset at line 474 and the result is checked  at line 475. If the garbage value in temp_offset results in offset becoming negative, this will result in this function randomly returning  OMPI_ERROR status.

Initializing temp_offset to 0 prevents this from happening.
Signed-off-by: David Wootton <dwootton@us.ibm.com>