### PR TITLE
v5.0.x: ULFM: new functions MPI_COMM_ACK/GET_FAILED (as per latest standard draft)

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -451,6 +451,7 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
 #if OPAL_ENABLE_FT_MPI
     comm->any_source_enabled  = true;
     comm->any_source_offset   = 0;
+    comm->num_acked           = 0;
     comm->comm_revoked        = false;
     comm->coll_revoked        = false;
     comm->c_epoch             = 0;

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -329,6 +329,8 @@ struct ompi_communicator_t {
 #if OPAL_ENABLE_FT_MPI
     /** agreement caching info for topology and previous returned decisions */
     opal_object_t           *agreement_specific;
+    /** num_acked - OMPI_Comm_ack_failed */
+    int                      num_acked;
     /** MPI_ANY_SOURCE Failed Group Offset - OMPI_Comm_failure_get_acked */
     int                      any_source_offset;
     /** Are MPI_ANY_SOURCE operations enabled? - OMPI_Comm_failure_ack */
@@ -597,6 +599,17 @@ static inline bool ompi_comm_is_revoked(ompi_communicator_t* comm)
 {
     return (comm->comm_revoked);
 }
+
+/*
+ * Obtain the group of locally known failed processes on comm
+ */
+OMPI_DECLSPEC int ompi_comm_get_failed_internal(ompi_communicator_t* comm, ompi_group_t** failed_group);
+
+/*
+ * Acknowledge failures and re-enable MPI_ANY_SOURCE
+ * Related to OMPI_Comm_failure_ack() and OMPI_Comm_failure_get_acked()
+ */
+OMPI_DECLSPEC int ompi_comm_ack_failed_internal(ompi_communicator_t* comm, int num_to_ack, int *num_acked);
 
 /*
  * Acknowledge failures and re-enable MPI_ANY_SOURCE

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -52,7 +52,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     ompi_communicator_t **low_comm = &(han_module->sub_comm[INTRA_NODE]);
     ompi_communicator_t **up_comm = &(han_module->sub_comm[INTER_NODE]);
     mca_coll_han_collectives_fallback_t fallbacks;
-    int vrank, *vranks;
+    int rc = OMPI_SUCCESS, vrank, *vranks;
     opal_info_t comm_info;
 
     /* The sub communicators have already been created */
@@ -91,9 +91,12 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
      * all participants.
      */
     int local_procs = ompi_group_count_local_peers(comm->c_local_group);
-    comm->c_coll->coll_allreduce(MPI_IN_PLACE, &local_procs, 1, MPI_INT,
-                                 MPI_MAX, comm,
-                                 comm->c_coll->coll_allreduce_module);
+    rc = comm->c_coll->coll_allreduce(MPI_IN_PLACE, &local_procs, 1, MPI_INT,
+                                      MPI_MAX, comm,
+                                      comm->c_coll->coll_allreduce_module);
+    if( OMPI_SUCCESS != rc ) {
+        goto return_with_error;
+    }
     if( local_procs == 1 ) {
         /* restore saved collectives */
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allgatherv);
@@ -118,8 +121,12 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
      */
     opal_info_set(&comm_info, "ompi_comm_coll_preference", "han");
     opal_info_set(&comm_info, "ompi_comm_coll_han_topo_level", "INTRA_NODE");
-    ompi_comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0,
-                         &comm_info, low_comm);
+    rc = ompi_comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0,
+                              &comm_info, low_comm);
+    if( OMPI_SUCCESS != rc ) {
+        /* cannot create subcommunicators. Return the error upstream */
+        goto return_with_error;
+    }
 
     /*
      * Get my local rank and the local size
@@ -132,7 +139,11 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
      * same intra-node rank id share such a sub-communicator
      */
     opal_info_set(&comm_info, "ompi_comm_coll_han_topo_level", "INTER_NODE");
