### PR TITLE
v5: Fixing missing lock release in mca_pml_ob1_record_htod_event

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_accelerator.c
+++ b/ompi/mca/pml/ob1/pml_ob1_accelerator.c
@@ -90,6 +90,7 @@ int mca_pml_ob1_record_htod_event(char *msg, struct mca_btl_base_descriptor_t *f
     if (accelerator_event_htod_num_used == accelerator_event_max) {
         opal_output_verbose(1, mca_pml_ob1_output, "Out of event handles. Max: %d. Suggested to rerun with new max with --mca mpi_common_accelerator_event_max %d.",
                             accelerator_event_max, accelerator_event_max + 100);
+        OPAL_THREAD_UNLOCK(&pml_ob1_accelerator_htod_lock);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 


### PR DESCRIPTION
Coverity static analysis reports a missing lock release in mca_pml_ob1_record_htod_event

The error return at line 92 is flagged as missing an unlock of the lock obtained at line 89, which could cause an application hang.

I added the missing lock release.

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 2c5429d68bc865a38fa94c7a9da1b977fe8cf35e)