### PR TITLE
Changed URL of CI repo to https://github.com/Mellanox/jenkins_scripts

### DIFF
--- a/.ci/mellanox/azure-pipelines.yml
+++ b/.ci/mellanox/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
   - MLNX_IB_DEVICE -equals yes
 
 variables:
-  ompi_jenkins_scripts_git_repo_url: https://github.com/mellanox-hpc/jenkins_scripts.git
+  ompi_jenkins_scripts_git_repo_url: https://github.com/Mellanox/jenkins_scripts.git
   ompi_jenkins_scripts_git_branch: master
   # Enable debug information, supported values: true, false
   debug: true


### PR DESCRIPTION
Minor changes due to migration from https://github.com/mellanox-hpc/jenkins_scripts.git to https://github.com/Mellanox/jenkins_scripts