### PR TITLE
fbtl/posix: fix data-sieving calculations

### DIFF
--- a/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
@@ -34,8 +34,6 @@ static ssize_t mca_fbtl_posix_pwritev_datasieving (ompio_file_t *fh, struct floc
 static ssize_t mca_fbtl_posix_pwritev_generic (ompio_file_t *fh, struct flock *lock, int *lock_counter );
 static ssize_t mca_fbtl_posix_pwritev_single (ompio_file_t *fh, struct flock *lock, int *lock_counter );
 
-#define MAX_RETRIES 10
-
 ssize_t  mca_fbtl_posix_pwritev(ompio_file_t *fh )
 {
     ssize_t bytes_written=0;
@@ -192,7 +190,6 @@ ssize_t mca_fbtl_posix_pwritev_datasieving (ompio_file_t *fh, struct flock *lock
             return OMPI_ERROR;
         }
         
-        int retries=0;
         while ( total_bytes < len ) {
             ret_code = pread (fh->fd, temp_buf, len, start);
             if ( ret_code == -1 ) {
@@ -203,13 +200,7 @@ ssize_t mca_fbtl_posix_pwritev_datasieving (ompio_file_t *fh, struct flock *lock
             }
             if ( ret_code == 0 ) {
                 // end of file
-                retries++;
-                if ( retries == MAX_RETRIES ) {
-                    break;
-                }
-                else {
-                    continue;
-                }
+		break;
             }
             total_bytes += ret_code;
         }


### PR DESCRIPTION
as part of introducing atomicity support for ompi v5.0, we also tried to improve the robustness in some file I/O routines. Unfortunately, this also introduced a bug since ret_code returned by a function does not necessarily contain the number of bytes read or written,
but could contain the last value (e.g. 0). The value was however used in a subsequent calculation and we ended not copying data out of the temporary buffer used in the data sieving at all.

This commit also simplifies some of the logic in the while loop, no need to retry to read past the end of the file multiple times.

Fixes issue #11917

Code was tested with the reproducer provided as part of the issue, our internal testsuite, and the hdf5-1.14.2 testsuite, all tests pass.