### PR TITLE
[v5.0.x] Minor fixes: comment correction and spelling "Registration"

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -111,8 +111,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_avail_coll_t);
 
 /**
  * A MPI_like function doing a send and a receive simultaneously.
- * If one of the communications results in a zero-byte message the
- * communication is ignored, and no message will cross to the peer.
+ * Posts a irecv, does a send, then gets irecv completion.
  */
 int ompi_coll_base_sendrecv_actual( const void* sendbuf, size_t scount,
                                     ompi_datatype_t* sdatatype,
@@ -125,10 +124,8 @@ int ompi_coll_base_sendrecv_actual( const void* sendbuf, size_t scount,
 
 
 /**
- * Similar to the function above this implementation of send-receive
- * do not generate communications for zero-bytes messages. Thus, it is
- * improper to use in the context of some algorithms for collective
- * communications.
+ * A wrapper around ompi_coll_base_sendrecv_actual, with an optimized
+ * path for self-directed send/recv.
  */
 static inline int
 ompi_coll_base_sendrecv( void* sendbuf, size_t scount, ompi_datatype_t* sdatatype,

--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -145,7 +145,7 @@ int ompi_osc_rdma_new_peer (struct ompi_osc_rdma_module_t *module, int peer_id, 
  *
  * This function reads the registration handle and state pointer from the peer that holds that data. If necessary
  * it will then ready information about the peer from its state data structure. This information includes the
- * displacement unit, base pointer, window size, and registation handle (if applicable).
+ * displacement unit, base pointer, window size, and registration handle (if applicable).
  */
 static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer)
 {

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -346,7 +346,7 @@ mca_btl_sm_component_init(int *num_btls, bool enable_progress_threads, bool enab
             mca_btl_sm.super.btl_max_send_size = mca_btl_sm.super.btl_eager_limit;
             mca_btl_sm.super.btl_min_rdma_pipeline_size = INT_MAX;
         }
-        if (mca_smsc_base_has_feature(MCA_SMSC_FEATURE_REQUIRE_REGISTATION)) {
+        if (mca_smsc_base_has_feature(MCA_SMSC_FEATURE_REQUIRE_REGISTRATION)) {
             ssize_t handle_size = mca_smsc_base_registration_data_size();
             if (handle_size > 0) {
                 mca_btl_sm.super.btl_registration_handle_size = (size_t) handle_size;

--- a/opal/mca/rcache/base/rcache_base_vma_tree.h
+++ b/opal/mca/rcache/base/rcache_base_vma_tree.h
@@ -25,7 +25,7 @@
  */
 /**
  * @file
- * Registation cache VMA tree implementation
+ * Registration cache VMA tree implementation
  */
 #ifndef MCA_RCACHE_BASE_VMA_TREE_H
 #define MCA_RCACHE_BASE_VMA_TREE_H

--- a/opal/mca/rcache/rcache.h
+++ b/opal/mca/rcache/rcache.h
@@ -39,7 +39,7 @@ enum {
     MCA_RCACHE_FLAGS_CACHE_BYPASS = 0x0001,
     /** persistent registration */
     MCA_RCACHE_FLAGS_PERSIST = 0x0002,
-    /** registation requires strong ordering (disables relaxed ordering) */
+    /** registration requires strong ordering (disables relaxed ordering) */
     MCA_RCACHE_FLAGS_SO_MEM = 0x0004,
     /** address range is accelerator buffer */
     MCA_RCACHE_FLAGS_ACCELERATOR_MEM = 0x0008,

--- a/opal/mca/smsc/knem/smsc_knem_module.c
+++ b/opal/mca/smsc/knem/smsc_knem_module.c
@@ -146,7 +146,7 @@ void mca_smsc_knem_unmap_peer_region(void *ctx)
 
 mca_smsc_knem_module_t mca_smsc_knem_module = {
     .super = {
-        .features = MCA_SMSC_FEATURE_REQUIRE_REGISTATION,
+        .features = MCA_SMSC_FEATURE_REQUIRE_REGISTRATION,
         .registration_data_size = sizeof(mca_smsc_knem_registration_data_t),
         .get_endpoint = mca_smsc_knem_get_endpoint,
         .return_endpoint = mca_smsc_knem_return_endpoint,

--- a/opal/mca/smsc/smsc.h
+++ b/opal/mca/smsc/smsc.h
@@ -133,7 +133,7 @@ enum {
     /** Module requires the local registration of any region that will be used for single-copy
      * operations. It is theresponsibility of the caller to pass this data with the pointer to the
      * peer. */
-    MCA_SMSC_FEATURE_REQUIRE_REGISTATION = 1,
+    MCA_SMSC_FEATURE_REQUIRE_REGISTRATION = 1,
     /** Module can map peer memory into the local processes' address space. */
     MCA_SMSC_FEATURE_CAN_MAP = 2,
 };
@@ -239,7 +239,7 @@ static inline bool mca_smsc_base_has_feature(uint64_t feature)
 
 static inline ssize_t mca_smsc_base_registration_data_size(void)
 {
-    if (NULL == mca_smsc || !mca_smsc_base_has_feature(MCA_SMSC_FEATURE_REQUIRE_REGISTATION)) {
+    if (NULL == mca_smsc || !mca_smsc_base_has_feature(MCA_SMSC_FEATURE_REQUIRE_REGISTRATION)) {
         return OPAL_ERR_NOT_AVAILABLE;
     }
 


### PR DESCRIPTION
Backport of https://github.com/open-mpi/ompi/pull/12281.

I'm primarily motivated to backport the enum rename, so we don't have to edit any other backports which use the enum.