### PR TITLE
Jenkinsfile: temporarily disable these CI tests

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -30,68 +30,15 @@ if (buildNumber > 1) {
 }
 milestone(buildNumber)
 
-check_stages = prepare_check_stages()
-println("Initialized Pipeline")
-
-// Today, we only expect to have one stage (do everything), but allow that
-// we may split build and test stages in the future.
-for (check_stage in check_stages) {
-    parallel(check_stage)
-}
-
-println('Tests Completed')
-
-// Returns a list of build stages ("build Open MPI", "Build Tests", etc.),
-// although currently we only support the one stage of "everything", where each
-// build stage is a map of different configurations to test.
-def prepare_check_stages() {
-    def configure_options = ["--disable-dlopen", "--disable-oshmem", "--enable-builtin-atomic", "--enable-ipv6"]
-    def compilers = ["clang10", "gcc5", "gcc6", "gcc7", "gcc8", "gcc9", "gcc10"]
-    def platforms = ["amazon_linux_2", "amazon_linux_2-arm64", "rhel7", "rhel8", "ubuntu_18.04"]
-
-    // TODO: While we are debugging, limit the number of combinations
-    // that we're running so that we don't waste a bunch of resources.
-    // Make all the lists empty so that the only check we do is the
-    // "distcheck" entry, below.  When we have finished debugging,
-    // remove the following lines so that we go back to the full set
-    // of test environments.
-    configure_options = []
-    compilers = []
-    platforms = []
-
-    def check_stages_list = []
-
-    // Build everything stage
-    def build_parallel_map = [:]
-    for (platform in platforms) {
-        def name = "Platform: ${platform}".replaceAll("-", "")
-        build_parallel_map.put(name, prepare_build(name, platform, ""))
-    }
-
-    for (compiler in compilers) {
-        def name = "Compiler: ${compiler}".replaceAll("-", "")
-        build_parallel_map.put(name, prepare_build(name, compiler, "--compiler \\\"${compiler}\\\""))
-    }
-
-      for (configure_option in configure_options) {
-        def name = "Configure: ${configure_option}".replaceAll("-", "")
-        build_parallel_map.put(name, prepare_build(name, "(ec2&&linux)", "--configure-args \\\"${configure_option}\\\""))
-    }
-
-    build_parallel_map.put("distcheck", prepare_build("distcheck", "tarball_build", "--distcheck"))
-
-    check_stages_list.add(build_parallel_map)
-
-    return check_stages_list
-}
-
-def prepare_build(build_name, label, build_arg) {
-    return {
-        stage("${build_name}") {
-            node(label) {
-                checkout(changelog: false, poll: false, scm: scm)
-                sh "/bin/bash -x .ci/community-jenkins/pr-builder.sh ${build_arg} ompi"
-            }
-        }
+// This is a temporary commmit which will be reverted.  We need to fix
+// the build status of a bunch of PRs and don't want to consume a
+// truckload of resources to do it.  So we'll commit this temp
+// Jenkinsfile which will blindly pass CI tests.  More to come shortly
+// (i.e., revering this blindly-pass-everything Jenkinsfile).
+println("Debugging start")
+stage("Jenkins debugging") {
+    node("amazon_linux_2") {
+        sh "/bin/true"
     }
 }
+println("Debugging end")


### PR DESCRIPTION
We need to reset the CI build status of a bunch of PRs in order to change some Jenkins config.  This commit effectively disables the Jenkinsfile tests by making them blindly pass.  We'll revert this commit shortly and resume actual CI tests.

(also note: these Jenkinsfile tests are secondary to OMPI's real CI, so removing these CI tests right now is not actually harmful because OMPI's real CI is still running via a different mechanism)

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>