### PR TITLE
Allow OMPI to compile on OSX with gcc13

### DIFF
--- a/3rd-party/romio341/mpl/configure.ac
+++ b/3rd-party/romio341/mpl/configure.ac
@@ -138,7 +138,7 @@ if test "$pac_cv_have___typeof" = "yes" ; then
 fi
 
 dnl Check if the necessary headers are available
-AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h unistd.h errno.h windows.h sys/mman.h)
+AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h unistd.h errno.h windows.h sys/mman.h sys/param.h)
 
 # A C99 compliant compiler should have inttypes.h for fixed-size int types
 AC_CHECK_HEADERS(inttypes.h stdint.h)

--- a/3rd-party/romio341/mpl/src/str/mpl_str.c
+++ b/3rd-party/romio341/mpl/src/str/mpl_str.c
@@ -6,15 +6,19 @@
 #include "mpl.h"
 #include <assert.h>
 
-#ifdef HAVE_UNISTD_H
+#ifdef MPL_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_SYS_TYPES_H
+#ifdef MPL_HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 
-#ifdef HAVE_TIME_H
+#ifdef MPL_HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
+#ifdef MPL_HAVE_TIME_H
 #include <time.h>
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -686,7 +686,7 @@ AC_CHECK_HEADERS([alloca.h aio.h arpa/inet.h dirent.h \
     sys/types.h sys/uio.h sys/un.h net/uio.h sys/utsname.h sys/vfs.h sys/wait.h syslog.h \
     termios.h ulimit.h unistd.h util.h utmp.h malloc.h \
     ifaddrs.h crt_externs.h regex.h mntent.h paths.h \
-    ioLib.h sockLib.h hostLib.h shlwapi.h sys/synch.h db.h ndbm.h ieee754.h])
+    ioLib.h sockLib.h hostLib.h shlwapi.h sys/synch.h db.h ndbm.h ieee754.h syslimits.h])
 
 AC_CHECK_HEADERS([sys/mount.h], [], [],
 [AC_INCLUDES_DEFAULT

--- a/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +27,9 @@
 #include "mpi.h"
 #include <unistd.h>
 #include <limits.h>
+#ifdef HAVE_SYSLIMITS_H
+#include <syslimits.h>
+#endif  /* HAVE_SYSLIMITS_H */
 #include "ompi/constants.h"
 #include "ompi/mca/fbtl/fbtl.h"
 

--- a/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,8 +26,10 @@
 
 #include "mpi.h"
 #include <unistd.h>
-#include <sys/uio.h>
 #include <limits.h>
+#ifdef HAVE_SYSLIMITS_H
+#include <syslimits.h>
+#endif  /* HAVE_SYSLIMITS_H */
 #include "ompi/constants.h"
 #include "ompi/mca/fbtl/fbtl.h"
 

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -567,6 +568,17 @@ typedef struct {
     opal_short_float_t imag;
 } opal_short_float_complex_t;
 #    endif
+
+/* gcc 13 does not define SSIZE_MAX as required by the POSIX standard.
+ * As a workaround we define ours.
+ */
+#ifndef SSIZE_MAX
+#  if SIZEOF_SSIZE_T == SIZEOF_LONG
+#    define SSIZE_MAX LONG_MAX
+#  elif SIZEOF_SSIZE_T == SIZEOF_LONG_LONG
+#    define SSIZE_MAX LONG_LONG_MAX
+#  endif
+#endif
 
 #else
 

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2012-2023 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -471,7 +471,7 @@ static struct mca_btl_base_endpoint_t *create_sm_endpoint(int local_proc, struct
     struct mca_btl_base_endpoint_t *ep;
 
 #if OPAL_ENABLE_PROGRESS_THREADS == 1
-    char path[PATH_MAX];
+    char path[OPAL_PATH_MAX];
 #endif
 
     ep = (struct mca_btl_base_endpoint_t *) malloc(sizeof(struct mca_btl_base_endpoint_t));

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2012-2013 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2012-2023 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +164,7 @@ struct mca_btl_smcuda_component_t {
     int num_mem_nodes;
 
 #if OPAL_ENABLE_PROGRESS_THREADS == 1
-    char sm_fifo_path[PATH_MAX]; /**< path to fifo used to signal this process */
+    char sm_fifo_path[OPAL_PATH_MAX]; /**< path to fifo used to signal this process */
     int sm_fifo_fd;              /**< file descriptor corresponding to opened fifo */
     opal_thread_t sm_fifo_thread;
 #endif

--- a/opal/mca/btl/usnic/btl_usnic_map.c
+++ b/opal/mca/btl/usnic/btl_usnic_map.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -245,7 +246,7 @@ void opal_btl_usnic_connectivity_map(void)
 
     fp = fopen(filename, "w");
     if (NULL == fp) {
-        char dirname[PATH_MAX];
+        char dirname[OPAL_PATH_MAX];
         getcwd(dirname, sizeof(dirname));
         dirname[sizeof(dirname) - 1] = '\0';
         opal_show_help("help-mpi-btl-usnic.txt", "cannot write to map file", true,

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -8,6 +8,7 @@
  *                         reserved.
  * Copyright (c) 2022      Google, LLC. All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -182,8 +183,8 @@ OPAL_DECLSPEC void opal_common_ucx_mca_deregister(void)
 #if HAVE_DECL_OPEN_MEMSTREAM
 static bool opal_common_ucx_check_device(const char *device_name, char **device_list)
 {
-    char sysfs_driver_link[PATH_MAX];
-    char driver_path[PATH_MAX];
+    char sysfs_driver_link[OPAL_PATH_MAX];
+    char driver_path[OPAL_PATH_MAX];
     char ib_device_name[NAME_MAX];
     char *driver_name;
     char **list_item;

--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -165,8 +166,8 @@ static int _check_pathname(uint64_t inode, const char *pathname)
 {
     static const char *proc_self_exe = "/proc/self/exe";
     static int warned = 0;
-    char exe_path[PATH_MAX];
-    char module_path[PATH_MAX];
+    char exe_path[OPAL_PATH_MAX];
+    char module_path[OPAL_PATH_MAX];
     char *path;
 
     if (0 == inode) {


### PR DESCRIPTION
Thanks @eschnett  for reporting the 3 issues related to gcc13.

I am not entirely convinced the root cause is on OMPI side. It seems to me that some versions of gcc13.2 fail to define critical POSIX constants/defines (IOV_MAX, PATH_MAX and SSIZE_MAX) as well as their minimal values. Digging a little around it seems gcc13.2 (at least the MacPort variant) fails to use the OSX system headers to get these constants, aka. basically missing an #include_next on limits.h (this #include_next existed in gcc12).

Anyway, until we figure out the real solution I need to be able to compile on my laptop with gcc13.

Fixes #12108 
Fixes #12109
Fixes #12110 