### PR TITLE
[4.1.x] pml/cm,mtl/ofi: fix datatype offsetting

### DIFF
--- a/ompi/mca/mtl/base/mtl_base_datatype.h
+++ b/ompi/mca/mtl/base/mtl_base_datatype.h
@@ -44,7 +44,7 @@ ompi_mtl_datatype_pack(struct opal_convertor_t *convertor,
 	opal_datatype_is_contiguous_memory_layout(convertor->pDesc,
 						  convertor->count)) {
 	    *freeAfter = false;
-	    *buffer = convertor->pBaseBuf;
+	    *buffer = convertor->pBaseBuf + convertor->bConverted + convertor->pDesc->true_lb;
 	    *buffer_len = convertor->local_size;
 	    return OPAL_SUCCESS;
     }

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -375,10 +375,11 @@ mca_pml_cm_send(const void *buf,
 		convertor.flags      = ompi_mpi_local_convertor->flags;
 		convertor.master     = ompi_mpi_local_convertor->master;
 
-		convertor.local_size = count * datatype->super.size;
-		convertor.pBaseBuf   = (unsigned char*)buf + datatype->super.true_lb;
-		convertor.count      = count;
-		convertor.pDesc      = &datatype->super;
+                /* Switches off device detection if
+                   MTL set MCA_MTL_BASE_FLAG_CUDA_INIT_DISABLE during init */
+		convertor.flags |= flags;
+		/* Sets CONVERTOR_CUDA flag if device buffer */
+		opal_convertor_prepare_for_send(&convertor, &datatype->super, count, (unsigned char *)buf);
 	} else
 #endif
 	{

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -236,12 +236,14 @@ do {                                                                    \
             ompi_mpi_local_convertor->flags;                            \
         (req_send)->req_base.req_convertor.master     =                 \
             ompi_mpi_local_convertor->master;                           \
-        (req_send)->req_base.req_convertor.local_size =                 \
-            count * datatype->super.size;                               \
-        (req_send)->req_base.req_convertor.pBaseBuf   =                 \
-            (unsigned char*)buf + datatype->super.true_lb;              \
-        (req_send)->req_base.req_convertor.count      = count;          \
-        (req_send)->req_base.req_convertor.pDesc      = &datatype->super; \
+        /* Switches off device buffer  detection if                 \
+         MTL set MCA_MTL_BASE_FLAG_CUDA_INIT_DISABLE during init */     \
+        MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);   \
+        (req_send)->req_base.req_convertor.flags |= flags;              \
+        /* Sets CONVERTOR_CUDA flag if device buffer */                   \
+        opal_convertor_prepare_for_send(                            \
+            &req_send->req_base.req_convertor,                      \
+            &datatype->super, count, (unsigned char*)buf); \
     } else {                                                            \
         MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);   \
         opal_convertor_copy_and_prepare_for_send(                       \

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -164,30 +164,14 @@ do {                                                                    \
     OMPI_DATATYPE_RETAIN(datatype);                                     \
     (req_send)->req_base.req_comm = comm;                               \
     (req_send)->req_base.req_datatype = datatype;                       \
-    if (opal_datatype_is_contiguous_memory_layout(&datatype->super, count)) { \
-        (req_send)->req_base.req_convertor.remoteArch =                 \
-            ompi_mpi_local_convertor->remoteArch;                       \
-        (req_send)->req_base.req_convertor.flags      =                 \
-            ompi_mpi_local_convertor->flags;                            \
-        (req_send)->req_base.req_convertor.master     =                 \
-            ompi_mpi_local_convertor->master;                           \
-        (req_send)->req_base.req_convertor.local_size =                 \
-            count * datatype->super.size;                               \
-        (req_send)->req_base.req_convertor.pBaseBuf   =                 \
-            (unsigned char*)buf + datatype->super.true_lb;              \
-        (req_send)->req_base.req_convertor.count      = count;          \
-        (req_send)->req_base.req_convertor.pDesc      = &datatype->super; \
-	(req_send)->req_base.req_convertor.use_desc = &(datatype->super.desc); \
-    } else { \
-        MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
-        opal_convertor_copy_and_prepare_for_send(                           \
-            ompi_mpi_local_convertor,                                       \
-            &(datatype->super),                                             \
-            count,                                                          \
-            buf,                                                            \
-            flags,                                                          \
-            &(req_send)->req_base.req_convertor );                          \
-    } \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
+    opal_convertor_copy_and_prepare_for_send(                           \
+        ompi_mpi_local_convertor,                                       \
+        &(datatype->super),                                             \
+        count,                                                          \
+        buf,                                                            \
+        flags,                                                          \
+        &(req_send)->req_base.req_convertor );                          \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
     (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
         comm->c_my_rank;                                                \


### PR DESCRIPTION
This reverts commit 6250f547926b31749298c47ee2f1121f4bab7c10 and manually picks 17b09d93901c30b4d1b6b5782c8ed2502e905f97

It fixes a segfault revealed by mtt ibm bsend test.

bot:notacherrypick