### PR TITLE
io/romio341: Remove initialization value from priority params

### DIFF
--- a/ompi/mca/io/romio341/src/io_romio341_component.c
+++ b/ompi/mca/io/romio341/src/io_romio341_component.c
@@ -64,8 +64,8 @@ static int register_datarep(const char *,
 /*
  * Private variables
  */
-static int priority_param = 20;
-static int delete_priority_param = 20;
+static int priority_param;
+static int delete_priority_param;
 
 
 /*


### PR DESCRIPTION
The values (20) were being overwritten which is misleading, thus remove them.