### PR TITLE
Fix memory leak in ompi_coll_base_reduce_intra_in_order_binary: Coverity CID 1397316

### DIFF
--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -583,7 +583,10 @@ int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recv
                                           op, io_root, comm, module,
                                           data->cached_in_order_bintree,
                                           segcount, max_outstanding_reqs );
-    if (MPI_SUCCESS != ret) { return ret; }
+    if (MPI_SUCCESS != ret) {
+        free(tmpbuf_free);
+        return ret;
+    }
 
     /* Clean up */
     if (io_root != root) {
@@ -592,14 +595,20 @@ int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recv
             ret = MCA_PML_CALL(recv(recvbuf, count, datatype, io_root,
                                     MCA_COLL_BASE_TAG_REDUCE, comm,
                                     MPI_STATUS_IGNORE));
-            if (MPI_SUCCESS != ret) { return ret; }
+            if (MPI_SUCCESS != ret) {
+                free(tmpbuf_free);
+                return ret;
+            }
 
         } else if (io_root == rank) {
             /* Send result from use_this_recvbuf to root */
             ret = MCA_PML_CALL(send(use_this_recvbuf, count, datatype, root,
                                     MCA_COLL_BASE_TAG_REDUCE,
                                     MCA_PML_BASE_SEND_STANDARD, comm));
-            if (MPI_SUCCESS != ret) { return ret; }
+            if (MPI_SUCCESS != ret) {
+                free(tmpbuf_free);
+                return ret;
+            }
         }
     }
     if (NULL != tmpbuf_free) {


### PR DESCRIPTION
Coverity static analysis reports a memory leak in  ompi_coll_base_reduce_intra_in_order_binary

The memory leak occurs if the call to ompi_coll_base_reduce_intra_in_order_binary fails, since tmpbuf_free is not freed until after the error status check.

This is fixed by moving the free(tmpbif_free) statement to just before the status check.

Signed-off-by: David Wootton <dwootton@us.ibm.com>