### PR TITLE
btlsmcuda: fix problem with makefile

### DIFF
--- a/opal/mca/btl/smcuda/Makefile.am
+++ b/opal/mca/btl/smcuda/Makefile.am
@@ -51,7 +51,7 @@ endif
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
-mca_btl_smcuda_la_LDFLAGS = -module -avoid-version
+mca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
 mca_btl_smcuda_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/sm/lib@OPAL_LIB_NAME@mca_common_sm.la \
     $(btl_smcuda_LIBS)
@@ -59,6 +59,6 @@ mca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
-libmca_btl_smcuda_la_LDFLAGS = -module -avoid-version
+libmca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
 libmca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
 libmca_btl_smcuda_la_LIBADD = $(btl_smcuda_LIBS)

--- a/opal/mca/rcache/gpusm/Makefile.am
+++ b/opal/mca/rcache/gpusm/Makefile.am
@@ -48,11 +48,11 @@ endif
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_gpusm_la_SOURCES = $(sources)
-mca_rcache_gpusm_la_LDFLAGS = -module -avoid-version
+mca_rcache_gpusm_la_LDFLAGS = -module -avoid-version $(rcache_gpusm_LDFLAGS)
 mca_rcache_gpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
 	$(rcache_gpusm_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rcache_gpusm_la_SOURCES = $(sources)
-libmca_rcache_gpusm_la_LDFLAGS = -module -avoid-version
+libmca_rcache_gpusm_la_LDFLAGS = -module -avoid-version $(rcache_gpusm_LDFLAGS)
 libmca_rcache_gpusm_la_LIBADD = $(rcache_gpusm_LIBS)

--- a/opal/mca/rcache/rgpusm/Makefile.am
+++ b/opal/mca/rcache/rgpusm/Makefile.am
@@ -46,11 +46,11 @@ endif
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_rgpusm_la_SOURCES = $(sources)
-mca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version
+mca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version $(rcache_rgpusm_LDFLAGS)
 mca_rcache_rgpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
 	$(rcache_rgpusm_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rcache_rgpusm_la_SOURCES = $(sources)
-libmca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version
+libmca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version $(rcache_rgpusm_LDFLAGS)
 libmca_rcache_rgpusm_la_LIBADD = $(rcache_rgpusm_LIBS)


### PR DESCRIPTION
when libcuda.so is in a non-standard location.

Similar fix to that in #12065