### PR TITLE
github-action: add a MPI4PY sanity check

### DIFF
--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -1,0 +1,111 @@
+name: GitHub Action CI
+
+on: [pull_request]
+
+jobs:
+  mpi4py:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Configure hostname
+      run:  echo 127.0.0.1 `hostname` | sudo tee -a /etc/hosts > /dev/null
+      if:   ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+        
+    - name: Install depencencies
+      run:  sudo apt-get install -y -q
+              libnuma-dev
+      
+    - name: Checkout Open MPI
+      uses: actions/checkout@v4
+      with:
+       path: mpi-build
+       submodules: recursive
+
+    - name: Bootstrap Open MPI
+      run:  ./autogen.pl
+      working-directory: mpi-build
+
+    - name: Configure Open MPI
+      run: ./configure
+              --disable-dependency-tracking
+              --disable-sphinx
+              --disable-man-pages
+              --disable-mpi-fortran
+              --disable-oshmem
+              --enable-debug
+              LDFLAGS=-Wl,-rpath,/usr/local/lib
+      working-directory: mpi-build
+
+    - name: Build MPI
+      run:  make -j 2
+      working-directory: mpi-build
+
+    - name: Install MPI
+      run:  sudo make install
+      working-directory: mpi-build
+
+    - name: Tweak MPI
+      run:  |
+        # Tweak MPI
+        mca_params="$HOME/.openmpi/mca-params.conf"
+        mkdir -p "$(dirname "$mca_params")"
+        echo mpi_param_check = true >> "$mca_params"
+        echo mpi_show_handle_leaks = true >> "$mca_params"
+        echo rmaps_base_oversubscribe = true >> "$mca_params"
+        mca_params="$HOME/.prte/mca-params.conf"
+        mkdir -p "$(dirname "$mca_params")"
+        echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+
+    - name: Show MPI
+      run:  ompi_info
+
+    - name: Show MPICC
+      run:  mpicc -show
+
+    - name: Use Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3
+        architecture: x64
+
+    - name: Install Python packages (build)
+      run:  python -m pip install --upgrade
+              setuptools pip wheel
+
+    - name: Install Python packages (test)
+      run:  python -m pip install --upgrade
+              numpy cffi pyyaml
+
+    - name: Checkout mpi4py
+      uses: actions/checkout@v4
+      with:
+        repository: "mpi4py/mpi4py"
+
+    - name: Install mpi4py
+      run:  python -m pip install .
+      env:
+        CFLAGS: "-O0"
+
+    - name: Test mpi4py (singleton)
+      run:  python test/main.py -v
+      if:   ${{ true }}
+    - name: Test mpi4py (np=1)
+      run:  mpiexec -n 1 python test/main.py -v
+    - name: Test mpi4py (np=2)
+      run:  mpiexec -n 2 python test/main.py -v -f
+    - name: Test mpi4py (np=3)
+      run:  mpiexec -n 3 python test/main.py -v -f
+      if:   ${{ true }}
+      timeout-minutes: 20
+    - name: Test mpi4py (np=4)
+      run:  mpiexec -n 4 python test/main.py -v -f
+      if:   ${{ true }}
+      timeout-minutes: 20
+    - name: Test mpi4py (np=5)
+      run:  mpiexec -n 5 python test/main.py -v -f
+      if:   ${{ true }}
+      timeout-minutes: 20
+    - name: Test mpi4py.run
+      run:  python demo/test-run/test_run.py -v
+      if:   ${{ true }}
+      timeout-minutes: 20

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -33,6 +33,7 @@ jobs:
               --disable-mpi-fortran
               --disable-oshmem
               --enable-debug
+              --enable-mem-debug
               LDFLAGS=-Wl,-rpath,/usr/local/lib
       working-directory: mpi-build
 


### PR DESCRIPTION
seems like mpi4py finds a problem almost every time we advance openpmix/prrte shas so catch it early here.

related to #12195