### PR TITLE
Fix multithread request wait

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -544,7 +544,7 @@ int ompi_comm_nextcid (ompi_communicator_t *newcomm, ompi_communicator_t *comm,
     }
 
     if (&ompi_request_empty != req) {
-        ompi_request_wait_completion (req);
+        ompi_request_wait_completion (&req);
         rc = req->req_status.MPI_ERROR;
         ompi_comm_request_return ((ompi_comm_request_t *) req);
     }
@@ -909,7 +909,7 @@ int ompi_comm_activate (ompi_communicator_t **newcomm, ompi_communicator_t *comm
     }
 
     if (&ompi_request_empty != req) {
-        ompi_request_wait_completion (req);
+        ompi_request_wait_completion (&req);
         rc = req->req_status.MPI_ERROR;
         ompi_comm_request_return ((ompi_comm_request_t *) req);
     }

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -3200,7 +3200,7 @@ int mca_coll_ftagree_era_intra(void *contrib,
     rc = mca_coll_ftagree_iera_intra(contrib, dt_count, dt, op, group, grp_update, comm, &req, module);
     if(OPAL_UNLIKELY( OMPI_SUCCESS != rc ))
         return rc;
-    ompi_request_wait_completion(req);
+    ompi_request_wait_completion(&req);
     rc = req->req_status.MPI_ERROR;
     ompi_request_free(&req);
     return rc;

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -204,7 +204,8 @@ mca_pml_cm_recv(void *addr,
         return ret;
     }
 
-    ompi_request_wait_completion(&req.req_ompi);
+    ompi_request_t *ompi_req = &req.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
 
     if (MPI_STATUS_IGNORE != status) {
         OMPI_COPY_STATUS(status, req.req_ompi.req_status, false);
@@ -533,7 +534,8 @@ mca_pml_cm_mrecv(void *buf,
         return ret;
     }
 
-    ompi_request_wait_completion(&recvreq->req_base.req_ompi);
+    ompi_request_t *ompi_req = &recvreq->req_base.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
 
     if (MPI_STATUS_IGNORE != status) {
         OMPI_COPY_STATUS(status, recvreq->req_base.req_ompi.req_status, false);

--- a/ompi/mca/pml/ob1/pml_ob1_iprobe.c
+++ b/ompi/mca/pml/ob1/pml_ob1_iprobe.c
@@ -69,7 +69,8 @@ int mca_pml_ob1_probe(int src,
     MCA_PML_OB1_RECV_REQUEST_INIT(&recvreq, NULL, 0, &ompi_mpi_char.dt, src, tag, comm, false);
     MCA_PML_OB1_RECV_REQUEST_START(&recvreq);
 
-    ompi_request_wait_completion(&recvreq.req_recv.req_base.req_ompi);
+    ompi_request_t *ompi_req = &recvreq.req_recv.req_base.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
     rc = recvreq.req_recv.req_base.req_ompi.req_status.MPI_ERROR;
     if( MPI_STATUS_IGNORE != status ) {
         OMPI_COPY_STATUS(status, recvreq.req_recv.req_base.req_ompi.req_status, false);
@@ -159,7 +160,8 @@ mca_pml_ob1_mprobe(int src,
                                   src, tag, comm, false);
     MCA_PML_OB1_RECV_REQUEST_START(recvreq);
 
-    ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+    ompi_request_t *ompi_req = &recvreq->req_recv.req_base.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
     rc = recvreq->req_recv.req_base.req_ompi.req_status.MPI_ERROR;
     if( MPI_STATUS_IGNORE != status ) {
        OMPI_COPY_STATUS(status, recvreq->req_recv.req_base.req_ompi.req_status, false);

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -133,7 +133,8 @@ int mca_pml_ob1_recv(void *addr,
                              PERUSE_RECV);
 
     MCA_PML_OB1_RECV_REQUEST_START(recvreq);
-    ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+    ompi_request_t *ompi_req = &recvreq->req_recv.req_base.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
 
     if (recvreq->req_recv.req_base.req_pml_complete) {
         /* make buffer defined when the request is completed */
@@ -153,7 +154,8 @@ int mca_pml_ob1_recv(void *addr,
 #if OPAL_ENABLE_FT_MPI
     if( OPAL_UNLIKELY( MPI_ERR_PROC_FAILED_PENDING == rc )) {
         ompi_request_cancel(&recvreq->req_recv.req_base.req_ompi);
-        ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+        ompi_request_t *ft_req = &recvreq->req_recv.req_base.req_ompi;
+        ompi_request_wait_completion(&ft_req);
         rc = MPI_ERR_PROC_FAILED;
     }
 #endif
@@ -358,7 +360,8 @@ mca_pml_ob1_mrecv( void *buf,
 
     ompi_message_return(*message);
     *message = MPI_MESSAGE_NULL;
-    ompi_request_wait_completion(&(recvreq->req_recv.req_base.req_ompi));
+    ompi_request_t *ompi_req = &recvreq->req_recv.req_base.req_ompi;
+    ompi_request_wait_completion(&ompi_req);
 
     MCA_PML_OB1_RECV_FRAG_RETURN(frag);
 
@@ -369,7 +372,8 @@ mca_pml_ob1_mrecv( void *buf,
 #if OPAL_ENABLE_FT_MPI
     if( OPAL_UNLIKELY( MPI_ERR_PROC_FAILED_PENDING == rc )) {
         ompi_request_cancel(&recvreq->req_recv.req_base.req_ompi);
-        ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+        ompi_request_t *ft_req = &recvreq->req_recv.req_base.req_ompi;
+        ompi_request_wait_completion(&ft_req);
         rc = MPI_ERR_PROC_FAILED;
     }
 #endif

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -279,7 +279,7 @@ int mca_pml_ob1_send(const void *buf,
             return rc;
         }
 
-        ompi_request_wait_completion (brequest);
+        ompi_request_wait_completion (&brequest);
         ompi_request_free (&brequest);
         return OMPI_SUCCESS;
     }
@@ -324,7 +324,8 @@ int mca_pml_ob1_send(const void *buf,
 
     MCA_PML_OB1_SEND_REQUEST_START_W_SEQ(sendreq, endpoint, seqn, rc);
     if (OPAL_LIKELY(rc == OMPI_SUCCESS)) {
-        ompi_request_wait_completion(&sendreq->req_send.req_base.req_ompi);
+        ompi_request_t *ompi_req = &sendreq->req_send.req_base.req_ompi;
+        ompi_request_wait_completion(&ompi_req);
 
         rc = sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR;
     }


### PR DESCRIPTION
Fixes #11965

Fix: multi-thread logic issue in ompi/request/request.h:ompi_request_wait_completion
Fix: ensure request free is only called once on each request in ompi/request/req_wait.c:ompi_request_default_wait

The wait fix must be done in waitany, waitsome, waitall, test, testany, testsome, testall to ensure request free is only called once.
If the wait change suits you, then I can apply it to the other functions.