### PR TITLE
framework: add the MCA_BASE_FRAMEWORK_FLAG_NOCOMPONENT flag

### DIFF
--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -8,6 +8,8 @@
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,9 +131,11 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
         }
 
         /* register components variables */
-        ret = mca_base_framework_components_register(framework, flags);
-        if (OPAL_SUCCESS != ret) {
-            return ret;
+        if (!(MCA_BASE_FRAMEWORK_FLAG_NOCOMPONENT & framework->framework_flags)) {
+            ret = mca_base_framework_components_register(framework, flags);
+            if (OPAL_SUCCESS != ret) {
+                return ret;
+            }
         }
     }
 

--- a/opal/mca/base/mca_base_framework.h
+++ b/opal/mca/base/mca_base_framework.h
@@ -5,6 +5,8 @@
  * Copyright (c) 2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,6 +122,8 @@ typedef enum {
     MCA_BASE_FRAMEWORK_FLAG_NO_DSO = 4,
     /** Internal. Don't set outside mca_base_framework.h */
     MCA_BASE_FRAMEWORK_FLAG_OPEN = 8,
+    /** Do not register components */
+    MCA_BASE_FRAMEWORK_FLAG_NOCOMPONENT = 16,
     /**
      * The upper 16 bits are reserved for project specific flags.
      */

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2022      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -114,4 +116,4 @@ static int opal_pmix_base_frame_open(mca_base_open_flag_t flags)
 
 MCA_BASE_FRAMEWORK_DECLARE(opal, pmix, "OPAL PMI Client Framework", opal_pmix_base_frame_register,
                            opal_pmix_base_frame_open, opal_pmix_base_frame_close,
-                           mca_pmix_base_static_components, 0);
+                           mca_pmix_base_static_components, MCA_BASE_FRAMEWORK_FLAG_NOCOMPONENT);


### PR DESCRIPTION
When a framework has the MCA_BASE_FRAMEWORK_FLAG_NOCOMPONENT flag, it will not try to register any components. That can prevent issues at finalization when a component is registered but not properly unregistered.

Thanks Kook Jin Noh for the bug report.

Refs. open-mpi/ompi#12282