### PR TITLE
OMPI v5.0.x: Fix possible invalid memory access in add_string_to_conversion_struct: Coverity CID 1515758

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -202,6 +202,7 @@ add_string_to_conversion_struct(comm_method_string_conversion_t *data, char *str
     if (i == 0) { // didn't find string in list, so add it
         if (data->n < MAX_COMM_METHODS) {
             strncpy(data->str[data->n], string, COMM_METHOD_STRING_SIZE);
+            data->str[data->n][COMM_METHOD_STRING_SIZE - 1] = '\0';
             ++(data->n);
         }
     }


### PR DESCRIPTION
There is a possible invalid memory access in the add_string_to_conversion struct function in
hook_comm_method_fns.c.

This function adds a string to an array of strings used to look up communication method information. The string copy is limited to COMM_METHOD_STRING_SIZE (200) bytes. However, if the source string is >= 200 bytes long, the target string is not terminated with '\0'. The result can be a string witch garbage at the end or possibly a SIGSEGV.

This fix ensures the string is '\0' terminated.

This is a cherry-pick of #11147

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit f3b890d59184cea9922b87465d934c70ac0cefc5)