### PR TITLE
Fix erroneous check for GCC version in compiler workaround in v4.1.x

### DIFF
--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -52,7 +52,7 @@
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 
 
-#if defined(PLATFORM_ARCH_X86_64) && defined(PLATFORM_COMPILER_GNU) && __GNUC__ < 8
+#if (OPAL_ASSEMBLY_ARCH == OPAL_X86_64) && defined (__GNUC__) && !defined(__llvm) && __GNUC__ < 8
     /* work around a bug in older gcc versions where ACQUIRE seems to get
      * treated as a no-op instead */
 #define OPAL_BUSTED_ATOMIC_MB 1


### PR DESCRIPTION
The cherry-pick from main (https://github.com/open-mpi/ompi/commit/d9895ce0de1abd488db5ce3debc4f9b5e77d599f) was missing the fact that PLATFORM_ARCH_X86_64 was not available.

Fixes https://github.com/open-mpi/ompi/issues/11772

bot:notacherrypick