### PR TITLE
[v5.0.x] backport docs/news: update contributors

### DIFF
--- a/docs/news/news-v5.0.x.rst
+++ b/docs/news/news-v5.0.x.rst
@@ -249,6 +249,7 @@ Open MPI version 5.0.0rc13
       - Sophia Fang
       - Rick Gleitz
       - Colton Kammes
+      - Quincey Koziol
       - Robert Langfield
       - Nick Papior
       - Luz Paz


### PR DESCRIPTION
Noticed a missing name for 5.0 release

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit c1e49ca678aa9fe0279c8b397420fc5260c64459)