-    ompi_comm_split_with_info(comm, low_rank, w_rank, &comm_info, up_comm, false);
+    rc = ompi_comm_split_with_info(comm, low_rank, w_rank, &comm_info, up_comm, false);
+    if( OMPI_SUCCESS != rc ) {
+        /* cannot create subcommunicators. Return the error upstream */
+        goto return_with_error;
+    }
 
     up_rank = ompi_comm_rank(*up_comm);
 
@@ -150,14 +161,13 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
      * gather vrank from each process so every process will know other processes
      * vrank
      */
-    comm->c_coll->coll_allgather(&vrank,
-                                 1,
-                                 MPI_INT,
-                                 vranks,
-                                 1,
-                                 MPI_INT,
-                                 comm,
-                                 comm->c_coll->coll_allgather_module);
+    rc = comm->c_coll->coll_allgather(&vrank, 1, MPI_INT,
+                                 vranks, 1, MPI_INT,
+                                 comm, comm->c_coll->coll_allgather_module);
+    if( OMPI_SUCCESS != rc ) {
+        /* cannot create subcommunicators. Return the error upstream */
+        goto return_with_error;
+    }
 
     /*
      * Set the cached info
@@ -175,6 +185,17 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
 
     OBJ_DESTRUCT(&comm_info);
     return OMPI_SUCCESS;
+
+return_with_error:
+    if( NULL != *low_comm ) {
+        ompi_comm_free(low_comm);
+        *low_comm = NULL;  /* don't leave the MPI_COMM_NULL set by ompi_comm_free */
+    }
+    if( NULL != *up_comm ) {
+        ompi_comm_free(up_comm);
+        *up_comm = NULL;  /* don't leave the MPI_COMM_NULL set by ompi_comm_free */
+    }
+    return rc;
 }
 
 /*

--- a/ompi/mpiext/ftmpi/c/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
-# Copyright (c) 2016-2018 The University of Tennessee and The University
+# Copyright (c) 2016-2022 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -29,6 +29,8 @@ libmpiext_ftmpi_c_la_SOURCES = \
     comm_shrink.c \
     comm_failure_ack.c \
     comm_failure_get_acked.c \
+    comm_get_failed.c \
+    comm_ack_failed.c \
     comm_agree.c \
     comm_iagree.c
 libmpiext_ftmpi_c_la_LIBADD = \

--- a/ompi/mpiext/ftmpi/c/comm_ack_failed.c
+++ b/ompi/mpiext/ftmpi/c/comm_ack_failed.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+#include "ompi/errhandler/errhandler.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_ack_failed = PMPIX_Comm_ack_failed
+#endif
+#define MPIX_Comm_ack_failed PMPIX_Comm_ack_failed
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_ack_failed";
+
+
+int MPIX_Comm_ack_failed(MPI_Comm comm, int num_to_ack, int* num_acked)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        if (num_to_ack > ompi_comm_size(comm)) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_ack_failed_internal( (ompi_communicator_t*)comm, num_to_ack, num_acked );
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_get_failed.c
+++ b/ompi/mpiext/ftmpi/c/comm_get_failed.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_get_failed = PMPIX_Comm_get_failed
+#endif
+#define MPIX_Comm_get_failed PMPIX_Comm_get_failed
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_get_failed";
+
+int MPIX_Comm_get_failed(MPI_Comm comm, MPI_Group *failedgrp)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_get_failed_internal( (ompi_communicator_t*)comm, (ompi_group_t**)failedgrp );
+    if( OMPI_SUCCESS != rc ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+
+    return MPI_SUCCESS;
+}
+

--- a/ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h
+++ b/ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h
@@ -27,6 +27,8 @@ OMPI_DECLSPEC int MPIX_Comm_is_revoked(MPI_Comm comm, int *flag);
 OMPI_DECLSPEC int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm);
 OMPI_DECLSPEC int MPIX_Comm_failure_ack(MPI_Comm comm);
 OMPI_DECLSPEC int MPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group *failedgrp);
+OMPI_DECLSPEC int MPIX_Comm_get_failed(MPI_Comm comm, MPI_Group *failedgroup);
+OMPI_DECLSPEC int MPIX_Comm_ack_failed(MPI_Comm comm, int num_to_ack, int *num_acked);
 OMPI_DECLSPEC int MPIX_Comm_agree(MPI_Comm comm, int *flag);
 OMPI_DECLSPEC int MPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request);
 
@@ -35,9 +37,14 @@ OMPI_DECLSPEC int PMPIX_Comm_is_revoked(MPI_Comm comm, int *flag);
 OMPI_DECLSPEC int PMPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm);
 OMPI_DECLSPEC int PMPIX_Comm_failure_ack(MPI_Comm comm);
 OMPI_DECLSPEC int PMPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group *failedgrp);
+OMPI_DECLSPEC int PMPIX_Comm_get_failed(MPI_Comm comm, MPI_Group *failedgroup);
+OMPI_DECLSPEC int PMPIX_Comm_ack_failed(MPI_Comm comm, int num_to_ack, int *num_acked);
 OMPI_DECLSPEC int PMPIX_Comm_agree(MPI_Comm comm, int *flag);
 OMPI_DECLSPEC int PMPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request);
 
 #include <stdbool.h>
 OMPI_DECLSPEC int OMPI_Comm_failure_inject(MPI_Comm comm, bool notify);
+/* Provide defines to facilitate the detection of the new API */
+#define OMPI_HAVE_MPIX_COMM_GET_FAILED 1
+#define OMPI_HAVE_MPIX_COMM_ACK_FAILED 1
 

