### PR TITLE
[v4.0.x]: RTD: Copy .readthedocs.yaml from main

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Currently, RTD needs to select an OS with OpenSSL>=1.1.1 because of
+# urllib3's dependence on that system library.  (alternately, pin urllib3<2
+# See https://github.com/urllib3/urllib3/issues/2168
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Copy ReadTheDocs configuration from main 814f4d2.  Cherry-picking this commit from the v4.1.x branch to v4.0.x.

Signed-off-by: Luke Robison <lrbison@amazon.com>
(cherry picked from commit 25d1b800b509cf957da7b916ef69350a814fd150)