### PR TITLE
coll/han: workaround for nvcc compiler

### DIFF
--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -90,7 +90,9 @@ mca_coll_han_component_t mca_coll_han_component = {
     /* han-component specific information */
 
     /* (default) priority */
-    20,
+    .han_priority = 20,
+    /* workaround for nvcc compiler */
+    .dynamic_rules_filename = NULL,
 };
 
 /*


### PR DESCRIPTION
the nvcc compiler seems to have problems with static initialization of 'c' structs with certain kinds of pointers.

This patch addresses that issue.

Related to #11384

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 435b993139aa8a2ffc2eb61720be796548aabf4d)