### PR TITLE
Github CI: use unique Github Action names

### DIFF
--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -1,4 +1,4 @@
-name: GitHub Action CI
+name: ROCM
 
 on: [pull_request]
 

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -1,4 +1,4 @@
-name: GitHub Action CI
+name: mpi4py
 
 on: [pull_request]
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,4 +1,4 @@
-name: GitHub Action CI
+name: Git commit checks
 
 # We're using pull_request_target here instead of just pull_request so that the
 # action runs in the context of the base of the pull request, rather than in the


### PR DESCRIPTION
Don't use the generic "GitHub Action CI" name/label for multiple different GitHub Actions -- doing so makes it difficult to know which Action is which on the GitHub Action web UI.  Instead, give them unique, descriptive names.