### PR TITLE
[5.0.x] Correct missing info argument in man pages for MPI_Psend_init and MPI_Precv_init

### DIFF
--- a/docs/man-openmpi/man3/MPI_Precv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Precv_init.3.rst
@@ -21,7 +21,7 @@ C Syntax
    #include <mpi.h>
 
    int MPI_Precv_init(const void *buf, int partitions, int count, MPI_Datatype datatype, int dest,
-   	int tag, MPI_Comm comm, MPI_Request *request)
+   	int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request)
 
 
 Fortran Syntax
@@ -31,9 +31,9 @@ Fortran Syntax
 
    USE MPI
    ! or the older form: INCLUDE 'mpif.h'
-   MPI_PRECV_INIT(BUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR)
+   MPI_PRECV_INIT(BUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, INFO, REQUEST, IERROR)
    	<type>	BUF(*)
-   	INTEGER	PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR
+   	INTEGER	PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, INFO, REQUEST, IERROR
 
 
 Fortran 2008 Syntax
@@ -42,11 +42,12 @@ Fortran 2008 Syntax
 .. code-block:: fortran
 
    USE mpi_f08
-   MPI_Precv_init(buf, partitions, count, datatype, dest, tag, comm, request, ierror)
+   MPI_Precv_init(buf, partitions, count, datatype, dest, tag, comm, info, request, ierror)
    	TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: buf
    	INTEGER, INTENT(IN) :: partitions, count, dest, tag
    	TYPE(MPI_Datatype), INTENT(IN) :: datatype
    	TYPE(MPI_Comm), INTENT(IN) :: comm
+   	TYPE(MPI_Info), INTENT(IN) :: info
    	TYPE(MPI_Request), INTENT(OUT) :: request
    	INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
@@ -60,6 +61,7 @@ INPUT PARAMETERS
 * ``dest``: Rank of source (integer).
 * ``tag``: Message tag (integer).
 * ``comm``: Communicator (handle).
+* ``info``: Info argument (handle).
 
 OUTPUT PARAMETERS
 -----------------

--- a/docs/man-openmpi/man3/MPI_Psend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Psend_init.3.rst
@@ -21,7 +21,7 @@ C Syntax
    #include <mpi.h>
 
    int MPI_Psend_init(const void *buf, int partitions, int count, MPI_Datatype datatype, int dest,
-   	int tag, MPI_Comm comm, MPI_Request *request)
+   	int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request)
 
 
 Fortran Syntax
@@ -31,9 +31,9 @@ Fortran Syntax
 
    USE MPI
    ! or the older form: INCLUDE 'mpif.h'
-   MPI_PSEND_INIT(BUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR)
+   MPI_PSEND_INIT(BUF, PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, INFO, REQUEST, IERROR)
    	<type>	BUF(*)
-   	INTEGER	PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, REQUEST, IERROR
+   	INTEGER	PARTITIONS, COUNT, DATATYPE, DEST, TAG, COMM, INFO, REQUEST, IERROR
 
 
 Fortran 2008 Syntax
@@ -42,11 +42,12 @@ Fortran 2008 Syntax
 .. code-block:: fortran
 
    USE mpi_f08
-   MPI_Psend_init(buf, partitions, count, datatype, dest, tag, comm, request, ierror)
+   MPI_Psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request, ierror)
    	TYPE(*), DIMENSION(..), INTENT(IN), ASYNCHRONOUS :: buf
    	INTEGER, INTENT(IN) :: partitions, count, dest, tag
    	TYPE(MPI_Datatype), INTENT(IN) :: datatype
    	TYPE(MPI_Comm), INTENT(IN) :: comm
+   	TYPE(MPI_Info), INTENT(IN) :: info
    	TYPE(MPI_Request), INTENT(OUT) :: request
    	INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
@@ -60,6 +61,7 @@ INPUT PARAMETERS
 * ``dest``: Rank of source (integer).
 * ``tag``: Message tag (integer).
 * ``comm``: Communicator (handle).
+* ``info``: Info argument (handle).
 
 OUTPUT PARAMETERS
 -----------------


### PR DESCRIPTION
Cherry-pick of #12304 for v5.0 as requested by @janjust 

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>
(cherry picked from commit d622835ab4e20dee66ec74ad34d632fe99ce10ad)