### PR TITLE
[v5.0.x]  backport bugfixes created during mtt bug bash

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -441,7 +441,7 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
     /* A keyhash will be created if/when an attribute is cached on
        this communicator */
     comm->c_keyhash      = NULL;
-
+    comm->errhandler_type = OMPI_ERRHANDLER_TYPE_COMM;
     comm->error_handler  = &ompi_mpi_errors_are_fatal.eh;
 #ifdef OMPI_WANT_PERUSE
     comm->c_peruse_handles = NULL;

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -313,6 +313,7 @@ struct ompi_communicator_t {
        that the OMPI_ERRHDL_* macros can find it, regardless of whether
        it's a comm, window, or file. */
     ompi_errhandler_t                  *error_handler;
+    ompi_errhandler_type_t             errhandler_type;
 
     /* Hooks for PML to hang things */
     struct mca_pml_comm_t  *c_pml_comm;

--- a/ompi/debuggers/predefined_gap_test.c
+++ b/ompi/debuggers/predefined_gap_test.c
@@ -71,6 +71,8 @@ int main(int argc, char **argv) {
 #else
     GAP_CHECK("error_handler", test_comm, error_handler, c_f_to_c_index, 1);
 #endif
+    GAP_CHECK("errhandler_type", test_comm, errhandler_type, error_handler, 1);
+    GAP_CHECK("c_pml_comm", test_comm, c_pml_comm, errhandler_type, 1);
     GAP_CHECK("c_coll", test_comm, c_coll, c_pml_comm, 1);
 
     /* Test Predefined group sizes */
@@ -125,7 +127,8 @@ int main(int argc, char **argv) {
     GAP_CHECK("w_keyhash", test_win, w_keyhash, w_flags, 1);
     GAP_CHECK("w_f_to_c_index", test_win, w_f_to_c_index, w_keyhash, 1);
     GAP_CHECK("error_handler", test_win, error_handler, w_f_to_c_index, 1);
-
+    GAP_CHECK("errhandler_type", test_win, errhandler_type, error_handler, 1);
+    GAP_CHECK("w_osc_module", test_win, w_osc_module, errhandler_type, 1);
     /* Test Predefined info sizes */
     printf("=============================================\n");
     printf("ompi_predefined_info_t = %lu bytes\n", sizeof(ompi_predefined_info_t));
@@ -145,6 +148,8 @@ int main(int argc, char **argv) {
     GAP_CHECK("f_flags", test_file, f_flags, f_amode,  1);
     GAP_CHECK("f_f_to_c_index", test_file, f_f_to_c_index, f_flags, 1);
     GAP_CHECK("error_handler", test_file, error_handler, f_f_to_c_index, 1);
+    GAP_CHECK("errhandler_type", test_file, errhandler_type, error_handler, 1);
+    GAP_CHECK("f_io_version", test_file, f_io_version, errhandler_type, 1);
     GAP_CHECK("f_io_selected_component", test_file, f_io_selected_component, f_io_version, 1);
     GAP_CHECK("f_io_selected_module", test_file, f_io_selected_module, f_io_selected_component, 1);
     GAP_CHECK("f_io_selected_data", test_file, f_io_selected_data, f_io_selected_module, 1);

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -388,10 +388,10 @@ int ompi_errhandler_proc_failed_internal(ompi_proc_t* ompi_proc, int status, boo
                              OMPI_NAME_PRINT(&ompi_proc->super.proc_name),
                              ompi_comm_print_cid(comm),
                              proc_rank,
-                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->error_handler->eh_mpi_object_type ? "P" :
-                              (OMPI_ERRHANDLER_TYPE_COMM == comm->error_handler->eh_mpi_object_type ? "C" :
-                               (OMPI_ERRHANDLER_TYPE_WIN == comm->error_handler->eh_mpi_object_type ? "W" :
-                                (OMPI_ERRHANDLER_TYPE_FILE == comm->error_handler->eh_mpi_object_type ? "F" : "U") ) ) )
+                             (OMPI_ERRHANDLER_TYPE_PREDEFINED == comm->errhandler_type ? "P" :
+                              (OMPI_ERRHANDLER_TYPE_COMM == comm->errhandler_type ? "C" :
+                               (OMPI_ERRHANDLER_TYPE_WIN == comm->errhandler_type ? "W" :
+                                (OMPI_ERRHANDLER_TYPE_FILE == comm->errhandler_type ? "F" : "U") ) ) )
                              ));
     }
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -238,7 +238,7 @@ extern opal_atomic_int32_t ompi_instance_count;
 #define OMPI_ERRHANDLER_INVOKE(mpi_object, err_code, message) \
   ompi_errhandler_invoke((mpi_object)->error_handler, \
                          (mpi_object), \
-                         (int)(mpi_object)->error_handler->eh_mpi_object_type, \
+                         (int)(mpi_object)->errhandler_type, \
                          ompi_errcode_get_mpi_code(err_code), \
                          (message));
 
@@ -269,7 +269,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int) (mpi_object)->error_handler->eh_mpi_object_type, \
+                           (int) (mpi_object)->errhandler_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \
@@ -307,7 +307,7 @@ extern opal_atomic_int32_t ompi_instance_count;
     int __mpi_err_code = ompi_errcode_get_mpi_code(err_code);         \
     ompi_errhandler_invoke((mpi_object)->error_handler, \
                            (mpi_object), \
-                           (int)(mpi_object)->error_handler->eh_mpi_object_type, \
+                           (int)(mpi_object)->errhandler_type, \
                            (__mpi_err_code), \
                            (message)); \
     return (__mpi_err_code); \

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -202,19 +202,19 @@ int ompi_errhandler_request_invoke(int count,
     case OMPI_REQUEST_COLL:
         return ompi_errhandler_invoke(mpi_object.comm->error_handler,
                                       mpi_object.comm,
-                                      mpi_object.comm->error_handler->eh_mpi_object_type,
+                                      mpi_object.comm->errhandler_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_IO:
         return ompi_errhandler_invoke(mpi_object.file->error_handler,
                                       mpi_object.file,
-                                      mpi_object.file->error_handler->eh_mpi_object_type,
+                                      mpi_object.file->errhandler_type,
                                       ec, message);
         break;
     case OMPI_REQUEST_WIN:
         return ompi_errhandler_invoke(mpi_object.win->error_handler,
                                       mpi_object.win,
-                                      mpi_object.win->error_handler->eh_mpi_object_type,
+                                      mpi_object.win->errhandler_type,
                                       ec, message);
         break;
     default:

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -419,16 +419,6 @@ int ompi_group_init(void)
         return OMPI_ERROR;
     }
 
-#if OPAL_ENABLE_FT_MPI
-    /* Setup global list of failed processes */
-    ompi_group_all_failed_procs = OBJ_NEW(ompi_group_t);
-    ompi_group_all_failed_procs->grp_proc_count     = 0;
-    ompi_group_all_failed_procs->grp_my_rank        = MPI_UNDEFINED;
-    ompi_group_all_failed_procs->grp_proc_pointers  = NULL;
-    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_DENSE;
-    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_INTRINSIC;
-#endif
-
     /* add MPI_GROUP_NULL to table */
     OBJ_CONSTRUCT(&ompi_mpi_group_null, ompi_group_t);
     ompi_mpi_group_null.group.grp_proc_count        = 0;
@@ -444,6 +434,17 @@ int ompi_group_init(void)
     ompi_mpi_group_empty.group.grp_proc_pointers     = NULL;
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_DENSE;
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_INTRINSIC;
+
+#if OPAL_ENABLE_FT_MPI
+    /* Setup global list of failed processes */
+    ompi_group_all_failed_procs = OBJ_NEW(ompi_group_t);
+    ompi_group_all_failed_procs->grp_proc_count     = 0;
+    ompi_group_all_failed_procs->grp_my_rank        = MPI_UNDEFINED;
+    ompi_group_all_failed_procs->grp_proc_pointers  = NULL;
+    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_DENSE;
+    ompi_group_all_failed_procs->grp_flags         |= OMPI_GROUP_INTRINSIC;
+#endif
+
 
     ompi_mpi_instance_append_finalize (ompi_group_finalize);
 

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -381,7 +381,7 @@ do {                                                                    \
                                  &max_data );                           \
             opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
                                              &(ompi_mpi_packed.dt.super),  \
-                                             max_data, sendreq->req_buff ); \
+                                             max_data, sendreq->req_addr ); \
         }                                                               \
     }                                                                   \
  } while(0);

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -83,7 +83,7 @@ bool ompi_async_mpi_finalize = false;
 uint32_t ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
 bool ompi_mpi_dynamics_enabled = true;
 
