### PR TITLE
Improving Jenkins error-handling and build description

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -30,6 +30,13 @@ if (buildNumber > 1) {
 }
 milestone(buildNumber)
 
+// Add build description linking back to PR. This is redundant to the "GitHub"
+// link on the Pull Request page, but the Build page does not have a direct link
+// back to the PR. The "Details" link at the bottom of the GitHub PR page brings
+// you to the Jenkins Build page, so we're adding the link back to the GitHub PR
+// page.
+currentBuild.description = "This is a build of <a href=\"${CHANGE_URL}\"}\">Open MPI PR #${CHANGE_ID}</a>"
+
 check_stages = prepare_check_stages()
 println("Initialized Pipeline")
 

--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -79,7 +79,16 @@ def prepare_build(build_name, label, build_arg) {
         stage("${build_name}") {
             node(label) {
                 checkout(changelog: false, poll: false, scm: scm)
-                sh "/bin/bash -x .ci/community-jenkins/pr-builder.sh ${build_arg} ompi"
+                // If pr-builder.sh fails, the sh step will throw an exception,
+                // which we catch so that the job doesn't abort and continues on
+                // to other steps - such as cleanup. Because we catch the
+                // exception, we need to tell Jenkins the overall job has
+                // failed.
+                try {
+                    sh "/bin/bash -x .ci/community-jenkins/pr-builder.sh ${build_arg} ompi"
+                } catch (Exception e) {
+                    currentBuild.result = "FAILURE"
+                }
                 cleanWs(notFailBuild: true)
             }
         }


### PR DESCRIPTION
Adds two improvements to Jenkins:
1. Handles exceptions raised by failures in `pr-builder.sh`.
2. Links back to the PR in the build description.
