### PR TITLE
examples/Makefile: use "grep -E" instead of "egrep"

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -86,7 +86,7 @@ mpi:
 	@ if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then \
 	    $(MAKE) hello_mpifh ring_mpifh; \
 	fi
-	@ if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -E -q bindings:use_mpi:\"\?yes >/dev/null; then \
 	    $(MAKE) hello_usempi ring_usempi; \
 	fi
 	@ if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then \


### PR DESCRIPTION
This is a follow-on to https://github.com/open-mpi/ompi/pull/11753