### PR TITLE
Patch the prrte.spec file.

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1643,6 +1643,10 @@ if (list_contains("prrte", @disabled_3rdparty_packages)) {
     if (! -f "3rd-party/prrte/configure.ac") {
         my_die("Could not find pmix files\n");
     }
+
+    verbose "Patching prrte.spec file\n";
+    system("$patch_prog -N -p0 < ./config/prrte.spec.diff > /dev/null 2>&1");
+
     push(@subdirs, "3rd-party/prrte/");
     $m4 .= "m4_define([package_prrte], [1])\n";
 

--- a/config/prrte.spec.diff
+++ b/config/prrte.spec.diff
@@ -1,0 +1,20 @@
+--- 3rd-party/prrte/contrib/dist/linux/prrte.spec	2023-10-03 08:12:43.842625000 -0400
++++ 3rd-party/prrte/contrib/dist/linux/prrte.spec	2023-10-03 08:12:27.849686000 -0400
+@@ -612,7 +612,7 @@
+ %{shell_scripts_path}/%{shell_scripts_basename}.sh
+ %{shell_scripts_path}/%{shell_scripts_basename}.csh
+ %endif
+-%doc README INSTALL LICENSE
++%doc README.md LICENSE
+ 
+ %else
+ 
+@@ -656,7 +656,7 @@
+ %{shell_scripts_path}/%{shell_scripts_basename}.sh
+ %{shell_scripts_path}/%{shell_scripts_basename}.csh
+ %endif
+-%doc README INSTALL LICENSE
++%doc README.md LICENSE
+ %{_pkgdatadir}
+ 
+ %files devel -f devel.files


### PR DESCRIPTION
This is already fixed in prrte but for v5.0.x
and main we'll want this fix applied for any
rpm generation. This can safely be removed
once main and v5.0.x advance. On v5.0.x this will
be the next prrte release. For main, the next submodule update is fine to remove this.