### PR TITLE
v5.0.x: docs: update static application build docs

### DIFF
--- a/docs/building-apps/building-static-apps.rst
+++ b/docs/building-apps/building-static-apps.rst
@@ -83,15 +83,14 @@ sub-optimal:
 
    In other words: *using dynamic linking saves memory.*
 
-#. If you disable Open MPI's ``dlopen`` functionality (which is
-   necessary to create *fully*-static MPI applications), you lose the
-   following:
+#. *Fully*-static applications are not linked to the dynamic linking library,
+   e.g. ``libdl`` on Linux, which provides ``dlopen(3)``, ``dlsym(3)``, etc.
+   This will break Open MPI functionalities that depend on such interfaces.
 
-   * CUDA, because |mdash| among other reasons |mdash| the CUDA
-     library is dynamically loaded at run-time via ``dlopen(3)``.
-
-   * Memory manager functionality, which is important for OS-bypass
-     networks such as InfiniBand.
+   .. warning:: Open MPI's memory management functionality, which provides
+                important performance optimizations on OS-bypass networks
+                such as InfiniBand, requires the ``dlsym(3)`` interface,
+                and therefore does not work with fully-static applications.
 
 Are you convinced yet?  *Please try to avoid building fully-static MPI
 applications if at all possible.*

--- a/docs/installing-open-mpi/configure-cli-options/misc.rst
+++ b/docs/installing-open-mpi/configure-cli-options/misc.rst
@@ -13,8 +13,10 @@ above categories that can be used with ``configure``:
   is not *necessary* for OpenFabrics networks, but some performance
   loss may be observed without it).
 
-  However, it may be necessary to disable the memory manager in order
-  to build Open MPI statically.
+  .. warning:: Open MPI's memory management functionality, which provides
+               important performance optimizations on OS-bypass networks
+               such as InfiniBand, requires the ``dlsym(3)`` interface,
+               and therefore does not work with fully-static applications.
 
 * ``--with-ft=TYPE``:
   Specify the type of fault tolerance to enable.  The only allowed


### PR DESCRIPTION
In 5.0+ CUDA is only linked to accelerator components which can be built as DSO or statically linked to ompi.
Therefore fully static build CAN have CUDA support.

Also add explanation for why memory manager does not work with fully-static applications.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit 2d1db897bbc5bcd2c855582f973a0707b2d33256)

This is the v5.0.x PR corresponding to main PR #12095