### PR TITLE
OMPI v5.0.x: Fix memory leak in component_select in osc_sm_component.c

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -275,6 +275,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         module->noncontig = false;
         if (OMPI_SUCCESS != opal_info_get_bool(info, "alloc_shared_noncontig",
                                                &module->noncontig, &flag)) {
+            free(rbuf);
             goto error;
         }
 
@@ -291,7 +292,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
                                                   rbuf, 1, MPI_UNSIGNED_LONG,
                                                   module->comm,
                                                   module->comm->c_coll->coll_allgather_module);
-        if (OMPI_SUCCESS != ret) return ret;
+        if (OMPI_SUCCESS != ret) {
+            free(rbuf);
+            return ret;
+        }
 
         total = 0;
         for (i = 0 ; i < comm_size ; ++i) {


### PR DESCRIPTION
Clang static analysis reported a memory leak in component_select where rbuf was not freed before control went to
the error label.

I found two error exits in the block where rbuf was allocated that were not freeing rbuf. I added free() calls before those exits.

This is a cherry-pick of #11135 

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 5f2d63399a455bdbca87ee9300813b26883ad4f5)