### PR TITLE
group: defer the insertion of ompi_group_all_failed_procs to group_table

### DIFF
--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -419,16 +419,6 @@ int ompi_group_init(void)
         return OMPI_ERROR;
     }
 
-#if OPAL_ENABLE_FT_MPI
-    /* Setup global list of failed processes */
-    ompi_group_all_failed_procs = OBJ_NEW(ompi_group_t);
-    ompi_group_all_failed_procs->grp_proc_count     = 0;
-    ompi_group_all_failed_procs->grp_my_rank        = MPI_UNDEFINED;
-    ompi_group_all_failed_procs->grp_proc_pointers  = NULL;
-    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_DENSE;
-    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_INTRINSIC;
-#endif
-
     /* add MPI_GROUP_NULL to table */
     OBJ_CONSTRUCT(&ompi_mpi_group_null, ompi_group_t);
     ompi_mpi_group_null.group.grp_proc_count        = 0;
@@ -444,6 +434,17 @@ int ompi_group_init(void)
     ompi_mpi_group_empty.group.grp_proc_pointers     = NULL;
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_DENSE;
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_INTRINSIC;
+
+#if OPAL_ENABLE_FT_MPI
+    /* Setup global list of failed processes */
+    ompi_group_all_failed_procs = OBJ_NEW(ompi_group_t);
+    ompi_group_all_failed_procs->grp_proc_count     = 0;
+    ompi_group_all_failed_procs->grp_my_rank        = MPI_UNDEFINED;
+    ompi_group_all_failed_procs->grp_proc_pointers  = NULL;
+    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_DENSE;
+    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_INTRINSIC;
+#endif
+
 
     ompi_mpi_instance_append_finalize (ompi_group_finalize);
 


### PR DESCRIPTION
The two pre-defined groups: group_null and group_empty must be the 0th and 1st group in the group_table, for MPI_Group_f2c to be able to convert fortran group index to c_group.

However, prior to this patch ompi_group_all_failed_procs was inserted to group table as the 0th group, which broke MPI_Group_f2c.

This patch moved the insertion of ompi_group_all_failed_procs to after group_null and group_empty.