### PR TITLE
Fixing VERSION file for v5.0.0rc10

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -94,15 +94,15 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=80:0:0
-libmpi_mpifh_so_version=80:0:0
-libmpi_usempi_tkr_so_version=80:0:0
-libmpi_usempi_ignore_tkr_so_version=80:0:0
-libmpi_usempif08_so_version=80:0:0
+libmpi_so_version=80:0:40
+libmpi_mpifh_so_version=80:0:40
+libmpi_usempi_tkr_so_version=80:0:40
+libmpi_usempi_ignore_tkr_so_version=80:0:40
+libmpi_usempif08_so_version=80:0:40
 libopen_pal_so_version=80:0:0
-libmpi_java_so_version=80:0:0
-liboshmem_so_version=80:0:0
-libompitrace_so_version=80:0:0
+libmpi_java_so_version=80:0:40
+liboshmem_so_version=80:0:40
+libompitrace_so_version=80:0:40
 
 # "Common" components install standalone libraries that are run-time
 # linked by one or more components.  So they need to be versioned as


### PR DESCRIPTION
bot:notacherrypick

Open MPI v5.0.0 shared libraries are ABI compatible with v4.1.x with a few subtle possible exceptions for Fortran.

In the rare case that you compile your application in such a way that the size of an integer for C is different than the size of an integer in Fortran, you'll need to rebuild and relink your application.

There are some additional Fortran API changes involving intents and asyncs, along with changing some interfaces from named to unamed.

Refer to https://docs.open-mpi.org/en/v5.0.x/version-numbering.html#shared-library-version-number for policy

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>