### PR TITLE
opal/common/ofi: match openfabrics device by uuid and osname

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -648,6 +648,10 @@ static bool is_near(pmix_device_distance_t *distances,
                 char lsguid[256], lnguid[256];
                 int ret;
 
+                if (!distances[i].osname || !osdev->name
+                    || strcmp(distances[i].osname, osdev->name))
+                    continue;
+
                 ret = sscanf(distances[i].uuid, "fab://%256s::%256s", lnguid, lsguid);
                 if (ret != 2)
                     continue;

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -645,14 +645,14 @@ static bool is_near(pmix_device_distance_t *distances,
                 continue;
 
             for (i = 0; i < num_distances; i++) {
-                char lsguid[256], lnguid[256];
+                char lsguid[20], lnguid[20];
                 int ret;
 
                 if (!distances[i].osname || !osdev->name
                     || strcmp(distances[i].osname, osdev->name))
                     continue;
 
-                ret = sscanf(distances[i].uuid, "fab://%256s::%256s", lnguid, lsguid);
+                ret = sscanf(distances[i].uuid, "fab://%19s::%19s", lnguid, lsguid);
                 if (ret != 2)
                     continue;
                 if (nguid && (0 == strcasecmp(lnguid, nguid))) {


### PR DESCRIPTION
This patch fixes a bug in device matching. uuid alone is not sufficient to match openfabrics devices, and therefore we need to also match osname.