### PR TITLE
coll/tuned: handle non-float-associative ops in allreduce and reduce-scatter

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -167,6 +167,11 @@ ompi_datatype_is_monotonic( ompi_datatype_t * type ) {
 }
 
 static inline int32_t
+ompi_datatype_is_float( ompi_datatype_t * type ) {
+    return !!(type->super.flags & OMPI_DATATYPE_FLAG_DATA_FLOAT);
+}
+
+static inline int32_t
 ompi_datatype_commit( ompi_datatype_t ** type )
 {
     return opal_datatype_commit ( (opal_datatype_t*)*type );

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -76,8 +76,12 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int coun
      *
      * Currently, ring, segmented ring, and rabenseifner do not support
      * non-commutative operations.
+     *
+     * Only nonoverlapping (reduce+bcast) guarantees stability for float values
      */
-    if( !ompi_op_is_commute(op) ) {
+    if ( !ompi_op_is_float_assoc(op) && ompi_datatype_is_float(dtype) ) {
+        alg = 2;
+    } else if( !ompi_op_is_commute(op) ) {
         if (communicator_size < 4) {
             if (total_dsize < 131072) {
                 alg = 3;
@@ -848,9 +852,9 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_fixed( const void *sbuf, void *rbuf
      *  {4, "butterfly"},
      *
      * Non commutative algorithm capability needs re-investigation.
-     * Defaulting to non overlapping for non commutative ops.
+     * Defaulting to non overlapping for non commutative and non-float-associative ops.
      */
-    if (!ompi_op_is_commute(op)) {
+    if (!ompi_op_is_commute(op) || (!ompi_op_is_float_assoc(op) && ompi_datatype_is_float(dtype))) {
         alg = 1;
     } else {
         if (communicator_size < 4) {
@@ -994,9 +998,9 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void 
      *  {4, "butterfly"},
      *
      * Non commutative algorithm capability needs re-investigation.
-     * Defaulting to basic linear for non commutative ops.
+     * Defaulting to basic linear for non commutative and non-float-associative ops.
      */
-    if( !ompi_op_is_commute(op) ) {
+    if( !ompi_op_is_commute(op) || (!ompi_op_is_float_assoc(op) && ompi_datatype_is_float(dtype)) ) {
         alg = 1;
     } else {
         if (communicator_size < 4) {


### PR DESCRIPTION
Sum and prod are not float-associative, i.e., the rounding of floating point numbers may lead to different results depending on the order of operations. For allreduce and reduce-scatter, we should select algorithms that guarantee the same result on all processes for these operations.

MPI Section 6.9.6:
> MPI requires that all processes from the same group participating
> in these operations receive identical results.

It appears that only the `non-overlapping` variants guarantee this, i.e., performing a reduce followed by bcast/scatter.