### PR TITLE
dlopen: fix configury issue

### DIFF
--- a/opal/mca/dl/dlopen/Makefile.am
+++ b/opal/mca/dl/dlopen/Makefile.am
@@ -2,6 +2,8 @@
 # Copyright (c) 2004-2010 The Trustees of Indiana University.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,4 +22,4 @@ noinst_LTLIBRARIES = libmca_dl_dlopen.la
 
 libmca_dl_dlopen_la_SOURCES = $(sources)
 libmca_dl_dlopen_la_LDFLAGS = -module -avoid-version
-libmca_dl_dlopen_la_LIBADD = $(opal_dl_dlopen_LIBS)
+libmca_dl_dlopen_la_LIBADD = $(dl_dlopen_LIBS)


### PR DESCRIPTION
Turns out most of the time we are getting lucky and some opal dependency needs dlopen lib. But there are certain types of builds, in particular a common one when building Open MPI within spack that that is not the case.

In this event the opal_pal lib fails to build owing to missing dlopen/dlsym, etc.

This issue currently prevents building typical spack variants of open mpi 5.0.0

Related to https://github.com/spack/spack/pull/40725