### PR TITLE
v5.0.x: ompi_info color coding

### DIFF
--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -908,7 +908,8 @@ int mca_base_pvar_dump(int index, char ***out, mca_base_var_dump_type_t output_t
         if (NULL != pvar->enumerator) {
             char *values;
 
-            ret = pvar->enumerator->dump(pvar->enumerator, &values);
+            ret = pvar->enumerator->dump(pvar->enumerator, &values,
+                MCA_BASE_VAR_DUMP_TYPE_TO_ENUM_DUMP_TYPE(output_type));
             if (OPAL_SUCCESS == ret) {
                 (void) opal_asprintf(out[0] + line++, "Values: %s", values);
                 free(values);

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -17,6 +17,8 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -699,7 +701,9 @@ typedef enum {
     /* Dump easily parsable strings */
     MCA_BASE_VAR_DUMP_PARSABLE = 1,
     /* Dump simple name=value string */
-    MCA_BASE_VAR_DUMP_SIMPLE = 2
+    MCA_BASE_VAR_DUMP_SIMPLE = 2,
+    /* Dump human-readable strings, with color where supported */
+    MCA_BASE_VAR_DUMP_READABLE_COLOR = 3
 } mca_base_var_dump_type_t;
 
 /**

--- a/opal/mca/base/mca_base_var_enum.h
+++ b/opal/mca/base/mca_base_var_enum.h
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +31,21 @@
 
 #    include "opal/class/opal_object.h"
 #    include "opal/constants.h"
+#    include "opal/runtime/opal_params_core.h"
+
+/* Output mode for dumping var enumerators.
+ * Caution: Not 1:1 with mca_base_var_dump_type_t, appropriate
+ * conversion is required, see MCA_BASE_VAR_DUMP_TYPE_TO_ENUM_DUMP_TYPE() */
+typedef enum {
+    /* Dump human-readable strings */
+    MCA_BASE_VAR_ENUM_DUMP_READABLE = 0,
+    /* Dump human-readable strings, with color where supported */
+    MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR = 1
+} mca_base_var_enum_dump_type_t;
+
+#define MCA_BASE_VAR_DUMP_TYPE_TO_ENUM_DUMP_TYPE(var_dump_type) \
+    (MCA_BASE_VAR_DUMP_READABLE_COLOR == (var_dump_type) ? \
+    MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR : MCA_BASE_VAR_ENUM_DUMP_READABLE)
 
 typedef struct mca_base_var_enum_t mca_base_var_enum_t;
 
@@ -69,11 +86,13 @@ typedef int (*mca_base_var_enum_vfs_fn_t)(mca_base_var_enum_t *self, const char 
  *
  * @param[in] self the enumerator
  * @param[out] out the string representation
+ * @param[in] output_type the type of output desired
  *
  * @retval OPAL_SUCCESS on success
  * @retval opal error on error
  */
-typedef int (*mca_base_var_enum_dump_fn_t)(mca_base_var_enum_t *self, char **out);
+typedef int (*mca_base_var_enum_dump_fn_t)(mca_base_var_enum_t *self, char **out,
+                                           mca_base_var_enum_dump_type_t output_type);
 
 /**
  * Get the string representation for an enumerator value

--- a/opal/runtime/help-opal-runtime.txt
+++ b/opal/runtime/help-opal-runtime.txt
@@ -12,6 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+#                         Laboratory, ICS Forth. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -57,3 +59,13 @@ WARNING: Cannot set both the MCA parameters opal_leave_pinned (a.k.a.,
 mpi_leave_pinned) and opal_leave_pinned_pipeline (a.k.a.,
 mpi_leave_pinned_pipeline) to "true".  Defaulting to mpi_leave_pinned
 ONLY.
+#
+[mpi-params:var_dump_color:format-error]
+WARNING: Token "%s" in opal_var_dump_color MCA parameter
+is not in the expected "key=value" format, ignoring.
+#
+[mpi-params:var_dump_color:unknown-key]
+WARNING: Key "%s" in opal_var_dump_color MCA parameter
+token "%s" is unknown, ignoring.
+
+  Valid keys are: %s

--- a/opal/runtime/opal_params_core.h
+++ b/opal/runtime/opal_params_core.h
@@ -20,6 +20,8 @@
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
+ *                         Laboratory, ICS Forth. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +36,17 @@ extern char *opal_signal_string;
 extern char *opal_stacktrace_output_filename;
 extern char *opal_net_private_ipv4;
 extern char *opal_set_max_sys_limits;
+
+/* Supported color configuration keys
+ * for dumping MCA variables with colors */
+typedef enum {
+    OPAL_VAR_DUMP_COLOR_VAR_NAME = 0,
+    OPAL_VAR_DUMP_COLOR_VAR_VALUE = 1,
+    OPAL_VAR_DUMP_COLOR_VALID_VALUES = 2,
+    OPAL_VAR_DUMP_COLOR_KEY_COUNT
+} opal_var_dump_color_key_t;
+
+extern char *opal_var_dump_color[OPAL_VAR_DUMP_COLOR_KEY_COUNT];
 
 #    if OPAL_ENABLE_TIMING
 extern char *opal_timing_sync_file;


### PR DESCRIPTION
Cherry-pick of #10820 which adds coloring to the output of ompi_info, for v5.0.x
FYI @jsquyres

Signed-off-by: George Katevenis <gkatev@ics.forth.gr>
(cherry picked from commit 40abfa36778b0428989f8e3e485f7e11559801f1)