### PR TITLE
[v4.1.x] osc/rdma: fix when determining the node with the rank_array info for …

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -53,6 +53,8 @@
 
 #include "opal_stdint.h"
 
+#define RANK_ARRAY_COUNT(module) ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count)
+
 enum {
     OMPI_OSC_RDMA_LOCKING_TWO_LEVEL,
     OMPI_OSC_RDMA_LOCKING_ON_DEMAND,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -397,8 +397,6 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
     return mca_osc_rdma_component.priority;
 }
 
-#define RANK_ARRAY_COUNT(module) ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count)
-
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {
     ompi_osc_rdma_region_t *region = (ompi_osc_rdma_region_t *) module->state->regions;
     int ret;


### PR DESCRIPTION
…a peer

(cherry picked from commit 3cae1492621a089703e01caf9e11195d18720d1f)

https://github.com/open-mpi/ompi/pull/6413 was not backported to v4.1.x branch. This PR backports it.

