### PR TITLE
opal/accelerator: introduce accelerator ipc APIs and implement stubs

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -41,6 +41,16 @@ static int accelerator_cuda_mem_release(int dev_id, void *ptr);
 static int accelerator_cuda_get_address_range(int dev_id, const void *ptr, void **base,
                                               size_t *size);
 
+static bool accelerator_cuda_is_ipc_enabled(void);
+static int accelerator_cuda_get_ipc_handle(int dev_id, void *dev_ptr,
+                                           opal_accelerator_ipc_handle_t *handle);
+static int accelerator_cuda_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                            void **dev_ptr);
+static int accelerator_cuda_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                 opal_accelerator_ipc_event_handle_t *handle);
+static int accelerator_cuda_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                  opal_accelerator_event_t *event);
+
 static int accelerator_cuda_host_register(int dev_id, void *ptr, size_t size);
 static int accelerator_cuda_host_unregister(int dev_id, void *ptr);
 
@@ -66,6 +76,12 @@ opal_accelerator_base_module_t opal_accelerator_cuda_module =
     accelerator_cuda_mem_alloc,
     accelerator_cuda_mem_release,
     accelerator_cuda_get_address_range,
+
+    accelerator_cuda_is_ipc_enabled,
+    accelerator_cuda_get_ipc_handle,
+    accelerator_cuda_open_ipc_handle,
+    accelerator_cuda_get_ipc_event_handle,
+    accelerator_cuda_open_ipc_event_handle,
 
     accelerator_cuda_host_register,
     accelerator_cuda_host_unregister,
@@ -518,6 +534,35 @@ static int accelerator_cuda_get_address_range(int dev_id, const void *ptr, void 
                             ptr, *(char **) base, *size);
     }
     return 0;
+}
+
+static bool accelerator_cuda_is_ipc_enabled(void)
+{
+    return false;
+}
+
+static int accelerator_cuda_get_ipc_handle(int dev_id, void *dev_ptr,
+                                           opal_accelerator_ipc_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_cuda_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                            void **dev_ptr)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_cuda_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                 opal_accelerator_ipc_event_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_cuda_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                  opal_accelerator_event_t *event)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 static int accelerator_cuda_host_register(int dev_id, void *ptr, size_t size)

--- a/opal/mca/accelerator/null/accelerator_null_component.c
+++ b/opal/mca/accelerator/null/accelerator_null_component.c
@@ -55,6 +55,16 @@ static int accelerator_null_mem_alloc(int dev_id, void **ptr, size_t size);
 static int accelerator_null_mem_release(int dev_id, void *ptr);
 static int accelerator_null_get_address_range(int dev_id, const void *ptr, void **base, size_t *size);
 
+static bool accelerator_null_is_ipc_enabled(void);
+static int accelerator_null_get_ipc_handle(int dev_id, void *dev_ptr,
+                                           opal_accelerator_ipc_handle_t *handle);
+static int accelerator_null_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                            void **dev_ptr);
+static int accelerator_null_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                 opal_accelerator_ipc_event_handle_t *handle);
+static int accelerator_null_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                  opal_accelerator_event_t *event);
+
 static int accelerator_null_host_register(int dev_id, void *ptr, size_t size);
 static int accelerator_null_host_unregister(int dev_id, void *ptr);
 
@@ -118,6 +128,12 @@ opal_accelerator_base_module_t opal_accelerator_null_module =
     accelerator_null_mem_alloc,
     accelerator_null_mem_release,
     accelerator_null_get_address_range,
+
+    accelerator_null_is_ipc_enabled,
+    accelerator_null_get_ipc_handle,
+    accelerator_null_open_ipc_handle,
+    accelerator_null_get_ipc_event_handle,
+    accelerator_null_open_ipc_event_handle,
 
     accelerator_null_host_register,
     accelerator_null_host_unregister,
@@ -218,6 +234,35 @@ static int accelerator_null_mem_release(int dev_id, void *ptr)
 
 static int accelerator_null_get_address_range(int dev_id, const void *ptr, void **base,
                                               size_t *size)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static bool accelerator_null_is_ipc_enabled(void)
+{
+    return false;
+}
+
+static int accelerator_null_get_ipc_handle(int dev_id, void *dev_ptr,
+                                           opal_accelerator_ipc_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_null_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                            void **dev_ptr)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_null_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                 opal_accelerator_ipc_event_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_null_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                  opal_accelerator_event_t *event)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -33,6 +33,16 @@ static int mca_accelerator_rocm_mem_release(int dev_id, void *ptr);
 static int mca_accelerator_rocm_get_address_range(int dev_id, const void *ptr, void **base,
                                                   size_t *size);
 
