### PR TITLE
oshmem/shmem/c: include missing headers

### DIFF
--- a/oshmem/shmem/c/shmem_alltoall.c
+++ b/oshmem/shmem/c/shmem_alltoall.c
@@ -17,6 +17,7 @@
 #include "oshmem/runtime/runtime.h"
 
 #include "oshmem/mca/scoll/scoll.h"
+#include "oshmem/mca/spml/spml.h"
 
 #include "oshmem/proc/proc.h"
 

--- a/oshmem/shmem/c/shmem_broadcast.c
+++ b/oshmem/shmem/c/shmem_broadcast.c
@@ -17,6 +17,7 @@
 #include "oshmem/runtime/runtime.h"
 
 #include "oshmem/mca/scoll/scoll.h"
+#include "oshmem/mca/spml/spml.h"
 
 #include "oshmem/proc/proc.h"
 

--- a/oshmem/shmem/c/shmem_collect.c
+++ b/oshmem/shmem/c/shmem_collect.c
@@ -17,6 +17,7 @@
 #include "oshmem/runtime/runtime.h"
 
 #include "oshmem/mca/scoll/scoll.h"
+#include "oshmem/mca/spml/spml.h"
 
 #include "oshmem/proc/proc.h"
 

--- a/oshmem/shmem/c/shmem_global_exit.c
+++ b/oshmem/shmem/c/shmem_global_exit.c
@@ -13,6 +13,7 @@
 
 #include "oshmem/include/shmem.h"
 #include "oshmem/runtime/runtime.h"
+#include "oshmem/proc/proc.h"
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"

--- a/oshmem/shmem/c/shmem_reduce.c
+++ b/oshmem/shmem/c/shmem_reduce.c
@@ -16,6 +16,7 @@
 #include "oshmem/runtime/runtime.h"
 
 #include "oshmem/mca/scoll/scoll.h"
+#include "oshmem/mca/spml/spml.h"
 #include "oshmem/proc/proc.h"
 #include "oshmem/op/op.h"
 


### PR DESCRIPTION
Not sure why no one has caught this before... these files simply fail to build without the additional include statements: `oshmem/mca/spml/spml.h` makes `MCA_SPML_CALL` available, and `oshmem/proc/proc.h` is required for `ompi_rte_abort`.