### PR TITLE
docs: update for Python 3.12

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,7 +242,7 @@ def find_man_pages_top():
         for root, dirs, files in os.walk(topdir):
             for filename in files:
                 # Parse filenames of the format a "foo.X.rst"
-                parts = re.search("^([^/]+?)\.([0-9]+)\.rst$", filename)
+                parts = re.search(r"^([^/]+?)\.([0-9]+)\.rst$", filename)
 
                 # Skip files that do not match that format (e.g.,
                 # "index.rst")


### PR DESCRIPTION
Python 3.12 no longer allows escapes in regular expressions.  Instead, use "r" strings.