### PR TITLE
OMPI v5.0.x: Fix double free in opal_common_ucx_wpool_init: Coverity CID 1462901

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -192,7 +192,6 @@ err_wpool_add:
     free(wpool->recv_waddr);
 err_get_addr:
     OBJ_RELEASE(winfo);
-    OBJ_RELEASE(wpool->dflt_winfo);
     wpool->dflt_winfo = NULL;
 err_worker_create:
     OBJ_DESTRUCT(&wpool->idle_workers);


### PR DESCRIPTION
Coverity static analysis reported storage access after free for the OBJ_RELEASE(wpool->dflt_winfo); statement at line 195, following the err_get_addr label.

winfo and wpool->default_winfo are identical following the assignment at line 173. There is no path from there to the err_get_addr label where it looks like either winfo or wpool->default_winfo.

Since the two variables are still identical at this point, the second OBJ_RELEASE is incorrect, and is removed.

This is a cherry-pick of #11175

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 61b8a1becb5ca258451df2cec3218abb96530cd3)