### PR TITLE
Added workflow for self-hosted runner Nvidia/Mellanox into branch v4.1.x

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,0 +1,36 @@
+name: ompi_NVIDIA CI
+on: [pull_request, push]
+jobs:
+  deployment:
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Checkout CI scripts
+      uses: actions/checkout@v3
+      with:
+        repository: Mellanox/jenkins_scripts
+        path: ompi_ci
+    - name: Deployment infrastructure
+      run: /start deploy
+  build:
+    needs: [deployment]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Building OMPI,UCX and tests
+      run: /start build
+  test:
+    needs: [deployment, build]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Running tests
+      run: /start test
+  clean:
+    if: ${{ always() }}
+    needs: [deployment, build, test]
+    runs-on: [self-hosted, linux, x64, nvidia]
+    steps:
+    - name: Cleaning
+      run: /start clean

--- a/.mailmap
+++ b/.mailmap
@@ -113,3 +113,5 @@ Anandhi S Jayakumar <anandhi.s.jayakumar@intel.com>
 Mohan Gandhi <mohgan@amazon.com>
 
 Harumi Kuno <harumi.kuno@hpe.com>
+
+Andrii Bilokur <abilokur@nvidia.com> B-a-S <abilokur@nvidia.com>


### PR DESCRIPTION
Added workflow for self-hosted runner Nvidia/Mellanox (cherry picked from commit https://github.com/open-mpi/ompi/commit/fcd03ef7385530dd1ff45c28bf54f877acbf719f)

Migration from AZURE pipeline to GitHub Actions (GA)
workflow file for GA (uses self-hosted runner Nvidia/Mellanox)
Merged: [fcd03ef](https://github.com/open-mpi/ompi/commit/fcd03ef7385530dd1ff45c28bf54f877acbf719f)