### PR TITLE
mpi/[send]recv.c: set memcheck for single-receive functions

### DIFF
--- a/ompi/mpi/c/recv.c
+++ b/ompi/mpi/c/recv.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,6 +91,12 @@ int MPI_Recv(void *buf, int count, MPI_Datatype type, int source,
     if (MPI_PROC_NULL == source) {
         if (MPI_STATUS_IGNORE != status) {
             OMPI_COPY_STATUS(status, ompi_request_empty.req_status, false);
+            /*
+             * Per MPI-1, the MPI_ERROR field is not defined for single-completion calls
+             */
+            MEMCHECKER(
+                opal_memchecker_base_mem_undefined(&status->MPI_ERROR, sizeof(int));
+            );
         }
         return MPI_SUCCESS;
     }

--- a/ompi/mpi/c/sendrecv.c
+++ b/ompi/mpi/c/sendrecv.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -121,6 +122,12 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     } else {
         if (MPI_STATUS_IGNORE != status) {
             OMPI_COPY_STATUS(status, ompi_request_empty.req_status, false);
+            /*
+             * Per MPI-1, the MPI_ERROR field is not defined for single-completion calls
+             */
+            MEMCHECKER(
+                opal_memchecker_base_mem_undefined(&status->MPI_ERROR, sizeof(int));
+            );
         }
         rc = MPI_SUCCESS;
     }


### PR DESCRIPTION
Similar to other functions (e.g., MPI_Wait[any]), ensure that if running under Valgrind or some other memory checker, don't raise an error because the status.MPI_ERROR field is undefined.

Found this while updating docs in #12058 