### PR TITLE
Properly initialize mca_rcache_base_module_t members [v5.0.x]

### DIFF
--- a/opal/mca/rcache/base/base.h
+++ b/opal/mca/rcache/base/base.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -72,6 +72,10 @@ extern int mca_rcache_base_used_mem_hooks;
  * Globals
  */
 OPAL_DECLSPEC extern opal_list_t mca_rcache_base_modules;
+
+OPAL_DECLSPEC void mca_rcache_base_module_init(mca_rcache_base_module_t *rcache);
+
+OPAL_DECLSPEC void mca_rcache_base_module_fini(mca_rcache_base_module_t *rcache);
 
 END_C_DECLS
 

--- a/opal/mca/rcache/base/rcache_base_frame.c
+++ b/opal/mca/rcache/base/rcache_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -136,3 +136,12 @@ static int mca_rcache_base_register_mca_variables(mca_base_register_flag_t flags
 MCA_BASE_FRAMEWORK_DECLARE(opal, rcache, "OPAL Registration Cache",
                            mca_rcache_base_register_mca_variables, mca_rcache_base_open,
                            mca_rcache_base_close, mca_rcache_base_static_components, 0);
+
+
+void mca_rcache_base_module_init(mca_rcache_base_module_t *rcache) {
+    OBJ_CONSTRUCT(&rcache->lock, opal_mutex_t);
+}
+
+void mca_rcache_base_module_fini(mca_rcache_base_module_t *rcache) {
+    OBJ_DESTRUCT(&rcache->lock);
+}

--- a/opal/mca/rcache/gpusm/rcache_gpusm_module.c
+++ b/opal/mca/rcache/gpusm/rcache_gpusm_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -89,6 +89,8 @@ OBJ_CLASS_INSTANCE(mca_rcache_gpusm_registration_t, mca_rcache_base_registration
  */
 void mca_rcache_gpusm_module_init(mca_rcache_gpusm_module_t *rcache)
 {
+    mca_rcache_base_module_init(&rcache->super);
+
     rcache->super.rcache_component = &mca_rcache_gpusm_component.super;
     rcache->super.rcache_register = mca_rcache_gpusm_register;
     rcache->super.rcache_find = mca_rcache_gpusm_find;
@@ -265,5 +267,8 @@ void mca_rcache_gpusm_finalize(struct mca_rcache_base_module_t *rcache)
     }
 
     OBJ_DESTRUCT(&rcache_gpusm->reg_list);
+
+    mca_rcache_base_module_fini(rcache);
+
     return;
 }

--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -110,6 +110,8 @@ void mca_rcache_grdma_module_init(mca_rcache_grdma_module_t *rcache,
 {
     OBJ_RETAIN(cache);
     rcache->cache = cache;
+
+    mca_rcache_base_module_init(&rcache->super);
 
     rcache->super.rcache_component = &mca_rcache_grdma_component.super;
     rcache->super.rcache_register = mca_rcache_grdma_register;
@@ -601,6 +603,8 @@ static void mca_rcache_grdma_finalize(mca_rcache_base_module_t *rcache)
     OBJ_RELEASE(rcache_grdma->cache);
 
     OBJ_DESTRUCT(&rcache_grdma->reg_list);
+
+    mca_rcache_base_module_fini(rcache);
 
     /* this rcache was allocated by grdma_init in rcache_grdma_component.c */
     free(rcache);

--- a/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
+++ b/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -207,6 +207,7 @@ static inline bool mca_rcache_rgpusm_deregister_lru(mca_rcache_base_module_t *rc
  */
 void mca_rcache_rgpusm_module_init(mca_rcache_rgpusm_module_t *rcache)
 {
+    mca_rcache_base_module_init(&rcache->super);
     rcache->super.rcache_component = &mca_rcache_rgpusm_component.super;
     rcache->super.rcache_register = mca_rcache_rgpusm_register;
     rcache->super.rcache_find = mca_rcache_rgpusm_find;
@@ -676,4 +677,5 @@ void mca_rcache_rgpusm_finalize(struct mca_rcache_base_module_t *rcache)
     OBJ_DESTRUCT(&rcache_rgpusm->lru_list);
     OBJ_DESTRUCT(&rcache_rgpusm->reg_list);
     OPAL_THREAD_UNLOCK(&rcache->lock);
+    mca_rcache_base_module_fini(rcache);
 }

--- a/opal/mca/rcache/udreg/rcache_udreg_module.c
+++ b/opal/mca/rcache/udreg/rcache_udreg_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -66,6 +66,8 @@ int mca_rcache_udreg_module_init(mca_rcache_udreg_module_t *rcache)
     struct udreg_cache_attr cache_attr;
     int urc;
 
+    mca_rcache_base_module_init(&rcache->super);
+
     rcache->super.rcache_component = &mca_rcache_udreg_component.super;
     rcache->super.rcache_register = mca_rcache_udreg_register;
     rcache->super.rcache_find = mca_rcache_udreg_find;
@@ -88,8 +90,6 @@ int mca_rcache_udreg_module_init(mca_rcache_udreg_module_t *rcache)
     if (mca_rcache_udreg_component.leave_pinned) {
         cache_attr.modes |= UDREG_CC_MODE_USE_LAZY_DEREG;
     }
-
-    OBJ_CONSTRUCT(&rcache->lock, opal_mutex_t);
 
     opal_string_copy(cache_attr.cache_name, rcache->resources.base.cache_name,
                      UDREG_MAX_CACHENAME_LEN);
@@ -363,4 +363,5 @@ static void mca_rcache_udreg_finalize(mca_rcache_base_module_t *rcache)
     UDREG_CacheRelease(rcache_udreg->udreg_handle);
     OBJ_DESTRUCT(&rcache_udreg->reg_list);
     OBJ_DESTRUCT(&rcache_udreg->lock);
+    mca_rcache_base_module_fini(rcache);
 }


### PR DESCRIPTION
All but the udreg rcache module did not properly initialize the `lock` member in the mca_rcache_base_module_t parent, which triggers an assert on Mac OSX when trying to take that lock.

Cherry-pick of #12248 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>