### PR TITLE
opal/mca/btl/ofi: Support full set of BTL ops

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_atomics.c
+++ b/opal/mca/btl/ofi/btl_ofi_atomics.c
@@ -21,6 +21,23 @@ static inline int to_fi_op(mca_btl_base_atomic_op_t op)
         return FI_SUM;
     case MCA_BTL_ATOMIC_SWAP:
         return FI_ATOMIC_WRITE;
+    case MCA_BTL_ATOMIC_MAX:
+        return FI_MAX;
+    case MCA_BTL_ATOMIC_MIN:
+        return FI_MIN;
+    case MCA_BTL_ATOMIC_LAND:
+        return FI_LAND;
+    case MCA_BTL_ATOMIC_AND:
+        return FI_BAND;
+    case MCA_BTL_ATOMIC_LOR:
+        return FI_LOR;
+    case MCA_BTL_ATOMIC_OR:
+        return FI_BOR;
+    case MCA_BTL_ATOMIC_LXOR:
+        return FI_LXOR;
+    case MCA_BTL_ATOMIC_XOR:
+        return FI_BXOR;
+
     default:
         BTL_ERROR(("Unknown or unsupported atomic op."));
         MCA_BTL_OFI_ABORT();


### PR DESCRIPTION
The OFI BTL has network-support for all BTL ops.  This adds support for these ops, which otherwise currently cause a segfault when handled by the OFI BTL.

Signed-off-by: Luke Robison <lrbison@amazon.com>