### PR TITLE
v4.1.x: Fix inconsistent configure-time check

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -141,7 +141,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
      end subroutine force_assumed_shape
   end interface
 
-  interface
+  interface foo
      subroutine foo(buffer, count)
        $1 buffer
        $2, intent(in) :: buffer


### PR DESCRIPTION
This fixes the inconsistency between what is tested at the configure time and what is actually used in the source code. Note that the issue was solved in the `main` with #9445. As far as I understand, there are no plans to backport that PR to `4.1.x` because it potentially changes the ABI compatibility. Therefore, this PR fixes the problem the other way around.

Starting version 23.3, NVHPC compiler supports `type(*)` and the configure script sets `ompi_cv_fortran_ignore_tkr_data` to `1:type(*), dimension(*):!GCC$ ATTRIBUTES NO_ARG_CHECK ::`, which makes the `mpi` Fortran module unusable in some cases. For example, we cannot compile the following:
```fortran
program main
  use mpi
  implicit none

  real(kind=selected_real_kind(12, 307)):: buf
  integer :: count, datatype, dest, tag, comm, ierror

  call mpi_send(buf, count, datatype, dest, tag, comm, ierror)
end program main
```
The compiler reports:
```console
NVFORTRAN-S-0155-Could not resolve generic procedure mpi_send (./test2.f90: 8)
  0 inform,   0 warnings,   1 severes, 0 fatal for main
```

As was mentioned in #9445, the unnamed interfaces are more forgiving when it comes to TKR mismatches. Indeed, the code snippet run by the configure script uses the unnamed interface and is too weak for the following use case. This PR makes the configure-time check stricter by switching to the named interface, which is what is actually used in the code. With this change, the configure script sets `ompi_cv_fortran_ignore_tkr_data` to `1:real, dimension(*):!DIR$ IGNORE_TKR` when using NVHPC 23.3+ (the same value as for the older versions of the compiler) and the code snipped above compiles successfully.

bot:notacherrypick