-bool ompi_mpi_compat_mpi3 = false;
+bool ompi_mpi_compat_mpi3 = true;
 
 char *ompi_mpi_spc_attach_string = NULL;
 bool ompi_mpi_spc_dump_enabled = false;
@@ -362,7 +362,7 @@ int ompi_mpi_register_params(void)
                                       MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     }
 
-    ompi_mpi_compat_mpi3 = false;
+    ompi_mpi_compat_mpi3 = true;
     (void) mca_base_var_register("ompi", "mpi", NULL, "compat_mpi3",
                                  "A boolean value for whether Open MPI operates in MPI-3 compatibility mode; this changes the following behavior: in operations without a handle, errors are raised on (true) MPI_COMM_WORLD (MPI-3 behavior) or (false) MPI_COMM_SELF (MPI-4 behavior).",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -123,8 +123,8 @@ OMPI_DECLSPEC extern int ompi_mpi_abort_delay;
 /**
  * Whether we operate in MPI3 compatibility, or MPI4 mode (default).
  *
- * true: use MPI3 compatibility
- * false: use MPI4 compatibility (default)
+ * true: use MPI3 compatibility (default)
+ * false: use MPI4 compatibility
  *
  * Behavioral changes:
  *   - errors in operations without a handle are raised on MPI_COMM_WORLD (MPI-3 behavior) or MPI_COMM_SELF (MPI-4 behavior)


### PR DESCRIPTION
This PR back port 4 patches that addressed issues in mtt:
coll/han: fix bug in reduce in place. 
This commit fix `reduce_big_in_place`

runtime/params: set ompi_mpi_compat_mpi3 to true by default.
This commit fix `MPI_Errhandler_set/get/free`

pml/cm: fix buffer usage in MCA_PML_CM_HVY_SEND_REQUEST_BSEND_ALLOC() 
This commit fix `MPI_Bsend_init`

group: defer the insertion of ompi_group_all_failed_procs to group_table
This commit fix `MPI_Group_union/intersection`

communicator: add errhandler_type back
This commit fix "MPI_Errhandler_fatal`
