### PR TITLE
opal/common/ofi: add net to provider exclude list

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -40,7 +40,7 @@
 opal_common_ofi_module_t opal_common_ofi = {.prov_include = NULL,
                                             .prov_exclude = NULL,
                                             .output = -1};
-static const char default_prov_exclude_list[] = "shm,sockets,tcp,udp,rstream,usnic";
+static const char default_prov_exclude_list[] = "shm,sockets,tcp,udp,rstream,usnic,net";
 static opal_mutex_t opal_common_ofi_mutex = OPAL_MUTEX_STATIC_INIT;
 static int opal_common_ofi_verbose_level = 0;
 static int opal_common_ofi_init_ref_cnt = 0;


### PR DESCRIPTION
The net provider is an enhanced version of tcp provider, therefore should also be excluded.

Signed-off-by: Wei Zhang <wzam@amazon.com>