### PR TITLE
Add platform files for Google Cloud HPC

### DIFF
--- a/contrib/platform/google/debug
+++ b/contrib/platform/google/debug
@@ -1,0 +1,13 @@
+# (c) 2023 Google, LLC. All rights reserved.
+
+enable_mem_debug=no
+enable_mem_profile=no
+enable_debug_symbols=yes
+enable_picky=no
+enable_debug=yes
+with_valgrind=no
+enable_memchecker=no
+
+# For now ensure that ob1 is used. It gives better performance than UCX at this
+# time.
+enable_pml_direct=ob1

--- a/contrib/platform/google/debug.conf
+++ b/contrib/platform/google/debug.conf
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2023      Google, LLC. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+#
+
+# Basic behavior to smooth startup
+mca_base_component_show_load_errors = 0
+
+btl = self,sm,tcp
+
+# Enabling the progress thread should give better performance in
+# most cases.
+btl_tcp_progress_thread = 1
+
+# Enable hierarchal collectives.
+coll_han_priority = 100
+
+# Enable coll/sm. This is commented out for now since coll/sm needs
+# some work before it is ready to be used in most cases.
+# coll_sm_priority = 100
+
+# If the system has busy polling enable (net.core.busy_read > 0)
+# the performance suffers greatly when using poll. Use epoll
+# instead. This should not hurt performance in other cases.
+opal_even_include = epoll
+
+## Setup MPI options
+mpi_show_handle_leaks = 0
+mpi_abort_print_stack = 0

--- a/contrib/platform/google/optimized
+++ b/contrib/platform/google/optimized
@@ -1,0 +1,13 @@
+# (c) 2023 Google, LLC. All rights reserved.
+
+enable_mem_debug=no
+enable_mem_profile=no
+enable_debug_symbols=no
+enable_picky=no
+enable_debug=no
+with_valgrind=no
+enable_memchecker=no
+
+# For now ensure that ob1 is used. It gives better performance than UCX at this
+# time.
+enable_pml_direct=ob1

--- a/contrib/platform/google/optimized.conf
+++ b/contrib/platform/google/optimized.conf
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2023      Google, LLC. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+#
+
+# Basic behavior to smooth startup
+mca_base_component_show_load_errors = 0
+
+btl = self,sm,tcp
+
+# Enabling the progress thread should give better performance in
+# most cases.
+btl_tcp_progress_thread = 1
+
+# Enable hierarchal collectives.
+coll_han_priority = 100
+
+# Enable coll/sm. This is commented out for now since coll/sm needs
+# some work before it is ready to be used in most cases.
+# coll_sm_priority = 100
+
+# If the system has busy polling enable (net.core.busy_read > 0)
+# the performance suffers greatly when using poll. Use epoll
+# instead. This should not hurt performance in other cases.
+opal_even_include = epoll
+
+## Setup MPI options
+mpi_show_handle_leaks = 0
+mpi_abort_print_stack = 0


### PR DESCRIPTION
These platform files provide the current recommended settings when running Open MPI on Google Cloud.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>