### PR TITLE
OMPI v5.0.x: Fix possible memory leaks in component_select (osc_sm_component.c): Coverity CID 1490191

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -275,6 +275,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         module->noncontig = false;
         if (OMPI_SUCCESS != opal_info_get_bool(info, "alloc_shared_noncontig",
                                                &module->noncontig, &flag)) {
+            free(rbuf);
             goto error;
         }
 
@@ -291,7 +292,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
                                                   rbuf, 1, MPI_UNSIGNED_LONG,
                                                   module->comm,
                                                   module->comm->c_coll->coll_allgather_module);
-        if (OMPI_SUCCESS != ret) return ret;
+        if (OMPI_SUCCESS != ret) {
+            free(rbuf);
+            return ret;
+        }
 
         total = 0;
         for (i = 0 ; i < comm_size ; ++i) {


### PR DESCRIPTION
Coverity static analysis reports a possible memory leak in component_select where rbuf is not always freed.

There are two error exits at lines 278 and 294 where rbuf was not freed.

The fix is to free rbuf at those points.

This is a cherry-pick of #11152 

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 4424938ded4c3ff08857981b6637835eb3934324)