### PR TITLE
opal/mca: fix ompi_info segfault due to empty enumerator

### DIFF
--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -434,6 +434,7 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
 {
     mca_base_var_enum_flag_t *new_enum;
     int i;
+    int __opal_attribute_unused__ all_flags = 0;
 
     *enumerator = NULL;
 
@@ -460,8 +461,6 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-#if OPAL_ENABLE_DEBUG
-    int all_flags = 0;
     for (i = 0; i < new_enum->super.enum_value_count; ++i) {
         new_enum->enum_flags[i].flag = flags[i].flag;
         new_enum->enum_flags[i].string = strdup(flags[i].string);
@@ -474,7 +473,6 @@ int mca_base_var_enum_create_flag(const char *name, const mca_base_var_enum_valu
         assert(flags[i].flag);
         all_flags |= flags[i].flag;
     }
-#endif
 
     *enumerator = new_enum;
 


### PR DESCRIPTION
This patch fixes a segfault that the enumerator variable is not assigned in mca_base_var_enum_create_flag, leaving it as NULL. This causes invalid memory access later when it is iterated over.

FYI after removing the `if` guard I don't see new compiler warnings.

The patch needs to be backported to v5.0.x