### PR TITLE
Fix pre-built docs check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1070,9 +1070,9 @@ AS_IF([test -z "$LEX" || \
 # Setup HTML and man page processing
 #
 
+dnl Note that we have to double escape the URL below
+dnl so that the # it contains doesn't confuse the Autotools
 OAC_SETUP_SPHINX([$srcdir/docs/_build/man/MPI_T.3],
-                 dnl Note that we have to double escape the string below
-                 dnl so that the # it contains doesn't confuse the Autotools
                  [[https://docs.open-mpi.org/en/main/developers/prerequisites.html#sphinx-and-therefore-python]])
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1070,7 +1070,7 @@ AS_IF([test -z "$LEX" || \
 # Setup HTML and man page processing
 #
 
-OAC_SETUP_SPHINX([$srcdir/docs/_build/man/MPI_T.5],
+OAC_SETUP_SPHINX([$srcdir/docs/_build/man/MPI_T.3],
                  dnl Note that we have to double escape the string below
                  dnl so that the # it contains doesn't confuse the Autotools
                  [[https://docs.open-mpi.org/en/main/developers/prerequisites.html#sphinx-and-therefore-python]])


### PR DESCRIPTION
Fixes #11571.

Fix an indenting problem in the emitted error message, too (see commit messages for details).

Thanks to @opoplawski for noticing the problem.