### PR TITLE
Increase segment sizes in coll/han and coll/adapt

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -45,7 +45,7 @@ int ompi_coll_adapt_ireduce_register(void)
         mca_coll_adapt_component.adapt_ireduce_algorithm = 1;
     }
 
-    mca_coll_adapt_component.adapt_ireduce_segment_size = 163740;
+    mca_coll_adapt_component.adapt_ireduce_segment_size = 524288;
     mca_base_component_var_register(c, "reduce_segment_size",
                                     "Segment size in bytes used by default for reduce algorithms. Only has meaning if algorithm is forced and supports segmenting. 0 bytes means no segmentation.",
                                     MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -261,7 +261,7 @@ static int han_register(void)
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &cs->han_output_verbose);
 
-    cs->han_bcast_segsize = 65536;
+    cs->han_bcast_segsize = 524288;
     (void) mca_base_component_var_register(c, "bcast_segsize",
                                            "segment size for bcast",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
@@ -281,7 +281,7 @@ static int han_register(void)
                                               &cs->han_bcast_low_module,
                                               &cs->han_op_module_name.bcast.han_op_low_module_name);
 
-    cs->han_reduce_segsize = 65536;
+    cs->han_reduce_segsize = 524288;
     (void) mca_base_component_var_register(c, "reduce_segsize",
                                            "segment size for reduce",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
@@ -300,7 +300,7 @@ static int han_register(void)
                                               OPAL_INFO_LVL_9, &cs->han_reduce_low_module,
                                               &cs->han_op_module_name.reduce.han_op_low_module_name);
 
-    cs->han_allreduce_segsize = 65536;
+    cs->han_allreduce_segsize = 524288;
     (void) mca_base_component_var_register(c, "allreduce_segsize",
                                            "segment size for allreduce",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,


### PR DESCRIPTION
Increase segment sizes for bcast, reduce, and allreduce to 512k. On modern machines, higher segment sizes seem to be more efficient as they reduce the overhead of segmenting (less messages, better chance at saturating the network).

Example for increased segment sizes on Hawk (64 core AMD EPYC Rome, ConnectX-6):

Reduce with 64k (current segment size)
![Screen Shot 2023-01-31 at 09 59 11](https://user-images.githubusercontent.com/10974502/215795682-a81e4174-6c89-4a67-9934-94a82c51b30e.png)

Reduce with 512k (new segment size)
![Screen Shot 2023-01-31 at 09 59 42](https://user-images.githubusercontent.com/10974502/215795800-f7f514e3-9f21-4d5f-8e88-cb9f280a50a0.png)

Note the lower latency on the right side of the plots. The change in segment size yields an improvement of about 10x for han over tuned. There is no data for han over sm because sm crashes at this segment size.
