### PR TITLE
timings: fixes to be usable again

### DIFF
--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -138,6 +138,8 @@ int opal_init(int *pargc, char ***pargv)
 {
     int ret;
 
+    OPAL_TIMING_ENV_INIT(otmng);
+
     if (opal_initialized != 0) {
         if (opal_initialized < 0) {
             return OPAL_ERROR;

--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -125,7 +125,7 @@ libopalutil_core_la_SOURCES = \
         uri.c
 
 if OPAL_COMPILE_TIMING
-libopalutil_la_SOURCES += timings.c
+libopalutil_core_la_SOURCES += timings.c
 endif
 
 libopalutil_core_la_LIBADD = \

--- a/opal/util/timings.c
+++ b/opal/util/timings.c
@@ -85,9 +85,6 @@ opal_timing_ts_func_t opal_timing_ts_func(opal_timer_type_t type)
         return NULL;
 #endif // OPAL_TIMER_USEC_NATIVE
     default:
-        if (!opal_initialized) {
-            return get_ts_gettimeofday;
-        }
 #if OPAL_TIMER_CYCLE_NATIVE
         return get_ts_cycle;
 #elif OPAL_TIMER_USEC_NATIVE


### PR DESCRIPTION
The timing infrastructure introduced with commit dfb952fa78c5f3ddc5330802552c042f168ba5ee was broken by changes made via commit fe1c3844ac0bd7ffafa5a7cb300eace0299a724c

This patches restores the ability to build Open MPI with the --enable-timings config option set.

Note the output generated wth env OMPI_TIMING_ENABLE=1 is a bit jumbled at the moment but that will be addressed as part of a solution to issue #11166

Signed-off-by: Howard Pritchard <howardp@lanl.gov>