### PR TITLE
OMPI v5.0.x:Fix memory leak in mca_base_alias_register: Coverity CID 1462700

### DIFF
--- a/opal/mca/base/mca_base_alias.c
+++ b/opal/mca/base/mca_base_alias.c
@@ -149,9 +149,7 @@ int mca_base_alias_register(const char *project, const char *framework, const ch
     if (NULL == alias) {
         alias = OBJ_NEW(mca_base_alias_t);
         if (NULL == alias) {
-            if (NULL != name) {
-                free(name);
-            }
+            free(name);
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
 
@@ -162,9 +160,7 @@ int mca_base_alias_register(const char *project, const char *framework, const ch
 
     mca_base_alias_item_t *alias_item = OBJ_NEW(mca_base_alias_item_t);
     if (NULL == alias_item) {
-        if (NULL != name) {
-            free(name);
-        }
+        free(name);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
@@ -173,6 +169,7 @@ int mca_base_alias_register(const char *project, const char *framework, const ch
 
     opal_list_append(&alias->component_aliases, &alias_item->super);
 
+    free(name);
     return OPAL_SUCCESS;
 }
 


### PR DESCRIPTION
mca_base_alias_register allocates a string for use in an alias hash table lookup. This string is freed on other exits from this function, but it is not freed for fall thru at the end of the function. Nothing is keeping a reference to this string, so it can be freed at fallthru exit.

This is a cherry-pick of #11176

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 37532fbdc115bb4236b238e674e8ac6ad90be79d)