### PR TITLE
Fix divide by zero error in calculate_num_nodes_up_to_level using MPI_Bcast with 2 tasks

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_topocache.c
+++ b/ompi/mca/coll/adapt/coll_adapt_topocache.c
@@ -59,7 +59,7 @@ static ompi_coll_tree_t *create_topology(
         {
             int fanout = ompi_comm_size(comm) - 1;
             ompi_coll_tree_t *tree;
-            if (fanout < 1) {
+            if (fanout <= 1) {
                 tree = ompi_coll_base_topo_build_chain(1, comm, root);
             } else if (fanout <= MAXTREEFANOUT) {
                 tree = ompi_coll_base_topo_build_tree(ompi_comm_size(comm) - 1, comm, root);

--- a/ompi/mca/coll/base/coll_base_topo.c
+++ b/ompi/mca/coll/base/coll_base_topo.c
@@ -59,7 +59,12 @@ static int calculate_num_nodes_up_to_level( int fanout, int level )
 {
     /* just use geometric progression formula for sum:
        a^0+a^1+...a^(n-1) = (a^n-1)/(a-1) */
-    return ((pown(fanout,level) - 1)/(fanout - 1));
+    if (1 == fanout) {
+        return level;
+    }
+    else {
+        return ((pown(fanout,level) - 1)/(fanout - 1));
+    }
 }
 
 /*


### PR DESCRIPTION
Clang static analysis reported a possible zerodivide exception at ompi/mca/coll/base/coll_base_topo.c:62 (calculate_num_nodes_up_to_level)

I was able to get this exception with the program

#include <mpi.h>
char buff[4096];
int main(int argc, char *argv[]) {
    MPI_Init(&argc, &argv);
    MPI_Bcast(buff, sizeof buff, MPI_CHAR, 0, MPI_COMM_WORLD);
    MPI_Finalize();
}

Using the command

mpirun -n 2  --mca coll_adapt_bcast_algorithm 6  --mca coll_adapt_priority 99 bcast

The calculate_num_nodes_up_to_level function is called from ompi_coll_base_topo_build_tree. The exception occurs because fanout is set to one in this case.

This is a cherry pick of #11103 from the main branch

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit a74927fc72294ef75c4c192a98ac95d170b98b60)