### PR TITLE
Prep for 4.1.6rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,8 +58,8 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
-4.1.6 -- February, 2024
------------------------
+4.1.6 -- August, 2023
+---------------------
 
 - Update to properly handle PMIx v>=4.2.3.  Thanks to Bruno Chareyre,
   Github user @sukanka, and Christof Koehler for raising the

--- a/VERSION
+++ b/VERSION
@@ -70,7 +70,7 @@ release=6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
4.1.6rc1 is tagged.  Update the version and update the release date, since it should happen faster than 6 months from now.

bot:notacherrypick