### PR TITLE
ofi: support RHEL7 and libfabric pre 1.9

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -137,7 +137,16 @@ AC_DEFUN([OPAL_CHECK_OFI],[
            AC_CHECK_DECLS([PMIX_PACKAGE_RANK],
                           [],
                           [],
-                          [#include <pmix.h>])])
+                          [#include <pmix.h>])
+
+           AC_CHECK_MEMBER([struct fi_mr_attr.iface],
+                           [opal_check_fi_mr_attr_iface=1],
+                           [opal_check_fi_mr_attr_iface=0],
+                           [[#include <rdma/fi_domain.h>]])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_MR_IFACE],
+                              [${opal_check_fi_mr_attr_iface}],
+                              [check if iface avaiable in fi_mr_attr])])
 
     CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -306,6 +306,8 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         return OMPI_SUCCESS;
     }
 
+#if OPAL_OFI_HAVE_FI_MR_IFACE
+
     if ((convertor->flags & CONVERTOR_ACCELERATOR) && ompi_mtl_ofi.hmem_needs_reg) {
         /* Register buffer */
         int ret;
@@ -342,6 +344,8 @@ reg:
             return OMPI_ERROR;
         }
     }
+
+#endif
 
     return OMPI_SUCCESS;
 }

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -16,7 +16,7 @@
  *
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -254,6 +254,7 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
     attr.context = NULL;
     attr.requested_key = (uint64_t) reg;
 
+#if  OPAL_OFI_HAVE_FI_MR_IFACE
     if (OPAL_LIKELY(NULL != base)) {
         rc = opal_accelerator.check_addr(base, &dev_id, &flags);
         if (rc < 0) {
@@ -270,6 +271,7 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
             }
         }
     }
+#endif
 
     rc = fi_mr_regattr(btl->domain, &attr, 0, &ur->ur_mr);
     if (0 != rc) {


### PR DESCRIPTION
Fix to allow Open MPI to build on RHEL7 systems with default distro libfabric.

Related to #10954

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>