### PR TITLE
Fix minor memory leaks

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -382,11 +383,6 @@ int mca_pml_ob1_add_procs(ompi_proc_t** procs, size_t nprocs)
     if(nprocs == 0)
         return OMPI_SUCCESS;
 
-    OBJ_CONSTRUCT(&reachable, opal_bitmap_t);
-    rc = opal_bitmap_init(&reachable, (int)nprocs);
-    if(OMPI_SUCCESS != rc)
-        return rc;
-
     /* make sure remote procs are using the same PML as us */
     if (OMPI_SUCCESS != (rc = mca_pml_base_pml_check_selected("ob1",
                                                               procs,
@@ -394,14 +390,14 @@ int mca_pml_ob1_add_procs(ompi_proc_t** procs, size_t nprocs)
         return rc;
     }
 
+    if (NULL == mca_bml.bml_add_procs) {
+        return OMPI_ERR_UNREACH;
+    }
+
     OBJ_CONSTRUCT(&reachable, opal_bitmap_t);
     rc = opal_bitmap_init(&reachable, (int)nprocs);
     if (OMPI_SUCCESS != rc) {
         return rc;
-    }
-
-    if (NULL == mca_bml.bml_add_procs) {
-        return OMPI_ERR_UNREACH;
     }
 
     rc = mca_bml.bml_add_procs (nprocs, procs, &reachable);

--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -246,9 +247,11 @@ int mca_base_framework_close(struct mca_base_framework_t *framework)
 
     /* close the framework and all of its components */
     if (is_open) {
+        ret = OPAL_SUCCESS;
         if (NULL != framework->framework_close) {
             ret = framework->framework_close();
-        } else {
+        }
+        if (OPAL_SUCCESS == ret) {
             ret = mca_base_framework_components_close(framework, NULL);
         }
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -472,7 +473,7 @@ static int mca_btl_tcp_component_close(void)
     OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_frag_max);
     OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_frag_user);
     OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_lock);
-    OBJ_DESTRUCT(&mca_btl_tcp_component.local_ifs);
+    OPAL_LIST_DESTRUCT(&mca_btl_tcp_component.local_ifs);
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -668,6 +668,7 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
                                     "btl: tcp: Using interface: %s ", argv[i]);
                 opal_argv_append(&interface_count, &interfaces, argv[i]);
             }
+            free(argv[i]);
             continue;
         }
 


### PR DESCRIPTION
Fix a few minor memory leaks found with clang's `-fsanitize=address` option.  Refs #12019 (even though that issue is about v4.1.x).

See individual commit messages for details.