### PR TITLE
timing framework: fix use of timers

### DIFF
--- a/opal/mca/timer/base/timer_base_open.c
+++ b/opal/mca/timer/base/timer_base_open.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,6 +23,7 @@
 
 #include "opal/constants.h"
 #include "opal/mca/timer/base/base.h"
+#include "opal/util/timings.h"
 
 bool mca_timer_base_monotonic = true;
 
@@ -41,9 +44,31 @@ static int mca_timer_base_register(mca_base_register_flag_t flags)
     return OPAL_SUCCESS;
 }
 
+static int opal_timer_base_open(mca_base_open_flag_t flags)
+{
+    if (OPAL_SUCCESS != mca_base_framework_components_open(&opal_timer_base_framework, flags)) {
+        return OPAL_ERROR;
+    }
+
+    OPAL_TIMING_ENABLE_NATIVE_TIMERS;
+
+    return OPAL_SUCCESS;
+}
+
+static int opal_timer_base_close(void)
+{
+    int ret;
+
+    OPAL_TIMING_DISABLE_NATIVE_TIMERS;
+
+    return OPAL_SUCCESS;
+}
+
 /*
  * Globals
  */
 /* Use default register/open/close functions */
-MCA_BASE_FRAMEWORK_DECLARE(opal, timer, "OPAL OS timer", mca_timer_base_register, NULL, NULL,
+MCA_BASE_FRAMEWORK_DECLARE(opal, timer, "OPAL OS timer", mca_timer_base_register,
+                           opal_timer_base_open,
+                           opal_timer_base_close,
                            mca_timer_base_static_components, 0);

--- a/opal/util/timings.c
+++ b/opal/util/timings.c
@@ -2,6 +2,8 @@
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +43,8 @@
 
 #include MCA_timer_IMPLEMENTATION_HEADER
 
+static bool opal_timer_native_timers_avail = false;
+
 static double get_ts_gettimeofday(void)
 {
     double ret;
@@ -66,6 +70,17 @@ static double get_ts_usec(void)
 }
 #endif
 
+void opal_timing_enable_native_timers(void)
+{
+    opal_timer_native_timers_avail = true;
+}
+
+void opal_timing_disable_native_timers(void)
+{
+    opal_timer_native_timers_avail = false;
+}
+
+
 opal_timing_ts_func_t opal_timing_ts_func(opal_timer_type_t type)
 {
     switch (type) {
@@ -85,6 +100,9 @@ opal_timing_ts_func_t opal_timing_ts_func(opal_timer_type_t type)
         return NULL;
 #endif // OPAL_TIMER_USEC_NATIVE
     default:
+        if( false == opal_timer_native_timers_avail ){
+            return get_ts_gettimeofday;
+        }
 #if OPAL_TIMER_CYCLE_NATIVE
         return get_ts_cycle;
 #elif OPAL_TIMER_USEC_NATIVE

--- a/opal/util/timings.h
+++ b/opal/util/timings.h
@@ -2,6 +2,8 @@
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017-2018 Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,6 +41,11 @@ typedef struct {
 } opal_timing_env_t;
 
 opal_timing_ts_func_t opal_timing_ts_func(opal_timer_type_t type);
+void opal_timing_enable_native_timers(void);
+void opal_timing_disable_native_timers(void);
+
+#    define OPAL_TIMING_ENABLE_NATIVE_TIMERS  opal_timing_enable_native_timers()
+#    define OPAL_TIMING_DISABLE_NATIVE_TIMERS  opal_timing_disable_native_timers()
 
 #    define OPAL_TIMING_ENV_START_TYPE(func, _nm, type, prefix)                   \
         do {                                                                      \
@@ -199,6 +206,9 @@ opal_timing_ts_func_t opal_timing_ts_func(opal_timer_type_t type);
         OPAL_TIMING_ENV_GETDESC_PREFIX("", file, func, index, desc)
 
 #else
+
+#    define OPAL_TIMING_ENABLE_NATIVE_TIMERS
+#    define OPAL_TIMING_DISABLE_NATIVE_TIMERS
 
 #    define OPAL_TIMING_ENV_START_TYPE(func, type, prefix)
 


### PR DESCRIPTION
Related to PR #11280

and issue #11213.

Turns out owing to the libopal-core.la refactor that we have to add in a bit of plumbing to help the timing framework know when it can use native counters vs gettimeofday.

With this patch, the timing framework now produces sensible time resuls even prior to initialization of opal, i.e. when there are timers present in the opal "util" initialization procedure.

Note that currently the timing points in ompi_mpi_init in main are messed up so output isn't very useful.

A subsequent PR wherein the PMIx fence usage in the init procedure is cleaned up will include refactored timing points.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>