### PR TITLE
v5: Fix memory leak in mca_coll_han_init_dynamic_rules: Coverity CID 1516452

### DIFF
--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -455,6 +455,7 @@ mca_coll_han_init_dynamic_rules(void)
     fclose(fptr);
 
     check_dynamic_rules();
+    free(algorithm_name);
     return OMPI_SUCCESS;
 
 cannot_allocate:
@@ -467,6 +468,7 @@ cannot_allocate:
     if( NULL != coll_name ) {
         free(coll_name);
     }
+    free(algorithm_name);
     fclose (fptr);
     /* We disable the module, we don't need to keep the rules */
     mca_coll_han_free_dynamic_rules();
@@ -482,6 +484,7 @@ file_reading_error:
     if( NULL != coll_name ) {
         free(coll_name);
     }
+    free(algorithm_name);
     fclose (fptr);
     /* We disable the module, we don't need to keep the rules */
     mca_coll_han_free_dynamic_rules();


### PR DESCRIPTION
Coverity static analysis reports a memory leak at the branch to file_reading_error in this function. The variable algorithm_name is allocated in the call to getnext_string at line 365 and is not freed anywhere other than a return in the case of a parse error, at line 379.

I added a free function call for algorithm_name at each of the function return points.

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 36e68d5059ebe24c902e554f414c00ceb1015bfd)