### PR TITLE
Prevent runs NVIDIA_CI in case triggered by PR in the fork

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,7 +1,9 @@
 name: ompi_NVIDIA CI
 on: [pull_request]
 jobs:
+
   deployment:
+    if: github.repository == 'open-mpi/ompi'
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Checkout
@@ -28,7 +30,11 @@ jobs:
     - name: Running tests
       run: /start test
   clean:
-    if: ${{ always() }}
+# always() should be used to run "clean" even when the workflow was canceled 
+#  ( in case of the right repository name)
+# The second condition doesn't work when the workflow was canceled
+
+    if: always() && (github.repository == 'open-mpi/ompi')
     needs: [deployment, build, test]
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:


### PR DESCRIPTION
Prevent runs NVIDIA_CI in case triggered by PR in the fork ( checking repo name)

It looks like https://github.com/B-a-S/ompi/actions/runs/6087266827
