### PR TITLE
v5: Fix memory leak in mca_btl_tcp_proc_handle_modex_addresses

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -347,14 +347,12 @@ static int mca_btl_tcp_proc_handle_modex_addresses(mca_btl_tcp_proc_t *btl_proc,
 
     rc = mca_btl_tcp_proc_store_matched_interfaces(btl_proc, local_proc_is_left, graph, num_matched,
                                                    matched_edges);
-    if (rc) {
-        goto cleanup;
-    }
 
 cleanup:
     if (NULL != graph) {
         opal_bp_graph_free(graph);
     }
+    free(matched_edges);
     return rc;
 }
 


### PR DESCRIPTION
Coverity CID 1458001

Signed-off-by: David Wootton <dwootton@us.ibm.com>
(cherry picked from commit 8a798fd3bdd1f5737d2c482662c4ce43f9f261d5)