### PR TITLE
pr-checks: add milestoner GitHub Action (cherry pick to v4.0.x)

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -37,3 +37,15 @@ jobs:
         uses: open-mpi/pr-labeler@v1.0.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+  milestone:
+    permissions:
+      issues: write
+      pull-requests: write
+    name: Milestone Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Milestoner
+        uses: open-mpi/pr-milestoner@v1.0.0
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The milestoner action adds a milestone to a pull request based on the base branch name. If the base branch name matches "vNUMBER.NUMBER", look for all open milestones matching this prefix. If any are found, apply the one with the earliest due date. If none are found or if a milestone is already applied, do nothing.

Signed-off-by: Joe Downs <joe@dwns.dev>
(cherry picked from commit 2040f91b7ffc492ab5133253208d20e00bd0d357)