### PR TITLE
Squash clang-14 warnings in OPAL

### DIFF
--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -1261,6 +1261,7 @@ static void mca_btl_smcuda_send_cuda_ipc_request(struct mca_btl_base_module_t *b
 
     MCA_BTL_SMCUDA_FIFO_WRITE(endpoint, endpoint->my_smp_rank, endpoint->peer_smp_rank,
                               (void *) VIRTUAL2RELATIVE(frag->hdr), false, true, rc);
+    (void)rc;
     return;
 }
 

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -634,6 +634,7 @@ static void mca_btl_smcuda_send_cuda_ipc_ack(struct mca_btl_base_module_t *btl,
 
     MCA_BTL_SMCUDA_FIFO_WRITE(endpoint, endpoint->my_smp_rank, endpoint->peer_smp_rank,
                               (void *) VIRTUAL2RELATIVE(frag->hdr), false, true, rc);
+    (void)rc;
 
     /* Set state now that we have sent message */
     if (ready) {
@@ -1040,6 +1041,7 @@ int mca_btl_smcuda_component_progress(void)
             /* return the fragment */
             MCA_BTL_SMCUDA_FIFO_WRITE(mca_btl_smcuda_component.sm_peers[peer_smp_rank], my_smp_rank,
                                       peer_smp_rank, hdr->frag, false, true, rc);
+            (void)rc;
             break;
         }
         case MCA_BTL_SMCUDA_FRAG_ACK: {
@@ -1086,6 +1088,7 @@ int mca_btl_smcuda_component_progress(void)
                                             | MCA_BTL_SMCUDA_FRAG_STATUS_MASK);
             MCA_BTL_SMCUDA_FIFO_WRITE(mca_btl_smcuda_component.sm_peers[peer_smp_rank], my_smp_rank,
                                       peer_smp_rank, hdr, false, true, rc);
+            (void)rc;
             break;
         }
     }

--- a/opal/mca/btl/smcuda/btl_smcuda_fifo.h
+++ b/opal/mca/btl/smcuda/btl_smcuda_fifo.h
@@ -85,7 +85,7 @@ static void add_pending(struct mca_btl_base_endpoint_t *ep, void *data, bool res
 #define MCA_BTL_SMCUDA_FIFO_WRITE(endpoint_peer, my_smp_rank, peer_smp_rank, hdr, resend,         \
                                   retry_pending_sends, rc)                                        \
     do {                                                                                          \
-        sm_fifo_t *fifo = &(mca_btl_smcuda_component.fifo[peer_smp_rank][FIFO_MAP(my_smp_rank)]); \
+        sm_fifo_t *_fifo = &(mca_btl_smcuda_component.fifo[peer_smp_rank][FIFO_MAP(my_smp_rank)]);\
                                                                                                   \
         if (retry_pending_sends) {                                                                \
             if (0 < opal_list_get_size(&endpoint_peer->pending_sends)) {                          \
@@ -93,16 +93,16 @@ static void add_pending(struct mca_btl_base_endpoint_t *ep, void *data, bool res
             }                                                                                     \
         }                                                                                         \
                                                                                                   \
-        opal_atomic_lock(&(fifo->head_lock));                                                     \
+        opal_atomic_lock(&(_fifo->head_lock));                                                    \
         /* post fragment */                                                                       \
-        if (sm_fifo_write(hdr, fifo) != OPAL_SUCCESS) {                                           \
+        if (sm_fifo_write(hdr, _fifo) != OPAL_SUCCESS) {                                          \
             add_pending(endpoint_peer, hdr, resend);                                              \
             rc = OPAL_ERR_RESOURCE_BUSY;                                                          \
         } else {                                                                                  \
             MCA_BTL_SMCUDA_SIGNAL_PEER(endpoint_peer);                                            \
             rc = OPAL_SUCCESS;                                                                    \
         }                                                                                         \
-        opal_atomic_unlock(&(fifo->head_lock));                                                   \
+        opal_atomic_unlock(&(_fifo->head_lock));                                                  \
     } while (0)
 
 #endif

--- a/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
+++ b/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
@@ -117,14 +117,14 @@ static int mca_rcache_rgpusm_open_mem_handle(void *base, size_t size, mca_rcache
     if (OPAL_UNLIKELY(OPAL_SUCCESS != result)) {
         opal_output_verbose(10, mca_rcache_rgpusm_component.output,
                             "open_ipc_handle failed: base=%p (remote base=%p,size=%d)",
-                            newreg->alloc_base, base, (int) size);
+                            (void*)newreg->alloc_base, base, (int) size);
         /* Currently, this is a non-recoverable error */
         return OPAL_ERROR;
     }
 
     opal_output_verbose(10, mca_rcache_rgpusm_component.output,
                         "open_ipc_handle passed: base=%p (remote base=%p,size=%d)",
-                        newreg->alloc_base, base, (int) size);
+                        (void*)newreg->alloc_base, base, (int) size);
 
     return OPAL_SUCCESS;
 }
