### PR TITLE
smsc/xpmem rcache: refactor to use tree find() instead of iterate()

### DIFF
--- a/opal/class/opal_interval_tree.c
+++ b/opal/class/opal_interval_tree.c
@@ -424,6 +424,8 @@ static opal_interval_tree_node_t *opal_interval_tree_find_interval(opal_interval
 static opal_interval_tree_node_t *
 opal_interval_tree_find_node(opal_interval_tree_t *tree, uint64_t low, uint64_t high, void *data)
 {
+    printf("tree find low 0x%lx high 0x%lx\n", low, high);
+
     return opal_interval_tree_find_interval(tree, tree->root.left, low, high, data);
 }
 
@@ -663,6 +665,8 @@ static void opal_interval_tree_insert_node(opal_interval_tree_t *tree,
     opal_interval_tree_node_t *parent = &tree->root;
     opal_interval_tree_node_t *n = parent->left; /* the real root of the tree */
     opal_interval_tree_node_t *nill = &tree->nill;
+
+    printf("tree insert low 0x%lx high 0x%lx\n", node->low, node->high);
 
     /* set up initial values for the node */
     node->color = OPAL_INTERVAL_TREE_COLOR_RED;

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -24,6 +24,8 @@
  * Copyright (c) 2019-2021 Google, Inc. All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -437,9 +439,9 @@ void mca_btl_sm_poll_handle_frag(mca_btl_sm_hdr_t *hdr, struct mca_btl_base_endp
                                               .cbdata = reg->cbdata};
 
     if (hdr->flags & MCA_BTL_SM_FLAG_SINGLE_COPY) {
-        void *ctx = MCA_SMSC_CALL(map_peer_region, endpoint->smsc_endpoint, /*flags=*/0,
-                                  hdr->sc_iov.iov_base, hdr->sc_iov.iov_len,
-                                  &segments[1].seg_addr.pval);
+        void *ctx = MCA_SMSC_CALL(map_peer_region, endpoint->smsc_endpoint,
+                                  MCA_RCACHE_FLAGS_PERSIST, hdr->sc_iov.iov_base,
+                                  hdr->sc_iov.iov_len, &segments[1].seg_addr.pval);
         assert(NULL != ctx);
 
         segments[1].seg_len = hdr->sc_iov.iov_len;

--- a/opal/mca/smsc/xpmem/smsc_xpmem_component.c
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_component.c
@@ -1,6 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2021      Google, Inc. All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,10 +78,7 @@ static int mca_smsc_xpmem_component_open(void)
 
 static int mca_smsc_xpmem_component_close(void)
 {
-    if (mca_smsc_xpmem_module.vma_module) {
-        OBJ_RELEASE(mca_smsc_xpmem_module.vma_module);
-    }
-
+    /* nothing to do */
     return OPAL_SUCCESS;
 }
 
@@ -160,8 +159,6 @@ static mca_smsc_module_t *mca_smsc_xpmem_component_enable(void)
     /* limit segment alignment to be between 4k and 16M */
     mca_smsc_xpmem_component.log_attach_align
         = opal_min(opal_max(mca_smsc_xpmem_component.log_attach_align, 12), 25);
-
-    mca_smsc_xpmem_module.vma_module = mca_rcache_base_vma_module_alloc();
 
     return &mca_smsc_xpmem_module.super;
 }

--- a/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
@@ -1,6 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2021      Google, Inc. All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,6 +14,7 @@
 #define OPAL_MCA_SMSC_XPMEM_SMSC_XPMEM_INTERNAL_H
 
 #include "opal/mca/smsc/xpmem/smsc_xpmem.h"
+#include "opal/mca/rcache/rcache.h"
 
 #include "opal/mca/rcache/base/rcache_base_vma.h"
 #if defined(HAVE_XPMEM_H)
@@ -42,6 +45,8 @@ struct mca_smsc_xpmem_endpoint_t {
     xpmem_apid_t apid;
     /** maximum address we can attach to on this peer */
     uintptr_t address_max;
+    /** cache of xpmem attachments created using this endpoint */
+    mca_rcache_base_vma_module_t *vma_module;
 };
 
 typedef struct mca_smsc_xpmem_endpoint_t mca_smsc_xpmem_endpoint_t;
@@ -67,10 +72,6 @@ typedef struct mca_smsc_xpmem_component_t mca_smsc_xpmem_component_t;
 
 struct mca_smsc_xpmem_module_t {
     mca_smsc_module_t super;
-
-    /** cache of xpmem attachments. this cache holds attachments for all peers. the registrations
-     * are differentiated by the alloc_base which is set to the endpoint. */
-    mca_rcache_base_vma_module_t *vma_module;
 };
 
 typedef struct mca_smsc_xpmem_module_t mca_smsc_xpmem_module_t;

--- a/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_internal.h
@@ -14,7 +14,6 @@
 #define OPAL_MCA_SMSC_XPMEM_SMSC_XPMEM_INTERNAL_H
 
 #include "opal/mca/smsc/xpmem/smsc_xpmem.h"
-#include "opal/mca/rcache/rcache.h"
 
 #include "opal/mca/rcache/base/rcache_base_vma.h"
 #if defined(HAVE_XPMEM_H)

--- a/opal/mca/smsc/xpmem/smsc_xpmem_module.c
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_module.c
@@ -7,6 +7,8 @@
  *                         reserved.
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,60 +48,22 @@ mca_smsc_endpoint_t *mca_smsc_xpmem_get_endpoint(opal_proc_t *peer_proc)
         return NULL;
     }
 
+    endpoint->vma_module = mca_rcache_base_vma_module_alloc();
+    if (OPAL_UNLIKELY(NULL == endpoint->vma_module)) {
+        OBJ_RELEASE(endpoint);
+        return NULL;
+    }
+
     endpoint->apid = xpmem_get(modex->seg_id, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
     endpoint->address_max = modex->address_max;
 
+    if(OPAL_UNLIKELY(-1 == endpoint->apid)) {
+        OBJ_RELEASE(endpoint->vma_module);
+        OBJ_RELEASE(endpoint);
+        return NULL;
+    }
+
     return &endpoint->super;
-}
-
-struct mca_smsc_xpmem_cleanup_reg_ctx_t {
-    mca_smsc_xpmem_endpoint_t *endpoint;
-    opal_list_t *registrations;
-};
-
-typedef struct mca_smsc_xpmem_cleanup_reg_ctx_t mca_smsc_xpmem_cleanup_reg_ctx_t;
-
-struct mca_smsc_xpmem_check_reg_ctx_t {
-    mca_smsc_xpmem_endpoint_t *endpoint;
-    mca_rcache_base_registration_t **reg;
-    uintptr_t base;
-    uintptr_t bound;
-};
-typedef struct mca_smsc_xpmem_check_reg_ctx_t mca_smsc_xpmem_check_reg_ctx_t;
-
-static int mca_smsc_xpmem_check_reg(mca_rcache_base_registration_t *reg, void *ctx)
-{
-    mca_smsc_xpmem_check_reg_ctx_t *xpmem_ctx = (mca_smsc_xpmem_check_reg_ctx_t *) ctx;
-
-    if (reg->alloc_base != (void *) xpmem_ctx->endpoint) {
-        /* ignore this registration */
-        return OPAL_SUCCESS;
-    }
-
-    xpmem_ctx->reg[0] = reg;
-
-    if (xpmem_ctx->bound <= (uintptr_t) reg->bound && xpmem_ctx->base >= (uintptr_t) reg->base) {
-        if (0 == opal_atomic_fetch_add_32(&reg->ref_count, 1)) {
-            /* registration is being deleted by a thread in sm_return_registration. the
-             * VMA tree implementation will block in mca_rcache_delete until we finish
-             * iterating over the VMA tree so it is safe to just ignore this registration
-             * and continue. */
-            xpmem_ctx->reg[0] = NULL;
-            return OPAL_SUCCESS;
-        }
-        return 1;
-    }
-
-    if (MCA_RCACHE_FLAGS_INVALID & opal_atomic_fetch_or_32(&reg->flags, MCA_RCACHE_FLAGS_INVALID)) {
-        /* another thread has already marked this registration as invalid. ignore and continue. */
-        xpmem_ctx->reg[0] = NULL;
-        return OPAL_SUCCESS;
-    }
-
-    /* let the caller know we found an overlapping registration that can be coalesced into
-     * the requested interval. the caller will remove the last reference and delete the
-     * registration. */
-    return 2;
 }
 
 /* look up the remote pointer in the peer rcache and attach if
@@ -108,10 +72,9 @@ void *mca_smsc_xpmem_map_peer_region(mca_smsc_endpoint_t *endpoint, uint64_t fla
                                      void *remote_ptr, size_t size, void **local_ptr)
 {
     mca_smsc_xpmem_endpoint_t *xpmem_endpoint = (mca_smsc_xpmem_endpoint_t *) endpoint;
-    mca_rcache_base_vma_module_t *vma_module = mca_smsc_xpmem_module.vma_module;
-    uint64_t attach_align = 1 << mca_smsc_xpmem_component.log_attach_align;
+    mca_rcache_base_vma_module_t *vma_module = xpmem_endpoint->vma_module;
+    uintptr_t attach_align = 1 << mca_smsc_xpmem_component.log_attach_align;
     mca_rcache_base_registration_t *reg = NULL;
-    mca_smsc_xpmem_check_reg_ctx_t check_ctx = {.endpoint = xpmem_endpoint, .reg = &reg};
     xpmem_addr_t xpmem_addr;
     uintptr_t base, bound;
     int rc;
@@ -122,55 +85,134 @@ void *mca_smsc_xpmem_map_peer_region(mca_smsc_endpoint_t *endpoint, uint64_t fla
         bound = xpmem_endpoint->address_max;
     }
 
-    check_ctx.base = base;
-    check_ctx.bound = bound;
+    rc = mca_rcache_base_vma_find(vma_module, (void *) base, bound - base, &reg);
+    assert(rc != OPAL_SUCCESS);
+    
+    // TODO Add rcache stats?
+    
+    /* For a number of operations here, while support for multiple threads is
+     * existent, might not produce the fully ideal result. Looks like this can't
+     * be fully resolved without respective support from the regcache tree.
+     * TODO finish comment. is it accurate?*/
+    
+    // TODO what if reg is deleted between finding it and atomically fetching the
+    // ref count? Or will the tree block? And this could also happen inside the
+    // tree's code.
+    
+    if (reg) {
+        int32_t old_ref_count = opal_atomic_fetch_add_32(&reg->ref_count, 1);
+        if(0 == old_ref_count) {
+            /* Registration is being deleted by another thread
+             * in mca_smsc_xpmem_unmap_peer_region, ignore it. */
+            reg = NULL;
+        }
+        
+        // TODO what if two threads increment the ref counter while a third one is
+        // deleting it? One of the increment-threads will see 1 as the old value
+        // and go ahead with using the registration, while the writer will delete it!
+        
+        // int32_t ref_count = opal_atomic_load_32(&reg->ref_count);
+        
+        // while(1) {
+            // if(0 == ref_count) {
+                // reg = NULL;
+                // break;
+            // }
+            
+            // if(opal_atomic_compare_exchange_strong_32(
+                    // &reg->ref_count, &ref_count, ref_count + 1)) {
+                // break;
+            // }
+        // }
+    
+    } else {
+        /* If there is a registration that overlaps with the requested range, but
+         * does not fully cover it, we destroy it and make a new one in its place
+         * to covers both the previous range and the new requested one. */
+        
+        rc = mca_rcache_base_vma_find(vma_module, (void *) base, 1, &reg);
+        assert(rc != OPAL_SUCCESS);
+        
+        // TODO is this correct?
+        // TODO check for hang. Only with non-debug?
+        
+        if(NULL == reg) {
+			rc = mca_rcache_base_vma_find(vma_module, (void *) (bound + 1), 1, &reg);
+			assert(rc != OPAL_SUCCESS);
+		}
+        
+        if (reg) {
+            /* Set the invalid flag, to mark the deletion of this registration
+             * (will take place in unmap_peer_region). If another thread has
+             * already marked deletion, ignore. */
 
-    /* several segments may match the base pointer */
-    rc = mca_rcache_base_vma_iterate(vma_module, (void *) base, bound - base, true,
-                                     mca_smsc_xpmem_check_reg, &check_ctx);
-    if (2 == rc) {
-        bound = bound < (uintptr_t) reg->bound ? (uintptr_t) reg->bound : bound;
-        base = base > (uintptr_t) reg->base ? (uintptr_t) reg->base : base;
-        mca_smsc_xpmem_unmap_peer_region(reg);
-        reg = NULL;
+            uint32_t old_flags = opal_atomic_fetch_or_32(
+                (volatile opal_atomic_int32_t *) &reg->flags, MCA_RCACHE_FLAGS_INVALID);
+
+            if (!(old_flags & MCA_RCACHE_FLAGS_INVALID)) {
+                base = opal_min(base, (uintptr_t) reg->base);
+                bound = opal_max(bound, (uintptr_t) reg->bound);
+
+                /* We did not increment the ref count when we found the registration.
+                 * When PERSIST is set, a superfluous ref is present, so no need to do
+                 * anything. If not, we must increment the ref counter before calling
+                 * unmap_peer_region (which will decrement it), to avoid it going negative. */
+                if(!(MCA_RCACHE_FLAGS_PERSIST & reg->flags))
+                    opal_atomic_add(&reg->ref_count, 1);
+
+                mca_smsc_xpmem_unmap_peer_region(reg);
+            }
+            
+            reg = NULL;
+        }
     }
-
+    
     if (NULL == reg) {
         reg = OBJ_NEW(mca_rcache_base_registration_t);
-        if (OPAL_LIKELY(NULL != reg)) {
-            /* stick around for awhile */
-            reg->ref_count = 2;
-            reg->base = (unsigned char *) base;
-            reg->bound = (unsigned char *) bound;
-            reg->alloc_base = (void *) endpoint;
+        if (OPAL_LIKELY(NULL == reg)) {
+            return NULL;
+        }
+
+        reg->ref_count = ((flags & MCA_RCACHE_FLAGS_PERSIST)
+			&& !(flags & MCA_RCACHE_FLAGS_CACHE_BYPASS) ? 2 : 1);
+        reg->flags = flags;
+        reg->base = (unsigned char *) base;
+        reg->bound = (unsigned char *) bound;
+        reg->alloc_base = (void *) endpoint;
 
 #if defined(HAVE_SN_XPMEM_H)
-            xpmem_addr.id = xpmem_endpoint->apid;
+        xpmem_addr.id = xpmem_endpoint->apid;
 #else
-            xpmem_addr.apid = xpmem_endpoint->apid;
+        xpmem_addr.apid = xpmem_endpoint->apid;
 #endif
-            xpmem_addr.offset = base;
+        xpmem_addr.offset = base;
 
-            opal_output_verbose(MCA_BASE_VERBOSE_INFO, opal_smsc_base_framework.framework_output,
-                                "mca_smsc_xpmem_map_peer_region: creating region mapping "
-                                "for endpoint %p address range %p-%p",
-                                endpoint, reg->base, reg->bound);
+        opal_output_verbose(MCA_BASE_VERBOSE_INFO, opal_smsc_base_framework.framework_output,
+                            "mca_smsc_xpmem_map_peer_region: creating region mapping "
+                            "for endpoint %p address range %p-%p",
+                            (void *) endpoint, reg->base, reg->bound);
 
+        reg->rcache_context = xpmem_attach(xpmem_addr, bound - base, NULL);
+        if (OPAL_UNLIKELY((void *) -1 == reg->rcache_context)) {
+            /* retry with the page as upper bound */
+            bound = OPAL_ALIGN((uintptr_t) remote_ptr + size, opal_getpagesize(), uintptr_t);
+            reg->bound = (unsigned char *) bound;
             reg->rcache_context = xpmem_attach(xpmem_addr, bound - base, NULL);
             if (OPAL_UNLIKELY((void *) -1 == reg->rcache_context)) {
-                /* retry with the page as upper bound */
-                bound = OPAL_ALIGN((uintptr_t) remote_ptr + size, opal_getpagesize(), uintptr_t);
-                reg->bound = (unsigned char *) bound;
-                reg->rcache_context = xpmem_attach(xpmem_addr, bound - base, NULL);
-                if (OPAL_UNLIKELY((void *) -1 == reg->rcache_context)) {
-                    OBJ_RELEASE(reg);
-                    return NULL;
-                }
+                OBJ_RELEASE(reg);
+                return NULL;
             }
+        }
 
-            opal_memchecker_base_mem_defined(reg->rcache_context, bound - base);
-
-            mca_rcache_base_vma_insert(vma_module, reg, 0);
+        opal_memchecker_base_mem_defined(reg->rcache_context, bound - base);
+        
+        if(!(reg->flags & MCA_RCACHE_FLAGS_CACHE_BYPASS)) {
+            rc = mca_rcache_base_vma_insert(vma_module, reg, 0);
+            assert(OPAL_SUCCESS == rc);
+            
+            if(OPAL_SUCCESS != rc) {
+                reg->flags |= MCA_RCACHE_FLAGS_CACHE_BYPASS;
+            }
         }
     }
 
@@ -184,61 +226,52 @@ void *mca_smsc_xpmem_map_peer_region(mca_smsc_endpoint_t *endpoint, uint64_t fla
 void mca_smsc_xpmem_unmap_peer_region(void *ctx)
 {
     mca_rcache_base_registration_t *reg = (mca_rcache_base_registration_t *) ctx;
-    mca_rcache_base_vma_module_t *vma_module = mca_smsc_xpmem_module.vma_module;
+    mca_smsc_xpmem_endpoint_t *endpoint = (mca_smsc_xpmem_endpoint_t *) reg->alloc_base;
     int32_t ref_count;
 
     ref_count = opal_atomic_add_fetch_32(&reg->ref_count, -1);
-    if (OPAL_UNLIKELY(0 == ref_count && !(reg->flags & MCA_RCACHE_FLAGS_PERSIST))) {
+    if (OPAL_UNLIKELY(0 == ref_count)) {
         opal_output_verbose(MCA_BASE_VERBOSE_INFO, opal_smsc_base_framework.framework_output,
                             "mca_smsc_xpmem_unmap_peer_region: deleting region mapping for "
                             "endpoint %p address range %p-%p",
-                            reg->alloc_base, reg->base, reg->bound);
+                            (void *) endpoint, reg->base, reg->bound);
+        if (!(reg->flags & MCA_RCACHE_FLAGS_CACHE_BYPASS)) {
 #if OPAL_ENABLE_DEBUG
-        int ret = mca_rcache_base_vma_delete(vma_module, reg);
-        assert(OPAL_SUCCESS == ret);
+            int ret = mca_rcache_base_vma_delete(endpoint->vma_module, reg);
+            assert(OPAL_SUCCESS == ret);
 #else
-        (void) mca_rcache_base_vma_delete(vma_module, reg);
+            (void) mca_rcache_base_vma_delete(endpoint->vma_module, reg);
 #endif
+        }
+
         opal_memchecker_base_mem_noaccess(reg->rcache_context, (uintptr_t)(reg->bound - reg->base));
         (void) xpmem_detach(reg->rcache_context);
+
         OBJ_RELEASE(reg);
     }
 }
 
 static int mca_smsc_xpmem_endpoint_rcache_cleanup(mca_rcache_base_registration_t *reg, void *ctx)
 {
-    mca_smsc_xpmem_cleanup_reg_ctx_t *cleanup_ctx = (mca_smsc_xpmem_cleanup_reg_ctx_t *) ctx;
-    if (reg->alloc_base == (void *) cleanup_ctx->endpoint) {
-        opal_list_append(cleanup_ctx->registrations, &reg->super.super);
-    }
-
+    mca_smsc_xpmem_unmap_peer_region(reg);
     return OPAL_SUCCESS;
 }
 
 static void mca_smsc_xpmem_cleanup_endpoint(mca_smsc_xpmem_endpoint_t *endpoint)
 {
-    mca_rcache_base_registration_t *reg;
-    opal_list_t registrations;
-    mca_smsc_xpmem_cleanup_reg_ctx_t cleanup_ctx = {.endpoint = endpoint,
-                                                    .registrations = &registrations};
-
     opal_output_verbose(MCA_BASE_VERBOSE_INFO, opal_smsc_base_framework.framework_output,
-                        "mca_smsc_xpmem_cleanup_endpoint: cleaning up endpoint %p", endpoint);
+                        "mca_smsc_xpmem_cleanup_endpoint: cleaning up endpoint %p", (void *) endpoint);
 
-    OBJ_CONSTRUCT(&registrations, opal_list_t);
-
-    /* clean out the registration cache */
-    (void) mca_rcache_base_vma_iterate(mca_smsc_xpmem_module.vma_module, NULL, (size_t) -1, true,
-                                       mca_smsc_xpmem_endpoint_rcache_cleanup,
-                                       (void *) &cleanup_ctx);
     opal_output_verbose(MCA_BASE_VERBOSE_INFO, opal_smsc_base_framework.framework_output,
                         "mca_smsc_xpmem_cleanup_endpoint: deleting %" PRIsize_t " region mappings",
-                        opal_list_get_size(&registrations));
-    while (NULL
-           != (reg = (mca_rcache_base_registration_t *) opal_list_remove_first(&registrations))) {
-        mca_smsc_xpmem_unmap_peer_region(reg);
-    }
-    OBJ_DESTRUCT(&registrations);
+                        endpoint->vma_module->tree.tree_size);
+
+    /* clean out the registration cache */
+    (void) mca_rcache_base_vma_iterate(endpoint->vma_module, NULL, (size_t) -1, true,
+                                       mca_smsc_xpmem_endpoint_rcache_cleanup, NULL);
+
+    OBJ_RELEASE(endpoint->vma_module);
+    endpoint->vma_module = NULL;
 
     xpmem_release(endpoint->apid);
     endpoint->apid = 0;
@@ -270,7 +303,8 @@ int mca_smsc_xpmem_copy_to(mca_smsc_endpoint_t *endpoint, void *local_address, v
     (void) reg_handle;
 
     void *remote_ptr, *ctx;
-    ctx = mca_smsc_xpmem_map_peer_region(endpoint, /*flags=*/0, remote_address, size, &remote_ptr);
+    ctx = mca_smsc_xpmem_map_peer_region(endpoint,
+        MCA_RCACHE_FLAGS_PERSIST, remote_address, size, &remote_ptr);
     mca_smsc_xpmem_memmove(remote_ptr, local_address, size);
 
     mca_smsc_xpmem_unmap_peer_region(ctx);
@@ -286,8 +320,8 @@ int mca_smsc_xpmem_copy_from(mca_smsc_endpoint_t *endpoint, void *local_address,
 
     void *remote_ptr, *ctx;
 
-    struct timespec start, stop;
-    ctx = mca_smsc_xpmem_map_peer_region(endpoint, /*flags=*/0, remote_address, size, &remote_ptr);
+    ctx = mca_smsc_xpmem_map_peer_region(endpoint,
+        MCA_RCACHE_FLAGS_PERSIST, remote_address, size, &remote_ptr);
     mca_smsc_xpmem_memmove(local_address, remote_ptr, size);
 
     mca_smsc_xpmem_unmap_peer_region(ctx);


### PR DESCRIPTION
Hi, I'd like to propose some changes to the registration cache in smsc/xpmem. Currently looking up a registration is an operation that iterates the whole tree (until found). This is necessary as the tree is used to store attachments to different procs/endpoints, but can get slow and scale poorly. I suggest creating one regcache/tree per each peer proc and using the `find()` (O(logn)) method.

The benefit will vary depending on the number of standing registrations and message size. I expect the relative gain to be relevant for small-to-medium messages (but larger than any copy-in-copy-out-to-single-copy thresholds). In a (single) node with 64 ranks, using mirobenchmarks, tuned's alltoall @ 1K improves from `~143 us to ~124 us`. Using my component (xhc), the hierarchical allreduce @ 16K improves from `~39 us to ~31 us`, while the (generally worse) non-hierarchical allreduce (more attachments/regs) @ 4K improves from `100 us to 42 us` .

This change will result in more trees, but the same total number of tree nodes. I considered alternatives like augmenting the base/bound with the endpoint/proc ID in the high/low values, but I think this approach is simpler. I want to also look into going from one tree per smsc endpoint to one tree per peer process, which would reduce duplication and allow sharing of xpmem mappings between defferent components (would require caching reg caches in a peer-proc-indexed structure, and creating/returning them in `get_endpoint`).

I wanted to get some input and general comments before proceeding with this PR.

---

I also took the chance to:
1. Add support for `(lack of) MCA_RCACHE_FLAGS_PERSIST` and `MCA_RCACHE_FLAGS_CACHE_BYPASS` (though they won't be used anywhere atm :-) )
2. Adjust/fix the bounds for the attachments and registrations (all the -1 and +1 here and there)

Regarding (2), I took "bound" to mean the last valid byte in the range, inclusive (is this accurate?). Thus, the last valid byte (aka the bound) in an XPMEM registration starting at `base` with length `x` is at `base + x - 1`). I adjusted the code following this rationale. But generally there's still a number of rogue +-1s in rcache_base and opal_interval_tree, which I'm not sure are 100% correct (but I'm not as comfortable with that code or with the one that would be affected by changing these).

Also as I was assimilating the code I had some concerns regarding the atomic operations and thread safety; I'm not sure if they are indeed problems or not, and how they depend on the various MPI thread support models. I've left two `TODO` comments regarding this inside `smsc_xpmem_module.c`.

Signed-off-by: George Katevenis <gkatev@ics.forth.gr>

FYI @devreal @hjelmn