### PR TITLE
coll/basic: mca_coll_basic_gatherv_intra root posts irecv

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_gatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_gatherv.c
@@ -42,9 +42,9 @@ mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
                              void *rbuf, const int *rcounts, const int *disps,
                              struct ompi_datatype_t *rdtype, int root,
                              struct ompi_communicator_t *comm,
-                            mca_coll_base_module_t *module)
+                             mca_coll_base_module_t *module)
 {
-    int i, rank, size, err;
+    int err, i, peer, rank, size;
     char *ptmp;
     ptrdiff_t lb, extent;
     size_t rdsize;
@@ -52,64 +52,91 @@ mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
     size = ompi_comm_size(comm);
     rank = ompi_comm_rank(comm);
 
+    if (root == rank) {
+        /* Root receives from everyone else */
+        ompi_datatype_type_size(rdtype, &rdsize);
+        if (OPAL_UNLIKELY(0 == rdsize)) {
+            /* bozzo case */
+            return MPI_SUCCESS;
+        }
+
+        err = ompi_datatype_get_extent(rdtype, &lb, &extent);
+        if (OMPI_SUCCESS != err) {
+            return OMPI_ERROR;
+        }
+
+        if (MPI_IN_PLACE != sbuf && (0 < scount) && (0 < rcounts[rank])) {
+            /* Directly copy self sbuf to rbuf */
+            err = ompi_datatype_sndrcv(sbuf, scount, sdtype,
+                                       ((char *) rbuf) + (extent * disps[rank]), rcounts[rank],
+                                       rdtype);
+            if (MPI_SUCCESS != err) {
+                return err;
+            }
+        }
+
+        ompi_request_t **reqs;
+        size_t nrecv = 0, recv_iter = 0;
+
+        for (i = 0; i < size; ++i) {
+            /* We directly copied the data from self */
+            if (0 < rcounts[i] && rank != i) {
+                ++nrecv;
+            }
+        }
+
+        if (0 == nrecv) {
+            /* Nothing to receive */
+            return MPI_SUCCESS;
+        }
+
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, nrecv);
+
+        for (i = 1; i < size; ++i) {
+            peer = (rank + i) % size;
+            ptmp = ((char *) rbuf) + (extent * disps[peer]);
+            /* Only receive if there is something to receive */
+            if (0 < rcounts[peer]) {
+                err = MCA_PML_CALL(irecv(ptmp, rcounts[peer], rdtype, peer,
+                                         MCA_COLL_BASE_TAG_GATHERV, comm, &reqs[recv_iter++]));
+            }
+        }
+
+        assert(nrecv == recv_iter);
+
+        err = ompi_request_wait_all(nrecv, reqs, MPI_STATUSES_IGNORE);
+
+        if (MPI_ERR_IN_STATUS == err) {
+            for (int i = 0; i < nrecv; i++) {
+                if (MPI_REQUEST_NULL == reqs[i])
+                    continue;
+                if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR)
+                    continue;
+                if (MPI_SUCCESS != reqs[i]->req_status.MPI_ERROR) {
+                    err = reqs[i]->req_status.MPI_ERROR;
+                    break;
+                }
+            }
+        }
+
+        ompi_coll_base_free_reqs(reqs, nrecv);
+        return err;
+    }
+
     /* Everyone but root sends data and returns.  Don't send anything
        for sendcounts of 0 (even though MPI_Gatherv has a guard for 0
        counts, this routine is used elsewhere, like the implementation
        of allgatherv, so it's possible to get here with a scount of
        0) */
 
