### PR TITLE
runtime/params: set ompi_mpi_compat_mpi3 to true by default

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -83,7 +83,7 @@ bool ompi_async_mpi_finalize = false;
 uint32_t ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
 bool ompi_mpi_dynamics_enabled = true;
 
-bool ompi_mpi_compat_mpi3 = false;
+bool ompi_mpi_compat_mpi3 = true;
 
 char *ompi_mpi_spc_attach_string = NULL;
 bool ompi_mpi_spc_dump_enabled = false;
@@ -362,7 +362,7 @@ int ompi_mpi_register_params(void)
                                       MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     }
 
-    ompi_mpi_compat_mpi3 = false;
+    ompi_mpi_compat_mpi3 = true;
     (void) mca_base_var_register("ompi", "mpi", NULL, "compat_mpi3",
                                  "A boolean value for whether Open MPI operates in MPI-3 compatibility mode; this changes the following behavior: in operations without a handle, errors are raised on (true) MPI_COMM_WORLD (MPI-3 behavior) or (false) MPI_COMM_SELF (MPI-4 behavior).",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -123,8 +123,8 @@ OMPI_DECLSPEC extern int ompi_mpi_abort_delay;
 /**
  * Whether we operate in MPI3 compatibility, or MPI4 mode (default).
  *
- * true: use MPI3 compatibility
- * false: use MPI4 compatibility (default)
+ * true: use MPI3 compatibility (default)
+ * false: use MPI4 compatibility
  *
  * Behavioral changes:
  *   - errors in operations without a handle are raised on MPI_COMM_WORLD (MPI-3 behavior) or MPI_COMM_SELF (MPI-4 behavior)


### PR DESCRIPTION
ompi_mpi_compat_mpi3 controls whether MPI default behavior fix MPI-3 standard or MPI-4 standard.

Because the main branch is following MPI-3 standard, this parameter's default value should be true, but it is false prior to this patch

This patch addressed the issue.
Fixes #11809