### PR TITLE
v4.0.x: pr-checks.yaml: update actions versions v1.0.1

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        uses: open-mpi/pr-git-commit-checker@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
           cherry-pick-required: true
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Labeler
-        uses: open-mpi/pr-labeler@v1.0.0
+        uses: open-mpi/pr-labeler@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -46,6 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Milestoner
-        uses: open-mpi/pr-milestoner@v1.0.0
+        uses: open-mpi/pr-milestoner@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Update all 3 Open MPI GitHub Actions scripts to v1.0.1.  This will squelch warnings that we get about using outdated Node.js versions.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 859cc77889b0d46ad7f14c7131907f082e5009b0)

Corresponds to main PR #11754