### PR TITLE
common/ucx: call opal_progress when waiting for pmix_fence

### DIFF
--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -416,8 +416,10 @@ OPAL_DECLSPEC int opal_common_ucx_mca_pmix_fence(ucp_worker_h worker)
         return ret;
     }
 
-    while (!fenced) {
-        ucp_worker_progress(worker);
+    MCA_COMMON_UCX_PROGRESS_LOOP(worker) {
+        if(fenced) {
+            break;
+        }
     }
 
     return ret;


### PR DESCRIPTION
## Why
Fix hang during exit with TCP transport

## How
Call opal_progress during pmix fence. Otherwise a ucx/tcp transport used by coll/hcoll component would not make progress an cause a hang.

Signed-off-by: Devendar Bureddy <devendar@nvidia.com>