### PR TITLE
Detect devel build in vpath builds

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -36,10 +36,9 @@ opal_show_subtitle "General configuration options"
 
 
 #
-# Is this a developer copy?
+# Is this a developer copy? Check for a known OMPI git hash
 #
-
-if test -d .git; then
+if git describe 43a3f4282055c7116ca618c17a9f27247f4923d2 &> /dev/null ; then
     OPAL_DEVEL=1
 else
     OPAL_DEVEL=0


### PR DESCRIPTION
Use `git describe` on a known OMPI commit sha instead of checking for .git directory. Git will walk up the tree trying to find the git metadata. This enables devel builds in typical vpath builds:

```
$ mkdir build
$ cd build
$ ../configure ...
```

