### PR TITLE
Conditionally destroy job session directory.

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -8,7 +8,7 @@
  *                         reserved.
  * Copyright (c) 2014-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2018-2020 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2023 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -62,6 +62,14 @@
 opal_process_name_t pmix_name_wildcard = {UINT32_MAX-1, UINT32_MAX-1};
 opal_process_name_t pmix_name_invalid = {UINT32_MAX, UINT32_MAX};
 bool ompi_singleton = false;
+
+/**
+ * Flag used to indicate whether we setup (and should destroy) our job session
+ * directory. We keep track of this information because we may be using run-time
+ * infrastructure that manages its structure (e.g., OpenPMIx). If we setup this
+ * session directory structure, then we shall cleanup after ourselves.
+ */
+static bool destroy_job_session_dir = false;
 
 static int _setup_top_session_dir(char **sdir);
 static int _setup_job_session_dir(char **sdir);
@@ -923,11 +931,12 @@ int ompi_rte_finalize(void)
     PMIx_Finalize(NULL, 0);
 
     /* cleanup the session directory we created */
-    if (NULL != opal_process_info.job_session_dir) {
+    if (NULL != opal_process_info.job_session_dir && destroy_job_session_dir) {
         opal_os_dirpath_destroy(opal_process_info.job_session_dir,
                                 false, check_file);
         free(opal_process_info.job_session_dir);
         opal_process_info.job_session_dir = NULL;
+        destroy_job_session_dir = false;
     }
 
     if (NULL != opal_process_info.top_session_dir) {
@@ -1127,7 +1136,7 @@ static int _setup_job_session_dir(char **sdir)
         opal_process_info.job_session_dir = NULL;
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-
+    destroy_job_session_dir = true;
     return OPAL_SUCCESS;
 }
 


### PR DESCRIPTION
Only destroy the contents rooted at opal_process_info.job_session_dir if we setup the root path. We now keep track of this information because we may be using run-time infrastructure that manages the job's session directory for us (e.g., OpenPMIx). If we setup this session directory structure, then we shall cleanup after ourselves. Otherwise, let infrastructure like OpenPMIx manage it for us.

This fixes a crash in the sessions_init_twice test where shared-memory information managed by OpenPMIx was deleted prematurely.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit ffa52edbfd634c274baf88daaafa832469b888fc)