### PR TITLE
Fix memory leak in mca_btl_tcp_proc_handle_modex_addresses: Coverity CID 1458001

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -347,14 +347,12 @@ static int mca_btl_tcp_proc_handle_modex_addresses(mca_btl_tcp_proc_t *btl_proc,
 
     rc = mca_btl_tcp_proc_store_matched_interfaces(btl_proc, local_proc_is_left, graph, num_matched,
                                                    matched_edges);
-    if (rc) {
-        goto cleanup;
-    }
 
 cleanup:
     if (NULL != graph) {
         opal_bp_graph_free(graph);
     }
+    free(matched_edges);
     return rc;
 }
 


### PR DESCRIPTION
Coverity static analysis reports a memory leak at exit from  mca_btl_tcp_proc_handle_modex_addresses.

The  mca_btl_tcp_proc_handle_modex_addresses function allocates the matched_edges array which is only used as an input to  mca_btl_tcp_proc_store_matched_interfaces.

The matched_edges array is now freed at exit. I also deleted an error status check that did nothing.

Signed-off-by: David Wootton <dwootton@us.ibm.com>