### PR TITLE
OMPI v5.0.x: Fix memory leak in mca_spml_ucx_register: Coverity CID 1498721

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -709,7 +709,7 @@ sshmem_mkey_t *mca_spml_ucx_register(void* addr,
     if (MEMHEAP_SEG_INVALID == segno) {
         SPML_UCX_ERROR("mca_spml_ucx_register failed because of invalid "
             "segment number: %d\n", segno);
-        return NULL;
+        goto error_out;
     }
     mem_seg = memheap_find_seg(segno);
 


### PR DESCRIPTION
 Coverity static analysis scan reported a possible memory leak in mca_spml_ucx_register. This leak occurs if the call to memheap_find_seg in this function fails.

This is fixed by changing the failure code path to jump to error_out where the memory is freed and then NULL returned.

This is a cherry-pick of #11149

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 296d9badc7a932b19f1ea31d32cacef8ee10ff7f)