### PR TITLE
coll/tuned: Change the allreduce default collective algorithm selection

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned.h
+++ b/ompi/mca/coll/tuned/coll_tuned.h
@@ -113,6 +113,7 @@ int ompi_coll_tuned_allgatherv_intra_check_forced_init(coll_tuned_force_algorith
 
 /* All Reduce */
 int ompi_coll_tuned_allreduce_intra_dec_fixed(ALLREDUCE_ARGS);
+int ompi_coll_tuned_allreduce_intra_disjoint_dec_fixed(ALLREDUCE_ARGS);
 int ompi_coll_tuned_allreduce_intra_dec_dynamic(ALLREDUCE_ARGS);
 int ompi_coll_tuned_allreduce_intra_do_this(ALLREDUCE_ARGS, int algorithm, int faninout, int segsize);
 int ompi_coll_tuned_allreduce_intra_check_forced_init (coll_tuned_force_algorithm_mca_param_indices_t *mca_param_indices);

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -218,6 +218,194 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, size_t c
                                                     comm, module, alg, 0, 0);
 }
 
+
+/*
+ *  allreduce_intra_disjoint
+ *
+ *  Function:   - selects allreduce algorithm to use for disjoint (inter-node)
+ *                communicators, whose communication patterns differ from intra-node.
+ *                This function implements a decision tree that selects the most
+ *                efficient allreduce algorithm based on communicator size, message
+ *                size, and operation commutativity.
+ *  Accepts:    - same as MPI_Allreduce()
+ *  Returns:    - MPI_SUCCESS or error code
+ */
+int
+ompi_coll_tuned_allreduce_intra_disjoint_dec_fixed(const void *sbuf, void *rbuf, size_t count,
+                                                   struct ompi_datatype_t *dtype,
+                                                   struct ompi_op_t *op,
+                                                   struct ompi_communicator_t *comm,
+                                                   mca_coll_base_module_t *module)
+{
+
+    size_t dsize, total_dsize;
+    int communicator_size, alg;
+    communicator_size = ompi_comm_size(comm);
+    OPAL_OUTPUT_VERBOSE((COLL_TUNED_TRACING_VERBOSE, ompi_coll_tuned_stream,
+        "ompi_coll_tuned_allreduce_intra_disjoint_dec_fixed"));
+
+    ompi_datatype_type_size(dtype, &dsize);
+    total_dsize = dsize * (ptrdiff_t)count;
+
+    /** Algorithms:
+     *  {1, "basic_linear"},
+     *  {2, "nonoverlapping"},
+     *  {3, "recursive_doubling"},
+     *  {4, "ring"},
+     *  {5, "segmented_ring"},
+     *  {6, "rabenseifner"},
+     *  {7, "allgather_reduce"}
+     *
+     * Currently, ring, segmented ring, and rabenseifner do not support
+     * non-commutative operations.
+     */
+    if( !ompi_op_is_commute(op) ) {
+        if (communicator_size == 2) {
+            alg = 3;
+        } else if (communicator_size < 4) {
+            alg = 7;
+        } else if (communicator_size < 8) {
+            if (total_dsize < 1048576) {
+                alg = 7;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size < 16) {
+            if (total_dsize < 262144) {
+                alg = 7;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size < 32) {
+            if (total_dsize < 32768) {
+                alg = 7;
+            } else if (total_dsize < 131072) {
+                alg = 2;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size <= 64) {
+            if (total_dsize < 32768) {
+                alg = 7;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size < 128) {
+            alg = 3;
+        } else if (communicator_size < 256) {
+            if (total_dsize < 131072) {
+                alg = 2;
+            } else if (total_dsize < 524288) {
+                alg = 3;
+            } else {
+                alg = 2;
+            }
+        } else if (communicator_size < 512) {
+            if (total_dsize < 4096) {
+                alg = 2;
+            } else if (total_dsize < 524288) {
+                alg = 3;
+            } else {
+                alg = 2;
+            }
+        } else {
+            if (total_dsize < 2048) {
+                alg = 2;
+            } else {
+                alg = 3;
+            }
+        }
+    } else {
+        if (communicator_size == 2) {
+            alg = 3;
+        } else if (communicator_size < 4) {
+            alg = 7;
+        } else if (communicator_size < 8) {
+            if (total_dsize < 1048576) {
+                alg = 7;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size < 16) {
+            if (total_dsize < 262144) {
+                alg = 7;
+            } else if (total_dsize < 1048576) {
+                alg = 6;
+            } else {
+                alg = 3;
+            }
+        } else if (communicator_size < 32) {
+            if (total_dsize < 32768) {
+                alg = 7;
+            } else if (total_dsize < 131072) {
+                alg = 2;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size <= 64) {
+            if (total_dsize < 32768) {
+                alg = 7;
+            } else if (total_dsize < 131072) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size < 128) {
+            if (total_dsize < 262144) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size < 256) {
+            if (total_dsize < 131072) {
+                alg = 2;
+            } else if (total_dsize < 262144) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size < 512) {
+            if (total_dsize < 4096) {
+                alg = 2;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size < 2048) {
+            if (total_dsize < 2048) {
+                alg = 2;
+            } else if (total_dsize < 16384) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        } else if (communicator_size < 4096) {
+            if (total_dsize < 2048) {
+                alg = 2;
+            } else if (total_dsize < 4096) {
+                alg = 5;
+            } else if (total_dsize < 16384) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        } else {
+            if (total_dsize < 2048) {
+                alg = 2;
+            } else if (total_dsize < 16384) {
+                alg = 5;
+            } else if (total_dsize < 32768) {
+                alg = 3;
+            } else {
+                alg = 6;
+            }
+        }
+    }
+
+    return ompi_coll_tuned_allreduce_intra_do_this (sbuf, rbuf, count, dtype, op,
+                                                    comm, module, alg, 0, 0);
+}
+
+                           
 /*
  *	alltoall_intra_dec
  *

--- a/ompi/mca/coll/tuned/coll_tuned_module.c
+++ b/ompi/mca/coll/tuned/coll_tuned_module.c
@@ -105,12 +105,13 @@ ompi_coll_tuned_comm_query(struct ompi_communicator_t *comm, int *priority)
      */
     if (OMPI_COMM_IS_DISJOINT_SET(comm) && OMPI_COMM_IS_DISJOINT(comm)) {
         tuned_module->super.coll_bcast  = ompi_coll_tuned_bcast_intra_disjoint_dec_fixed;
+        tuned_module->super.coll_allreduce  = ompi_coll_tuned_allreduce_intra_disjoint_dec_fixed;
     } else {
         tuned_module->super.coll_bcast  = ompi_coll_tuned_bcast_intra_dec_fixed;
+        tuned_module->super.coll_allreduce  = ompi_coll_tuned_allreduce_intra_dec_fixed;
     }
     tuned_module->super.coll_allgather  = ompi_coll_tuned_allgather_intra_dec_fixed;
     tuned_module->super.coll_allgatherv = ompi_coll_tuned_allgatherv_intra_dec_fixed;
-    tuned_module->super.coll_allreduce  = ompi_coll_tuned_allreduce_intra_dec_fixed;
     tuned_module->super.coll_alltoall   = ompi_coll_tuned_alltoall_intra_dec_fixed;
     tuned_module->super.coll_alltoallv  = ompi_coll_tuned_alltoallv_intra_dec_fixed;
     tuned_module->super.coll_barrier    = ompi_coll_tuned_barrier_intra_dec_fixed;


### PR DESCRIPTION
Include the new allreduce algorithm allgather_reduce in the default algorithm selections. The default algorithm selections were out of date and not performing well. After gathering data using the ompi-collectives-tuning package, new default algorithm decisions are selected for allreduce, which have significant speedup for small node number and message size.