### PR TITLE
v5.0.x: docs: update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 --use-feature=2020-resolver
-sphinx>=4.2.0,<=5.3.0
+sphinx>=4.2.0
 recommonmark
 docutils
-sphinx-rtd-theme<1.2.0
+sphinx-rtd-theme


### PR DESCRIPTION
The new version of the sphinx-rtd-theme has been released that is compatible with the latest version of Sphinx.  Hence, we can remove the restrictions in docs/requirements.txt.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit b4cab9e6b81099a9ec3512e5c056c2045b205e69)