### PR TITLE
Prepare ompio frameworks for bigcount

### DIFF
--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -289,8 +289,8 @@ static void file_destructor(ompi_file_t *file)
     /* Finalize the module */
 
     switch (file->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        file->f_io_selected_module.v2_0_0.io_module_file_close(file);
+    case MCA_IO_BASE_V_3_0_0:
+        file->f_io_selected_module.v3_0_0.io_module_file_close(file);
         break;
     default:
         /* Should never get here */

--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -15,6 +15,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -249,34 +251,34 @@ typedef struct mca_common_ompio_data_t mca_common_ompio_data_t;
 #include "common_ompio_print_queue.h"
 #include "common_ompio_aggregators.h"
 
-OMPI_DECLSPEC int mca_common_ompio_file_write (ompio_file_t *fh, const void *buf,  int count,
+OMPI_DECLSPEC int mca_common_ompio_file_write (ompio_file_t *fh, const void *buf, size_t count,
                                                struct ompi_datatype_t *datatype, 
                                                ompi_status_public_t *status);
 
 OMPI_DECLSPEC int mca_common_ompio_file_write_at (ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE offset,  const void *buf,
-                                                  int count,  struct ompi_datatype_t *datatype, 
+                                                  size_t count, struct ompi_datatype_t *datatype,
                                                   ompi_status_public_t *status);
 
-OMPI_DECLSPEC int mca_common_ompio_file_iwrite (ompio_file_t *fh, const void *buf, int count,
+OMPI_DECLSPEC int mca_common_ompio_file_iwrite (ompio_file_t *fh, const void *buf, size_t count,
                                                 struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at (ompio_file_t *fh,  OMPI_MPI_OFFSET_TYPE offset,
-                                                   const void *buf,  int count,  struct ompi_datatype_t *datatype,
+                                                   const void *buf,  size_t count,  struct ompi_datatype_t *datatype,
                                                    ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_write_all (ompio_file_t *fh, const void *buf,
-                                                   int count, struct ompi_datatype_t *datatype, 
+                                                   size_t count, struct ompi_datatype_t *datatype,
                                                    ompi_status_public_t *status);
 
 OMPI_DECLSPEC int mca_common_ompio_file_write_at_all (ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE offset, const void *buf,
-                                                      int count, struct ompi_datatype_t *datatype, 
+                                                      size_t count, struct ompi_datatype_t *datatype,
                                                       ompi_status_public_t *status);
 
 OMPI_DECLSPEC int mca_common_ompio_file_iwrite_all (ompio_file_t *fp, const void *buf,
-                                                    int count, struct ompi_datatype_t *datatype, ompi_request_t **request);
+                                                    size_t count, struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp, OMPI_MPI_OFFSET_TYPE offset, const void *buf,
-                                                       int count, struct ompi_datatype_t *datatype, ompi_request_t **request);
+                                                       size_t count, struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_build_io_array ( ompio_fview_t *fview, int index, int cycles,
                                                     size_t bytes_per_cycle, size_t max_data, uint32_t iov_count,
@@ -285,32 +287,32 @@ OMPI_DECLSPEC int mca_common_ompio_build_io_array ( ompio_fview_t *fview, int in
                                                     int *num_io_entries );
 
 
-OMPI_DECLSPEC int mca_common_ompio_file_read (ompio_file_t *fh,  void *buf,  int count,
+OMPI_DECLSPEC int mca_common_ompio_file_read (ompio_file_t *fh,  void *buf,  size_t count,
                                               struct ompi_datatype_t *datatype, ompi_status_public_t *status);
 
 OMPI_DECLSPEC int mca_common_ompio_file_read_at (ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE offset,  void *buf,
-                                                 int count, struct ompi_datatype_t *datatype, 
+                                                 size_t count, struct ompi_datatype_t *datatype,
                                                  ompi_status_public_t * status);
 
-OMPI_DECLSPEC int mca_common_ompio_file_iread (ompio_file_t *fh, void *buf, int count,
+OMPI_DECLSPEC int mca_common_ompio_file_iread (ompio_file_t *fh, void *buf, size_t count,
                                                struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_iread_at (ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE offset,
-                                                  void *buf, int count, struct ompi_datatype_t *datatype,
+                                                  void *buf, size_t count, struct ompi_datatype_t *datatype,
                                                   ompi_request_t **request);
 
-OMPI_DECLSPEC int mca_common_ompio_file_read_all (ompio_file_t *fh, void *buf, int count, struct ompi_datatype_t *datatype,
+OMPI_DECLSPEC int mca_common_ompio_file_read_all (ompio_file_t *fh, void *buf, size_t count, struct ompi_datatype_t *datatype,
                                                   ompi_status_public_t * status);
 
 OMPI_DECLSPEC int mca_common_ompio_file_read_at_all (ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE offset,
-                                                     void *buf, int count, struct ompi_datatype_t *datatype,
+                                                     void *buf, size_t count, struct ompi_datatype_t *datatype,
                                                      ompi_status_public_t * status);
 
-OMPI_DECLSPEC int mca_common_ompio_file_iread_all (ompio_file_t *fp, void *buf, int count, struct ompi_datatype_t *datatype,
+OMPI_DECLSPEC int mca_common_ompio_file_iread_all (ompio_file_t *fp, void *buf, size_t count, struct ompi_datatype_t *datatype,
                                                    ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_iread_at_all (ompio_file_t *fp, OMPI_MPI_OFFSET_TYPE offset,
-                                                      void *buf, int count, struct ompi_datatype_t *datatype,
+                                                      void *buf, size_t count, struct ompi_datatype_t *datatype,
                                                       ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_file_open (ompi_communicator_t *comm, const char *filename,
@@ -330,7 +332,7 @@ OMPI_DECLSPEC int mca_common_ompio_set_file_defaults (ompio_file_t *fh);
 OMPI_DECLSPEC int mca_common_ompio_set_view (ompio_file_t *fh,  OMPI_MPI_OFFSET_TYPE disp,
                                              ompi_datatype_t *etype,  ompi_datatype_t *filetype, const char *datarep,
                                              opal_info_t *info);
-OMPI_DECLSPEC int mca_common_ompio_base_file_read_all (struct ompio_file_t *fh, void *buf, int count,
+OMPI_DECLSPEC int mca_common_ompio_base_file_read_all (struct ompio_file_t *fh, void *buf, size_t count,
                                                        struct ompi_datatype_t *datatype, ompi_status_public_t *status);
 
  
@@ -341,7 +343,7 @@ OMPI_DECLSPEC int mca_common_ompio_base_file_read_all (struct ompio_file_t *fh, 
  */
 OMPI_DECLSPEC int mca_common_ompio_decode_datatype (struct ompio_file_t *fh,
                                                     struct ompi_datatype_t *datatype,
-                                                    int count,
+                                                    size_t count,
                                                     const void *buf,
                                                     size_t *max_data,
                                                     opal_convertor_t *convertor,

--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -17,6 +17,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1048,11 +1050,11 @@ int mca_common_ompio_merge_groups(ompio_file_t *fh,
 			          int num_merge_aggrs)
 {
     int i = 0;
-    int *sizes_old_group;
+    size_t *sizes_old_group;
     int ret;
-    int *displs = NULL;
+    ptrdiff_t *displs = NULL;
 
-    sizes_old_group = (int*)malloc(num_merge_aggrs * sizeof(int));
+    sizes_old_group = (size_t *)malloc(num_merge_aggrs * sizeof(size_t));
     if (NULL == sizes_old_group) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -1060,7 +1062,7 @@ int mca_common_ompio_merge_groups(ompio_file_t *fh,
     }
 
 
-    displs = (int*)malloc(num_merge_aggrs * sizeof(int));
+    displs = (ptrdiff_t *)malloc(num_merge_aggrs * sizeof(ptrdiff_t));
     if (NULL == displs) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -591,7 +593,7 @@ int mca_common_ompio_create_incomplete_file_handle (const char *filename,
 
 int mca_common_ompio_decode_datatype (struct ompio_file_t *fh,
                                       ompi_datatype_t *datatype,
-                                      int count,
+                                      size_t count,
                                       const void *buf,
                                       size_t *max_data,
                                       opal_convertor_t *conv,

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -13,6 +13,8 @@
  *  Copyright (c) 2018      Research Organization for Information Science
  *                          and Technology (RIST). All rights reserved.
  *  Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *  Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                          reserved.
  *  $COPYRIGHT$
  *
  *  Additional copyrights may follow
@@ -55,16 +57,16 @@
 */
 
 static int mca_common_ompio_file_read_default (ompio_file_t *fh, void *buf,
-                                               int count, struct ompi_datatype_t *datatype,
+                                               size_t count, struct ompi_datatype_t *datatype,
                                                ompi_status_public_t *status);
 
 static int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
-                                                 int count, struct ompi_datatype_t *datatype,
+                                                 size_t count, struct ompi_datatype_t *datatype,
                                                  ompi_status_public_t *status);
 
 int mca_common_ompio_file_read (ompio_file_t *fh,
                               void *buf,
-                              int count,
+                              size_t count,
                               struct ompi_datatype_t *datatype,
                               ompi_status_public_t *status)
 {
@@ -109,7 +111,7 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
 }
 
 int mca_common_ompio_file_read_default (ompio_file_t *fh, void *buf,
-                                        int count, struct ompi_datatype_t *datatype,
+                                        size_t count, struct ompi_datatype_t *datatype,
                                         ompi_status_public_t *status)
 {
     size_t total_bytes_read = 0;       /* total bytes that have been read*/
@@ -171,7 +173,7 @@ int mca_common_ompio_file_read_default (ompio_file_t *fh, void *buf,
 }
 
 int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
-                                          int count, struct ompi_datatype_t *datatype,
+                                          size_t count, struct ompi_datatype_t *datatype,
                                           ompi_status_public_t *status)
 {
     size_t tbr = 0;               /* total bytes that have been read*/
@@ -322,7 +324,7 @@ int mca_common_ompio_file_read_pipelined (ompio_file_t *fh, void *buf,
 int mca_common_ompio_file_read_at (ompio_file_t *fh,
 				 OMPI_MPI_OFFSET_TYPE offset,
 				 void *buf,
-				 int count,
+				 size_t count,
 				 struct ompi_datatype_t *datatype,
 				 ompi_status_public_t * status)
 {
@@ -403,7 +405,7 @@ static void mca_common_ompio_post_next_read_subreq(struct mca_ompio_request_t *r
 
 int mca_common_ompio_file_iread (ompio_file_t *fh,
                                void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_request_t **request)
 {
@@ -531,7 +533,7 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
 int mca_common_ompio_file_iread_at (ompio_file_t *fh,
 				  OMPI_MPI_OFFSET_TYPE offset,
 				  void *buf,
-				  int count,
+				  size_t count,
 				  struct ompi_datatype_t *datatype,
 				  ompi_request_t **request)
 {
@@ -563,7 +565,7 @@ int mca_common_ompio_file_iread_at (ompio_file_t *fh,
 /* Infrastructure for collective operations  */
 int mca_common_ompio_file_read_all (ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t * status)
 {
@@ -617,7 +619,7 @@ int mca_common_ompio_file_read_all (ompio_file_t *fh,
 int mca_common_ompio_file_read_at_all (ompio_file_t *fh,
 				     OMPI_MPI_OFFSET_TYPE offset,
 				     void *buf,
-				     int count,
+				     size_t count,
 				     struct ompi_datatype_t *datatype,
 				     ompi_status_public_t * status)
 {
@@ -638,7 +640,7 @@ int mca_common_ompio_file_read_at_all (ompio_file_t *fh,
 
 int mca_common_ompio_file_iread_all (ompio_file_t *fp,
                                      void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_request_t **request)
 {
@@ -664,7 +666,7 @@ int mca_common_ompio_file_iread_all (ompio_file_t *fp,
 int mca_common_ompio_file_iread_at_all (ompio_file_t *fp,
 				      OMPI_MPI_OFFSET_TYPE offset,
 				      void *buf,
-				      int count,
+				      size_t count,
 				      struct ompi_datatype_t *datatype,
 				      ompi_request_t **request)
 {

--- a/ompi/mca/common/ompio/common_ompio_file_read_all.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read_all.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +56,7 @@ static int read_heap_sort (mca_io_ompio_local_io_array *io_array,
 int
 mca_common_ompio_base_file_read_all (struct ompio_file_t *fh,
                                      void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t *status)
 {

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,16 +39,16 @@
 #include <math.h>
 
 static int mca_common_ompio_file_write_pipelined (ompio_file_t *fh, const void *buf,
-                                                  int count, struct ompi_datatype_t *datatype,
+                                                  size_t count, struct ompi_datatype_t *datatype,
                                                   ompi_status_public_t *status);
 
 static int mca_common_ompio_file_write_default (ompio_file_t *fh, const void *buf,
-                                                int count, struct ompi_datatype_t *datatype,
+                                                size_t count, struct ompi_datatype_t *datatype,
                                                 ompi_status_public_t *status);
 
 int mca_common_ompio_file_write (ompio_file_t *fh,
                                const void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_status_public_t *status)
 {
@@ -93,7 +95,7 @@ int mca_common_ompio_file_write (ompio_file_t *fh,
 
 int mca_common_ompio_file_write_default (ompio_file_t *fh,
                                          const void *buf,
-                                         int count,
+                                         size_t count,
                                          struct ompi_datatype_t *datatype,
                                          ompi_status_public_t *status)
 {
@@ -152,7 +154,7 @@ int mca_common_ompio_file_write_default (ompio_file_t *fh,
 
 int mca_common_ompio_file_write_pipelined (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status)
 {
@@ -289,7 +291,7 @@ int mca_common_ompio_file_write_pipelined (ompio_file_t *fh,
 int mca_common_ompio_file_write_at (ompio_file_t *fh,
 				  OMPI_MPI_OFFSET_TYPE offset,
 				  const void *buf,
-				  int count,
+				  size_t count,
 				  struct ompi_datatype_t *datatype,
 				  ompi_status_public_t *status)
 {
@@ -345,7 +347,7 @@ static void mca_common_ompio_post_next_write_subreq(struct mca_ompio_request_t *
 
 int mca_common_ompio_file_iwrite (ompio_file_t *fh,
                                 const void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request)
 {
@@ -473,7 +475,7 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
 int mca_common_ompio_file_iwrite_at (ompio_file_t *fh,
 				   OMPI_MPI_OFFSET_TYPE offset,
 				   const void *buf,
-				   int count,
+				   size_t count,
 				   struct ompi_datatype_t *datatype,
 				   ompi_request_t **request)
 {
@@ -505,7 +507,7 @@ int mca_common_ompio_file_iwrite_at (ompio_file_t *fh,
 /******************************************************************/
 int mca_common_ompio_file_write_all (ompio_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t *status)
 {
@@ -560,7 +562,7 @@ int mca_common_ompio_file_write_all (ompio_file_t *fh,
 int mca_common_ompio_file_write_at_all (ompio_file_t *fh,
 				      OMPI_MPI_OFFSET_TYPE offset,
 				      const void *buf,
-				      int count,
+				      size_t count,
 				      struct ompi_datatype_t *datatype,
 				      ompi_status_public_t *status)
 {
@@ -581,7 +583,7 @@ int mca_common_ompio_file_write_at_all (ompio_file_t *fh,
 
 int mca_common_ompio_file_iwrite_all (ompio_file_t *fp,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_request_t **request)
 {
@@ -608,7 +610,7 @@ int mca_common_ompio_file_iwrite_all (ompio_file_t *fp,
 int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp,
 				       OMPI_MPI_OFFSET_TYPE offset,
 				       const void *buf,
-				       int count,
+				       size_t count,
 				       struct ompi_datatype_t *datatype,
 				       ompi_request_t **request)
 {

--- a/ompi/mca/fcoll/base/base.h
+++ b/ompi/mca/fcoll/base/base.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,7 +57,7 @@ OMPI_DECLSPEC int ompi_fcoll_base_sort_iovec (struct iovec *iov, int num_entries
 
 OMPI_DECLSPEC mca_fcoll_base_component_t* mca_fcoll_base_component_lookup(const char* name);
 
-OMPI_DECLSPEC int mca_fcoll_base_file_read_all (ompio_file_t *fh, void *buf, int count,
+OMPI_DECLSPEC int mca_fcoll_base_file_read_all (ompio_file_t *fh, void *buf, size_t count,
                                                 struct ompi_datatype_t *datatype,
                                                 ompi_status_public_t *status);
 

--- a/ompi/mca/fcoll/base/fcoll_base_coll_array.h
+++ b/ompi/mca/fcoll/base/fcoll_base_coll_array.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,32 +45,32 @@
  * Based on an array of procs in group
  */
 OMPI_DECLSPEC int ompi_fcoll_base_coll_gatherv_array (void *sbuf,
-                                                 int scount,
+                                                 size_t scount,
                                                  ompi_datatype_t *sdtype,
                                                  void *rbuf,
-                                                 int *rcounts,
-                                                 int *disps,
+                                                 size_t *rcounts,
+                                                 ptrdiff_t *disps,
                                                  ompi_datatype_t *rdtype,
                                                  int root_index,
                                                  int *procs_in_group,
                                                  int procs_per_group,
                                                  ompi_communicator_t *comm);
 OMPI_DECLSPEC int ompi_fcoll_base_coll_scatterv_array (void *sbuf,
-                                                  int *scounts,
-                                                  int *disps,
+                                                  size_t *scounts,
+                                                  ptrdiff_t *disps,
                                                   ompi_datatype_t *sdtype,
                                                   void *rbuf,
-                                                  int rcount,
+                                                  size_t rcount,
                                                   ompi_datatype_t *rdtype,
                                                   int root_index,
                                                   int *procs_in_group,
                                                   int procs_per_group,
                                                   ompi_communicator_t *comm);
 OMPI_DECLSPEC int ompi_fcoll_base_coll_allgather_array (void *sbuf,
-                                                   int scount,
+                                                   size_t scount,
                                                    ompi_datatype_t *sdtype,
                                                    void *rbuf,
-                                                   int rcount,
+                                                   size_t rcount,
                                                    ompi_datatype_t *rdtype,
                                                    int root_index,
                                                    int *procs_in_group,
@@ -76,28 +78,28 @@ OMPI_DECLSPEC int ompi_fcoll_base_coll_allgather_array (void *sbuf,
                                                    ompi_communicator_t *comm);
 
 OMPI_DECLSPEC int ompi_fcoll_base_coll_allgatherv_array (void *sbuf,
-                                                    int scount,
+                                                    size_t scount,
                                                     ompi_datatype_t *sdtype,
                                                     void *rbuf,
-                                                    int *rcounts,
-                                                    int *disps,
+                                                    size_t *rcounts,
+                                                    ptrdiff_t *disps,
                                                     ompi_datatype_t *rdtype,
                                                     int root_index,
                                                     int *procs_in_group,
                                                     int procs_per_group,
                                                     ompi_communicator_t *comm);
 OMPI_DECLSPEC int ompi_fcoll_base_coll_gather_array (void *sbuf,
-                                                int scount,
+                                                size_t scount,
                                                 ompi_datatype_t *sdtype,
                                                 void *rbuf,
-                                                int rcount,
+                                                size_t rcount,
                                                 ompi_datatype_t *rdtype,
                                                 int root_index,
                                                 int *procs_in_group,
                                                 int procs_per_group,
                                                 ompi_communicator_t *comm);
 OMPI_DECLSPEC int ompi_fcoll_base_coll_bcast_array (void *buff,
-                                               int count,
+                                               size_t count,
                                                ompi_datatype_t *datatype,
                                                int root_index,
                                                int *procs_in_group,

--- a/ompi/mca/fcoll/base/fcoll_base_find_available.c
+++ b/ompi/mca/fcoll/base/fcoll_base_find_available.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 static int init_query(const mca_base_component_t *m,
                       bool enable_progress_threads,
                       bool enable_mpi_threads);
-static int init_query_2_0_0(const mca_base_component_t *component,
+static int init_query_3_0_0(const mca_base_component_t *component,
                             bool enable_progress_threads,
                             bool enable_mpi_threads);
 
@@ -83,10 +85,10 @@ static int init_query(const mca_base_component_t *m,
                         m->mca_component_name);
 
     /* This component has been successfully opened, now try to query it */
-    if (2 == m->mca_type_major_version &&
+    if (3 == m->mca_type_major_version &&
         0 == m->mca_type_minor_version &&
         0 == m->mca_type_release_version) {
-        ret = init_query_2_0_0(m, enable_progress_threads,
+        ret = init_query_3_0_0(m, enable_progress_threads,
                                enable_mpi_threads);
     } else {
         /* unrecognised API version */
@@ -114,12 +116,12 @@ static int init_query(const mca_base_component_t *m,
 }
 
 
-static int init_query_2_0_0(const mca_base_component_t *component,
+static int init_query_3_0_0(const mca_base_component_t *component,
                             bool enable_progress_threads,
                             bool enable_mpi_threads)
 {
-    mca_fcoll_base_component_2_0_0_t *fcoll =
-        (mca_fcoll_base_component_2_0_0_t *) component;
+    mca_fcoll_base_component_3_0_0_t *fcoll =
+        (mca_fcoll_base_component_3_0_0_t *) component;
 
     return fcoll->fcollm_init_query(enable_progress_threads,
                               enable_mpi_threads);

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
@@ -38,13 +38,13 @@ BEGIN_C_DECLS
 
 extern int mca_fcoll_dynamic_priority;
 
-OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_3_0_0_t mca_fcoll_dynamic_component;
 
 /* API functions */
 
 int mca_fcoll_dynamic_component_init_query(bool enable_progress_threads,
                                            bool enable_mpi_threads);
-struct mca_fcoll_base_module_1_0_0_t *
+struct mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_dynamic_component_file_query (ompio_file_t *fh, int *priority);
 
 int mca_fcoll_dynamic_component_file_unquery (ompio_file_t *file);

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2022 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,12 +54,12 @@ int mca_fcoll_dynamic_module_finalize (ompio_file_t *file);
 
 int mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t * status);
 int mca_fcoll_dynamic_file_read_all (struct ompio_file_t *fh,
                                      void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t * status);
 

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_component.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_component.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,13 +53,13 @@ static int dynamic_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_component = {
+mca_fcoll_base_component_3_0_0_t mca_fcoll_dynamic_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .fcollm_version = {
-        MCA_FCOLL_BASE_VERSION_2_0_0,
+        MCA_FCOLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "dynamic",

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 int
 mca_fcoll_dynamic_file_read_all (struct ompio_file_t *fh,
                                  void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -84,8 +84,10 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     /* global iovec at the writers that contain the iovecs created from
        file_set_view */
     uint32_t total_fview_count = 0;
-    int local_count = 0, temp_pindex;
-    int *fview_count = NULL, *disp_index=NULL, *temp_disp_index=NULL;
+    size_t local_count = 0, temp_pindex;
+    int temp_local_count;
+    size_t *fview_count = NULL;
+    ptrdiff_t *disp_index=NULL, *temp_disp_index=NULL;
     int current_index = 0, temp_index=0;
 
     char *global_buf = NULL;
@@ -95,7 +97,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
 
     /* array that contains the sorted indices of the global_iov */
     int *sorted = NULL, *sorted_file_offsets=NULL;
-    int *displs = NULL;
+    ptrdiff_t *displs = NULL;
     int dynamic_num_io_procs;
     size_t max_data = 0, datatype_size = 0;
     int **blocklen_per_process=NULL;
@@ -213,10 +215,11 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     ret = fh->f_generate_current_file_view( (struct ompio_file_t *) fh,
 					    max_data,
 					    &local_iov_array,
-					    &local_count);
+					    &temp_local_count);
     if (ret != OMPI_SUCCESS){
 	goto exit;
     }
+    local_count = temp_local_count;
 
 #if DEBUG_ON
     for (i=0 ; i<local_count ; i++) {
@@ -232,7 +235,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     /*************************************************************
      *** 4. Allgather the offset/lengths array from all processes
      *************************************************************/
-    fview_count = (int *) malloc (fh->f_procs_per_group * sizeof (int));
+    fview_count = (size_t *)malloc (fh->f_procs_per_group * sizeof (size_t));
     if (NULL == fview_count) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -242,11 +245,11 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     start_comm_time = MPI_Wtime();
 #endif
     ret = ompi_fcoll_base_coll_allgather_array (&local_count,
-                                           1,
-                                           MPI_INT,
+                                           sizeof(size_t),
+                                           MPI_BYTE,
                                            fview_count,
-                                           1,
-                                           MPI_INT,
+                                           sizeof(size_t),
+                                           MPI_BYTE,
                                            0,
                                            fh->f_procs_in_group,
                                            fh->f_procs_per_group,
@@ -260,7 +263,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     comm_time += (end_comm_time - start_comm_time);
 #endif
 
-    displs = (int*) malloc (fh->f_procs_per_group * sizeof (int));
+    displs = (ptrdiff_t *)malloc (fh->f_procs_per_group * sizeof (ptrdiff_t));
     if (NULL == displs) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -278,11 +281,11 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     printf("total_fview_count : %d\n", total_fview_count);
     if (my_aggregator == fh->f_rank) {
         for (i=0 ; i<fh->f_procs_per_group ; i++) {
-            printf ("%d: PROCESS: %d  ELEMENTS: %d  DISPLS: %d\n",
+            printf ("%d: PROCESS: %d  ELEMENTS: %zu  DISPLS: %ld\n",
                     fh->f_rank,
                     i,
                     fview_count[i],
-                    displs[i]);
+                    (long) displs[i]);
         }
     }
 #endif
@@ -370,7 +373,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
     cycles = ceil((double)total_bytes/bytes_per_cycle);
 
     if (my_aggregator == fh->f_rank) {
-        disp_index = (int *)malloc (fh->f_procs_per_group * sizeof (int));
+        disp_index = (ptrdiff_t *)malloc (fh->f_procs_per_group * sizeof (ptrdiff_t));
         if (NULL == disp_index) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -709,7 +712,7 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                     file_offsets_for_agg[sorted_file_offsets[i-1]].length;
             }
 
-            temp_disp_index = (int *)calloc (1, fh->f_procs_per_group * sizeof (int));
+            temp_disp_index = (ptrdiff_t *)calloc (1, fh->f_procs_per_group * sizeof (ptrdiff_t));
             if (NULL == temp_disp_index) {
                 opal_output (1, "OUT OF MEMORY\n");
                 ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -728,9 +731,9 @@ mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                 if (temp_disp_index[temp_pindex] < disp_index[temp_pindex])
                     temp_disp_index[temp_pindex] += 1;
                 else{
-                    printf("temp_disp_index[%d]: %d is greater than disp_index[%d]: %d\n",
-                           temp_pindex, temp_disp_index[temp_pindex],
-                           temp_pindex, disp_index[temp_pindex]);
+                    printf("temp_disp_index[%zu]: %ld is greater than disp_index[%zu]: %ld\n",
+                           temp_pindex, (long) temp_disp_index[temp_pindex],
+                           temp_pindex, (long) disp_index[temp_pindex]);
                 }
 #if DEBUG_ON
                 global_count +=

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -14,6 +14,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +56,7 @@ static int local_heap_sort (mca_io_ompio_local_io_array *io_array,
 int
 mca_fcoll_dynamic_file_write_all (struct ompio_file_t *fh,
                                   const void *buf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *datatype,
                                   ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_module.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_module.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2022 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +36,7 @@
  * ************************ actions structure ************************
  * *******************************************************************
  */
-static mca_fcoll_base_module_1_0_0_t dynamic =  {
+static mca_fcoll_base_module_2_0_0_t dynamic =  {
     mca_fcoll_dynamic_module_init,
     mca_fcoll_dynamic_module_finalize,
     mca_fcoll_dynamic_file_read_all,
@@ -54,7 +56,7 @@ mca_fcoll_dynamic_component_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-mca_fcoll_base_module_1_0_0_t *
+mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_dynamic_component_file_query (ompio_file_t *fh, int *priority)
 {
     *priority = mca_fcoll_dynamic_priority;

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2022 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,12 +58,12 @@ int mca_fcoll_dynamic_gen2_module_finalize (ompio_file_t *file);
 
 int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t * status);
 int mca_fcoll_dynamic_gen2_file_read_all (struct ompio_file_t *fh,
                                           void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype,
                                           ompi_status_public_t * status);
 

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2.h
@@ -42,13 +42,13 @@ BEGIN_C_DECLS
 extern int mca_fcoll_dynamic_gen2_priority;
 extern int mca_fcoll_dynamic_gen2_num_groups;
 
-OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_gen2_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_3_0_0_t mca_fcoll_dynamic_gen2_component;
 
 /* API functions */
 
 int mca_fcoll_dynamic_gen2_component_init_query(bool enable_progress_threads,
                                            bool enable_mpi_threads);
-struct mca_fcoll_base_module_1_0_0_t *
+struct mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_dynamic_gen2_component_file_query (ompio_file_t *fh, int *priority);
 
 int mca_fcoll_dynamic_gen2_component_file_unquery (ompio_file_t *file);

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_component.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_component.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2008-2020 University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,13 +54,13 @@ static int dynamic_gen2_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_fcoll_base_component_2_0_0_t mca_fcoll_dynamic_gen2_component = {
+mca_fcoll_base_component_3_0_0_t mca_fcoll_dynamic_gen2_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .fcollm_version = {
-        MCA_FCOLL_BASE_VERSION_2_0_0,
+        MCA_FCOLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "dynamic_gen2",

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
@@ -14,6 +14,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 
 int mca_fcoll_dynamic_gen2_file_read_all (struct ompio_file_t *fh,
                                           void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype,
                                           ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,7 +117,7 @@ int mca_fcoll_dynamic_gen2_split_iov_array ( ompio_file_t *fh, mca_common_ompio_
 
 int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -48,7 +48,8 @@ typedef struct mca_io_ompio_local_io_array{
 }mca_io_ompio_local_io_array;
 
 typedef struct mca_io_ompio_aggregator_data {
-    int *disp_index, *sorted, *fview_count, n;
+    int *disp_index, *sorted, n;
+    size_t *fview_count;
     int *max_disp_index;
     int **blocklen_per_process;
     MPI_Aint **displs_per_process, total_bytes, bytes_per_cycle, total_bytes_written;
@@ -133,7 +134,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     ompi_request_t **curr_reqs=NULL,**prev_reqs=NULL;
     mca_io_ompio_aggregator_data **aggr_data=NULL;
     
-    int *displs = NULL;
+    ptrdiff_t *displs = NULL;
     int dynamic_gen2_num_io_procs;
     size_t max_data = 0;
     MPI_Aint *total_bytes_per_process = NULL;
@@ -146,6 +147,8 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
 
     int *aggregators=NULL;
     int *result_counts=NULL;
+
+    int *temp_displs = NULL, *temp_counts = NULL;
     
     
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
@@ -359,7 +362,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     for ( i=0; i< dynamic_gen2_num_io_procs; i++ ) {
         aggr_data[i]->total_bytes = broken_total_lengths[i];
         aggr_data[i]->decoded_iov = broken_decoded_iovs[i];
-        aggr_data[i]->fview_count = (int *) malloc (fh->f_procs_per_group * sizeof (int));
+        aggr_data[i]->fview_count = (size_t *)malloc (fh->f_procs_per_group * sizeof (size_t));
         if (NULL == aggr_data[i]->fview_count) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -368,7 +371,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
         for ( j=0; j <fh->f_procs_per_group; j++ ) {
             aggr_data[i]->fview_count[j] = result_counts[dynamic_gen2_num_io_procs*j+i];
         }
-        displs = (int*) malloc (fh->f_procs_per_group * sizeof (int));
+        displs = (ptrdiff_t *)malloc (fh->f_procs_per_group * sizeof (ptrdiff_t));
         if (NULL == displs) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -376,7 +379,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
         }
         
         displs[0] = 0;
-        total_fview_count = aggr_data[i]->fview_count[0];
+        total_fview_count = (int) aggr_data[i]->fview_count[0];
         for (j=1 ; j<fh->f_procs_per_group ; j++) {
             total_fview_count += aggr_data[i]->fview_count[j];
             displs[j] = displs[j-1] + aggr_data[i]->fview_count[j-1];
@@ -410,15 +413,29 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
         start_comm_time = MPI_Wtime();
 #endif
         if ( 1 == mca_fcoll_dynamic_gen2_num_groups ) {
+            /* TODO:BIGCOUNT: Remove temporary values here once the coll
+             * framework is using size_t/ptrdiff_t */
+            temp_counts = (int *)malloc(2 * fh->f_procs_per_group * sizeof(int));
+            if (NULL == temp_counts) {
+                opal_output(1, "OUT OF MEMORY\n");
+                ret = OMPI_ERR_OUT_OF_RESOURCE;
+                goto exit;
+            }
+            temp_displs = temp_counts + total_fview_count;
+            for (j = 0; j < fh->f_procs_per_group; j++) {
+                temp_counts[j] = aggr_data[i]->fview_count[j];
+                temp_displs[j] = displs[j];
+            }
             ret = fh->f_comm->c_coll->coll_allgatherv (broken_iov_arrays[i],
                                                       broken_counts[i],
                                                       fh->f_iov_type,
                                                       aggr_data[i]->global_iov_array,
-                                                      aggr_data[i]->fview_count,
-                                                      displs,
+                                                      temp_counts,
+                                                      temp_displs,
                                                       fh->f_iov_type,
                                                       fh->f_comm,
                                                       fh->f_comm->c_coll->coll_allgatherv_module );
+            free(temp_counts);
         }
         else {
             ret = ompi_fcoll_base_coll_allgatherv_array (broken_iov_arrays[i],

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_module.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_module.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2022 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +36,7 @@
  * ************************ actions structure ************************
  * *******************************************************************
  */
-static mca_fcoll_base_module_1_0_0_t dynamic_gen2 =  {
+static mca_fcoll_base_module_2_0_0_t dynamic_gen2 =  {
     mca_fcoll_dynamic_gen2_module_init,
     mca_fcoll_dynamic_gen2_module_finalize,
     mca_fcoll_dynamic_gen2_file_read_all,
@@ -54,7 +56,7 @@ mca_fcoll_dynamic_gen2_component_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-mca_fcoll_base_module_1_0_0_t *
+mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_dynamic_gen2_component_file_query (ompio_file_t *fh, int *priority)
 {
     *priority = mca_fcoll_dynamic_gen2_priority;

--- a/ompi/mca/fcoll/fcoll.h
+++ b/ompi/mca/fcoll/fcoll.h
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,28 +117,28 @@ typedef int (*mca_fcoll_base_module_finalize_1_0_0_fn_t)
 typedef int (*mca_fcoll_base_module_file_read_all_fn_t)
 (struct ompio_file_t *fh,
  void *buf,
- int count,
+ size_t count,
  struct ompi_datatype_t *datatype,
  ompi_status_public_t *status);
 
 typedef int (*mca_fcoll_base_module_file_iread_all_fn_t)
 (struct ompio_file_t *fh,
  void *buf,
- int count,
+ size_t count,
  struct ompi_datatype_t *datatype,
  ompi_request_t **request);
 
 typedef int (*mca_fcoll_base_module_file_write_all_fn_t)
 (struct ompio_file_t *fh,
  const void *buf,
- int count,
+ size_t count,
  struct ompi_datatype_t *datatype,
  ompi_status_public_t *status);
 
 typedef int (*mca_fcoll_base_module_file_iwrite_all_fn_t)
 (struct ompio_file_t *fh,
  const void *buf,
- int count,
+ size_t count,
  struct ompi_datatype_t *datatype,
  ompi_request_t **request);
 

--- a/ompi/mca/fcoll/fcoll.h
+++ b/ompi/mca/fcoll/fcoll.h
@@ -41,8 +41,8 @@ struct mca_fcoll_request_t;
 /*
  * Macro for use in components that are of type coll
  */
-#define MCA_FCOLL_BASE_VERSION_2_0_0 \
-    OMPI_MCA_BASE_VERSION_2_1_0("fcoll", 2, 0, 0)
+#define MCA_FCOLL_BASE_VERSION_3_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("fcoll", 3, 0, 0)
 
 /*
  * This framework provides the abstraction for the collective file
@@ -77,7 +77,7 @@ typedef int (*mca_fcoll_base_component_init_query_1_0_0_fn_t)
     (bool enable_progress_threads,
      bool enable_mpi_threads);
 
-typedef struct mca_fcoll_base_module_1_0_0_t *
+typedef struct mca_fcoll_base_module_2_0_0_t *
 (*mca_fcoll_base_component_file_query_1_0_0_fn_t) (struct ompio_file_t *file,
                                                    int *priority);
 
@@ -86,10 +86,10 @@ typedef int (*mca_fcoll_base_component_file_unquery_1_0_0_fn_t)
 
 /*
  * ****************** component struct ******************************
- * Structure for fcoll v2.0.0 components.This is chained to MCA v2.0.0
+ * Structure for fcoll v3.0.0 components.This is chained to MCA v2.0.0
  * ****************** component struct ******************************
  */
-struct mca_fcoll_base_component_2_0_0_t {
+struct mca_fcoll_base_component_3_0_0_t {
     mca_base_component_t fcollm_version;
     mca_base_component_data_t fcollm_data;
 
@@ -97,8 +97,8 @@ struct mca_fcoll_base_component_2_0_0_t {
     mca_fcoll_base_component_file_query_1_0_0_fn_t fcollm_file_query;
     mca_fcoll_base_component_file_unquery_1_0_0_fn_t fcollm_file_unquery;
 };
-typedef struct mca_fcoll_base_component_2_0_0_t mca_fcoll_base_component_2_0_0_t;
-typedef struct mca_fcoll_base_component_2_0_0_t mca_fcoll_base_component_t;
+typedef struct mca_fcoll_base_component_3_0_0_t mca_fcoll_base_component_3_0_0_t;
+typedef struct mca_fcoll_base_component_3_0_0_t mca_fcoll_base_component_t;
 
 /*
  * ***********************************************************************
@@ -153,7 +153,7 @@ typedef void (*mca_fcoll_base_module_request_free_fn_t)
  * ***************************  module structure *************************
  * ***********************************************************************
  */
-struct mca_fcoll_base_module_1_0_0_t {
+struct mca_fcoll_base_module_2_0_0_t {
     /*
      * Per-file initialization function. This is called only
      * on the module which is selected. The finalize corresponding to
@@ -171,8 +171,8 @@ struct mca_fcoll_base_module_1_0_0_t {
     mca_fcoll_base_module_request_free_fn_t            fcoll_request_free;
 
 };
-typedef struct mca_fcoll_base_module_1_0_0_t mca_fcoll_base_module_1_0_0_t;
-typedef mca_fcoll_base_module_1_0_0_t mca_fcoll_base_module_t;
+typedef struct mca_fcoll_base_module_2_0_0_t mca_fcoll_base_module_2_0_0_t;
+typedef mca_fcoll_base_module_2_0_0_t mca_fcoll_base_module_t;
 
 END_C_DECLS
 

--- a/ompi/mca/fcoll/individual/fcoll_individual.h
+++ b/ompi/mca/fcoll/individual/fcoll_individual.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,14 +54,14 @@ int mca_fcoll_individual_module_finalize (ompio_file_t *file);
 
 int mca_fcoll_individual_file_read_all (ompio_file_t *fh,
                                      void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t * status);
 
 
 int mca_fcoll_individual_file_write_all (ompio_file_t *fh,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t * status);
 

--- a/ompi/mca/fcoll/individual/fcoll_individual.h
+++ b/ompi/mca/fcoll/individual/fcoll_individual.h
@@ -38,13 +38,13 @@ BEGIN_C_DECLS
 
 extern int mca_fcoll_individual_priority;
 
-OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_individual_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_3_0_0_t mca_fcoll_individual_component;
 
 /* API functions */
 
 int mca_fcoll_individual_component_init_query(bool enable_progress_threads,
                                            bool enable_mpi_threads);
-struct mca_fcoll_base_module_1_0_0_t *
+struct mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_individual_component_file_query (ompio_file_t *fh, int *priority);
 
 int mca_fcoll_individual_component_file_unquery (ompio_file_t *file);

--- a/ompi/mca/fcoll/individual/fcoll_individual_component.c
+++ b/ompi/mca/fcoll/individual/fcoll_individual_component.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,13 +56,13 @@ static int individual_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_fcoll_base_component_2_0_0_t mca_fcoll_individual_component = {
+mca_fcoll_base_component_3_0_0_t mca_fcoll_individual_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .fcollm_version = {
-        MCA_FCOLL_BASE_VERSION_2_0_0,
+        MCA_FCOLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "individual",

--- a/ompi/mca/fcoll/individual/fcoll_individual_file_read_all.c
+++ b/ompi/mca/fcoll/individual/fcoll_individual_file_read_all.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +37,7 @@
 int
 mca_fcoll_individual_file_read_all (ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/individual/fcoll_individual_file_write_all.c
+++ b/ompi/mca/fcoll/individual/fcoll_individual_file_write_all.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +34,7 @@
 
 int mca_fcoll_individual_file_write_all (ompio_file_t *fh,
                                          const void *buf,
-                                         int count,
+                                         size_t count,
                                          struct ompi_datatype_t *datatype,
                                          ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/individual/fcoll_individual_module.c
+++ b/ompi/mca/fcoll/individual/fcoll_individual_module.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +36,7 @@
  * ************************ actions structure ************************
  * *******************************************************************
  */
-static mca_fcoll_base_module_1_0_0_t individual =  {
+static mca_fcoll_base_module_2_0_0_t individual =  {
     mca_fcoll_individual_module_init,
     mca_fcoll_individual_module_finalize,
     mca_fcoll_individual_file_read_all,
@@ -54,7 +56,7 @@ mca_fcoll_individual_component_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-mca_fcoll_base_module_1_0_0_t *
+mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_individual_component_file_query (ompio_file_t *fh, int *priority)
 {
     *priority = mca_fcoll_individual_priority;

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
@@ -44,13 +44,13 @@ extern int mca_fcoll_vulcan_num_groups;
 extern int mca_fcoll_vulcan_write_chunksize;
 extern int mca_fcoll_vulcan_async_io;
 
-OMPI_DECLSPEC extern mca_fcoll_base_component_2_0_0_t mca_fcoll_vulcan_component;
+OMPI_DECLSPEC extern mca_fcoll_base_component_3_0_0_t mca_fcoll_vulcan_component;
 
 /* API functions */
 
 int mca_fcoll_vulcan_component_init_query(bool enable_progress_threads,
                                            bool enable_mpi_threads);
-struct mca_fcoll_base_module_1_0_0_t *
+struct mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_vulcan_component_file_query (ompio_file_t *fh, int *priority);
 
 int mca_fcoll_vulcan_component_file_unquery (ompio_file_t *file);

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,12 +60,12 @@ int mca_fcoll_vulcan_module_finalize (ompio_file_t *file);
 
 int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t * status);
 int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t * status);
 

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_component.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_component.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,13 +56,13 @@ static int vulcan_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_fcoll_base_component_2_0_0_t mca_fcoll_vulcan_component = {
+mca_fcoll_base_component_3_0_0_t mca_fcoll_vulcan_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .fcollm_version = {
-        MCA_FCOLL_BASE_VERSION_2_0_0,
+        MCA_FCOLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "vulcan",

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2021 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,7 +30,7 @@
 
 int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,7 +121,7 @@ static int mca_fcoll_vulcan_minmax ( ompio_file_t *fh, struct iovec *iov, int io
 
 int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype,
                                       ompi_status_public_t *status)
 {

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -47,7 +47,8 @@ typedef struct mca_io_ompio_local_io_array{
 }mca_io_ompio_local_io_array;
 
 typedef struct mca_io_ompio_aggregator_data {
-    int *disp_index, *sorted, *fview_count, n;
+    int *disp_index, *sorted, n;
+    size_t *fview_count;
     int *max_disp_index;
     int **blocklen_per_process;
     MPI_Aint **displs_per_process, total_bytes, bytes_per_cycle, total_bytes_written;
@@ -137,7 +138,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     ompi_request_t *req_iwrite = MPI_REQUEST_NULL;
     mca_io_ompio_aggregator_data **aggr_data=NULL;
     
-    int *displs = NULL;
+    ptrdiff_t *displs = NULL;
     int vulcan_num_io_procs;
     size_t max_data = 0;
     MPI_Aint *total_bytes_per_process = NULL;
@@ -151,6 +152,8 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     int aggr_index = NOT_AGGR_INDEX;
     int write_synch_type = 2;
     int write_chunksize, *result_counts=NULL;
+
+    int *temp_displs = NULL, *temp_counts = NULL;
     
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     double write_time = 0.0, start_write_time = 0.0, end_write_time = 0.0;
@@ -365,7 +368,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     for ( i=0; i< fh->f_num_aggrs; i++ ) {
         aggr_data[i]->total_bytes = broken_total_lengths[i];
         aggr_data[i]->decoded_iov = broken_decoded_iovs[i];
-        aggr_data[i]->fview_count = (int *) malloc (fh->f_procs_per_group * sizeof (int));
+        aggr_data[i]->fview_count = (size_t *)malloc (fh->f_procs_per_group * sizeof (size_t));
         if (NULL == aggr_data[i]->fview_count) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -374,7 +377,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         for ( j=0; j <fh->f_procs_per_group; j++ ) {
             aggr_data[i]->fview_count[j] = result_counts[fh->f_num_aggrs*j+i];
         }
-        displs = (int*) malloc (fh->f_procs_per_group * sizeof (int));
+        displs = (ptrdiff_t *)malloc (fh->f_procs_per_group * sizeof (ptrdiff_t));
         if (NULL == displs) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -382,7 +385,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         }
         
         displs[0] = 0;
-        total_fview_count = aggr_data[i]->fview_count[0];
+        total_fview_count = (uint32_t) aggr_data[i]->fview_count[0];
         for (j=1 ; j<fh->f_procs_per_group ; j++) {
             total_fview_count += aggr_data[i]->fview_count[j];
             displs[j] = displs[j-1] + aggr_data[i]->fview_count[j-1];
@@ -416,15 +419,29 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         start_comm_time = MPI_Wtime();
 #endif
         if ( 1 == mca_fcoll_vulcan_num_groups ) {
+            /* TODO:BIGCOUNT: Remove temporary variables when coll framework is
+             * udpated to use size_t/ptrdiff_t */
+            temp_counts = (int *)malloc (2 * fh->f_procs_per_group * sizeof(int));
+            if (NULL == temp_counts) {
+                opal_output (1, "OUT OF MEMORY\n");
+                ret = OMPI_ERR_OUT_OF_RESOURCE;
+                goto exit;
+            }
+            temp_displs = temp_counts + fh->f_procs_per_group;
+            for (j = 0; j < fh->f_procs_per_group; j++) {
+                temp_counts[j] = (int) aggr_data[i]->fview_count[j];
+                temp_displs[j] = (int) displs[j];
+            }
             ret = fh->f_comm->c_coll->coll_allgatherv (broken_iov_arrays[i],
                                                       broken_counts[i],
                                                       fh->f_iov_type,
                                                       aggr_data[i]->global_iov_array,
-                                                      aggr_data[i]->fview_count,
-                                                      displs,
+                                                      temp_counts,
+                                                      temp_displs,
                                                       fh->f_iov_type,
                                                       fh->f_comm,
                                                       fh->f_comm->c_coll->coll_allgatherv_module );
+            free(temp_counts);
         }
         else {
             ret = ompi_fcoll_base_coll_allgatherv_array (broken_iov_arrays[i],

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_module.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_module.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +36,7 @@
  * ************************ actions structure ************************
  * *******************************************************************
  */
-static mca_fcoll_base_module_1_0_0_t vulcan =  {
+static mca_fcoll_base_module_2_0_0_t vulcan =  {
     mca_fcoll_vulcan_module_init,
     mca_fcoll_vulcan_module_finalize,
     mca_fcoll_vulcan_file_read_all,
@@ -54,7 +56,7 @@ mca_fcoll_vulcan_component_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-mca_fcoll_base_module_1_0_0_t *
+mca_fcoll_base_module_2_0_0_t *
 mca_fcoll_vulcan_component_file_query (ompio_file_t *fh, int *priority)
 {
     *priority = mca_fcoll_vulcan_priority;

--- a/ompi/mca/io/base/io_base_delete.c
+++ b/ompi/mca/io/base/io_base_delete.c
@@ -14,6 +14,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,7 +66,7 @@ static avail_io_t *check_one_component(const mca_base_component_t *component,
 
 static avail_io_t *query(const mca_base_component_t *component,
                          const char *filename, struct opal_info_t *info);
-static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *io_component,
+static avail_io_t *query_3_0_0(const mca_io_base_component_3_0_0_t *io_component,
                                const char *filename, struct opal_info_t *info);
 
 static void unquery(avail_io_t *avail, const char *filename, struct opal_info_t *info);
@@ -147,7 +149,7 @@ int mca_io_base_delete(const char *filename, struct opal_info_t *info)
     }
     OBJ_RELEASE(selectable);
 
-    if (!strcmp (selected.ai_component.v2_0_0.io_version.mca_component_name,
+    if (!strcmp (selected.ai_component.v3_0_0.io_version.mca_component_name,
                  "ompio")) {
         int ret;
 
@@ -174,7 +176,7 @@ int mca_io_base_delete(const char *filename, struct opal_info_t *info)
 
     opal_output_verbose(10, ompi_io_base_framework.framework_output,
                         "io:base:delete: Selected io component %s",
-                        selected.ai_component.v2_0_0.io_version.mca_component_name);
+                        selected.ai_component.v3_0_0.io_version.mca_component_name);
 
     return OMPI_SUCCESS;
 }
@@ -308,16 +310,16 @@ static avail_io_t *check_one_component(const mca_base_component_t *component,
 static avail_io_t *query(const mca_base_component_t *component,
                          const char *filename, struct opal_info_t *info)
 {
-    const mca_io_base_component_2_0_0_t *ioc_200;
+    const mca_io_base_component_3_0_0_t *ioc_300;
 
-    /* io v2.0.0 */
+    /* io v3.0.0 */
 
     if (MCA_BASE_VERSION_MAJOR == component->mca_major_version &&
         MCA_BASE_VERSION_MINOR == component->mca_minor_version &&
         MCA_BASE_VERSION_RELEASE == component->mca_release_version) {
-        ioc_200 = (mca_io_base_component_2_0_0_t *) component;
+        ioc_300 = (mca_io_base_component_3_0_0_t *) component;
 
-        return query_2_0_0(ioc_200, filename, info);
+        return query_3_0_0(ioc_300, filename, info);
     }
 
     /* Unknown io API version -- return error */
@@ -326,7 +328,7 @@ static avail_io_t *query(const mca_base_component_t *component,
 }
 
 
-static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
+static avail_io_t *query_3_0_0(const mca_io_base_component_3_0_0_t *component,
                                const char *filename, struct opal_info_t *info)
 {
     bool usable;
@@ -334,7 +336,7 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
     avail_io_t *avail;
     struct mca_io_base_delete_t *private_data;
 
-    /* Query v2.0.0 */
+    /* Query v3.0.0 */
 
     avail = NULL;
     private_data = NULL;
@@ -343,9 +345,9 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
                                      &priority);
     if (OMPI_SUCCESS == ret && usable) {
         avail = OBJ_NEW(avail_io_t);
-        avail->ai_version = MCA_IO_BASE_V_2_0_0;
+        avail->ai_version = MCA_IO_BASE_V_3_0_0;
         avail->ai_priority = priority;
-        avail->ai_component.v2_0_0 = *component;
+        avail->ai_component.v3_0_0 = *component;
         avail->ai_private_data = private_data;
     }
 
@@ -359,13 +361,13 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
 
 static void unquery(avail_io_t *avail, const char *filename, struct opal_info_t *info)
 {
-    const mca_io_base_component_2_0_0_t *ioc_200;
+    const mca_io_base_component_3_0_0_t *ioc_300;
 
     switch(avail->ai_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        ioc_200 = &(avail->ai_component.v2_0_0);
-        if (NULL != ioc_200->io_delete_unquery) {
-            ioc_200->io_delete_unquery(filename, info, avail->ai_private_data);
+    case MCA_IO_BASE_V_3_0_0:
+        ioc_300 = &(avail->ai_component.v3_0_0);
+        if (NULL != ioc_300->io_delete_unquery) {
+            ioc_300->io_delete_unquery(filename, info, avail->ai_private_data);
         }
         break;
 
@@ -384,12 +386,12 @@ static void unquery(avail_io_t *avail, const char *filename, struct opal_info_t 
  */
 static int delete_file(avail_io_t *avail, const char *filename, struct opal_info_t *info)
 {
-    const mca_io_base_component_2_0_0_t *ioc_200;
+    const mca_io_base_component_3_0_0_t *ioc_300;
 
     switch(avail->ai_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        ioc_200 = &(avail->ai_component.v2_0_0);
-        return ioc_200->io_delete_select(filename, info,
+    case MCA_IO_BASE_V_3_0_0:
+        ioc_300 = &(avail->ai_component.v3_0_0);
+        return ioc_300->io_delete_select(filename, info,
                                          avail->ai_private_data);
         break;
 

--- a/ompi/mca/io/base/io_base_file_select.c
+++ b/ompi/mca/io/base/io_base_file_select.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +78,7 @@ static avail_io_t *check_one_component(ompi_file_t *file,
 
 static avail_io_t *query(const mca_base_component_t *component,
                          ompi_file_t *file);
-static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *io_component,
+static avail_io_t *query_2_0_0(const mca_io_base_component_3_0_0_t *io_component,
                                ompi_file_t *file);
 
 static void unquery(avail_io_t *avail, ompi_file_t *file);
@@ -195,7 +197,7 @@ int mca_io_base_file_select(ompi_file_t *file,
 
     OBJ_RELEASE(selectable);
 
-    if (!strcmp (selected.ai_component.v2_0_0.io_version.mca_component_name,
+    if (!strcmp (selected.ai_component.v3_0_0.io_version.mca_component_name,
                  "ompio")) {
         int ret;
 
@@ -254,15 +256,15 @@ int mca_io_base_file_select(ompi_file_t *file,
 
     opal_output_verbose(10, ompi_io_base_framework.framework_output,
                         "io:base:file_select: Selected io module %s",
-                        selected.ai_component.v2_0_0.io_version.mca_component_name);
+                        selected.ai_component.v3_0_0.io_version.mca_component_name);
 
 #if OPAL_ENABLE_FT_MPI
     if(ompi_ftmpi_enabled) {
         /* check if module is tested for FT, warn if not. */
         const char* ft_whitelist="";
         opal_show_help("help-mpi-ft.txt", "module:untested:failundef", true,
-            selected.ai_component.v2_0_0.io_version.mca_type_name,
-            selected.ai_component.v2_0_0.io_version.mca_component_name,
+            selected.ai_component.v3_0_0.io_version.mca_type_name,
+            selected.ai_component.v3_0_0.io_version.mca_component_name,
             ft_whitelist);
     }
 #endif /* OPAL_ENABLE_FT_MPI */
@@ -396,16 +398,16 @@ static avail_io_t *check_one_component(ompi_file_t *file,
 static avail_io_t *query(const mca_base_component_t *component,
                          ompi_file_t *file)
 {
-    const mca_io_base_component_2_0_0_t *ioc_200;
+    const mca_io_base_component_3_0_0_t *ioc_300;
 
     /* MCA version check */
 
     if (MCA_BASE_VERSION_MAJOR == component->mca_major_version &&
         MCA_BASE_VERSION_MINOR == component->mca_minor_version &&
         MCA_BASE_VERSION_RELEASE == component->mca_release_version) {
-        ioc_200 = (mca_io_base_component_2_0_0_t *) component;
+        ioc_300 = (mca_io_base_component_3_0_0_t *) component;
 
-        return query_2_0_0(ioc_200, file);
+        return query_2_0_0(ioc_300, file);
     }
 
     /* Unknown io API version -- return error */
@@ -414,12 +416,12 @@ static avail_io_t *query(const mca_base_component_t *component,
 }
 
 
-static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
+static avail_io_t *query_2_0_0(const mca_io_base_component_3_0_0_t *component,
                                ompi_file_t *file)
 {
     int priority;
     avail_io_t *avail;
-    const mca_io_base_module_2_0_0_t *module;
+    const mca_io_base_module_3_0_0_t *module;
     struct mca_io_base_file_t *module_data;
 
     /* Query v2.0.0 */
@@ -429,10 +431,10 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
     module = component->io_file_query(file, &module_data, &priority);
     if (NULL != module) {
         avail = OBJ_NEW(avail_io_t);
-        avail->ai_version = MCA_IO_BASE_V_2_0_0;
+        avail->ai_version = MCA_IO_BASE_V_3_0_0;
         avail->ai_priority = priority;
-        avail->ai_component.v2_0_0 = *component;
-        avail->ai_module.v2_0_0 = *module;
+        avail->ai_component.v3_0_0 = *component;
+        avail->ai_module.v3_0_0 = *module;
         avail->ai_module_data = module_data;
     }
 
@@ -446,12 +448,12 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
 
 static void unquery(avail_io_t *avail, ompi_file_t *file)
 {
-    const mca_io_base_component_2_0_0_t *ioc_200;
+    const mca_io_base_component_3_0_0_t *ioc_300;
 
     switch(avail->ai_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        ioc_200 = &(avail->ai_component.v2_0_0);
-        ioc_200->io_file_unquery(file, avail->ai_module_data);
+    case MCA_IO_BASE_V_3_0_0:
+        ioc_300 = &(avail->ai_component.v3_0_0);
+        ioc_300->io_file_unquery(file, avail->ai_module_data);
         break;
 
     default:
@@ -469,12 +471,12 @@ static void unquery(avail_io_t *avail, ompi_file_t *file)
  */
 static int module_init(ompi_file_t *file)
 {
-    const mca_io_base_module_2_0_0_t *iom_200;
+    const mca_io_base_module_3_0_0_t *iom_300;
 
     switch(file->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        iom_200 = &(file->f_io_selected_module.v2_0_0);
-        return iom_200->io_module_file_open(file->f_comm, file->f_filename,
+    case MCA_IO_BASE_V_3_0_0:
+        iom_300 = &(file->f_io_selected_module.v3_0_0);
+        return iom_300->io_module_file_open(file->f_comm, file->f_filename,
                                             file->f_amode, file->super.s_info,
                                             file);
         break;

--- a/ompi/mca/io/base/io_base_find_available.c
+++ b/ompi/mca/io/base/io_base_find_available.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +41,7 @@
 static int init_query(const mca_base_component_t *ls,
                       bool enable_progress_threads,
                       bool enable_mpi_threads);
-static int init_query_2_0_0(const mca_base_component_t *ls,
+static int init_query_3_0_0(const mca_base_component_t *ls,
                             bool enable_progress_threads,
                             bool enable_mpi_threads);
 
@@ -106,10 +108,10 @@ static int init_query(const mca_base_component_t *m,
     /* This component has already been successfully opened.  So now
        query it. */
 
-    if (2 == m->mca_type_major_version &&
+    if (3 == m->mca_type_major_version &&
         0 == m->mca_type_minor_version &&
         0 == m->mca_type_release_version) {
-        ret = init_query_2_0_0(m, enable_progress_threads,
+        ret = init_query_3_0_0(m, enable_progress_threads,
                                enable_mpi_threads);
     } else {
         /* Unrecognized io API version */
@@ -142,14 +144,14 @@ static int init_query(const mca_base_component_t *m,
 
 
 /*
- * Query a specific component, io v2.0.0
+ * Query a specific component, io v3.0.0
  */
-static int init_query_2_0_0(const mca_base_component_t *component,
+static int init_query_3_0_0(const mca_base_component_t *component,
                             bool enable_progress_threads,
                             bool enable_mpi_threads)
 {
-    mca_io_base_component_2_0_0_t *io =
-	(mca_io_base_component_2_0_0_t *) component;
+    mca_io_base_component_3_0_0_t *io =
+	(mca_io_base_component_3_0_0_t *) component;
 
     return io->io_init_query(enable_progress_threads,
                              enable_mpi_threads);

--- a/ompi/mca/io/base/io_base_register_datarep.c
+++ b/ompi/mca/io/base/io_base_register_datarep.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +39,7 @@ mca_io_base_register_datarep(const char *datarep,
 {
     mca_base_component_list_item_t *cli;
     const mca_base_component_t *component;
-    const mca_io_base_component_2_0_0_t *v200;
+    const mca_io_base_component_3_0_0_t *v200;
     int tmp, ret = OMPI_SUCCESS;
 
     /* Find the maximum additional number of bytes required by all io
@@ -50,7 +52,7 @@ mca_io_base_register_datarep(const char *datarep,
         if (component->mca_type_major_version == 2 &&
             component->mca_type_minor_version == 0 &&
             component->mca_type_release_version == 0) {
-            v200 = (mca_io_base_component_2_0_0_t *) component;
+            v200 = (mca_io_base_component_3_0_0_t *) component;
 
             /* return first non-good error-code */
             tmp = v200->io_register_datarep(datarep, read_fn, write_fn,

--- a/ompi/mca/io/io.h
+++ b/ompi/mca/io/io.h
@@ -17,6 +17,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +45,7 @@ struct mca_io_base_delete_t;
 /*
  * Forward declarations of things declared in this file
  */
-struct mca_io_base_module_2_0_0_t;
+struct mca_io_base_module_3_0_0_t;
 union mca_io_base_modules_t;
 
 
@@ -59,7 +61,7 @@ union mca_io_base_modules_t;
  */
 enum mca_io_base_version_t {
     MCA_IO_BASE_V_NONE,
-    MCA_IO_BASE_V_2_0_0,
+    MCA_IO_BASE_V_3_0_0,
 
     MCA_IO_BASE_V_MAX
 };
@@ -73,18 +75,18 @@ typedef enum mca_io_base_version_t mca_io_base_version_t;
  * Macro for use in components that are of type io
  * 1-1 mapping of all MPI-IO functions
  */
-#define MCA_IO_BASE_VERSION_2_0_0 \
-    OMPI_MCA_BASE_VERSION_2_1_0("io", 2, 0, 0)
+#define MCA_IO_BASE_VERSION_3_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("io", 3, 0, 0)
 
 /*
  * Component
  */
 
-struct mca_io_base_module_2_0_0_t;
+struct mca_io_base_module_3_0_0_t;
 typedef int (*mca_io_base_component_init_query_fn_t)
     (bool enable_progress_threads, bool enable_mpi_threads);
-typedef const struct mca_io_base_module_2_0_0_t *
-    (*mca_io_base_component_file_query_2_0_0_fn_t)
+typedef const struct mca_io_base_module_3_0_0_t *
+    (*mca_io_base_component_file_query_3_0_0_fn_t)
     (struct ompi_file_t *file, struct mca_io_base_file_t **private_data,
      int *priority);
 typedef int (*mca_io_base_component_file_unquery_fn_t)
@@ -110,12 +112,12 @@ typedef int (*mca_io_base_component_register_datarep_fn_t)(
 
 
 /* IO component version and interface functions. */
-struct mca_io_base_component_2_0_0_t {
+struct mca_io_base_component_3_0_0_t {
     mca_base_component_t io_version;
     mca_base_component_data_t io_data;
 
     mca_io_base_component_init_query_fn_t io_init_query;
-    mca_io_base_component_file_query_2_0_0_fn_t io_file_query;
+    mca_io_base_component_file_query_3_0_0_fn_t io_file_query;
     mca_io_base_component_file_unquery_fn_t io_file_unquery;
 
     mca_io_base_component_file_delete_query_fn_t io_delete_query;
@@ -124,14 +126,14 @@ struct mca_io_base_component_2_0_0_t {
 
     mca_io_base_component_register_datarep_fn_t io_register_datarep;
 };
-typedef struct mca_io_base_component_2_0_0_t mca_io_base_component_2_0_0_t;
+typedef struct mca_io_base_component_3_0_0_t mca_io_base_component_3_0_0_t;
 
 
 /*
  * All component versions
  */
 union mca_io_base_components_t {
-    mca_io_base_component_2_0_0_t v2_0_0;
+    mca_io_base_component_3_0_0_t v3_0_0;
 };
 typedef union mca_io_base_components_t mca_io_base_components_t;
 
@@ -169,64 +171,64 @@ typedef int (*mca_io_base_module_file_get_view_fn_t)
 
 typedef int (*mca_io_base_module_file_read_at_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_read_at_all_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_at_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, const void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_at_all_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, const void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_status_public_t *status);
 
 typedef int (*mca_io_base_module_file_iread_at_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_iwrite_at_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, const void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_request_t **request);
 
 typedef int (*mca_io_base_module_file_iread_at_all_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_iwrite_at_all_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, const void *buf,
-     int count, struct ompi_datatype_t *datatype,
+     size_t count, struct ompi_datatype_t *datatype,
      struct ompi_request_t **request);
 
 typedef int (*mca_io_base_module_file_read_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count, struct ompi_datatype_t *
+    (struct ompi_file_t *fh, void *buf, size_t count, struct ompi_datatype_t *
      datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_read_all_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count, struct ompi_datatype_t *
+    (struct ompi_file_t *fh, void *buf, size_t count, struct ompi_datatype_t *
      datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count, struct ompi_datatype_t *
+    (struct ompi_file_t *fh, const void *buf, size_t count, struct ompi_datatype_t *
      datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_all_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count, struct ompi_datatype_t *
+    (struct ompi_file_t *fh, const void *buf, size_t count, struct ompi_datatype_t *
      datatype, struct ompi_status_public_t *status);
 
 typedef int (*mca_io_base_module_file_iread_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_iwrite_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 
 typedef int (*mca_io_base_module_file_iread_all_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_iwrite_all_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 
 typedef int (*mca_io_base_module_file_seek_fn_t)
@@ -237,22 +239,22 @@ typedef int (*mca_io_base_module_file_get_byte_offset_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, MPI_Offset *disp);
 
 typedef int (*mca_io_base_module_file_read_shared_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_shared_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_iread_shared_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_iwrite_shared_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_request_t **request);
 typedef int (*mca_io_base_module_file_read_ordered_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_ordered_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_seek_shared_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, int whence);
@@ -261,31 +263,31 @@ typedef int (*mca_io_base_module_file_get_position_shared_fn_t)
 
 typedef int (*mca_io_base_module_file_read_at_all_begin_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, void *buf,
-     int count, struct ompi_datatype_t *datatype);
+     size_t count, struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_read_at_all_end_fn_t)
     (struct ompi_file_t *fh, void *buf, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_at_all_begin_fn_t)
     (struct ompi_file_t *fh, MPI_Offset offset, const void *buf,
-     int count, struct ompi_datatype_t *datatype);
+     size_t count, struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_write_at_all_end_fn_t)
     (struct ompi_file_t *fh, const void *buf, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_read_all_begin_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_read_all_end_fn_t)
     (struct ompi_file_t *fh, void *buf, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_all_begin_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_write_all_end_fn_t)
     (struct ompi_file_t *fh, const void *buf, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_read_ordered_begin_fn_t)
-    (struct ompi_file_t *fh, void *buf, int count,
+    (struct ompi_file_t *fh, void *buf, size_t count,
      struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_read_ordered_end_fn_t)
     (struct ompi_file_t *fh, void *buf, struct ompi_status_public_t *status);
 typedef int (*mca_io_base_module_file_write_ordered_begin_fn_t)
-    (struct ompi_file_t *fh, const void *buf, int count,
+    (struct ompi_file_t *fh, const void *buf, size_t count,
      struct ompi_datatype_t *datatype);
 typedef int (*mca_io_base_module_file_write_ordered_end_fn_t)
     (struct ompi_file_t *fh, const void *buf, struct ompi_status_public_t *status);
@@ -300,7 +302,7 @@ typedef int (*mca_io_base_module_file_get_atomicity_fn_t)
     (struct ompi_file_t *fh, int *flag);
 typedef int (*mca_io_base_module_file_sync_fn_t)(struct ompi_file_t *fh);
 
-struct mca_io_base_module_2_0_0_t {
+struct mca_io_base_module_3_0_0_t {
 
     /* Back-ends to MPI API calls (pretty much a 1-to-1 mapping) */
 
@@ -369,14 +371,14 @@ struct mca_io_base_module_2_0_0_t {
     mca_io_base_module_file_get_atomicity_fn_t        io_module_file_get_atomicity;
     mca_io_base_module_file_sync_fn_t                 io_module_file_sync;
 };
-typedef struct mca_io_base_module_2_0_0_t mca_io_base_module_2_0_0_t;
+typedef struct mca_io_base_module_3_0_0_t mca_io_base_module_3_0_0_t;
 
 
 /*
  * All module versions
  */
 union mca_io_base_modules_t {
-    mca_io_base_module_2_0_0_t v2_0_0;
+    mca_io_base_module_3_0_0_t v3_0_0;
 };
 typedef union mca_io_base_modules_t mca_io_base_modules_t;
 

--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -15,6 +15,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,12 +88,12 @@ OMPI_DECLSPEC extern int mca_io_ompio_coll_timing_info;
 
 BEGIN_C_DECLS
 
-OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_ompio_component;
+OMPI_DECLSPEC extern mca_io_base_component_3_0_0_t mca_io_ompio_component;
 /*
  * global variables, instantiated in module.c
  */
-extern mca_io_base_module_2_0_0_t mca_io_ompio_module;
-OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_ompio_component;
+extern mca_io_base_module_3_0_0_t mca_io_ompio_module;
+OMPI_DECLSPEC extern mca_io_base_component_3_0_0_t mca_io_ompio_component;
 
 /*Used in extracting offset adj-matrix*/
 typedef struct mca_io_ompio_offlen_array_t{
@@ -181,92 +183,92 @@ int mca_io_ompio_file_get_view (struct ompi_file_t *fh,
 int mca_io_ompio_file_read_at (struct ompi_file_t *fh,
                                OMPI_MPI_OFFSET_TYPE offset,
                                void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_status_public_t *status);
 int mca_io_ompio_file_read_at_all (struct ompi_file_t *fh,
                                    OMPI_MPI_OFFSET_TYPE offset,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status);
 int mca_io_ompio_file_write_at (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE offset,
                                 const void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t *status);
 int mca_io_ompio_file_write_at_all (struct ompi_file_t *fh,
                                     OMPI_MPI_OFFSET_TYPE offset,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t *status);
 int mca_io_ompio_file_iread_at (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE offset,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request);
 int mca_io_ompio_file_iwrite_at (struct ompi_file_t *fh,
                                  OMPI_MPI_OFFSET_TYPE offset,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_request_t **request);
 
 /* Section 9.4.3 */
 int mca_io_ompio_file_read (struct ompi_file_t *fh,
                             void *buf,
-                            int count,
+                            size_t count,
                             struct ompi_datatype_t *datatype,
                             ompi_status_public_t *status);
 int mca_io_ompio_file_read_all (struct ompi_file_t *fh,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t *status);
 int mca_io_ompio_file_iread_all (ompi_file_t *fh,
 				void *buf,
-				int count,
+				size_t count,
 				struct ompi_datatype_t *datatype,
 				 ompi_request_t **request);
 int mca_io_ompio_file_iread_at_all (ompi_file_t *fh,
 				    OMPI_MPI_OFFSET_TYPE offset,
 				    void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_request_t **request);
 
 int mca_io_ompio_file_write (struct ompi_file_t *fh,
                              const void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_status_public_t *status);
 int mca_io_ompio_file_write_all (struct ompi_file_t *fh,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_status_public_t *status);
 int mca_io_ompio_file_iwrite_all (ompi_file_t *fh,
 				  const void *buf,
-				  int count,
+				  size_t count,
 				  struct ompi_datatype_t *datatype,
 				  ompi_request_t **request);
 int mca_io_ompio_file_iwrite_at_all (ompi_file_t *fh,
 				     OMPI_MPI_OFFSET_TYPE offset,
 				     const void *buf,
-				     int count,
+				     size_t count,
 				     struct ompi_datatype_t *datatype,
 				     ompi_request_t **request);
 int mca_io_ompio_file_iread (struct ompi_file_t *fh,
                              void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_request_t **request);
 int mca_io_ompio_file_iwrite (struct ompi_file_t *fh,
                               const void *buf,
-                              int count,
+                              size_t count,
                               struct ompi_datatype_t *datatype,
                               ompi_request_t **request);
 int mca_io_ompio_file_seek (struct ompi_file_t *fh,
@@ -281,32 +283,32 @@ int mca_io_ompio_file_get_byte_offset (struct ompi_file_t *fh,
 /* Section 9.4.4 */
 int mca_io_ompio_file_read_shared (struct ompi_file_t *fh,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status);
 int mca_io_ompio_file_write_shared (struct ompi_file_t *fh,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t *status);
 int mca_io_ompio_file_iread_shared (struct ompi_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_io_ompio_file_iwrite_shared (struct ompi_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_request_t **request);
 int mca_io_ompio_file_read_ordered (struct ompi_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t *status);
 int mca_io_ompio_file_write_ordered (struct ompi_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t *status);
 int mca_io_ompio_file_seek_shared (struct ompi_file_t *fh,
@@ -319,7 +321,7 @@ int mca_io_ompio_file_get_position_shared (struct ompi_file_t *fh,
 int mca_io_ompio_file_read_at_all_begin (struct ompi_file_t *fh,
                                          OMPI_MPI_OFFSET_TYPE offset,
                                          void *buf,
-                                         int count,
+                                         size_t count,
                                          struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_read_at_all_end (struct ompi_file_t *fh,
                                        void *buf,
@@ -327,35 +329,35 @@ int mca_io_ompio_file_read_at_all_end (struct ompi_file_t *fh,
 int mca_io_ompio_file_write_at_all_begin (struct ompi_file_t *fh,
                                           OMPI_MPI_OFFSET_TYPE offset,
                                           const void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_write_at_all_end (struct ompi_file_t *fh,
                                         const void *buf,
                                         ompi_status_public_t *status);
 int mca_io_ompio_file_read_all_begin (struct ompi_file_t *fh,
                                       void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_read_all_end (struct ompi_file_t *fh,
                                     void *buf,
                                     ompi_status_public_t *status);
 int mca_io_ompio_file_write_all_begin (struct ompi_file_t *fh,
                                        const void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_write_all_end (struct ompi_file_t *fh,
                                      const void *buf,
                                      ompi_status_public_t *status);
 int mca_io_ompio_file_read_ordered_begin (struct ompi_file_t *fh,
                                           void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_read_ordered_end (struct ompi_file_t *fh,
                                         void *buf,
                                         ompi_status_public_t *status);
 int mca_io_ompio_file_write_ordered_begin (struct ompi_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype);
 int mca_io_ompio_file_write_ordered_end (struct ompi_file_t *fh,
                                          const void *buf,

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -18,6 +18,8 @@
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +60,7 @@ static int open_component(void);
 static int close_component(void);
 static int init_query(bool enable_progress_threads,
                       bool enable_mpi_threads);
-static const struct mca_io_base_module_2_0_0_t *
+static const struct mca_io_base_module_3_0_0_t *
 file_query (struct ompi_file_t *file,
             struct mca_io_base_file_t **private_data,
             int *priority);
@@ -97,12 +99,12 @@ const char *mca_io_ompio_component_version_string =
 "OMPI/MPI OMPIO io MCA component version " OMPI_VERSION;
 
 
-mca_io_base_component_2_0_0_t mca_io_ompio_component = {
+mca_io_base_component_3_0_0_t mca_io_ompio_component = {
     /* First, the mca_base_component_t struct containing meta information
        about the component itself */
 
     .io_version = {
-        MCA_IO_BASE_VERSION_2_0_0,
+        MCA_IO_BASE_VERSION_3_0_0,
         .mca_component_name = "ompio",
         MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
                               OMPI_RELEASE_VERSION),
@@ -289,7 +291,7 @@ static int init_query(bool enable_progress_threads,
 }
 
 
-static const struct mca_io_base_module_2_0_0_t *
+static const struct mca_io_base_module_3_0_0_t *
 file_query(struct ompi_file_t *file,
            struct mca_io_base_file_t **private_data,
            int *priority)

--- a/ompi/mca/io/ompio/io_ompio_file_read.c
+++ b/ompi/mca/io/ompio/io_ompio_file_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,7 +55,7 @@
 
 int mca_io_ompio_file_read (ompi_file_t *fp,
 			    void *buf,
-			    int count,
+			    size_t count,
 			    struct ompi_datatype_t *datatype,
 			    ompi_status_public_t *status)
 {
@@ -71,7 +73,7 @@ int mca_io_ompio_file_read (ompi_file_t *fp,
 int mca_io_ompio_file_read_at (ompi_file_t *fh,
 			       OMPI_MPI_OFFSET_TYPE offset,
 			       void *buf,
-			       int count,
+			       size_t count,
 			       struct ompi_datatype_t *datatype,
 			       ompi_status_public_t * status)
 {
@@ -88,7 +90,7 @@ int mca_io_ompio_file_read_at (ompi_file_t *fh,
 
 int mca_io_ompio_file_iread (ompi_file_t *fh,
 			     void *buf,
-			     int count,
+			     size_t count,
 			     struct ompi_datatype_t *datatype,
 			     ompi_request_t **request)
 {
@@ -107,7 +109,7 @@ int mca_io_ompio_file_iread (ompi_file_t *fh,
 int mca_io_ompio_file_iread_at (ompi_file_t *fh,
 				OMPI_MPI_OFFSET_TYPE offset,
 				void *buf,
-				int count,
+				size_t count,
 				struct ompi_datatype_t *datatype,
 				ompi_request_t **request)
 {
@@ -127,7 +129,7 @@ int mca_io_ompio_file_iread_at (ompi_file_t *fh,
 /******************************************************/
 int mca_io_ompio_file_read_all (ompi_file_t *fh,
 				void *buf,
-				int count,
+				size_t count,
 				struct ompi_datatype_t *datatype,
 				ompi_status_public_t * status)
 {
@@ -155,7 +157,7 @@ int mca_io_ompio_file_read_all (ompi_file_t *fh,
 
 int mca_io_ompio_file_iread_all (ompi_file_t *fh,
 				void *buf,
-				int count,
+				size_t count,
 				struct ompi_datatype_t *datatype,
 				ompi_request_t **request)
 {
@@ -179,7 +181,7 @@ int mca_io_ompio_file_iread_all (ompi_file_t *fh,
 int mca_io_ompio_file_read_at_all (ompi_file_t *fh,
 				   OMPI_MPI_OFFSET_TYPE offset,
 				   void *buf,
-				   int count,
+				   size_t count,
 				   struct ompi_datatype_t *datatype,
 				   ompi_status_public_t * status)
 {
@@ -197,7 +199,7 @@ int mca_io_ompio_file_read_at_all (ompi_file_t *fh,
 int mca_io_ompio_file_iread_at_all (ompi_file_t *fh,
 				    OMPI_MPI_OFFSET_TYPE offset,
 				    void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_request_t **request)
 {
@@ -217,7 +219,7 @@ int mca_io_ompio_file_iread_at_all (ompi_file_t *fh,
 /******************************************************/
 int mca_io_ompio_file_read_shared (ompi_file_t *fp,
 				   void *buf,
-				   int count,
+				   size_t count,
 				   struct ompi_datatype_t *datatype,
 				   ompi_status_public_t * status)
 {
@@ -244,7 +246,7 @@ int mca_io_ompio_file_read_shared (ompi_file_t *fp,
 
 int mca_io_ompio_file_iread_shared (ompi_file_t *fh,
 				    void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_request_t **request)
 {
@@ -271,7 +273,7 @@ int mca_io_ompio_file_iread_shared (ompi_file_t *fh,
 
 int mca_io_ompio_file_read_ordered (ompi_file_t *fh,
 				    void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_status_public_t * status)
 {
@@ -297,7 +299,7 @@ int mca_io_ompio_file_read_ordered (ompi_file_t *fh,
 
 int mca_io_ompio_file_read_ordered_begin (ompi_file_t *fh,
 					  void *buf,
-					  int count,
+					  size_t count,
 					  struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -351,7 +353,7 @@ int mca_io_ompio_file_read_ordered_end (ompi_file_t *fh,
 /**********************************************************************/
 int mca_io_ompio_file_read_all_begin (ompi_file_t *fh,
 				      void *buf,
-				      int count,
+				      size_t count,
 				      struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -391,7 +393,7 @@ int mca_io_ompio_file_read_all_end (ompi_file_t *fh,
 int mca_io_ompio_file_read_at_all_begin (ompi_file_t *fh,
 					 OMPI_MPI_OFFSET_TYPE offset,
 					 void *buf,
-					 int count,
+					 size_t count,
 					 struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/io/ompio/io_ompio_file_write.c
+++ b/ompi/mca/io/ompio/io_ompio_file_write.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,7 +58,7 @@
 
 int mca_io_ompio_file_write (ompi_file_t *fp,
 			     const void *buf,
-			     int count,
+			     size_t count,
 			     struct ompi_datatype_t *datatype,
 			     ompi_status_public_t *status)
 {
@@ -76,7 +78,7 @@ int mca_io_ompio_file_write (ompi_file_t *fp,
 int mca_io_ompio_file_write_at (ompi_file_t *fh,
 				OMPI_MPI_OFFSET_TYPE offset,
 				const void *buf,
-				int count,
+				size_t count,
 				struct ompi_datatype_t *datatype,
 				ompi_status_public_t *status)
 {
@@ -93,7 +95,7 @@ int mca_io_ompio_file_write_at (ompi_file_t *fh,
 
 int mca_io_ompio_file_iwrite (ompi_file_t *fp,
 			      const void *buf,
-			      int count,
+			      size_t count,
 			      struct ompi_datatype_t *datatype,
 			      ompi_request_t **request)
 {
@@ -112,7 +114,7 @@ int mca_io_ompio_file_iwrite (ompi_file_t *fp,
 int mca_io_ompio_file_iwrite_at (ompi_file_t *fh,
 				 OMPI_MPI_OFFSET_TYPE offset,
 				 const void *buf,
-				 int count,
+				 size_t count,
 				 struct ompi_datatype_t *datatype,
 				 ompi_request_t **request)
 {
@@ -133,7 +135,7 @@ int mca_io_ompio_file_iwrite_at (ompi_file_t *fh,
 
 int mca_io_ompio_file_write_all (ompi_file_t *fh,
 				 const void *buf,
-				 int count,
+				 size_t count,
 				 struct ompi_datatype_t *datatype,
 				 ompi_status_public_t *status)
 {
@@ -162,7 +164,7 @@ int mca_io_ompio_file_write_all (ompi_file_t *fh,
 int mca_io_ompio_file_write_at_all (ompi_file_t *fh,
 				    OMPI_MPI_OFFSET_TYPE offset,
 				    const void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_status_public_t *status)
 {
@@ -179,7 +181,7 @@ int mca_io_ompio_file_write_at_all (ompi_file_t *fh,
 
 int mca_io_ompio_file_iwrite_all (ompi_file_t *fh,
 				  const void *buf,
-				  int count,
+				  size_t count,
 				  struct ompi_datatype_t *datatype,
 				  ompi_request_t **request)
 {
@@ -203,7 +205,7 @@ int mca_io_ompio_file_iwrite_all (ompi_file_t *fh,
 int mca_io_ompio_file_iwrite_at_all (ompi_file_t *fh,
 				     OMPI_MPI_OFFSET_TYPE offset,
 				     const void *buf,
-				     int count,
+				     size_t count,
 				     struct ompi_datatype_t *datatype,
 				     ompi_request_t **request)
 {
@@ -224,7 +226,7 @@ int mca_io_ompio_file_iwrite_at_all (ompi_file_t *fh,
 
 int mca_io_ompio_file_write_shared (ompi_file_t *fp,
 				    const void *buf,
-				    int count,
+				    size_t count,
 				    struct ompi_datatype_t *datatype,
 				    ompi_status_public_t * status)
 {
@@ -251,7 +253,7 @@ int mca_io_ompio_file_write_shared (ompi_file_t *fp,
 
 int mca_io_ompio_file_iwrite_shared (ompi_file_t *fp,
 				     const void *buf,
-				     int count,
+				     size_t count,
 				     struct ompi_datatype_t *datatype,
 				     ompi_request_t **request)
 {
@@ -278,7 +280,7 @@ int mca_io_ompio_file_iwrite_shared (ompi_file_t *fp,
 
 int mca_io_ompio_file_write_ordered (ompi_file_t *fp,
 				     const void *buf,
-				     int count,
+				     size_t count,
 				     struct ompi_datatype_t *datatype,
 				     ompi_status_public_t * status)
 {
@@ -305,7 +307,7 @@ int mca_io_ompio_file_write_ordered (ompi_file_t *fp,
 
 int mca_io_ompio_file_write_ordered_begin (ompi_file_t *fp,
 					   const void *buf,
-					   int count,
+					   size_t count,
 					   struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -359,7 +361,7 @@ int mca_io_ompio_file_write_ordered_end (ompi_file_t *fp,
 /**********************************************************************/
 int mca_io_ompio_file_write_all_begin (ompi_file_t *fh,
 				       const void *buf,
-				       int count,
+				       size_t count,
 				       struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -400,7 +402,7 @@ int mca_io_ompio_file_write_all_end (ompi_file_t *fh,
 int mca_io_ompio_file_write_at_all_begin (ompi_file_t *fh,
 					  OMPI_MPI_OFFSET_TYPE offset,
 					  const void *buf,
-					  int count,
+					  size_t count,
 					  struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/io/ompio/io_ompio_module.c
+++ b/ompi/mca/io/ompio/io_ompio_module.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +29,7 @@
 /*
  * The OMPIO module operations
  */
-mca_io_base_module_2_0_0_t mca_io_ompio_module = {
+mca_io_base_module_3_0_0_t mca_io_ompio_module = {
 
     mca_io_ompio_file_open,
     mca_io_ompio_file_close,

--- a/ompi/mca/io/romio341/src/io_romio341.h
+++ b/ompi/mca/io/romio341/src/io_romio341.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,14 +36,14 @@
 
 BEGIN_C_DECLS
 
-OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_romio341_component;
+OMPI_DECLSPEC extern mca_io_base_component_3_0_0_t mca_io_romio341_component;
 
 /*
  * global variables, instantiated in module.c
  */
 extern opal_mutex_t mca_io_romio341_mutex;
-extern mca_io_base_module_2_0_0_t mca_io_romio341_module;
-OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_romio341_component;
+extern mca_io_base_module_3_0_0_t mca_io_romio341_module;
+OMPI_DECLSPEC extern mca_io_base_component_3_0_0_t mca_io_romio341_component;
 
 /*
  * Private data for ROMIO modules
@@ -51,6 +53,12 @@ struct mca_io_romio341_data_t {
 };
 typedef struct mca_io_romio341_data_t mca_io_romio341_data_t;
 
+#define OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(x) \
+    do { \
+        if ((x) > INT_MAX) { \
+            return OMPI_ERROR; \
+        } \
+    } while (0)
 
 /*
  * Module functions
@@ -102,91 +110,91 @@ int mca_io_romio341_file_get_view (struct ompi_file_t *fh,
 int mca_io_romio341_file_read_at (struct ompi_file_t *fh,
                                MPI_Offset offset,
                                void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_status_public_t * status);
 int mca_io_romio341_file_read_at_all (struct ompi_file_t *fh,
                                    MPI_Offset offset,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t * status);
 int mca_io_romio341_file_write_at (struct ompi_file_t *fh,
                                 MPI_Offset offset,
                                 const void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t * status);
 int mca_io_romio341_file_write_at_all (struct ompi_file_t *fh,
                                     MPI_Offset offset,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t * status);
 int mca_io_romio341_file_iread_at (struct ompi_file_t *fh,
                                 MPI_Offset offset,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request);
 int mca_io_romio341_file_iread_at_all (struct ompi_file_t *fh,
                                        MPI_Offset offset,
                                        void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype,
                                        ompi_request_t **request);
 int mca_io_romio341_file_iwrite_at (struct ompi_file_t *fh,
                                  MPI_Offset offset,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_request_t **request);
 int mca_io_romio341_file_iwrite_at_all (struct ompi_file_t *fh,
                                         MPI_Offset offset,
                                         const void *buf,
-                                        int count,
+                                        size_t count,
                                         struct ompi_datatype_t *datatype,
                                         ompi_request_t **request);
 
 /* Section 9.4.3 */
 int mca_io_romio341_file_read (struct ompi_file_t *fh,
                             void *buf,
-                            int count,
+                            size_t count,
                             struct ompi_datatype_t *datatype,
                             ompi_status_public_t * status);
 int mca_io_romio341_file_read_all (struct ompi_file_t *fh,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t * status);
 int mca_io_romio341_file_write (struct ompi_file_t *fh,
                              const void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_status_public_t * status);
 int mca_io_romio341_file_write_all (struct ompi_file_t *fh,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_status_public_t * status);
 int mca_io_romio341_file_iread (struct ompi_file_t *fh,
                              void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_request_t **request);
 int mca_io_romio341_file_iread_all (struct ompi_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_io_romio341_file_iwrite (struct ompi_file_t *fh,
                               const void *buf,
-                              int count,
+                              size_t count,
                               struct ompi_datatype_t *datatype,
                               ompi_request_t **request);
 int mca_io_romio341_file_iwrite_all (struct ompi_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_request_t **request);
 int mca_io_romio341_file_seek (struct ompi_file_t *fh,
@@ -201,32 +209,32 @@ int mca_io_romio341_file_get_byte_offset (struct ompi_file_t *fh,
 /* Section 9.4.4 */
 int mca_io_romio341_file_read_shared (struct ompi_file_t *fh,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t * status);
 int mca_io_romio341_file_write_shared (struct ompi_file_t *fh,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t * status);
 int mca_io_romio341_file_iread_shared (struct ompi_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_io_romio341_file_iwrite_shared (struct ompi_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_request_t **request);
 int mca_io_romio341_file_read_ordered (struct ompi_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_status_public_t * status);
 int mca_io_romio341_file_write_ordered (struct ompi_file_t *fh,
                                      const void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype,
                                      ompi_status_public_t * status);
 int mca_io_romio341_file_seek_shared (struct ompi_file_t *fh,
@@ -239,7 +247,7 @@ int mca_io_romio341_file_get_position_shared (struct ompi_file_t *fh,
 int mca_io_romio341_file_read_at_all_begin (struct ompi_file_t *fh,
                                          MPI_Offset offset,
                                          void *buf,
-                                         int count,
+                                         size_t count,
                                          struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_read_at_all_end (struct ompi_file_t *fh,
                                        void *buf,
@@ -247,35 +255,35 @@ int mca_io_romio341_file_read_at_all_end (struct ompi_file_t *fh,
 int mca_io_romio341_file_write_at_all_begin (struct ompi_file_t *fh,
                                           MPI_Offset offset,
                                           const void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_write_at_all_end (struct ompi_file_t *fh,
                                         const void *buf,
                                         ompi_status_public_t * status);
 int mca_io_romio341_file_read_all_begin (struct ompi_file_t *fh,
                                       void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_read_all_end (struct ompi_file_t *fh,
                                     void *buf,
                                     ompi_status_public_t * status);
 int mca_io_romio341_file_write_all_begin (struct ompi_file_t *fh,
                                        const void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_write_all_end (struct ompi_file_t *fh,
                                      const void *buf,
                                      ompi_status_public_t * status);
 int mca_io_romio341_file_read_ordered_begin (struct ompi_file_t *fh,
                                           void *buf,
-                                          int count,
+                                          size_t count,
                                           struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_read_ordered_end (struct ompi_file_t *fh,
                                         void *buf,
                                         ompi_status_public_t * status);
 int mca_io_romio341_file_write_ordered_begin (struct ompi_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype);
 int mca_io_romio341_file_write_ordered_end (struct ompi_file_t *fh,
                                          const void *buf,

--- a/ompi/mca/io/romio341/src/io_romio341_component.c
+++ b/ompi/mca/io/romio341/src/io_romio341_component.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +44,7 @@ static int open_component(void);
 static int close_component(void);
 static int init_query(bool enable_progress_threads,
                       bool enable_mpi_threads);
-static const struct mca_io_base_module_2_0_0_t *
+static const struct mca_io_base_module_3_0_0_t *
   file_query(struct ompi_file_t *file,
              struct mca_io_base_file_t **private_data,
              int *priority);
@@ -81,12 +83,12 @@ const char *mca_io_romio341_component_version_string =
 "OMPI/MPI ROMIO io MCA component version " OMPI_VERSION ", " ROMIO_VERSION_STRING;
 
 
-mca_io_base_component_2_0_0_t mca_io_romio341_component = {
+mca_io_base_component_3_0_0_t mca_io_romio341_component = {
     /* First, the mca_base_component_t struct containing meta information
        about the component itself */
 
     .io_version = {
-        MCA_IO_BASE_VERSION_2_0_0,
+        MCA_IO_BASE_VERSION_3_0_0,
         .mca_component_name = "romio341",
         MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
                               OMPI_RELEASE_VERSION),
@@ -187,7 +189,7 @@ static int init_query(bool enable_progress_threads,
 }
 
 
-static const struct mca_io_base_module_2_0_0_t *
+static const struct mca_io_base_module_3_0_0_t *
 file_query(struct ompi_file_t *file,
            struct mca_io_base_file_t **private_data,
            int *priority)

--- a/ompi/mca/io/romio341/src/io_romio341_file_read.c
+++ b/ompi/mca/io/romio341/src/io_romio341_file_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,12 +31,14 @@ int
 mca_io_romio341_file_read_at (ompi_file_t *fh,
                            MPI_Offset offset,
                            void *buf,
-                           int count,
+                           size_t count,
                            struct ompi_datatype_t *datatype,
                            ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -51,12 +55,14 @@ int
 mca_io_romio341_file_read_at_all (ompi_file_t *fh,
                                MPI_Offset offset,
                                void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -73,12 +79,14 @@ int
 mca_io_romio341_file_iread_at (ompi_file_t *fh,
                             MPI_Offset offset,
                             void *buf,
-                            int count,
+                            size_t count,
                             struct ompi_datatype_t *datatype,
                             ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -94,12 +102,14 @@ int
 mca_io_romio341_file_iread_at_all (ompi_file_t *fh,
                                    MPI_Offset offset,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_request_t **request)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -121,12 +131,14 @@ mca_io_romio341_file_iread_at_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_read (ompi_file_t *fh,
                         void *buf,
-                        int count,
+                        size_t count,
                         struct ompi_datatype_t *datatype,
                         ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -142,12 +154,14 @@ mca_io_romio341_file_read (ompi_file_t *fh,
 int
 mca_io_romio341_file_read_all (ompi_file_t *fh,
                             void *buf,
-                            int count,
+                            size_t count,
                             struct ompi_datatype_t *datatype,
                             ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -163,12 +177,14 @@ mca_io_romio341_file_read_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_iread (ompi_file_t *fh,
                          void *buf,
-                         int count,
+                         size_t count,
                          struct ompi_datatype_t *datatype,
                          ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -183,12 +199,14 @@ mca_io_romio341_file_iread (ompi_file_t *fh,
 int
 mca_io_romio341_file_iread_all (ompi_file_t *fh,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -209,12 +227,14 @@ mca_io_romio341_file_iread_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_read_shared (ompi_file_t *fh,
                                void *buf,
-                               int count,
+                               size_t count,
                                struct ompi_datatype_t *datatype,
                                ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -230,12 +250,14 @@ mca_io_romio341_file_read_shared (ompi_file_t *fh,
 int
 mca_io_romio341_file_iread_shared (ompi_file_t *fh,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -251,12 +273,14 @@ mca_io_romio341_file_iread_shared (ompi_file_t *fh,
 int
 mca_io_romio341_file_read_ordered (ompi_file_t *fh,
                                 void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -273,11 +297,13 @@ int
 mca_io_romio341_file_read_at_all_begin (ompi_file_t *fh,
                                      MPI_Offset offset,
                                      void *buf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -310,11 +336,13 @@ mca_io_romio341_file_read_at_all_end (ompi_file_t *fh,
 int
 mca_io_romio341_file_read_all_begin (ompi_file_t *fh,
                                   void *buf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -347,11 +375,13 @@ mca_io_romio341_file_read_all_end (ompi_file_t *fh,
 int
 mca_io_romio341_file_read_ordered_begin (ompi_file_t *fh,
                                       void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);

--- a/ompi/mca/io/romio341/src/io_romio341_file_write.c
+++ b/ompi/mca/io/romio341/src/io_romio341_file_write.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,12 +31,14 @@ int
 mca_io_romio341_file_write_at (ompi_file_t *fh,
                             MPI_Offset offset,
                             const void *buf,
-                            int count,
+                            size_t count,
                             struct ompi_datatype_t *datatype,
                             ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -52,12 +56,14 @@ int
 mca_io_romio341_file_write_at_all (ompi_file_t *fh,
                                 MPI_Offset offset,
                                 const void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -75,12 +81,14 @@ int
 mca_io_romio341_file_iwrite_at (ompi_file_t *fh,
                              MPI_Offset offset,
                              const void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -97,12 +105,14 @@ int
 mca_io_romio341_file_iwrite_at_all (ompi_file_t *fh,
                                     MPI_Offset offset,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -125,12 +135,14 @@ mca_io_romio341_file_iwrite_at_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_write (ompi_file_t *fh,
                          const void *buf,
-                         int count,
+                         size_t count,
                          struct ompi_datatype_t *datatype,
                          ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -145,12 +157,14 @@ mca_io_romio341_file_write (ompi_file_t *fh,
 int
 mca_io_romio341_file_write_all (ompi_file_t *fh,
                              const void *buf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *datatype,
                              ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -165,12 +179,14 @@ mca_io_romio341_file_write_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_iwrite (ompi_file_t *fh,
                           const void *buf,
-                          int count,
+                          size_t count,
                           struct ompi_datatype_t *datatype,
                           ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -185,12 +201,14 @@ mca_io_romio341_file_iwrite (ompi_file_t *fh,
 int
 mca_io_romio341_file_iwrite_all (ompi_file_t *fh,
                                 const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_request_t **request)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -212,12 +230,14 @@ mca_io_romio341_file_iwrite_all (ompi_file_t *fh,
 int
 mca_io_romio341_file_write_shared (ompi_file_t *fh,
                                 const void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -232,12 +252,14 @@ mca_io_romio341_file_write_shared (ompi_file_t *fh,
 int
 mca_io_romio341_file_iwrite_shared (ompi_file_t *fh,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_request_t **request)
 {
     int ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -252,12 +274,14 @@ mca_io_romio341_file_iwrite_shared (ompi_file_t *fh,
 int
 mca_io_romio341_file_write_ordered (ompi_file_t *fh,
                                  const void *buf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_status_public_t * status)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -273,11 +297,13 @@ int
 mca_io_romio341_file_write_at_all_begin (ompi_file_t *fh,
                                       MPI_Offset offset,
                                       const void *buf,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -308,11 +334,13 @@ mca_io_romio341_file_write_at_all_end (ompi_file_t *fh,
 int
 mca_io_romio341_file_write_all_begin (ompi_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);
@@ -342,11 +370,13 @@ mca_io_romio341_file_write_all_end (ompi_file_t *fh,
 int
 mca_io_romio341_file_write_ordered_begin (ompi_file_t *fh,
                                        const void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype)
 {
     int         ret;
     mca_io_romio341_data_t *data;
+
+    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(count);
 
     data = (mca_io_romio341_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio341_mutex);

--- a/ompi/mca/io/romio341/src/io_romio341_module.c
+++ b/ompi/mca/io/romio341/src/io_romio341_module.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2017-2019 IBM Corporation. All rights reserved.
  * Copyright (c) 2017-2021 Research Organization for Information Science
  *                         and Technology  (RIST).  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +42,7 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag);
 /*
  * The ROMIO module operations
  */
-mca_io_base_module_2_0_0_t mca_io_romio341_module = {
+mca_io_base_module_3_0_0_t mca_io_romio341_module = {
     /* Back end to MPI API calls (pretty much a 1-to-1 mapping) */
 
     mca_io_romio341_file_open,

--- a/ompi/mca/sharedfp/base/sharedfp_base_find_available.c
+++ b/ompi/mca/sharedfp/base/sharedfp_base_find_available.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +38,7 @@ static int init_query(const mca_base_component_t *m,
                       mca_base_component_list_item_t *entry,
                       bool enable_progress_threads,
                       bool enable_mpi_threads);
-static int init_query_2_0_0(const mca_base_component_t *component,
+static int init_query_3_0_0(const mca_base_component_t *component,
                             mca_base_component_list_item_t *entry,
                             bool enable_progress_threads,
                             bool enable_mpi_threads);
@@ -95,10 +97,10 @@ static int init_query(const mca_base_component_t *m,
                         m->mca_component_name);
 
     /* This component has been successfully opened, now try to query it */
-    if (2 == m->mca_type_major_version &&
+    if (3 == m->mca_type_major_version &&
         0 == m->mca_type_minor_version &&
         0 == m->mca_type_release_version) {
-        ret = init_query_2_0_0(m, entry, enable_progress_threads,
+        ret = init_query_3_0_0(m, entry, enable_progress_threads,
                                enable_mpi_threads);
     } else {
         /* unrecognised API version */
@@ -129,13 +131,13 @@ static int init_query(const mca_base_component_t *m,
 }
 
 
-static int init_query_2_0_0(const mca_base_component_t *component,
+static int init_query_3_0_0(const mca_base_component_t *component,
                             mca_base_component_list_item_t *entry,
                             bool enable_progress_threads,
                             bool enable_mpi_threads)
 {
-    mca_sharedfp_base_component_2_0_0_t *sharedfp =
-        (mca_sharedfp_base_component_2_0_0_t *) component;
+    mca_sharedfp_base_component_3_0_0_t *sharedfp =
+        (mca_sharedfp_base_component_3_0_0_t *) component;
 
     return sharedfp->sharedfpm_init_query(enable_progress_threads,
                               enable_mpi_threads);

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +40,7 @@
  * *******************************************************************
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
-static mca_sharedfp_base_module_1_0_0_t individual =  {
+static mca_sharedfp_base_module_2_0_0_t individual =  {
     mca_sharedfp_individual_module_init, /* initialise after being selected */
     mca_sharedfp_individual_module_finalize, /* close a module on a communicator */
     mca_sharedfp_individual_seek,
@@ -70,7 +72,7 @@ int mca_sharedfp_individual_component_init_query(bool enable_progress_threads,
    return OMPI_SUCCESS;
 }
 
-struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file_query (ompio_file_t *fh, int *priority) {
+struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_individual_component_file_query (ompio_file_t *fh, int *priority) {
 
     int amode;
     bool wronly_flag=false;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.h
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,42 +65,42 @@ int mca_sharedfp_individual_file_open (struct ompi_communicator_t *comm,
                                        ompio_file_t *fh);
 int mca_sharedfp_individual_file_close (ompio_file_t *fh);
 int mca_sharedfp_individual_read (ompio_file_t *fh,
-                                  void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+                                  void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status);
 int mca_sharedfp_individual_read_ordered (ompio_file_t *fh,
-                                          void *buf, int count, struct ompi_datatype_t *datatype,
+                                          void *buf, size_t count, struct ompi_datatype_t *datatype,
                                           ompi_status_public_t *status);
 int mca_sharedfp_individual_read_ordered_begin (ompio_file_t *fh,
                                                  void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_individual_read_ordered_end (ompio_file_t *fh,
                                                void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_individual_iread (ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_sharedfp_individual_write (ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status);
 int mca_sharedfp_individual_write_ordered (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status);
 int mca_sharedfp_individual_write_ordered_begin (ompio_file_t *fh,
                                                  const void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_individual_write_ordered_end (ompio_file_t *fh,
                                                const void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_individual_iwrite (ompio_file_t *fh,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.h
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
 
 int mca_sharedfp_individual_component_init_query(bool enable_progress_threads,
                                                  bool enable_mpi_threads);
-struct mca_sharedfp_base_module_1_0_0_t *
+struct mca_sharedfp_base_module_2_0_0_t *
         mca_sharedfp_individual_component_file_query (ompio_file_t *file, int *priority);
 int mca_sharedfp_individual_component_file_unquery (ompio_file_t *file);
 
@@ -46,7 +46,7 @@ extern int mca_sharedfp_individual_priority;
 extern int mca_sharedfp_individual_verbose;
 extern int mca_sharedfp_individual_usage_counter;
 
-OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_individual_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_3_0_0_t mca_sharedfp_individual_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_component.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_component.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2013      University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +50,13 @@ static int individual_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_sharedfp_base_component_2_0_0_t mca_sharedfp_individual_component = {
+mca_sharedfp_base_component_3_0_0_t mca_sharedfp_individual_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .sharedfpm_version = {
-        MCA_SHAREDFP_BASE_VERSION_2_0_0,
+        MCA_SHAREDFP_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "individual",

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +32,7 @@
 
 int mca_sharedfp_individual_iwrite(ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    ompi_datatype_t *datatype,
                                    MPI_Request * request)
 {
@@ -79,7 +81,7 @@ int mca_sharedfp_individual_iwrite(ompio_file_t *fh,
 
 int mca_sharedfp_individual_write_ordered_begin(ompio_file_t *fh,
                                                 const void *buf,
-                                                int count,
+                                                size_t count,
                                                 struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_read.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,14 +31,14 @@
 #include "ompi/mca/sharedfp/base/base.h"
 
 int mca_sharedfp_individual_read ( ompio_file_t *fh,
-				   void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
+				   void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status)
 {
     opal_output(0,"mca_sharedfp_individual_read: NOT SUPPORTED by this component\n");
     return OMPI_ERROR;
 }
 
 int mca_sharedfp_individual_read_ordered ( ompio_file_t *fh,
-                                   void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
+                                   void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status)
 {
     opal_output(0,"mca_sharedfp_individual_read_ordered: NOT SUPPORTED by this component\n");
     return OMPI_ERROR;
@@ -44,7 +46,7 @@ int mca_sharedfp_individual_read_ordered ( ompio_file_t *fh,
 
 int mca_sharedfp_individual_iread(ompio_file_t *fh,
                                    void *buf,
-                                   int count,
+                                   size_t count,
                                    ompi_datatype_t *datatype,
                                    MPI_Request * request)
 {
@@ -54,7 +56,7 @@ int mca_sharedfp_individual_iread(ompio_file_t *fh,
 
 int mca_sharedfp_individual_read_ordered_begin(ompio_file_t *fh,
                                                 void *buf,
-                                                int count,
+                                                size_t count,
                                                 struct ompi_datatype_t *datatype)
 {
     opal_output(0,"mca_sharedfp_individual_read_ordered_begin: NOT SUPPORTED by this component\n");

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +32,7 @@
 
 int mca_sharedfp_individual_write (ompio_file_t *fh,
                                        const void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype,
                                        ompi_status_public_t *status)
 {
@@ -79,7 +81,7 @@ int mca_sharedfp_individual_write (ompio_file_t *fh,
 
 int mca_sharedfp_individual_write_ordered (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status)
 {

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013      University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +44,7 @@
  * *******************************************************************
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
-static mca_sharedfp_base_module_1_0_0_t lockedfile =  {
+static mca_sharedfp_base_module_2_0_0_t lockedfile =  {
     mca_sharedfp_lockedfile_module_init, /* initialise after being selected */
     mca_sharedfp_lockedfile_module_finalize, /* close a module on a communicator */
     mca_sharedfp_lockedfile_seek,
@@ -74,7 +76,7 @@ int mca_sharedfp_lockedfile_component_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_lockedfile_component_file_query(ompio_file_t *fh, int *priority) {
+struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_lockedfile_component_file_query(ompio_file_t *fh, int *priority) {
     struct flock lock;
     int fd, err;
     /*char *filename;*/

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,43 +64,43 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
                                        ompio_file_t *fh);
 int mca_sharedfp_lockedfile_file_close (ompio_file_t *fh);
 int mca_sharedfp_lockedfile_read (ompio_file_t *fh,
-                                  void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+                                  void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status);
 int mca_sharedfp_lockedfile_read_ordered (ompio_file_t *fh,
-                                          void *buf, int count, struct ompi_datatype_t *datatype,
+                                          void *buf, size_t count, struct ompi_datatype_t *datatype,
                                           ompi_status_public_t *status
                                           );
 int mca_sharedfp_lockedfile_read_ordered_begin (ompio_file_t *fh,
                                                  void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_lockedfile_read_ordered_end (ompio_file_t *fh,
                                                void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_lockedfile_iread (ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_sharedfp_lockedfile_write (ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status);
 int mca_sharedfp_lockedfile_write_ordered (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status);
 int mca_sharedfp_lockedfile_write_ordered_begin (ompio_file_t *fh,
                                                  const void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_lockedfile_write_ordered_end (ompio_file_t *fh,
                                                const void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_lockedfile_iwrite (ompio_file_t *fh,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
 
 int mca_sharedfp_lockedfile_component_init_query(bool enable_progress_threads,
                                                  bool enable_mpi_threads);
-struct mca_sharedfp_base_module_1_0_0_t *
+struct mca_sharedfp_base_module_2_0_0_t *
         mca_sharedfp_lockedfile_component_file_query (ompio_file_t *file, int *priority);
 int mca_sharedfp_lockedfile_component_file_unquery (ompio_file_t *file);
 
@@ -45,7 +45,7 @@ int mca_sharedfp_lockedfile_module_finalize (ompio_file_t *file);
 extern int mca_sharedfp_lockedfile_priority;
 extern int mca_sharedfp_lockedfile_verbose;
 
-OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_lockedfile_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_3_0_0_t mca_sharedfp_lockedfile_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_component.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_component.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2013      University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,13 +49,13 @@ static int lockedfile_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_sharedfp_base_component_2_0_0_t mca_sharedfp_lockedfile_component = {
+mca_sharedfp_base_component_3_0_0_t mca_sharedfp_lockedfile_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .sharedfpm_version = {
-        MCA_SHAREDFP_BASE_VERSION_2_0_0,
+        MCA_SHAREDFP_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "lockedfile",

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 
 int mca_sharedfp_lockedfile_iread(ompio_file_t *fh,
                                   void *buf,
-                                  int count,
+                                  size_t count,
                                   ompi_datatype_t *datatype,
                                   MPI_Request * request)
 {
@@ -79,7 +81,7 @@ int mca_sharedfp_lockedfile_iread(ompio_file_t *fh,
 
 int mca_sharedfp_lockedfile_read_ordered_begin(ompio_file_t *fh,
                                        void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 
 int mca_sharedfp_lockedfile_iwrite(ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    ompi_datatype_t *datatype,
                                    MPI_Request * request)
 {
@@ -77,7 +79,7 @@ int mca_sharedfp_lockedfile_iwrite(ompio_file_t *fh,
 
 int mca_sharedfp_lockedfile_write_ordered_begin(ompio_file_t *fh,
                                                 const void *buf,
-                                                int count,
+                                                size_t count,
                                                 struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +31,7 @@
 #include "ompi/mca/sharedfp/base/base.h"
 
 int mca_sharedfp_lockedfile_read ( ompio_file_t *fh,
-                                   void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
+                                   void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status)
 {
     int ret = OMPI_SUCCESS;
     OMPI_MPI_OFFSET_TYPE offset = 0;
@@ -76,7 +78,7 @@ int mca_sharedfp_lockedfile_read ( ompio_file_t *fh,
 
 int mca_sharedfp_lockedfile_read_ordered (ompio_file_t *fh,
                                            void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status)
 {

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +32,7 @@
 
 int mca_sharedfp_lockedfile_write (ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status)
 {
@@ -75,7 +77,7 @@ int mca_sharedfp_lockedfile_write (ompio_file_t *fh,
 
 int mca_sharedfp_lockedfile_write_ordered (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status)
 {

--- a/ompi/mca/sharedfp/sharedfp.h
+++ b/ompi/mca/sharedfp/sharedfp.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -125,19 +127,19 @@ typedef int (*mca_sharedfp_base_module_get_position_fn_t)(
 typedef int (*mca_sharedfp_base_module_write_fn_t)(
         struct ompio_file_t *fh,
         const void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_status_public_t *status);
 typedef int (*mca_sharedfp_base_module_write_ordered_fn_t)(
         struct ompio_file_t *fh,
         const void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_status_public_t *status);
 typedef int (*mca_sharedfp_base_module_write_ordered_begin_fn_t)(
         struct ompio_file_t *fh,
         const void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype);
 typedef int (*mca_sharedfp_base_module_write_ordered_end_fn_t)(
         struct ompio_file_t *fh,
@@ -146,31 +148,31 @@ typedef int (*mca_sharedfp_base_module_write_ordered_end_fn_t)(
 typedef int (*mca_sharedfp_base_module_iwrite_fn_t)(
         struct ompio_file_t *fh,
         const void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_request_t ** request);
 typedef int (*mca_sharedfp_base_module_read_fn_t)(
         struct ompio_file_t *fh,
         void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_status_public_t *status);
 typedef int (*mca_sharedfp_base_module_read_ordered_fn_t)(
         struct ompio_file_t *fh,
         void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_status_public_t *status);
 typedef int (*mca_sharedfp_base_module_iread_fn_t)(
         struct ompio_file_t *fh,
         void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype,
         ompi_request_t ** request);
 typedef int (*mca_sharedfp_base_module_read_ordered_begin_fn_t)(
         struct ompio_file_t *fh,
         void *buf,
-        int count,
+        size_t count,
         struct ompi_datatype_t *datatype);
 typedef int (*mca_sharedfp_base_module_read_ordered_end_fn_t)(
         struct ompio_file_t *fh,

--- a/ompi/mca/sharedfp/sharedfp.h
+++ b/ompi/mca/sharedfp/sharedfp.h
@@ -43,8 +43,8 @@ struct ompi_file_t;
 /*
  * Macro for use in components that are of type coll
  */
-#define MCA_SHAREDFP_BASE_VERSION_2_0_0 \
-    OMPI_MCA_BASE_VERSION_2_1_0("sharedfp", 2, 0, 0)
+#define MCA_SHAREDFP_BASE_VERSION_3_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("sharedfp", 3, 0, 0)
 
 /*
  * This framework abstracts out operations of the shared filepointer
@@ -80,7 +80,7 @@ typedef int (*mca_sharedfp_base_component_init_query_1_0_0_fn_t)
 (bool enable_progress_threads,
  bool enable_mpi_threads);
 
-typedef struct mca_sharedfp_base_module_1_0_0_t *
+typedef struct mca_sharedfp_base_module_2_0_0_t *
         (*mca_sharedfp_base_component_file_query_1_0_0_fn_t)
         (struct ompio_file_t *file, int *priority);
 
@@ -89,11 +89,11 @@ typedef int (*mca_sharedfp_base_component_file_unquery_1_0_0_fn_t)
 
 /*
  * ****************** component struct ******************************
- * Structure for sharedfp v2.0.0 components.This is chained to MCA v2.0.0
+ * Structure for sharedfp v3.0.0 components.This is chained to MCA v2.0.0
  * ****************** component struct ******************************
  */
 
-struct mca_sharedfp_base_component_2_0_0_t {
+struct mca_sharedfp_base_component_3_0_0_t {
     mca_base_component_t sharedfpm_version;
     mca_base_component_data_t sharedfpm_data;
 
@@ -101,8 +101,8 @@ struct mca_sharedfp_base_component_2_0_0_t {
     mca_sharedfp_base_component_file_query_1_0_0_fn_t sharedfpm_file_query;
     mca_sharedfp_base_component_file_unquery_1_0_0_fn_t sharedfpm_file_unquery;
 };
-typedef struct mca_sharedfp_base_component_2_0_0_t mca_sharedfp_base_component_2_0_0_t;
-typedef struct mca_sharedfp_base_component_2_0_0_t mca_sharedfp_base_component_t;
+typedef struct mca_sharedfp_base_component_3_0_0_t mca_sharedfp_base_component_3_0_0_t;
+typedef struct mca_sharedfp_base_component_3_0_0_t mca_sharedfp_base_component_t;
 
 /*
  * ***********************************************************************
@@ -189,7 +189,7 @@ typedef int (*mca_sharedfp_base_module_file_close_fn_t)(struct ompio_file_t *fh)
  * ***************************  module structure *************************
  * ***********************************************************************
  */
-struct mca_sharedfp_base_module_1_0_0_t {
+struct mca_sharedfp_base_module_2_0_0_t {
     /*
      * Per-file initialization function. This is called only
      * on the module which is selected. The finalize corresponding to
@@ -215,8 +215,8 @@ struct mca_sharedfp_base_module_1_0_0_t {
     mca_sharedfp_base_module_file_open_fn_t   sharedfp_file_open;
     mca_sharedfp_base_module_file_close_fn_t  sharedfp_file_close;
 };
-typedef struct mca_sharedfp_base_module_1_0_0_t mca_sharedfp_base_module_1_0_0_t;
-typedef mca_sharedfp_base_module_1_0_0_t mca_sharedfp_base_module_t;
+typedef struct mca_sharedfp_base_module_2_0_0_t mca_sharedfp_base_module_2_0_0_t;
+typedef mca_sharedfp_base_module_2_0_0_t mca_sharedfp_base_module_t;
 
 
 /* This structure keeps all of the data needed by a sharedfp module.

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +48,7 @@
  * *******************************************************************
  */
  /* IMPORTANT: Update here when adding sharedfp component interface functions*/
-static mca_sharedfp_base_module_1_0_0_t sm =  {
+static mca_sharedfp_base_module_2_0_0_t sm =  {
     mca_sharedfp_sm_module_init, /* initialise after being selected */
     mca_sharedfp_sm_module_finalize, /* close a module on a communicator */
     mca_sharedfp_sm_seek,
@@ -78,7 +80,7 @@ int mca_sharedfp_sm_component_init_query(bool enable_progress_threads,
    return OMPI_SUCCESS;
 }
 
-struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_sm_component_file_query(ompio_file_t *fh, int *priority)
+struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_sm_component_file_query(ompio_file_t *fh, int *priority)
 {
     int i;
     ompi_proc_t *proc;

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.h
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.h
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
 
 int mca_sharedfp_sm_component_init_query(bool enable_progress_threads,
                                                  bool enable_mpi_threads);
-struct mca_sharedfp_base_module_1_0_0_t *
+struct mca_sharedfp_base_module_2_0_0_t *
         mca_sharedfp_sm_component_file_query (ompio_file_t *file, int *priority);
 int mca_sharedfp_sm_component_file_unquery (ompio_file_t *file);
 
@@ -46,7 +46,7 @@ int mca_sharedfp_sm_module_finalize (ompio_file_t *file);
 extern int mca_sharedfp_sm_priority;
 extern int mca_sharedfp_sm_verbose;
 
-OMPI_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_sm_component;
+OMPI_DECLSPEC extern mca_sharedfp_base_component_3_0_0_t mca_sharedfp_sm_component;
 /*
  * ******************************************************************
  * ********* functions which are implemented in this module *********

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.h
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,43 +64,43 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
                                        ompio_file_t *fh);
 int mca_sharedfp_sm_file_close (ompio_file_t *fh);
 int mca_sharedfp_sm_read (ompio_file_t *fh,
-                                  void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+                                  void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status);
 int mca_sharedfp_sm_read_ordered (ompio_file_t *fh,
-                                          void *buf, int count, struct ompi_datatype_t *datatype,
+                                          void *buf, size_t count, struct ompi_datatype_t *datatype,
                                           ompi_status_public_t *status
                                           );
 int mca_sharedfp_sm_read_ordered_begin (ompio_file_t *fh,
                                                  void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_sm_read_ordered_end (ompio_file_t *fh,
                                                void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_sm_iread (ompio_file_t *fh,
                                     void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 int mca_sharedfp_sm_write (ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status);
 int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
                                            const void *buf,
-                                           int count,
+                                           size_t count,
                                            struct ompi_datatype_t *datatype,
                                            ompi_status_public_t *status);
 int mca_sharedfp_sm_write_ordered_begin (ompio_file_t *fh,
                                                  const void *buf,
-                                                 int count,
+                                                 size_t count,
                                                  struct ompi_datatype_t *datatype);
 int mca_sharedfp_sm_write_ordered_end (ompio_file_t *fh,
                                                const void *buf,
                                                ompi_status_public_t *status);
 int mca_sharedfp_sm_iwrite (ompio_file_t *fh,
                                     const void *buf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *datatype,
                                     ompi_request_t **request);
 /*--------------------------------------------------------------*
@@ -128,7 +130,7 @@ typedef struct mca_sharedfp_sm_data sm_data_global;
 
 
 int mca_sharedfp_sm_request_position (ompio_file_t *fh,
-                                      int bytes_requested,
+                                      long long bytes_requested,
                                       OMPI_MPI_OFFSET_TYPE * offset);
 /*
  * ******************************************************************

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_component.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_component.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,13 +49,13 @@ static int sm_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-mca_sharedfp_base_component_2_0_0_t mca_sharedfp_sm_component = {
+mca_sharedfp_base_component_3_0_0_t mca_sharedfp_sm_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .sharedfpm_version = {
-        MCA_SHAREDFP_BASE_VERSION_2_0_0,
+        MCA_SHAREDFP_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "sm",

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,13 +32,13 @@
 
 int mca_sharedfp_sm_iread(ompio_file_t *fh,
                           void *buf,
-                          int count,
+                          size_t count,
                           ompi_datatype_t *datatype,
                           MPI_Request * request)
 {
     int ret = OMPI_SUCCESS;
     OMPI_MPI_OFFSET_TYPE offset = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     size_t numofBytes;
 
     if( NULL == fh->f_sharedfp_data){
@@ -51,7 +53,7 @@ int mca_sharedfp_sm_iread(ompio_file_t *fh,
 
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "sharedfp_sm_iread: Bytes Requested is %ld\n",bytesRequested);
+                    "sharedfp_sm_iread: Bytes Requested is %lld\n",bytesRequested);
     }
     /*Request the offset to write bytesRequested bytes*/
     ret = mca_sharedfp_sm_request_position(fh,bytesRequested,&offset);
@@ -71,7 +73,7 @@ int mca_sharedfp_sm_iread(ompio_file_t *fh,
 
 int mca_sharedfp_sm_read_ordered_begin(ompio_file_t *fh,
                                        void *buf,
-                                       int count,
+                                       size_t count,
                                        struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -80,7 +82,7 @@ int mca_sharedfp_sm_read_ordered_begin(ompio_file_t *fh,
     long *buff=NULL;
     long offsetBuff;
     OMPI_MPI_OFFSET_TYPE offsetReceived = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     int recvcnt = 1, sendcnt = 1;
     size_t numofBytes;
     int i;
@@ -129,7 +131,7 @@ int mca_sharedfp_sm_read_ordered_begin(ompio_file_t *fh,
 	    bytesRequested += buff[i];
 	    if ( mca_sharedfp_sm_verbose ) {
 		opal_output(ompi_sharedfp_base_framework.framework_output,
-			    "mca_sharedfp_sm_read_ordered_begin: Bytes requested are %ld\n",
+			    "mca_sharedfp_sm_read_ordered_begin: Bytes requested are %lld\n",
 			    bytesRequested);
 	    }
         }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,13 +32,13 @@
 
 int mca_sharedfp_sm_iwrite(ompio_file_t *fh,
                            const void *buf,
-                           int count,
+                           size_t count,
                            ompi_datatype_t *datatype,
                            MPI_Request * request)
 {
      int ret = OMPI_SUCCESS;
      OMPI_MPI_OFFSET_TYPE offset = 0;
-     long bytesRequested = 0;
+     long long bytesRequested = 0;
      size_t numofBytes;
 
      if( NULL == fh->f_sharedfp_data){
@@ -51,7 +53,7 @@ int mca_sharedfp_sm_iwrite(ompio_file_t *fh,
 
      if ( mca_sharedfp_sm_verbose ) {
          opal_output(ompi_sharedfp_base_framework.framework_output,
-		     "sharedfp_sm_iwrite: Bytes Requested is %ld\n",bytesRequested);
+		     "sharedfp_sm_iwrite: Bytes Requested is %lld\n",bytesRequested);
      }
     /* Request the offset to write bytesRequested bytes */
      ret = mca_sharedfp_sm_request_position(fh,bytesRequested,&offset);
@@ -72,7 +74,7 @@ int mca_sharedfp_sm_iwrite(ompio_file_t *fh,
 
 int mca_sharedfp_sm_write_ordered_begin(ompio_file_t *fh,
                                         const void *buf,
-                                        int count,
+                                        size_t count,
                                         struct ompi_datatype_t *datatype)
 {
     int ret = OMPI_SUCCESS;
@@ -81,7 +83,7 @@ int mca_sharedfp_sm_write_ordered_begin(ompio_file_t *fh,
     long *buff=NULL;
     long offsetBuff;
     OMPI_MPI_OFFSET_TYPE offsetReceived = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     int recvcnt = 1, sendcnt = 1;
     size_t numofBytes;
     int i;
@@ -123,7 +125,7 @@ int mca_sharedfp_sm_write_ordered_begin(ompio_file_t *fh,
 	    bytesRequested += buff[i];
 	    if ( mca_sharedfp_sm_verbose ) {
 		opal_output(ompi_sharedfp_base_framework.framework_output,
-			    "mca_sharedfp_sm_write_ordered_begin: Bytes requested are %ld\n",
+			    "mca_sharedfp_sm_write_ordered_begin: Bytes requested are %lld\n",
 			    bytesRequested);
 	    }
         }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,11 +31,11 @@
 #include "ompi/mca/sharedfp/base/base.h"
 
 int mca_sharedfp_sm_read ( ompio_file_t *fh,
-                           void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
+                           void *buf, size_t count, MPI_Datatype datatype, MPI_Status *status)
 {
     int ret = OMPI_SUCCESS;
     OMPI_MPI_OFFSET_TYPE offset = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     size_t numofBytes;
 
     if( NULL == fh->f_sharedfp_data){
@@ -48,7 +50,7 @@ int mca_sharedfp_sm_read ( ompio_file_t *fh,
 
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "sharedfp_sm_read: Bytes Requested is %ld\n",bytesRequested);
+                    "sharedfp_sm_read: Bytes Requested is %lld\n",bytesRequested);
     }
 
     /*Request the offset to write bytesRequested bytes*/
@@ -70,7 +72,7 @@ int mca_sharedfp_sm_read ( ompio_file_t *fh,
 
 int mca_sharedfp_sm_read_ordered (ompio_file_t *fh,
                                   void *buf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *datatype,
                                   ompi_status_public_t *status)
 {
@@ -80,7 +82,7 @@ int mca_sharedfp_sm_read_ordered (ompio_file_t *fh,
     long *buff=NULL;
     long offsetBuff;
     OMPI_MPI_OFFSET_TYPE offsetReceived = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     int recvcnt = 1, sendcnt = 1;
     size_t numofBytes;
     int i;
@@ -122,7 +124,7 @@ int mca_sharedfp_sm_read_ordered (ompio_file_t *fh,
             bytesRequested += buff[i];
             if ( mca_sharedfp_sm_verbose ) {
                 opal_output(ompi_sharedfp_base_framework.framework_output,
-                            "mca_sharedfp_sm_read_ordered: Bytes requested are %ld\n",bytesRequested);
+                            "mca_sharedfp_sm_read_ordered: Bytes requested are %lld\n",bytesRequested);
             }
         }
 

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_request_position.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_request_position.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,7 @@
 #include <semaphore.h>
 
 int mca_sharedfp_sm_request_position(ompio_file_t *fh, 
-                                     int bytes_requested,
+                                     long long bytes_requested,
                                      OMPI_MPI_OFFSET_TYPE *offset)
 {
     int ret = OMPI_SUCCESS;
@@ -70,7 +72,7 @@ int mca_sharedfp_sm_request_position(ompio_file_t *fh,
     position = old_offset + bytes_requested;
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "old_offset=%lld, bytes_requested=%d, new offset=%lld!\n",old_offset,bytes_requested,position);
+                    "old_offset=%lld, bytes_requested=%lld, new offset=%lld!\n",old_offset,bytes_requested,position);
     }
     sm_offset_ptr->offset=position;
 

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,13 +32,13 @@
 
 int mca_sharedfp_sm_write (ompio_file_t *fh,
                            const void *buf,
-                           int count,
+                           size_t count,
                            struct ompi_datatype_t *datatype,
                            ompi_status_public_t *status)
 {
     int ret = OMPI_SUCCESS;
     OMPI_MPI_OFFSET_TYPE offset = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     size_t numofBytes;
 
     if( NULL == fh->f_sharedfp_data ){
@@ -53,7 +55,7 @@ int mca_sharedfp_sm_write (ompio_file_t *fh,
 
     if ( mca_sharedfp_sm_verbose ) {
         opal_output(ompi_sharedfp_base_framework.framework_output,
-                    "sharedfp_sm_write: Requested is %ld\n",bytesRequested);
+                    "sharedfp_sm_write: Requested is %lld\n",bytesRequested);
     }
 
     /*Request the offset to write bytesRequested bytes*/
@@ -74,7 +76,7 @@ int mca_sharedfp_sm_write (ompio_file_t *fh,
 
 int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
                                    const void *buf,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t *datatype,
                                    ompi_status_public_t *status)
 {
@@ -84,7 +86,7 @@ int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
     long *buff=NULL;
     long offsetBuff;
     OMPI_MPI_OFFSET_TYPE offsetReceived = 0;
-    long bytesRequested = 0;
+    long long bytesRequested = 0;
     int recvcnt = 1, sendcnt = 1;
     size_t numofBytes;
     int i;
@@ -120,7 +122,7 @@ int mca_sharedfp_sm_write_ordered (ompio_file_t *fh,
             bytesRequested += buff[i];
             if ( mca_sharedfp_sm_verbose ) {
                 opal_output(ompi_sharedfp_base_framework.framework_output,
-                            "sharedfp_sm_write_ordered: Bytes requested are %ld\n",bytesRequested);
+                            "sharedfp_sm_write_ordered: Bytes requested are %lld\n",bytesRequested);
             }
         }
 

--- a/ompi/mpi/c/file_get_amode.c
+++ b/ompi/mpi/c/file_get_amode.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int MPI_File_get_amode(MPI_File fh, int *amode)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_amode(fh, amode);
         break;
 

--- a/ompi/mpi/c/file_get_atomicity.c
+++ b/ompi/mpi/c/file_get_atomicity.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int MPI_File_get_atomicity(MPI_File fh, int *flag)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_atomicity(fh, flag);
         break;
 

--- a/ompi/mpi/c/file_get_byte_offset.c
+++ b/ompi/mpi/c/file_get_byte_offset.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_byte_offset(fh, offset, disp);
         break;
 

--- a/ompi/mpi/c/file_get_info.c
+++ b/ompi/mpi/c/file_get_info.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -57,11 +57,11 @@ int MPI_File_get_info(MPI_File fh, MPI_Info *info_used)
 // Some components we're still letting handle info internally, eg romio321.
 // Components that want to handle it themselves will fill in the get/set
 // info function pointers, components that don't will use NULL.
-    if (fh->f_io_selected_module.v2_0_0.io_module_file_get_info != NULL) {
+    if (fh->f_io_selected_module.v3_0_0.io_module_file_get_info != NULL) {
         int rc;
         switch (fh->f_io_version) {
-        case MCA_IO_BASE_V_2_0_0:
-            rc = fh->f_io_selected_module.v2_0_0.
+        case MCA_IO_BASE_V_3_0_0:
+            rc = fh->f_io_selected_module.v3_0_0.
               io_module_file_get_info(fh, info_used);
             break;
 

--- a/ompi/mpi/c/file_get_position.c
+++ b/ompi/mpi/c/file_get_position.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int MPI_File_get_position(MPI_File fh, MPI_Offset *offset)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_position(fh, offset);
         break;
 

--- a/ompi/mpi/c/file_get_position_shared.c
+++ b/ompi/mpi/c/file_get_position_shared.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_position_shared(fh, offset);
         break;
 

--- a/ompi/mpi/c/file_get_size.c
+++ b/ompi/mpi/c/file_get_size.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_size(fh, size);
         break;
 

--- a/ompi/mpi/c/file_get_type_extent.c
+++ b/ompi/mpi/c/file_get_type_extent.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_type_extent(fh, datatype, extent);
         break;
 

--- a/ompi/mpi/c/file_get_view.c
+++ b/ompi/mpi/c/file_get_view.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,8 +61,8 @@ int MPI_File_get_view(MPI_File fh, MPI_Offset *disp,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_get_view(fh, disp, etype, filetype, datarep);
         break;
 

--- a/ompi/mpi/c/file_iread.c
+++ b/ompi/mpi/c/file_iread.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +69,8 @@ int MPI_File_iread(MPI_File fh, void *buf, int count,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_iread(fh, buf, count, datatype, request);
         break;
 

--- a/ompi/mpi/c/file_iread_all.c
+++ b/ompi/mpi/c/file_iread_all.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,12 +71,12 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iread_all) ) {
+    case MCA_IO_BASE_V_3_0_0:
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v3_0_0.io_module_file_iread_all) ) {
             rc = MPI_ERR_UNSUPPORTED_OPERATION;
         }
         else {
-            rc = fh->f_io_selected_module.v2_0_0.
+            rc = fh->f_io_selected_module.v3_0_0.
                 io_module_file_iread_all(fh, buf, count, datatype, request);
         }
         break;

--- a/ompi/mpi/c/file_iread_at.c
+++ b/ompi/mpi/c/file_iread_at.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +69,8 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_iread_at(fh, offset, buf, count, datatype,
                                     request);
         break;

--- a/ompi/mpi/c/file_iread_at_all.c
+++ b/ompi/mpi/c/file_iread_at_all.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,12 +71,12 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iread_at_all) ) {
+    case MCA_IO_BASE_V_3_0_0:
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v3_0_0.io_module_file_iread_at_all) ) {
             rc = MPI_ERR_UNSUPPORTED_OPERATION;
         }
         else {
-            rc = fh->f_io_selected_module.v2_0_0.
+            rc = fh->f_io_selected_module.v3_0_0.
                 io_module_file_iread_at_all(fh, offset, buf, count, datatype,
                                             request);
         }

--- a/ompi/mpi/c/file_iread_shared.c
+++ b/ompi/mpi/c/file_iread_shared.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +69,8 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_iread_shared(fh, buf, count, datatype, request);
         break;
 

--- a/ompi/mpi/c/file_iwrite.c
+++ b/ompi/mpi/c/file_iwrite.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,8 +73,8 @@ int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_iwrite(fh, buf, count, datatype, request);
         break;
 

--- a/ompi/mpi/c/file_iwrite_all.c
+++ b/ompi/mpi/c/file_iwrite_all.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,12 +75,12 @@ int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iwrite_all) ) {
+    case MCA_IO_BASE_V_3_0_0:
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v3_0_0.io_module_file_iwrite_all) ) {
             rc = MPI_ERR_UNSUPPORTED_OPERATION;
         }
         else {
-            rc = fh->f_io_selected_module.v2_0_0.
+            rc = fh->f_io_selected_module.v3_0_0.
                 io_module_file_iwrite_all(fh, buf, count, datatype, request);
         }
         break;

--- a/ompi/mpi/c/file_iwrite_at.c
+++ b/ompi/mpi/c/file_iwrite_at.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,8 +74,8 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_iwrite_at(fh, offset, buf, count, datatype,
                                      request);
         break;

--- a/ompi/mpi/c/file_iwrite_at_all.c
+++ b/ompi/mpi/c/file_iwrite_at_all.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,12 +76,12 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iwrite_at_all) ) {
+    case MCA_IO_BASE_V_3_0_0:
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v3_0_0.io_module_file_iwrite_at_all) ) {
             rc = MPI_ERR_UNSUPPORTED_OPERATION;
         }
         else {
-            rc = fh->f_io_selected_module.v2_0_0.
+            rc = fh->f_io_selected_module.v3_0_0.
                 io_module_file_iwrite_at_all(fh, offset, buf, count, datatype,
                                              request);
         }

--- a/ompi/mpi/c/file_iwrite_shared.c
+++ b/ompi/mpi/c/file_iwrite_shared.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,8 +72,8 @@ int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
 
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_iwrite_shared(fh, buf, count, datatype, request);
         break;
 

--- a/ompi/mpi/c/file_preallocate.c
+++ b/ompi/mpi/c/file_preallocate.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_preallocate(MPI_File fh, MPI_Offset size)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_preallocate(fh, size);
         break;
 

--- a/ompi/mpi/c/file_read.c
+++ b/ompi/mpi/c/file_read.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_read_all.c
+++ b/ompi/mpi/c/file_read_all.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_all(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_read_all_begin.c
+++ b/ompi/mpi/c/file_read_all_begin.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_all_begin(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_all_begin(fh, buf, count, datatype);
         break;
 

--- a/ompi/mpi/c/file_read_all_end.c
+++ b/ompi/mpi/c/file_read_all_end.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_all_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_read_at.c
+++ b/ompi/mpi/c/file_read_at.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_at(fh, offset, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_read_at_all.c
+++ b/ompi/mpi/c/file_read_at_all.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,8 +67,8 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_at_all(fh, offset, buf, count, datatype,
                                        status);
         break;

--- a/ompi/mpi/c/file_read_at_all_begin.c
+++ b/ompi/mpi/c/file_read_at_all_begin.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_at_all_begin(fh, offset, buf, count, datatype);
         break;
 

--- a/ompi/mpi/c/file_read_at_all_end.c
+++ b/ompi/mpi/c/file_read_at_all_end.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_at_all_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_read_ordered.c
+++ b/ompi/mpi/c/file_read_ordered.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,8 +61,8 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_ordered(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_read_ordered_begin.c
+++ b/ompi/mpi/c/file_read_ordered_begin.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_ordered_begin(fh, buf, count, datatype);
         break;
 

--- a/ompi/mpi/c/file_read_ordered_end.c
+++ b/ompi/mpi/c/file_read_ordered_end.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_ordered_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_read_shared.c
+++ b/ompi/mpi/c/file_read_shared.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +66,8 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_read_shared(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_seek.c
+++ b/ompi/mpi/c/file_seek.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_seek(fh, offset, whence);
         break;
 

--- a/ompi/mpi/c/file_seek_shared.c
+++ b/ompi/mpi/c/file_seek_shared.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_seek_shared(fh, offset, whence);
         break;
 

--- a/ompi/mpi/c/file_set_atomicity.c
+++ b/ompi/mpi/c/file_set_atomicity.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_set_atomicity(MPI_File fh, int flag)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_set_atomicity(fh, flag);
         break;
 

--- a/ompi/mpi/c/file_set_info.c
+++ b/ompi/mpi/c/file_set_info.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,11 +63,11 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
 // Some components we're still letting handle info internally, eg romio321.
 // Components that want to handle it themselves will fill in the get/set
 // info function pointers, components that don't will use NULL.
-    if (fh->f_io_selected_module.v2_0_0.io_module_file_set_info != NULL) {
+    if (fh->f_io_selected_module.v3_0_0.io_module_file_set_info != NULL) {
         int rc;
         switch (fh->f_io_version) {
-        case MCA_IO_BASE_V_2_0_0:
-            rc = fh->f_io_selected_module.v2_0_0.
+        case MCA_IO_BASE_V_3_0_0:
+            rc = fh->f_io_selected_module.v3_0_0.
               io_module_file_set_info(fh, info);
             break;
 

--- a/ompi/mpi/c/file_set_size.c
+++ b/ompi/mpi/c/file_set_size.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_set_size(fh, size);
         break;
 

--- a/ompi/mpi/c/file_set_view.c
+++ b/ompi/mpi/c/file_set_view.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,8 +76,8 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_set_view(fh, disp, etype, filetype, datarep, &(info->super));
         break;
 

--- a/ompi/mpi/c/file_sync.c
+++ b/ompi/mpi/c/file_sync.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +55,8 @@ int MPI_File_sync(MPI_File fh)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
             io_module_file_sync(fh);
         break;
 

--- a/ompi/mpi/c/file_write.c
+++ b/ompi/mpi/c/file_write.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write(MPI_File fh, const void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_write_all.c
+++ b/ompi/mpi/c/file_write_all.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_all(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_write_all_begin.c
+++ b/ompi/mpi/c/file_write_all_begin.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_all_begin(fh, buf, count, datatype);
         break;
 

--- a/ompi/mpi/c/file_write_all_end.c
+++ b/ompi/mpi/c/file_write_all_end.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_all_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_write_at.c
+++ b/ompi/mpi/c/file_write_at.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,8 +71,8 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_at(fh, offset, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_write_at_all.c
+++ b/ompi/mpi/c/file_write_at_all.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,8 +71,8 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_at_all(fh, offset, buf, count, datatype,
                                         status);
         break;

--- a/ompi/mpi/c/file_write_at_all_begin.c
+++ b/ompi/mpi/c/file_write_at_all_begin.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_at_all_begin(fh, offset, buf, count,
                                               datatype);
         break;

--- a/ompi/mpi/c/file_write_at_all_end.c
+++ b/ompi/mpi/c/file_write_at_all_end.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_at_all_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_write_ordered.c
+++ b/ompi/mpi/c/file_write_ordered.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_ordered(MPI_File fh, const void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_ordered(fh, buf, count, datatype, status);
         break;
 

--- a/ompi/mpi/c/file_write_ordered_begin.c
+++ b/ompi/mpi/c/file_write_ordered_begin.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_ordered_begin(fh, buf, count, datatype);
         break;
 

--- a/ompi/mpi/c/file_write_ordered_end.c
+++ b/ompi/mpi/c/file_write_ordered_end.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,8 +58,8 @@ int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status)
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_ordered_end(fh, buf, status);
         break;
 

--- a/ompi/mpi/c/file_write_shared.c
+++ b/ompi/mpi/c/file_write_shared.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,8 +70,8 @@ int MPI_File_write_shared(MPI_File fh, const void *buf, int count,
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
+    case MCA_IO_BASE_V_3_0_0:
+        rc = fh->f_io_selected_module.v3_0_0.
           io_module_file_write_shared(fh, buf, count, datatype, status);
         break;
 


### PR DESCRIPTION
This updates ompio-related frameworks and components to use size_t instead of int for counts.

I updated the version in the io framework from 2.0.0 to 3.0.0. fcoll and sharedfp both seem to be using different versions for the component and module structs, so I wasn't quite sure what version to use for those.