### PR TITLE
sessions: fix a problem with fortran interface

### DIFF
--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -393,7 +393,7 @@ PN2(void, MPI_Session_call_errhandler, mpi_session_call_errhandler, MPI_SESSION_
 PN2(void, MPI_Session_create_errhandler, mpi_session_create_errhandler, MPI_SESSION_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
 PN2(void, MPI_Session_get_errhandler, mpi_session_get_errhandler, MPI_SESSION_GET_ERRHANDLER, (MPI_Fint *session, MPI_Fint *erhandler, MPI_Fint *ierr));
 PN2(void, MPI_Session_get_info, mpi_session_get_info, MPI_SESSION_GET_INFO, (MPI_Fint *session, MPI_Fint *info, MPI_Fint *ierr));
-PN2(void, MPI_Session_get_nth_pset, mpi_session_get_nth_pset, MPI_SESSION_GET_NTH_PSET, (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_nth_pset, mpi_session_get_nth_pset, MPI_SESSION_GET_NTH_PSET, (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr, int pset_name_len));
 PN2(void, MPI_Session_get_num_psets, mpi_session_get_num_psets, MPI_SESSION_GET_NUM_PSETS, (MPI_Fint *session, MPI_Fint *info, MPI_Fint *npset_names, MPI_Fint *ierr));
 PN2(void, MPI_Session_get_pset_info, mpi_session_get_pset_info, MPI_SESSION_GET_PSET_INFO, (MPI_Fint *session, char *pset_name, MPI_Fint *info, MPI_Fint *ierr, int name_len));
 PN2(void, MPI_Session_init, mpi_session_init, MPI_SESSION_INIT, (MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *session, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
@@ -46,8 +46,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_NTH_PSET,
                             pmpi_session_get_nth_pset_,
                             pmpi_session_get_nth_pset__,
                             pompi_session_get_nth_pset_f,
-                            (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr),
-                            (session, info, n, pset_len, pset_name, ierr))
+                            (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr, int pset_name_len),
+                            (session, info, n, pset_len, pset_name, ierr, pset_name_len))
 #endif
 #endif
 
@@ -66,14 +66,15 @@ OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_NTH_PSET,
                             mpi_session_get_nth_pset_,
                             mpi_session_get_nth_pset__,
                             ompi_session_get_nth_pset_f,
-                            (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr),
-                            (session, info, n, pset_len, pset_name, ierr))
+                            (MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr, int pset_name_len),
+                            (session, info, n, pset_len, pset_name, ierr, pset_name_len))
 #else
 #define ompi_session_get_nth_pset_f pompi_session_get_nth_pset_f
 #endif
 #endif
 
-void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr)
+void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr,
+                                 int pset_name_len)
 {
     int c_ierr;
     MPI_Session c_session;
@@ -94,8 +95,12 @@ void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *n,
         c_ierr = PMPI_Session_get_nth_pset(c_session, MPI_INFO_NULL, *n,
                                            OMPI_SINGLE_NAME_CONVERT(pset_len),
                                            c_name);
+        /*
+         * use pset_name_len as that is the length of the supplied pset_name 
+         * otherwise there may be gibberish characters past *pset_len
+         */
         if (MPI_SUCCESS == c_ierr) {
-            ompi_fortran_string_c2f(c_name, pset_name, *pset_len);
+            ompi_fortran_string_c2f(c_name, pset_name, pset_name_len);
         }
     }
 

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -3998,57 +3998,58 @@ end subroutine ompi_neighbor_alltoallw_init_f
 subroutine ompi_session_get_info_f(session, info, ierror) &
    BIND(C, name="ompi_session_get_info_f")
    implicit none
-   integer, intent(in) :: session
-   integer, intent(out) :: info
-   integer, intent(out) :: ierror
+   INTEGER, INTENT(IN) :: session
+   INTEGER, INTENT(out) :: info
+   INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_get_info_f
 
-subroutine ompi_session_get_nth_pset_f(session, info, n, pset_len, pset_name, ierror) &
+subroutine ompi_session_get_nth_pset_f(session, info, n, pset_len, pset_name, ierror, pset_name_len) &
    BIND(C, name="ompi_session_get_nth_pset_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
-   integer, intent(in) :: session
-   integer, intent(in) :: info
-   integer, intent(in) :: n
-   integer, intent(inout) :: pset_len
+   INTEGER, INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: info
+   INTEGER, INTENT(IN) :: n
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: pset_name_len
+   INTEGER, INTENT(INOUT) :: pset_len
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: pset_name
-   integer, intent(out) :: ierror
+   INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_get_nth_pset_f
 
 subroutine ompi_session_get_num_psets_f(session, info, npset_names, ierror) &
    BIND(C, name="ompi_session_get_num_psets_f")
-  implicit none
-  integer, intent(in) :: session
-  integer, intent(in) :: info
-  integer, intent(out) :: npset_names
-  integer, intent(out) :: ierror
+   implicit none
+   INTEGER, INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: info
+   INTEGER, INTENT(out) :: npset_names
+   INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_get_num_psets_f
 
 subroutine ompi_session_get_pset_info_f(session, pset_name, info, ierror, name_len) &
    BIND(C, name="ompi_session_get_pset_info_f")
    use, intrinsic :: ISO_C_BINDING, only : C_CHAR
    implicit none
-   integer, intent(in) :: session
+   INTEGER, INTENT(IN) :: session
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: pset_name
    INTEGER, VALUE, INTENT(IN) :: name_len
-   integer, intent(out) :: info
-   integer, intent(out) :: ierror
+   INTEGER, INTENT(out) :: info
+   INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_get_pset_info_f
 
 subroutine ompi_session_init_f(info, errhandler, session, ierror) &
    BIND(C, name="ompi_session_init_f")
-  implicit none
-  integer, intent(in) :: info
-  integer, intent(in) :: errhandler
-  integer, intent(out) :: session
-  integer, intent(out) :: ierror
+   implicit none
+   INTEGER, INTENT(IN) :: info
+   INTEGER, INTENT(IN) :: errhandler
+   INTEGER, INTENT(out) :: session
+   INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_init_f
 
 subroutine ompi_session_finalize_f(session, ierror) &
-   BIND(C, name="ompi_session_finalize_f")
+  BIND(C, name="ompi_session_finalize_f")
   implicit none
-  integer, intent(out) :: session
-  integer, intent(out) :: ierror
+  INTEGER, INTENT(out) :: session
+  INTEGER, INTENT(out) :: ierror
 end subroutine ompi_session_finalize_f
 
 subroutine ompi_session_call_errhandler_f(session,errorcode,ierror) &

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
@@ -23,7 +23,8 @@ subroutine MPI_Session_get_nth_pset_f08(session, info, n, pset_len, pset_name, i
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_session_get_nth_pset_f(session%MPI_VAL, MPI_INFO_NULL%MPI_VAL, n, pset_len, pset_name, c_ierror)
+   call ompi_session_get_nth_pset_f(session%MPI_VAL, MPI_INFO_NULL%MPI_VAL, n,     &
+                                    pset_len, pset_name, c_ierror, len(pset_name))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Session_get_nth_pset_f08


### PR DESCRIPTION
For fortran interfaces for MPI_Session_get_nth_pset, the input character array in which to return the process set names was not being properly handled to trim out potential junk characers in the input array.

This is easiest to observe when the user is supplying an input character array of MPI_MAX_PSET_NAME_LEN size.

Related to #12084.

Also do some fix-up of capitalization and indention.