### PR TITLE
v5.0.x: MPI_Get_processor_name.3.rst: trivial typo fix

### DIFF
--- a/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_processor_name.3.rst
@@ -47,7 +47,7 @@ OUTPUT PARAMETERS
 -----------------
 
 * ``name`` : A unique specifier for the actual (as opposed to virtual)
-   node.
+  node.
 * ``resultlen`` : Length (in characters) of result returned in name.
 * ``ierror`` : Fortran only: Error status (integer).
 


### PR DESCRIPTION
Remote an errant space which causes RST to render it incorrectly.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 48b61e962f52e42c6fb39b15b11788b4ffc522fe)

Corresponds to main PR #11596