### PR TITLE
Use acquire/release barrier to synchronize completion of request and test/wait

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -39,6 +39,9 @@ int ompi_request_default_wait(
 
     ompi_request_wait_completion(req);
 
+    /* make sure we get the correct status */
+    opal_atomic_rmb();
+
 #if OPAL_ENABLE_FT_MPI
     /* Special case for MPI_ANY_SOURCE */
     if( MPI_ERR_PROC_FAILED_PENDING == req->req_status.MPI_ERROR ) {
@@ -198,6 +201,8 @@ recheck:
         rc = ompi_grequest_invoke_query(request, &request->req_status);
     }
     if (MPI_STATUS_IGNORE != status) {
+        /* make sure we get the correct status */
+        opal_atomic_rmb();
         OMPI_COPY_STATUS(status, request->req_status, false);
     }
     rc = request->req_status.MPI_ERROR;
@@ -302,6 +307,9 @@ recheck:
  finish:
     rptr = requests;
     if (MPI_STATUSES_IGNORE != statuses) {
+        /* make sure we get the correct status */
+        opal_atomic_rmb();
+
         /* fill out status and free request if required */
         for( i = 0; i < count; i++, rptr++ ) {
             void *_tmp_ptr = &sync;
@@ -573,6 +581,9 @@ int ompi_request_default_wait_some(size_t count,
     }
 
     *outcount = num_requests_done;
+
+    /* make sure we get the correct status */
+    opal_atomic_rmb();
 
     for (size_t i = 0; i < num_requests_done; i++) {
         request = requests[indices[i]];

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -527,6 +527,8 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
     if (0 == rc) {
         if (OPAL_LIKELY(with_signal)) {
+            /* make sure everything in the request is visible before we mark it complete */
+            opal_atomic_wmb();
 
             ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                     REQUEST_COMPLETED);


### PR DESCRIPTION
Before completing the request we should make sure that all other pieces are visible, i.e., the status. The release barrier should synchronize with an acquire barrier before reading the status in test/wait to ensure that status is current.

This also removes a full memory barrier at the beginning of test functions that does not seem to serve any purpose.

Thanks to @joerowell for the report.

Fixes https://github.com/open-mpi/ompi/issues/11652