### PR TITLE
v5.0.x: oac: strengthen Sphinx check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1069,7 +1069,8 @@ AS_IF([test -z "$LEX" || \
 dnl Note that we have to double escape the URL below
 dnl so that the # it contains doesn't confuse the Autotools
 OAC_SETUP_SPHINX([$srcdir/docs/man/MPI_T.3],
-                 [[https://docs.open-mpi.org/en/main/developers/prerequisites.html#sphinx-and-therefore-python]])
+                 [[https://docs.open-mpi.org/en/main/developers/prerequisites.html#sphinx-and-therefore-python]],
+                 [$srcdir/docs/requirements.txt])
 
 #
 # File system case sensitivity


### PR DESCRIPTION
Update oac submodule pointer to pick up a stronger test for Sphinx. Also add (new) optional 3rd param to OAC_SETUP_SPHINX.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 51526f7d4038abe176fff5db7fdfa9d46ae1dc24)

This is the v5.0.x PR corresponding to #12370

Fixes #12333