### PR TITLE
Don't overwhelm the blockLength.

### DIFF
--- a/ompi/datatype/ompi_datatype_create_struct.c
+++ b/ompi/datatype/ompi_datatype_create_struct.c
@@ -33,8 +33,8 @@ int32_t ompi_datatype_create_struct( int count, const int* pBlockLength, const p
 {
     ptrdiff_t disp = 0, endto, lastExtent, lastDisp;
     ompi_datatype_t *pdt, *lastType;
-    int lastBlock;
     int i, start_from;
+    size_t lastBlock;
 
     /* Find first non-zero length element */
     for( i = 0; (i < count) && (0 == pBlockLength[i]); i++ );

--- a/test/datatype/opal_ddt_lib.c
+++ b/test/datatype/opal_ddt_lib.c
@@ -366,8 +366,7 @@ static int32_t opal_datatype_create_struct( int count, const int* pBlockLength, 
                                             opal_datatype_t** pTypes, opal_datatype_t** newType )
 {
     int i;
-    ptrdiff_t disp = 0, endto, lastExtent, lastDisp;
-    int lastBlock;
+    ptrdiff_t disp = 0, endto, lastExtent, lastDisp, lastBlock;
     opal_datatype_t *pdt, *lastType;
 
     if( 0 == count ) {


### PR DESCRIPTION
During the optimization process the datatype engine will merge contiguous elements. When this happen adding two integers might result in a "largher than int" value and the resulting datatype will be incorrectly sized. Use size_t instead of int (this is correct because the MPI standard mandates the block lengths to be non-negative numbers).

Thanks @albandil for finding the issue and providing a patch.

cherry-pick 3c7f93f