### PR TITLE
Fix uninitialized variable in mca_coll_base_alltoallv_intra_basic_inplace: Coverity CID 1498685

### DIFF
--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -108,37 +108,58 @@ mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
                                         (char *) rbuf + (MPI_Aint) right * rcount * extent);
         packed_size = max_size;
         err = opal_convertor_pack(&convertor, &iov, &iov_count, &packed_size);
-        if (1 != err) { goto error_hndl; }
+        if (1 != err) {
+            line = __LINE__;
+            goto error_hndl;
+        }
 
         /* Receive data from the right */
         err = MCA_PML_CALL(irecv ((char *) rbuf + (MPI_Aint) right * rcount * extent, rcount, rdtype,
                                   right, MCA_COLL_BASE_TAG_ALLTOALL, comm, &req));
-        if (MPI_SUCCESS != err) { goto error_hndl; }
+        if (MPI_SUCCESS != err) {
+            line = __LINE__;
+            goto error_hndl;
+        }
 
         if( left != right ) {
             /* Send data to the left */
             err = MCA_PML_CALL(send ((char *) rbuf + (MPI_Aint) left * rcount * extent, rcount, rdtype,
                                      left, MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD,
                                      comm));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
 
             err = ompi_request_wait (&req, MPI_STATUSES_IGNORE);
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
 
             /* Receive data from the left */
             err = MCA_PML_CALL(irecv ((char *) rbuf + (MPI_Aint) left * rcount * extent, rcount, rdtype,
                                       left, MCA_COLL_BASE_TAG_ALLTOALL, comm, &req));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
         }
 
         /* Send data to the right */
         err = MCA_PML_CALL(send ((char *) tmp_buffer,  packed_size, MPI_PACKED,
                                  right, MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD,
                                  comm));
-        if (MPI_SUCCESS != err) { goto error_hndl; }
+        if (MPI_SUCCESS != err) {
+            line = __LINE__;
+            goto error_hndl;
+        }
 
         err = ompi_request_wait (&req, MPI_STATUSES_IGNORE);
-        if (MPI_SUCCESS != err) { goto error_hndl; }
+        if (MPI_SUCCESS != err) {
+            line = __LINE__;
+            goto error_hndl;
+        }
     }
 
  error_hndl:
@@ -148,8 +169,7 @@ mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
 
     if( MPI_SUCCESS != err ) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                     "%s:%4d\tError occurred %d, rank %2d", __FILE__, line, err,
-                     rank));
+                     "%s:%4d\tError occurred %d, rank %2d", __FILE__, line, err, rank));
         (void)line;  // silence compiler warning
     }
 

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -118,12 +118,18 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
                                             (char *) rbuf + rdisps[right] * extent);
             packed_size = max_size;
             err = opal_convertor_pack(&convertor, &iov, &iov_count, &packed_size);
-            if (1 != err) { goto error_hndl; }
+            if (1 != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
 
             /* Receive data from the right */
             err = MCA_PML_CALL(irecv ((char *) rbuf + rdisps[right] * extent, rcounts[right], rdtype,
                                       right, MCA_COLL_BASE_TAG_ALLTOALLV, comm, &req));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
         }
 
         if( (left != right) && (0 != rcounts[left]) ) {
@@ -131,15 +137,24 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
             err = MCA_PML_CALL(send ((char *) rbuf + rdisps[left] * extent, rcounts[left], rdtype,
                                      left, MCA_COLL_BASE_TAG_ALLTOALLV, MCA_PML_BASE_SEND_STANDARD,
                                      comm));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+             }
 
             err = ompi_request_wait (&req, MPI_STATUSES_IGNORE);
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+             }
 
             /* Receive data from the left */
             err = MCA_PML_CALL(irecv ((char *) rbuf + rdisps[left] * extent, rcounts[left], rdtype,
                                       left, MCA_COLL_BASE_TAG_ALLTOALLV, comm, &req));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
         }
 
         if( 0 != rcounts[right] ) {  /* nothing to exchange with the peer on the right */
@@ -147,11 +162,17 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
             err = MCA_PML_CALL(send ((char *) tmp_buffer,  packed_size, MPI_PACKED,
                                      right, MCA_COLL_BASE_TAG_ALLTOALLV, MCA_PML_BASE_SEND_STANDARD,
                                      comm));
-            if (MPI_SUCCESS != err) { goto error_hndl; }
+            if (MPI_SUCCESS != err) {
+                line = __LINE__;
+                goto error_hndl;
+            }
         }
 
         err = ompi_request_wait (&req, MPI_STATUSES_IGNORE);
-        if (MPI_SUCCESS != err) { goto error_hndl; }
+        if (MPI_SUCCESS != err) {
+            line = __LINE__;
+            goto error_hndl;
+        }
     }
 
  error_hndl:
@@ -161,8 +182,7 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
 
     if( MPI_SUCCESS != err ) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                     "%s:%4d\tError occurred %d, rank %2d", __FILE__, line, err,
-                     rank));
+                     "%s:%4d\tError occurred %d, rank %2d", __FILE__, line, err, rank));
         (void)line;  // silence compiler warning
     }
 


### PR DESCRIPTION
A Coverity static analysis scan reported an uninitialized variable **line** in mca_coll_base_alltoallv_intra_basic_inplace.

This variable was intended to be set to the line number of a failing function call so that line number could be reported in an error message.

The fix sets **line** before branching to the exit point for each failing function call. Since line numbers may shift over time, I also added the function name to the error message.

Signed-off-by: David Wootton <dwootton@us.ibm.com>