### PR TITLE
v4.1.x: dist: update NEWS and VERSION for v4.1.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,6 +61,16 @@ included in the vX.Y.Z section and be denoted as:
 4.1.6 -- February, 2024
 -----------------------
 
+- Update to properly handle PMIx v>=4.2.3.  Thanks to Bruno Chareyre,
+  Github user @sukanka, and Christof Koehler for raising the
+  compatibility issues and helping test the fixes.
+- Fix minor issues and add some minor performance optimizations with
+  OFI support.
+- Support the "striping_factor" and "striping_unit" MPI_Info names
+  recomended by the MPI standard for parallel IO.
+- Fixed some minor issues with UCX support.
+- Minor optimization for 0-byte MPI_Alltoallw (i.e., make it a no-op).
+
 
 4.1.5 -- February, 2023
 -----------------------

--- a/VERSION
+++ b/VERSION
@@ -37,7 +37,7 @@
 ############################################################################
 
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2008-2021 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2023 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
@@ -70,7 +70,7 @@ release=6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -128,7 +128,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=70:5:30
+libmpi_so_version=70:6:30
 libmpi_cxx_so_version=70:1:30
 libmpi_mpifh_so_version=70:0:30
 libmpi_usempi_tkr_so_version=70:0:30


### PR DESCRIPTION
@bwbarrett This is a fairly small release (motivated by the desire to get the PMIx fixes out there).  As such, there's really only 1 small change to `libmpi` itself; all the other changes are in non-common components.

bot:notacherrypick