### PR TITLE
OSC/UCX: avoid creating ucp context if MPI-RMA is not used

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -35,6 +35,7 @@ typedef struct ompi_osc_ucx_component {
     opal_free_list_t requests; /* request free list for the r* communication variants */
     opal_free_list_t accumulate_requests; /* request free list for the r* communication variants */
     bool env_initialized; /* UCX environment is initialized or not */
+    bool priority_is_set; /* Is ucp_ctx created and component priority has been set */
     int comm_world_size;
     ucp_ep_h *endpoints;
     int num_modules;


### PR DESCRIPTION
OSC/UCX: avoid creating ucp context if osc init is not called by the application

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>