### PR TITLE
move include of sys/mount back to where it was

### DIFF
--- a/ompi/mca/fs/base/base.h
+++ b/ompi/mca/fs/base/base.h
@@ -43,9 +43,6 @@
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#ifdef HAVE_SYS_MOUNT_H
-#include <sys/mount.h>
-#endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif

--- a/ompi/mca/fs/base/fs_base_get_parent_dir.c
+++ b/ompi/mca/fs/base/fs_base_get_parent_dir.c
@@ -35,6 +35,14 @@
 #include "ompi/mca/fs/base/base.h"
 #include "ompi/mca/common/ompio/common_ompio.h"
 
+/*
+ * Be careful moving this include.
+ * It's easy to hit problems similar to that reported in
+ * https://github.com/systemd/systemd/issues/8507
+ */
+#ifdef HAVE_SYS_MOUNT_H
+#include <sys/mount.h>
+#endif
 
 void mca_fs_base_get_parent_dir ( char *filename, char **dirnamep)
 {


### PR DESCRIPTION
Turns out the sys/mount.h can be tricky to use
because various other system include files sometimes redefine some of the symbols in this include file, leading
to compile failures.

Careful ordering of include files may solve the problem, but here it simpler just to move the include of sys/mount.h back to its original location.

related to #12181

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit d2af1d7d52361d8b53cfc1177451966106d0ab8e)