### PR TITLE
Revert "accelerator/cuda: Check for cuda devices"

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda_component.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_component.c
@@ -188,15 +188,7 @@ static opal_accelerator_base_module_t* accelerator_cuda_init(void)
     if (!opal_cuda_support) {
         return NULL;
     }
-    int count = 0;
-    /* If cuInit fails or there are no cuda capable devices, return NULL. */
-    if (cuInit(0)) {
-        return NULL;
-    }
-    CUresult ret = cuDeviceGetCount(&count);
-    if (ret || count == 0) {
-        return NULL;
-    }
+
     opal_accelerator_cuda_delayed_init();
     return &opal_accelerator_cuda_module;
 }


### PR DESCRIPTION
This reverts commit ae98e0453252cbf026dbd784f618d320ef1066fc.

This is a temporary mitigation for https://github.com/open-mpi/ompi/issues/12156