### PR TITLE
v5.0.x: Fix a bunch of compiler warnings

### DIFF
--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -6,6 +6,7 @@
  *                         reserved.
  *
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -441,10 +442,13 @@ bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remot
 
 int ompi_comm_set_rank_failed(ompi_communicator_t *comm, int peer_id, bool remote)
 {
-    /* populate the proc in the comm's group array so that it is not a sentinel and can be read as failed */
+#if OPAL_ENABLE_DEBUG
+    /* populate the proc in the comm's group array so that it is not a
+       sentinel and can be read as failed */
     ompi_proc_t *ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
                                                      peer_id, true);
     assert(NULL != ompi_proc);
+#endif
 
     /* Disable ANY_SOURCE */
     comm->any_source_enabled = false;

--- a/ompi/communicator/ft/comm_ft_detector.c
+++ b/ompi/communicator/ft/comm_ft_detector.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
  *
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -579,7 +580,7 @@ static void fd_event_cb(int fd, short flags, void* pdetector)
 }
 
 void* fd_progress(opal_object_t* obj) {
-    int ret;
+    int __opal_attribute_unused__ ret;
     MPI_Request req;
     if( OMPI_SUCCESS != ompi_comm_start_detector(&ompi_mpi_comm_world.comm)) {
         OPAL_THREAD_ADD_FETCH32(&fd_thread_active, -1);

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -663,7 +664,6 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
             con->next_recv_segs[i] = min - 1;
         }
 
-        int num_recvs = 0;
         for (int32_t seg_index = 0; seg_index < min; seg_index++)
         {
             /* For each child */
@@ -711,8 +711,6 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
                 }
                 /* Set the recv callback */
                 ompi_request_set_callback(recv_req, recv_cb, context);
-
-                ++num_recvs;
             }
         }
     }

--- a/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2018      Siberian State University of Telecommunications
  *                         and Information Sciences. All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -245,7 +246,6 @@ ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
     int is_commutative = ompi_op_is_commute(op);
 
     /* Recursive distance doubling */
-    int rdoubling_step = 0;
     for (int mask = 1; mask < comm_size; mask <<= 1) {
         int remote = rank ^ mask;
         int cur_tree_root = ompi_rounddown(rank, mask);
@@ -350,7 +350,6 @@ ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
                 if (MPI_SUCCESS != err) { goto cleanup_and_return; }
             }
         }
