### PR TITLE
v4.1.x: docs: update readthedocs.org config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,10 @@ build:
   tools:
     python: "3.10"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=4.2.0
+recommonmark
+docutils
+sphinx-rtd-theme


### PR DESCRIPTION
RTD is removing the option to use pre-installed packages.  Instead, we just need to tell them where our Python requirements.txt file is located so that they'll install exactly those packages.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 5691d80585fd43a08927247031fd64680ecbf093)