### PR TITLE
Enable Libfabric providers to perform CUDA memory transfers via `FI_HMEM` by default

### DIFF
--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2020-2022 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021      Amazon.com, Inc. or its affiliates. All rights
+ * Copyright (c) 2021-2023 Amazon.com, Inc. or its affiliates. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -30,6 +30,7 @@ typedef struct opal_common_ofi_module {
     char **prov_include;
     char **prov_exclude;
     int output;
+    bool hmem_cuda_enable_xfer;
 } opal_common_ofi_module_t;
 
 extern opal_common_ofi_module_t opal_common_ofi;


### PR DESCRIPTION
When `FI_HMEM_CUDA_ENABLE_XFER` is unspecified, Libfabric providers are free to choose their own default behavior for CUDA memory transfers. Some providers may choose to disable CUDA memory transfers by default. This change allows providers to perform CUDA memory transfers if needed.

Signed-off-by: Darryl Abbate <drl@amazon.com>

See also:
- ofiwg/libfabric#8354