### PR TITLE
ompi/ofi: fix compile with libfabric

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -4,8 +4,8 @@
  *                         reserved.
  * Copyright (c) 2019-2020 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates.  All Rights reserved.
- *                         reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -612,17 +612,7 @@ ompi_mtl_ofi_isend_generic(struct mca_mtl_base_module_t *mtl,
             goto free_request_buffer;
     }
 
-    ompi_ret = ompi_mtl_ofi_register_buffer(convertor, ofi_req, start);
-    if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_ret)) {
-        return ompi_ret;
-    }
-
-
-    /** Inject does not currently support device memory
-     *  https://github.com/ofiwg/libfabric/issues/5861
-     */
-    if (!(convertor->flags & CONVERTOR_ACCELERATOR)
-        && (ompi_mtl_ofi.max_inject_size >= length)) {
+    if (ompi_mtl_ofi.max_inject_size >= length) {
         if (ofi_cq_data) {
             ret = fi_tinjectdata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
                     start,


### PR DESCRIPTION
The previous backport inadvertently broken compilation with libfabric. It introduces accelerator and HMEM changes which are not supported in 4.1.x. This patch fixes that.

Reference: https://github.com/open-mpi/ompi/commit/e8d296caf6b60af90a526c7ea689c0f0261e0d5f

bot:notacherrypick