### PR TITLE
Topic/ompio pipeline iread iwrite3

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -239,13 +239,13 @@ int mca_common_ompio_fview_based_grouping(ompio_file_t *fh,
     OMPI_MPI_OFFSET_TYPE *start_offsets_lens = NULL;
 
     //Store start offset,length and corresponding rank in an array
-    if(NULL == fh->f_decoded_iov){
+    if(NULL == fh->f_fview.f_decoded_iov){
       start_offset_len[0] = 0;
       start_offset_len[1] = 0;
     }
     else{
-       start_offset_len[0] = (OMPI_MPI_OFFSET_TYPE) fh->f_decoded_iov[0].iov_base;
-       start_offset_len[1] = fh->f_decoded_iov[0].iov_len;
+       start_offset_len[0] = (OMPI_MPI_OFFSET_TYPE) fh->f_fview.f_decoded_iov[0].iov_base;
+       start_offset_len[1] = fh->f_fview.f_decoded_iov[0].iov_len;
     }
     start_offset_len[2] = fh->f_rank;
 
@@ -1275,13 +1275,13 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
     int ret=OMPI_SUCCESS;
 
     //Store start offset and length in an array //also add bytes per process
-    if(NULL == fh->f_decoded_iov){
+    if(NULL == fh->f_fview.f_decoded_iov){
          start_offset_len[0] = 0;
          start_offset_len[1] = 0;
     }
     else{
-         start_offset_len[0] = (OMPI_MPI_OFFSET_TYPE) fh->f_decoded_iov[0].iov_base;
-         start_offset_len[1] = fh->f_decoded_iov[0].iov_len;
+         start_offset_len[0] = (OMPI_MPI_OFFSET_TYPE) fh->f_fview.f_decoded_iov[0].iov_base;
+         start_offset_len[1] = fh->f_fview.f_decoded_iov[0].iov_len;
     }
     start_offset_len[2] = bytes_per_proc;
     start_offsets_lens_tmp = (OMPI_MPI_OFFSET_TYPE* )malloc (3 * fh->f_init_procs_per_group * sizeof(OMPI_MPI_OFFSET_TYPE));

--- a/ompi/mca/common/ompio/common_ompio_buffer.h
+++ b/ompi/mca/common/ompio/common_ompio_buffer.h
@@ -31,14 +31,10 @@
         opal_output(1, "common_ompio: error allocating memory\n");      \
         return OMPI_ERR_OUT_OF_RESOURCE;                                \
     }                                                                   \
-    _decoded_iov = (struct iovec *) malloc ( sizeof ( struct iovec ));  \
-    if ( NULL == _decoded_iov ) {                                       \
-        opal_output(1, "common_ompio: could not allocate memory.\n");   \
-        return OMPI_ERR_OUT_OF_RESOURCE;                                \
-    }                                                                   \
-    _decoded_iov->iov_base = _tbuf;                                     \
-    _decoded_iov->iov_len  = _max_data;                                 \
-    _iov_count=1;}
+    if (NULL != _decoded_iov) {                                         \
+        ((struct iovec*)_decoded_iov)->iov_base = _tbuf;                \
+        ((struct iovec*)_decoded_iov)->iov_len  = _max_data;            \
+        _iov_count=1;}}
 
 #define OMPIO_PREPARE_READ_BUF(_fh,_buf,_count,_datatype,_tbuf,_convertor,_max_data,_tmp_buf_size,_decoded_iov,_iov_count){ \
         OBJ_CONSTRUCT( _convertor, opal_convertor_t);                                    \
@@ -49,14 +45,10 @@
         opal_output(1, "common_ompio: error allocating memory\n");      \
         return OMPI_ERR_OUT_OF_RESOURCE;                                \
     }                                                                   \
-    _decoded_iov = (struct iovec *) malloc ( sizeof ( struct iovec ));  \
-    if ( NULL == _decoded_iov ) {                                       \
-        opal_output(1, "common_ompio: could not allocate memory.\n");   \
-        return OMPI_ERR_OUT_OF_RESOURCE;                                \
-    }                                                                   \
-    _decoded_iov->iov_base = _tbuf;                                     \
-    _decoded_iov->iov_len  = _max_data;                                 \
-    _iov_count=1;}
+    if (NULL != _decoded_iov) {                                         \
+        ((struct iovec*)_decoded_iov)->iov_base = _tbuf;                \
+        ((struct iovec*)_decoded_iov)->iov_len  = _max_data;            \
+	_iov_count=1;}}
 
 void mca_common_ompio_check_gpu_buf ( ompio_file_t *fh, const void *buf, 
 				      int *is_gpu, int *is_managed);

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -99,8 +99,8 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     ompio_fh->f_info   = info;
 
     /* set some function pointers required for fcoll, fbtls and sharedfp modules*/
-    ompio_fh->f_generate_current_file_view=generate_current_file_view_fn;
-    ompio_fh->f_get_mca_parameter_value=get_mca_parameter_value_fn;
+    ompio_fh->f_generate_current_file_view = generate_current_file_view_fn;
+    ompio_fh->f_get_mca_parameter_value    = get_mca_parameter_value_fn;
 
     ompio_fh->f_filename = filename;
     if (opal_path_is_absolute(filename) ) {
@@ -343,9 +343,9 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
         ompio_fh->f_procs_in_group = NULL;
     }
 
