### PR TITLE
opal/datatype: Account for error possibility in check addr

### DIFF
--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -55,22 +55,20 @@
         }                                                                                   \
     } while (0)
 
-static bool opal_datatype_is_accel(void *dest, const void *src) {
-    int dev_id;
-    uint64_t flags;
-    if (opal_accelerator.check_addr(dest, &dev_id, &flags)) {
-        return true;
-    }
-    if (opal_accelerator.check_addr(src, &dev_id, &flags)) {
-        return true;
-    }
-    return false;
-}
-
 static void *opal_datatype_accelerator_memcpy(void *dest, const void *src, size_t size)
 {
     int res;
-    if (!opal_datatype_is_accel(dest, src)) {
+    int dev_id;
+    uint64_t flags;
+    /* If accelerator check addr returns an error, we can only
+     * assume it is a host buffer. If device buffer checking fails,
+     * it's also highly likely that a device copy will fail. The best
+     * we can do is fail as this is not a recoverable/ignorable failure
+     * and retries are also unlikely to succeed. We identify these
+     * buffers as host buffers as attempting a memcpy would provide
+     * a chance to succeed. */
+    if (0 >= opal_accelerator.check_addr(dest, &dev_id, &flags) &&
+        0 >= opal_accelerator.check_addr(src, &dev_id, &flags)) {
         return memcpy(dest, src, size);
     }
     res = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
@@ -85,7 +83,17 @@ static void *opal_datatype_accelerator_memcpy(void *dest, const void *src, size_
 static void *opal_datatype_accelerator_memmove(void *dest, const void *src, size_t size)
 {
     int res;
-    if (!opal_datatype_is_accel(dest, src)) {
+    int dev_id;
+    uint64_t flags;
+    /* If accelerator check addr returns an error, we can only
+     * assume it is a host buffer. If device buffer checking fails,
+     * it's also highly likely that a device copy will fail. The best
+     * we can do is fail as this is not a recoverable/ignorable failure
+     * and retries are also unlikely to succeed. We identify these
+     * buffers as host buffers as attempting a memmove would provide
+     * a chance to succeed. */
+    if (0 >= opal_accelerator.check_addr(dest, &dev_id, &flags) &&
+        0 >= opal_accelerator.check_addr(src, &dev_id, &flags)) {
         return memmove(dest, src, size);
     }
     res = opal_accelerator.mem_move(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,


### PR DESCRIPTION
Also removed the opal_datatype_is_accel function due to the naming and boolean type conversion confusion.

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit 0ec220e604c0901829352127f12130b0ee907043)