### PR TITLE
ompi/datatype: use size_t for count arguments

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -278,19 +278,20 @@ static inline int32_t
 ompi_datatype_copy_content_same_ddt( const ompi_datatype_t* type, size_t count,
                                      char* pDestBuf, char* pSrcBuf )
 {
-    int32_t length, rc;
+    int32_t rc;
+    size_t length;
     ptrdiff_t extent;
 
     ompi_datatype_type_extent( type, &extent );
     while( 0 != count ) {
         length = INT_MAX;
-        if( ((size_t)length) > count ) length = (int32_t)count;
+        if( length > count ) length = count;
         rc = opal_datatype_copy_content_same_ddt( &type->super, length,
                                                   pDestBuf, pSrcBuf );
         if( 0 != rc ) return rc;
         pDestBuf += ((ptrdiff_t)length) * extent;
         pSrcBuf  += ((ptrdiff_t)length) * extent;
-        count -= (size_t)length;
+        count -= length;
     }
     return 0;
 }

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -194,8 +194,8 @@ OPAL_DECLSPEC extern const opal_datatype_t opal_datatype_unsigned_long;
  */
 int opal_datatype_register_params(void);
 OPAL_DECLSPEC int32_t opal_datatype_init(void);
-OPAL_DECLSPEC opal_datatype_t *opal_datatype_create(int32_t expectedSize);
-OPAL_DECLSPEC int32_t opal_datatype_create_desc(opal_datatype_t *datatype, int32_t expectedSize);
+OPAL_DECLSPEC opal_datatype_t *opal_datatype_create(size_t expectedSize);
+OPAL_DECLSPEC int32_t opal_datatype_create_desc(opal_datatype_t *datatype, size_t expectedSize);
 OPAL_DECLSPEC int32_t opal_datatype_commit(opal_datatype_t *pData);
 OPAL_DECLSPEC int32_t opal_datatype_destroy(opal_datatype_t **);
 OPAL_DECLSPEC int32_t opal_datatype_is_monotonic(opal_datatype_t *type);
