### PR TITLE
CI: Bot to mark abandoned Github Issues stale/closed

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,65 @@
+# The idea behind this Action is to prevent the situation where a user
+# files a Github Issue, someone asks for clarification / more
+# information, but the original poster never provides the information.
+# The issue then becomes forgotten and abondoned.
+#
+# Instead of that scenario, Open MPI community members can assign a
+# label to Github Issues indicating that we're waiting for the user to
+# reply.  If too much time elapses with no reply, mark the Issue as
+# stale and emit a warning that we'll close the issue if we continue
+# to receive no reply.  If we timeout again with no reply after the
+# warning, close the Issue and emit a comment explaining why.
+#
+# If the user *does* reply, the label is removed, and this bot won't
+# touch the Issue.  Specifically: this bot will never mark stale /
+# close an Issue that doesn't have the specified label.
+#
+# Additionally, we are *only* marking stale / auto-closing Github
+# Issues -- not Pull Requests.
+#
+# This is a cron-based Action that runs a few times a day, just so
+# that we don't mark stale / close a bunch of issues all at once.
+#
+# While the actions/stale bot Action used here is capable of removing
+# the label when a user replies to the Issue, we actually use a 2nd
+# Action (removing-awaiting-user-info-label.yaml) to remove the label.
+# We do this because that 2nd Action runs whenever a comment is
+# created -- not via cron.  Hence, the 2nd Action will remove the
+# label effectively immediately when the user replies (vs. up to
+# several hours later).
+
+name: Close stale issues
+on:
+  schedule:
+    # Run it a few times a day so as not to necessarily mark stale /
+    # close a bunch of issues at once.
+    - cron: '0 1,5,9,13,17,21 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/close-stale-issues
+      - uses: actions/stale@v9
+        with:
+          # If there are no replies for 14 days, mark the issue as
+          # "stale" (and emit a warning).
+          days-before-stale: 14
+          # If there are no replies for 14 days after becoming stale,
+          # then close the issue (and emit a message explaining why).
+          days-before-close: 14
+
+          # Never close PRs
+          days-before-pr-close: -1
+
+          # We only close issues with this label
+          only-labels: "State: Awaiting user information"
+          close-issue-label: Closed due to no reply
+
+          # Messages that we put in comments on issues
+          stale-issue-message: |
+            It looks like this issue is expecting a response, but hasn't gotten one yet.  If there are no responses in the next 2 weeks, we'll assume that the issue has been abandoned and will close it.
+          close-issue-message: |
+            Per the above comment, it has been a month with no reply on this issue.  It looks like this issue has been abandoned.
+
+            I'm going to close this issue.  If I'm wrong and this issue is *not* abandoned, please feel free to re-open it.  Thank you!

--- a/.github/workflows/remove-awaiting-user-info-label.yaml
+++ b/.github/workflows/remove-awaiting-user-info-label.yaml
@@ -1,0 +1,30 @@
+# This Action is run in conjunction with close-stale-issues.yaml.  See
+# that file for a more complete description of how they work together.
+
+name: 'Remove "State: Awaiting user information" label when there has been a reply'
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # From
+    # https://github.com/marketplace/actions/close-issues-after-no-reply:
+    # only remove the label if someone replies to an issue who is not
+    # an owner or collaborator on the repo.
+    if: |
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    steps:
+      - name: 'Remove "State: Awaiting user information" label'
+        uses: octokit/request-action@v2.x
+        continue-on-error: true
+        with:
+          route: DELETE /repos/:repository/issues/:issue/labels/:label
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          label: "State: Awaiting user information"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When an Open MPI community member assigns the label "State: Awaiting user information" to a Github Issue, if someone without write permissions to the repo doesn't reply in 14 days, mark the Github Issue stale.  If no reply is received in a further 14 days, close the Github Issue.

See lengthy comment in close-stale-issues.yaml for a more detailed explanation.