### PR TITLE
Github issue: also name the template "question"

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -1,0 +1,49 @@
+---
+name: Ask a question
+about: Got a problem or question?  This is the place to ask.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please submit all the information below so that we can understand the
+working environment that is the context for your question.
+
+* If you have a problem building or installing Open MPI, [be sure to
+  read this](https://docs.open-mpi.org/en/main/getting-help.html#for-problems-building-or-installing-open-mpi).
+* If you have a problem launching MPI or OpenSHMEM applications, [be
+  sure to read this](https://docs.open-mpi.org/en/main/getting-help.html#for-problems-launching-mpi-or-openshmem-applications).
+* If you have a problem running MPI or OpenSHMEM applications (i.e.,
+  after launching them), [be sure to read this](https://docs.open-mpi.org/en/main/getting-help.html#for-problems-running-mpi-or-openshmem-applications).
+
+## Background information
+
+### What version of Open MPI are you using? (e.g., v3.0.5, v4.0.2, git branch name and hash, etc.)
+
+
+
+### Describe how Open MPI was installed (e.g., from a source/distribution tarball, from a git clone, from an operating system distribution package, etc.)
+
+
+
+### If you are building/installing from a git clone, please copy-n-paste the output from `git submodule status`.
+
+
+
+### Please describe the system on which you are running
+
+* Operating system/version:
+* Computer hardware:
+* Network type:
+
+-----------------------------
+
+## Details of the problem
+
+Please describe, in detail, the problem that you are having, including the behavior you expect to see, the actual behavior that you are seeing, steps to reproduce the problem, etc.  It is most helpful if you can attach a small program that a developer can use to reproduce your problem.
+
+**Note**: If you include verbatim output (or a code block), please use a [GitHub Markdown](https://help.github.com/articles/creating-and-highlighting-code-blocks/) code block like below:
+```shell
+shell$ mpirun -n 2 ./hello_world
+```


### PR DESCRIPTION
We've had a recent spate of users wholly disregarding the template when submitting a new github issue (i.e., they delete the template and just ask a question, without all the useful information that the template asks for).
    
For users who just want to ask a question, let's give them an explicit template just for that (so that they don't just choose "bug report" and then erase the template because they think the template won't apply to them).