### PR TITLE
lanl/ci: workaround for xlc builds

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -174,6 +174,7 @@ test:ibm:
     - ls
     - module load ibm
     - export PATH=$PWD/install_test/bin:$PATH
+    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/install_test/lib
     - which mpirun
     - pushd examples
     - mpirun -np 4 hostname


### PR DESCRIPTION
For some reason the ci builds on ibm nodes (with xl) need help with finding the pmix libraries installed as part of the build. Add the library install path to LD_LIBRARY_PATH as a workaround

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit dd656b5ad58bb701abe9dc6801a88e7cdbe01c95)