### PR TITLE
Update embedded PMIx to 3.2.5

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/NEWS
+++ b/opal/mca/pmix/pmix3x/pmix/NEWS
@@ -1,6 +1,6 @@
 Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
-Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -20,6 +20,23 @@ to only bug fixes.  Since these series are semi-independent of each
 other, a single NEWS-worthy item might apply to different series. For
 example, a bug might be fixed in the master, and then moved to
 multiple release branches.
+
+3.2.5 -- 12 Sep 2023
+--------------------
+Warning:: CVE-2023-41915
+
+A security issue was reported by François Diakhate (CEA)
+which is addressed in the PMIx v4.2.6 and v5.0.1 releases.
+(Older PMIx versions may be vulnerable, but are no longer
+supported.)
+
+A filesystem race condition could permit a malicious user
+to obtain ownership of an arbitrary file on the filesystem
+when parts of the PMIx library are called by a process
+running as uid 0. This may happen under the default
+configuration of certain workload managers, including Slurm.
+
+ - PR #3156: Do not follow links when doing "chown"
 
 
 3.2.4 -- 22 Jan 2023

--- a/opal/mca/pmix/pmix3x/pmix/VERSION
+++ b/opal/mca/pmix/pmix3x/pmix/VERSION
@@ -16,7 +16,7 @@
 
 major=3
 minor=2
