### PR TITLE
hwloc: add the use_perf_cpus_only option

### DIFF
--- a/opal/mca/hwloc/base/base.h
+++ b/opal/mca/hwloc/base/base.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2023 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,6 +68,7 @@ OPAL_DECLSPEC char* opal_hwloc_base_print_locality(opal_hwloc_locality_t localit
 OPAL_DECLSPEC extern char *opal_hwloc_base_cpu_list;
 OPAL_DECLSPEC extern hwloc_cpuset_t opal_hwloc_base_given_cpus;
 OPAL_DECLSPEC extern char *opal_hwloc_base_topo_file;
+OPAL_DECLSPEC extern bool opal_hwloc_use_perf_cpus_only;
 
 /* convenience macro for debugging */
 #define OPAL_HWLOC_SHOW_BINDING(n, v, t)                                \

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2011-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2016-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2023 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,6 +58,7 @@ hwloc_obj_type_t opal_hwloc_levels[] = {
 };
 bool opal_hwloc_use_hwthreads_as_cpus = false;
 char *opal_hwloc_base_topo_file = NULL;
+int opal_hwloc_use_perf_cpus_only= false;
 
 static mca_base_var_enum_value_t hwloc_base_map[] = {
     {OPAL_HWLOC_BASE_MAP_NONE, "none"},
@@ -161,6 +162,12 @@ static int opal_hwloc_base_register(mca_base_register_flag_t flags)
                                  "Read local topology from file instead of directly sensing it",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_topo_file);
+
+    opal_hwloc_use_perf_cpus_only = false;
+    (void) mca_base_var_register("opal", "hwloc", "base", "use_perf_cpus_only",
+                                 "Only use performance cpus",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_cpukind);
 
     /* register parameters */
     return OPAL_SUCCESS;

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2023 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (C) 2018      Mellanox Technologies, Ltd.
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
@@ -160,6 +160,20 @@ int opal_hwloc_base_filter_cpus(hwloc_topology_t topo)
         #else
             avail = hwloc_bitmap_dup(root->cpuset);
         #endif
+        if (opal_hwloc_use_perf_cpus_only) {
+            #if HWLOC_API_VERSION < 0x24000
+                OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+                return OPAL_ERR_NOT_SUPPORTED;
+            #else
+                int nr = hwloc_cpukinds_get_nr(topo, 0);
+                if (0 < nr) {
+                    hwloc_bitmap_t perf_cpuset;
+                    if (0 <= hwloc_cpukinds_get_info(topo, perf_cpuset, nr-1 , NULL, NULL, NULL, 0)) {
+                        hwloc_bitmap_and(avail, avail, perf_cpuset);
+                    }
+                }
+            #endif
+        }
         OPAL_OUTPUT_VERBOSE((5, opal_hwloc_base_framework.framework_output,
                              "hwloc:base: no cpus specified - using root available cpuset"));
     } else {


### PR DESCRIPTION
only use the performance cpus when true (default is false) requires hwloc >= 2.4

Refs. open-mpi/ompi#11345

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>