### PR TITLE
communicator: make c_name a dynamic array and reorder struct

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -215,6 +216,11 @@ int ompi_comm_set_nb (ompi_communicator_t **ncomm, ompi_communicator_t *oldcomm,
     if (NULL == newcomm) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
+    newcomm->c_name = (char*) malloc (OPAL_MAX_OBJECT_NAME);
+    if (NULL == newcomm->c_name) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+    newcomm->c_name[0]    = '\0';
     newcomm->super.s_info = NULL;
     /* fill in the inscribing hyper-cube dimensions */
     newcomm->c_cube_dim = opal_cube_dim(local_size);

--- a/ompi/debuggers/predefined_gap_test.c
+++ b/ompi/debuggers/predefined_gap_test.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009      Sun Microsystems, Inc  All rights reserved.
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2013 The University of Tennessee and The University
+ * Copyright (c) 2012-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -59,8 +59,6 @@ int main(int argc, char **argv) {
     GAP_CHECK("c_contextid", test_comm, c_contextid, c_name, 1);
     GAP_CHECK("c_my_rank", test_comm, c_my_rank, c_contextid, 1);
     GAP_CHECK("c_flags", test_comm, c_flags, c_my_rank, 1);
-    GAP_CHECK("c_id_available", test_comm, c_id_available, c_flags, 1);
-    GAP_CHECK("c_id_start_index", test_comm, c_id_start_index, c_id_available,  1);
     GAP_CHECK("c_remote_group", test_comm, c_remote_group, c_local_group, 1);
     GAP_CHECK("c_local_comm", test_comm, c_local_comm,  c_remote_group,  1);
     GAP_CHECK("c_keyhash", test_comm, c_keyhash, c_local_comm,  1);
@@ -73,8 +71,6 @@ int main(int argc, char **argv) {
 #else
     GAP_CHECK("error_handler", test_comm, error_handler, c_f_to_c_index, 1);
 #endif
-    GAP_CHECK("errhandler_type", test_comm, errhandler_type, error_handler, 1);
-    GAP_CHECK("c_pml_comm", test_comm, c_pml_comm, errhandler_type, 1);
     GAP_CHECK("c_coll", test_comm, c_coll, c_pml_comm, 1);
 
     /* Test Predefined group sizes */
@@ -129,8 +125,6 @@ int main(int argc, char **argv) {
     GAP_CHECK("w_keyhash", test_win, w_keyhash, w_flags, 1);
     GAP_CHECK("w_f_to_c_index", test_win, w_f_to_c_index, w_keyhash, 1);
     GAP_CHECK("error_handler", test_win, error_handler, w_f_to_c_index, 1);
-    GAP_CHECK("errhandler_type", test_win, errhandler_type, error_handler, 1);
-    GAP_CHECK("w_osc_module", test_win, w_osc_module, errhandler_type, 1);
 
     /* Test Predefined info sizes */
     printf("=============================================\n");
@@ -151,8 +145,6 @@ int main(int argc, char **argv) {
     GAP_CHECK("f_flags", test_file, f_flags, f_amode,  1);
     GAP_CHECK("f_f_to_c_index", test_file, f_f_to_c_index, f_flags, 1);
     GAP_CHECK("error_handler", test_file, error_handler, f_f_to_c_index, 1);
-    GAP_CHECK("errhandler_type", test_file, errhandler_type, error_handler, 1);
-    GAP_CHECK("f_io_version", test_file, f_io_version, errhandler_type, 1);
     GAP_CHECK("f_io_selected_component", test_file, f_io_selected_component, f_io_version, 1);
     GAP_CHECK("f_io_selected_module", test_file, f_io_selected_module, f_io_selected_component, 1);
     GAP_CHECK("f_io_selected_data", test_file, f_io_selected_data, f_io_selected_module, 1);

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2022 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -388,10 +388,10 @@ int ompi_errhandler_proc_failed_internal(ompi_proc_t* ompi_proc, int status, boo
                              OMPI_NAME_PRINT(&ompi_proc->super.proc_name),
                              ompi_comm_print_cid(comm),
                              proc_rank,
-                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->errhandler_type ? "P" :
-                              (OMPI_ERRHANDLER_TYPE_COMM == comm->errhandler_type ? "C" :
-                               (OMPI_ERRHANDLER_TYPE_WIN == comm->errhandler_type ? "W" :
-                                (OMPI_ERRHANDLER_TYPE_FILE == comm->errhandler_type ? "F" : "U") ) ) )
+                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->error_handler->eh_mpi_object_type ? "P" :
+                              (OMPI_ERRHANDLER_TYPE_COMM == comm->error_handler->eh_mpi_object_type ? "C" :
+                               (OMPI_ERRHANDLER_TYPE_WIN == comm->error_handler->eh_mpi_object_type ? "W" :
+                                (OMPI_ERRHANDLER_TYPE_FILE == comm->error_handler->eh_mpi_object_type ? "F" : "U") ) ) )
                              ));
     }
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2022 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -238,7 +238,7 @@ extern opal_atomic_int32_t ompi_instance_count;
 #define OMPI_ERRHANDLER_INVOKE(mpi_object, err_code, message) \
   ompi_errhandler_invoke((mpi_object)->error_handler, \
                          (mpi_object), \
-                         (int)(mpi_object)->errhandler_type, \
+                         (int)(mpi_object)->error_handler->eh_mpi_object_type, \
                          ompi_errcode_get_mpi_code(err_code), \
                          (message));
 
@@ -269,7 +269,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int) (mpi_object)->errhandler_type, \
+                           (int) (mpi_object)->error_handler->eh_mpi_object_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \
@@ -307,7 +307,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int)(mpi_object)->errhandler_type, \
+                           (int)(mpi_object)->error_handler->eh_mpi_object_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -183,19 +183,19 @@ int ompi_errhandler_request_invoke(int count,
     case OMPI_REQUEST_COLL:
         return ompi_errhandler_invoke(mpi_object.comm->error_handler,
                                       mpi_object.comm,
-                                      mpi_object.comm->errhandler_type,
+                                      mpi_object.comm->error_handler->eh_mpi_object_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_IO:
         return ompi_errhandler_invoke(mpi_object.file->error_handler,
                                       mpi_object.file,
-                                      mpi_object.file->errhandler_type,
+                                      mpi_object.file->error_handler->eh_mpi_object_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_WIN:
         return ompi_errhandler_invoke(mpi_object.win->error_handler,
                                       mpi_object.win,
-                                      mpi_object.win->errhandler_type,
+                                      mpi_object.win->error_handler->eh_mpi_object_type,
                                       ec, message);
         break;
     default:

--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
- * Copyright (c) 2010-2017 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
@@ -220,8 +220,6 @@ static inline int memchecker_comm(MPI_Comm comm)
     opal_memchecker_base_isdefined (&comm->c_name, MPI_MAX_OBJECT_NAME);
     opal_memchecker_base_isdefined (&comm->c_my_rank, sizeof(int));
     opal_memchecker_base_isdefined (&comm->c_flags, sizeof(uint32_t));
-    opal_memchecker_base_isdefined (&comm->c_id_available, sizeof(int));
-    opal_memchecker_base_isdefined (&comm->c_id_start_index, sizeof(int));
     opal_memchecker_base_isdefined (&comm->c_local_group, sizeof(ompi_group_t *));
     opal_memchecker_base_isdefined (&comm->c_remote_group, sizeof(ompi_group_t *));
     opal_memchecker_base_isdefined (&comm->c_keyhash, sizeof(struct opal_hash_table_t *));


### PR DESCRIPTION
make the c_name element of the communicator structure a dynamic
element. This allows us to reduce the size of PREDEFINED_COMMUNICATOR_PAD
back to 512 to maintain backwards compatibility with the ompi 4.1.x release
series.

Reorder the communicator fields to reduce the struct size.
This brings the communicator size at 536 bytes with FT, PERUSE enabled
and compiled in debug mode.

Fixes issue https://github.com/open-mpi/ompi/issues/11373

Signed-off-by: Edgar Gabriel <edgar.gabriel@amd.com>
Signed-off-by: George Bosilca <bosilca@icl.utk.edu>