-    if (NULL != ompio_fh->f_decoded_iov) {
-        free (ompio_fh->f_decoded_iov);
-        ompio_fh->f_decoded_iov = NULL;
+    if (NULL != ompio_fh->f_fview.f_decoded_iov) {
+        free (ompio_fh->f_fview.f_decoded_iov);
+        ompio_fh->f_fview.f_decoded_iov = NULL;
     }
 
     if (NULL != ompio_fh->f_mem_convertor) {
@@ -415,21 +415,21 @@ int mca_common_ompio_file_get_position (ompio_file_t *fh,
 {
     OMPI_MPI_OFFSET_TYPE off;
 
-    if ( 0 == fh->f_view_extent ||
-         0 == fh->f_view_size   ||
-         0 == fh->f_etype_size ) {
+    if ( 0 == fh->f_fview.f_view_extent ||
+         0 == fh->f_fview.f_view_size   ||
+         0 == fh->f_fview.f_etype_size ) {
         /* not sure whether we should raise an error here */
         *offset = 0;
         return OMPI_SUCCESS;
     }
     /* No. of copies of the entire file view */
-    off = (fh->f_offset - fh->f_disp)/fh->f_view_extent;
+    off = (fh->f_fview.f_offset - fh->f_fview.f_disp)/fh->f_fview.f_view_extent;
 
     /* No. of elements per view */
-    off *= (fh->f_view_size / fh->f_etype_size);
+    off *= (fh->f_fview.f_view_size / fh->f_fview.f_etype_size);
 
     /* No of elements used in the current copy of the view */
-    off += fh->f_total_bytes / fh->f_etype_size;
+    off += fh->f_fview.f_total_bytes / fh->f_fview.f_etype_size;
 
     *offset = off;
     return OMPI_SUCCESS;
@@ -445,9 +445,9 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
        ptrdiff_t d[2], base;
        int i, flag;
        
-       fh->f_io_array = NULL;
-       fh->f_perm = OMPIO_PERM_NULL;
-       fh->f_flags = 0;
+       fh->f_flags         = 0;
+       fh->f_perm          = OMPIO_PERM_NULL;
+       fh->f_io_array      = NULL;
        
        fh->f_bytes_per_agg = OMPIO_MCA_GET(fh, bytes_per_agg);
        opal_info_get (fh->f_info, "cb_buffer_size", &stripe_str, &flag);
@@ -458,43 +458,41 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
            OBJ_RELEASE(stripe_str);
        }
 
-       fh->f_atomicity = 0;
        fh->f_fs_block_size = 4096;
+       fh->f_atomicity     = 0;
+       fh->f_stripe_size   = 0;
+       fh->f_stripe_count  = 0;
        
-       fh->f_offset = 0;
-       fh->f_disp = 0;
-       fh->f_position_in_file_view = 0;
-       fh->f_index_in_file_view = 0;
-       fh->f_total_bytes = 0;
+       /* File View */
+       fh->f_fview.f_flags                 = 0;
+       fh->f_fview.f_offset                = 0;
+       fh->f_fview.f_disp                  = 0;
+       fh->f_fview.f_position_in_file_view = 0;
+       fh->f_fview.f_index_in_file_view    = 0;
+       fh->f_fview.f_total_bytes           = 0;
+       fh->f_fview.f_decoded_iov           = NULL;
+
+       fh->f_iov_type      = MPI_DATATYPE_NULL;
+       fh->f_etype         = MPI_DATATYPE_NULL;
+       fh->f_filetype      = MPI_DATATYPE_NULL;
+       fh->f_orig_filetype = MPI_DATATYPE_NULL;
        
        fh->f_init_procs_per_group = -1;
-       fh->f_init_procs_in_group = NULL;
-       
-       fh->f_procs_per_group = -1;
-       fh->f_procs_in_group = NULL;
-       
-       fh->f_init_num_aggrs = -1;
-       fh->f_init_aggr_list = NULL;
-       
-       fh->f_num_aggrs = -1;
-       fh->f_aggr_list = NULL;
-       
-       /* Default file View */
-       fh->f_iov_type = MPI_DATATYPE_NULL;
-       fh->f_stripe_size = 0;
-       /*Decoded iovec of the file-view*/
-       fh->f_decoded_iov = NULL;
-       fh->f_etype = MPI_DATATYPE_NULL;
-       fh->f_filetype = MPI_DATATYPE_NULL;
-       fh->f_orig_filetype = MPI_DATATYPE_NULL;
-       fh->f_datarep = NULL;
+       fh->f_init_procs_in_group  = NULL;
+       fh->f_procs_per_group      = -1;
+       fh->f_procs_in_group       = NULL;
+       fh->f_init_num_aggrs       = -1;
+       fh->f_init_aggr_list       = NULL;
+       fh->f_num_aggrs            = -1;
+       fh->f_aggr_list            = NULL;
+       fh->f_datarep              = NULL;
        
        /*Create a derived datatype for the created iovec */
        types[0] = &ompi_mpi_long.dt;
        types[1] = &ompi_mpi_long.dt;
        
-       d[0] = (ptrdiff_t) fh->f_decoded_iov;
-       d[1] = (ptrdiff_t) &fh->f_decoded_iov[0].iov_len;
+       d[0] = (ptrdiff_t) fh->f_fview.f_decoded_iov;
+       d[1] = (ptrdiff_t) &fh->f_fview.f_decoded_iov[0].iov_len;
        
        base = d[0];
        for (i=0 ; i<2 ; i++) {

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -12,7 +12,7 @@
  *  Copyright (c) 2008-2019 University of Houston. All rights reserved.
  *  Copyright (c) 2018      Research Organization for Information Science
  *                          and Technology (RIST). All rights reserved.
- *  Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ *  Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  *  $COPYRIGHT$
  *
  *  Additional copyrights may follow
@@ -75,7 +75,7 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
         return MPI_ERR_ACCESS;
     }
 
-    if (0 == count || 0 == fh->f_iov_count) {
+    if (0 == count || 0 == fh->f_fview.f_iov_count) {
         if (MPI_STATUS_IGNORE != status) {
             status->_ucount = 0;
         }
@@ -124,7 +124,6 @@ int mca_common_ompio_file_read_default (ompio_file_t *fh, void *buf,
     size_t spc=0;
     ssize_t ret_code=0;
     int i = 0; /* index into the decoded iovec of the buffer */
-    int j = 0; /* index into the file via iovec */
 
     mca_common_ompio_decode_datatype (fh, datatype, count, buf,
                                       &max_data, fh->f_mem_convertor,
@@ -138,11 +137,10 @@ int mca_common_ompio_file_read_default (ompio_file_t *fh, void *buf,
             cycles, max_data);
 #endif
 
-    j = fh->f_index_in_file_view;
     for (index = 0; index < cycles; index++) {
-        mca_common_ompio_build_io_array (fh, index, cycles, bytes_per_cycle,
+        mca_common_ompio_build_io_array (&(fh->f_fview), index, cycles, bytes_per_cycle,
                                          max_data, iov_count, decoded_iov,
-                                         &i, &j, &total_bytes_read, &spc,
+                                         &i, &total_bytes_read, &spc,
                                          &fh->f_io_array, &fh->f_num_of_io_entries);
         if (fh->f_num_of_io_entries == 0) {
 	    ret_code = 0;
@@ -182,13 +180,12 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
     int index = 0;
     int cycles = 0;
     uint32_t iov_count = 0;
-    struct iovec *decoded_iov = NULL;
+    struct iovec decoded_iov;
 
     size_t max_data=0, real_bytes_read=0;
     size_t spc=0;
     ssize_t ret_code=0;
     int i = 0; /* index into the decoded iovec of the buffer */
-    int j = 0; /* index into the file via iovec */
 
     char *tbuf1=NULL, *tbuf2=NULL;
     char *unpackbuf=NULL, *readbuf=NULL;
@@ -198,7 +195,7 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
 
     bytes_per_cycle = OMPIO_MCA_GET(fh, pipeline_buffer_size);
     OMPIO_PREPARE_READ_BUF (fh, buf, count, datatype, tbuf1, &convertor,
-                            max_data, bytes_per_cycle, decoded_iov, iov_count);
+                            max_data, bytes_per_cycle, &decoded_iov, iov_count);
     cycles = ceil((double)max_data/bytes_per_cycle);
 
     readbuf = unpackbuf = tbuf1;
@@ -206,7 +203,6 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
         tbuf2 = mca_common_ompio_alloc_buf (fh, bytes_per_cycle);
         if (NULL == tbuf2) {
             opal_output(1, "common_ompio: error allocating memory\n");
-            free (decoded_iov);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         unpackbuf = tbuf2;
@@ -236,15 +232,14 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
     **    - unpack buffer i
     */
     
-    j = fh->f_index_in_file_view;
     if (can_overlap) {
 	mca_common_ompio_register_progress ();	    
     }
 
     for (index = 0; index < cycles+1; index++) {
         if (index < cycles) {
-            decoded_iov->iov_base = readbuf;
-            decoded_iov->iov_len  = bytes_per_cycle;
+            decoded_iov.iov_base  = readbuf;
+            decoded_iov.iov_len   = bytes_per_cycle;
             bytes_this_cycle      = (index == cycles-1) ?
                 (max_data - (index * bytes_per_cycle)) :
                 bytes_per_cycle;
@@ -253,9 +248,9 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
             spc = 0;
             tbr = 0;
 
-            mca_common_ompio_build_io_array (fh, index, cycles, bytes_per_cycle,
+            mca_common_ompio_build_io_array (&(fh->f_fview), index, cycles, bytes_per_cycle,
                                              bytes_this_cycle, iov_count,
-                                             decoded_iov, &i, &j, &tbr, &spc,
+                                             &decoded_iov, &i, &tbr, &spc,
                                              &fh->f_io_array, &fh->f_num_of_io_entries);
 	    if (fh->f_num_of_io_entries == 0) {
 		ret_code = 0;
@@ -263,7 +258,7 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
 	    }
 
             if (can_overlap) {
-                mca_common_ompio_request_alloc ( &ompio_req, MCA_OMPIO_REQUEST_READ);
+                mca_common_ompio_request_alloc (&ompio_req, MCA_OMPIO_REQUEST_READ);
 		fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *)ompio_req);
             } else {
 		ret_code = fh->f_fbtl->fbtl_preadv (fh);
@@ -293,9 +288,9 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
 	if ((can_overlap && index != 0) ||
 	    (!can_overlap && index < cycles)) {
 	    size_t pos = 0;
-	    decoded_iov->iov_base = unpackbuf;
-	    decoded_iov->iov_len  = can_overlap ? bytes_prev_cycle : bytes_this_cycle;
-	    opal_convertor_unpack (&convertor, decoded_iov, &iov_count, &pos);
+	    decoded_iov.iov_base = unpackbuf;
+	    decoded_iov.iov_len  = can_overlap ? bytes_prev_cycle : bytes_this_cycle;
+	    opal_convertor_unpack (&convertor, &decoded_iov, &iov_count, &pos);
 	}
 
 	fh->f_num_of_io_entries = 0;
@@ -317,7 +312,6 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
         mca_common_ompio_release_buf (fh, tbuf2);
     }
 
-    free (decoded_iov);
     if ( MPI_STATUS_IGNORE != status ) {
         status->_ucount = real_bytes_read;
     }
@@ -352,52 +346,100 @@ int mca_common_ompio_file_read_at (ompio_file_t *fh,
     return ret;
 }
 
+static void mca_common_ompio_post_next_read_subreq(struct mca_ompio_request_t *req, int index)
+{
+    uint32_t iov_count = 1;
+    size_t pos = 0, spc = 0, tbw = 0;
+    int i = 0;
+    mca_ompio_request_t *ompio_subreq=NULL;
+    size_t bytes_per_cycle = OMPIO_MCA_GET(req->req_fh, pipeline_buffer_size);
+    struct iovec decoded_iov;
+
+    /* Step 1: finish index-1 unpack operation */
+    if (index - 1 >= 0) {
+        size_t num_bytes = bytes_per_cycle;
+        /**
+         *  should really be 'req_num_subreqs -1 == index -1'
+         *  which is the same as below.
+         */
+        if (req->req_num_subreqs == index) {
+            num_bytes = req->req_max_data - (index-1)* bytes_per_cycle;
+        }
+        decoded_iov.iov_base = req->req_tbuf;
+        decoded_iov.iov_len  = num_bytes;
+        opal_convertor_unpack (&req->req_convertor, &decoded_iov, &iov_count, &pos);
+    }
+
+    /* Step 2: post next iread subrequest */
+    if (req->req_num_subreqs == index) {
+        /* all done */
+        return;
+    }
+
+    decoded_iov.iov_base = req->req_tbuf;
+    decoded_iov.iov_len  = (req->req_num_subreqs-1 == index) ?
+	req->req_max_data - (index* bytes_per_cycle) : req->req_size;
+    mca_common_ompio_build_io_array (req->req_fview, index, req->req_num_subreqs,
+                                     bytes_per_cycle, decoded_iov.iov_len,
+                                     iov_count, &decoded_iov,
+                                     &i, &tbw, &spc,
+                                     &req->req_fh->f_io_array,
+                                     &req->req_fh->f_num_of_io_entries);
+#if 0
+    printf("Next subreq: memory address %p offset %lu length %ld first element %ld\n",
+	   req->req_fh->f_io_array[0].memory_address,
+	   (long unsigned)req->req_fh->f_io_array[0].offset,
+	   req->req_fh->f_io_array[0].length,
+	   ((long*)req->req_fh->f_io_array[0].memory_address)[0]);
+#endif
+    mca_common_ompio_request_alloc ( &ompio_subreq, MCA_OMPIO_REQUEST_READ);
+    ompio_subreq->req_parent = req;
+    req->req_fh->f_fbtl->fbtl_ipreadv (req->req_fh, (ompi_request_t *)ompio_subreq);
+
+    free(req->req_fh->f_io_array);
+    req->req_fh->f_io_array = NULL;
+    req->req_fh->f_num_of_io_entries = 0;
+}
 
 int mca_common_ompio_file_iread (ompio_file_t *fh,
-			       void *buf,
-			       int count,
-			       struct ompi_datatype_t *datatype,
-			       ompi_request_t **request)
+                               void *buf,
+                               int count,
+                               struct ompi_datatype_t *datatype,
+                               ompi_request_t **request)
 {
     int ret = OMPI_SUCCESS;
     mca_ompio_request_t *ompio_req=NULL;
-    size_t spc=0;
+    struct iovec *decoded_iov = NULL;
 
     if (fh->f_amode & MPI_MODE_WRONLY){
-//      opal_output(10, "Improper use of FILE Mode, Using WRONLY for Read!\n");
         ret = MPI_ERR_ACCESS;
-      return ret;
+        return ret;
     }
 
-    mca_common_ompio_request_alloc ( &ompio_req, MCA_OMPIO_REQUEST_READ);
+    mca_common_ompio_request_alloc (&ompio_req, MCA_OMPIO_REQUEST_READ);
 
-    if ( 0 == count ) {
+    if (0 == count || 0 == fh->f_fview.f_iov_count) {
         ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
         ompio_req->req_ompi.req_status._ucount = 0;
         ompi_request_complete (&ompio_req->req_ompi, false);
         *request = (ompi_request_t *) ompio_req;
-        
+
         return OMPI_SUCCESS;
     }
 
-    if ( NULL != fh->f_fbtl->fbtl_ipreadv ) {
+    if (NULL != fh->f_fbtl->fbtl_ipreadv) {
         // This fbtl has support for non-blocking operations
-
-        size_t total_bytes_read = 0;       /* total bytes that have been read*/
         uint32_t iov_count = 0;
-        struct iovec *decoded_iov = NULL;
-        
         size_t max_data = 0;
-        int i = 0; /* index into the decoded iovec of the buffer */
-        int j = 0; /* index into the file via iovec */
-        
         bool need_to_copy = false;    
-    
         int is_gpu, is_managed;
-        mca_common_ompio_check_gpu_buf ( fh, buf, &is_gpu, &is_managed);
-        if ( is_gpu && !is_managed ) {
+
+        mca_common_ompio_check_gpu_buf (fh, buf, &is_gpu, &is_managed);
+        if (is_gpu && !is_managed) {
             need_to_copy = true;
         }
+
+        mca_common_ompio_register_progress ();
 
         if ( !( fh->f_flags & OMPIO_DATAREP_NATIVE ) &&
              !(datatype == &ompi_mpi_byte.dt  ||
@@ -411,87 +453,80 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
             need_to_copy = true;
         }         
         
-        if ( need_to_copy ) {
-            char *tbuf=NULL;
+        if (need_to_copy) {
+            OMPI_MPI_OFFSET_TYPE prev_offset;
+            size_t pipeline_buf_size = OMPIO_MCA_GET(fh, pipeline_buffer_size);
             
-            OMPIO_PREPARE_READ_BUF(fh, buf, count, datatype, tbuf, &ompio_req->req_convertor,
-                                   max_data, 0, decoded_iov, iov_count);
-            
-            ompio_req->req_tbuf = tbuf;
-            ompio_req->req_size = max_data;
+            OMPIO_PREPARE_READ_BUF(fh, buf, count, datatype, ompio_req->req_tbuf,
+                                   &ompio_req->req_convertor, max_data,
+                                   pipeline_buf_size, NULL, iov_count);
+
+            ompio_req->req_num_subreqs = ceil((double)max_data/pipeline_buf_size);
+            ompio_req->req_size        = pipeline_buf_size;
+            ompio_req->req_max_data    = max_data;
+            ompio_req->req_post_next_subreq = mca_common_ompio_post_next_read_subreq;
+            ompio_req->req_fh          = fh;
+            ompio_req->req_ompi.req_status.MPI_ERROR = MPI_SUCCESS;
+
+	    ompio_req->req_fview = (struct ompio_fview_t *) malloc(sizeof(struct ompio_fview_t));
+	    if (NULL == ompio_req->req_fview) {
+		opal_output(1, "common_ompio: error allocating memory\n");
+		return OMPI_ERR_OUT_OF_RESOURCE;
+	    }
+            ret = mca_common_ompio_fview_duplicate(ompio_req->req_fview, &fh->f_fview);
+            if (OMPI_SUCCESS != ret) {
+                return ret;
+            }
+            mca_common_ompio_file_get_position (fh, &prev_offset );
+            mca_common_ompio_post_next_read_subreq (ompio_req, 0);
+
+            /* Move file pointer to the end of the operation.
+             * Otherwise posting another I/O operation will start of
+             * from the wrong file position. The request will update
+             * the position where to write the next chunk of data
+             * using its internal copy of the file view and file pointer
+             * position.
+             */
+            mca_common_ompio_set_explicit_offset (fh, prev_offset+max_data);
         }
         else {
-            mca_common_ompio_decode_datatype (fh,
-                                              datatype,
-                                              count,
-                                              buf,
-                                              &max_data,
-                                              fh->f_mem_convertor,
-                                              &decoded_iov,
-                                              &iov_count);
+	    int i = 0;
+	    size_t spc = 0, tbr = 0;
+	    mca_common_ompio_decode_datatype (fh, datatype, count, buf,
+                                              &max_data, fh->f_mem_convertor,
+                                              &decoded_iov, &iov_count);
+
+            /**
+             * Non-blocking operations have to occur in a single cycle
+             * If the f_io_array is too long, the fbtl will chunk it up
+             * internally.
+             */
+            mca_common_ompio_build_io_array (&(fh->f_fview), 0, 1, max_data, max_data,
+                                             iov_count, decoded_iov, &i,
+                                             &tbr, &spc,
+                                             &fh->f_io_array, &fh->f_num_of_io_entries);
+
+            fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
         }
-    
-        if ( 0 < max_data && 0 == fh->f_iov_count  ) {
-            ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
-            ompio_req->req_ompi.req_status._ucount = 0;
-            ompi_request_complete (&ompio_req->req_ompi, false);
-            *request = (ompi_request_t *) ompio_req;
-            if (NULL != decoded_iov) {
-                free (decoded_iov);
-                decoded_iov = NULL;
-            }
-
-            return OMPI_SUCCESS;
-        }
-
-        // Non-blocking operations have to occur in a single cycle
-        j = fh->f_index_in_file_view;
-        
-        mca_common_ompio_build_io_array ( fh,
-                                          0,         // index
-                                          1,         // no. of cyces
-                                          max_data,  // setting bytes per cycle to match data
-                                          max_data,
-                                          iov_count,
-                                          decoded_iov,
-                                          &i,
-                                          &j,
-                                          &total_bytes_read, 
-                                          &spc,
-                                          &fh->f_io_array,
-                                          &fh->f_num_of_io_entries);
-
-	if (fh->f_num_of_io_entries) {
-	  fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
-	}
-
-        mca_common_ompio_register_progress ();
-
-	fh->f_num_of_io_entries = 0;
-	if (NULL != fh->f_io_array) {
-	    free (fh->f_io_array);
-	    fh->f_io_array = NULL;
-	}
-
-	if (NULL != decoded_iov) {
-	    free (decoded_iov);
-	    decoded_iov = NULL;
-	}
     }
     else {
-	// This fbtl does not  support non-blocking operations
-	ompi_status_public_t status;
-	ret = mca_common_ompio_file_read (fh, buf, count, datatype, &status);
+        // This fbtl does not  support non-blocking operations
+        ompi_status_public_t status;
+        ret = mca_common_ompio_file_read (fh, buf, count, datatype, &status);
 
-	ompio_req->req_ompi.req_status.MPI_ERROR = ret;
-	ompio_req->req_ompi.req_status._ucount = status._ucount;
-	ompi_request_complete (&ompio_req->req_ompi, false);
+        ompio_req->req_ompi.req_status.MPI_ERROR = ret;
+        ompio_req->req_ompi.req_status._ucount = status._ucount;
+        ompi_request_complete (&ompio_req->req_ompi, false);
     }
+
+    fh->f_num_of_io_entries = 0;
+    free (fh->f_io_array);
+    fh->f_io_array = NULL;
+    free (decoded_iov);
 
     *request = (ompi_request_t *) ompio_req;
     return ret;
 }
-
 
 int mca_common_ompio_file_iread_at (ompio_file_t *fh,
 				  OMPI_MPI_OFFSET_TYPE offset,
@@ -554,24 +589,20 @@ int mca_common_ompio_file_read_all (ompio_file_t *fh,
         size_t pos=0, max_data=0;
         char *tbuf=NULL;
         opal_convertor_t convertor;
-        struct iovec *decoded_iov = NULL;
+        struct iovec decoded_iov;
         uint32_t iov_count = 0;
 
         OMPIO_PREPARE_READ_BUF(fh, buf, count, datatype, tbuf, &convertor,
-                               max_data, 0, decoded_iov, iov_count);
+                               max_data, 0, &decoded_iov, iov_count);
         ret = fh->f_fcoll->fcoll_file_read_all (fh,
-                                                decoded_iov->iov_base,
-                                                decoded_iov->iov_len,
+                                                decoded_iov.iov_base,
+                                                decoded_iov.iov_len,
                                                 MPI_BYTE,
                                                 status);
-        opal_convertor_unpack (&convertor, decoded_iov, &iov_count, &pos );
+        opal_convertor_unpack (&convertor, &decoded_iov, &iov_count, &pos );
 
         opal_convertor_cleanup (&convertor);
-        mca_common_ompio_release_buf (fh, decoded_iov->iov_base);
-        if (NULL != decoded_iov) {
-            free (decoded_iov);
-            decoded_iov = NULL;
-        }
+        mca_common_ompio_release_buf (fh, decoded_iov.iov_base);
     }
     else {
         ret = fh->f_fcoll->fcoll_file_read_all (fh,
@@ -660,29 +691,29 @@ int mca_common_ompio_set_explicit_offset (ompio_file_t *fh,
     size_t i = 0;
     size_t k = 0;
 
-    if ( fh->f_view_size  > 0 ) {
+    if ( fh->f_fview.f_view_size  > 0 ) {
 	/* starting offset of the current copy of the filew view */
-	fh->f_offset = (fh->f_view_extent *
-			((offset*fh->f_etype_size) / fh->f_view_size)) + fh->f_disp;
+	fh->f_fview.f_offset = (fh->f_fview.f_view_extent *
+			((offset*fh->f_fview.f_etype_size) / fh->f_fview.f_view_size)) + fh->f_fview.f_disp;
 
 
 	/* number of bytes used within the current copy of the file view */
-	fh->f_total_bytes = (offset*fh->f_etype_size) % fh->f_view_size;
-	i = fh->f_total_bytes;
+	fh->f_fview.f_total_bytes = (offset*fh->f_fview.f_etype_size) % fh->f_fview.f_view_size;
+	i = fh->f_fview.f_total_bytes;
 
 
 	/* Initialize the block id and the starting offset of the current block
 	   within the current copy of the file view to zero */
-	fh->f_index_in_file_view = 0;
-	fh->f_position_in_file_view = 0;
+	fh->f_fview.f_index_in_file_view = 0;
+	fh->f_fview.f_position_in_file_view = 0;
 
 	/* determine block id that the offset is located in and
 	   the starting offset of that block */
-	k = fh->f_decoded_iov[fh->f_index_in_file_view].iov_len;
+	k = fh->f_fview.f_decoded_iov[fh->f_fview.f_index_in_file_view].iov_len;
 	while (i >= k) {
-	    fh->f_position_in_file_view = k;
-	    fh->f_index_in_file_view++;
-	    k += fh->f_decoded_iov[fh->f_index_in_file_view].iov_len;
+	    fh->f_fview.f_position_in_file_view = k;
+	    fh->f_fview.f_index_in_file_view++;
+	    k += fh->f_fview.f_decoded_iov[fh->f_fview.f_index_in_file_view].iov_len;
 	}
     }
 

--- a/ompi/mca/common/ompio/common_ompio_request.c
+++ b/ompi/mca/common/ompio/common_ompio_request.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,6 +19,8 @@
  * $HEADER$
  */
 
+#include "opal_config.h"
+#include "opal/class/opal_list.h"
 #include "common_ompio_request.h"
 #include "common_ompio_buffer.h"
 
@@ -30,7 +33,7 @@ bool mca_common_ompio_progress_is_registered=false;
  */
 opal_list_t mca_common_ompio_pending_requests = {{0}};
 
-
+static opal_mutex_t mca_common_ompio_mutex = OPAL_MUTEX_STATIC_INIT;
 
 static int mca_common_ompio_request_free ( struct ompi_request_t **req)
 {
@@ -69,19 +72,28 @@ OBJ_CLASS_INSTANCE(mca_ompio_request_t, ompi_request_t,
 void mca_common_ompio_request_construct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_INIT (&(req->req_ompi), false );
-    req->req_ompi.req_free   = mca_common_ompio_request_free;
-    req->req_ompi.req_cancel = mca_common_ompio_request_cancel;
-    req->req_ompi.req_type   = OMPI_REQUEST_IO;
-    req->req_data            = NULL;
-    req->req_tbuf            = NULL;
-    req->req_size            = 0;
-    req->req_progress_fn     = NULL;
-    req->req_free_fn         = NULL;
+    req->req_ompi.req_free     = mca_common_ompio_request_free;
+    req->req_ompi.req_cancel   = mca_common_ompio_request_cancel;
+    req->req_ompi.req_type     = OMPI_REQUEST_IO;
+    req->req_data              = NULL;
+    req->req_tbuf              = NULL;
+    req->req_size              = 0;
+    req->req_max_data          = 0;
+    req->req_progress_fn       = NULL;
+    req->req_free_fn           = NULL;
+    req->req_parent            = NULL;
+    req->req_post_next_subreq  = NULL;
+    req->req_num_subreqs       = 0;
+    req->req_subreqs_completed = 0;
+    req->req_fh                = NULL;
+    req->req_fview             = NULL;
+    req->req_post_followup     = false;
 
     OBJ_CONSTRUCT(&req->req_item, opal_list_item_t);
     opal_list_append (&mca_common_ompio_pending_requests, &req->req_item);
     return;
 }
+
 void mca_common_ompio_request_destruct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_FINI ( &(req->req_ompi));
@@ -89,7 +101,10 @@ void mca_common_ompio_request_destruct(mca_ompio_request_t* req)
     if ( NULL != req->req_data ) {
         free (req->req_data);
     }
-
+    if (NULL != req->req_fview) {
+	free (req->req_fview->f_decoded_iov);
+	free (req->req_fview);
+    }
     return;
 }
 
@@ -107,6 +122,15 @@ void mca_common_ompio_request_fini ( void )
        were not destroyed / completed upon MPI_FINALIZE */
 
     OBJ_DESTRUCT(&mca_common_ompio_pending_requests);
+    if (mca_common_ompio_progress_is_registered) {
+        OPAL_THREAD_LOCK (&mca_common_ompio_mutex);
+        if (mca_common_ompio_progress_is_registered) {
+            opal_progress_unregister(mca_common_ompio_progress);
+            mca_common_ompio_progress_is_registered=false;
+        }
+        OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
+    }
+
     return;
 }
 
@@ -125,33 +149,105 @@ void mca_common_ompio_request_alloc ( mca_ompio_request_t **req, mca_ompio_reque
 
 void mca_common_ompio_register_progress ( void ) 
 {
-    if ( false == mca_common_ompio_progress_is_registered) {
+    if (false == mca_common_ompio_progress_is_registered) {
+        OPAL_THREAD_LOCK (&mca_common_ompio_mutex);
+        if (mca_common_ompio_progress_is_registered) {
+            OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
+            return;
+        }
         opal_progress_register (mca_common_ompio_progress);
         mca_common_ompio_progress_is_registered=true;
+        OPAL_THREAD_UNLOCK (&mca_common_ompio_mutex);
     }
     return;
 }
+
 int mca_common_ompio_progress ( void )
 {
     mca_ompio_request_t *req=NULL;
     opal_list_item_t *litem=NULL;
+    opal_list_item_t *lnext=NULL;
     int completed=0;
 
-    OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
-        req = GET_OMPIO_REQ_FROM_ITEM(litem);
-        if( REQUEST_COMPLETE(&req->req_ompi) ) {
-            continue;
-        }
-        if ( NULL != req->req_progress_fn ) {
-            if ( req->req_progress_fn(req) ) {
-                completed++;
-                ompi_request_complete (&req->req_ompi, true);
-                /* The fbtl progress function is expected to set the
-                 * status elements
+    /* The mca_common_ompio_mutex is used to
+    ** avoid multiple progress threads potentially interfering
+    ** with each other
+    */
+    if (!OPAL_THREAD_TRYLOCK(&mca_common_ompio_mutex)) {
+        OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
+            req = GET_OMPIO_REQ_FROM_ITEM(litem);
+            if (REQUEST_COMPLETE(&req->req_ompi) ) {
+                continue;
+            }
+            if (NULL != req->req_progress_fn) {
+                if (req->req_progress_fn(req)) {
+                    /**
+                     * To support pipelined read/write operations, a user level request
+                     * can contain multiple internal requests. These sub-requests
+                     * contain a pointer to the parent request.
+                     */
+                    mca_ompio_request_t *parent = req->req_parent;
+                    if (NULL != parent) {
+                        /* This is a subrequest */
+                        if (OMPI_SUCCESS != req->req_ompi.req_status.MPI_ERROR) {
+                            parent->req_ompi.req_status.MPI_ERROR = req->req_ompi.req_status.MPI_ERROR;
+                            ompi_request_complete (&parent->req_ompi, true);
+                            continue;
+                        }
+                        parent->req_subreqs_completed++;
+                        parent->req_ompi.req_status._ucount += req->req_ompi.req_status._ucount;
+                        req->req_post_followup = true;
+                    } else {
+                        /* This is a request without subrequests */
+                        completed++;
+                        ompi_request_complete (&req->req_ompi, true);
+                    }
+                    /* The fbtl progress function is expected to set the
+                     * status elements
+                     */
+                }
+            } else {
+                /* This is a request without a lower level progress function, .e.g
+                 * a parent request
                  */
+                if (req->req_num_subreqs == req->req_subreqs_completed) {
+                    completed++;
+                    ompi_request_complete (&req->req_ompi, true);
+                }
             }
         }
 
+        /**
+         * Splitting the ompio progress loop is necessary to avoid that a pending operation
+         * consisting of multiple subrequests is executed in a single invokation of the progress
+         * function.
+         *
+         * Otherwise it can happen that the next subrequest is posted, which ends up at the tail
+         * of the ompio_pending_requests_list, and would be processed in the same loop execution;
+         * which then posts the next subrequest, which is also processed potentially right away
+         * etc. This would make the ompio_progress function block for a long time, and prevent
+         * overlapping operations.
+         *
+         * Splitting the loop into two parts, one checking for completion and one posting
+         * the next subrequest if necessary avoids the problem.
+         */
+        OPAL_LIST_FOREACH_SAFE(litem, lnext, &mca_common_ompio_pending_requests, opal_list_item_t) {
+            req = GET_OMPIO_REQ_FROM_ITEM(litem);
+            if (true == req->req_post_followup) {
+                /* This lock is used to serialize access to the
+                ** file across multiple threads.
+                */
+                if (OPAL_THREAD_TRYLOCK(&req->req_fh->f_fh->f_lock)) {
+                    continue;
+                }
+                mca_ompio_request_t *parent = req->req_parent;
+                parent->req_post_next_subreq(parent, parent->req_subreqs_completed);
+                OPAL_THREAD_UNLOCK(&req->req_fh->f_fh->f_lock);
+                ompi_request_complete (&req->req_ompi, false);
+                ompi_request_free ((ompi_request_t**)&req);
+            }
+        }
+        OPAL_THREAD_UNLOCK(&mca_common_ompio_mutex);
     }
 
     return completed;

--- a/ompi/mca/common/ompio/common_ompio_request.h
+++ b/ompi/mca/common/ompio/common_ompio_request.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,6 +44,8 @@ typedef enum {
     MCA_OMPIO_REQUEST_READ_ALL,
 } mca_ompio_request_type_t;
 
+struct mca_ompio_request_t;
+typedef void(*mca_ompio_post_next_subreq_t)(struct mca_ompio_request_t *req, int val);
 
 /**
  * Main structure for OMPIO requests
@@ -54,9 +57,17 @@ struct mca_ompio_request_t {
     opal_list_item_t                               req_item;
     void                                          *req_tbuf;
     size_t                                         req_size;
+    size_t                                     req_max_data;
     opal_convertor_t                          req_convertor;
     mca_fbtl_base_module_progress_fn_t      req_progress_fn;
     mca_fbtl_base_module_request_free_fn_t      req_free_fn;
+    mca_ompio_post_next_subreq_t       req_post_next_subreq;
+    struct mca_ompio_request_t                  *req_parent;
+    int                                     req_num_subreqs;
+    int                               req_subreqs_completed;
+    ompio_file_t                                    *req_fh;
+    ompio_fview_t                                *req_fview;
+    bool                                  req_post_followup;
 };
 typedef struct mca_ompio_request_t mca_ompio_request_t;
 OBJ_CLASS_DECLARATION(mca_ompio_request_t);

--- a/ompi/mca/fs/base/fs_base_file_get_size.c
+++ b/ompi/mca/fs/base/fs_base_file_get_size.c
@@ -44,7 +44,7 @@ int mca_fs_base_file_get_size (ompio_file_t *fh,
         return OMPI_ERROR;
     }
 
-    if (-1 == (lseek(fh->fd, fh->f_offset, SEEK_SET))) {
+    if (-1 == (lseek(fh->fd, fh->f_fview.f_offset, SEEK_SET))) {
         perror ("lseek");
         return OMPI_ERROR;
     }

--- a/ompi/mca/io/ompio/io_ompio.c
+++ b/ompi/mca/io/ompio/io_ompio.c
@@ -62,8 +62,8 @@ int ompi_io_ompio_generate_current_file_view (struct ompio_file_t *fh,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    sum_previous_counts = fh->f_position_in_file_view;
-    j = fh->f_index_in_file_view;
+    sum_previous_counts = fh->f_fview.f_position_in_file_view;
+    j = fh->f_fview.f_index_in_file_view;
     bytes_to_write = max_data;
     k = 0;
 
@@ -80,40 +80,40 @@ int ompi_io_ompio_generate_current_file_view (struct ompio_file_t *fh,
             }
         }
 
-        if (fh->f_decoded_iov[j].iov_len -
-            (fh->f_total_bytes - sum_previous_counts) <= 0) {
-            sum_previous_counts += fh->f_decoded_iov[j].iov_len;
+        if (fh->f_fview.f_decoded_iov[j].iov_len -
+            (fh->f_fview.f_total_bytes - sum_previous_counts) <= 0) {
+            sum_previous_counts += fh->f_fview.f_decoded_iov[j].iov_len;
             j = j + 1;
-            if (j == (int)fh->f_iov_count) {
+            if (j == (int)fh->f_fview.f_iov_count) {
                 j = 0;
                 sum_previous_counts = 0;
-                fh->f_offset += fh->f_view_extent;
-                fh->f_position_in_file_view = sum_previous_counts;
-                fh->f_index_in_file_view = j;
-                fh->f_total_bytes = 0;
+                fh->f_fview.f_offset += fh->f_fview.f_view_extent;
+                fh->f_fview.f_position_in_file_view = sum_previous_counts;
+                fh->f_fview.f_index_in_file_view = j;
+                fh->f_fview.f_total_bytes = 0;
             }
         }
 
-        disp = (ptrdiff_t)(fh->f_decoded_iov[j].iov_base) +
-            (fh->f_total_bytes - sum_previous_counts);
-        iov[k].iov_base = (IOVBASE_TYPE *)(intptr_t)(disp + fh->f_offset);
+        disp = (ptrdiff_t)(fh->f_fview.f_decoded_iov[j].iov_base) +
+            (fh->f_fview.f_total_bytes - sum_previous_counts);
+        iov[k].iov_base = (IOVBASE_TYPE *)(intptr_t)(disp + fh->f_fview.f_offset);
 
-        if ((fh->f_decoded_iov[j].iov_len -
-             (fh->f_total_bytes - sum_previous_counts))
+        if ((fh->f_fview.f_decoded_iov[j].iov_len -
+             (fh->f_fview.f_total_bytes - sum_previous_counts))
             >= bytes_to_write) {
             iov[k].iov_len = bytes_to_write;
         }
         else {
-            iov[k].iov_len =  fh->f_decoded_iov[j].iov_len -
-                (fh->f_total_bytes - sum_previous_counts);
+            iov[k].iov_len =  fh->f_fview.f_decoded_iov[j].iov_len -
+                (fh->f_fview.f_total_bytes - sum_previous_counts);
         }
 
-        fh->f_total_bytes += iov[k].iov_len;
+        fh->f_fview.f_total_bytes += iov[k].iov_len;
         bytes_to_write -= iov[k].iov_len;
         k = k + 1;
     }
-    fh->f_position_in_file_view = sum_previous_counts;
-    fh->f_index_in_file_view = j;
+    fh->f_fview.f_position_in_file_view = sum_previous_counts;
+    fh->f_fview.f_index_in_file_view = j;
     *iov_count = k;
     *f_iov = iov;
 

--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -90,7 +90,6 @@ OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_ompio_component;
 /*
  * global variables, instantiated in module.c
  */
-extern opal_mutex_t mca_io_ompio_mutex;
 extern mca_io_base_module_2_0_0_t mca_io_ompio_module;
 OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_ompio_component;
 

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
- * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,13 +88,7 @@ static int io_progress(void);
 static int priority_param = 30;
 static int delete_priority_param = 30;
 
-
-/*
- * Global, component-wide OMPIO mutex because OMPIO is not thread safe
- */
-opal_mutex_t mca_io_ompio_mutex = {{0}};
-
-
+static opal_mutex_t mca_io_ompio_mutex = OPAL_MUTEX_STATIC_INIT;
 
 /*
  * Public string showing this component's version number
@@ -272,9 +266,6 @@ static int register_component(void)
 
 static int open_component(void)
 {
-    /* Create the mutex */
-    OBJ_CONSTRUCT(&mca_io_ompio_mutex, opal_mutex_t);
-
     mca_common_ompio_request_init ();
 
     return mca_common_ompio_set_callbacks(ompi_io_ompio_generate_current_file_view,
@@ -286,7 +277,6 @@ static int close_component(void)
 {
     mca_common_ompio_request_fini ();
     mca_common_ompio_buffer_alloc_fini();
-    OBJ_DESTRUCT(&mca_io_ompio_mutex);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -411,25 +411,25 @@ static void mca_io_ompio_file_get_eof_offset (ompio_file_t *fh,
     size_t k=0, blocklen=0;
     size_t index_in_file_view=0;
 
-    in_offset -= fh->f_disp;
-    if ( fh->f_view_size  > 0 ) {
+    in_offset -= fh->f_fview.f_disp;
+    if ( fh->f_fview.f_view_size  > 0 ) {
         /* starting offset of the current copy of the filew view */
-        start_offset = in_offset / fh->f_view_extent;
+        start_offset = in_offset / fh->f_fview.f_view_extent;
         
         index_in_file_view = 0;
         /* determine block id that the offset is located in and
            the starting offset of that block */
-        while ( offset <= in_offset && index_in_file_view < fh->f_iov_count) {
+        while ( offset <= in_offset && index_in_file_view < fh->f_fview.f_iov_count) {
             prev_offset = offset;
-            offset = start_offset + (OMPI_MPI_OFFSET_TYPE)(intptr_t) fh->f_decoded_iov[index_in_file_view++].iov_base;
+            offset = start_offset + (OMPI_MPI_OFFSET_TYPE)(intptr_t) fh->f_fview.f_decoded_iov[index_in_file_view++].iov_base;
         }
         
         offset = prev_offset;
-        blocklen = fh->f_decoded_iov[index_in_file_view-1].iov_len;
+        blocklen = fh->f_fview.f_decoded_iov[index_in_file_view-1].iov_len;
         while (  offset <= in_offset && k <= blocklen )  {
             prev_offset = offset;
-            offset += fh->f_etype_size;
-            k += fh->f_etype_size;
+            offset += fh->f_fview.f_etype_size;
+            k += fh->f_fview.f_etype_size;
         }
 
         *out_offset = prev_offset;
@@ -449,7 +449,7 @@ int mca_io_ompio_file_seek (ompi_file_t *fh,
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     OPAL_THREAD_LOCK(&fh->f_lock);
-    offset = off * data->ompio_fh.f_etype_size;
+    offset = off * data->ompio_fh.f_fview.f_etype_size;
 
     switch(whence) {
     case MPI_SEEK_SET:
@@ -461,7 +461,7 @@ int mca_io_ompio_file_seek (ompi_file_t *fh,
     case MPI_SEEK_CUR:
         ret = mca_common_ompio_file_get_position (&data->ompio_fh,
                                                   &temp_offset);
-        offset += temp_offset * data->ompio_fh.f_etype_size;
+        offset += temp_offset * data->ompio_fh.f_fview.f_etype_size;
         if (offset < 0) {
             OPAL_THREAD_UNLOCK(&fh->f_lock);
             return OMPI_ERROR;
@@ -484,7 +484,7 @@ int mca_io_ompio_file_seek (ompi_file_t *fh,
     }
 
     ret = mca_common_ompio_set_explicit_offset (&data->ompio_fh,
-                                             offset/data->ompio_fh.f_etype_size);
+                                             offset/data->ompio_fh.f_fview.f_etype_size);
     OPAL_THREAD_UNLOCK(&fh->f_lock);
 
     return ret;
@@ -520,24 +520,24 @@ int mca_io_ompio_file_get_byte_offset (ompi_file_t *fh,
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
 
     OPAL_THREAD_LOCK(&fh->f_lock);
-    if ( data->ompio_fh.f_view_size == 0 ) {
+    if ( data->ompio_fh.f_fview.f_view_size == 0 ) {
         *disp = 0;
         OPAL_THREAD_UNLOCK(&fh->f_lock);
         return OMPI_SUCCESS;
     }
-    temp_offset = (long) data->ompio_fh.f_view_extent *
-        (offset*data->ompio_fh.f_etype_size / data->ompio_fh.f_view_size);
+    temp_offset = (long) data->ompio_fh.f_fview.f_view_extent *
+        (offset*data->ompio_fh.f_fview.f_etype_size / data->ompio_fh.f_fview.f_view_size);
     if ( 0 > temp_offset ) {
         OPAL_THREAD_UNLOCK(&fh->f_lock);
         return MPI_ERR_ARG;
     }
     
-    i = (offset*data->ompio_fh.f_etype_size) % data->ompio_fh.f_view_size;
+    i = (offset*data->ompio_fh.f_fview.f_etype_size) % data->ompio_fh.f_fview.f_view_size;
     index = 0;
     k = 0;
 
     while (1) {
-        k = data->ompio_fh.f_decoded_iov[index].iov_len;
+        k = data->ompio_fh.f_fview.f_decoded_iov[index].iov_len;
         if (i >= k) {
             i -= k;
             index++;
@@ -552,8 +552,8 @@ int mca_io_ompio_file_get_byte_offset (ompi_file_t *fh,
         }
     }
 
-    *disp = data->ompio_fh.f_disp + temp_offset +
-        (OMPI_MPI_OFFSET_TYPE)(intptr_t)data->ompio_fh.f_decoded_iov[index].iov_base + k;
+    *disp = data->ompio_fh.f_fview.f_disp + temp_offset +
+        (OMPI_MPI_OFFSET_TYPE)(intptr_t)data->ompio_fh.f_fview.f_decoded_iov[index].iov_base + k;
     OPAL_THREAD_UNLOCK(&fh->f_lock);
 
     return OMPI_SUCCESS;
@@ -605,7 +605,7 @@ int mca_io_ompio_file_get_position_shared (ompi_file_t *fp,
     }
     OPAL_THREAD_LOCK(&fp->f_lock);
     ret = shared_fp_base_module->sharedfp_get_position(fh,offset);
-    *offset = *offset / fh->f_etype_size;
+    *offset = *offset / fh->f_fview.f_etype_size;
     OPAL_THREAD_UNLOCK(&fp->f_lock);
 
     return ret;

--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -104,7 +104,7 @@ int mca_io_ompio_file_get_view (struct ompi_file_t *fp,
     fh = &data->ompio_fh;
 
     OPAL_THREAD_LOCK(&fp->f_lock);
-    *disp = fh->f_disp;
+    *disp = fh->f_fview.f_disp;
     datatype_duplicate (fh->f_etype, etype);
     datatype_duplicate (fh->f_orig_filetype, filetype);
     strcpy (datarep, fh->f_datarep);

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
@@ -62,7 +62,7 @@ int mca_sharedfp_lockedfile_iread(ompio_file_t *fh,
 
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_lockedfile_request_position(sh,bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( -1 != ret )  {
 	if ( mca_sharedfp_lockedfile_verbose ) {
@@ -175,7 +175,7 @@ int mca_sharedfp_lockedfile_read_ordered_begin(ompio_file_t *fh,
 
     /*Each process now has its own individual offset*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_lockedfile_verbose ) {
 	opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
@@ -60,7 +60,7 @@ int mca_sharedfp_lockedfile_iwrite(ompio_file_t *fh,
 
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_lockedfile_request_position(sh,bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( -1 != ret) {
 	if ( mca_sharedfp_lockedfile_verbose ) {
@@ -184,7 +184,7 @@ int mca_sharedfp_lockedfile_write_ordered_begin(ompio_file_t *fh,
 
     /*Each process now has its own individual offset*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_lockedfile_verbose ) {
 	opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
@@ -59,7 +59,7 @@ int mca_sharedfp_lockedfile_read ( ompio_file_t *fh,
 
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_lockedfile_request_position(sh,bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if (-1 != ret )  {
 	if ( mca_sharedfp_lockedfile_verbose ) {
@@ -162,7 +162,7 @@ int mca_sharedfp_lockedfile_read_ordered (ompio_file_t *fh,
 
     /*Each process now has its own individual offset in recvBUFF*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
@@ -52,7 +52,7 @@ mca_sharedfp_lockedfile_seek (ompio_file_t *fh,
     }
 
     sh = fh->f_sharedfp_data;
-    offset = off * fh->f_etype_size;
+    offset = off * fh->f_fview.f_etype_size;
 
     if( 0 == fh->f_rank ){
         if ( MPI_SEEK_SET == whence ){

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
@@ -59,7 +59,7 @@ int mca_sharedfp_lockedfile_write (ompio_file_t *fh,
 
     /* Request the offset to write bytesRequested bytes */
     ret = mca_sharedfp_lockedfile_request_position ( sh, bytesRequested, &offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if (-1 != ret )  {
 	if ( mca_sharedfp_lockedfile_verbose ) {
@@ -177,7 +177,7 @@ int mca_sharedfp_lockedfile_write_ordered (ompio_file_t *fh,
 
     /*Each process now has its own individual offset*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_lockedfile_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
@@ -55,7 +55,7 @@ int mca_sharedfp_sm_iread(ompio_file_t *fh,
     }
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_sm_request_position(fh,bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if (  -1 != ret ) {
         if ( mca_sharedfp_sm_verbose ) {
@@ -171,7 +171,7 @@ int mca_sharedfp_sm_read_ordered_begin(ompio_file_t *fh,
 
     /*Each process now has its own individual offset in recvBUFF*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_sm_verbose ) {
 	opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
@@ -55,7 +55,7 @@ int mca_sharedfp_sm_iwrite(ompio_file_t *fh,
      }
     /* Request the offset to write bytesRequested bytes */
      ret = mca_sharedfp_sm_request_position(fh,bytesRequested,&offset);
-     offset /= fh->f_etype_size;
+     offset /= fh->f_fview.f_etype_size;
 
      if ( -1 != ret ) {
         if ( mca_sharedfp_sm_verbose ) {
@@ -159,7 +159,7 @@ int mca_sharedfp_sm_write_ordered_begin(ompio_file_t *fh,
 
     /*Each process now has its own individual offset in recvBUFF*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_sm_verbose ) {
 	opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
@@ -53,7 +53,7 @@ int mca_sharedfp_sm_read ( ompio_file_t *fh,
 
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_sm_request_position(fh,bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if (  -1 != ret ) {
         if ( mca_sharedfp_sm_verbose ) {
@@ -163,7 +163,7 @@ int mca_sharedfp_sm_read_ordered (ompio_file_t *fh,
 
     /*Each process now has its own individual offset in recvBUFF*/
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
@@ -50,7 +50,7 @@ mca_sharedfp_sm_seek (ompio_file_t *fh,
     }
 
     sh = fh->f_sharedfp_data;
-    offset = off * fh->f_etype_size;
+    offset = off * fh->f_fview.f_etype_size;
 
     if( 0 == fh->f_rank ){
         if ( MPI_SEEK_SET == whence){

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
@@ -58,7 +58,7 @@ int mca_sharedfp_sm_write (ompio_file_t *fh,
 
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_sm_request_position(fh, bytesRequested,&offset);
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
     if ( -1 != ret ) {
         if ( mca_sharedfp_sm_verbose ) {
             opal_output(ompi_sharedfp_base_framework.framework_output,
@@ -156,7 +156,7 @@ int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
 
     /* Each process now has its own individual offset */
     offset = offsetBuff - sendBuff;
-    offset /= fh->f_etype_size;
+    offset /= fh->f_fview.f_etype_size;
 
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,


### PR DESCRIPTION
Second attempt at the pipelined iread/iwrite operations optimized for GPU buffers and external32 representation.

The current pr has three separate commits:
1. identical commit to the first attempt ( I probably overreacted by reverting that one, but I didn't immediately see how to fix the problem).
2. extract the most relevant parameters of the fileview and the file pointer position into a separate data structure
3. Upon posting an File_iread/iwrite operation that uses the pipeline protocol:
     a. replicate the fileview structure from file handle onto the request. This way, the position calculated when posting the next segment from the progress engine is completely independent of what other operations on the file handle are currently ongoing. Hence, other iread/iwrite operations or e.g. setting the file view will not interfere with an already ongoing operation.
      b. Move the file pointer on the file handle to the expected end of the operation after initiating the iread/iwrite. This way, subsequent read/write operations will continue where the iread/iwrite is expected to end, and not interfere (overwrite) ongoing operations - unless the user explicitly moves the file pointer back.