### PR TITLE
update bml.h

### DIFF
--- a/ompi/mca/bml/bml.h
+++ b/ompi/mca/bml/bml.h
@@ -22,7 +22,7 @@
 /**
  * @file
  *
- * BML Management Layer (BML)
+ * BTL Management Layer (BML)
  *
  */
 


### PR DESCRIPTION
BML is short for BTL Management Layer instead of BML Management Layer. I have corrected it. #11247 

Signed-off-by: zhuodong <jopillar11@gmail.com>
(cherry picked from commit 19b515f15f3d0e6a7b6faa5f75861fcf89e04440)