### PR TITLE
Prevent runs NVIDIA_CI on the fork V4.0.x

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,6 +1,5 @@
 name: ompi_NVIDIA CI
-on: [pull_request, push]
-
+on: [pull_request]
 jobs:
 
   deployment:


### PR DESCRIPTION
Prevent runs NVIDIA_CI on the forks. (cherry-picked from [76a4441](https://github.com/open-mpi/ompi/pull/11879/commits/76a444127081e74b3fb9d19d8694172c7c044b43)