### PR TITLE
v5.0.x: Change the PMIX event observed to capture faults from PRTE

### DIFF
--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2021 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -453,7 +453,7 @@ struct ompi_proc_t;
 
 OMPI_DECLSPEC int ompi_errhandler_proc_failed_internal(struct ompi_proc_t *ompi_proc, int status, bool forward);
 static inline int ompi_errhandler_proc_failed(struct ompi_proc_t* ompi_proc) {
-    return ompi_errhandler_proc_failed_internal(ompi_proc, OPAL_ERR_PROC_ABORTED, true);
+    return ompi_errhandler_proc_failed_internal(ompi_proc, PMIX_ERR_PROC_TERM_WO_SYNC, true);
 }
 #endif /* OPAL_ENABLE_FT_MPI */
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -435,11 +438,10 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
     /* give it a name so we can distinguish it */
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_NAME, "ULFM-Event-handler", PMIX_STRING);
     OPAL_PMIX_CONSTRUCT_LOCK(&mylock);
-    pmix_status_t codes[4] = {
-        PMIX_ERR_PROC_ABORTED,
-        PMIX_ERR_EXIT_NONZERO_TERM,
+    pmix_status_t codes[3] = {
+        PMIX_ERR_PROC_TERM_WO_SYNC,
         PMIX_ERR_PROC_ABORTED_BY_SIG,
-        PMIX_ERR_LOST_CONNECTION
+        PMIX_ERR_PROC_ABORTED
     };
     PMIx_Register_event_handler(codes, 3, info, 2, ompi_errhandler_callback, evhandler_reg_callbk, (void*)&mylock);
     OPAL_PMIX_WAIT_THREAD(&mylock);


### PR DESCRIPTION
v5.0.x version of #11173

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>
(cherry picked from commit c4bd78c45ad38b4dfc942f048028023c1438d580)