### PR TITLE
mtl/ofi: scope down ompi_mtl_ofi_wc to function level

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -74,7 +74,6 @@ int ompi_mtl_ofi_progress_no_inline(void);
 
 #if OPAL_HAVE_THREAD_LOCAL
 extern opal_thread_local int ompi_mtl_ofi_per_thread_ctx;
-extern opal_thread_local struct fi_cq_tagged_entry ompi_mtl_ofi_wc[MTL_OFI_MAX_PROG_EVENT_COUNT];
 #endif
 
 #define MCA_MTL_OFI_CID_NOT_EXCHANGED 2
@@ -136,9 +135,7 @@ ompi_mtl_ofi_context_progress(int ctxt_id)
     ompi_mtl_ofi_request_t *ofi_req = NULL;
     struct fi_cq_err_entry error = { 0 };
     ssize_t ret;
-#if !OPAL_HAVE_THREAD_LOCAL
     struct fi_cq_tagged_entry ompi_mtl_ofi_wc[MTL_OFI_MAX_PROG_EVENT_COUNT];
-#endif
 
     /**
      * Read the work completions from the CQ.

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -39,7 +39,6 @@ static int ofi_tag_mode;
 
 #if OPAL_HAVE_THREAD_LOCAL
     opal_thread_local int ompi_mtl_ofi_per_thread_ctx;
-    opal_thread_local struct fi_cq_tagged_entry ompi_mtl_ofi_wc[MTL_OFI_MAX_PROG_EVENT_COUNT];
 #endif
 
 /*


### PR DESCRIPTION
Currently, ompi_mtl_ofi_wc is scoped to be thread level, but not function level, so if calls to ompi_mtl_ofi_context_progress are nested, the ompi_mtl_ofi_wc will be overwritten. For example, the callback of the ofi_req extracted from the cq entry can trigger progress engine in the ssend path, in which the receiver will post a tsendmsg (and run progress engine when hitting EAGAIN) to sender as ack. After the callback finishes, it falls back to the original progress engine loop, then it could progress the cqe that is already finished in the callback.