@@ -225,7 +225,7 @@ static inline int32_t opal_datatype_is_predefined(const opal_datatype_t *type)
  * is contiguous in the memory. And false (0) otherwise.
  */
 static inline int32_t opal_datatype_is_contiguous_memory_layout(const opal_datatype_t *datatype,
-                                                                int32_t count)
+                                                                size_t count)
 {
     if (!(datatype->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS))
         return 0;
@@ -246,7 +246,7 @@ OPAL_DECLSPEC int32_t opal_datatype_clone(const opal_datatype_t *src_type,
 /**
  * A contiguous array of identical datatypes.
  */
-OPAL_DECLSPEC int32_t opal_datatype_create_contiguous(int count, const opal_datatype_t *oldType,
+OPAL_DECLSPEC int32_t opal_datatype_create_contiguous(size_t count, const opal_datatype_t *oldType,
                                                       opal_datatype_t **newType);
 /**
  * Add a new datatype to the base type description. The count is the number
@@ -306,7 +306,7 @@ OPAL_DECLSPEC ssize_t opal_datatype_get_element_count(const opal_datatype_t *pDa
 OPAL_DECLSPEC int32_t opal_datatype_set_element_count(const opal_datatype_t *pData, size_t count,
                                                       size_t *length);
 OPAL_DECLSPEC int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *pData,
-                                                          int32_t count, char *pDestBuf,
+                                                          size_t count, char *pDestBuf,
                                                           char *pSrcBuf);
 
 OPAL_DECLSPEC int opal_datatype_compute_ptypes(opal_datatype_t *datatype);
@@ -348,10 +348,10 @@ static inline ptrdiff_t opal_datatype_span(const opal_datatype_t *pData, size_t 
  * to make it stop on all pack and unpack errors.
  */
 OPAL_DECLSPEC int opal_datatype_safeguard_pointer_debug_breakpoint(const void *actual_ptr,
-                                                                   int length,
+                                                                   size_t length,
                                                                    const void *initial_ptr,
                                                                    const opal_datatype_t *pData,
-                                                                   int count);
+                                                                   size_t count);
 #endif /* OPAL_ENABLE_DEBUG */
 
 END_C_DECLS

--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -137,13 +137,13 @@ static void *opal_datatype_accelerator_memmove(void *dest, const void *src, size
 #define MEM_OP opal_datatype_accelerator_memmove
 #include "opal_datatype_copy.h"
 
-int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, int32_t count,
+int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *datatype, size_t count,
                                             char *destination_base, char *source_base)
 {
     ptrdiff_t extent;
-    int32_t (*fct)(const opal_datatype_t *, int32_t, char *, char *);
+    int32_t (*fct)(const opal_datatype_t *, size_t, char *, char *);
 
-    DO_DEBUG(opal_output(0, "opal_datatype_copy_content_same_ddt( %p, %d, dst %p, src %p )\n",
+    DO_DEBUG(opal_output(0, "opal_datatype_copy_content_same_ddt( %p, %zu, dst %p, src %p )\n",
                          (void *) datatype, count, (void *) destination_base,
                          (void *) source_base););
 

--- a/opal/datatype/opal_datatype_copy.h
+++ b/opal/datatype/opal_datatype_copy.h
@@ -109,7 +109,7 @@ static inline void _contiguous_loop(const dt_elem_desc_t *ELEM, const opal_datat
     *(SPACE) -= _copy_loops;
 }
 
-static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, int32_t count,
+static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, size_t count,
                                              char *destination_base, char *source_base)
 {
     dt_stack_t *pStack;  /* pointer to the position on the stack */
@@ -122,10 +122,10 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
     unsigned char *source = (unsigned char *) source_base,
                   *destination = (unsigned char *) destination_base;
 
-    DO_DEBUG(opal_output(0, "_copy_content_same_ddt( %p, %d, dst %p, src %p )\n", (void *) datatype,
+    DO_DEBUG(opal_output(0, "_copy_content_same_ddt( %p, %zu, dst %p, src %p )\n", (void *) datatype,
                          count, (void *) destination_base, (void *) source_base););
 
-    iov_len_local = (size_t) count * datatype->size;
+    iov_len_local = count * datatype->size;
 
     /* If we have to copy a contiguous datatype then simply
      * do a MEM_OP.
@@ -155,7 +155,7 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
             }
             return 0; /* completed */
         }
-        for (pos_desc = 0; (int32_t) pos_desc < count; pos_desc++) {
+        for (pos_desc = 0; pos_desc < count; pos_desc++) {
             OPAL_DATATYPE_SAFEGUARD_POINTER(destination, datatype->size,
                                             (unsigned char *) destination_base, datatype, count);
             OPAL_DATATYPE_SAFEGUARD_POINTER(source, datatype->size, (unsigned char *) source_base,

--- a/opal/datatype/opal_datatype_create.c
+++ b/opal/datatype/opal_datatype_create.c
@@ -91,11 +91,11 @@ static void opal_datatype_destruct(opal_datatype_t *datatype)
 
 OBJ_CLASS_INSTANCE(opal_datatype_t, opal_object_t, opal_datatype_construct, opal_datatype_destruct);
 
-opal_datatype_t *opal_datatype_create(int32_t expectedSize)
+opal_datatype_t *opal_datatype_create(size_t expectedSize)
 {
     opal_datatype_t *datatype = (opal_datatype_t *) OBJ_NEW(opal_datatype_t);
 
-    if (expectedSize == -1) {
+    if (expectedSize == (size_t) -1) {
         expectedSize = DT_INCREASE_STACK;
     }
     datatype->desc.length = expectedSize + 1; /* one for the fake elem at the end */
@@ -107,9 +107,9 @@ opal_datatype_t *opal_datatype_create(int32_t expectedSize)
     return datatype;
 }
 
-int32_t opal_datatype_create_desc(opal_datatype_t *datatype, int32_t expectedSize)
+int32_t opal_datatype_create_desc(opal_datatype_t *datatype, size_t expectedSize)
 {
-    if (expectedSize == -1) {
+    if (expectedSize == (size_t) -1) {
         expectedSize = DT_INCREASE_STACK;
     }
     datatype->desc.length = expectedSize + 1; /* one for the fake elem at the end */

--- a/opal/datatype/opal_datatype_create_contiguous.c
+++ b/opal/datatype/opal_datatype_create_contiguous.c
@@ -24,7 +24,7 @@
 #include "opal/datatype/opal_datatype.h"
 #include "opal/datatype/opal_datatype_internal.h"
 
-int32_t opal_datatype_create_contiguous(int count, const opal_datatype_t *oldType,
+int32_t opal_datatype_create_contiguous(size_t count, const opal_datatype_t *oldType,
                                         opal_datatype_t **newType)
 {
     opal_datatype_t *pdt;

--- a/opal/datatype/opal_datatype_module.c
+++ b/opal/datatype/opal_datatype_module.c
@@ -293,9 +293,9 @@ int32_t opal_datatype_init(void)
  * Set a breakpoint to this function in your favorite debugger
  * to make it stop on all pack and unpack errors.
  */
-int opal_datatype_safeguard_pointer_debug_breakpoint(const void *actual_ptr, int length,
+int opal_datatype_safeguard_pointer_debug_breakpoint(const void *actual_ptr, size_t length,
                                                      const void *initial_ptr,
-                                                     const opal_datatype_t *pData, int count)
+                                                     const opal_datatype_t *pData, size_t count)
 {
     return 0;
 }

--- a/test/datatype/opal_ddt_lib.c
+++ b/test/datatype/opal_ddt_lib.c
@@ -408,7 +408,7 @@ static int32_t opal_datatype_create_struct(int count, const int *pBlockLength,
     lastDisp = pDisp[0];
     endto = pDisp[0] + lastExtent * lastBlock;
 
-    pdt = opal_datatype_create((int32_t) disp);
+    pdt = opal_datatype_create((size_t) disp);
 
     /* Do again the same loop but now add the elements */
     for (i = 1; i < count; i++) {


### PR DESCRIPTION
The use of int for count arguments is becoming restrictive especially to adopt large count. This change extends the argument type to size_t.