### PR TITLE
mtl/ofi: Fix EP Naming Bug for fi_av_insert()

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi.c
@@ -267,7 +267,7 @@ ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
     /**
      * Retrieve the processes' EP names from modex.
      */
-    for (i = 0; i < nprocs; ++i) {
+    for (i = 0, count = 0; i < nprocs; ++i, count += size) {
         OFI_COMPAT_MODEX_RECV(ret,
                               &mca_mtl_ofi_component.super.mtl_version,
                               procs[i],
@@ -281,7 +281,13 @@ ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
             free(errhost);
             goto bail;
         }
-        memcpy(&ep_names[i*namelen], ep_name, namelen);
+
+        if (size > namelen) {
+            size = namelen - 1;
+            ep_name[size + 1] = '\0';
+        }
+
+        memcpy(&ep_names[count], ep_name, size);
     }
 
     /**

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -1096,7 +1096,7 @@ select_prov:
         goto error;
     }
 
-    ompi_mtl_ofi.epnamelen = namelen;
+    ompi_mtl_ofi.epnamelen = FI_NAME_MAX;
     free(ep_name);
 
     /**
@@ -1105,7 +1105,7 @@ select_prov:
     ompi_mtl_ofi.any_addr = FI_ADDR_UNSPEC;
     ompi_mtl_ofi.is_initialized = false;
     ompi_mtl_ofi.has_posted_initial_buffer = false;
-    
+
     ompi_mtl_ofi.base.mtl_flags |= MCA_MTL_BASE_FLAG_SUPPORTS_EXT_CID;
 
     return &ompi_mtl_ofi.base;


### PR DESCRIPTION
Endpoint names can never be longer than FI_NAME_MAX.  The size returned from fi_getname() is specific to the endpoint it is being called on.

https://ofiwg.github.io/libfabric/v1.1.1/man/fi_cm.3.html

Libfabric expects the list of endpoint names to be contiguous in memory, and deliminated by the NULL terminator. OMPI was allocating an arrays of strings with size of its local endpoints name. OMPI was putting the start of each endpoint name at the start of each string in the array of strings. This leads to gaps/incomplete names if the endpoint name that was being added is a different size than the endpoint that had fi_getname() called on it. This bug will cause startup hangs b/c libfabric will try to send to an endpoint which doesn't exist.