-        rdoubling_step++;
         err = ompi_datatype_destroy(&dtypesend);
         if (MPI_SUCCESS != err) { goto cleanup_and_return; }
         err = ompi_datatype_destroy(&dtyperecv);

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -398,7 +399,7 @@ int ompi_coll_base_file_getnext_long(FILE *fptr, int *fileline, long* val)
 
 int ompi_coll_base_file_getnext_string(FILE *fptr, int *fileline, char** val)
 {
-    char trash, token[32];
+    char trash, token[33];
     int rc;
 
     *val = NULL;  /* security in case we fail */

--- a/ompi/mca/coll/inter/coll_inter_allreduce.c
+++ b/ompi/mca/coll/inter/coll_inter_allreduce.c
@@ -49,7 +49,8 @@ mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
                                mca_coll_base_module_t *module)
 {
     int err, rank, root = 0;
-    char *tmpbuf = NULL, *pml_buffer = NULL, *source;
+    char *tmpbuf = NULL, *pml_buffer = NULL;
+    const char *source;
     ptrdiff_t gap, span;
 
     rank = ompi_comm_rank(comm);

--- a/ompi/mca/coll/inter/coll_inter_allreduce.c
+++ b/ompi/mca/coll/inter/coll_inter_allreduce.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mca/coll/libnbc/libdict/dict.c
+++ b/ompi/mca/coll/libnbc/libdict/dict.c
@@ -16,34 +16,6 @@
 dict_malloc_func ompi_coll_libnbc_dict_malloc = malloc;
 dict_free_func ompi_coll_libnbc_dict_free = free;
 
-static inline dict_malloc_func
-dict_set_malloc(dict_malloc_func func)
-{
-	dict_malloc_func old = ompi_coll_libnbc_dict_malloc;
-	ompi_coll_libnbc_dict_malloc = func ? func : malloc;
-	return old;
-}
-
-static inline dict_free_func
-dict_set_free(dict_free_func func)
-{
-	dict_free_func old = ompi_coll_libnbc_dict_free;
-	ompi_coll_libnbc_dict_free = func ? func : free;
-	return old;
-}
-
-/*
- * In comparing, we cannot simply subtract because that might result in signed
- * overflow.
- */
-static inline int
-dict_int_cmp(const void *k1, const void *k2)
-{
-	const int *a = (int*)k1, *b = (int*)k2;
-
-	return (*a < *b) ? -1 : (*a > *b) ? +1 : 0;
-}
-
 int
 ompi_coll_libnbc_dict_uint_cmp(const void *k1, const void *k2)
 {

--- a/ompi/mca/coll/libnbc/libdict/hb_tree.c
+++ b/ompi/mca/coll/libnbc/libdict/hb_tree.c
@@ -53,30 +53,6 @@ static hb_node *node_max __P((hb_node *node));
 static hb_node *node_next __P((hb_node *node));
 static hb_node *node_prev __P((hb_node *node));
 
-static dict *hb_dict_new __P((dict_cmp_func key_cmp, dict_del_func key_del,
-                                                  dict_del_func dat_del));
-static dict_itor *hb_dict_itor_new __P((hb_tree *tree));
-static void hb_itor_invalidate __P((hb_itor *itor));
-static int hb_itor_first __P((hb_itor *itor));
-static void *hb_itor_data __P((hb_itor *itor));
-static const void *hb_itor_cdata __P((const hb_itor *itor));
-static int hb_itor_last __P((hb_itor *itor));
-static int hb_itor_nextn __P((hb_itor *itor, unsigned count));
-static int hb_itor_prev __P((hb_itor *itor));
-static int hb_itor_prevn __P((hb_itor *itor, unsigned count));
-static int hb_itor_search __P((hb_itor *itor, const void *key));
-static int hb_itor_set_data __P((hb_itor *itor, void *dat, int del));
-static unsigned hb_tree_count __P((const hb_tree *tree));
-static void hb_tree_destroy __P((hb_tree *tree, int del));
-static void hb_tree_empty __P((hb_tree *tree, int del));
-static unsigned hb_tree_height __P((const hb_tree *tree));
-static const void *hb_tree_max __P((const hb_tree *tree));
-static unsigned hb_tree_mheight __P((const hb_tree *tree));
-static const void *hb_tree_min __P((const hb_tree *tree));
-static unsigned hb_tree_pathlen __P((const hb_tree *tree));
-static int hb_tree_probe __P((hb_tree *tree, void *key, void **dat));
-static void hb_tree_walk __P((hb_tree *tree, dict_vis_func visit));
-
 hb_tree *
 ompi_coll_libnbc_hb_tree_new(dict_cmp_func key_cmp, dict_del_func key_del,
 			dict_del_func dat_del)

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,8 +70,10 @@ int ompi_coll_tuned_read_rules_config_file (char *fname, ompi_coll_alg_rule_t** 
 
     /* stats info */
     int total_alg_count = 0;
+#if OPAL_ENABLE_DEBUG
     int total_com_count = 0;
     int total_msg_count = 0;
+#endif
 
     if (!fname) {
         OPAL_OUTPUT((ompi_coll_tuned_stream,"Gave NULL as rule table configuration file for tuned collectives... ignoring!\n"));
@@ -203,11 +206,15 @@ int ompi_coll_tuned_read_rules_config_file (char *fname, ompi_coll_alg_rule_t** 
                     goto on_file_error;
                 }
 
+#if OPAL_ENABLE_DEBUG
                 total_msg_count++;
+#endif
 
             } /* msg size */
 
+#if OPAL_ENABLE_DEBUG
             total_com_count++;
+#endif
 
         } /* comm size */
 

--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -195,16 +196,13 @@ int  mca_common_ompio_forced_grouping ( ompio_file_t *fh,
     int rest = fh->f_size % num_groups;
     int flag = OMPI_COMM_IS_MAPBY_NODE (&ompi_mpi_comm_world.comm);
     int k=0, p=0, g=0;
-    int total_procs = 0; 
 
     for ( k=0, p=0; p<num_groups; p++ ) {
         if ( p < rest ) {
             contg_groups[p].procs_per_contg_group = group_size+1;
-            total_procs +=(group_size+1);
         }
         else {
             contg_groups[p].procs_per_contg_group = group_size;
-            total_procs +=group_size;
         }
 
         if ( flag ) {
@@ -1269,9 +1267,6 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
     int i = 0;
     int j = 0;
     int k = 0;
-    int merge_count = 0;
-    int split_count = 0; //not req?
-    int retain_as_is_count = 0; //not req?
     int ret=OMPI_SUCCESS;
 
     //Store start offset and length in an array //also add bytes per process
@@ -1367,16 +1362,13 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
        if((size_t)(aggr_bytes_per_group_tmp[i])>
           (size_t)OMPIO_MCA_GET(fh, bytes_per_agg)){
           decision_list_tmp[i] = OMPIO_SPLIT;
-          split_count++;
        }
        else if((size_t)(aggr_bytes_per_group_tmp[i])<
                (size_t)OMPIO_MCA_GET(fh, bytes_per_agg)){
             decision_list_tmp[i] = OMPIO_MERGE;
-            merge_count++;
        }
        else{
 	   decision_list_tmp[i] = OMPIO_RETAIN;
-	   retain_as_is_count++;
 	   }
     }
 

--- a/ompi/mca/common/ompio/common_ompio_file_read_all.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2022 University of Houston. All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,7 +86,6 @@ mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
     int **blocklen_per_process=NULL;
     MPI_Aint **displs_per_process=NULL;
     char *global_buf = NULL;
-    MPI_Aint global_count = 0;
     mca_io_ompio_local_io_array *file_offsets_for_agg=NULL;
 
     /* array that contains the sorted indices of the global_iov */
@@ -607,13 +607,11 @@ mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
                 }
                 /*Moving file offsets to an IO array!*/
                 temp_index = 0;
-                global_count = 0;
                 for (i=0;i<fh->f_procs_per_group; i++){
                     for(j=0;j<disp_index[i];j++){
                         if (blocklen_per_process[i][j] > 0){
                             file_offsets_for_agg[temp_index].length =
                                 blocklen_per_process[i][j];
-                            global_count += blocklen_per_process[i][j];
                             file_offsets_for_agg[temp_index].process_id = i;
                             file_offsets_for_agg[temp_index].offset =
                                 displs_per_process[i][j];

--- a/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -221,11 +222,11 @@ ssize_t mca_fbtl_posix_preadv_datasieving (ompio_file_t *fh, struct flock *lock,
         size_t start_offset = (size_t) fh->f_io_array[startindex].offset;
         for ( i = startindex ; i < endindex ; i++) {
             pos = (size_t) fh->f_io_array[i].offset - start_offset;
-            if ( (ssize_t) pos > total_bytes ) {
+            if ( pos > total_bytes ) {
                 break;
             }
             num_bytes = fh->f_io_array[i].length;
-            if ( ((ssize_t) pos + (ssize_t)num_bytes) > total_bytes ) {
+            if ( (pos + (size_t)num_bytes) > total_bytes ) {
                 num_bytes = total_bytes - (ssize_t)pos;
             }
             

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,8 +87,9 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     int current_index = 0, temp_index=0;
 
     char *global_buf = NULL;
+#if DEBUG_ON
     MPI_Aint global_count = 0;
-
+#endif
 
     /* array that contains the sorted indices of the global_iov */
     int *sorted = NULL, *sorted_file_offsets=NULL;
@@ -713,7 +715,9 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
             }
 
             /*Now update the displacements array  with memory offsets*/
+#if DEBUG_ON
             global_count = 0;
+#endif
             for (i=0;i<entries_per_aggregator;i++){
                 temp_pindex =
                     file_offsets_for_agg[sorted_file_offsets[i]].process_id;
@@ -726,8 +730,10 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                            temp_pindex, temp_disp_index[temp_pindex],
                            temp_pindex, disp_index[temp_pindex]);
                 }
+#if DEBUG_ON
                 global_count +=
                     file_offsets_for_agg[sorted_file_offsets[i]].length;
+#endif
             }
 
             if (NULL != temp_disp_index){

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -788,7 +789,9 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
     int temp_index=0;
     MPI_Aint *memory_displacements=NULL;
     int *temp_disp_index=NULL;
+#if DEBUG_ON
     MPI_Aint global_count = 0;
+#endif
     int* blocklength_proc=NULL;
     ptrdiff_t* displs_proc=NULL;
 
@@ -1085,7 +1088,9 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
             }
             
             /*Now update the displacements array  with memory offsets*/
+#if DEBUG_ON
             global_count = 0;
+#endif
             for (i=0;i<entries_per_aggregator;i++){
                 temp_pindex =
                     file_offsets_for_agg[sorted_file_offsets[i]].process_id;
@@ -1098,8 +1103,10 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
                            temp_pindex, temp_disp_index[temp_pindex],
                            temp_pindex, data->disp_index[temp_pindex]);
                 }
+#if DEBUG_ON
                 global_count +=
                     file_offsets_for_agg[sorted_file_offsets[i]].length;
+#endif
             }
             
             if (NULL != temp_disp_index){

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -812,7 +813,9 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
     int temp_index=0;
     MPI_Aint *memory_displacements=NULL;
     int *temp_disp_index=NULL;
+#if DEBUG_ON
     MPI_Aint global_count = 0;
+#endif
     int* blocklength_proc=NULL;
     ptrdiff_t* displs_proc=NULL;
 
@@ -1112,7 +1115,9 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
             }
             
             /*Now update the displacements array  with memory offsets*/
+#if DEBUG_ON
             global_count = 0;
+#endif
             for (i=0;i<entries_per_aggregator;i++){
                 temp_pindex =
                     file_offsets_for_agg[sorted_file_offsets[i]].process_id;
@@ -1125,8 +1130,10 @@ static int shuffle_init ( int index, int cycles, int aggregator, int rank, mca_i
                            temp_pindex, temp_disp_index[temp_pindex],
                            temp_pindex, data->disp_index[temp_pindex]);
                 }
+#if DEBUG_ON
                 global_count +=
                     file_offsets_for_agg[sorted_file_offsets[i]].length;
+#endif
             }
             
             if (NULL != temp_disp_index){

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -18,6 +18,7 @@
  * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -753,7 +754,7 @@ static inline int osc_rdma_accelerator_mem_move(void *dest, const void *src, siz
  * @retval >0                 The buffer belongs to a managed buffer in
  *                            device memory.
  */
-static inline int osc_rdma_is_accel(void *buf)
+static inline int osc_rdma_is_accel(const void *buf)
 {
     int dev_id;
     uint64_t flags;

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -544,7 +545,6 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
     /* needed for opal_convertor_raw but not used */
     size_t source_size, target_size;
     ompi_osc_rdma_request_t *subreq;
-    size_t result_position;
     ptrdiff_t lb, extent;
     int ret, acc_len;
     bool done;
@@ -667,7 +667,6 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
     target_iov_index = 0;
     target_iov_count = 0;
     source_iov_index = 0;
-    result_position = 0;
     subreq = NULL;
 
     do {
@@ -729,8 +728,6 @@ static inline int ompi_osc_rdma_gacc_master (ompi_osc_rdma_sync_t *sync, const v
             target_iovec[target_iov_index].iov_len -= acc_len;
             target_iovec[target_iov_index].iov_base = (void *)((intptr_t) target_iovec[target_iov_index].iov_base + acc_len);
             target_iov_index += (0 == target_iovec[target_iov_index].iov_len);
-
-            result_position += acc_len;
 
             if (source_datatype) {
                 source_iov_index += (0 == source_iovec[source_iov_index].iov_len);

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -294,11 +294,11 @@ static int ompi_osc_rdma_fetch_and_op_cas (ompi_osc_rdma_sync_t *sync, const voi
                 return ret;
             }
 	} else if (&ompi_mpi_op_no_op.op != op) {
-            ret = osc_rdma_is_accel(origin_addr + dt->super.true_lb);
+            ret = osc_rdma_is_accel(((const char*) origin_addr) + dt->super.true_lb);
             if (0 < ret) {
                 tmp_origin = malloc(dt->super.size);
                 ret = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
-                                                tmp_origin, origin_addr + dt->super.true_lb, dt->super.size, MCA_ACCELERATOR_TRANSFER_DTOH);
+                                                tmp_origin, ((const char*) origin_addr) + dt->super.true_lb, dt->super.size, MCA_ACCELERATOR_TRANSFER_DTOH);
                 ompi_op_reduce (op, (void *) tmp_origin, (void*)((ptrdiff_t) &new_value + offset), 1, dt);
                 free(tmp_origin);
             } else if (0 == ret) {

--- a/ompi/mca/pml/cm/pml_cm_component.c
+++ b/ompi/mca/pml/cm/pml_cm_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,18 +64,6 @@ mca_pml_base_component_2_1_0_t mca_pml_cm_component = {
     .pmlm_init = mca_pml_cm_component_init,
     .pmlm_finalize = mca_pml_cm_component_fini,
 };
-
-/* Array of send completion callback - one per send type
- * These are called internally by the library when the send
- * is completed from its perspective.
- */
-static void (*send_completion_callbacks[MCA_PML_BASE_SEND_SIZE])
-    (struct mca_mtl_request_t *mtl_request) =
-  { mca_pml_cm_send_request_completion,
-    mca_pml_cm_send_request_completion,
-    mca_pml_cm_send_request_completion,
-    mca_pml_cm_send_request_completion,
-    mca_pml_cm_send_request_completion } ;
 
 static int
 mca_pml_cm_component_register(void)

--- a/ompi/mpi/c/info_f2c.c
+++ b/ompi/mpi/c/info_f2c.c
@@ -15,6 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +38,7 @@
 #define MPI_Info_f2c PMPI_Info_f2c
 #endif
 
-static const char FUNC_NAME[] = "MPI_Info_f2c";
+static const char FUNC_NAME[] __opal_attribute_unused__ = "MPI_Info_f2c";
 
 
 /**

--- a/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,7 +87,7 @@ void ompi_comm_spawn_multiple_f(MPI_Fint *count, char *array_commands,
     int *c_errs;
     char **c_array_commands;
     char ***c_array_argv;
-    int maxprocs;
+    int __opal_attribute_unused__ maxprocs;
     OMPI_ARRAY_NAME_DECL(array_maxprocs);
     OMPI_ARRAY_NAME_DECL(array_errcds);
 

--- a/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
@@ -9,6 +9,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,7 +73,8 @@ void ompi_dist_graph_create_f(MPI_Fint *comm_old, MPI_Fint *n, MPI_Fint *sources
                               MPI_Fint *ierr)
 {
     MPI_Comm c_comm_old, c_comm_graph;
-    int count = 0, i;
+    int __opal_attribute_unused__ count = 0;
+    int i;
     MPI_Info c_info;
     int *c_weights;
     int c_ierr;

--- a/ompi/patterns/net/netpatterns_nary_tree.c
+++ b/ompi/patterns/net/netpatterns_nary_tree.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +38,7 @@ int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_node
         netpatterns_tree_node_t *my_node)
 {
     /* local variables */
-    int n_levels, result;
+    int result;
     int my_level_in_tree, cnt;
     int lvl,cum_cnt, my_rank_in_my_level,n_lvls_in_tree;
     int start_index,end_index;
@@ -51,11 +52,9 @@ int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_node
     my_node->tree_size=num_nodes;
 
     /* figure out number of levels in tree */
-    n_levels=0;
     result=num_nodes-1;
     while (0 < result ) {
         result/=tree_order;
-        n_levels++;
     };
 
     /* figure out who my children and parents are */
@@ -177,7 +176,7 @@ int ompi_netpatterns_setup_narray_knomial_tree(
         netpatterns_narray_knomial_tree_node_t *my_node)
 {
     /* local variables */
-    int n_levels, result;
+    int result;
     int my_level_in_tree, cnt ;
     int lvl,cum_cnt, my_rank_in_my_level,n_lvls_in_tree;
     int start_index,end_index;
@@ -192,11 +191,9 @@ int ompi_netpatterns_setup_narray_knomial_tree(
     my_node->tree_size=num_nodes;
 
     /* figure out number of levels in tree */
-    n_levels=0;
     result=num_nodes-1;
     while (0 < result ) {
         result/=tree_order;
-        n_levels++;
     };
 
     /* figure out who my children and parents are */

--- a/opal/datatype/opal_datatype_get_count.c
+++ b/opal/datatype/opal_datatype_get_count.c
@@ -4,6 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,7 +169,10 @@ int opal_datatype_compute_ptypes(opal_datatype_t *datatype)
 {
     dt_stack_t *pStack; /* pointer to the position on the stack */
     uint32_t pos_desc;  /* actual position in the description of the derived datatype */
-    ssize_t nbElems = 0, stack_pos = 0;
+    ssize_t stack_pos = 0;
+#if defined(VERBOSE)
+    ssize_t nbElems = 0;
+#endif
     dt_elem_desc_t *pElems;
 
     if (NULL != datatype->ptypes) {
@@ -213,12 +217,14 @@ int opal_datatype_compute_ptypes(opal_datatype_t *datatype)
             datatype->ptypes[pElems[pos_desc].elem.common.type] += (size_t) pElems[pos_desc]
                                                                        .elem.count
                                                                    * pElems[pos_desc].elem.blocklen;
+#if defined(VERBOSE)
             nbElems += (size_t) pElems[pos_desc].elem.count * pElems[pos_desc].elem.blocklen;
 
             DUMP("  compute_ptypes-add: type %d count %" PRIsize_t " (total type %u total %lld)\n",
                  pElems[pos_desc].elem.common.type,
                  datatype->ptypes[pElems[pos_desc].elem.common.type], pElems[pos_desc].elem.count,
                  nbElems);
+#endif
             pos_desc++; /* advance to the next data */
         }
     }

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,7 +73,8 @@ int32_t opal_unpack_homogeneous_contig_function(opal_convertor_t *pConv, struct 
 {
     const opal_datatype_t *pData = pConv->pDesc;
     unsigned char *user_memory, *packed_buffer;
-    uint32_t iov_idx, i;
+    uint32_t iov_idx;
+    uint32_t __opal_attribute_unused__ i;
     size_t remaining, initial_bytes_converted = pConv->bConverted;
     dt_stack_t *stack = pConv->pStack;
     ptrdiff_t extent = pData->ub - pData->lb;

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
  *                         Laboratory, ICS Forth. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1547,7 +1548,7 @@ int mca_base_var_register(const char *project_name, const char *framework_name,
     }
 
     OPAL_LIST_FOREACH_DECL(alias_item, &alias->component_aliases, mca_base_alias_item_t) {
-        mca_base_var_syn_flag_t flags_derived = flags;
+        mca_base_var_syn_flag_t flags_derived = 0;
         if (alias_item->alias_flags & MCA_BASE_ALIAS_FLAG_DEPRECATED) {
             flags_derived = MCA_BASE_VAR_SYN_FLAG_DEPRECATED;
         }

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -19,6 +19,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
  *                         Laboratory, ICS Forth. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -459,6 +460,7 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
+#if OPAL_ENABLE_DEBUG
     int all_flags = 0;
     for (i = 0; i < new_enum->super.enum_value_count; ++i) {
         new_enum->enum_flags[i].flag = flags[i].flag;
@@ -472,6 +474,7 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
         assert(flags[i].flag);
         all_flags |= flags[i].flag;
     }
+#endif
 
     *enumerator = new_enum;
 

--- a/opal/mca/btl/template/btl_template_component.c
+++ b/opal/mca/btl/template/btl_template_component.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -143,7 +144,7 @@ mca_btl_base_module_t **mca_btl_template_component_init(int *num_btl_modules,
  *  TEMPLATE component progress.
  */
 
-int mca_btl_template_component_progress()
+int mca_btl_template_component_progress(void)
 {
     return 0;
 }

--- a/opal/mca/patcher/base/patcher_base_patch.c
+++ b/opal/mca/patcher/base/patcher_base_patch.c
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -84,7 +85,7 @@ static int PatchLoadImm(uintptr_t addr, unsigned int reg, size_t value)
 
 #endif
 
-#if !HAVE___CLEAR_CACHE
+#if !defined(HAVE___CLEAR_CACHE)
 static void flush_and_invalidate_cache(unsigned long a)
 {
 #    if defined(PLATFORM_ARCH_X86)
@@ -149,7 +150,7 @@ static inline void apply_patch(unsigned char *patch_data, uintptr_t address, siz
 {
     ModifyMemoryProtection(address, data_size, PROT_EXEC | PROT_READ | PROT_WRITE);
     memcpy((void *) address, patch_data, data_size);
-#if HAVE___CLEAR_CACHE
+#if defined(HAVE___CLEAR_CACHE)
     /* do not allow global declaration of compiler intrinsic */
     void __clear_cache(void *beg, void *end);
 

--- a/opal/mca/timer/base/timer_base_open.c
+++ b/opal/mca/timer/base/timer_base_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,8 +58,6 @@ static int opal_timer_base_open(mca_base_open_flag_t flags)
 
 static int opal_timer_base_close(void)
 {
-    int ret;
-
     OPAL_TIMING_DISABLE_NATIVE_TIMERS;
 
     return OPAL_SUCCESS;

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
  *                         Laboratory, ICS Forth. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -842,12 +843,12 @@ void opal_info_show_mca_params(const char *type, const char *component,
     }
 }
 
-void opal_info_do_arch()
+void opal_info_do_arch(void)
 {
     opal_info_out("Configured architecture", "config:arch", OPAL_ARCH);
 }
 
-void opal_info_do_hostname()
+void opal_info_do_hostname(void)
 {
     opal_info_out("Configure host", "config:host", OPAL_CONFIGURE_HOST);
 }

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,8 +61,6 @@ static void opal_deregister_params(void)
 
 int opal_register_params(void)
 {
-    int ret;
-
     if (opal_register_done) {
         return OPAL_SUCCESS;
     }
@@ -70,15 +69,20 @@ int opal_register_params(void)
 
 #if defined(HAVE_SCHED_YIELD)
     opal_progress_yield_when_idle = false;
-    ret = mca_base_var_register("opal", "opal", "progress", "yield_when_idle",
+    int ret1;
+    ret1 = mca_base_var_register("opal", "opal", "progress", "yield_when_idle",
                                 "Yield the processor when waiting on progress",
                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                 OPAL_INFO_LVL_8, MCA_BASE_VAR_SCOPE_LOCAL,
                                 &opal_progress_yield_when_idle);
+    if (ret1 < 0) {
+        return ret1;
+    }
 #endif
 
 #if OPAL_ENABLE_DEBUG
     opal_progress_debug = false;
+    int ret;
     ret = mca_base_var_register("opal", "opal", "progress", "debug",
                                 "Set to non-zero to debug progress engine features",
                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,


### PR DESCRIPTION
See individual commit messages for details.

This is the v5.0.x PR corresponding to main PR #12129 -- **with one exception.**

The last commit on this PR, "libdict/hb_tree.c: remove dead code" is not a cherry-pick from main because this warning fix is somehow not relevant to main.  I.e., some prior commit must have happened on main to fix this, and then was not cherry-picked.  Since it's a straight removal of code, it's a little difficult to track down where this happened and how it wasn't previously cherry-picked.  So I just made this one unique fix here on the v5.0.x branch that is not a cherry pick.  All the others are cherry-picked from main PR #12129.

bot:notacherrypick