### PR TITLE
ompi/op: change reduce function prototypes to use a const source pointer

### DIFF
--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -59,20 +59,20 @@ BEGIN_C_DECLS
  * repeated code, but it's better this way (and this typedef will
  * never change, so there's not much of a maintenance worry).
  */
-typedef void (ompi_op_c_handler_fn_t)(void *, void *, int *,
+typedef void (ompi_op_c_handler_fn_t)(const void *, void *, int *,
                                       struct ompi_datatype_t **);
 
 /**
  * Typedef for fortran user-defined MPI_Ops.
  */
-typedef void (ompi_op_fortran_handler_fn_t)(void *, void *,
+typedef void (ompi_op_fortran_handler_fn_t)(const void *, void *,
                                             MPI_Fint *, MPI_Fint *);
 
 /**
  * Typedef for Java op functions intercept (used for user-defined
  * MPI.Ops).
  */
-typedef void (ompi_op_java_handler_fn_t)(void *, void *, int *,
+typedef void (ompi_op_java_handler_fn_t)(const void *, void *, int *,
                                          struct ompi_datatype_t **,
                                          int baseType,
                                          void *jnienv, void *object);
@@ -500,7 +500,7 @@ static inline bool ompi_op_is_valid(ompi_op_t * op, ompi_datatype_t * ddt,
  * optimization).  If you give it an intrinsic op with a datatype that
  * is not defined to have that operation, it is likely to seg fault.
  */
-static inline void ompi_op_reduce(ompi_op_t * op, void *source,
+static inline void ompi_op_reduce(ompi_op_t * op, const void *source,
                                   void *target, size_t full_count,
                                   ompi_datatype_t * dtype)
 {
@@ -531,7 +531,7 @@ static inline void ompi_op_reduce(ompi_op_t * op, void *source,
             }
             shift = done_count * ext;
             // Recurse one level in iterations of 'int'
-            ompi_op_reduce(op, (char*)source + shift, (char*)target + shift, iter_count, dtype);
+            ompi_op_reduce(op, (const char*)source + shift, (char*)target + shift, iter_count, dtype);
             done_count += iter_count;
         }
         return;
@@ -595,7 +595,7 @@ static inline void ompi_op_reduce(ompi_op_t * op, void *source,
 static inline void ompi_3buff_op_user (ompi_op_t *op, void * restrict source1, void * restrict source2,
                                        void * restrict result, int count, struct ompi_datatype_t *dtype)
 {
-    ompi_datatype_copy_content_same_ddt (dtype, count, result, source1);
+    ompi_datatype_copy_content_same_ddt (dtype, count, (char*)result, (char*)source1);
     op->o_func.c_fn (source2, result, &count, &dtype);
 }
 


### PR DESCRIPTION
and a minor casting fix, found when using GCC v13