### PR TITLE
LANL/CI: workaround for aocc module

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -221,6 +221,7 @@ test:amd:
     - ls
     - module load aocc/3.0.0
     - export PATH=$PWD/install_test/bin:$PATH
+    - export LD_LIBRARY_PATH=$PWD/install_test/lib:$LD_LIBRARY_PATH
     - which mpirun
     - cd examples
     - mpirun -np 4 hostname


### PR DESCRIPTION
which sets the LD_LIBRARY_PATH to point to a system pmix which is too old for the prte used by main and v5.0.x.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit fdaa901dd6d7e6d4f5e79d58c1e4a08c05664b61)