### PR TITLE
Add MPI_SESSION_NULL to fortran

### DIFF
--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -148,6 +148,7 @@ $handles->{MPI_OP_NULL} = 0;
 $handles->{MPI_REQUEST_NULL} = 0;
 $handles->{MPI_WIN_NULL} = 0;
 $handles->{MPI_MESSAGE_NULL} = 0;
+$handles->{MPI_SESSION_NULL} = 0;
 
 $handles->{MPI_BYTE} =  1;
 $handles->{MPI_PACKED} =  2;

--- a/ompi/mpi/fortran/mpif-h/session_finalize_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_finalize_f.c
@@ -80,4 +80,11 @@ void ompi_session_finalize_f(MPI_Fint *session, MPI_Fint *ierr)
 
     c_ierr = PMPI_Session_finalize(&c_session);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    /* This value comes from the MPI_SESSION_NULL value in mpif.h.  Do not
+       change without consulting mpif.h! */
+
+    if (MPI_SUCCESS == c_ierr) {
+        *session = 0;
+    }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -74,6 +74,7 @@ module mpi_f08_types
   type(MPI_Request), parameter   :: MPI_REQUEST_NULL             = MPI_Request(OMPI_MPI_REQUEST_NULL)
   type(MPI_Win), parameter       :: MPI_WIN_NULL                 = MPI_Win(OMPI_MPI_WIN_NULL)
   type(MPI_File), parameter      :: MPI_FILE_NULL                = MPI_File(OMPI_MPI_FILE_NULL)
+  type(MPI_Session), parameter   :: MPI_SESSION_NULL             = MPI_Session(OMPI_MPI_SESSION_NULL)
 
   !
   ! Pre-defined datatype bindings


### PR DESCRIPTION
Hello,

I wanted to write some Fortran code that uses MPI Sessions and realized that `MPI_SESSION_NULL` is not available in Fortran. As a consequence, I added support myself by adding the constant to the Fortran header generator + implementing comparison functions for `type(MPI_Session)` and by making `MPI_Session_finalize` return an `MPI_SESSION_NULL` handle on return.

Here are is a code pieces that wouldn't compile (because `MPI_SESSION_NULL` was not defined), but works now:
````
program main
  use mpi
  implicit none

  integer :: ierror
  integer :: session

  call mpi_session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, session, ierror)
  if (ierror /=0) stop 'mpi session init fail'

  call mpi_session_finalize(session, ierror)
  if (ierror /=0) stop 'mpi session finalize fail'

  if (session /= MPI_SESSION_NULL) then
    print *, "Session handle was not set to MPI_SESSION_NULL!"
  end if

end program main
````