### PR TITLE
[arm64] fix atomic operations opal_atomic_compare_exchange_strong_

### DIFF
--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -73,7 +73,7 @@ static inline bool opal_atomic_compare_exchange_strong_32(opal_atomic_int32_t *a
     __asm__ __volatile__("1:  ldaxr    %w0, [%2]      \n"
                          "    cmp     %w0, %w3        \n"
                          "    bne     2f              \n"
-                         "    stxr    %w1, %w4, [%2]  \n"
+                         "    stlxr    %w1, %w4, [%2]  \n"
                          "    cbnz    %w1, 1b         \n"
                          "2:                          \n"
                          : "=&r"(prev), "=&r"(tmp)
@@ -142,7 +142,7 @@ static inline bool opal_atomic_compare_exchange_strong_64(opal_atomic_int64_t *a
     __asm__ __volatile__("1:  ldaxr    %0, [%2]       \n"
                          "    cmp     %0, %3          \n"
                          "    bne     2f              \n"
-                         "    stxr    %w1, %4, [%2]   \n"
+                         "    stlxr    %w1, %4, [%2]   \n"
                          "    cbnz    %w1, 1b         \n"
                          "2:                          \n"
                          : "=&r"(prev), "=&r"(tmp)


### PR DESCRIPTION
in arm64  ldxr and stxr must be used with memory barrier.  this cause the spinlock not work in arm64.  program may crash or get a wrong result when using multi-thread.  Actually we already got both program crash and wrong result of allreduce sum when using  multi-pthreads, and  fix by this modifition