### PR TITLE
v4.0.x: ci: Clean workspace after every stage

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -79,6 +79,7 @@ def prepare_build(build_name, label, build_arg) {
             node(label) {
                 checkout(changelog: false, poll: false, scm: scm)
                 sh "/bin/bash -x .ci/community-jenkins/pr-builder.sh ${build_arg} ompi"
+                cleanWs(notFailBuild: true)
             }
         }
     }


### PR DESCRIPTION
Clean the workspace after every stage (ie, test) to avoid filling disk.  The downside of this change is that we can't reuse a checkout of OMPI between stages that run on the same build node.  The upside is that we are much less likely to run out of disk space during a test.  We ran into some issues today when there were many builds, because the workspace name is different between pull requests, and when a build node had enough checkouts (one for each pull request), we filled the disk.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit c5d57cc9e961f3c07546ead61767c11116358321)