### PR TITLE
OSC/RDMA: Fix Compare_and_swap return value when comp != target

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -183,6 +183,8 @@ static inline int ompi_osc_rdma_cas_local (const void *source_addr, const void *
         if (ret) {
             goto out;
         }
+    } else {
+        ret = OMPI_SUCCESS;
     }
 
     ompi_osc_rdma_peer_accumulate_cleanup (module, peer, lock_acquired);


### PR DESCRIPTION
When comparison and target were equal, the return value was not initialized, causing nonsense error codes.

Signed-off-by: Luke Robison <lrbison@amazon.com>