### PR TITLE
opal/accelerator: allow 0 size copies - v5.0.x

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -364,8 +364,11 @@ static int accelerator_cuda_memcpy_async(int dest_dev_id, int src_dev_id, void *
         return delayed_init;
     }
 
-    if (NULL == stream || NULL == dest || NULL == src || size <= 0) {
+    if (NULL == stream || NULL == dest || NULL == src || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     result = cuMemcpyAsync((CUdeviceptr) dest, (CUdeviceptr) src, size, *(CUstream *)stream->stream);
@@ -387,8 +390,11 @@ static int accelerator_cuda_memcpy(int dest_dev_id, int src_dev_id, void *dest, 
         return delayed_init;
     }
 
-    if (NULL == dest || NULL == src || size <= 0) {
+    if (NULL == dest || NULL == src || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     /* Async copy then synchronize is the default behavior as some applications

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -254,8 +254,11 @@ static int mca_accelerator_rocm_memcpy_async(int dest_dev_id, int src_dev_id, vo
                                              opal_accelerator_transfer_type_t type)
 {
     if (NULL == stream || NULL == src ||
-        NULL == dest   || size <= 0) {
+        NULL == dest   || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     hipError_t err = hipMemcpyAsync(dest, src, size, hipMemcpyDefault,
@@ -275,8 +278,11 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
 {
     hipError_t err;
 
-    if (NULL == src || NULL == dest || size <=0) {
+    if (NULL == src || NULL == dest || size < 0) {
         return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == size) {
+        return OPAL_SUCCESS;
     }
 
     if (type == MCA_ACCELERATOR_TRANSFER_DTOH && size <= opal_accelerator_rocm_memcpyD2H_limit) {


### PR DESCRIPTION
it looks like zero size messages with valid buffer pointers are triggered for send-to-self operations and with persistent request even for message sizes > 0. The current accelerator components return however an error for size 0 making those tests fail in our testsuite.

This commit allows size 0 messages, and returns immediately.

Signed-off-by: Edgar Gabriel <Edgar.Gabriel@amd.com>
(cherry picked from commit 9965f6c518956cd88be18de6633b28e2bbaf0ea4)