### PR TITLE
[v5.0.x] coll/han: correctly handle MPI_IN_PLACE

### DIFF
--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -184,7 +184,7 @@ mca_coll_han_allreduce_intra(const void *sbuf,
         mca_coll_task_t *t_next_seg = OBJ_NEW(mca_coll_task_t);
         /* Setup up t_next_seg task arguments */
         t->cur_task = t_next_seg;
-        t->sbuf = (char *) t->sbuf + extent * t->seg_count;
+        t->sbuf = (t->sbuf == MPI_IN_PLACE) ? MPI_IN_PLACE : (char *) t->sbuf + extent * t->seg_count;
         t->rbuf = (char *) t->rbuf + extent * t->seg_count;
         t->cur_seg = t->cur_seg + 1;
         /* Init t_next_seg task */
@@ -262,11 +262,26 @@ int mca_coll_han_allreduce_t1_task(void *task_args)
         if (t->cur_seg == t->num_segments - 2 && t->last_seg_count != t->seg_count) {
             tmp_count = t->last_seg_count;
         }
-        t->low_comm->c_coll->coll_reduce((char *) t->sbuf + extent * t->seg_count,
-                                         (char *) t->rbuf + extent * t->seg_count, tmp_count,
-                                         t->dtype, t->op, t->root_low_rank, t->low_comm,
-                                         t->low_comm->c_coll->coll_reduce_module);
 
+        if (t->sbuf == MPI_IN_PLACE) {
+            if (!t->noop) {
+                t->low_comm->c_coll->coll_reduce(MPI_IN_PLACE,
+                                                 (char *) t->rbuf + extent * t->seg_count, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+            } else {
+                t->low_comm->c_coll->coll_reduce((char *) t->rbuf + extent * t->seg_count,
+                                                 NULL, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+
+            }
+        } else {
+            t->low_comm->c_coll->coll_reduce((char *) t->sbuf + extent * t->seg_count,
+                                             (char *) t->rbuf + extent * t->seg_count, tmp_count,
+                                             t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                             t->low_comm->c_coll->coll_reduce_module);
+	}
     }
     if (!t->noop) {
         ompi_request_wait(&ireduce_req, MPI_STATUS_IGNORE);
@@ -321,10 +336,26 @@ int mca_coll_han_allreduce_t2_task(void *task_args)
         if (t->cur_seg == t->num_segments - 3 && t->last_seg_count != t->seg_count) {
             tmp_count = t->last_seg_count;
         }
-        t->low_comm->c_coll->coll_reduce((char *) t->sbuf + 2 * extent * t->seg_count,
-                                         (char *) t->rbuf + 2 * extent * t->seg_count, tmp_count,
-                                         t->dtype, t->op, t->root_low_rank, t->low_comm,
-                                         t->low_comm->c_coll->coll_reduce_module);
+
+	if (t->sbuf == MPI_IN_PLACE) {
+	    if (!t->noop) {
+                t->low_comm->c_coll->coll_reduce(MPI_IN_PLACE,
+                                                 (char *) t->rbuf + 2 * extent * t->seg_count, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+	    } else {
+                t->low_comm->c_coll->coll_reduce((char *) t->rbuf + 2 * extent * t->seg_count,
+                                                 NULL, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+
+	    }
+	} else {
+            t->low_comm->c_coll->coll_reduce((char *) t->sbuf + 2 * extent * t->seg_count,
+                                             (char *) t->rbuf + 2 * extent * t->seg_count, tmp_count,
+                                             t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                             t->low_comm->c_coll->coll_reduce_module);
+	}
     }
     if (!t->noop && req_count > 0) {
         ompi_request_wait_all(req_count, reqs, MPI_STATUSES_IGNORE);
@@ -385,10 +416,25 @@ int mca_coll_han_allreduce_t3_task(void *task_args)
         if (t->cur_seg == t->num_segments - 4 && t->last_seg_count != t->seg_count) {
             tmp_count = t->last_seg_count;
         }
-        t->low_comm->c_coll->coll_reduce((char *) t->sbuf + 3 * extent * t->seg_count,
-                                         (char *) t->rbuf + 3 * extent * t->seg_count, tmp_count,
-                                         t->dtype, t->op, t->root_low_rank, t->low_comm,
-                                         t->low_comm->c_coll->coll_reduce_module);
+
+        if (t->sbuf == MPI_IN_PLACE) {
+            if (!t->noop) {
+                t->low_comm->c_coll->coll_reduce(MPI_IN_PLACE,
+                                                 (char *) t->rbuf + 3 * extent * t->seg_count, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+	    } else {
+                t->low_comm->c_coll->coll_reduce((char *) t->rbuf + 3 * extent * t->seg_count,
+                                                 NULL, tmp_count,
+                                                 t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_reduce_module);
+            }
+        } else {
+            t->low_comm->c_coll->coll_reduce((char *) t->sbuf + 3 * extent * t->seg_count,
+                                             (char *) t->rbuf + 3 * extent * t->seg_count, tmp_count,
+                                             t->dtype, t->op, t->root_low_rank, t->low_comm,
+                                             t->low_comm->c_coll->coll_reduce_module);
+        }
     }
     /* lb of cur_seg */
     if (t->cur_seg == t->num_segments - 1 && t->last_seg_count != t->seg_count) {


### PR DESCRIPTION
This patch fixed the incorrect handling of MPI_IN_PLACE in t1, t2, t3 task in calling reduce and ireduce.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit d9d639811d0c0296790a66a39a779208ef58a22b)