### PR TITLE
OMPI v5.0.x: Fix memory use after free in dpm_convert Covertity CID 1515770

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -737,10 +737,7 @@ static int dpm_convert(opal_list_t *infos,
                if (0 != strncasecmp(ck, directive, strlen(directive))) {
                     opal_asprintf(&help_str, "Conflicting directives \"%s %s\"", ck, directive);
 #if PMIX_NUMERIC_VERSION >= 0x00040000
-                    /* TODO: remove strdup if PMIx_Get_attribute_string takes const char* */
-                    char *option_dup = strdup(option);
-                    attr = PMIx_Get_attribute_string(option_dup);
-                    free(option_dup);
+                    attr = PMIx_Get_attribute_string(option);
 #else
                     attr = option;
 #endif


### PR DESCRIPTION
Memory was used after it was freed in the dpm_convert function.
The code which checked for an existing match to the option allocated a temporary copy of the option for use when calling
PMIx_Get_attribute_string.

PMIx_Get_attribute string performs a lookup in the pmix_dictionary array and either returns the matching string from the lookup, or in the case of no match, the option string itself, and attr is set to that value.

Since attr is set to the duplicate copy of option, that string should not be freed.

The fix is to remove the allocation and de-allocation of the duplicate option string.

This is a cherry-pick of #11145

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 1e5b880e59f1259eb764a38ab74f07064bf2ad00)