### PR TITLE
Allow for optimized scale launches

### DIFF
--- a/ompi/mca/pml/base/base.h
+++ b/ompi/mca/pml/base/base.h
@@ -72,6 +72,7 @@ OMPI_DECLSPEC int mca_pml_base_revoke_comm(struct ompi_communicator_t *comm, boo
 OMPI_DECLSPEC extern mca_pml_base_component_t mca_pml_base_selected_component;
 OMPI_DECLSPEC extern mca_pml_base_module_t mca_pml;
 OMPI_DECLSPEC extern opal_pointer_array_t mca_pml_base_pml;
+OMPI_DECLSPEC extern bool ompi_pml_base_check_pml;
 
 END_C_DECLS
 

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -98,6 +98,7 @@ mca_pml_base_module_t mca_pml = {
 mca_pml_base_component_t mca_pml_base_selected_component = {{0}};
 opal_pointer_array_t mca_pml_base_pml = {{0}};
 char *ompi_pml_base_bsend_allocator_name = NULL;
+bool ompi_pml_base_check_pml = true;
 
 #if !MCA_ompi_pml_DIRECT_CALL
 static char *ompi_pml_base_wrapper = NULL;
@@ -158,6 +159,15 @@ static int mca_pml_base_register(mca_base_register_flag_t flags)
                     ompi_pml_base_warn_dep_cancel_send_level);
     }
 #endif
+
+    ompi_pml_base_check_pml = true;
+    (void) mca_base_var_register("ompi", "pml", "base", "check_pml",
+                                 "Whether to check the pml selections to ensure they all match",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &ompi_pml_base_check_pml);
+
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -346,6 +346,10 @@ mca_pml_base_pml_check_selected(const char *my_pml,
     int ret = 0;
     size_t i;
 
+    if (!ompi_pml_base_check_pml) {
+        return OMPI_SUCCESS;
+    }
+
     if (!opal_pmix_collect_all_data) {
         /*
          * If direct modex, then compare our PML with the peer's PML


### PR DESCRIPTION
Many environments do not face the problem of inconsistent pml component selection. Yet the current pml implementation requires that either a modex be executed so that each process can check their pml selection against that of rank=0, or that each process engage in a very expensive all-to-all direct modex exchange of the pml selection.

Provide an opportunity for users and system admins to bypass both of these methods by setting an MCA param (via one of the several OMPI-supported methods) that disables the check. This has significant launch
performance impact for most large-scale systems, but we will leave the param set to default to executing the check since those who need it are probably not savvy enough to know that they do.