### PR TITLE
v5.0: doc: Add links to disable-io-romio option

### DIFF
--- a/docs/installing-open-mpi/configure-cli-options/mpi.rst
+++ b/docs/installing-open-mpi/configure-cli-options/mpi.rst
@@ -75,7 +75,10 @@ MPI API behaviors that can be used with ``configure``:
   component
 
 * ``--disable-io-romio``:
-  Disable the ROMIO MPI-IO component
+  Disable the :ref:`ROMIO MPI-IO <label-romio-reference>` component
+  from being compiled. This is a deprecated mechanism; it is effectively
+  the same as adding ``io-romio341`` to the list of items passed to
+  ``--enable-mca-no-build``.
 
 * ``--with-io-romio-flags=FLAGS``:
   Pass ``FLAGS`` to the ROMIO distribution configuration script.  This

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -68,6 +68,8 @@ The following *projects* exist in Open MPI |ompi_ver|:
           See :ref:`the role of PMIx and PRRTE
           <label-running-role-of-pmix-and-prte>` for more information.
 
+.. _label-mca-frameworks:
+
 Frameworks
 ^^^^^^^^^^
 
@@ -94,6 +96,8 @@ between different versions of Open MPI.  You can use the
 :ref:`ompi_info(1) <man1-ompi_info>` command to see the full list of
 frameworks that are included in Open MPI |ompi_ver|.
 
+.. _label-mca-components:
+
 Components
 ^^^^^^^^^^
 
@@ -110,6 +114,8 @@ MPI.  Open MPI's code base includes support for many components, but
 not all of them may be present or available on your system.  You can
 use the :ref:`ompi_info(1) <man1-ompi_info>` command to see what
 components are included in Open MPI |ompi_ver| on your system.
+
+.. _label-mca-modules:
 
 Modules
 ^^^^^^^

--- a/docs/tuning-apps/mpi-io/romio.rst
+++ b/docs/tuning-apps/mpi-io/romio.rst
@@ -1,6 +1,12 @@
+.. _label-romio-reference:
+
 ROMIO
 =====
 
 ROMIO is an implementation of the MPI I/O functions defined in version
 two of the Message Passing Interface specification.  It has been
 ported over to Open MPI from `MPICH <https://mpich.org/>`_.
+
+It is utilized through the ``romio341`` :ref:`component
+<label-mca-components>` as an implementation of
+the ``io`` :ref:`framework <label-mca-frameworks>`


### PR DESCRIPTION
Added links to other documents explaining ROMIO
and describe it being a deprecated option similar
to --enable-mca-no-build

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit 97b493885bbd94a55b17341d9bc92254866655c6)