### PR TITLE
v5.0.x: pml/ucx: move pmix finalize to the end of ompi_rte_finalize()

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -967,8 +967,6 @@ static bool check_file(const char *root, const char *path)
 
 int ompi_rte_finalize(void)
 {
-    /* shutdown pmix */
-    PMIx_Finalize(NULL, 0);
 
     /* cleanup the session directory we created */
     if (NULL != opal_process_info.job_session_dir) {
@@ -1027,6 +1025,9 @@ int ompi_rte_finalize(void)
 
 
     opal_finalize ();
+
+    /* shutdown pmix */
+    PMIx_Finalize(NULL, 0);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION

v5.0.x: pml/ucx: move pmix finalize to the end of ompi_rte_finalize()

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
(cherry picked from commit a12aa2f9081cfcf8980c0a840a1ff1efffacdf3c)