### PR TITLE
pml/ucx: move pmix finalize to the end of ompi_rte_finalize()

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -972,8 +972,6 @@ static bool check_file(const char *root, const char *path)
 
 int ompi_rte_finalize(void)
 {
-    /* shutdown pmix */
-    PMIx_Finalize(NULL, 0);
 
     /* cleanup the session directory we created */
     if (NULL != opal_process_info.job_session_dir) {
@@ -1032,6 +1030,9 @@ int ompi_rte_finalize(void)
 
 
     opal_finalize ();
+
+    /* shutdown pmix */
+    PMIx_Finalize(NULL, 0);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
v5.0.x fails inside MPI_Finalize when we run NWCHEM (when --mca pml ucx is set).  

We searched for a smaller reproducer and we found out that osu_allgather also fails with exact same backtrace. Please see the bottom of this description to find the backtrace and how to reproduce it.

We suspected that issue might be coming from the UCX library. Therefore, we searched for a UCX commit that does not fail with these tests. 

We found the below commit before which there is no such failure:

````
commit 7c35b423e95d1bfc1a196961309cd3db15e9a22b
Author: Yossi Itigin <[yosefe@mellanox.com](mailto:yosefe@mellanox.com)>
Date:   Tue Dec 31 17:56:12 2019 +0000
 
    UCP/RNDV: Enable shared memory rendezvous protocol over xpmem
````

Then we reached out to @yosefe for his thoughts. He debugged the open mpi main branch and found out that since this commit enables shared memory, processes must be accessing a remote mem that no longer exists when ep_disconnect is called.  It seems the issue is that PMI is finalized before UCX del_procs is called. As a result, PMIx_Fence() called from opal_common_ucx_mca_pmix_fence() fails silently and is actually a no-op.


Based on these suggestions, this PR is made. Please let me know your thoughts. This PR fixes all these failures in NWCHEM and osu_allgather.

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>


Reproduce the issue:
`````
- Benchmark:
        osu_allgather on 4 nodes 40 processes per node on iris partition (HPCAC)

- UCX and OPEN MPI version:
        Latest master/main branches

- Runtime command options for OPEN MPI:
        “--mca pml ucx    -x UCX_NET_DEVICES=mlx5_0:1”

- OPEN MPI config:
      $ configure -C --enable-debug --with-ompi-param-check --enable-picky --prefix=xx --with-ucx=xx --with-verbs --enable-mpi1-              compatibility --without-xpmem --with-libevent=/usr --with-slurm --enable-wrapper-rpath --with-pmix=internal --with-hwloc=internal

- UCX config:
      $ configure --enable-gtest --enable-examples --with-valgrind --enable-profiling --enable-frame-pointer --enable-stats --enable-fault-   injection --enable-debug-data --enable-mt -C --enable-mt --prefix=xx  --without-valgrind --enable-debug

and here is the backtrace:

==== backtrace (tid:1400578) ====
0 0x0000000000012ce0 __funlockfile()  :0
1 0x000000000001a047 uct_mm_ep_has_tx_resources()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/uct/sm/mm/base/mm_ep.c:423
2 0x000000000001a047 uct_mm_ep_flush()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/uct/sm/mm/base/mm_ep.c:534
3 0x0000000000061048 uct_ep_flush()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/uct/api/uct.h:3105
4 0x0000000000061901 ucp_ep_flush_internal()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/ucp/rma/flush.c:341
5 0x0000000000061901 ucp_ep_flush_internal()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/ucp/rma/flush.c:343
6 0x0000000000032885 ucp_ep_close_nbx()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/ucp/core/ucp_ep.c:1620
7 0x00000000000326f6 ucp_ep_close_nb()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/ucp/core/ucp_ep.c:1589
8 0x00000000000329ce ucp_ep_destroy()  /build-result/src/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.12-x86_64/ucx-master/src/ucp/core/ucp_ep.c:1658
9 0x000000000000dcfe component_finalize()  /dev/shm/openmpi-gitclone/ompi/mca/osc/ucx/osc_ucx_component.c:157
10 0x00000000000ba966 ompi_osc_base_finalize()  /dev/shm/openmpi-gitclone/ompi/mca/osc/base/osc_base_frame.c:72
11 0x00000000000ba966 opal_obj_update()  /dev/shm/openmpi-gitclone/ompi/mca/osc/../../../opal/class/opal_object.h:534
12 0x00000000000ba966 ompi_osc_base_finalize()  /dev/shm/openmpi-gitclone/ompi/mca/osc/base/osc_base_frame.c:73
13 0x0000000000056730 ompi_mpi_finalize()  /dev/shm/openmpi-gitclone/ompi/runtime/ompi_mpi_finalize.c:323
`````


