### PR TITLE
v4.1.x: help-mpi-btl-openib: fix grammar

### DIFF
--- a/opal/mca/btl/openib/help-mpi-btl-openib.txt
+++ b/opal/mca/btl/openib/help-mpi-btl-openib.txt
@@ -16,6 +16,7 @@
 # Copyright (c) 2013-2014 NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2018      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -228,7 +229,7 @@ You may need to consult with your system administrator to get this
 problem fixed.
 #
 [no active ports found]
-WARNING: There is at least non-excluded one OpenFabrics device found,
+WARNING: There is at least one non-excluded one OpenFabrics device found,
 but there are no active ports detected (or Open MPI was unable to use
 them).  This is most certainly not what you wanted.  Check your
 cables, subnet manager configuration, etc.  The openib BTL will be


### PR DESCRIPTION
Thanks to Erik Schnetter for identifying a grammer error in the openib BTL help text.

Fixes #11856

bot:notacherrypick

This is not a cherry pick because it's in the openib BTL, which is no longer on main.