### PR TITLE
pr/ompio info fixes - v4.1.x

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -76,16 +76,30 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "striping_factor", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
     }
-
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        if ( flag ) {
+            sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
+        }
+    }
+    
+    opal_info_get (info, "striping_unit", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
     }
-
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.        
+        opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        if ( flag ) {
+            sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
+        }
+    }
+    
     if (fs_lustre_stripe_size < 0) {
         fs_lustre_stripe_size = mca_fs_lustre_stripe_size;
     }   

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -76,7 +76,7 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "striping_factor", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "striping_unit", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
     }
@@ -88,7 +88,7 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
         }
     }
     
-    opal_info_get (info, "striping_unit", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "striping_factor", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
     }

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -109,16 +109,31 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
        update mca_fs_pvfs2_stripe_width and mca_fs_pvfs2_stripe_size
        before calling fake_an_open() */
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "striping_factor", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_size );
     }
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        if ( flag ) {
+            sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_size );
+        }
+    }
 
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "striping_unit", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_width );
     }
+    else {
+        //internal info object name used earlier. Kept for backwards compatibility.
+        opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        if ( flag ) {
+            sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_width );
+        }
+    }
 
+    
     if (fs_pvfs2_stripe_size < 0) {
         fs_pvfs2_stripe_size = mca_fs_pvfs2_stripe_size;
     }


### PR DESCRIPTION
This pr brings the changes to the info handling in ompio from main to the v4.1.x branch.
It contains two commits: 
 - PR #10135 
 - PR #11191

Note, that the PRs had to be adjusted, since there were changes to the info object processing in main compared to v4.1.x