### PR TITLE
Pass NULL to the collective components for unused buffers.

### DIFF
--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -37,9 +37,9 @@
  * handler invocation, but the collective components provide all other
  * functionality.
  *
- * Component selection is done per commuicator, at Communicator
+ * Component selection is done per communicator, at Communicator
  * construction time.  mca_coll_base_comm_select() is used to
- * create the list of components available to the componenent
+ * create the list of components available to the component
  * collm_comm_query function, instantiating a module for each
  * component that is usable, and sets the module collective function pointers.
  * mca_coll_base_comm_select() then loops through the list of available
@@ -59,6 +59,15 @@
  * components should be able to handle either style of communicator
  * during initialization (although handling may include indicating the
  * component is not available).
+ *
+ * Unlike the MPI standard, all buffers that are not supposed to be used (and
+ * therefore where the MPI standard does not require the tuple 
+ * (buffer, datatype, count) to be accessible, are replaced with NULL.
+ * As an example, the recvbuf for all non-root ranks in an MPI_Reduce,
+ * will be set to NULL at the MPI API level. The reason behind this is to
+ * allow collective components to indicate when buffers are really valid,
+ * such that collective modules delegating collectives to other modules
+ * can share temporary buffer.
  */
 
 #ifndef OMPI_MCA_COLL_COLL_H
@@ -508,7 +517,7 @@ typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
  *
  * Module interface to the Collective framework.  Modules are
  * reference counted based on the number of functions from the module
- * used on the commuicator.  There is at most one module per component
+ * used on the communicator.  There is at most one module per component
  * on a given communicator, and there can be many component modules on
  * a given communicator.
  *

--- a/ompi/mpi/c/gather.c
+++ b/ompi/mpi/c/gather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -189,10 +189,16 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         (0 == recvcount && (MPI_ROOT == root || MPI_PROC_NULL == root))) {
         return MPI_SUCCESS;
     }
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_gather(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm,
-                                   comm->c_coll->coll_gather_module);
+    err = comm->c_coll->coll_gather(sendbuf, sendcount, sendtype, updated_recvbuf,
+                                    recvcount, recvtype, root, comm,
+                                    comm->c_coll->coll_gather_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/gather_init.c
+++ b/ompi/mpi/c/gather_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -168,8 +168,15 @@ int MPI_Gather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_gather_init(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_gather_init(sendbuf, sendcount, sendtype, updated_recvbuf,
                                          recvcount, recvtype, root, comm, info, request,
                                          comm->c_coll->coll_gather_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -202,8 +202,15 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     }
 #endif
 
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_gatherv(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_gatherv(sendbuf, sendcount, sendtype, updated_recvbuf,
                                     recvcounts, displs,
                                     recvtype, root, comm,
                                     comm->c_coll->coll_gatherv_module);

--- a/ompi/mpi/c/gatherv_init.c
+++ b/ompi/mpi/c/gatherv_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -192,8 +192,15 @@ int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_gatherv_init(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_gatherv_init(sendbuf, sendcount, sendtype, updated_recvbuf,
                                           recvcounts, displs, recvtype,
                                           root, comm, info, request,
                                           comm->c_coll->coll_gatherv_init_module);

--- a/ompi/mpi/c/igather.c
+++ b/ompi/mpi/c/igather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -168,8 +168,15 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_igather(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_igather(sendbuf, sendcount, sendtype, updated_recvbuf,
                                     recvcount, recvtype, root, comm, request,
                                     comm->c_coll->coll_igather_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {

--- a/ompi/mpi/c/igatherv.c
+++ b/ompi/mpi/c/igatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -191,8 +191,15 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    void* updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+    } else {
+        updated_recvbuf = (root == MPI_ROOT) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_igatherv(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_igatherv(sendbuf, sendcount, sendtype, updated_recvbuf,
                                      recvcounts, displs, recvtype,
                                      root, comm, request, comm->c_coll->coll_igatherv_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {

--- a/ompi/mpi/c/iscatter.c
+++ b/ompi/mpi/c/iscatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -151,10 +151,20 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    const void *updated_sendbuf;
+    void *updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_sendbuf = (ompi_comm_rank(comm) != root) ? NULL : sendbuf;
+        updated_recvbuf = recvbuf;
+    } else {
+        updated_sendbuf = (MPI_ROOT != root ) ? NULL : sendbuf;
+        updated_recvbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : recvbuf;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_iscatter(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, root, comm, request,
-                                     comm->c_coll->coll_iscatter_module);
+    err = comm->c_coll->coll_iscatter(updated_sendbuf, sendcount, sendtype, updated_recvbuf,
+                                      recvcount, recvtype, root, comm, request,
+                                      comm->c_coll->coll_iscatter_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         if (OMPI_COMM_IS_INTRA(comm)) {
             if (MPI_IN_PLACE == recvbuf) {

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -144,12 +144,21 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
         return MPI_SUCCESS;
     }
 
-    /* Invoke the coll component to perform the back-end operation */
+    void *updated_recvbuf;
+    const void *updated_sendbuf;
+    if(OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+        updated_sendbuf = sendbuf;
+    } else {
+        updated_sendbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : sendbuf;
+        updated_recvbuf = (MPI_ROOT == root) ? recvbuf : NULL;
+    }
 
+    /* Invoke the coll component to perform the back-end operation */
     OBJ_RETAIN(op);
-    err = comm->c_coll->coll_reduce(sendbuf, recvbuf, count,
-                                   datatype, op, root, comm,
-                                   comm->c_coll->coll_reduce_module);
+    err = comm->c_coll->coll_reduce(updated_sendbuf, updated_recvbuf, count,
+                                    datatype, op, root, comm,
+                                    comm->c_coll->coll_reduce_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/reduce_init.c
+++ b/ompi/mpi/c/reduce_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -136,8 +136,18 @@ int MPI_Reduce_init(const void *sendbuf, void *recvbuf, int count,
         OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
     }
 
+    void *updated_recvbuf;
+    const void *updated_sendbuf;
+    if(OMPI_COMM_IS_INTRA(comm)) {
+        updated_recvbuf = (ompi_comm_rank(comm) == root) ? recvbuf : NULL;
+        updated_sendbuf = sendbuf;
+    } else {
+        updated_sendbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : sendbuf;
+        updated_recvbuf = (MPI_ROOT == root) ? recvbuf : NULL;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_reduce_init(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_reduce_init(updated_sendbuf, updated_recvbuf, count,
                                          datatype, op, root, comm, info, request,
                                          comm->c_coll->coll_reduce_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {

--- a/ompi/mpi/c/scatter.c
+++ b/ompi/mpi/c/scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -173,9 +173,19 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         return MPI_SUCCESS;
     }
 
+    const void *updated_sendbuf;
+    void *updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_sendbuf = (ompi_comm_rank(comm) != root) ? NULL : sendbuf;
+        updated_recvbuf = recvbuf;
+    } else {
+        updated_sendbuf = (MPI_ROOT != root ) ? NULL : sendbuf;
+        updated_recvbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : recvbuf;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_scatter(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, root, comm,
-                                    comm->c_coll->coll_scatter_module);
+    err = comm->c_coll->coll_scatter(updated_sendbuf, sendcount, sendtype, updated_recvbuf,
+                                     recvcount, recvtype, root, comm,
+                                     comm->c_coll->coll_scatter_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/scatter_init.c
+++ b/ompi/mpi/c/scatter_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -151,8 +151,18 @@ int MPI_Scatter_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+    const void *updated_sendbuf;
+    void *updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_sendbuf = (ompi_comm_rank(comm) != root) ? NULL : sendbuf;
+        updated_recvbuf = recvbuf;
+    } else {
+        updated_sendbuf = (MPI_ROOT != root ) ? NULL : sendbuf;
+        updated_recvbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : recvbuf;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_scatter_init(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_scatter_init(updated_sendbuf, sendcount, sendtype, updated_recvbuf,
                                           recvcount, recvtype, root, comm, info, request,
                                           comm->c_coll->coll_scatter_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {

--- a/ompi/mpi/c/scatterv.c
+++ b/ompi/mpi/c/scatterv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -202,9 +202,19 @@ int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[]
     }
 #endif
 
+    const void *updated_sendbuf;
+    void *updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_sendbuf = (ompi_comm_rank(comm) != root) ? NULL : sendbuf;
+        updated_recvbuf = recvbuf;
+    } else {
+        updated_sendbuf = (MPI_ROOT != root ) ? NULL : sendbuf;
+        updated_recvbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : recvbuf;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_scatterv(sendbuf, sendcounts, displs,
-                                     sendtype, recvbuf, recvcount, recvtype, root, comm,
-                                     comm->c_coll->coll_scatterv_module);
+    err = comm->c_coll->coll_scatterv(updated_sendbuf, sendcounts, displs,
+                                      sendtype, updated_recvbuf, recvcount, recvtype, root, comm,
+                                      comm->c_coll->coll_scatterv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/scatterv_init.c
+++ b/ompi/mpi/c/scatterv_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -191,9 +191,19 @@ int MPI_Scatterv_init(const void *sendbuf, const int sendcounts[], const int dis
         }
     }
 
+    const void *updated_sendbuf;
+    void *updated_recvbuf;
+    if (OMPI_COMM_IS_INTRA(comm)) {
+        updated_sendbuf = (ompi_comm_rank(comm) != root) ? NULL : sendbuf;
+        updated_recvbuf = recvbuf;
+    } else {
+        updated_sendbuf = (MPI_ROOT != root ) ? NULL : sendbuf;
+        updated_recvbuf = ((MPI_ROOT == root) || (MPI_PROC_NULL == root)) ? NULL : recvbuf;
+    }
+
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_scatterv_init(sendbuf, sendcounts, displs,
-                                           sendtype, recvbuf, recvcount, recvtype, root, comm,
+    err = comm->c_coll->coll_scatterv_init(updated_sendbuf, sendcounts, displs,
+                                           sendtype, updated_recvbuf, recvcount, recvtype, root, comm,
                                            info, request, comm->c_coll->coll_scatterv_init_module);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         if (OMPI_COMM_IS_INTRA(comm)) {


### PR DESCRIPTION
We want the underlying algorithms to know when they can use a buffer as a temporary, such as when one module delegate a collective to another. Instead of allocating temporaries everywhere, we allow the upper level module to handle the temporary buffers, and pass them into all the others. Thus, we need to make sure that the user provided buffers are screened such that they don't make it as temporaries.

This could help #11418 to streamline the call to the xhc reduction.