### PR TITLE
OFI:  add Intel Level Zero (aka ZE) to OFI MTL/BTL

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -4,6 +4,8 @@ dnl Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl Copyright (c) 2023      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -155,7 +157,16 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ROCR],
                               [${opal_check_fi_hmem_rocr}],
-                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])])
+                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])
+
+           AC_CHECK_DECL([FI_HMEM_ZE],
+                         [opal_check_fi_hmem_ze=1],
+                         [opal_check_fi_hmem_ze=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ZE],
+                              [${opal_check_fi_hmem_ze}],
+                              [check if FI_HMEM_ZE avaiable in fi_hmem_iface])])
 
     CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019-2022 Triad National Security, LLC. All rights
+ * Copyright (c) 2019-2023 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  *                         reserved.
@@ -327,6 +327,11 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
             attr.iface = FI_HMEM_ROCR;
             opal_accelerator.get_device(&attr.device.cuda);
+#endif
+#if OPAL_OFI_HAVE_FI_HMEM_ZE
+        } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "ze")) {
+            attr.iface = FI_HMEM_ZE;
+            opal_accelerator.get_device(&attr.device.ze);
 #endif
         } else {
             return OPAL_ERROR;

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -268,6 +268,11 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
                 attr.iface = FI_HMEM_ROCR;
                 opal_accelerator.get_device(&attr.device.cuda);
 #endif
+#if OPAL_OFI_HAVE_FI_HMEM_ZE
+            } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "ze")) {
+                attr.iface = FI_HMEM_ZE;
+                opal_accelerator.get_device(&attr.device.ze);
+#endif
             } else {
                 return OPAL_ERROR;
             }


### PR DESCRIPTION
This commits adds support for registering Intel accelerator memory backed buffers with an OFI provider.


Related to #11763