### PR TITLE
OPAL/MCA/COMMON/UCX: #11632 bugfix - mca string variables registration

### DIFF
--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -5,6 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019-2020 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,8 +91,8 @@ typedef struct opal_common_ucx_module {
     int progress_iterations;
     int registered;
     bool opal_mem_hooks;
-    char *tls;
-    char *devices;
+    char **tls;
+    char **devices;
 } opal_common_ucx_module_t;
 
 typedef struct opal_common_ucx_del_proc {


### PR DESCRIPTION
Fixing #11632 segfault

# The root cause for the segfault:
`ompi_info` was hitting a segfault while trying to deregister the UCX `tls` mca-variable after UCX components were already unloaded - resulting in illegal memory access.

# Suggested solution
Cherry-pick from a commit that already fixed this issue in v4.1.x: https://github.com/open-mpi/ompi/commit/d79d5e84b8b2cb7ef872c971e94323bdfb218fda 