### PR TITLE
v5.0.x: VERSION: Advance to v5.0.1a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=5
 minor=0
-release=0
+release=1
 
 # MPI Standard Compliance Level
 mpi_standard_version=3
@@ -41,7 +41,7 @@ flex_min_version=2.5.4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc16
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Since v5.0.0 has been released, we need to advance `VERSION` so that the nightly snapshot tarballs stop identifying themselves as `v5.0.0rc16` (see https://www.open-mpi.org/nightly/v5.0.x/); with this PR, they will now identify themselves as `v5.0.1a1`.

bot:notacherrypick