### PR TITLE
v5.0.x: mpif-h: add missing declaration in session_get_nth_pset_f()

### DIFF
--- a/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
@@ -13,8 +13,8 @@
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2023 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
  *
  * $COPYRIGHT$
@@ -78,6 +78,7 @@ void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n,
     int c_ierr;
     MPI_Session c_session;
     char c_name[MPI_MAX_PSET_NAME_LEN];
+    OMPI_SINGLE_NAME_DECL(pset_len);
 
     c_session = PMPI_Session_f2c(*session);
 


### PR DESCRIPTION
Add a missing OMPI_SINGLE_NAME_DECL() to correctly support 8 bytes Fortran INTEGER

Thanks Neil Mehta for the report.

Ref. open-mpi/ompi#11887

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit 234ad2a39c6ee11afd2fec8987af468427e8cdc1)

This is a v5.0 PR corresponding to main PR #11888 