### PR TITLE
[v5.0.x] btl/usnic: move btl_usnic_lock initialization

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -160,6 +160,8 @@ static int usnic_component_open(void)
 
     /* initialize objects */
     OBJ_CONSTRUCT(&mca_btl_usnic_component.usnic_procs, opal_list_t);
+    OBJ_CONSTRUCT(&btl_usnic_lock, opal_recursive_mutex_t);
+
 
     /* Sanity check: if_include and if_exclude need to be mutually
        exclusive */
@@ -586,8 +588,6 @@ usnic_component_init(int *num_btl_modules, bool want_progress_threads, bool want
             return NULL;
         }
     }
-
-    OBJ_CONSTRUCT(&btl_usnic_lock, opal_recursive_mutex_t);
 
     /* There are multiple dimensions to consider when requesting an
        API version number from libfabric:


### PR DESCRIPTION
Previously it was in component_init, but after
https://github.com/open-mpi/ompi/pull/12057 I noticed MPI finalize would find an uninitialized object and segfault.  This change moves the initialization to component_open, so that component_close() can rely on the opal object initialization having been completed.

Signed-off-by: Luke Robison <lrbison@amazon.com>
(cherry picked from commit 5ff314c802e1069bd25056839a3f4400baa3e2a4)

-- Backport of https://github.com/open-mpi/ompi/pull/12355