### PR TITLE
Have configure abort if building for 32 bit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2006-2023 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -458,6 +458,10 @@ AC_CHECK_SIZEOF(double _Complex)
 AC_CHECK_SIZEOF(long double _Complex)
 
 AC_CHECK_SIZEOF(void *)
+AS_IF([test "$ac_cv_sizeof_void_p" -eq 4],
+      [AC_MSG_WARN([Open MPI no longer supports 32 bit builds.])
+       AC_MSG_WARN([Please use Open MPI v4.x or earlier if you need 32 bit support.])
+       AC_MSG_ERROR([Cannot continue])])
 AC_CHECK_SIZEOF(size_t)
 if test "$ac_cv_type_ssize_t" = yes ; then
     AC_CHECK_SIZEOF(ssize_t)

--- a/docs/faq/supported-systems.rst
+++ b/docs/faq/supported-systems.rst
@@ -155,19 +155,6 @@ multi-threaded MPI applications.
 
 /////////////////////////////////////////////////////////////////////////
 
-Does Open MPI support 32 bit environments?
-------------------------------------------
-
-As far as we know, yes.  64 bit architectures have effectively taken
-over the world, though, so 32-bit is not tested nearly as much as
-64-bit.
-
-Specifically, most of the Open MPI developers only have 64-bit
-machines, and therefore only test 32-bit in emulation mode.
-
-
-/////////////////////////////////////////////////////////////////////////
-
 Does Open MPI support 64 bit environments?
 ------------------------------------------
 

--- a/docs/release-notes/platform.rst
+++ b/docs/release-notes/platform.rst
@@ -22,8 +22,7 @@ Platform Notes
 
 * Other systems have been lightly (but not fully) tested:
 
-  * Linux (various flavors/distros), 32 bit, with gcc
-  * Cygwin 32 & 64 bit with gcc
+  * Cygwin 64 bit with gcc
   * ARMv6, ARMv7, ARMv9
   * Other 64 bit platforms.
   * OpenBSD.  Requires configure options ``--enable-mca-no-build=patcher``
@@ -31,6 +30,8 @@ Platform Notes
   * Problems have been reported when building Open MPI on FreeBSD 11.1
     using the clang-4.0 system compiler. A workaround is to build
     Open MPI using the GNU compiler.
+
+.. note:: 32-bit environments are no longer supported.
 
 * The run-time systems that are currently supported are:
 


### PR DESCRIPTION
Per #11248, have configure abort if it detects that it is building in a 32-bit environment.

The intent here is to see -- especially after v5.0.0 has been released and gets real-world usage -- if anyone cares about 32-bit builds any more (we suspect that no one does).  This PR is trivial to revert if someone cares about 32-bit builds.

If v5.0.x gets "enough" real-world usage and no one cares about 32-bit builds, we can start thinking about removing 32-bit infrastructure from within the Open MPI code base.