### PR TITLE
Revert "common/ompio: implement pipelined file_iwrite and iread"

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -14,7 +14,6 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
- * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,8 +100,6 @@
 
 #define OMPIO_PERM_NULL               -1
 #define OMPIO_IOVEC_INITIAL_SIZE      100
-
-extern opal_mutex_t mca_common_ompio_mutex;
 
 enum ompio_fs_type
 {
@@ -277,7 +274,7 @@ OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp, OMPI_MP
 
 OMPI_DECLSPEC int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
                                                     size_t bytes_per_cycle, size_t max_data, uint32_t iov_count,
-                                                    struct iovec *decoded_iov, int *ii, size_t *tbw,
+                                                    struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw,
                                                     size_t *spc, mca_common_ompio_io_array_t **io_array,
                                                     int *num_io_entries );
 

--- a/ompi/mca/common/ompio/common_ompio_buffer.h
+++ b/ompi/mca/common/ompio/common_ompio_buffer.h
@@ -31,10 +31,14 @@
         opal_output(1, "common_ompio: error allocating memory\n");      \
         return OMPI_ERR_OUT_OF_RESOURCE;                                \
     }                                                                   \
-    if (NULL != _decoded_iov) {                                         \
-        ((struct iovec*)_decoded_iov)->iov_base = _tbuf;                \
-        ((struct iovec*)_decoded_iov)->iov_len  = _max_data;            \
-        _iov_count=1;}}
+    _decoded_iov = (struct iovec *) malloc ( sizeof ( struct iovec ));  \
+    if ( NULL == _decoded_iov ) {                                       \
+        opal_output(1, "common_ompio: could not allocate memory.\n");   \
+        return OMPI_ERR_OUT_OF_RESOURCE;                                \
+    }                                                                   \
+    _decoded_iov->iov_base = _tbuf;                                     \
+    _decoded_iov->iov_len  = _max_data;                                 \
+    _iov_count=1;}
 
 #define OMPIO_PREPARE_READ_BUF(_fh,_buf,_count,_datatype,_tbuf,_convertor,_max_data,_tmp_buf_size,_decoded_iov,_iov_count){ \
         OBJ_CONSTRUCT( _convertor, opal_convertor_t);                                    \
@@ -45,10 +49,14 @@
         opal_output(1, "common_ompio: error allocating memory\n");      \
         return OMPI_ERR_OUT_OF_RESOURCE;                                \
     }                                                                   \
-    if (NULL != _decoded_iov) {                                         \
-        ((struct iovec*)_decoded_iov)->iov_base = _tbuf;                \
-        ((struct iovec*)_decoded_iov)->iov_len  = _max_data;            \
-	_iov_count=1;}}
+    _decoded_iov = (struct iovec *) malloc ( sizeof ( struct iovec ));  \
+    if ( NULL == _decoded_iov ) {                                       \
+        opal_output(1, "common_ompio: could not allocate memory.\n");   \
+        return OMPI_ERR_OUT_OF_RESOURCE;                                \
+    }                                                                   \
+    _decoded_iov->iov_base = _tbuf;                                     \
+    _decoded_iov->iov_len  = _max_data;                                 \
+    _iov_count=1;}
 
 void mca_common_ompio_check_gpu_buf ( ompio_file_t *fh, const void *buf, 
 				      int *is_gpu, int *is_managed);

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -48,12 +48,6 @@
 static mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view_fn;
 static mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value_fn;
 
