### PR TITLE
ofi: push part of commit 450c72d to v50x

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -473,7 +473,7 @@ static int compute_dev_distances(pmix_device_distance_t **distances,
     size_t ninfo;
     pmix_info_t *info;
     pmix_cpuset_t cpuset;
-    pmix_topology_t pmix_topo;
+    pmix_topology_t pmix_topo = PMIX_TOPOLOGY_STATIC_INIT;
     pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS |
       PMIX_DEVTYPE_NETWORK;
 


### PR DESCRIPTION
part of commit 450c72d is needed on v50x.
Without it v50x branch can't be used on some systems with HPE SS11/CXI OFI provider.

this patch pulls in initialization of pmix_topology struct but not the sha advancing on prrte and openpmix submodules.

related to #11841

bot:notacherrypick