### PR TITLE
fs/lustre: fix assignment of info objects to lustre args

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -76,7 +76,7 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "striping_factor", &stripe_str, &flag);
+    opal_info_get (info, "striping_unit", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
         OBJ_RELEASE(stripe_str);
@@ -90,7 +90,7 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
         }
     }
     
-    opal_info_get (info, "striping_unit", &stripe_str, &flag);
+    opal_info_get (info, "striping_factor", &stripe_str, &flag);
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
         OBJ_RELEASE(stripe_str);


### PR DESCRIPTION
It seems that commit 1631f387704641dd7939cbce156a47ea8eda39eb accidentally reverted the two info objects setting stripe size and stripe width for lustre file systems.

Signed-off-by: Edgar Gabriel <edgar.gabriel@amd.com>
(cherry picked from commit 2778e26869955bfd90ab8cac64613cfb6ad380b5)