### PR TITLE
v5.0.x: docs: Fix build case with --disable-prrte

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -962,10 +962,9 @@ $(builddir)/schizo-ompi-rst-content/schizo-ompi-cli.rstxt: $(OMPI_SCHIZO_OMPI_RS
 else
 $(builddir)/schizo-ompi-rst-content/schizo-ompi-cli.rstxt: $(builddir)/schizo-ompi-rst-content
 $(builddir)/schizo-ompi-rst-content/schizo-ompi-cli.rstxt: $(srcdir)/no-prrte-content.rst.txt
-	if test ! -d "$$dir"; then mkdir "$$dir"; fi
+	dir=`dirname $@`; if test ! -d "$$dir"; then mkdir "$$dir"; fi
 	$(OMPI_V_SPHINX_COPYRST) \
-	dir=`dirname $@`; \
-	cp -pf $(srcdir)/no-prrte-content.rst.txt "$$dir"
+	cp -pf $(srcdir)/no-prrte-content.rst.txt "$@"
 endif
 
 $(ALL_MAN_BUILT): $(builddir)/prrte-rst-content


### PR DESCRIPTION
Fix a small issue in properly setting filename when building the empty schizo rst file.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 5adb240f6509e86407d642214251b5640c2344f8)

Fixes #11959 