### PR TITLE
Fix additional memory leaks in component_select

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -294,7 +294,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
                                                   module->comm->c_coll->coll_allgather_module);
         if (OMPI_SUCCESS != ret) {
             free(rbuf);
-            return ret;
+            goto error;
         }
 
         total = 0;
@@ -317,7 +317,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
                                  ompi_comm_print_cid(module->comm));
             if (ret < 0) {
                 free(rbuf);
-                return OMPI_ERR_OUT_OF_RESOURCE;
+                ret = OMPI_ERR_OUT_OF_RESOURCE;
+                goto error;
             }
 
             ret = opal_shmem_segment_create (&module->seg_ds, data_file, total + data_base_size);


### PR DESCRIPTION
In review of #11157 for v5.0.x, @awlauria  noticed that a memory leak had been missed since the error path returned an error status rather than branching to **error** to free allocated memory as was done in other error paths. 

This is now fixed.

Additionally, there was another error path near line 315 that returned an error status instead of branching to **error**. That has also been fixed.

Signed-off-by: David Wootton <dwootton@us.ibm.com>