### PR TITLE
remove redundant PMIx fence calls at initialization

### DIFF
--- a/ompi/instance/instance.h
+++ b/ompi/instance/instance.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Triad National Security, LLC.  All rights reserved.
+ * Copyright (c) 2018-2022  Triad National Security, LLC.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -122,9 +122,14 @@ void ompi_mpi_instance_release (void);
  * @param[in]    ts_level  thread support level (see mpi.h)
  * @param[in]    info      info object
  * @param[in]    errhander errhandler to set on the instance
+ * @param[in]    argc       argument count to application
+ * @param[in]    argv       arrray of arguments to application
+ * @param[out]   background_fence set to true if pmix non-blocking fence initiated
+ * @param[out]   instance  handler to instance
  */
 OMPI_DECLSPEC int ompi_mpi_instance_init (int ts_level, opal_info_t *info, ompi_errhandler_t *errhandler,
-                                          ompi_instance_t **instance, int argc, char **argv);
+                                          ompi_instance_t **instance, int argc, char **argv,
+                                          bool *background_fence);
 
 /**
  * @brief Destroy an MPI instance and set it to MPI_SESSION_NULL

--- a/ompi/mpi/c/session_init.c
+++ b/ompi/mpi/c/session_init.c
@@ -54,7 +54,7 @@ int MPI_Session_init (MPI_Info info, MPI_Errhandler errhandler, MPI_Session *ses
         }
     }
 
-    rc = ompi_mpi_instance_init (ts_level, &info->super, errhandler, session, 0, NULL);
+    rc = ompi_mpi_instance_init (ts_level, &info->super, errhandler, session, 0, NULL, NULL);
     /* if an error occurred raise it on the null session */
     OMPI_ERRHANDLER_RETURN (rc, MPI_SESSION_NULL, rc, FUNC_NAME);
 }


### PR DESCRIPTION
related to issue #11166

Turns out making these changes revealed some issues with the way MPI_Session_init is implemented.  Unless async modex and disabling of collective info is turned on, the path through MPI initialization for Sessions isn't really local.  The code in ompi_mpi_instance_init_common will eventually need to be refactored to move synchronizing elements up into ompi_mpi_init for the world process model and into some delayed-till- comm creation routine(s) when using the sessions process model.

also, remove a second wait on a debugger.  We should only do this once.  At some point a solution for attaching a debugger to an application which only uses the sessions process model will need to implemented. Given the semantics of sessions, its not clear when is the right point to synchronize processes with a debugger.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>