### PR TITLE
docs: put restrictions on Sphinx versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 --use-feature=2020-resolver
-sphinx>=4.2.0
+sphinx>=4.2.0,<=5.3.0
 recommonmark
 docutils
-sphinx-rtd-theme
+sphinx-rtd-theme<1.2.0


### PR DESCRIPTION
Sphinx has released v6.0.0 (and several versions beyond) in the past few weeks, which unfortunately broke some aspects of the ReadTheDocs Sphinx theme that we use (sphinx-rtd-theme).  See https://github.com/readthedocs/sphinx_rtd_theme/issues/1403 for some details.
    
Temporarily put some restrictions on the Sphinx and sphinx-rtd-theme versions that we use so that everything renders correctly.  Once sphinx-rtd-theme >= v1.2.0 is available (which correctly handles Sphinx >= v6.0.0), we can remove the version restriction, and go back to using whatever versions are current.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>