### PR TITLE
Fix wrong buffer size in ompi_session_get_nth_pset_f

### DIFF
--- a/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
@@ -77,7 +77,7 @@ void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n,
 {
     int c_ierr;
     MPI_Session c_session;
-    char c_name[MPI_MAX_OBJECT_NAME];
+    char c_name[MPI_MAX_PSET_NAME_LEN];
 
     c_session = PMPI_Session_f2c(*session);
 


### PR DESCRIPTION
Signed-off-by: Jan Fecht <mail@fecht.cc>
(cherry picked from commit ca10d77bb7f0d549600fadb36533439062b80cc1)