### PR TITLE
docs: update readthedocs.org config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,10 @@ build:
   tools:
     python: "3.10"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
RTD is removing the option to use pre-installed packages.  Instead, we just need to tell them where our Python requirements.txt file is located so that they'll install exactly those packages.