### PR TITLE
accelerator: introduce compare_ipc_handles fnct

### DIFF
--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -366,7 +366,8 @@ typedef int (*opal_accelerator_base_module_get_address_range_fn_t)(
  *
  * opal_accelerator_base_module_get_ipc_handle_fn_t()
  * opal_accelerator_base_module_open_ipc_handle_fn_t()
- * opal_accelerator_base_module_import_ipc_event_handle_fn_t()
+ * opal_accelerator_base_module_import_ipc_handle_fn_t()
+ * opal_accelerator_base_module_compare_ipc_handles_fn_t()
  * opal_accelerator_base_module_get_ipc_event_handle_fn_t()
  * opal_accelerator_base_module_open_ipc_event_handle_fn_t()
  * opal_accelerator_base_module_import_ipc_event_handle_fn_t()
@@ -426,6 +427,19 @@ typedef int (*opal_accelerator_base_module_import_ipc_handle_fn_t)(
  */
 typedef int (*opal_accelerator_base_module_open_ipc_handle_fn_t)(
     int dev_id, opal_accelerator_ipc_handle_t *handle, void **dev_ptr);
+
+/**
+ * Compare two IPC handles
+ *
+ * @param[IN] handle_1       First IPC handle
+ * @param[IN] handle_2       Second IPC handle
+ *
+ * @return                   zero if IPC handles are identical
+ *                           non-zero value otherwise
+ */
+
+typedef int (*opal_accelerator_base_module_compare_ipc_handles_fn_t)(
+    uint8_t handle_1[IPC_MAX_HANDLE_SIZE], uint8_t handle_2[IPC_MAX_HANDLE_SIZE]);
 
 /**
  * Gets an IPC event handle for an event created by opal_accelerator_base_module_create_event_fn_t.
@@ -568,6 +582,7 @@ typedef struct {
     opal_accelerator_base_module_get_ipc_handle_fn_t get_ipc_handle;
     opal_accelerator_base_module_import_ipc_handle_fn_t import_ipc_handle;
     opal_accelerator_base_module_open_ipc_handle_fn_t open_ipc_handle;
+    opal_accelerator_base_module_compare_ipc_handles_fn_t compare_ipc_handles;
     opal_accelerator_base_module_get_ipc_event_handle_fn_t get_ipc_event_handle;
     opal_accelerator_base_module_import_ipc_event_handle_fn_t import_ipc_event_handle;
     opal_accelerator_base_module_open_ipc_event_handle_fn_t open_ipc_event_handle;

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -49,6 +49,8 @@ static int accelerator_cuda_import_ipc_handle(int dev_id, uint8_t ipc_handle[IPC
                                               opal_accelerator_ipc_handle_t *handle);
 static int accelerator_cuda_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
                                             void **dev_ptr);
+static int accelerator_cuda_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+                                                uint8_t handle_2[IPC_MAX_HANDLE_SIZE]);
 static int accelerator_cuda_get_ipc_event_handle(opal_accelerator_event_t *event,
                                                  opal_accelerator_ipc_event_handle_t *handle);
 static int accelerator_cuda_import_ipc_event_handle(uint8_t ipc_handle[IPC_MAX_HANDLE_SIZE],
@@ -89,6 +91,7 @@ opal_accelerator_base_module_t opal_accelerator_cuda_module =
     accelerator_cuda_get_ipc_handle,
     accelerator_cuda_import_ipc_handle,
     accelerator_cuda_open_ipc_handle,
+    accelerator_cuda_compare_ipc_handles,
     accelerator_cuda_get_ipc_event_handle,
     accelerator_cuda_import_ipc_event_handle,
     accelerator_cuda_open_ipc_event_handle,
@@ -582,6 +585,12 @@ static int accelerator_cuda_open_ipc_handle(int dev_id, opal_accelerator_ipc_han
                                             void **dev_ptr)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_cuda_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+                                                uint8_t handle_2[IPC_MAX_HANDLE_SIZE])
+{
+    return memcmp(handle_1, handle_2, IPC_MAX_HANDLE_SIZE);
 }
 
 static int accelerator_cuda_get_ipc_event_handle(opal_accelerator_event_t *event,

--- a/opal/mca/accelerator/null/accelerator_null_component.c
+++ b/opal/mca/accelerator/null/accelerator_null_component.c
@@ -64,6 +64,8 @@ static int accelerator_null_import_ipc_handle(int dev_id, uint8_t ipc_handle[IPC
                                               opal_accelerator_ipc_handle_t *handle);
 static int accelerator_null_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
                                             void **dev_ptr);
+static int accelerator_null_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+                                                uint8_t handle_2[IPC_MAX_HANDLE_SIZE]);
 static int accelerator_null_get_ipc_event_handle(opal_accelerator_event_t *event,
                                                  opal_accelerator_ipc_event_handle_t *handle);
 static int accelerator_null_import_ipc_event_handle(uint8_t ipc_handle[IPC_MAX_HANDLE_SIZE],
@@ -140,6 +142,7 @@ opal_accelerator_base_module_t opal_accelerator_null_module =
     accelerator_null_get_ipc_handle,
     accelerator_null_import_ipc_handle,
     accelerator_null_open_ipc_handle,
+    accelerator_null_compare_ipc_handles,
     accelerator_null_get_ipc_event_handle,
     accelerator_null_import_ipc_event_handle,
     accelerator_null_open_ipc_event_handle,
@@ -271,6 +274,12 @@ static int accelerator_null_import_ipc_handle(int dev_id, uint8_t ipc_handle[IPC
 
 static int accelerator_null_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
                                             void **dev_ptr)
+{
+    return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_null_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+						uint8_t handle_2[IPC_MAX_HANDLE_SIZE])
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }

--- a/opal/mca/accelerator/ze/accelerator_ze_module.c
+++ b/opal/mca/accelerator/ze/accelerator_ze_module.c
@@ -46,6 +46,8 @@ static int mca_accelerator_ze_import_ipc_handle(int dev_id, uint8_t ipc_handle[I
                                                 opal_accelerator_ipc_handle_t *handle);
 static int mca_accelerator_ze_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
                                               void **dev_ptr);
+static int accelerator_ze_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+                                             uint8_t handle_2[IPC_MAX_HANDLE_SIZE]);
 static int mca_accelerator_ze_get_ipc_event_handle(opal_accelerator_event_t *event,
                                                    opal_accelerator_ipc_event_handle_t *handle);
 static int mca_accelerator_ze_import_ipc_event_handle(uint8_t ipc_handle[IPC_MAX_HANDLE_SIZE],
@@ -85,6 +87,7 @@ opal_accelerator_base_module_t opal_accelerator_ze_module =
     .get_ipc_handle = mca_accelerator_ze_get_ipc_handle,
     .import_ipc_handle = mca_accelerator_ze_import_ipc_handle,
     .open_ipc_handle = mca_accelerator_ze_open_ipc_handle,
+    .compare_ipc_handles = mca_accelerator_ze_compare_ipc_handles,
     .get_ipc_event_handle = mca_accelerator_ze_get_ipc_event_handle,
     .import_ipc_event_handle = mca_accelerator_ze_import_ipc_event_handle,
     .open_ipc_event_handle = mca_accelerator_ze_open_ipc_event_handle,
@@ -648,6 +651,12 @@ static int mca_accelerator_ze_open_ipc_handle(int dev_id, opal_accelerator_ipc_h
                                               void **dev_ptr)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
+}
+
+static int accelerator_ze_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
+                                              uint8_t handle_2[IPC_MAX_HANDLE_SIZE])
+{
+    return memcmp(handle_1, handle_2, IPC_MAX_HANDLE_SIZE);
 }
 
 static int mca_accelerator_ze_get_ipc_event_handle(opal_accelerator_event_t *event,

--- a/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
+++ b/opal/mca/rcache/rgpusm/rcache_rgpusm_module.c
@@ -248,7 +248,6 @@ int mca_rcache_rgpusm_register(mca_rcache_base_module_t *rcache, void *addr, siz
         rgpusm_reg->base.rcache = rcache;
         rgpusm_reg->base.base = addr;
         rgpusm_reg->base.bound = (unsigned char *) addr + size - 1;
-        ;
         rgpusm_reg->base.flags = flags;
 
         /* The rget_reg registration is holding the memory handle needed
@@ -294,9 +293,8 @@ int mca_rcache_rgpusm_register(mca_rcache_base_module_t *rcache, void *addr, siz
                             "RGPUSM: Found addr=%p,size=%d (base=%p,size=%d) in cache", addr,
                             (int) size, (void*)(*reg)->base, (int) ((*reg)->bound - (*reg)->base));
 
-        if (0 ==
-            memcmp(((mca_opal_gpu_reg_t *)*reg)->data.ipcHandle.handle, rget_reg->data.ipcHandle.handle,
-                  sizeof(((mca_opal_gpu_reg_t *)*reg)->data.ipcHandle.handle))) {
+        if (0 == opal_accelerator.compare_ipc_handles(((mca_opal_gpu_reg_t *)*reg)->data.ipcHandle.handle,
+                                                      rget_reg->data.ipcHandle.handle)) {
             /* Registration matches what was requested.  All is good. */
             rcache_rgpusm->stat_cache_valid++;
         } else {


### PR DESCRIPTION
comparing ipc handles might not be always just a memcmp of the two handles. Introduce an abstraction for this functionality. Use the memcmp function that was used so far in the cuda and ze component, but use only certain parts of the ipc handle in rocm.