### PR TITLE
OMPI v5.0.x: Fix memory leak in mca_base_alias_register

### DIFF
--- a/opal/mca/base/mca_base_alias.c
+++ b/opal/mca/base/mca_base_alias.c
@@ -149,6 +149,9 @@ int mca_base_alias_register(const char *project, const char *framework, const ch
     if (NULL == alias) {
         alias = OBJ_NEW(mca_base_alias_t);
         if (NULL == alias) {
+            if (NULL != name) {
+                free(name);
+            }
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
 


### PR DESCRIPTION
Clang static analysis flagged a memory leak on the error path following the call to mca_base_alias_lookup_internal where storage allocated to name was not freed.

This is a cherry-pick of #11134

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit c5703b01757d24dfe2de27fb8778c9e8a37d56e5)