### PR TITLE
io/romio: Break make dist on config failure

### DIFF
--- a/ompi/mca/io/romio341/configure.m4
+++ b/ompi/mca/io/romio341/configure.m4
@@ -114,6 +114,7 @@ AC_DEFUN([MCA_ompi_io_romio341_CONFIG],[
 
                    AS_IF([test "$io_romio341_happy" = "1"],
                          [$1],
-                         [$2])])])
+                         [OPAL_MAKEDIST_DISABLE="$OPAL_MAKEDIST_DISABLE ROMIO"
+			  $2])])])
     OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
If ROMIO does not think it can build, set the flag to break "make dist", as that means the resulting tarball will not include ROMIO (which is not what we want).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit f93a20316429b479457d4d004b31530027b86d1e)