### PR TITLE
v5.0.x OSC/UCX: avoid creating ucp context if the application does not have MPI-RMA

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -35,6 +35,7 @@ typedef struct ompi_osc_ucx_component {
     opal_free_list_t requests; /* request free list for the r* communication variants */
     opal_free_list_t accumulate_requests; /* request free list for the r* communication variants */
     bool env_initialized; /* UCX environment is initialized or not */
+    bool priority_is_set; /* Is ucp_ctx created and component priority has been set */
     int comm_world_size;
     ucp_ep_h *endpoints;
     int num_modules;


### PR DESCRIPTION
v5.0.x OSC/UCX: avoid creating ucp context if the application does not have MPI-RMA

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit 076fca7853c0d25ae1b3e56fd5f0eac3ed561dbb)