### PR TITLE
[v5.0.x] opal/mca/accelerator: introduce get_device_pci_attr api

### DIFF
--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2014-2021 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
  * $COPYRIGHT$
  *
@@ -110,6 +110,15 @@ struct opal_accelerator_stream_t {
     void *stream;
 };
 typedef struct opal_accelerator_stream_t opal_accelerator_stream_t;
+
+struct opal_accelerator_pci_attr_t {
+    uint16_t domain_id;
+    uint8_t bus_id;
+    uint8_t device_id;
+    uint8_t function_id;
+};
+typedef struct opal_accelerator_pci_attr_t opal_accelerator_pci_attr_t;
+
 OBJ_CLASS_DECLARATION(opal_accelerator_stream_t);
 
 struct opal_accelerator_event_t {
@@ -347,6 +356,17 @@ typedef int (*opal_accelerator_base_module_get_device_fn_t)(
     int *dev_id);
 
 /**
+ * Retrieves PCI attributes of an accelerator device.
+ *
+ * @param[int] dev_id        Accelerator device id
+ * @param[out] pci_attr      PCI attributes of the requested device
+ *
+ * @return                   OPAL_SUCCESS or error status on failure
+ */
+typedef int (*opal_accelerator_base_module_get_device_pci_attr_fn_t)(
+    int dev_id, opal_accelerator_pci_attr_t *pci_attr);
+
+/**
  * Queries if a device may directly access a peer device's memory.
  *
  * @param[OUT] access        Returns 1 if dev1 can directly access memory on dev2
@@ -398,6 +418,7 @@ typedef struct {
     opal_accelerator_base_module_host_unregister_fn_t host_unregister;
 
     opal_accelerator_base_module_get_device_fn_t get_device;
+    opal_accelerator_base_module_get_device_pci_attr_fn_t get_device_pci_attr;
     opal_accelerator_base_module_device_can_access_peer_fn_t device_can_access_peer;
 
     opal_accelerator_base_module_get_buffer_id_fn_t get_buffer_id;

--- a/opal/mca/accelerator/null/accelerator_null_component.c
+++ b/opal/mca/accelerator/null/accelerator_null_component.c
@@ -6,7 +6,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
  * $COPYRIGHT$
  *
@@ -59,6 +59,7 @@ static int accelerator_null_host_register(int dev_id, void *ptr, size_t size);
 static int accelerator_null_host_unregister(int dev_id, void *ptr);
 
 static int accelerator_null_get_device(int *dev_id);
+static int accelerator_null_get_device_pci_attr(int dev_id, opal_accelerator_pci_attr_t *pci_attr);
 static int accelerator_null_device_can_access_peer(int *access, int dev1, int dev2);
 
 static int accelerator_null_get_buffer_id(int dev_id, const void *addr, opal_accelerator_buffer_id_t *buf_id);
@@ -122,6 +123,7 @@ opal_accelerator_base_module_t opal_accelerator_null_module =
     accelerator_null_host_unregister,
 
     accelerator_null_get_device,
+    accelerator_null_get_device_pci_attr,
     accelerator_null_device_can_access_peer,
 
     accelerator_null_get_buffer_id
@@ -231,6 +233,11 @@ static int accelerator_null_host_unregister(int dev_id, void *ptr)
 }
 
 static int accelerator_null_get_device(int *dev_id)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_null_get_device_pci_attr(int dev_id, opal_accelerator_pci_attr_t *pci_attr)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
Introduce get_device_pci_attr api to query accelerator device PCI attributes. This enables intelligent selection of other PCI(e) devices based on affinity with the accelerator, e.g. NICs.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit 00a567ee732c1dca5c0e8dfb52f66a1e8f858636)