### PR TITLE
CI: remove ":" from close-the-issue bot label names

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -53,7 +53,7 @@ jobs:
           days-before-pr-close: -1
 
           # We only close issues with this label
-          only-labels: "State: Awaiting user information"
+          only-labels: State-Awaiting user information
           close-issue-label: Closed due to no reply
 
           # Messages that we put in comments on issues

--- a/.github/workflows/remove-awaiting-user-info-label.yaml
+++ b/.github/workflows/remove-awaiting-user-info-label.yaml
@@ -25,6 +25,6 @@ jobs:
           route: DELETE /repos/:repository/issues/:issue/labels/:label
           repository: ${{ github.repository }}
           issue: ${{ github.event.issue.number }}
-          label: "State: Awaiting user information"
+          label: State-Awaiting user information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The bot to mark Github issues as stale and/or close them does not properly handle when labels contain ":".  After removing ":" from the label name on Github, update the corresponding Github Actions here to match the new label names.