--- a/ompi/mpiext/ftmpi/c/profile/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/profile/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2018 The University of Tennessee and The University
+# Copyright (c) 2016-2022 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
@@ -21,6 +21,8 @@ nodist_libpmpiext_ftmpi_c_la_SOURCES = \
     pcomm_revoke.c \
     pcomm_is_revoked.c \
     pcomm_shrink.c \
+    pcomm_get_failed.c \
+    pcomm_ack_failed.c \
     pcomm_failure_ack.c \
     pcomm_failure_get_acked.c \
     pcomm_agree.c \

--- a/ompi/mpiext/ftmpi/mpif-h/Makefile.am
+++ b/ompi/mpiext/ftmpi/mpif-h/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
-# Copyright (c) 2016-2020 The University of Tennessee and The University
+# Copyright (c) 2016-2022 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -24,6 +24,8 @@ f77_sources = \
     comm_revoke_f.c \
     comm_is_revoked_f.c \
     comm_shrink_f.c \
+    comm_get_failed_f.c \
+    comm_ack_failed_f.c \
     comm_failure_ack_f.c \
     comm_failure_get_acked_f.c \
     comm_agree_f.c \

--- a/ompi/mpiext/ftmpi/mpif-h/comm_ack_failed_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_ack_failed_f.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022      The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_ACK_FAILED = ompix_comm_ack_failed_f
+#pragma weak pmpix_comm_ack_failed = ompix_comm_ack_failed_f
+#pragma weak pmpix_comm_ack_failed_ = ompix_comm_ack_failed_f
+#pragma weak pmpix_comm_ack_failed__ = ompix_comm_ack_failed_f
+#pragma weak PMPIX_Comm_ack_failed_f = ompix_comm_ack_failed_f
+#pragma weak PMPIX_Comm_ack_failed_f08 = ompix_comm_ack_failed_f
+
+#pragma weak MPIX_COMM_ACK_FAILED = ompix_comm_ack_failed_f
+#pragma weak mpix_comm_ack_failed = ompix_comm_ack_failed_f
+#pragma weak mpix_comm_ack_failed_ = ompix_comm_ack_failed_f
+#pragma weak mpix_comm_ack_failed__ = ompix_comm_ack_failed_f
+#pragma weak MPIX_Comm_ack_failed_f = ompix_comm_ack_failed_f
+#pragma weak MPIX_Comm_ack_failed_f08 = ompix_comm_ack_failed_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_ACK_FAILED,
+                        pmpix_comm_ack_failed,
+                        pmpix_comm_ack_failed_,
+                        pmpix_comm_ack_failed__,
+                        ompix_comm_ack_failed_f,
+                        (MPI_Fint *comm, MPI_Fint *num_to_ack, MPI_Fint *num_acked, MPI_Fint *ierr),
+                        (comm, num_to_ack, num_acked, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_ACK_FAILED,
+                        mpix_comm_ack_failed,
+                        mpix_comm_ack_failed_,
+                        mpix_comm_ack_failed__,
+                        ompix_comm_ack_failed_f,
+                        (MPI_Fint *comm, MPI_Fint *num_to_ack, MPI_Fint *num_acked, MPI_Fint *ierr),
+                        (comm, num_to_ack, num_acked, ierr))
+#endif
+
+void ompix_comm_ack_failed_f(MPI_Fint *comm, MPI_Fint *num_to_ack, MPI_Fint *num_acked, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_ack_failed(c_comm, OMPI_FINT_2_INT(*num_to_ack), OMPI_PFINT_2_PINT(num_acked)));
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_get_failed_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_get_failed_f.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022      The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_GET_FAILED = ompix_comm_get_failed_f
+#pragma weak pmpix_comm_get_failed = ompix_comm_get_failed_f
+#pragma weak pmpix_comm_get_failed_ = ompix_comm_get_failed_f
+#pragma weak pmpix_comm_get_failed__ = ompix_comm_get_failed_f
+#pragma weak PMPIX_Comm_get_failed_f = ompix_comm_get_failed_f
+#pragma weak PMPIX_Comm_get_failed_f08 = ompix_comm_get_failed_f
+
+#pragma weak MPIX_COMM_GET_FAILED = ompix_comm_get_failed_f
+#pragma weak mpix_comm_get_failed = ompix_comm_get_failed_f
+#pragma weak mpix_comm_get_failed_ = ompix_comm_get_failed_f
+#pragma weak mpix_comm_get_failed__ = ompix_comm_get_failed_f
+#pragma weak MPIX_Comm_get_failed_f = ompix_comm_get_failed_f
+#pragma weak MPIX_Comm_get_failed_f08 = ompix_comm_get_failed_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_GET_FAILED,
+                        pmpix_comm_get_failed,
+                        pmpix_comm_get_failed_,
+                        pmpix_comm_get_failed__,
+                        ompix_comm_get_failed_f,
+                        (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr),
+                        (comm, group, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_GET_FAILED,
+                        mpix_comm_get_failed,
+                        mpix_comm_get_failed_,
+                        mpix_comm_get_failed__,
+                        ompix_comm_get_failed_f,
+                        (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr),
+                        (comm, group, ierr))
+#endif
+
+void ompix_comm_get_failed_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr)
+{
+    MPI_Group c_group;
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_get_failed(c_comm,
+                                                         &c_group));
+    if (MPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+        *group = PMPI_Group_c2f (c_group);
+    }
+}

