### PR TITLE
singleton: better fix for quieting ofi common

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -553,6 +553,14 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
     pname.jobid = OPAL_PROC_MY_NAME.jobid;
     pname.vpid = OPAL_VPID_WILDCARD;
 
+    /*
+     * if we are a singleton just return myprocid.rank
+     * because we by definition don't know about any local peers
+     */
+    if (opal_process_info.is_singleton) {
+        return (uint32_t) process_info->myprocid.rank;
+    }
+
 #if HAVE_DECL_PMIX_PACKAGE_RANK
     // Try to get the PACKAGE_RANK from PMIx
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PACKAGE_RANK, &pname, &package_rank_ptr, PMIX_UINT16);


### PR DESCRIPTION
about not knowing about local peers.  Because
with a singleton there aren't local peers so
don't emit a message about locality to devices.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit df1691aeef6edcdfb3626d24b3fc125efcc5e32e)