### PR TITLE
OMPI v5.0.x: Fix divide by zero in ompi_netpatterns_setup_recursive_knomial_tree_node 

### DIFF
--- a/ompi/patterns/net/netpatterns_knomial_tree.c
+++ b/ompi/patterns/net/netpatterns_knomial_tree.c
@@ -548,6 +548,10 @@ OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_tree_node(
 
     assert(num_nodes > 1);
     assert(tree_order > 1);
+    /* Also validate in release build where asserts are compiled out */
+    if ((num_nodes <= 1) || (tree_order <= 1)) {
+        goto Error;
+    }
     if (tree_order > num_nodes) {
         tree_order = num_nodes;
     }


### PR DESCRIPTION
Clang static analysis reports a possible divide by zero at line 620 in ompi_netpatterns_setup_recursive_knomial_tree_node
where tree-order - 1 may evaluate to zero.

This can occur in release builds, where the asserts are compiled out.

I left the asserts in-place since in debug builds these should generate a traceback.

This is a cherry pick of #11127

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 429feaf765d5f2e537bbdd98dc2d725f94d501b0)