--- a/ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h
+++ b/ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019      The University of Tennessee and The University
+ * Copyright (c) 2019-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -46,6 +46,9 @@ PN2(void, MPIX_Comm_iagree, mpix_comm_iagree, MPIX_COMM_IAGREE, (MPI_Fint *comm,
 PN2(void, MPIX_Comm_is_revoked, mpix_comm_is_revoked, MPIX_COMM_IS_REVOKED, (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr));
 PN2(void, MPIX_Comm_revoke, mpix_comm_revoke, MPIX_COMM_REVOKE, (MPI_Fint *comm, MPI_Fint *ierr));
 PN2(void, MPIX_Comm_shrink, mpix_comm_shrink, MPIX_COMM_SHRINK, (MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_get_failed, mpix_comm_get_failed, MPIX_COMM_GET_FAILED, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_ack_failed, mpix_comm_ack_failed, MPI_COMM_ACK_FAILED, (MPI_Fint *comm, MPI_Fint *num_to_ack, MPI_Fint *num_acked, MPI_Fint *ierr));
+
 
 END_C_DECLS
 

--- a/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
@@ -3,7 +3,7 @@
 # Copyright (c) 2017-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
-# Copyright (c) 2018      The University of Tennessee and The University
+# Copyright (c) 2018-2022 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2022      IBM Corporation.  All rights reserved.
@@ -58,6 +58,8 @@ mpi_api_files = \
     comm_is_revoked_f08.F90 \
     comm_failure_ack_f08.F90 \
     comm_failure_get_acked_f08.F90 \
+    comm_get_failed_f08.F90 \
+    comm_ack_failed_f08.F90 \
     comm_agree_f08.F90 \
     comm_iagree_f08.F90 \
     comm_shrink_f08.F90
@@ -67,6 +69,8 @@ pmpi_api_files = \
     profile/pcomm_is_revoked_f08.F90 \
     profile/pcomm_failure_ack_f08.F90 \
     profile/pcomm_failure_get_acked_f08.F90 \
+    profile/pcomm_get_failed_f08.F90 \
+    profile/pcomm_ack_failed_f08.F90 \
     profile/pcomm_agree_f08.F90 \
     profile/pcomm_iagree_f08.F90 \
     profile/pcomm_shrink_f08.F90

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_ack_failed_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_ack_failed_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2022      The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_ack_failed_f08(comm, num_to_ack, num_acked, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_ack_failed_f(comm, num_to_ack, num_acked, ierror) &
+          BIND(C, name="ompix_comm_ack_failed_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm, num_to_ack
+       INTEGER, INTENT(OUT) :: num_acked, ierror
+     end subroutine ompix_comm_ack_failed_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(IN) :: num_to_ack
+  INTEGER, INTENT(OUT) :: num_acked
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_ack_failed_f(comm%MPI_VAL, num_to_ack, num_acked, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_ack_failed_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_get_failed_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_get_failed_f08.F90
@@ -1,0 +1,32 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2022      The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_get_failed_f08(comm, failedgrp, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+  implicit none
+  interface
+     subroutine ompix_comm_get_failed_f(comm, failedgrp, ierror) &
+          BIND(C, name="ompix_comm_get_failed_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: failedgrp, ierror
+     end subroutine ompix_comm_get_failed_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_get_failed_f(comm%MPI_VAL, failedgrp%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_get_failed_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/mpiext_ftmpi_usempif08.h
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/mpiext_ftmpi_usempif08.h
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2018-2020 The University of Tennessee and the University
+! Copyright (c) 2018-2022 The University of Tennessee and the University
 !                         of Tennessee Research Foundation.  All rights
 !                         reserved.
 ! $COPYRIGHT$
@@ -88,6 +88,25 @@ subroutine pmpix_comm_failure_get_acked_f08(comm,failedgrp,ierror)
 end subroutine pmpix_comm_failure_get_acked_f08
 end interface pmpix_comm_failure_get_acked
 
+interface mpix_comm_get_failed
+subroutine mpix_comm_get_failed_f08(comm,failedgrp,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_get_failed_f08
+end interface mpix_comm_get_failed
+
+interface pmpix_comm_get_failed
+subroutine pmpix_comm_get_failed_f08(comm,failedgrp,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_get_failed_f08
+end interface pmpix_comm_get_failed
 interface mpix_comm_agree
 subroutine mpix_comm_agree_f08(comm,flag,ierror)
    use :: mpi_f08_types, only : MPI_Comm
@@ -97,6 +116,28 @@ subroutine mpix_comm_agree_f08(comm,flag,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine mpix_comm_agree_f08
 end interface mpix_comm_agree
+
+interface mpix_comm_ack_failed
+subroutine mpix_comm_ack_failed_f08(comm,num_to_ack,num_acked,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(IN) :: num_to_ack
+   INTEGER, INTENT(OUT) :: num_acked
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_ack_failed_f08
+end interface mpix_comm_ack_failed
+
+interface pmpix_comm_ack_failed
+subroutine pmpix_comm_ack_failed_f08(comm,num_to_ack,num_acked,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(IN) :: num_to_ack
+   INTEGER, INTENT(OUT) :: num_acked
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_ack_failed_f08
+end interface pmpix_comm_ack_failed
 
 interface pmpix_comm_agree
 subroutine pmpix_comm_agree_f08(comm,flag,ierror)

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_ack_failed_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_ack_failed_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2022      The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_ack_failed_f08(comm, num_to_ack, num_acked, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_ack_failed_f(comm, num_to_ack, num_acked, ierror) &
+          BIND(C, name="ompix_comm_ack_failed_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm, num_to_ack
+       INTEGER, INTENT(OUT) :: num_acked, ierror
+     end subroutine ompix_comm_ack_failed_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(IN) :: num_to_ack
+  INTEGER, INTENT(OUT) :: num_acked
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_ack_failed_f(comm%MPI_VAL, num_to_ack, num_acked, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_ack_failed_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_get_failed_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_get_failed_f08.F90
@@ -1,0 +1,32 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2022      The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_get_failed_f08(comm, failedgrp, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+  implicit none
+  interface
+     subroutine ompix_comm_get_failed_f(comm, failedgrp, ierror) &
+          BIND(C, name="ompix_comm_get_failed_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: failedgrp, ierror
+     end subroutine ompix_comm_get_failed_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_get_failed_f(comm%MPI_VAL, failedgrp%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_get_failed_f08

--- a/ompi/mpiext/ftmpi/use-mpi/mpiext_ftmpi_usempi.h
+++ b/ompi/mpiext/ftmpi/use-mpi/mpiext_ftmpi_usempi.h
@@ -1,6 +1,6 @@
 ! -*- fortran -*-
 ! Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
-! Copyright (c) 2010-2020 The University of Tennessee and the University
+! Copyright (c) 2010-2022 The University of Tennessee and the University
 !                         of Tennessee research foundation.  All rights
 !                         reserved.
 ! $COPYRIGHT$
@@ -60,6 +60,34 @@ interface pmpix_comm_shrink
       integer, intent(OUT) :: newcomm, ierr
     end subroutine pmpix_comm_shrink
 end interface pmpix_comm_shrink
+
+interface mpix_comm_get_failed
+    subroutine mpix_comm_get_failed(comm, failedgrp, ierr)
+        integer, intent(IN) :: comm
+        integer, intent(OUT) :: failedgrp, ierr
+    end subroutine mpix_comm_get_failed
+end interface mpix_comm_get_failed
+
+interface pmpix_comm_get_failed
+    subroutine pmpix_comm_get_failed(comm, failedgrp, ierr)
+        integer, intent(IN) :: comm
+        integer, intent(OUT) :: failedgrp, ierr
+    end subroutine pmpix_comm_get_failed
+end interface pmpix_comm_get_failed
+
+interface mpix_comm_ack_failed
+    subroutine mpix_comm_ack_failed(comm, num_to_ack, num_acked, ierr)
+        integer, intent(IN) :: comm, num_to_ack
+        integer, intent(OUT) :: num_acked, ierr
+    end subroutine mpix_comm_ack_failed
+end interface mpix_comm_ack_failed
+
+interface pmpix_comm_ack_failed
+    subroutine pmpix_comm_ack_failed(comm, num_to_ack, num_acked, ierr)
+        integer, intent(IN) :: comm, num_to_ack
+        integer, intent(OUT) :: num_acked, ierr
+    end subroutine pmpix_comm_ack_failed
+end interface pmpix_comm_ack_failed
 
 interface mpix_comm_failure_ack
     subroutine mpix_comm_failure_ack(comm, ierr)


### PR DESCRIPTION
v5.0.x version of #10507