### PR TITLE
Fix wrong buffer size in ompi_session_get_nth_pset_f

### DIFF
--- a/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
@@ -77,7 +77,7 @@ void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n,
 {
     int c_ierr;
     MPI_Session c_session;
-    char c_name[MPI_MAX_OBJECT_NAME];
+    char c_name[MPI_MAX_PSET_NAME_LEN];
 
     c_session = PMPI_Session_f2c(*session);
 


### PR DESCRIPTION
When using `MPI_session_get_nth_pset` in Fortran with `use mpi`, and passing a `pset_name_len` value greater than 64, a buffer overflow occurs. This is because the `c_name` variable in the wrapper function has a size of `MPI_MAX_OBJECT_NAME`., instead of `MPI_MAX_PSET_NAME_LEN`.

To be more precise, strncpy is eventually called with the c_name as the destination and the user provided length as the maximum string length argument.
On my machine (glibc 2.28, __strncpy_avx2) strncpy actually nulls the destination buffer after the string is copied and this nulling overflows c_name.

Here is a small reproducer, that crashes on the latest (a75f933) main branch:
````
program main
  use mpi
  implicit none

  integer :: ierror
  integer :: session
  character(len=MPI_MAX_PSET_NAME_LEN) :: pset_name
  integer :: pset_name_len

  call mpi_session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, session, ierror)
  if (ierror /=0) stop 'mpi session init fail'

  pset_name_len = MPI_MAX_PSET_NAME_LEN
  call mpi_session_get_nth_pset(session, MPI_INFO_NULL, 0, pset_name_len, pset_name, ierror)
  if (ierror /=0) stop 'mpi session get num psets fail'

  print *, pset_name(1:pset_name_len)

  call mpi_session_finalize(session, ierror)
  if (ierror /=0) stop 'mpi session finalize fail'
end program main
````

This PR fixes this bug by adjusting the length of the c_name buffer.