### PR TITLE
OMPI v5.0.x: Fix memory leak in start_dvm: Coverity CID 1490117

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -1998,6 +1998,7 @@ static int start_dvm(char **hostfiles, char **dash_host)
      */
     if (pipe(p) < 0) {
         OMPI_ERROR_LOG(OMPI_ERROR);
+        free(cmd);
         return OMPI_ERROR;
     }
 
@@ -2010,6 +2011,7 @@ static int start_dvm(char **hostfiles, char **dash_host)
         OMPI_ERROR_LOG(OMPI_ERROR);
         close(p[0]);
         close(p[1]);
+        free(cmd);
         return OMPI_ERROR;
     }
 


### PR DESCRIPTION
Coverity static analysis reports a memory leak in start_dvm (dpm.c)

start_dvm calls opal_find_absolute_path to find the path to prrte. The opal_find_absolute_path function allocates memory to hold the absolute pathname and returns a pointer to that memory.

There are two error paths after this call that return without freeing that memory.

This is a cherry-pick of #11171

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 7bdb4dd6a8061c4e6d760aeb5d4a16113797957b)