### PR TITLE
Github workflows: update to newer Github actions versions

### DIFF
--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -18,7 +18,7 @@ jobs:
         echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg]  https://repo.radeon.com/rocm/apt/debian focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
         sudo apt-get update
         sudo apt-get install -y rocm-hip-sdk
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        uses: open-mpi/pr-git-commit-checker@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
   label:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Labeler
-        uses: open-mpi/pr-labeler@v1.0.0
+        uses: open-mpi/pr-labeler@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -45,6 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Milestoner
-        uses: open-mpi/pr-milestoner@v1.0.0
+        uses: open-mpi/pr-milestoner@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Per
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/, update to use newer versions of github actions so that we stop getting warnings about outdated Node.js versions.