### PR TITLE
MPI_Comm_create_from_group: fix help message

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -355,7 +355,7 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
             opal_show_help("help-comm.txt",
                            "MPI function not supported",
                            true,
-                           "MPI_Comm_from_group/MPI_Intercomm_from_groups",
+                           "MPI_Comm_create_from_group/MPI_Intercomm_create_from_groups",
                            msg_string);
 
             ret = MPI_ERR_UNSUPPORTED_OPERATION;


### PR DESCRIPTION
to use correct MPI function name

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit d9605fd0d0ee4d4ce052507fa5ade2c549f4ee48)