### PR TITLE
Update PMIX to 4ba37c25 of v3.2 branch

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_connect.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_connect.c
@@ -147,7 +147,7 @@ pmix_status_t pmix_ptl_base_recv_blocking(int sd, char *data, size_t size)
                 pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
                                     "blocking_recv received error %d:%s from remote - cycling",
                                     pmix_socket_errno, strerror(pmix_socket_errno));
-                return PMIX_ERR_TEMP_UNAVAILABLE;
+		continue;
             }
             if (pmix_socket_errno != EINTR ) {
                 /* If we overflow the listen backlog, it's

--- a/opal/mca/pmix/pmix3x/pmix/test/test_spawn.c
+++ b/opal/mca/pmix/pmix3x/pmix/test/test_spawn.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +37,7 @@ static int test_spawn_common(char *my_nspace, int my_rank, int blocking)
     memset(nspace, 0, PMIX_MAX_NSLEN+1);
     napps = 1;
     PMIX_APP_CREATE(apps, napps);
+    apps[0].cmd = strdup("foo");  // need SOMETHING we intend to spawn!
     if (blocking) {
         if (PMIX_SUCCESS != (rc = PMIx_Spawn(NULL, 0, apps, napps, nspace))) {
             PMIX_APP_FREE(apps, napps);


### PR DESCRIPTION
This patch cherry-picked the following two commits:

4ba37c25 ptl/base: retry recv() when it encounter EAGAIN or EWOULDBLOCK 57e9d93a You have to at least spawn SOMETHING

from the v3.2 branch of openpmix to v4.1.x branch of openmpi

Signed-off-by: Wei Zhang <wzam@amazon.com>