### PR TITLE
OSHMEM/MCA/SSHMEM/UCX: DEVICE_NIC_MEM hint - implementation should use RDMA memory type

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -107,7 +107,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                            UCP_ATOMIC_FETCH_OP_FXOR,
                            UCP_PARAM_FIELD_ESTIMATED_NUM_PPN,
                            UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK,
-                           UCP_OP_ATTR_FLAG_MULTI_SEND],
+                           UCP_OP_ATTR_FLAG_MULTI_SEND,
+                           UCS_MEMORY_TYPE_RDMA],
                           [], [],
                           [#include <ucp/api/ucp.h>])
            AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],

--- a/oshmem/mca/sshmem/ucx/configure.m4
+++ b/oshmem/mca/sshmem/ucx/configure.m4
@@ -28,34 +28,9 @@ AC_DEFUN([MCA_oshmem_sshmem_ucx_CONFIG],[
     save_LIBS="$LIBS"
     save_CPPFLAGS="$CPPFLAGS"
 
-    alloc_dm_LDFLAGS=" -L$ompi_check_ucx_libdir/ucx"
-    alloc_dm_LIBS=" -luct_ib"
     CPPFLAGS+=" $sshmem_ucx_CPPFLAGS"
-    LDFLAGS+=" $sshmem_ucx_LDFLAGS $alloc_dm_LDFLAGS"
-    LIBS+=" $sshmem_ucx_LIBS $alloc_dm_LIBS"
-
-    AC_LANG_PUSH([C])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM(
-          [[
-            #include <ucp/core/ucp_resource.h>
-            #include <uct/ib/base/ib_alloc.h>
-          ]],
-          [[
-            uct_md_h md = ucp_context_find_tl_md((ucp_context_h)NULL, "");
-            (void)uct_ib_md_alloc_device_mem(md, NULL, NULL, 0, "", NULL);
-            uct_ib_md_release_device_mem(NULL);
-          ]])],
-          [
-           AC_MSG_NOTICE([UCX device memory allocation is supported])
-           AC_DEFINE([HAVE_UCX_DEVICE_MEM], [1], [Support for device memory allocation])
-           sshmem_ucx_LIBS+=" $alloc_dm_LIBS"
-           sshmem_ucx_LDFLAGS+=" $alloc_dm_LDFLAGS"
-          ],
-          [
-           AC_MSG_NOTICE([UCX device memory allocation is not supported])
-           AC_DEFINE([HAVE_UCX_DEVICE_MEM], [0], [Support for device memory allocation])
-          ])
-    AC_LANG_POP([C])
+    LDFLAGS+=" $sshmem_ucx_LDFLAGS"
+    LIBS+=" $sshmem_ucx_LIBS"
 
     CPPFLAGS="$save_CPPFLAGS"
     LDFLAGS="$save_LDFLAGS"
@@ -66,4 +41,3 @@ AC_DEFUN([MCA_oshmem_sshmem_ucx_CONFIG],[
     AC_SUBST([sshmem_ucx_LDFLAGS])
     AC_SUBST([sshmem_ucx_LIBS])
 ])dnl
-

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx.h
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx.h
@@ -35,7 +35,6 @@ OSHMEM_DECLSPEC extern mca_sshmem_ucx_component_t
 mca_sshmem_ucx_component;
 
 typedef struct mca_sshmem_ucx_segment_context {
-    void                           *dev_mem;
     sshmem_ucx_shadow_allocator_t  *shadow_allocator;
     ucp_mem_h                       ucp_memh;
 } mca_sshmem_ucx_segment_context_t;


### PR DESCRIPTION
- Updated the implementation for using the DEVICE_NIC_MEM to use ucp_mem_map with [the new RDMA memory type](https://github.com/openucx/ucx/pull/9118/files). 
- Cleanup for old code which used uct api