### PR TITLE
Allow the monitoring infrastructure to be compiled.

### DIFF
--- a/ompi/mca/coll/monitoring/configure.m4
+++ b/ompi/mca/coll/monitoring/configure.m4
@@ -15,9 +15,6 @@
 # ------------------------------------------------
 AC_DEFUN([MCA_ompi_coll_monitoring_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/coll/monitoring/Makefile])
-
-    AS_IF([test "$MCA_BUILD_ompi_common_monitoring_DSO_TRUE" = ''],
-          [$1],
-          [$2])
+    [$1]
 ])dnl
 

--- a/ompi/mca/common/monitoring/configure.m4
+++ b/ompi/mca/common/monitoring/configure.m4
@@ -16,13 +16,10 @@
 AC_DEFUN([MCA_ompi_common_monitoring_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/common/monitoring/Makefile])
 
-    m4_ifdef([project_ompi], [
-          m4_ifdef([MCA_BUILD_ompi_common_monitoring_DSO_TRUE],
-                   [AC_CONFIG_LINKS(profile2mat.pl:test/monitoring/profile2mat.pl
-                                    aggregate_profile.pl:test/monitoring/aggregate_profile.pl)])])
+    m4_ifdef([project_ompi],
+             [AC_CONFIG_LINKS(test/monitoring/profile2mat.pl:ompi/mca/common/monitoring/profile2mat.pl
+                              test/monitoring/aggregate_profile.pl:ompi/mca/common/monitoring/aggregate_profile.pl)])
 
 
-    AS_IF([test "$MCA_BUILD_ompi_common_monitoring_DSO_TRUE" = ''],
-          [$1],
-          [$2])
+    [$1]
 ])dnl

--- a/ompi/mca/osc/monitoring/configure.m4
+++ b/ompi/mca/osc/monitoring/configure.m4
@@ -91,10 +91,7 @@ EOF
 AC_DEFUN(
     [MCA_ompi_osc_monitoring_CONFIG],
     [AC_CONFIG_FILES([ompi/mca/osc/monitoring/Makefile])
-
-     AS_IF([test "$MCA_BUILD_ompi_common_monitoring_DSO_TRUE" = ''],
-           [$1],
-           [$2])
+    [$1]
 
      MCA_OMPI_OSC_MONITORING_GENERATE_TEMPLATES(
          [ompi/mca/osc/monitoring/osc_monitoring_template_gen.h],

--- a/ompi/mca/pml/monitoring/configure.m4
+++ b/ompi/mca/pml/monitoring/configure.m4
@@ -15,10 +15,7 @@
 # ------------------------------------------------
 AC_DEFUN([MCA_ompi_pml_monitoring_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/pml/monitoring/Makefile])
-
-    AS_IF([test "$MCA_BUILD_ompi_common_monitoring_DSO_TRUE" = ''],
-          [$1],
-          [$2])
+    [$1]
 ])dnl
 
 


### PR DESCRIPTION
During the last update of the building infrastructure we failed to update the monitoring component. With this update it will be built again by default, and can be activated by providing the MCA variable `pml_monitoring_enable`.