### PR TITLE
Bump priority of coll/han to make it the default

### DIFF
--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -249,7 +249,7 @@ static int han_register(void)
     TOPO_LVL_T topo_lvl;
     COMPONENT_T component;
 
-    cs->han_priority = 0;
+    cs->han_priority = 35;
     (void) mca_base_component_var_register(c, "priority", "Priority of the HAN coll component",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,


### PR DESCRIPTION
coll/tuned has default priority 30, give han 35 to make it the default.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>