### PR TITLE
v5.0.x: 4.1.x news: trivial update

### DIFF
--- a/docs/news/news-v4.1.x.rst
+++ b/docs/news/news-v4.1.x.rst
@@ -44,8 +44,11 @@ Open MPI version 4.1.5
 - Update embedded OpenPMIx to version 3.2.4
 - Fix issue building with ``ifort`` on MacOS.
 - Backport patches to Libevent for CVE-2016-10195, CVE-2016-10196, and
-  CVE-2016-10197.  Note that Open MPI's internal libevent does not
-  use the impacted portions of the Libevent code base.
+  CVE-2016-10197.
+
+  .. note:: Open MPI's internal libevent does not use the impacted
+            portions of the Libevent code base.
+
 - SHMEM improvements:
 
   - Fix initializer bugs in SHMEM interface.


### PR DESCRIPTION
Similar to our security update about PMIx, make the security update about libevent be an RST ".. note::" to make it stand out a little more in the rendered HTML.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 8edb4cedccb037c7cfb5f3b39eece9e690912d03)

This is the v5.0.x PR corresponding to main PR #12114