-release=4
+release=5
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -24,7 +24,7 @@ release=4
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=rc1
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -76,7 +76,7 @@ date="Oct 30, 2020"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=4:34:2
+libpmix_so_version=4:35:2
 libpmi_so_version=1:1:0
 libpmi2_so_version=1:0:0
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/common/dstore/dstore_base.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/common/dstore/dstore_base.c
@@ -528,7 +528,7 @@ static int _esh_session_init(pmix_common_dstore_ctx_t *ds_ctx, size_t idx, ns_ma
             }
         }
         if (s->setjobuid > 0){
-            if (0 > lchown(s->nspace_path, (uid_t) s->jobuid, (gid_t) -1)){  // DO NOT FOLLOW LINKS
+            if (0 > lchown(s->nspace_path, (uid_t) s->jobuid, (gid_t) -1)){
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 return rc;
@@ -1682,7 +1682,7 @@ pmix_common_dstore_ctx_t *pmix_common_dstor_init(const char *ds_name, pmix_info_
             }
         }
         if (ds_ctx->setjobuid > 0) {
-            if (lchown(ds_ctx->base_path, (uid_t) ds_ctx->jobuid, (gid_t) -1) < 0){  // DO NOT FOLLOW LINKS
+            if (lchown(ds_ctx->base_path, (uid_t) ds_ctx->jobuid, (gid_t) -1) < 0){
                 rc = PMIX_ERR_NO_PERMISSIONS;
                 PMIX_ERROR_LOG(rc);
                 goto err_exit;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/common/dstore/dstore_segment.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/common/dstore/dstore_segment.c
@@ -120,7 +120,7 @@ PMIX_EXPORT pmix_dstore_seg_desc_t *pmix_common_dstor_create_new_lock_seg(const 
 
             if (setuid > 0){
                 rc = PMIX_ERR_PERM;
-                if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){  // DO NOT FOLLOW LINKS
+                if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){
                     PMIX_ERROR_LOG(rc);
                     goto err_exit;
                 }
@@ -211,7 +211,7 @@ PMIX_EXPORT pmix_dstore_seg_desc_t *pmix_common_dstor_create_new_segment(pmix_ds
 
         if (setuid > 0){
             rc = PMIX_ERR_PERM;
-            if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){  // DO NOT FOLLOW LINKS
+            if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){
                 PMIX_ERROR_LOG(rc);
                 goto err_exit;
             }

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
@@ -127,7 +127,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             }
         }
         if (0 != setuid) {
-            if (0 > chown(lock_ctx->lockfile, uid, (gid_t) -1)) {
+            if (0 > lchown(lock_ctx->lockfile, uid, (gid_t) -1)) {
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 goto error;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -113,7 +113,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
         }
         memset(lock_ctx->segment->seg_base_addr, 0, size);
         if (0 != setuid) {
-            if (0 > lchown(lock_ctx->lockfile, (uid_t) uid, (gid_t) -1)){  // DO NOT FOLLOW LINKS
+            if (0 > lchown(lock_ctx->lockfile, (uid_t) uid, (gid_t) -1)){
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 goto error;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/usock/ptl_usock_component.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/usock/ptl_usock_component.c
@@ -267,14 +267,14 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     }
     /* chown as required */
     if (lt->owner_given) {
-        if (0 != lchown(address->sun_path, lt->owner, -1)) {  // DO NOT FOLLOW LINKS
+        if (0 != chown(address->sun_path, lt->owner, -1)) {
             pmix_output(0, "CANNOT CHOWN socket %s: %s", address->sun_path, strerror (errno));
             CLOSE_THE_SOCKET(lt->socket);
             goto sockerror;
         }
     }
     if (lt->group_given) {
-        if (0 != lchown(address->sun_path, -1, lt->group)) {  // DO NOT FOLLOW LINKS
+        if (0 != chown(address->sun_path, -1, lt->group)) {
             pmix_output(0, "CANNOT CHOWN socket %s: %s", address->sun_path, strerror (errno));
             CLOSE_THE_SOCKET(lt->socket);
             goto sockerror;

--- a/opal/mca/pmix/pmix3x/pmix/src/util/pmix_pty.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/pmix_pty.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -248,7 +249,7 @@ static int ptys_open(int fdm, char *pts_name)
         gid = -1;               /* group tty is not in the group file */
     }
     /* following two functions don't work unless we're root */
-    lchown(pts_name, getuid(), gid); // DO NOT FOLLOW LINKS
+    lchown(pts_name, getuid(), gid);  // DO NOT FOLLOW LINKS
     chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
     fds = open(pts_name, O_RDWR);
     if (fds < 0) {

--- a/opal/mca/pmix/pmix3x/pmix/test/simple/Makefile.am
+++ b/opal/mca/pmix/pmix3x/pmix/test/simple/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,103 +29,103 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   gwtest gwclient stability quietclient simpjctrl \
                   pmitest
 
-simptest_SOURCES = \
+simptest_SOURCES = $(headers) \
         simptest.c
 simptest_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptest_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpclient_SOURCES = \
+simpclient_SOURCES = $(headers) \
         simpclient.c
 simpclient_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpclient_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simppub_SOURCES = \
+simppub_SOURCES = $(headers) \
         simppub.c
 simppub_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simppub_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpdmodex_SOURCES = \
+simpdmodex_SOURCES = $(headers) \
         simpdmodex.c
 simpdmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpdmodex_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpft_SOURCES = \
+simpft_SOURCES = $(headers) \
         simpft.c
 simpft_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpft_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpdyn_SOURCES = \
+simpdyn_SOURCES = $(headers) \
         simpdyn.c
 simpdyn_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpdyn_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-test_pmix_SOURCES = \
+test_pmix_SOURCES = $(headers) \
         test_pmix.c
 test_pmix_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 test_pmix_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simptool_SOURCES = \
+simptool_SOURCES = $(headers) \
         simptool.c
 simptool_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptool_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpdie_SOURCES = \
+simpdie_SOURCES = $(headers) \
         simpdie.c
 simpdie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpdie_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simplegacy_SOURCES = \
+simplegacy_SOURCES = $(headers) \
         simplegacy.c
 simplegacy_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simplegacy_LDADD = \
     $(top_builddir)/src/libpmi.la
 
-simptimeout_SOURCES = \
+simptimeout_SOURCES = $(headers) \
         simptimeout.c
 simptimeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptimeout_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-gwtest_SOURCES = \
+gwtest_SOURCES = $(headers) \
         gwtest.c
 gwtest_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 gwtest_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-gwclient_SOURCES = \
+gwclient_SOURCES = $(headers) \
         gwclient.c
 gwclient_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 gwclient_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-stability_SOURCES = \
+stability_SOURCES = $(headers) \
         stability.c
 stability_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 stability_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-quietclient_SOURCES = \
+quietclient_SOURCES = $(headers) \
         quietclient.c
 quietclient_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 quietclient_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-simpjctrl_SOURCES = \
+simpjctrl_SOURCES = $(headers) \
         simpjctrl.c
 simpjctrl_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpjctrl_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-pmitest_SOURCES = \
+pmitest_SOURCES = $(headers) \
         pmitest.c
 pmitest_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmitest_LDADD = \


### PR DESCRIPTION
Sync embedded PMIx to the 3.2.5 release, which includes the one backported commit to avoid following symlinks.

bot:notacherrypick