### PR TITLE
pcomm:fix fortran interface for precv/psend

### DIFF
--- a/ompi/mpi/fortran/mpif-h/precv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/precv_init_f.c
@@ -14,6 +14,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2021      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +43,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_PRECV_INIT,
                            pmpi_precv_init_,
                            pmpi_precv_init__,
                            pompi_precv_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
                            (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #endif
 #endif
@@ -61,7 +63,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PRECV_INIT,
                            mpi_precv_init_,
                            mpi_precv_init__,
                            ompi_precv_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
                            (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #else
 #define ompi_precv_init_f pompi_precv_init_f
@@ -69,7 +71,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PRECV_INIT,
 #endif
 
 
-void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
+void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
 {
    int c_ierr;
    MPI_Info c_info;
@@ -82,7 +84,7 @@ void ompi_precv_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fin
 
    c_ierr = PMPI_Precv_init(OMPI_F2C_BOTTOM(buf), 
                       OMPI_FINT_2_INT(*partitions),
-                      OMPI_FINT_2_INT(*count),
+                      *count,
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag),
                       c_comm, c_info, &c_req);

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2016-2023 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2019-2022 Triad National Security, LLC. All rights
+ * Copyright (c) 2019-2023 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Bull S.A.S. All rights reserved.
  * $COPYRIGHT$
@@ -355,8 +355,8 @@ PN2(void, MPI_Pcontrol, mpi_pcontrol, MPI_PCONTROL, (MPI_Fint *level));
 PN2(void, MPI_Pready, mpi_pready, MPI_PREADY, (MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Pready_list, mpi_pready_list, MPI_PREADY_LIST, (MPI_Fint *length, MPI_Fint *partition, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Pready_range, mpi_pready_range, MPI_PREADY_RANGE, (MPI_Fint *partition_low, MPI_Fint *partition_high, MPI_Fint *request, MPI_Fint *ierr));
-PN2(void, MPI_Precv_init, mpi_precv_init, MPI_PRECV_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *src, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
-PN2(void, MPI_Psend_init, mpi_psend_init, MPI_PSEND_INIT, (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Precv_init, mpi_precv_init, MPI_PRECV_INIT, (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *src, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPI_Psend_init, mpi_psend_init, MPI_PSEND_INIT, (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Probe, mpi_probe, MPI_PROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *status, MPI_Fint *ierr));
 PN2(void, MPI_Publish_name, mpi_publish_name, MPI_PUBLISH_NAME, (char *service_name, MPI_Fint *info, char *port_name, MPI_Fint *ierr, int service_name_len, int port_name_len));
 PN2(void, MPI_Put, mpi_put, MPI_PUT, (char *origin_addr, MPI_Fint *origin_count, MPI_Fint *origin_datatype, MPI_Fint *target_rank, MPI_Aint *target_disp, MPI_Fint *target_count, MPI_Fint *target_datatype, MPI_Fint *win, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/psend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/psend_init_f.c
@@ -14,6 +14,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2021      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +43,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_PSEND_INIT,
                            pmpi_psend_init_,
                            pmpi_psend_init__,
                            pompi_psend_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
                            (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #endif
 #endif
@@ -61,7 +63,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PSEND_INIT,
                            mpi_psend_init_,
                            mpi_psend_init__,
                            ompi_psend_init_f,
-                           (char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
+                           (char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr),
                            (buf, partitions, count, datatype, dest, tag, comm, info, request, ierr) )
 #else
 #define ompi_psend_init_f pompi_psend_init_f
@@ -69,7 +71,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PSEND_INIT,
 #endif
 
 
-void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
+void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Count *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
 {
    int c_ierr;
    MPI_Info c_info;
@@ -82,7 +84,7 @@ void ompi_psend_init_f(char *buf, MPI_Fint *partitions, MPI_Fint *count, MPI_Fin
 
    c_ierr = PMPI_Psend_init(OMPI_F2C_BOTTOM(buf), 
                       OMPI_FINT_2_INT(*partitions),
-                      OMPI_FINT_2_INT(*count),
+                      *count,
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag),
                       c_comm, c_info, &c_req);

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -310,9 +310,11 @@ end subroutine ompi_issend_f
 
 subroutine ompi_psend_init_f(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror) &
    BIND(C, name="ompi_psend_init_f")
+   use :: mpi_f08_types, only : MPI_COUNT_KIND
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(KIND=MPI_COUNT_KIND), INTENT(IN):: count
    INTEGER, INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: comm
    INTEGER, INTENT(IN) :: info
@@ -322,9 +324,11 @@ end subroutine ompi_psend_init_f
 
 subroutine ompi_precv_init_f(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror) &
    BIND(C, name="ompi_precv_init_f")
+   use :: mpi_f08_types, only : MPI_COUNT_KIND
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(KIND=MPI_COUNT_KIND), INTENT(IN):: count
    INTEGER, INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: comm
    INTEGER, INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
@@ -10,7 +10,7 @@
 ! Copyright (c) 2015-2020 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
-! Copyright (c) 2021-2022 Triad National Security, LLC. All rights
+! Copyright (c) 2021-2023 Triad National Security, LLC. All rights
 !                         reserved.
 ! $COPYRIGHT$
 !
@@ -201,7 +201,7 @@ end interface  MPI_Issend
 
 interface  MPI_Precv_init
 subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request, MPI_COUNT_KIND
    implicit none
    !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
    !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -209,7 +209,8 @@ subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,reques
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(MPI_COUNT_KIND), INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -219,7 +220,7 @@ end interface  MPI_Precv_init
 
 interface  MPI_Psend_init
 subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request, MPI_COUNT_KIND
    implicit none
    !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
    !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -227,7 +228,8 @@ subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,reques
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions, count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(MPI_COUNT_KIND), INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Request), INTENT(OUT) :: request

--- a/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/precv_init_f08.F90
@@ -7,6 +7,8 @@
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
 ! Copyright (c) 2021      Bull S.A.S. All rights reserved.
+! Copyright (c) 2023      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,11 +16,12 @@
 #include "mpi-f08-rename.h"
 
 subroutine MPI_Precv_init_f08(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request, MPI_COUNT_KIND
    use :: ompi_mpifh_bindings, only : ompi_precv_init_f
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(KIND=MPI_COUNT_KIND), INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/psend_init_f08.F90
@@ -7,16 +7,19 @@
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
 ! Copyright (c) 2021      Bull S.A.S. All rights reserved.
+! Copyright (c) 2023      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPI_Psend_init_f08(buf,partitions,count,datatype,dest,tag,comm,info,request,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
+   use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request, MPI_COUNT_KIND
    use :: ompi_mpifh_bindings, only : ompi_psend_init_f
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
-   INTEGER, INTENT(IN) :: partitions,count, dest, tag
+   INTEGER, INTENT(IN) :: partitions, dest, tag
+   INTEGER(KIND=MPI_COUNT_KIND), INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -11,7 +11,7 @@
 !                         reserved.
 ! Copyright (c) 2015-2023 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
-! Copyright (c) 2019-2022 Triad National Security, LLC. All rights
+! Copyright (c) 2019-2023 Triad National Security, LLC. All rights
 !                         reserved.
 ! Copyright (c) 2021      Bull S.A.S. All rights reserved.
 ! Copyright (c) 2021      IBM Corporation.  All rights reserved.
@@ -2619,10 +2619,11 @@ interface
 
 subroutine MPI_Psend_init(buf, partitions, count, datatype, dest, tag, &
         comm, info, request, ierror)
+  include 'mpif-config.h'
   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
   integer, intent(in) :: partitions 
-  integer, intent(in) :: count
+  integer(KIND=MPI_COUNT_KIND), intent(in) :: count
   integer, intent(in) :: datatype
   integer, intent(in) :: dest
   integer, intent(in) :: tag
@@ -2639,10 +2640,11 @@ interface
 
 subroutine MPI_Precv_init(buf, partitions, count, datatype, dest, tag, &
         comm, info, request, ierror)
+  include 'mpif-config.h'
   @OMPI_FORTRAN_IGNORE_TKR_PREDECL@ buf
   @OMPI_FORTRAN_IGNORE_TKR_TYPE@, intent(in) :: buf
   integer, intent(in) :: partitions
-  integer, intent(in) :: count 
+  integer(KIND=MPI_COUNT_KIND), intent(in) :: count
   integer, intent(in) :: datatype
   integer, intent(in) :: dest
   integer, intent(in) :: tag


### PR DESCRIPTION
The Fortran interfaces were using INTEGER for count argument.  The MPI-4 standard states that this argument should be INTEGER(KIND=MPI_COUNT_KIND).

related to #11982

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit e1134affa5587e028907b0359f85a8837f60e809)