### PR TITLE
opal_var_dump_color_keys: fix an array overflow

### DIFF
--- a/opal/runtime/opal_params_core.c
+++ b/opal/runtime/opal_params_core.c
@@ -17,8 +17,8 @@
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2023 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
@@ -92,10 +92,11 @@ static bool opal_register_util_done = false;
 
 static char *opal_var_dump_color_string = NULL;
 
-static char *opal_var_dump_color_keys[OPAL_VAR_DUMP_COLOR_KEY_COUNT] = {
+static char *opal_var_dump_color_keys[OPAL_VAR_DUMP_COLOR_KEY_COUNT+1] = {
     [OPAL_VAR_DUMP_COLOR_VAR_NAME] = "name",
     [OPAL_VAR_DUMP_COLOR_VAR_VALUE] = "value",
-    [OPAL_VAR_DUMP_COLOR_VALID_VALUES] = "valid_values"
+    [OPAL_VAR_DUMP_COLOR_VALID_VALUES] = "valid_values",
+    [OPAL_VAR_DUMP_COLOR_KEY_COUNT] = NULL
 };
 
 /**


### PR DESCRIPTION
since opal_var_dump_color_keys is used with opal_argv_count() and friends, make sure is is long enough and NULL terminated

Thanks to Niv Shpak for reporting this and identifying the root cause.

Refs. open-mpi/ompi#11826