### PR TITLE
MPI_Get_processor_name.3.rst: trivial typo fix

### DIFF
--- a/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
@@ -47,7 +47,7 @@ OUTPUT PARAMETERS
 -----------------
 
 * ``name`` : A unique specifier for the actual (as opposed to virtual)
-   node.
+  node.
 * ``resultlen`` : Length (in characters) of result returned in name.
 * ``ierror`` : Fortran only: Error status (integer).
 


### PR DESCRIPTION
Remote an errant space which causes RST to render it incorrectly.