@@ -172,7 +172,7 @@ static inline bool mca_rcache_rgpusm_deregister_lru(mca_rcache_base_module_t *rc
     if (OPAL_SUCCESS != rc) {
         opal_output_verbose(10, mca_rcache_rgpusm_component.output,
                             "RGPUSM: Failed to deregister the memory addr=%p, size=%d",
-                            old_reg->base, (int) (old_reg->bound - old_reg->base + 1));
+                            (void*)old_reg->base, (int) (old_reg->bound - old_reg->base + 1));
         return false;
     }
 
@@ -291,7 +291,7 @@ int mca_rcache_rgpusm_register(mca_rcache_base_module_t *rcache, void *addr, siz
         rcache_rgpusm->stat_cache_hit++;
         opal_output_verbose(10, mca_rcache_rgpusm_component.output,
                             "RGPUSM: Found addr=%p,size=%d (base=%p,size=%d) in cache", addr,
-                            (int) size, (*reg)->base, (int) ((*reg)->bound - (*reg)->base));
+                            (int) size, (void*)(*reg)->base, (int) ((*reg)->bound - (*reg)->base));
 
         if (0 ==
             memcmp(((mca_opal_gpu_reg_t *)*reg)->data.ipcHandle.handle, rget_reg->data.ipcHandle.handle,
@@ -303,7 +303,7 @@ int mca_rcache_rgpusm_register(mca_rcache_base_module_t *rcache, void *addr, siz
             opal_output_verbose(10, mca_rcache_rgpusm_component.output,
                                 "RGPUSM: Mismatched Handle: Evicting/unregistering "
                                 "addr=%p,size=%d (base=%p,size=%d) from cache",
-                                addr, (int) size, (*reg)->base,
+                                addr, (int) size, (void*)(*reg)->base,
                                 (int) ((*reg)->bound - (*reg)->base));
 
             /* The ref_count has to be zero as this memory cannot possibly
@@ -507,10 +507,6 @@ int mca_rcache_rgpusm_find(struct mca_rcache_base_module_t *rcache, void *addr, 
 {
     mca_rcache_rgpusm_module_t *rcache_rgpusm = (mca_rcache_rgpusm_module_t *) rcache;
     int rc;
-    unsigned char *base, *bound;
-
-    base = addr;
-    bound = base + size - 1; /* To keep cache hits working correctly */
 
     OPAL_THREAD_LOCK(&rcache->lock);
     opal_output(-1, "Looking for addr=%p, size=%d", addr, (int) size);
@@ -554,7 +550,7 @@ int mca_rcache_rgpusm_deregister(struct mca_rcache_base_module_t *rcache,
         opal_output_verbose(20, mca_rcache_rgpusm_component.output,
                             "RGPUSM: Deregister: addr=%p, size=%d: cacheable and pinned, leave in "
                             "cache, PUSH IN LRU",
-                            reg->base, (int) (reg->bound - reg->base + 1));
+                            (void*)reg->base, (int) (reg->bound - reg->base + 1));
         opal_list_prepend(&rcache_rgpusm->lru_list, (opal_list_item_t *) reg);
     } else {
         /* Remove from rcache first */


### PR DESCRIPTION
- Set but unused `rc` variable
- Shadowed `fifo` variable
- Format string warning (`void*` vs `char*`)