### PR TITLE
[v4.1.x] pml/cm: make heavy send request initialization to be same as thin one

### DIFF
--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -164,14 +164,30 @@ do {                                                                    \
     OMPI_DATATYPE_RETAIN(datatype);                                     \
     (req_send)->req_base.req_comm = comm;                               \
     (req_send)->req_base.req_datatype = datatype;                       \
-    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
-    opal_convertor_copy_and_prepare_for_send(                           \
-        ompi_mpi_local_convertor,                                       \
-        &(datatype->super),                                             \
-        count,                                                          \
-        buf,                                                            \
-        flags,                                                          \
-        &(req_send)->req_base.req_convertor );                          \
+    if (opal_datatype_is_contiguous_memory_layout(&datatype->super, count)) { \
+        (req_send)->req_base.req_convertor.remoteArch =                 \
+            ompi_mpi_local_convertor->remoteArch;                       \
+        (req_send)->req_base.req_convertor.flags      =                 \
+            ompi_mpi_local_convertor->flags;                            \
+        (req_send)->req_base.req_convertor.master     =                 \
+            ompi_mpi_local_convertor->master;                           \
+        (req_send)->req_base.req_convertor.local_size =                 \
+            count * datatype->super.size;                               \
+        (req_send)->req_base.req_convertor.pBaseBuf   =                 \
+            (unsigned char*)buf + datatype->super.true_lb;              \
+        (req_send)->req_base.req_convertor.count      = count;          \
+        (req_send)->req_base.req_convertor.pDesc      = &datatype->super; \
+	(req_send)->req_base.req_convertor.use_desc = &(datatype->super.desc); \
+    } else { \
+        MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
+        opal_convertor_copy_and_prepare_for_send(                           \
+            ompi_mpi_local_convertor,                                       \
+            &(datatype->super),                                             \
+            count,                                                          \
+            buf,                                                            \
+            flags,                                                          \
+            &(req_send)->req_base.req_convertor );                          \
+    } \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
     (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
         comm->c_my_rank;                                                \


### PR DESCRIPTION
The macro MCA_PML_CM_HVY_SEND_REQUEST_INIT_COMMON() is different from MCA_PML_CM_SEND_REQUEST_INIT_COMMON(): an "if" branch for data type with continuous memory layout that is present in MCA_PML_CM_SEND_REQUEST_INIT_COMMON() is missing from MCA_PML_CM_HVY_SEND_REQUEST_INIT_COMMON(). As a result, heavy send request is sending from wrong offset of user buffer if the data type's has a non-zero "true_lb"

This patch added that branch to fix the issue.

This patch was applied to the v4.1.x branch directly because the 
main and v5.0.x branch went through a series refactors in the data
type code path, and the issue does not apply any more.

bot:notacherrypick