### PR TITLE
4.1.x news: trivial update

### DIFF
--- a/docs/news/news-v4.1.x.rst
+++ b/docs/news/news-v4.1.x.rst
@@ -44,8 +44,11 @@ Open MPI version 4.1.5
 - Update embedded OpenPMIx to version 3.2.4
 - Fix issue building with ``ifort`` on MacOS.
 - Backport patches to Libevent for CVE-2016-10195, CVE-2016-10196, and
-  CVE-2016-10197.  Note that Open MPI's internal libevent does not
-  use the impacted portions of the Libevent code base.
+  CVE-2016-10197.
+
+  .. note:: Open MPI's internal libevent does not use the impacted
+            portions of the Libevent code base.
+
 - SHMEM improvements:
 
   - Fix initializer bugs in SHMEM interface.


### PR DESCRIPTION
Similar to our security update about PMIx, make the security update about libevent be an RST ".. note::" to make it stand out a little more in the rendered HTML.

This is a trivial change to the RST docs that does not change the text at all -- just the formatting.  Since the RST docs do not exist on the v4.1.x branch, there is nothing to backport to v4.1.x.  This change will be cherry-picked to v5.0.x, however.