### PR TITLE
OSC/UCX: preserve the accumulate ordering for overlapping buffers during acc-lock less epocs and  setting a proper wpool context mutex type

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -110,6 +110,11 @@ typedef struct ompi_osc_ucx_state {
     volatile ompi_osc_dynamic_win_info_t dynamic_wins[OMPI_OSC_UCX_ATTACH_MAX];
 } ompi_osc_ucx_state_t;
 
+typedef struct ompi_osc_ucx_mem_ranges {
+    uint64_t base;
+    uint64_t tail;
+} ompi_osc_ucx_mem_ranges_t;
+
 typedef struct ompi_osc_ucx_module {
     ompi_osc_base_module_t super;
     struct ompi_communicator_t *comm;
@@ -140,7 +145,7 @@ typedef struct ompi_osc_ucx_module {
     opal_common_ucx_ctx_t *ctx;
     opal_common_ucx_wpmem_t *mem;
     opal_common_ucx_wpmem_t *state_mem;
-
+    ompi_osc_ucx_mem_ranges_t *epoc_outstanding_ops_mems;
     bool skip_sync_check;
     bool noncontig_shared_win;
     size_t *sizes;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -839,6 +839,9 @@ select_unlock:
         goto error;
     }
 
+    module->epoc_outstanding_ops_mems =
+        calloc(ompi_osc_ucx_outstanding_ops_flush_threshold,
+                sizeof(ompi_osc_ucx_mem_ranges_t));
     module->addrs = calloc(comm_size, sizeof(uint64_t));
     module->state_addrs = calloc(comm_size, sizeof(uint64_t));
     module->comm_world_ranks = calloc(comm_size, sizeof(uint64_t));
@@ -1140,6 +1143,9 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
         }
     }
 
+    if (NULL != module->epoc_outstanding_ops_mems) {
+        free(module->epoc_outstanding_ops_mems);
+    }
     free(module->addrs);
     free(module->state_addrs);
     free(module->comm_world_ranks);

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -81,7 +81,7 @@ extern opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts;
  * Context is bound to a particular Worker Pool object.
  */
 typedef struct {
-    opal_mutex_t mutex;
+    opal_recursive_mutex_t mutex;
 
     /* the reference to a Worker pool this context belongs to*/
     opal_common_ucx_wpool_t *wpool;


### PR DESCRIPTION
OSC/UCX: preserve the accumulate ordering for overlapping buffers during acc-lock less epocs and setting a proper wpool context mutex type

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>