### PR TITLE
mtl/ofi: Remove unused variables, and check ompi_ret

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi.c
@@ -224,14 +224,11 @@ ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
     int ret = OMPI_SUCCESS;
     size_t i;
     size_t size;
-    size_t namelen;
     int count = 0;
     char *ep_name = NULL;
     fi_addr_t *fi_addrs = NULL;
     mca_mtl_ofi_endpoint_t *endpoint = NULL;
     int num_peers_limit = (1 << ompi_mtl_ofi.num_bits_source_rank) - 1;
-
-    namelen = ompi_mtl_ofi.epnamelen;
 
     /* We cannot add more ranks than available tag bits */
     if ((false == ompi_mtl_ofi.fi_cq_data) &&

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -865,11 +865,17 @@ ompi_mtl_ofi_send_generic(struct mca_mtl_base_module_t *mtl,
         if (mtl_comm->c_index_vec[dest].c_index_state == MCA_MTL_OFI_CID_NOT_EXCHANGED) {
             mtl_comm->c_index_vec[dest].c_index_state = MCA_MTL_OFI_CID_EXCHANGING;
             ompi_ret = ompi_mtl_ofi_send_excid(mtl, comm, dest, ofi_cq_data, true);
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_ret)) {
+                return ompi_ret;
+            }
         }
 
         if (mtl_comm->c_index_vec[dest].c_index_state > MCA_MTL_OFI_CID_EXCHANGED) {
              while (mtl_comm->c_index_vec[dest].c_index_state > MCA_MTL_OFI_CID_EXCHANGED) {
                 ompi_ret = ompi_mtl_ofi_post_recv_excid_buffer(true, comm, dest);
+                if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_ret)) {
+                    return ompi_ret;
+                }
             }
         }
         c_index_for_tag = mtl_comm->c_index_vec[dest].c_index;

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -576,7 +576,6 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     struct fi_info *hints, *hints_dup = NULL;
     struct fi_info *providers = NULL;
     struct fi_info *prov = NULL;
-    struct fi_info *prov_cq_data = NULL;
     void *ep_name = NULL;
     size_t namelen = 0;
     int universe_size;
@@ -1136,9 +1135,6 @@ error:
     }
     if (providers) {
         (void) fi_freeinfo(providers);
-    }
-    if (prov_cq_data) {
-        (void) fi_freeinfo(prov_cq_data);
     }
     if (hints) {
         (void) fi_freeinfo(hints);


### PR DESCRIPTION
Fix two issues in mtl/ofi found by Coverity.