### PR TITLE
Pr/rocm ldflags libs v5.0

### DIFF
--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -6,18 +6,21 @@ env:
   ROCM_VER: 5-4
 jobs:
   compile-rocm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
+        sudo apt update
+        sudo apt install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
     - name: Install extra dependencies
       run: |
-        curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
-        echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg]  https://repo.radeon.com/rocm/apt/debian focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
-        sudo apt-get update
-        sudo apt-get install -y rocm-hip-runtime
+        sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/5.7.1/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/amdgpu.list
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/5.7.1 jammy main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
+        echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+        sudo apt update
+        sudo apt install -y rocm-hip-runtime
     - uses: actions/checkout@v3
       with:
             submodules: recursive
@@ -25,10 +28,4 @@ jobs:
       run: |
         ./autogen.pl
         ./configure --prefix=${PWD}/install --with-rocm=/opt/rocm --disable-mpi-fortran
-        make -j
-    - name: Clean up
-      run: |
-        ls -la ./
-        rm -rf ./* 
-        rm -rf ./.??*
-        ls -la ./
+        LD_LIBRARY_PATH=/opt/rocm/lib make -j

--- a/config/opal_check_rocm.m4
+++ b/config/opal_check_rocm.m4
@@ -36,7 +36,7 @@ AC_DEFUN([OPAL_CHECK_ROCM],[
            [ with_rocm="/opt/rocm"] )
 
      rocm_CPPFLAGS="-D__HIP_PLATFORM_AMD__"
-     rocm_LDFLAGS="-L${with_rocm}/lib/hip"
+     rocm_LDFLAGS="-L${with_rocm}/lib/"
 
      AS_IF([ test -n "$with_rocm" && test "$with_rocm" != "no" ],
            [ OPAL_APPEND([CPPFLAGS], [$rocm_CPPFLAGS])
@@ -52,15 +52,11 @@ AC_DEFUN([OPAL_CHECK_ROCM],[
 
      LDFLAGS="$rocm_save_LDFLAGS"
      LIBS="$rocm_save_LIBS"
-     OPAL_APPEND([CPPFLAGS], [${$1_CPPFLAGS}] )
-     OPAL_APPEND([LDFLAGS], [${$1_LDFLAGS}] )
-     OPAL_APPEND([LIBS], [${$1_LIBS}] )
-
-     AS_IF([ test "$opal_check_rocm_happy" = "no" ],
-           [ CPPFLAGS="$rocm_save_CPPFLAGS"])
+     CPPFLAGS="$rocm_save_CPPFLAGS"
 
      AS_IF([ test "$opal_check_rocm_happy" = "yes" ],
-           [ AC_DEFINE_UNQUOTED([OPAL_ROCM_SUPPORT], [1], [Enable ROCm support])
+           [ OPAL_APPEND([$1_CPPFLAGS], [$rocm_CPPFLAGS])
+	     AC_DEFINE_UNQUOTED([OPAL_ROCM_SUPPORT], [1], [Enable ROCm support])
              ROCM_SUPPORT=1 ],
            [ AC_DEFINE_UNQUOTED([OPAL_ROCM_SUPPORT], [0], [Disable ROCm support])
              ROCM_SUPPORT=0 ])

--- a/opal/mca/accelerator/rocm/Makefile.am
+++ b/opal/mca/accelerator/rocm/Makefile.am
@@ -13,7 +13,7 @@
 #
 
 
-AM_CPPFLAGS = $(common_rocm_CPPFLAGS)
+AM_CPPFLAGS = $(opal_rocm_CPPFLAGS)
 
 sources = \
         accelerator_rocm.h \

--- a/opal/mca/accelerator/rocm/configure.m4
+++ b/opal/mca/accelerator/rocm/configure.m4
@@ -24,4 +24,5 @@ AC_DEFUN([MCA_opal_accelerator_rocm_CONFIG],[
 	  [$2])
     AC_SUBST([opal_rocm_LDFLAGS])
     AC_SUBST([opal_rocm_LIBS])
+    AC_SUBST([opal_rocm_CPPFLAGS])
 ])dnl


### PR DESCRIPTION
do not add the rocm_libs to the generic LIBS, they will be used to link the rocm accelerator component only.

Fixes issue https://github.com/open-mpi/ompi/issues/11971

This pr brings over the commits of pr  #12026