### PR TITLE
v4.1.x: find_common_syms: use "grep -E" instead of "egrep"

### DIFF
--- a/config/find_common_syms
+++ b/config/find_common_syms
@@ -91,7 +91,7 @@ OBJECT: while (my $obj_line = <FIND>) {
     # that turns out to be the case, we can try switching to "nm -P", which is
     # supposed to activate the "portable" (yet ugly) format.  It's also unclear
     # at this point how common support for "nm -P" is.
-    open(NM, '-|', "nm '${obj}' 2>/dev/null | egrep '\\s[cC]\\s'");
+    open(NM, '-|', "nm '${obj}' 2>/dev/null | grep -E '\\s[cC]\\s'");
     SYMBOL: while (my $sym_line = <NM>) {
         if (!$all and is_whitelisted($sym_line)) {
             next SYMBOL;


### PR DESCRIPTION
Newer Linux systems are starting to emit warnings about using "egrep", and ask that we use "grep -E", instead.

This patch tested on a system as old as RHEL 6; didn't bother checking a system older than that.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 3b6796bbd91f42c02fc571b0a865987ad50db4e8)

This corresponds to main PR #11753