### PR TITLE
Avoid claiming copyright for future years

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 
 # -- Project information -----------------------------------------------------
 
@@ -18,7 +17,7 @@ import os
 import re
 import datetime
 
-year = datetime.datetime.now().year
+year = 2023
 
 project = 'Open MPI'
 copyright = f'2003-{year}, The Open MPI Community'


### PR DESCRIPTION
Avoid claiming copyright for future years

When building today's version in 2025, it should not say `Copyright (c) 2003-2025, The Open MPI Community`
because nobody did any work in 2025 (yet).