### PR TITLE
Re-enable all Jenkinsfile tests.

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -48,17 +48,6 @@ def prepare_check_stages() {
     def configure_options = ["--disable-dlopen", "--disable-oshmem", "--enable-builtin-atomic", "--enable-ipv6"]
     def compilers = ["clang10", "gcc5", "gcc6", "gcc7", "gcc8", "gcc9", "gcc10"]
     def platforms = ["amazon_linux_2", "amazon_linux_2-arm64", "rhel7", "rhel8", "ubuntu_18.04"]
-
-    // TODO: While we are debugging, limit the number of combinations
-    // that we're running so that we don't waste a bunch of resources.
-    // Make all the lists empty so that the only check we do is the
-    // "distcheck" entry, below.  When we have finished debugging,
-    // remove the following lines so that we go back to the full set
-    // of test environments.
-    configure_options = []
-    compilers = []
-    platforms = []
-
     def check_stages_list = []
 
     // Build everything stage

--- a/.ci/community-jenkins/pr-builder.sh
+++ b/.ci/community-jenkins/pr-builder.sh
@@ -299,7 +299,7 @@ if test "${MPIRUN_MODE}" != "none"; then
             exec="timeout -s SIGSEGV 3m mpirun -hostfile ${WORKSPACE}/hostfile -np 2 "
             ;;
         *)
-            exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 "
+            exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 --bind-to none "
             ;;
     esac
     singleton="timeout -s SIGSEGV 1m "


### PR DESCRIPTION
The new Jenkins CI appears to be ready.  This commit effectively reverts 6406e005, and re-enables all the Jenkinsfile-based tests.

FYI @Joe-Downs 