### PR TITLE
[v5.0.x] coll/base: do not send and receive 0 byte message for linear alltoallv

### DIFF
--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -310,12 +310,14 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
             continue;
         }
 
-        ++nreqs;
-        prcv = ((char *) rbuf) + (ptrdiff_t)rdisps[i] * rext;
-        err = MCA_PML_CALL(irecv_init(prcv, rcounts[i], rdtype,
-                                      i, MCA_COLL_BASE_TAG_ALLTOALLV, comm,
-                                      preq++));
-        if (MPI_SUCCESS != err) { goto err_hndl; }
+        if (rcounts[i] > 0) {
+            ++nreqs;
+            prcv = ((char *) rbuf) + (ptrdiff_t)rdisps[i] * rext;
+            err = MCA_PML_CALL(irecv_init(prcv, rcounts[i], rdtype,
+                                          i, MCA_COLL_BASE_TAG_ALLTOALLV, comm,
+                                          preq++));
+            if (MPI_SUCCESS != err) { goto err_hndl; }
+        }
     }
 
     /* Now post all sends */
@@ -324,13 +326,15 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
             continue;
         }
 
-        ++nreqs;
-        psnd = ((char *) sbuf) + (ptrdiff_t)sdisps[i] * sext;
-        err = MCA_PML_CALL(isend_init(psnd, scounts[i], sdtype,
-                                      i, MCA_COLL_BASE_TAG_ALLTOALLV,
-                                      MCA_PML_BASE_SEND_STANDARD, comm,
-                                      preq++));
-        if (MPI_SUCCESS != err) { goto err_hndl; }
+        if (scounts[i] > 0) {
+            ++nreqs;
+            psnd = ((char *) sbuf) + (ptrdiff_t)sdisps[i] * sext;
+            err = MCA_PML_CALL(isend_init(psnd, scounts[i], sdtype,
+                                         i, MCA_COLL_BASE_TAG_ALLTOALLV,
+                                         MCA_PML_BASE_SEND_STANDARD, comm,
+                                         preq++));
+            if (MPI_SUCCESS != err) { goto err_hndl; }
+        }
     }
 
     /* Start your engines.  This will never return an error. */


### PR DESCRIPTION
Prior to this change, the linear algorithm of alltoallv will post send and receive even when sendcount and recvcount is 0.

This patch make the algorithm to skip 0 byte send/receive.

This patch works because MPI standard has strict requirement on collective message size.

According to MPI standard's Collectives Introduction and Overview (6.1) section:

For collective operations, the amount of data sent must exactly match the amount of data specified by
the receiver.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit c1a98f19ea108db1f6e895c5805f47ca318c70ff)