### PR TITLE
accelerator/cuda: Check for cuda devices

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda_component.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_component.c
@@ -188,7 +188,15 @@ static opal_accelerator_base_module_t* accelerator_cuda_init(void)
     if (!opal_cuda_support) {
         return NULL;
     }
-
+    int count = 0;
+    /* If cuInit fails or there are no cuda capable devices, return NULL. */
+    if (cuInit(0)) {
+        return NULL;
+    }
+    CUresult ret = cuDeviceGetCount(&count);
+    if (ret || count == 0) {
+        return NULL;
+    }
     opal_accelerator_cuda_delayed_init();
     return &opal_accelerator_cuda_module;
 }


### PR DESCRIPTION
Adds a check during component initialization for
cuda capable devices. Does not select the component if no cuda capable devices are detected.