### PR TITLE
OMPI v5.0.x: Fix memory leak in mca_coll_han_scatter_intra_simple: Coverity CID 1490148

### DIFF
--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -380,10 +380,6 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
                     root_up_rank,
                     up_comm,
                     up_comm->c_coll->coll_scatter_module);
-        if(reorder_buf != sbuf){
-            free(reorder_buf);
-            reorder_buf = NULL;
-        }
     }
 
     /* 2. low scatter on nodes leaders */
@@ -400,6 +396,9 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
     if (low_rank == root_low_rank) {
         free(tmp_buf);
         tmp_buf = NULL;
+    }
+    if (reorder_buf != sbuf) {
+        free(reorder_buf);
     }
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
Coverity static analysis reports a memory leak of memory allocated to reorder_buf in mca_coll_han_scatter_intra_simple at return from this function.

It looks like the conditions for allocating reorder_buf and freeing may result in reorder_buf not being freed in all ranks where it was allocated. A free is added at the end of the function to ensure the memory allocated to reorder_buf is freed.

This fixes #11164 

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit ed922a86d43f57373b8cc1e6859e0070e1f18dc8)