### PR TITLE
[v5.0.x] ofi: follow user specified include/exclude list to select providers

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -764,12 +764,20 @@ no_hmem:
                         "%s:%d: fi_getinfo(): %s\n",
                         __FILE__, __LINE__, fi_strerror(-ret));
 
-    if (FI_ENODATA == -ret) {
+    if ((FI_ENODATA == -ret)
+        || (0 == ret && include_list
+            && 0 == opal_common_ofi_count_providers_in_list(providers, include_list))
+        || (0 == ret && !include_list && exclude_list
+            && opal_common_ofi_providers_subset_of_list(providers, exclude_list))) {
 #if defined(FI_HMEM)
         /* Attempt selecting a provider without FI_HMEM hints */
         if (hints->caps & FI_HMEM) {
             hints->caps &= ~FI_HMEM;
             hints->domain_attr->mr_mode &= ~FI_MR_HMEM;
+            if (providers) {
+                (void) fi_freeinfo(providers);
+                providers = NULL;
+            }
             goto no_hmem;
         }
 #endif

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -101,6 +101,38 @@ OPAL_DECLSPEC int opal_common_ofi_export_memory_monitor(void);
 OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item);
 
 /**
+ * Get the number of providers whose names are included in a list
+ *
+ * This function takes a list of providers and a list of name strings
+ * as inputs, and return the number of providers whose names are included
+ * in the name strings.
+ *
+ * @param provider_list (IN)    List of providers
+ * @param list          (IN)    List of name string
+ *
+ * @return                      Number of matched providers
+ *
+ */
+OPAL_DECLSPEC int opal_common_ofi_count_providers_in_list(struct fi_info *provider_list,
+                                                          char **list);
+
+/**
+ * Determine whether all providers are included in a list
+ *
+ * This function takes a list of providers and a list of name strings
+ * as inputs, and return whether all provider names are included in the name strings.
+ *
+ * @param provider_list (IN)    List of providers
+ * @param list          (IN)    List of name string
+ *
+ * @return  0                   At least one provider's name is not included in the name strings.
+ * @return  1                   All provider names are included in the name strings.
+ *
+ */
+OPAL_DECLSPEC int opal_common_ofi_providers_subset_of_list(struct fi_info *provider_list,
+                                                           char **list);
+
+/**
  * Selects NIC (provider) based on hardware locality
  *
  * In multi-nic situations, use hardware topology to pick the "best"


### PR DESCRIPTION
This PR addresses #12233

Since 5.0.x, we introduced an optional FI_HMEM capability in ofi provider selection logic(both mtl and btl) in order to support accelerator memory. As described in the issue, this introduced a bug that can cause the wrong ofi provider to be selected, even if the user explicitly includes/excludes the provider name.

This change refactors the selection logic to correctly handle the include/exclude list, and therefore fixes the bug.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit 29efcef4a45379495a657f369e9cc42b3d3a01f7)