### PR TITLE
[v4.1.x]: RTD: Copy .readthedocs.yaml from main

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Currently, RTD needs to select an OS with OpenSSL>=1.1.1 because of
+# urllib3's dependence on that system library.  (alternately, pin urllib3<2
+# See https://github.com/urllib3/urllib3/issues/2168
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Copy ReadTheDocs configuration from main 814f4d2.  This is not a cherry-pick as 4.1.x branch did not have this configuration file.

bot:notacherrypick