### PR TITLE
accelerator/rocm: silence warnings from header file

### DIFF
--- a/opal/mca/accelerator/rocm/accelerator_rocm.h
+++ b/opal/mca/accelerator/rocm/accelerator_rocm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022-2023  Advanced Micro Devices, Inc. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -14,8 +14,24 @@
 #include "opal_config.h"
 
 #include <stdio.h>
+
+/* Not interested in warnings generated in hip_runtime_api.h */
+#pragma GCC diagnostic push
+/* Clang won't quietly accept "-pedantic", but GCC versions older than ~4.8
+ * won't quietly accept "-Wpedanic".  The whole "#pragma GCC diagnostic ..."
+ * facility only was added to GCC as of version 4.6. */
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 6)
+#    pragma GCC diagnostic ignored "-Wpedantic"
+#    pragma GCC diagnostic ignored "-Wundef"
+#    pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#else
+#    pragma GCC diagnostic ignored "-pedantic"
+#endif
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_version.h>
+/* Restore warnings to original state */
+#pragma GCC diagnostic pop
+
 
 #include "opal/mca/accelerator/accelerator.h"
 


### PR DESCRIPTION
silence the warnings generated when compiling the rocm component that stem from the hip_runtime_api.h header file. There is nothing we can do about them here, and it just makes it harder to identify actually issues in the component code itself.

Signed-off-by: Edgar Gabriel <Edgar.Gabriel@amd.com>
