### PR TITLE
v5.0.x: RTD: use ubuntu-22.04 as ReadTheDoc build OS

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,14 @@
 # Required
 version: 2
 
+# Currently, RTD needs to select an OS with OpenSSL>=1.1.1 because of
+# urllib3's dependence on that system library.  (alternately, pin urllib3<2
+# See https://github.com/urllib3/urllib3/issues/2168
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
urllib3 requires an OS with newer version of OpenSSL. See: https://github.com/urllib3/urllib3/issues/2168

Signed-off-by: Luke Robison <lrbison@amazon.com>
(cherry picked from commit 814f4d2c483c60b56363c8433acfb14358c4f9db)