-/*
- * Global, component-wide OMPIO mutex
- */
-opal_mutex_t mca_common_ompio_mutex = {{0}};
-
-
 int mca_common_ompio_file_open (ompi_communicator_t *comm,
                                 const char *filename,
                                 int amode,

--- a/ompi/mca/common/ompio/common_ompio_request.c
+++ b/ompi/mca/common/ompio/common_ompio_request.c
@@ -11,7 +11,6 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
- * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +29,8 @@ bool mca_common_ompio_progress_is_registered=false;
  * Global list of requests for this component
  */
 opal_list_t mca_common_ompio_pending_requests = {{0}};
+
+
 
 static int mca_common_ompio_request_free ( struct ompi_request_t **req)
 {
@@ -68,27 +69,19 @@ OBJ_CLASS_INSTANCE(mca_ompio_request_t, ompi_request_t,
 void mca_common_ompio_request_construct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_INIT (&(req->req_ompi), false );
-    req->req_ompi.req_free     = mca_common_ompio_request_free;
-    req->req_ompi.req_cancel   = mca_common_ompio_request_cancel;
-    req->req_ompi.req_type     = OMPI_REQUEST_IO;
-    req->req_data              = NULL;
-    req->req_tbuf              = NULL;
-    req->req_size              = 0;
-    req->req_max_data          = 0;
-    req->req_progress_fn       = NULL;
-    req->req_free_fn           = NULL;
-    req->req_parent            = NULL;
-    req->req_post_next_subreq  = NULL;
-    req->req_num_subreqs       = 0;
-    req->req_subreqs_completed = 0;
-    req->req_fh                = NULL;
-    req->req_post_followup     = false;
+    req->req_ompi.req_free   = mca_common_ompio_request_free;
+    req->req_ompi.req_cancel = mca_common_ompio_request_cancel;
+    req->req_ompi.req_type   = OMPI_REQUEST_IO;
+    req->req_data            = NULL;
+    req->req_tbuf            = NULL;
+    req->req_size            = 0;
+    req->req_progress_fn     = NULL;
+    req->req_free_fn         = NULL;
 
     OBJ_CONSTRUCT(&req->req_item, opal_list_item_t);
     opal_list_append (&mca_common_ompio_pending_requests, &req->req_item);
     return;
 }
-
 void mca_common_ompio_request_destruct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_FINI ( &(req->req_ompi));
@@ -114,15 +107,6 @@ void mca_common_ompio_request_fini ( void )
        were not destroyed / completed upon MPI_FINALIZE */
 
     OBJ_DESTRUCT(&mca_common_ompio_pending_requests);
-    if (mca_common_ompio_progress_is_registered) {
-        OPAL_THREAD_LOCK (&mca_common_ompio_mutex);
-        if (mca_common_ompio_progress_is_registered) {
-            opal_progress_unregister(mca_common_ompio_progress);
-            mca_common_ompio_progress_is_registered=false;
-        }
-        OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
-    }
-
     return;
 }
 
@@ -141,97 +125,33 @@ void mca_common_ompio_request_alloc ( mca_ompio_request_t **req, mca_ompio_reque
 
 void mca_common_ompio_register_progress ( void ) 
 {
-    if (false == mca_common_ompio_progress_is_registered) {
-        OPAL_THREAD_LOCK (&mca_common_ompio_mutex);
-        if (mca_common_ompio_progress_is_registered) {
-            OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
-            return;
-        }
+    if ( false == mca_common_ompio_progress_is_registered) {
         opal_progress_register (mca_common_ompio_progress);
         mca_common_ompio_progress_is_registered=true;
-        OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
     }
     return;
 }
-
 int mca_common_ompio_progress ( void )
 {
     mca_ompio_request_t *req=NULL;
     opal_list_item_t *litem=NULL;
     int completed=0;
 
-    if (!OPAL_THREAD_TRYLOCK(&mca_common_ompio_mutex)) {
-        OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
-            req = GET_OMPIO_REQ_FROM_ITEM(litem);
-            if (REQUEST_COMPLETE(&req->req_ompi) ) {
-                continue;
-            }
-            if (NULL != req->req_progress_fn) {
-                if (req->req_progress_fn(req)) {
-                    /**
-                     * To support pipelined read/write operations, a user level request
-                     * can contain multiple internal requests. These sub-requests
-                     * contain a pointer to the parent request.
-                     */
-                    mca_ompio_request_t *parent = req->req_parent;
-                    if (NULL != parent) {
-                        /* This is a subrequest */
-                        if (OMPI_SUCCESS != req->req_ompi.req_status.MPI_ERROR) {
-                            parent->req_ompi.req_status.MPI_ERROR = req->req_ompi.req_status.MPI_ERROR;
-                            ompi_request_complete (&parent->req_ompi, true);
-                            continue;
-                        }
-                        parent->req_subreqs_completed++;
-                        parent->req_ompi.req_status._ucount += req->req_ompi.req_status._ucount;
-                        req->req_post_followup = true;
-                    } else {
-                        /* This is a request without subrequests */
-                        completed++;
-                        ompi_request_complete (&req->req_ompi, true);
-                    }
-                    /* The fbtl progress function is expected to set the
-                     * status elements
-                     */
-                }
-            } else {
-                /* This is a request without a lower level progress function, .e.g
-                 * a parent request
+    OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
+        req = GET_OMPIO_REQ_FROM_ITEM(litem);
+        if( REQUEST_COMPLETE(&req->req_ompi) ) {
+            continue;
+        }
+        if ( NULL != req->req_progress_fn ) {
+            if ( req->req_progress_fn(req) ) {
+                completed++;
+                ompi_request_complete (&req->req_ompi, true);
+                /* The fbtl progress function is expected to set the
+                 * status elements
                  */
-                if (req->req_num_subreqs == req->req_subreqs_completed) {
-                    completed++;
-                    ompi_request_complete (&req->req_ompi, true);
-                }
             }
         }
 
-        /**
-         * Splitting the ompio progress loop is necessary to avoid that a pending operation
-         * consisting of multiple subrequests is executed in a single invokation of the progress
-         * function.
-         *
-         * Otherwise it can happen that the next subrequest is posted, which ends up at the tail
-         * of the ompio_pending_requests_list, and would be processed in the same loop execution;
-         * which then posts the next subrequest, which is also processed potentially right away
-         * etc. This would make the ompio_progress function block for a long time, and prevent
-         * overlapping operations.
-         *
-         * Splitting the loop into two parts, one checking for completion and one posting
-         * the next subrequest if necessary avoids the problem.
-         */
-        OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
-            req = GET_OMPIO_REQ_FROM_ITEM(litem);
-            if (true == req->req_post_followup) {
-                if (OPAL_THREAD_TRYLOCK(&req->req_fh->f_fh->f_lock)) {
-                    continue;
-                }
-                mca_ompio_request_t *parent = req->req_parent;
-                parent->req_post_next_subreq(parent, parent->req_subreqs_completed);
-                OPAL_THREAD_UNLOCK(&req->req_fh->f_fh->f_lock);
-                ompi_request_complete (&req->req_ompi, false);
-                ompi_request_free ((ompi_request_t**)&req);
-            }
-        }
-        OPAL_THREAD_UNLOCK(&mca_common_ompio_mutex);
     }
 
     return completed;

--- a/ompi/mca/common/ompio/common_ompio_request.h
+++ b/ompi/mca/common/ompio/common_ompio_request.h
@@ -13,7 +13,6 @@
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,8 +43,6 @@ typedef enum {
     MCA_OMPIO_REQUEST_READ_ALL,
 } mca_ompio_request_type_t;
 
-struct mca_ompio_request_t;
-typedef void(*mca_ompio_post_next_subreq_t)(struct mca_ompio_request_t *req, int val);
 
 /**
  * Main structure for OMPIO requests
@@ -57,16 +54,9 @@ struct mca_ompio_request_t {
     opal_list_item_t                               req_item;
     void                                          *req_tbuf;
     size_t                                         req_size;
-    size_t                                     req_max_data;
     opal_convertor_t                          req_convertor;
     mca_fbtl_base_module_progress_fn_t      req_progress_fn;
     mca_fbtl_base_module_request_free_fn_t      req_free_fn;
-    mca_ompio_post_next_subreq_t       req_post_next_subreq;
-    struct mca_ompio_request_t                  *req_parent;
-    int                                     req_num_subreqs;
-    int                               req_subreqs_completed;
-    ompio_file_t                                    *req_fh;
-    bool                                  req_post_followup;
 };
 typedef struct mca_ompio_request_t mca_ompio_request_t;
 OBJ_CLASS_DECLARATION(mca_ompio_request_t);

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -88,6 +88,14 @@ static int io_progress(void);
 static int priority_param = 30;
 static int delete_priority_param = 30;
 
+
+/*
+ * Global, component-wide OMPIO mutex because OMPIO is not thread safe
+ */
+opal_mutex_t mca_io_ompio_mutex = {{0}};
+
+
+
 /*
  * Public string showing this component's version number
  */
@@ -265,7 +273,7 @@ static int register_component(void)
 static int open_component(void)
 {
     /* Create the mutex */
-    OBJ_CONSTRUCT(&mca_common_ompio_mutex, opal_mutex_t);
+    OBJ_CONSTRUCT(&mca_io_ompio_mutex, opal_mutex_t);
 
     mca_common_ompio_request_init ();
 
@@ -278,7 +286,7 @@ static int close_component(void)
 {
     mca_common_ompio_request_fini ();
     mca_common_ompio_buffer_alloc_fini();
-    OBJ_DESTRUCT(&mca_common_ompio_mutex);
+    OBJ_DESTRUCT(&mca_io_ompio_mutex);
 
     return OMPI_SUCCESS;
 }
@@ -344,9 +352,9 @@ static int delete_select(const char *filename, struct opal_info_t *info,
 {
     int ret;
 
-    OPAL_THREAD_LOCK (&mca_common_ompio_mutex);
+    OPAL_THREAD_LOCK (&mca_io_ompio_mutex);
     ret = mca_common_ompio_file_delete (filename, info);
-    OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
+    OPAL_THREAD_UNLOCK (&mca_io_ompio_mutex);
 
     return ret;
 }


### PR DESCRIPTION
This reverts commit ff7458a8b973a1bd89b7b9565f2d197225de4c6f.

There is a major logical flaw in this commit. Bits and pieces of this commit will be reused on the correct solution, but as it is the code will potentially not work correctly for multiple simultaneous, large,  iread/iwrite operations on the same file handle.

Signed-off-by: Edgar Gabriel <edgar.gabriel@amd.com>