### PR TITLE
v5.0.x: Add support for MPI_ERR_VALUE_TOO_LARGE

### DIFF
--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -126,6 +126,7 @@ static ompi_mpi_errcode_t ompi_err_proc_fail_pending;
 static ompi_mpi_errcode_t ompi_err_revoked;
 #endif
 static ompi_mpi_errcode_t ompi_err_session;
+static ompi_mpi_errcode_t ompi_err_value_too_large;
 
 static void ompi_mpi_errcode_construct(ompi_mpi_errcode_t* errcode);
 static void ompi_mpi_errcode_destruct(ompi_mpi_errcode_t* errcode);
@@ -243,6 +244,7 @@ int ompi_mpi_errcode_init (void)
     CONSTRUCT_ERRCODE( ompi_err_revoked,  MPI_ERR_REVOKED,  "MPI_ERR_REVOKED: Communication Object Revoked" );
 #endif
     CONSTRUCT_ERRCODE( ompi_err_session,  MPI_ERR_SESSION,  "MPI_ERR_SESSION: Invalid session handle" );
+    CONSTRUCT_ERRCODE( ompi_err_value_too_large,  MPI_ERR_VALUE_TOO_LARGE,  "MPI_ERR_VALUE_TOO_LARGE: Value is too large to store" );
 
     /* Per MPI-3 p353:27-32, MPI_LASTUSEDCODE must be >=
        MPI_ERR_LASTCODE.  So just start it as == MPI_ERR_LASTCODE. */
@@ -359,6 +361,7 @@ int ompi_mpi_errcode_finalize (void)
     OBJ_DESTRUCT(&ompi_err_revoked);
 #endif
     OBJ_DESTRUCT(&ompi_err_session);
+    OBJ_DESTRUCT(&ompi_err_value_too_large);
     OBJ_DESTRUCT(&ompi_mpi_errcodes);
     ompi_mpi_errcode_lastpredefined = 0;
     opal_mutex_unlock(&errcode_lock);

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -746,6 +746,7 @@ enum {
 #define MPI_ERR_PROC_FAILED_PENDING   76
 #define MPI_ERR_REVOKED               77
 #define MPI_ERR_SESSION               78
+#define MPI_ERR_VALUE_TOO_LARGE       79
 
 /* Per MPI-3 p349 47, MPI_ERR_LASTCODE must be >= the last predefined
    MPI_ERR_<foo> code. Set the last code to allow some room for adding

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -381,6 +381,7 @@ $constants->{MPI_ERR_RMA_FLAVOR} = 70;
 $constants->{MPI_ERR_RMA_SHARED} = 71;
 $constants->{MPI_T_ERR_INVALID} = 72;
 $constants->{MPI_ERR_SESSION} = 78;
+$constants->{MPI_ERR_VALUE_TOO_LARGE} = 79;
 $constants->{MPI_ERR_LASTCODE} = 92;
 
 $constants->{MPI_IDENT} = 0;


### PR DESCRIPTION
Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit d1d9ad631aec398534032563e7ca6f2615f6162f)

Refs #11973 

Thanks to @dalcinl for identifying the issue.