### PR TITLE
Prevent runs NVIDIA_CI on the fork v4.1.x

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,5 +1,5 @@
 name: ompi_NVIDIA CI
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   deployment:
     runs-on: [self-hosted, linux, x64, nvidia]


### PR DESCRIPTION
(cherry picked from commit 76a444127081e74b3fb9d19d8694172c7c044b43)