### PR TITLE
lanl-ci: remove ibm from test matrix

### DIFF
--- a/.ci/lanl/gitlab-darwin-ci.yml
+++ b/.ci/lanl/gitlab-darwin-ci.yml
@@ -30,31 +30,6 @@ build:intel:
       - install_test
     expire_in: 1 week
 
-build:ibm:
-  stage: build
-  tags: [darwin-slurm-shared]
-  variables:
-    SCHEDULER_PARAMETERS: "-ppower9 -t 4:00:00 -N 1 --ntasks-per-node=16"
-  script:
-    - module load ibm
-    - rm .gitmodules
-    - cp $GITSUBMODULEPATCH .gitmodules
-    - git submodule update --init --recursive
-    - ./autogen.pl
-    - ./configure CC=xlc FC=xlf CXX=xlc++ --prefix=$PWD/install_test --with-libevent=internal
-    - make -j 8 install
-    - make check
-    - export PATH=$PWD/install_test/bin:$PATH
-    - cd examples
-    - make
-  artifacts:
-    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
-    untracked: true
-    paths:
-      - examples
-      - install_test
-    expire_in: 1 week
-
 build:amd:
   stage: build
   tags: [darwin-slurm-shared]
@@ -126,54 +101,6 @@ test:intel:
     - mpirun -np 4 ./hello_usempif08
     - mpirun -np 4 ./ring_usempif08
     - mpirun -np 4 ./connectivity_c
-  artifacts:
-    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
-    expire_in: 1 week
-
-test:ibm:
-  stage: test
-  tags: [darwin-slurm-shared]
-  variables:
-    SCHEDULER_PARAMETERS: "-ppower9 -t 2:00:00 -N 1 --ntasks-per-node=16"
-  dependencies:
-    - build:ibm
-  needs: ["build:ibm"]
-  script:
-    - pwd
-    - ls
-    - module load ibm
-    - export PATH=$PWD/install_test/bin:$PATH
-    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/install_test/lib
-    - which mpirun
-    - pushd examples
-    - mpirun -np 4 hostname
-    - mpirun -np 4 ./hello_c
-    - mpirun -np 4 ./ring_c
-    - mpirun -np 4 ./hello_mpifh
-    - mpirun -np 4 ./ring_mpifh
-    - mpirun -np 4 ./hello_usempi
-    - mpirun -np 4 ./ring_usempi
-    - mpirun -np 4 ./hello_usempif08
-    - mpirun -np 4 ./ring_usempif08
-    - mpirun -np 4 ./connectivity_c
-    - popd
-    - mkdir osu-tests
-    - pushd osu-tests
-    - cp -p -r $OSU_TESTS_FOLDER/* .
-    - ./configure CC=mpicc FC=mpifort F77=mpifort CXX=mpiCC && make -j 8 clean && make -j 8 
-    - pushd mpi/pt2pt
-    - mpirun -np 2 ./osu_latency
-    - mpirun -np 2 ./osu_latency D H
-    - mpirun -np 2 ./osu_latency H D
-    - mpirun -np 2 ./osu_latency H H
-    - mpirun -np 2 ./osu_bw
-    - mpirun -np 2 ./osu_bw D H
-    - mpirun -np 2 ./osu_bw H D
-    - mpirun -np 2 ./osu_bw H H
-    - mpirun -np 2 ./osu_bibw
-    - mpirun -np 2 ./osu_bibw D H
-    - mpirun -np 2 ./osu_bibw H D
-    - mpirun -np 2 ./osu_bibw H H
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
     expire_in: 1 week


### PR DESCRIPTION
The IBM nodes were deactivated on our test cluster so removing ibm from the gitlab ci yml file.