### PR TITLE
make_dist_tarball: update m4 and Automake versions

### DIFF
--- a/contrib/dist/make_dist_tarball
+++ b/contrib/dist/make_dist_tarball
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
@@ -23,8 +23,8 @@
 # Version of auto tools that we want
 #
 
-M4_TARGET_VERSION=1.4.17
-AM_TARGET_VERSION=1.15
+M4_TARGET_VERSION=1.4.19
+AM_TARGET_VERSION=1.15.1
 AC_TARGET_VERSION=2.69
 LT_TARGET_VERSION=2.4.6
 FLEX_TARGET_VERSION=2.5.35


### PR DESCRIPTION
* Automake v1.15 has a bug such that it fails to build on RHEL 8 platforms.  Upgrading to v1.15.1 solves the issue.
* m4 1.4.17 has a bug such that it fails to build on Ubuntu 18.04. Updating to v1.4.19 solves the issue.

Neither of these issues affect Open MPI, per se, but rather cause problems in upcoming changes we have planned for Open MPI's CI system. Specifically, CI build scripts extract the target GNU Autotools versions from make_dist_script to build+install local versions of the GNU Autotools (to build Open MPI from a PR git clone).  Updating to these versions of the GNU Autotools works on all the platforms where we wish to run CI.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
Signed-off-by: Joe Downs <joe@dwns.dev>