### PR TITLE
v5.0.x: examples/Makefile: use "grep -E" instead of "egrep"

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -86,7 +86,7 @@ mpi:
 	@ if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then \
 	    $(MAKE) hello_mpifh ring_mpifh; \
 	fi
-	@ if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -E -q bindings:use_mpi:\"\?yes >/dev/null; then \
 	    $(MAKE) hello_usempi ring_usempi; \
 	fi
 	@ if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then \


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit e6a27b2a6feafe41cd4586a36215db3a802777f4)