### PR TITLE
v4.1.x: ORTE: a prefix of "/" is ok

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -475,7 +476,12 @@ static int setup_launch(int *argcptr, char ***argvptr,
          */
 
         value = opal_basename(opal_install_dirs.bindir);
-        asprintf(&bin_base, "%s/%s", prefix_dir, value);
+        /* Ensure that we don't have a prefix that ends in "/" */
+        if ('/' == prefix_dir[strlen(prefix_dir) - 1]) {
+            asprintf(&bin_base, "%s%s", prefix_dir, value);
+        } else {
+            asprintf(&bin_base, "%s/%s", prefix_dir, value);
+        }
         free(value);
 
         if (NULL != orted_cmd) {

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -487,10 +488,13 @@ int orte_submit_init(int argc, char *argv[],
                     param[param_len-1] = '\0';
                     param_len--;
                     if (0 == param_len) {
-                        orte_show_help("help-orterun.txt", "orterun:empty-prefix",
-                                       true, orte_basename, orte_basename);
-                        free(param);
-                        return ORTE_ERR_FATAL;
+                        /* We get here if we removed all PATH_SEP's
+                           and end up with an empty string.  In this
+                           case, the prefix is just a single
+                           PATH_SEP. */
+                        param[0] = '\\';
+                        param[1] = '\0';
+                        break;
                     }
                 }
 
@@ -1583,10 +1587,13 @@ static int create_app(int argc, char* argv[],
                     param[param_len-1] = '\0';
                     param_len--;
                     if (0 == param_len) {
-                        orte_show_help("help-orterun.txt", "orterun:empty-prefix",
-                                       true, orte_basename, orte_basename);
-                        free(param);
-                        return ORTE_ERR_FATAL;
+                        /* We get here if we removed all PATH_SEP's
+                           and end up with an empty string.  In this
+                           case, the prefix is just a single
+                           PATH_SEP. */
+                        param[0] = '\\';
+                        param[1] = '\0';
+                        break;
                     }
                 }
                 orte_set_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, ORTE_ATTR_GLOBAL, param, OPAL_STRING);

--- a/orte/tools/orterun/help-orterun.txt
+++ b/orte/tools/orterun/help-orterun.txt
@@ -13,6 +13,7 @@
 # Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -173,11 +174,6 @@ prefix provided for the first app_context:
 Only one should be specified to avoid potential version
 confusion. Operation will continue, but the application's prefix
 option will be ignored.
-#
-[orterun:empty-prefix]
-A prefix was supplied to %s that only contained slashes.
-
-This is a fatal error; %s will now abort.  No processes were launched.
 #
 [debugger-mca-param-not-found]
 Internal error -- the orte_base_user_debugger MCA parameter was not able to


### PR DESCRIPTION
This is a backport of https://github.com/openpmix/prrte/pull/1848 to ORTE.  A prefix of `/` is not an error; there's no need to emit a message and fail.  We want to ensure to not pass a double slash in the ssh module to the remote host (i.e., the prefix of `/` followed by `/<bindir>`), so make sure to handle that properly.

Fixes #12071

bot:notacherrypick

This is an ORTE-specific backport; the cited PRTE PR above is where the fix is going in upstream.  But this is why it's not a cherry pick from OMPI's main.