### PR TITLE
v4.1.x: osc/ucx: fixed memory leak

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -236,16 +236,18 @@ static int component_finalize(void) {
 
     if (mca_osc_ucx_component.ucp_worker != NULL) {
         ucp_worker_destroy(mca_osc_ucx_component.ucp_worker);
+        mca_osc_ucx_component.ucp_worker = NULL;
     }
 
     assert(mca_osc_ucx_component.num_incomplete_req_ops == 0);
     if (mca_osc_ucx_component.env_initialized == true) {
         OBJ_DESTRUCT(&mca_osc_ucx_component.requests);
-        if (NULL != mca_osc_ucx_component.ucp_context) {
-            ucp_cleanup(mca_osc_ucx_component.ucp_context);
-            mca_osc_ucx_component.ucp_context = NULL;
-        }
         mca_osc_ucx_component.env_initialized = false;
+    }
+
+    if (NULL != mca_osc_ucx_component.ucp_context) {
+        ucp_cleanup(mca_osc_ucx_component.ucp_context);
+        mca_osc_ucx_component.ucp_context = NULL;
     }
 
     return OMPI_SUCCESS;
@@ -776,8 +778,13 @@ select_unlock:
 error_nomem:
     if (env_initialized == true) {
         OBJ_DESTRUCT(&mca_osc_ucx_component.requests);
+
         ucp_worker_destroy(mca_osc_ucx_component.ucp_worker);
+        mca_osc_ucx_component.ucp_worker = NULL;
+
         ucp_cleanup(mca_osc_ucx_component.ucp_context);
+        mca_osc_ucx_component.ucp_context = NULL;
+
         mca_osc_ucx_component.env_initialized = false;
     }
     return ret;


### PR DESCRIPTION
Fix memory leak introduced in [#10443](https://github.com/open-mpi/ompi/pull/10443)
The problem is manifested as diagnostic messages appearing at the end of certain tests:
```
mpirun -n 2 -mca osc ucx -x UCX_LOG_LEVEL=info --report-bindings osu_latency

 async.c:681  UCX  DIAG  async handler table is not empty during exit (contains 4 elems)
thread.c:434  UCX  DIAG  async thread still running (use count 4)
```
This warning indicates that some UCP resources were not properly released. And the root cause is that `ucp_cleanup` is not invoked in this particular case.
Root cause analysis:
[#10443](https://github.com/open-mpi/ompi/pull/10443) changed the initialization routine, which became split into 2 parts: the first is in `component_init` (where `ucp_init` is called), and second one is `component_select` (which initialises requests and sets `env_initialized = true`). And then destruction is in `component_finalize` is triggered only if `env_initialized` is set to true. The problem is that sometimes `component_select` is never invoked, and therefore there is no appropriate resource cleanup for allocated ucp_context.

bot:notacherrypick