### PR TITLE
opal/accelerator: allow 0 size copies

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -399,8 +399,11 @@ static int accelerator_cuda_memcpy_async(int dest_dev_id, int src_dev_id, void *
     }
 
     if ((MCA_ACCELERATOR_STREAM_DEFAULT != stream && NULL == stream) ||
-        NULL == dest || NULL == src || size <= 0) {
+        NULL == dest || NULL == src || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     result = cuMemcpyAsync((CUdeviceptr) dest, (CUdeviceptr) src, size, GET_STREAM(stream));
@@ -422,8 +425,11 @@ static int accelerator_cuda_memcpy(int dest_dev_id, int src_dev_id, void *dest, 
         return delayed_init;
     }
 
-    if (NULL == dest || NULL == src || size <= 0) {
+    if (NULL == dest || NULL == src || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     /* Async copy then synchronize is the default behavior as some applications

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -303,8 +303,11 @@ static int mca_accelerator_rocm_memcpy_async(int dest_dev_id, int src_dev_id, vo
 {
     if ((MCA_ACCELERATOR_STREAM_DEFAULT != stream &&
         (NULL == stream || NULL == stream->stream)) ||
-        NULL == src || NULL == dest || size <= 0) {
+        NULL == src || NULL == dest || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     hipError_t err = hipMemcpyAsync(dest, src, size, hipMemcpyDefault,
@@ -324,8 +327,11 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
 {
     hipError_t err;
 
-    if (NULL == src || NULL == dest || size <=0) {
+    if (NULL == src || NULL == dest || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     if (type == MCA_ACCELERATOR_TRANSFER_DTOH && size <= opal_accelerator_rocm_memcpyD2H_limit) {

--- a/opal/mca/accelerator/ze/accelerator_ze_module.c
+++ b/opal/mca/accelerator/ze/accelerator_ze_module.c
@@ -403,11 +403,14 @@ static int mca_accelerator_ze_memcpy_async(int dest_dev_id, int src_dev_id, void
    opal_accelerator_ze_stream_t *ze_stream = NULL;
 
    if (NULL == stream || NULL == src ||
-        NULL == dest   || size <= 0) {
+        NULL == dest   || size < 0) {
         return OPAL_ERR_BAD_PARAM;
     }
+   if (0 == size) {
+       return OPAL_SUCCESS;
+   }
 
-    ze_stream = (opal_accelerator_ze_stream_t  *)stream->stream;
+   ze_stream = (opal_accelerator_ze_stream_t  *)stream->stream;
     assert(NULL != ze_stream);
 
     zret = zeCommandListAppendMemoryCopy(ze_stream->hCommandList,
@@ -435,9 +438,12 @@ static int mca_accelerator_ze_memcpy(int dest_dev_id, int src_dev_id, void *dest
 
     opal_accelerator_ze_stream_t *ze_stream = NULL;
 
-    if (NULL == src || NULL == dest || size <=0) {
+    if (NULL == src || NULL == dest || size <0) {
         return OPAL_ERR_BAD_PARAM;
     }                           
+    if (0 == size) {
+        return OPAL_SUCCESS;
+    }
 
     if (MCA_ACCELERATOR_NO_DEVICE_ID == src_dev_id) {
         dev_id = 0;


### PR DESCRIPTION
it looks like zero size messages with valid buffer pointers can occur for send-to-self operations and with persistent request, even if the actual message size is not 0 bytes. The current accelerator components return however an error for size 0 making those tests fail in our testsuite.

This commit allows size 0 messages, and returns immediatly.