### PR TITLE
Fix memory leak in dpm_convert (dpm.c)

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -791,6 +791,7 @@ static int dpm_convert(opal_list_t *infos,
                     return OMPI_SUCCESS;
                 }
             }
+            free(ck);
         }
     }
 


### PR DESCRIPTION
Coverity static analysis reports a memory leak at exit from the dpm_convert function (line 822).

The variable ck is allocated by strdup in the loop at line 729. If control falls thru the end of the loop, ck is not freed.

This is fixed by freeing ck at the end of the loop.
Coverity CID 1462618

Signed-off-by: David Wootton <dwootton@us.ibm.com>