### PR TITLE
v4.1.x: datatype: Fix MPI_Type_dup() to propagate errors from inner calls

### DIFF
--- a/ompi/mpi/c/type_dup.c
+++ b/ompi/mpi/c/type_dup.c
@@ -41,6 +41,8 @@ static const char FUNC_NAME[] = "MPI_Type_dup";
 int MPI_Type_dup (MPI_Datatype type,
                   MPI_Datatype *newtype)
 {
+   int ret;
+
    MEMCHECKER(
       memchecker_datatype(type);
    );
@@ -56,10 +58,9 @@ int MPI_Type_dup (MPI_Datatype type,
 
    OPAL_CR_ENTER_LIBRARY();
 
-   if (OMPI_SUCCESS != ompi_datatype_duplicate( type, newtype)) {
+   if (OMPI_SUCCESS != (ret = ompi_datatype_duplicate( type, newtype))) {
        ompi_datatype_destroy( newtype );
-       OMPI_ERRHANDLER_RETURN (MPI_ERR_INTERN, MPI_COMM_WORLD,
-                               MPI_ERR_INTERN, FUNC_NAME );
+       OMPI_ERRHANDLER_RETURN( ret, MPI_COMM_WORLD, ret, FUNC_NAME );
    }
 
    ompi_datatype_set_args( *newtype, 0, NULL, 0, NULL, 1, &type, MPI_COMBINER_DUP );
@@ -71,13 +72,12 @@ int MPI_Type_dup (MPI_Datatype type,
       copy attributes.  Really. */
    if (NULL != type->d_keyhash) {
        ompi_attr_hash_init(&(*newtype)->d_keyhash);
-       if (OMPI_SUCCESS != ompi_attr_copy_all(TYPE_ATTR,
-                                              type, *newtype,
-                                              type->d_keyhash,
-                                              (*newtype)->d_keyhash)) {
+       if (OMPI_SUCCESS != (ret = ompi_attr_copy_all(TYPE_ATTR,
+                                                     type, *newtype,
+                                                     type->d_keyhash,
+                                                     (*newtype)->d_keyhash))) {
            ompi_datatype_destroy(newtype);
-           OMPI_ERRHANDLER_RETURN( MPI_ERR_INTERN, MPI_COMM_WORLD,
-                                   MPI_ERR_INTERN, FUNC_NAME );
+           OMPI_ERRHANDLER_RETURN( ret, MPI_COMM_WORLD, ret, FUNC_NAME );
        }
    }
 


### PR DESCRIPTION
Backport #11834.