### PR TITLE
OMPI v5.0.x: Fix missing lock release in ompi_coll_adapt_ibcast_generic: Coverity CID 1498641

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -558,11 +558,11 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
                 MCA_PML_CALL(irecv
                              (recv_buff, recv_count, datatype, context->peer,
                               con->ibcast_tag - i, comm, &recv_req));
+            /* Set receive callback */
+            OPAL_THREAD_UNLOCK(mutex);
             if (MPI_SUCCESS != err) {
                 return err;
             }
-            /* Set receive callback */
-            OPAL_THREAD_UNLOCK(mutex);
             ompi_request_set_callback(recv_req, recv_cb, context);
             OPAL_THREAD_LOCK(mutex);
         }


### PR DESCRIPTION
Coverity static analysis reports a missing lock release in ompi_coll_adapt_ibcast_generic.

The lock is initially obtained before entering the loop at line 477. The lock is released and then obtained again at
the bottom of each loop iteration.

If the call at line 499 fails, the lock is not released an there can be an application hang.

Since the lock needs to be released both for the error return and normal loop iteration, I moved
the OMPI_THREAD_UNLOCK macro before the error return check.

This is a cherry-pick of #11200

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 5d771aa7bfce8d6168e364c60f224bd1abbd4e95)