### PR TITLE
btl/ofi: increase outstanding_rdma eariler for flush

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_atomics.c
+++ b/opal/mca/btl/ofi/btl_ofi_atomics.c
@@ -63,6 +63,7 @@ int mca_btl_ofi_afop(struct mca_btl_base_module_t *btl, struct mca_btl_base_endp
     mca_btl_ofi_rdma_completion_t *comp = NULL;
     mca_btl_ofi_context_t *ofi_context;
 
+    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
     ofi_context = get_ofi_context(ofi_btl);
 
     if (flags & MCA_BTL_ATOMIC_FLAG_32BIT) {
@@ -87,15 +88,15 @@ int mca_btl_ofi_afop(struct mca_btl_base_module_t *btl, struct mca_btl_base_endp
                          fi_datatype, fi_op, &comp->comp_ctx);
 
     if (rc == -FI_EAGAIN) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         return OPAL_ERR_OUT_OF_RESOURCE;
     } else if (rc < 0) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         BTL_ERROR(("fi_fetch_atomic failed with rc=%d (%s)", rc, fi_strerror(-rc)));
         MCA_BTL_OFI_ABORT();
     }
-
-    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     return OPAL_SUCCESS;
 }
@@ -114,6 +115,7 @@ int mca_btl_ofi_aop(struct mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *
     mca_btl_ofi_rdma_completion_t *comp = NULL;
     mca_btl_ofi_context_t *ofi_context;
 
+    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
     ofi_context = get_ofi_context(ofi_btl);
 
     if (flags & MCA_BTL_ATOMIC_FLAG_32BIT) {
@@ -136,15 +138,15 @@ int mca_btl_ofi_aop(struct mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *
                    fi_datatype, fi_op, &comp->comp_ctx);
 
     if (rc == -FI_EAGAIN) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         return OPAL_ERR_OUT_OF_RESOURCE;
     } else if (rc < 0) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         BTL_ERROR(("fi_atomic failed with rc=%d (%s)", rc, fi_strerror(-rc)));
         MCA_BTL_OFI_ABORT();
     }
-
-    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     return OPAL_SUCCESS;
 }
@@ -165,6 +167,7 @@ int mca_btl_ofi_acswap(struct mca_btl_base_module_t *btl, struct mca_btl_base_en
     mca_btl_ofi_endpoint_t *btl_endpoint = (mca_btl_ofi_endpoint_t *) endpoint;
     mca_btl_ofi_context_t *ofi_context;
 
+    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
     ofi_context = get_ofi_context(ofi_btl);
 
     if (flags & MCA_BTL_ATOMIC_FLAG_32BIT) {
@@ -188,15 +191,15 @@ int mca_btl_ofi_acswap(struct mca_btl_base_module_t *btl, struct mca_btl_base_en
                            fi_datatype, FI_CSWAP, &comp->comp_ctx);
 
     if (rc == -FI_EAGAIN) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         return OPAL_ERR_OUT_OF_RESOURCE;
     } else if (rc < 0) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         BTL_ERROR(("fi_compare_atomic failed with rc=%d (%s)", rc, fi_strerror(-rc)));
         MCA_BTL_OFI_ABORT();
     }
-
-    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/ofi/btl_ofi_rdma.c
+++ b/opal/mca/btl/ofi/btl_ofi_rdma.c
@@ -66,6 +66,8 @@ int mca_btl_ofi_get(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
     mca_btl_ofi_endpoint_t *btl_endpoint = (mca_btl_ofi_endpoint_t *) endpoint;
     mca_btl_ofi_context_t *ofi_context;
 
+    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
+
     ofi_context = get_ofi_context(ofi_btl);
 
     /* create completion context */
@@ -84,17 +86,18 @@ int mca_btl_ofi_get(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
                  &comp->comp_ctx); /* completion context */
 
     if (-FI_EAGAIN == rc) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
     if (0 != rc) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         BTL_ERROR(("fi_read failed with %d:%s", rc, fi_strerror(-rc)));
         MCA_BTL_OFI_ABORT();
     }
 
-    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     return OPAL_SUCCESS;
 }
@@ -110,6 +113,8 @@ int mca_btl_ofi_put(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
     mca_btl_ofi_module_t *ofi_btl = (mca_btl_ofi_module_t *) btl;
     mca_btl_ofi_endpoint_t *btl_endpoint = (mca_btl_ofi_endpoint_t *) endpoint;
     mca_btl_ofi_context_t *ofi_context;
+
+    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     ofi_context = get_ofi_context(ofi_btl);
 
@@ -127,17 +132,17 @@ int mca_btl_ofi_put(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
                   &comp->comp_ctx); /* completion context */
 
     if (-FI_EAGAIN == rc) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
     if (0 != rc) {
+        MCA_BTL_OFI_NUM_RDMA_DEC(ofi_btl);
         opal_free_list_return(comp->base.my_list, (opal_free_list_item_t *) comp);
         BTL_ERROR(("fi_write failed with %d:%s", rc, fi_strerror(-rc)));
         MCA_BTL_OFI_ABORT();
     }
-
-    MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
Piror to this patch, outstanding_rdma was increased after rdma request was sent. This could cause mca_btl_ofi_flush() to return before the rdma submitted by the caller completed under multi-thread environment.

To address, this patch moved the increment of outstanding_rdma to before RDMA requests were submitted, and decrease the counter when submission failed.