### PR TITLE
opal/common/ofi: do not compute device distances if process is unbound

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -783,7 +783,7 @@ struct fi_info *opal_common_ofi_select_provider(struct fi_info *provider_list,
     struct fi_info **provider_table;
 #if OPAL_OFI_PCI_DATA_AVAILABLE
     pmix_device_distance_t *distances = NULL;
-    pmix_value_t *pmix_val;
+    pmix_value_t *pmix_val = NULL;
     struct fi_pci_attr pci;
     int num_distances = 0;
 #endif
@@ -815,7 +815,7 @@ struct fi_info *opal_common_ofi_select_provider(struct fi_info *provider_list,
     /* find all the nearest devices to this thread, then out of these
      * determine which device we should bind to.
      */
-    distances = get_nearest_nics(&num_distances, &pmix_val);
+    distances = process_info->proc_is_bound ? get_nearest_nics(&num_distances, &pmix_val) : NULL;
 #endif
 
     current_provider = provider;

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -472,12 +472,10 @@ static int compute_dev_distances(pmix_device_distance_t **distances,
     int ret = OPAL_SUCCESS;
     size_t ninfo;
     pmix_info_t *info;
-    pmix_cpuset_t cpuset;
+    pmix_cpuset_t cpuset = PMIX_CPUSET_STATIC_INIT;
     pmix_topology_t pmix_topo = PMIX_TOPOLOGY_STATIC_INIT;
-    pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS |
-      PMIX_DEVTYPE_NETWORK;
+    pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS | PMIX_DEVTYPE_NETWORK;
 
-    PMIX_CPUSET_CONSTRUCT(&cpuset);
     ret = PMIx_Get_cpuset(&cpuset, PMIX_CPUBIND_THREAD);
     if (PMIX_SUCCESS != ret) {
         /* we are not bound */


### PR DESCRIPTION
2nd attempt to skip device distance calculation if process is unbound. The previous change was not sufficient and we still saw pmix errors, e.g.
```
[queue-c5n18xlarge-st-c5n18xlarge-1:07220] PMIX ERROR: ERROR in file client/pmix_client_topology.c at line 352
```