### PR TITLE
Update Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -15,7 +15,7 @@ Please submit all the information below so that we can understand the working en
 
 ## Background information
 
-### What version of Open MPI are you using? (e.g., v3.0.5, v4.0.2, git branch name and hash, etc.)
+### What version of Open MPI are you using? (e.g., v4.1.6, v5.0.1, git branch name and hash, etc.)
 
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ Thank you for taking the time to submit an issue!
 
 ## Background information
 
-### What version of Open MPI are you using? (e.g., v3.0.5, v4.0.2, git branch name and hash, etc.)
+### What version of Open MPI are you using? (e.g., v4.1.6, v5.0.1, git branch name and hash, etc.)
 
 
 


### PR DESCRIPTION
Update the sample version numbers that we list in the Github issue templates to be v4.1.6 and v5.0.2 (vs. the v3.0.x and v4.0.x versions we were citing before).  We don't need to update these every time we release, but it is good to show at least the current generation of major.minor series that are supported.