### PR TITLE
NB Accumulate with DT and fix for issue/11114

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -68,7 +68,7 @@ extern opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts;
         opal_atomic_add_fetch_64(&(_var), (_val));                                  \
     } while(0);
 #else
-#define OPAL_COMMON_UCX_DEBUG_ATOMIC_ADD(&(_var), (_val));
+#define OPAL_COMMON_UCX_DEBUG_ATOMIC_ADD(_var, _val);
 #endif
 
 /* Worker Pool Context (wpctx) is an object that is comprised of a set of UCP


### PR DESCRIPTION
    OSC/UCX: Allow nonblocking get_accumulate to be called with results_addr
    equal to NULL (can happen with non-contiguous dt) and  Fix for issue/11114 (non-debug build failure)
    
    Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
    Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
    
    