### PR TITLE
opal/mca/ofi: Patch series to fix a crash due to double free on error path

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -765,6 +765,7 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
         relative_locality = opal_hwloc_compute_relative_locality(process_info->locality,
                                                                  locality_string);
         free(locality_string);
+        locality_string = NULL;
 
         if ((uint16_t) pname.vpid == process_info->myprocid.rank) {
             return ranks_on_package;

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -698,13 +698,14 @@ static int count_providers(struct fi_info *provider_list)
     return num_provider;
 }
 
-/* Calculate the current process package rank.
- *     @param (IN) process_info     struct opal_process_info_t information
- *                                  about the current process. used to get
- *                                  num_local_peers, myprocid.rank, and
- *                                  my_local_rank.
+/**
+ * @brief the current process package rank.
  *
- *     @param (OUT)                 uint32_t package rank or myprocid.rank
+ * @param[in]   process_info    struct opal_process_info_t information
+ *                              about the current process. used to get
+ *                              num_local_peers, myprocid.rank.
+ *
+ * @return package rank or myprocid.rank
  *
  * If successful, returns PMIX_PACKAGE_RANK, or an
  * equivalent calculated package rank.
@@ -765,7 +766,7 @@ static uint32_t get_package_rank(opal_process_info_t *process_info)
                                                                  locality_string);
         free(locality_string);
 
-        if ((uint16_t) pname.vpid == process_info->my_local_rank) {
+        if ((uint16_t) pname.vpid == process_info->myprocid.rank) {
             return ranks_on_package;
         }
 


### PR DESCRIPTION
There is a bug in the current impl which attempts to compare local rank vs global rank. Furthermore, when this fails it triggers a double free on the error path, i.e. crash.

This change set addresss the root cause.