### PR TITLE
communicator: add errhandler_type back

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -441,7 +441,7 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
     /* A keyhash will be created if/when an attribute is cached on
        this communicator */
     comm->c_keyhash      = NULL;
-
+    comm->errhandler_type = OMPI_ERRHANDLER_TYPE_COMM;
     comm->error_handler  = &ompi_mpi_errors_are_fatal.eh;
 #ifdef OMPI_WANT_PERUSE
     comm->c_peruse_handles = NULL;

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -313,6 +313,7 @@ struct ompi_communicator_t {
        that the OMPI_ERRHDL_* macros can find it, regardless of whether
        it's a comm, window, or file. */
     ompi_errhandler_t                  *error_handler;
+    ompi_errhandler_type_t             errhandler_type;
 
     /* Hooks for PML to hang things */
     struct mca_pml_comm_t  *c_pml_comm;

--- a/ompi/debuggers/predefined_gap_test.c
+++ b/ompi/debuggers/predefined_gap_test.c
@@ -71,6 +71,8 @@ int main(int argc, char **argv) {
 #else
     GAP_CHECK("error_handler", test_comm, error_handler, c_f_to_c_index, 1);
 #endif
+    GAP_CHECK("errhandler_type", test_comm, errhandler_type, error_handler, 1);
+    GAP_CHECK("c_pml_comm", test_comm, c_pml_comm, errhandler_type, 1);
     GAP_CHECK("c_coll", test_comm, c_coll, c_pml_comm, 1);
 
     /* Test Predefined group sizes */
@@ -125,7 +127,8 @@ int main(int argc, char **argv) {
     GAP_CHECK("w_keyhash", test_win, w_keyhash, w_flags, 1);
     GAP_CHECK("w_f_to_c_index", test_win, w_f_to_c_index, w_keyhash, 1);
     GAP_CHECK("error_handler", test_win, error_handler, w_f_to_c_index, 1);
-
+    GAP_CHECK("errhandler_type", test_win, errhandler_type, error_handler, 1);
+    GAP_CHECK("w_osc_module", test_win, w_osc_module, errhandler_type, 1);
     /* Test Predefined info sizes */
     printf("=============================================\n");
     printf("ompi_predefined_info_t = %lu bytes\n", sizeof(ompi_predefined_info_t));
@@ -145,6 +148,8 @@ int main(int argc, char **argv) {
     GAP_CHECK("f_flags", test_file, f_flags, f_amode,  1);
     GAP_CHECK("f_f_to_c_index", test_file, f_f_to_c_index, f_flags, 1);
     GAP_CHECK("error_handler", test_file, error_handler, f_f_to_c_index, 1);
+    GAP_CHECK("errhandler_type", test_file, errhandler_type, error_handler, 1);
+    GAP_CHECK("f_io_version", test_file, f_io_version, errhandler_type, 1);
     GAP_CHECK("f_io_selected_component", test_file, f_io_selected_component, f_io_version, 1);
     GAP_CHECK("f_io_selected_module", test_file, f_io_selected_module, f_io_selected_component, 1);
     GAP_CHECK("f_io_selected_data", test_file, f_io_selected_data, f_io_selected_module, 1);

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -388,10 +388,10 @@ int ompi_errhandler_proc_failed_internal(ompi_proc_t* ompi_proc, int status, boo
                              OMPI_NAME_PRINT(&ompi_proc->super.proc_name),
                              ompi_comm_print_cid(comm),
                              proc_rank,
-                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->error_handler->eh_mpi_object_type ? "P" :
-                              (OMPI_ERRHANDLER_TYPE_COMM == comm->error_handler->eh_mpi_object_type ? "C" :
-                               (OMPI_ERRHANDLER_TYPE_WIN == comm->error_handler->eh_mpi_object_type ? "W" :
-                                (OMPI_ERRHANDLER_TYPE_FILE == comm->error_handler->eh_mpi_object_type ? "F" : "U") ) ) )
+                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->errhandler_type ? "P" :
+                              (OMPI_ERRHANDLER_TYPE_COMM == comm->errhandler_type ? "C" :
+                               (OMPI_ERRHANDLER_TYPE_WIN == comm->errhandler_type ? "W" :
+                                (OMPI_ERRHANDLER_TYPE_FILE == comm->errhandler_type ? "F" : "U") ) ) )
                              ));
     }
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -238,7 +238,7 @@ extern opal_atomic_int32_t ompi_instance_count;
 #define OMPI_ERRHANDLER_INVOKE(mpi_object, err_code, message) \
   ompi_errhandler_invoke((mpi_object)->error_handler, \
                          (mpi_object), \
-                         (int)(mpi_object)->error_handler->eh_mpi_object_type, \
+                         (int)(mpi_object)->errhandler_type, \
                          ompi_errcode_get_mpi_code(err_code), \
                          (message));
 
@@ -269,7 +269,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int) (mpi_object)->error_handler->eh_mpi_object_type, \
+                           (int) (mpi_object)->errhandler_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \
@@ -307,7 +307,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int)(mpi_object)->error_handler->eh_mpi_object_type, \
+                           (int)(mpi_object)->errhandler_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -202,19 +202,19 @@ int ompi_errhandler_request_invoke(int count,
     case OMPI_REQUEST_COLL:
         return ompi_errhandler_invoke(mpi_object.comm->error_handler,
                                       mpi_object.comm,
-                                      mpi_object.comm->error_handler->eh_mpi_object_type,
+                                      mpi_object.comm->errhandler_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_IO:
         return ompi_errhandler_invoke(mpi_object.file->error_handler,
                                       mpi_object.file,
-                                      mpi_object.file->error_handler->eh_mpi_object_type,
+                                      mpi_object.file->errhandler_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_WIN:
         return ompi_errhandler_invoke(mpi_object.win->error_handler,
                                       mpi_object.win,
-                                      mpi_object.win->error_handler->eh_mpi_object_type,
+                                      mpi_object.win->errhandler_type,
                                       ec, message);
         break;
     default:


### PR DESCRIPTION
Previous commit 2d68804b21cd759be1fe removed "errhandler_type" from communicator, and replaced it with
"errhandler->eh_mpi_object_type".

However, for an errhandler to be invoked on a communicator, errhandler_type must always be OMPI_ERRHANDLER_TYPE_COMM. But, errhandler->eh_mpi_object_type can be
OMPI_ERRHANDLER_TYPE_PREDEFINED for predefined error handlers such as MPI_ERRORS_ARE_FATAL.

This patch added "errhandler_type" back to communicator to address the issue.

Refs #11817