### PR TITLE
ulfm fix comm_agree deadlocks due to faults not being visible

### DIFF
--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -334,11 +334,27 @@ bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remot
     /* If the proc is not known yet (get_proc_ptr returns NULL for a valid
      * peer_id), then we assume that the proc is alive. When it is dead, the
      * proc will exist. */
+#if OPAL_ENABLE_DEBUG
+    if(NULL == ompi_proc) {
+        /* this debug has side effects on behavior/performance: it loads up the
+         * proc for every query and may end-up being equivalent to the 'preconnect
+         * all' option in the worse case. */
+        ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
+                                             peer_id, true);
+        assert(NULL != ompi_proc);
+        assert(ompi_proc_is_active(ompi_proc));
+    }
+#endif
     return (NULL == ompi_proc) ? true : ompi_proc_is_active(ompi_proc);
 }
 
 int ompi_comm_set_rank_failed(ompi_communicator_t *comm, int peer_id, bool remote)
 {
+    /* populate the proc in the comm's group array so that it is not a sentinel and can be read as failed */
+    ompi_proc_t *ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
+                                                     peer_id, true);
+    assert(NULL != ompi_proc);
+
     /* Disable ANY_SOURCE */
     comm->any_source_enabled = false;
     opal_atomic_wmb(); /* non-locked update needs a memory barrier to propagate */

--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -334,17 +334,6 @@ bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remot
     /* If the proc is not known yet (get_proc_ptr returns NULL for a valid
      * peer_id), then we assume that the proc is alive. When it is dead, the
      * proc will exist. */
-#if OPAL_ENABLE_DEBUG
-    if(NULL == ompi_proc) {
-        /* this debug has side effects on behavior/performance: it loads up the
-         * proc for every query and may end-up being equivalent to the 'preconnect
-         * all' option in the worse case. */
-        ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
-                                             peer_id, true);
-        assert(NULL != ompi_proc);
-        assert(ompi_proc_is_active(ompi_proc));
-    }
-#endif
     return (NULL == ompi_proc) ? true : ompi_proc_is_active(ompi_proc);
 }
 

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -808,12 +808,12 @@ static void era_update_new_dead_list(ompi_coll_ftagree_era_agreement_info_t *ci)
     }
 
     OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
-                         "%s ftagree:agreement (ERA) agreement (%d.%d).%d -- adding %d procs to the list of newly dead processes",
+                         "%s ftagree:agreement (ERA) agreement (%d.%d).%d -- adding %d procs to the list of newly dead processes (%d currently; AFR size is %d)",
                          OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
                          ci->agreement_id.ERAID_FIELDS.contextid,
                          ci->agreement_id.ERAID_FIELDS.epoch,
                          ci->agreement_id.ERAID_FIELDS.agreementid,
-                         r));
+                         r, ci->current_value->new_dead_array, ags->afr_size));
 
 #if OPAL_ENABLE_DEBUG
     {
@@ -1372,16 +1372,14 @@ static void era_build_tree_structure(ompi_coll_ftagree_era_agreement_info_t *ci)
 
     era_call_tree_fn(ci);
 
-    if( ompi_comm_rank(ci->comm) == 0 ) {
-        OPAL_OUTPUT_VERBOSE((4, ompi_ftmpi_output_handle,
-                             "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: re-built the tree structure with size %d: %s\n",
-                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
-                             ci->agreement_id.ERAID_FIELDS.contextid,
-                             ci->agreement_id.ERAID_FIELDS.epoch,
-                             ci->agreement_id.ERAID_FIELDS.agreementid,
-                             AGS(ci->comm)->tree_size,
-                             era_debug_tree(ci->ags->tree, ci->ags->tree_size)));
-    }
+    OPAL_OUTPUT_VERBOSE(((ompi_comm_rank(ci->comm) == 0)? 4: 50, ompi_ftmpi_output_handle,
+                        "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: re-built the tree structure with size %d: %s\n",
+                        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                        ci->agreement_id.ERAID_FIELDS.contextid,
+                        ci->agreement_id.ERAID_FIELDS.epoch,
+                        ci->agreement_id.ERAID_FIELDS.agreementid,
+                        AGS(ci->comm)->tree_size,
+                        era_debug_tree(ci->ags->tree, ci->ags->tree_size)));
 
 #if OPAL_ENABLE_DEBUG
     era_tree_check(ci->ags->tree, ci->ags->tree_size, 0);

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -471,6 +471,7 @@ static inline void ompi_proc_mark_as_failed(ompi_proc_t *proc) {
         abort();
     }
     proc->proc_active = false;
+    opal_atomic_wmb(); /* non-locked update needs a memory barrier to propagate */
 }
 #endif /* OPAL_ENABLE_FT_MPI */
 


### PR DESCRIPTION
Under a number of conditions, the MPI_COMM_AGREE operation would not terminate due to the faulty processes not being visible to the algorithm: this is due to multiple conditions, each fixed by one of the commits of this PR. 