### PR TITLE
Added workflow for self-hosted runner Nvidia/Mellanox

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,0 +1,37 @@
+name: ompi_NVIDIA CI
+on: [pull_request, push]
+
+jobs:
+  deployment:
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Checkout CI scripts
+      uses: actions/checkout@v3
+      with:
+        repository: Mellanox/jenkins_scripts
+        path: ompi_ci
+    - name: Deployment infrastructure
+      run: /start deploy
+  build:
+    needs: [deployment]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Building OMPI,UCX and tests
+      run: /start build
+  test:
+    needs: [deployment, build]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Running tests
+      run: /start test
+  clean:
+    if: ${{ always() }}
+    needs: [deployment, build, test]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Cleaning
+      run: /start clean

--- a/.mailmap
+++ b/.mailmap
@@ -134,3 +134,5 @@ William P. LePera <lepera@us.ibm.com>
 George Katevenis <gkatev@ics.forth.gr>
 
 Brian Barrett <brian@bbarrett.org>
+
+Andrii Bilokur <abilokur@nvidia.com> B-a-S <abilokur@nvidia.com>


### PR DESCRIPTION
Migration from AZURE pipeline to GitHub Actions (GA)
workflow file for GA (uses self-hosted runner Nvidia/Mellanox)
https://github.com/B-a-S/ompi/actions/runs/5348344132