### PR TITLE
smcuda: fix edge case when using enable mca dso

### DIFF
--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.c
@@ -37,7 +37,7 @@ static int accelerator_event_max = 400;
 static int accelerator_event_ipc_most = 0;
 static bool smcuda_accelerator_initialized = false;
 
-static void mca_btl_smcuda_accelerator_fini(void);
+void mca_btl_smcuda_accelerator_fini(void);
 
 int mca_btl_smcuda_accelerator_init(void)
 {
@@ -83,14 +83,6 @@ int mca_btl_smcuda_accelerator_init(void)
         goto cleanup_and_error;
     }
 
-    /*
-     * add smcuda acclerator fini code to opal's list of cleanup functions.
-     * Cleanups are called before all the MCA frameworks are closed, so by
-     * adding this function to the callback list, we avoid issues with ordering
-     * of the closing of the BTL framework with the accelerator framework, etc. etc.
-     */
-    opal_finalize_register_cleanup(mca_btl_smcuda_accelerator_fini);
-
     smcuda_accelerator_initialized = true;
 
 cleanup_and_error:
@@ -115,7 +107,7 @@ cleanup_and_error:
     return rc;
 }
 
-static void mca_btl_smcuda_accelerator_fini(void)
+void mca_btl_smcuda_accelerator_fini(void)
 {
     int i;
 

--- a/opal/mca/btl/smcuda/btl_smcuda_accelerator.h
+++ b/opal/mca/btl/smcuda/btl_smcuda_accelerator.h
@@ -22,5 +22,6 @@ OPAL_DECLSPEC int mca_btl_smcuda_accelerator_init(void);
 OPAL_DECLSPEC int mca_btl_smcuda_progress_one_ipc_event(struct mca_btl_base_descriptor_t **frag);
 OPAL_DECLSPEC int mca_btl_smcuda_memcpy(void *dst, void *src, size_t amount, char *msg,
                            struct mca_btl_base_descriptor_t *frag);
+OPAL_DECLSPEC void mca_btl_smcuda_accelerator_fini(void);
 
 #endif /* MCA_BTL_SMCUDA_ACCELERATOR_H */


### PR DESCRIPTION
turns out singleton and single process per node hit an edge case - a segfault in MPI_Finalize - without this patch

related to #11627

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit e398fc242ef8a30142d07a7c7639cbad026a3b9e)