### PR TITLE
V5.0.x: Avoid static initialization of recursive mutexes

### DIFF
--- a/config/opal_check_attributes.m4
+++ b/config/opal_check_attributes.m4
@@ -559,6 +559,14 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
         [],
         [])
 
+    _OPAL_CHECK_SPECIFIC_ATTRIBUTE([constructor],
+        [
+        void foo(void) __attribute__ ((__constructor__));
+        void foo(void) { return ; }
+        ],
+        [],
+        [])
+
     _OPAL_CHECK_SPECIFIC_ATTRIBUTE([destructor],
         [
         void foo(void) __attribute__ ((__destructor__));
@@ -631,6 +639,8 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
                      [Whether your compiler has __attribute__ warn unused result or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_WEAK_ALIAS, [$opal_cv___attribute__weak_alias],
                      [Whether your compiler has __attribute__ weak alias or not])
+  AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_CONSTRUCTOR, [$opal_cv___attribute__constructor],
+                     [Whether your compiler has __attribute__ constructor or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_DESTRUCTOR, [$opal_cv___attribute__destructor],
                      [Whether your compiler has __attribute__ destructor or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_OPTNONE, [$opal_cv___attribute__optnone],

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -61,11 +61,13 @@ ompi_predefined_instance_t ompi_mpi_instance_null = {{{{0}}}};
 
 #if defined(OPAL_RECURSIVE_MUTEX_STATIC_INIT)
 static opal_recursive_mutex_t instance_lock = OPAL_RECURSIVE_MUTEX_STATIC_INIT;
-#else
+#elif defined(OPAL_HAVE_ATTRIBUTE_CONSTRUCTOR)
 static opal_recursive_mutex_t instance_lock;
-__attribute__((__constructor__)) static void instance_lock_init(void) {
+__opal_attribute_constructor__ static void instance_lock_init(void) {
     OBJ_CONSTRUCT(&instance_lock, opal_recursive_mutex_t);
 }
+#else
+#error "No support for recursive mutexes available on this platform.
 #endif  /* defined(OPAL_RECURSIVE_MUTEX_STATIC_INIT) */
 
 /** MPI_Init instance */

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -59,7 +59,14 @@
 
 ompi_predefined_instance_t ompi_mpi_instance_null = {{{{0}}}};
 
+#if defined(OPAL_RECURSIVE_MUTEX_STATIC_INIT)
 static opal_recursive_mutex_t instance_lock = OPAL_RECURSIVE_MUTEX_STATIC_INIT;
+#else
+static opal_recursive_mutex_t instance_lock;
+__attribute__((__constructor__)) static void instance_lock_init(void) {
+    OBJ_CONSTRUCT(&instance_lock, opal_recursive_mutex_t);
+}
+#endif  /* defined(OPAL_RECURSIVE_MUTEX_STATIC_INIT) */
 
 /** MPI_Init instance */
 ompi_instance_t *ompi_mpi_instance_default = NULL;

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -229,6 +229,12 @@
 #    define __opal_attribute_weak_alias__(a)
 #endif
 
+#if OPAL_HAVE_ATTRIBUTE_CONSTRUCTOR
+#    define __opal_attribute_constructor__ __attribute__((__constructor__))
+#else
+#    define __opal_attribute_constructor__
+#endif
+
 #if OPAL_HAVE_ATTRIBUTE_DESTRUCTOR
 #    define __opal_attribute_destructor__ __attribute__((__destructor__))
 #else

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -83,7 +83,7 @@
 #define OPAL_BTL_USNIC_NUM_COMPLETIONS 500
 
 /* MPI_THREAD_MULTIPLE_SUPPORT */
-opal_recursive_mutex_t btl_usnic_lock = OPAL_RECURSIVE_MUTEX_STATIC_INIT;
+opal_recursive_mutex_t btl_usnic_lock;  /* recursive mutexes must be dynamically initialized */
 
 /* RNG buffer definition */
 opal_rng_buff_t opal_btl_usnic_rand_buff = {{0}};


### PR DESCRIPTION
There is no portable way to statically initialize recursive mutexes. Where possible avoid doing so, and where not possible add a specialized constructor (thanks @eschnett for the patch).

Fixes https://github.com/open-mpi/ompi/issues/12029.