### PR TITLE
check-help-strings.pl: skip the 3rd-party directory

### DIFF
--- a/contrib/check-help-strings.pl
+++ b/contrib/check-help-strings.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 #
 # Copyright (c) 2014-2022 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Simple script to check all the opal_show_help (and orte_show_help)
@@ -94,6 +95,7 @@ sub match_files {
     # Don't recurse down "special" directories
     if (-d $_ &&
         ((/^\.deps$/) || (/^\.libs$/) ||
+         (/3rd-party/) ||
          (/^\.svn$/) || (/^\.hg$/) || (/^\.git$/))) {
         $File::Find::prune = 1;
         return;


### PR DESCRIPTION
We only want to check the help strings in the Open MPI source, not 3rd party source.