### PR TITLE
Replace writev by sendmsg

### DIFF
--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -459,19 +459,17 @@ static inline struct ompi_proc_t *ompi_group_peer_lookup_existing (ompi_group_t 
  */
 static inline int ompi_group_proc_lookup_rank (ompi_group_t* group, ompi_proc_t* proc)
 {
-    int i, np, v;
+    int i, np, rank;
+    opal_vpid_t v;
     assert( NULL != proc );
     assert( !ompi_proc_is_sentinel(proc) );
     np = ompi_group_size(group);
     if( 0 == np ) return MPI_PROC_NULL;
     /* heuristic: On comm_world, start the lookup from v=vpid, so that
-     * when working on comm_world, the search is O(1);
-     * Otherwise, wild guess: start from a proportional position
-     * compared to comm_world position. */
+     * when working on comm_world, on average, the search remains O(1). */
     v = proc->super.proc_name.vpid;
-    v = (v<np)? v: v*ompi_proc_world_size()/np;
     for( i = 0; i < np; i++ ) {
-        int rank = (i+v)%np;
+        rank = (i+v)%np;
         /* procs are lazy initialized and may be a sentinel. Handle both cases. */
         ompi_proc_t* p = ompi_group_get_proc_ptr_raw(group, rank);
         if(OPAL_LIKELY(!ompi_proc_is_sentinel(p))) {

--- a/opal/win32/opal_uio.c
+++ b/opal/win32/opal_uio.c
@@ -2,7 +2,7 @@
  Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
                          University Research and Technology
                          Corporation.  All rights reserved.
- Copyright (c) 2004-2005 The University of Tennessee and The University
+ Copyright (c) 2004-2023 The University of Tennessee and The University
                          of Tennessee Research Foundation.  All rights
                          reserved.
  Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -26,12 +26,12 @@
  of code to handle the windows error flags
  */
 
-int writev(int fd, struct iovec *iov, int cnt)
+ssize_t sendmsg(int fd, const struct msghdr *message, int flags)
 {
     int err;
     DWORD sendlen;
 
-    err = WSASend((SOCKET) fd, &(iov->data), cnt, &sendlen, 0, NULL, NULL);
+    err = WSASendMsg((SOCKET) fd, message, flags, &sendlen, NULL, NULL);
 
     if (err < 0) {
         return err;

--- a/opal/win32/opal_uio.h
+++ b/opal/win32/opal_uio.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -33,14 +33,14 @@ struct iovec {
 #define iov_len  data.len
 
 BEGIN_C_DECLS
+
 /*
- * writev:
-   writev  writes  data  to  file  descriptor  fd,  and  from  the buffers
-   described by iov. The number of buffers is specified by  cnt.  The
-   buffers  are  used  in  the  order specified.  Operates just like write
-   except that data is taken from iov instead of a contiguous buffer.
+ * sendmsg:
+ *     writes data to a file descriptor. This is a convenience function to allow
+ *     the TCP BTL to support Windows. Overall is should behave similarly to the
+ *     POSIX sendmsg function.
  */
-OPAL_DECLSPEC int writev(int fd, struct iovec *iov, int cnt);
+OPAL_DECLSPEC ssize_t sendmsg(int socket, const struct msghdr *message, int flags);
 
 /*
    readv  reads  data  from file descriptor fd, and puts the result in the


### PR DESCRIPTION
This allows the TCP BTL to avoid raising SIGPIPE on OSes that do not support SO_NOSIGPIPE.