+static bool mca_accelerator_rocm_is_ipc_enabled(void);
+static int mca_accelerator_rocm_get_ipc_handle(int dev_id, void *dev_ptr,
+                                               opal_accelerator_ipc_handle_t *handle);
+static int mca_accelerator_rocm_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                                void **dev_ptr);
+static int mca_accelerator_rocm_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                     opal_accelerator_ipc_event_handle_t *handle);
+static int mca_accelerator_rocm_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                      opal_accelerator_event_t *event);
+
 static int mca_accelerator_rocm_host_register(int dev_id, void *ptr, size_t size);
 static int mca_accelerator_rocm_host_unregister(int dev_id, void *ptr);
 
@@ -58,6 +68,12 @@ opal_accelerator_base_module_t opal_accelerator_rocm_module =
     mca_accelerator_rocm_mem_alloc,
     mca_accelerator_rocm_mem_release,
     mca_accelerator_rocm_get_address_range,
+
+    mca_accelerator_rocm_is_ipc_enabled,
+    mca_accelerator_rocm_get_ipc_handle,
+    mca_accelerator_rocm_open_ipc_handle,
+    mca_accelerator_rocm_get_ipc_event_handle,
+    mca_accelerator_rocm_open_ipc_event_handle,
 
     mca_accelerator_rocm_host_register,
     mca_accelerator_rocm_host_unregister,
@@ -436,6 +452,35 @@ static int mca_accelerator_rocm_get_address_range(int dev_id, const void *ptr, v
     *base = (char *) tBase;
 
     return OPAL_SUCCESS;
+}
+
+static bool mca_accelerator_rocm_is_ipc_enabled(void)
+{
+    return false;
+}
+
+static int mca_accelerator_rocm_get_ipc_handle(int dev_id, void *dev_ptr,
+                                               opal_accelerator_ipc_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_rocm_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                                void **dev_ptr)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_rocm_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                     opal_accelerator_ipc_event_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_rocm_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                      opal_accelerator_event_t *event)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 static int mca_accelerator_rocm_host_register(int dev_id, void *ptr, size_t size)

--- a/opal/mca/accelerator/ze/accelerator_ze_module.c
+++ b/opal/mca/accelerator/ze/accelerator_ze_module.c
@@ -38,6 +38,16 @@ static int mca_accelerator_ze_mem_release(int dev_id, void *ptr);
 static int mca_accelerator_ze_get_address_range(int dev_id, const void *ptr, void **base,
                                                   size_t *size);
 
+static bool mca_accelerator_ze_is_ipc_enabled(void);
+static int mca_accelerator_ze_get_ipc_handle(int dev_id, void *dev_ptr,
+                                             opal_accelerator_ipc_handle_t *handle);
+static int mca_accelerator_ze_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                              void **dev_ptr);
+static int mca_accelerator_ze_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                   opal_accelerator_ipc_event_handle_t *handle);
+static int mca_accelerator_ze_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                    opal_accelerator_event_t *event);
+
 static int mca_accelerator_ze_host_register(int dev_id, void *ptr, size_t size);
 static int mca_accelerator_ze_host_unregister(int dev_id, void *ptr);
 
@@ -64,6 +74,12 @@ opal_accelerator_base_module_t opal_accelerator_ze_module =
     .mem_alloc = mca_accelerator_ze_mem_alloc,
     .mem_release = mca_accelerator_ze_mem_release,
     .get_address_range = mca_accelerator_ze_get_address_range,
+
+    .is_ipc_enabled = mca_accelerator_ze_is_ipc_enabled,
+    .get_ipc_handle = mca_accelerator_ze_get_ipc_handle,
+    .open_ipc_handle = mca_accelerator_ze_open_ipc_handle,
+    .get_ipc_event_handle = mca_accelerator_ze_get_ipc_event_handle,
+    .open_ipc_event_handle = mca_accelerator_ze_open_ipc_event_handle,
 
     .host_register = mca_accelerator_ze_host_register,
     .host_unregister = mca_accelerator_ze_host_unregister,
@@ -569,6 +585,35 @@ static int mca_accelerator_ze_get_address_range(int dev_id, const void *ptr, voi
     *base = (char *) pBase;
 
     return OPAL_SUCCESS;
+}
+
+static bool mca_accelerator_ze_is_ipc_enabled(void)
+{
+    return false;
+}
+
+static int mca_accelerator_ze_get_ipc_handle(int dev_id, void *dev_ptr,
+                                             opal_accelerator_ipc_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_ze_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
+                                              void **dev_ptr)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_ze_get_ipc_event_handle(opal_accelerator_event_t *event,
+                                                   opal_accelerator_ipc_event_handle_t *handle)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int mca_accelerator_ze_open_ipc_event_handle(opal_accelerator_ipc_event_handle_t *handle,
+                                                    opal_accelerator_event_t *event)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 /*


### PR DESCRIPTION
Attempt 2

This time we have dropped the destroy* APIs - I also left out other stream* APIs and only focus on IPC

Ran a simple ring program for testing.