### PR TITLE
V4.1.x UCC/HCOLL: return req null in request free

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -331,7 +331,7 @@ request_free(struct ompi_request_t **ompi_req)
         return OMPI_ERROR;
     }
     coll_handle_free(req);
-    *ompi_req = &ompi_request_empty;
+    *ompi_req = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -515,7 +515,7 @@ int mca_coll_ucc_req_free(struct ompi_request_t **ompi_req)
 {
     opal_free_list_return (&mca_coll_ucc_component.requests,
                            (opal_free_list_item_t *)(*ompi_req));
-    *ompi_req = &ompi_request_empty;
+    *ompi_req = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
V4.1.x  UCC/HCOLL: return req null in request free

Signed-off-by: Mamzi Bayatpour  <mbayatpour@nvidia.com>
(cherry picked from commit 364fe25d40439c1615432308fe6dbe7a0605b8d7)

@janjust 