### PR TITLE
ofi: check if libfabric has FI_HMEM_ROCR at configure time

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -146,7 +146,16 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_MR_IFACE],
                               [${opal_check_fi_mr_attr_iface}],
-                              [check if iface avaiable in fi_mr_attr])])
+                              [check if iface avaiable in fi_mr_attr])
+
+           AC_CHECK_DECL([FI_HMEM_ROCR],
+                         [opal_check_fi_hmem_rocr=1],
+                         [opal_check_fi_hmem_rocr=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ROCR],
+                              [${opal_check_fi_hmem_rocr}],
+                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])])
 
     CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -326,9 +326,11 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
             attr.iface = FI_HMEM_CUDA;
             opal_accelerator.get_device(&attr.device.cuda);
+#if OPAL_OFI_HAVE_FI_HMEM_ROCR
         } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
             attr.iface = FI_HMEM_ROCR;
             opal_accelerator.get_device(&attr.device.cuda);
+#endif
         } else {
             return OPAL_ERROR;
         }

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -263,9 +263,11 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
             if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
                 attr.iface = FI_HMEM_CUDA;
                 opal_accelerator.get_device(&attr.device.cuda);
+#if OPAL_OFI_HAVE_FI_HMEM_ROCR
 	    } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
                 attr.iface = FI_HMEM_ROCR;
                 opal_accelerator.get_device(&attr.device.cuda);
+#endif
             } else {
                 return OPAL_ERROR;
             }


### PR DESCRIPTION
Fixes the issue (https://github.com/open-mpi/ompi/issues/10954) that libfabric < 1.11.0 does not have `FI_HMEM_ROCR` and compilation fails.

Signed-off-by: Shumpei Shiina <shiina@eidos.ic.i.u-tokyo.ac.jp>