### PR TITLE
ofi: check if libfabric has FI_HMEM_ROCR at configure time

### DIFF
--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -17,7 +17,7 @@ jobs:
         curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
         echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg]  https://repo.radeon.com/rocm/apt/debian focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
         sudo apt-get update
-        sudo apt-get install -y rocm-hip-sdk
+        sudo apt-get install -y rocm-hip-runtime
     - uses: actions/checkout@v3
       with:
             submodules: recursive
@@ -26,3 +26,9 @@ jobs:
         ./autogen.pl
         ./configure --prefix=${PWD}/install --with-rocm=/opt/rocm --disable-mpi-fortran
         make -j
+    - name: Clean up
+      run: |
+        ls -la ./
+        rm -rf ./* 
+        rm -rf ./.??*
+        ls -la ./

--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -146,7 +146,16 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_MR_IFACE],
                               [${opal_check_fi_mr_attr_iface}],
-                              [check if iface avaiable in fi_mr_attr])])
+                              [check if iface avaiable in fi_mr_attr])
+
+           AC_CHECK_DECL([FI_HMEM_ROCR],
+                         [opal_check_fi_hmem_rocr=1],
+                         [opal_check_fi_hmem_rocr=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ROCR],
+                              [${opal_check_fi_hmem_rocr}],
+                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])])
 
     CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -323,9 +323,11 @@ int ompi_mtl_ofi_register_buffer(struct opal_convertor_t *convertor,
         } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
             attr.iface = FI_HMEM_CUDA;
             opal_accelerator.get_device(&attr.device.cuda);
+#if OPAL_OFI_HAVE_FI_HMEM_ROCR
         } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
             attr.iface = FI_HMEM_ROCR;
             opal_accelerator.get_device(&attr.device.cuda);
+#endif
         } else {
             return OPAL_ERROR;
         }

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -263,9 +263,11 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
             if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "cuda")) {
                 attr.iface = FI_HMEM_CUDA;
                 opal_accelerator.get_device(&attr.device.cuda);
+#if OPAL_OFI_HAVE_FI_HMEM_ROCR
 	    } else if (0 == strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "rocm")) {
                 attr.iface = FI_HMEM_ROCR;
                 opal_accelerator.get_device(&attr.device.cuda);
+#endif
             } else {
                 return OPAL_ERROR;
             }


### PR DESCRIPTION
This allows compiling ompi-5.0.0rc12 with btl/ofi and mtl/ofi on clusters not providing rocm.