-    if (rank != root) {
-        size_t sdsize;
-        ompi_datatype_type_size(sdtype, &sdsize);
-        if (scount > 0 && sdsize > 0) {
-            return MCA_PML_CALL(send(sbuf, scount, sdtype, root,
-                                     MCA_COLL_BASE_TAG_GATHERV,
-                                     MCA_PML_BASE_SEND_STANDARD, comm));
-        }
-        return MPI_SUCCESS;
+    size_t sdsize;
+    ompi_datatype_type_size(sdtype, &sdsize);
+    if (scount > 0 && sdsize > 0) {
+        return MCA_PML_CALL(send(sbuf, scount, sdtype, root, MCA_COLL_BASE_TAG_GATHERV,
+                                 MCA_PML_BASE_SEND_STANDARD, comm));
     }
-
-    /* I am the root, loop receiving data. */
-
-    ompi_datatype_type_size(rdtype, &rdsize);
-    if (OPAL_UNLIKELY(0 == rdsize)) {
-        /* bozzo case */
-        return MPI_SUCCESS;
-    }
-
-    err = ompi_datatype_get_extent(rdtype, &lb, &extent);
-    if (OMPI_SUCCESS != err) {
-        return OMPI_ERROR;
-    }
-
-    for (i = 0; i < size; ++i) {
-        ptmp = ((char *) rbuf) + (extent * disps[i]);
-
-        if (i == rank) {
-            /* simple optimization */
-            if (MPI_IN_PLACE != sbuf && (0 < scount) && (0 < rcounts[i])) {
-                err = ompi_datatype_sndrcv(sbuf, scount, sdtype,
-                                      ptmp, rcounts[i], rdtype);
-            }
-        } else {
-            /* Only receive if there is something to receive */
-            if (rcounts[i] > 0) {
-                err = MCA_PML_CALL(recv(ptmp, rcounts[i], rdtype, i,
-                                        MCA_COLL_BASE_TAG_GATHERV,
-                                        comm, MPI_STATUS_IGNORE));
-            }
-        }
-
-        if (MPI_SUCCESS != err) {
-            return err;
-        }
-    }
-
-    /* All done */
-
     return MPI_SUCCESS;
 }
-
 
 /*
  *	gatherv_inter


### PR DESCRIPTION
Match mca_coll_basic_gatherv_inter and post recvs all at once and wait for completion.

On 16 nodes x 64 procs per node.

Before change
```
# OSU MPI Gatherv Latency Test v7.2
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
1                       4.70              0.44           1536.99        1000
2                       4.55              0.44           1349.49        1000
4                       4.55              0.44           1354.38        1000
8                       4.57              0.43           1355.60        1000
16                      4.54              0.43           1358.09        1000
32                      4.57              0.43           1367.16        1000
64                      4.65              0.51           1401.43        1000
128                     4.71              0.51           1435.00        1000
256                     6.67              0.54           1481.32        1000
512                     6.79              0.62           1506.00        1000
1024                    7.07              0.75           1636.05        1000
2048                    7.58              1.02           1885.09        1000
4096                  176.95              1.34           2374.75        1000
8192                  334.70             42.01           3105.94        1000
16384                 675.91             48.24           5991.97         100
32768                1398.70             49.25          11533.55         100
65536                2796.40             56.01          22327.21         100
131072              28857.40            126.02          58478.83         100
262144              39252.54            143.59          79549.07         100
524288              74975.66            154.49         153863.74         100
```

After change
```
# OSU MPI Gatherv Latency Test v7.2
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
1                       4.07              0.43            837.03        1000
2                       4.12              0.43            855.29        1000
4                       4.12              0.40            867.89        1000
8                       4.13              0.41            871.72        1000
16                      4.11              0.41            867.32        1000
32                      4.12              0.31            868.77        1000
64                      4.19              0.49            890.67        1000
128                     4.23              0.39            904.01        1000
256                     5.81              0.53            922.80        1000
512                     5.93              0.60            951.96        1000
1024                    6.15              0.73           1038.52        1000
2048                    6.58              0.99           1181.65        1000
4096                  175.48              1.41           1485.15        1000
8192                  337.08             40.62           1980.23        1000
16384                 695.01             47.09           3501.86         100
32768                1366.80             50.47           6609.68         100
65536                2806.96             55.93          12364.52         100
131072               7446.11            289.31          23053.06         100
262144              22079.03            316.72          44473.66         100
524288              57385.71            401.17          86912.28         100
```