### PR TITLE
accelerator/rocm: add SYNC_MEMOPS support

### DIFF
--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -504,5 +504,15 @@ static int mca_accelerator_rocm_get_buffer_id(int dev_id, const void *addr, opal
     }
 #endif
 
+#if HIP_VERSION >= 50530201
+    int enable = 1;
+    hipError_t err = hipPointerSetAttribute(&enable, HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+					    (hipDeviceptr_t)addr);
+    if (hipSuccess != err) {
+        opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+			    "error in hipPointerSetAttribute, could not set SYNC_MEMOPS");
+        return OPAL_ERROR;
+    }
+#endif
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
starting from ROCm 5.5.0 hip supports the SYNC_MEMOPS attribute.

Signed-off-by: Edgar Gabriel <Edgar.Gabriel@amd.com>
(cherry picked from commit fec8e6acdb5cadaba1c4313898f4d06f82f3f2eb)