### PR TITLE
v4.1.x: NEWS: Bump v4.1.5 release to January 2023 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,7 @@ Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2006 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2023 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006      Voltaire, Inc. All rights reserved.
 Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
                         Use is subject to license terms.
@@ -58,8 +58,8 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
-4.1.5 -- December, 2022
------------------------
+4.1.5 -- January, 2023
+----------------------
 
 - Fix issue building with ifort on MacOS.
 - Backport patches to Libevent for CVE-2016-10195, CVE-2016-10196, and


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

bot:notacherrypick