### PR TITLE
Implement hierarchical MPI_Gatherv and MPI_Scatterv

### DIFF
--- a/ompi/mca/coll/han/Makefile.am
+++ b/ompi/mca/coll/han/Makefile.am
@@ -21,6 +21,7 @@ coll_han_barrier.c \
 coll_han_bcast.c \
 coll_han_reduce.c \
 coll_han_scatter.c \
+coll_han_scatterv.c \
 coll_han_gather.c \
 coll_han_gatherv.c \
 coll_han_allreduce.c \

--- a/ompi/mca/coll/han/Makefile.am
+++ b/ompi/mca/coll/han/Makefile.am
@@ -22,6 +22,7 @@ coll_han_bcast.c \
 coll_han_reduce.c \
 coll_han_scatter.c \
 coll_han_gather.c \
+coll_han_gatherv.c \
 coll_han_allreduce.c \
 coll_han_allgather.c \
 coll_han_component.c \
@@ -31,7 +32,8 @@ coll_han_algorithms.c \
 coll_han_dynamic.c \
 coll_han_dynamic_file.c \
 coll_han_topo.c \
-coll_han_subcomms.c
+coll_han_subcomms.c \
+coll_han_utils.c
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -191,6 +191,7 @@ typedef struct mca_coll_han_op_module_name_t {
     mca_coll_han_op_up_low_module_name_t allreduce;
     mca_coll_han_op_up_low_module_name_t allgather;
     mca_coll_han_op_up_low_module_name_t gather;
+    mca_coll_han_op_up_low_module_name_t gatherv;
     mca_coll_han_op_up_low_module_name_t scatter;
 } mca_coll_han_op_module_name_t;
 
@@ -235,6 +236,10 @@ typedef struct mca_coll_han_component_t {
     uint32_t han_gather_up_module;
     /* low level module for gather */
     uint32_t han_gather_low_module;
+    /* up level module for gatherv */
+    uint32_t han_gatherv_up_module;
+    /* low level module for gatherv */
+    uint32_t han_gatherv_low_module;
     /* up level module for scatter */
     uint32_t han_scatter_up_module;
     /* low level module for scatter */
@@ -279,6 +284,7 @@ typedef struct mca_coll_han_single_collective_fallback_s {
         mca_coll_base_module_barrier_fn_t barrier;
         mca_coll_base_module_bcast_fn_t bcast;
         mca_coll_base_module_gather_fn_t gather;
+        mca_coll_base_module_gatherv_fn_t gatherv;
         mca_coll_base_module_reduce_fn_t reduce;
         mca_coll_base_module_scatter_fn_t scatter;
     } module_fn;
@@ -298,6 +304,7 @@ typedef struct mca_coll_han_collectives_fallback_s {
     mca_coll_han_single_collective_fallback_t bcast;
     mca_coll_han_single_collective_fallback_t reduce;
     mca_coll_han_single_collective_fallback_t gather;
+    mca_coll_han_single_collective_fallback_t gatherv;
     mca_coll_han_single_collective_fallback_t scatter;
 } mca_coll_han_collectives_fallback_t;
 
@@ -371,6 +378,9 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 #define previous_gather             fallback.gather.module_fn.gather
 #define previous_gather_module      fallback.gather.module
 
+#define previous_gatherv            fallback.gatherv.module_fn.gatherv
+#define previous_gatherv_module     fallback.gatherv.module
+
 #define previous_scatter            fallback.scatter.module_fn.scatter
 #define previous_scatter_module     fallback.scatter.module
 
@@ -394,6 +404,7 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, bcast);                     \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, scatter);                   \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, gather);                    \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, gatherv);                    \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, reduce);                    \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, allreduce);                 \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, allgather);                 \
@@ -476,6 +487,9 @@ int
 mca_coll_han_gather_intra_dynamic(GATHER_BASE_ARGS,
                                   mca_coll_base_module_t *module);
 int
+mca_coll_han_gatherv_intra_dynamic(GATHERV_BASE_ARGS,
+                                   mca_coll_base_module_t *module);
+int
 mca_coll_han_reduce_intra_dynamic(REDUCE_BASE_ARGS,
                                   mca_coll_base_module_t *module);
 int
@@ -493,4 +507,10 @@ ompi_coll_han_reorder_gather(const void *sbuf,
                              struct ompi_communicator_t *comm,
                              int * topo);
 
+size_t
+coll_han_utils_gcd(const size_t *numerators, const size_t size);
+
+int
+coll_han_utils_create_contiguous_datatype(size_t count, const ompi_datatype_t *oldType,
+                                          ompi_datatype_t **newType);
 #endif                          /* MCA_COLL_HAN_EXPORT_H */

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -193,6 +193,7 @@ typedef struct mca_coll_han_op_module_name_t {
     mca_coll_han_op_up_low_module_name_t gather;
     mca_coll_han_op_up_low_module_name_t gatherv;
     mca_coll_han_op_up_low_module_name_t scatter;
+    mca_coll_han_op_up_low_module_name_t scatterv;
 } mca_coll_han_op_module_name_t;
 
 /**
@@ -244,6 +245,10 @@ typedef struct mca_coll_han_component_t {
     uint32_t han_scatter_up_module;
     /* low level module for scatter */
     uint32_t han_scatter_low_module;
+    /* up level module for scatterv */
+    uint32_t han_scatterv_up_module;
+    /* low level module for scatterv */
+    uint32_t han_scatterv_low_module;
     /* name of the modules */
     mca_coll_han_op_module_name_t han_op_module_name;
     /* whether we need reproducible results
@@ -287,6 +292,7 @@ typedef struct mca_coll_han_single_collective_fallback_s {
         mca_coll_base_module_gatherv_fn_t gatherv;
         mca_coll_base_module_reduce_fn_t reduce;
         mca_coll_base_module_scatter_fn_t scatter;
+        mca_coll_base_module_scatterv_fn_t scatterv;
     } module_fn;
     mca_coll_base_module_t* module;
 } mca_coll_han_single_collective_fallback_t;
@@ -306,6 +312,7 @@ typedef struct mca_coll_han_collectives_fallback_s {
     mca_coll_han_single_collective_fallback_t gather;
     mca_coll_han_single_collective_fallback_t gatherv;
     mca_coll_han_single_collective_fallback_t scatter;
+    mca_coll_han_single_collective_fallback_t scatterv;
 } mca_coll_han_collectives_fallback_t;
 
 /** Coll han module */
@@ -384,6 +391,8 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 #define previous_scatter            fallback.scatter.module_fn.scatter
 #define previous_scatter_module     fallback.scatter.module
 
+#define previous_scatterv           fallback.scatterv.module_fn.scatterv
+#define previous_scatterv_module    fallback.scatterv.module
 
 /* macro to correctly load a fallback collective module */
 #define HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, COLL)                            \
@@ -403,6 +412,7 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, barrier);                   \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, bcast);                     \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, scatter);                   \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, scatterv);                  \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, gather);                    \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, gatherv);                    \
         HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, reduce);                    \
@@ -495,6 +505,9 @@ mca_coll_han_reduce_intra_dynamic(REDUCE_BASE_ARGS,
 int
 mca_coll_han_scatter_intra_dynamic(SCATTER_BASE_ARGS,
                                    mca_coll_base_module_t *module);
+int
+mca_coll_han_scatterv_intra_dynamic(SCATTERV_BASE_ARGS,
+                                    mca_coll_base_module_t *module);
 
 int mca_coll_han_barrier_intra_simple(struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
  * Copyright (c) 2020-2022 Bull S.A.S. All rights reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -432,11 +434,16 @@ int *mca_coll_han_topo_init(struct ompi_communicator_t *comm, mca_coll_han_modul
 
 /* Utils */
 static inline void
-mca_coll_han_get_ranks(int *vranks, int root, int low_size,
-                       int *root_low_rank, int *root_up_rank)
+mca_coll_han_get_ranks(int *vranks, int w_rank, int low_size,
+                       int *low_rank, int *up_rank)
 {
-    *root_up_rank = vranks[root] / low_size;
-    *root_low_rank = vranks[root] % low_size;
+    if (up_rank) {
+        *up_rank = vranks[w_rank] / low_size;
+    }
+
+    if (low_rank) {
+        *low_rank = vranks[w_rank] % low_size;
+    }
 }
 
 const char* mca_coll_han_topo_lvl_to_str(TOPO_LVL_T topo_lvl);

--- a/ompi/mca/coll/han/coll_han_algorithms.c
+++ b/ompi/mca/coll/han/coll_han_algorithms.c
@@ -64,6 +64,10 @@ mca_coll_han_algorithm_value_t*  mca_coll_han_available_algorithms[COLLCOUNT] = 
         {"simple", (fnptr_t) &mca_coll_han_gather_intra_simple}, // 2-level
         { 0 }
     },
+    [GATHERV] = (mca_coll_han_algorithm_value_t[]){
+        {"intra", (fnptr_t) &mca_coll_han_gatherv_intra}, // 2-level
+        { 0 }
+    },
     [ALLGATHER] = (mca_coll_han_algorithm_value_t[]){
         {"intra", (fnptr_t)&mca_coll_han_allgather_intra}, // 2-level
         {"simple", (fnptr_t)&mca_coll_han_allgather_intra_simple}, // 2-level

--- a/ompi/mca/coll/han/coll_han_algorithms.c
+++ b/ompi/mca/coll/han/coll_han_algorithms.c
@@ -59,6 +59,10 @@ mca_coll_han_algorithm_value_t*  mca_coll_han_available_algorithms[COLLCOUNT] = 
         {"simple", (fnptr_t) &mca_coll_han_scatter_intra_simple}, // 2-level
         { 0 }
     },
+    [SCATTERV] = (mca_coll_han_algorithm_value_t[]){
+        {"intra", (fnptr_t) &mca_coll_han_scatterv_intra}, // 2-level
+        { 0 }
+    },
     [GATHER] = (mca_coll_han_algorithm_value_t[]){
         {"intra", (fnptr_t) &mca_coll_han_gather_intra}, // 2-level
         {"simple", (fnptr_t) &mca_coll_han_gather_intra_simple}, // 2-level

--- a/ompi/mca/coll/han/coll_han_algorithms.h
+++ b/ompi/mca/coll/han/coll_han_algorithms.h
@@ -159,6 +159,16 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t * module);
 
+/* Scatterv */
+int
+mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts,
+                            const int *displs, struct ompi_datatype_t *sdtype,
+                            void *rbuf, int rcount,
+                            struct ompi_datatype_t *rdtype, 
+                            int root,
+                            struct ompi_communicator_t *comm,
+                            mca_coll_base_module_t *module);
+
 /* Gather */
 int
 mca_coll_han_gather_intra(const void *sbuf, int scount,

--- a/ompi/mca/coll/han/coll_han_algorithms.h
+++ b/ompi/mca/coll/han/coll_han_algorithms.h
@@ -176,6 +176,13 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 
+/* Gatherv */
+int
+mca_coll_han_gatherv_intra(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
+                           void *rbuf, const int *rcounts, const int *displs,
+                           struct ompi_datatype_t *rdtype, int root,
+                           struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
+
 /* Allgather */
 int
 mca_coll_han_allgather_intra(const void *sbuf, int scount,

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -156,6 +156,11 @@ static int han_close(void)
     free(mca_coll_han_component.han_op_module_name.scatter.han_op_low_module_name);
     mca_coll_han_component.han_op_module_name.scatter.han_op_low_module_name = NULL;
 
+    free(mca_coll_han_component.han_op_module_name.scatterv.han_op_up_module_name);
+    mca_coll_han_component.han_op_module_name.scatterv.han_op_up_module_name = NULL;
+    free(mca_coll_han_component.han_op_module_name.scatterv.han_op_low_module_name);
+    mca_coll_han_component.han_op_module_name.scatterv.han_op_low_module_name = NULL;
+
     return OMPI_SUCCESS;
 }
 
@@ -372,6 +377,18 @@ static int han_register(void)
                                               "low level module for scatter, 0 tuned, 1 sm",
                                               OPAL_INFO_LVL_9, &cs->han_scatter_low_module,
                                               &cs->han_op_module_name.scatter.han_op_low_module_name);
+
+    cs->han_scatterv_up_module = 0;
+    (void) mca_coll_han_query_module_from_mca(c, "scatterv_up_module",
+                                              "up level module for scatterv, 0 basic",
+                                              OPAL_INFO_LVL_9, &cs->han_scatterv_up_module,
+                                              &cs->han_op_module_name.scatterv.han_op_up_module_name);
+
+    cs->han_scatterv_low_module = 0;
+    (void) mca_coll_han_query_module_from_mca(c, "scatterv_low_module",
+                                              "low level module for scatterv, 0 basic",
+                                              OPAL_INFO_LVL_9, &cs->han_scatterv_low_module,
+                                              &cs->han_op_module_name.scatterv.han_op_low_module_name);
 
     cs->han_reproducible = 0;
     (void) mca_base_component_var_register(c, "reproducible",

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -146,6 +146,11 @@ static int han_close(void)
     free(mca_coll_han_component.han_op_module_name.gather.han_op_low_module_name);
     mca_coll_han_component.han_op_module_name.gather.han_op_low_module_name = NULL;
 
+    free(mca_coll_han_component.han_op_module_name.gatherv.han_op_up_module_name);
+    mca_coll_han_component.han_op_module_name.gatherv.han_op_up_module_name = NULL;
+    free(mca_coll_han_component.han_op_module_name.gatherv.han_op_low_module_name);
+    mca_coll_han_component.han_op_module_name.gatherv.han_op_low_module_name = NULL;
+
     free(mca_coll_han_component.han_op_module_name.scatter.han_op_up_module_name);
     mca_coll_han_component.han_op_module_name.scatter.han_op_up_module_name = NULL;
     free(mca_coll_han_component.han_op_module_name.scatter.han_op_low_module_name);
@@ -343,6 +348,18 @@ static int han_register(void)
                                               "low level module for gather, 0 tuned, 1 sm",
                                               OPAL_INFO_LVL_9, &cs->han_gather_low_module,
                                               &cs->han_op_module_name.gather.han_op_low_module_name);
+
+    cs->han_gatherv_up_module = 0;
+    (void) mca_coll_han_query_module_from_mca(c, "gatherv_up_module",
+                                              "up level module for gatherv, 0 basic",
+                                              OPAL_INFO_LVL_9, &cs->han_gatherv_up_module,
+                                              &cs->han_op_module_name.gatherv.han_op_up_module_name);
+
+    cs->han_gatherv_low_module = 0;
+    (void) mca_coll_han_query_module_from_mca(c, "gatherv_low_module",
+                                              "low level module for gatherv, 0 basic",
+                                              OPAL_INFO_LVL_9, &cs->han_gatherv_low_module,
+                                              &cs->han_op_module_name.gatherv.han_op_low_module_name);
 
     cs->han_scatter_up_module = 0;
     (void) mca_coll_han_query_module_from_mca(c, "scatter_up_module",

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -46,6 +46,7 @@ bool mca_coll_han_is_coll_dynamic_implemented(COLLTYPE_T coll_id)
     case GATHERV:
     case REDUCE:
     case SCATTER:
+    case SCATTERV:
         return true;
     default:
         return false;
@@ -1396,4 +1397,114 @@ mca_coll_han_scatter_intra_dynamic(const void *sbuf, int scount,
                    rbuf, rcount, rdtype,
                    root, comm,
                    sub_module);
+}
+
+
+/*
+ * Scatterv selector:
+ * On a sub-communicator, checks the stored rules to find the module to use
+ * On the global communicator, calls the han collective implementation, or
+ * calls the correct module if fallback mechanism is activated
+ */
+int
+mca_coll_han_scatterv_intra_dynamic(const void *sbuf, const int *scounts,
+                                    const int *displs, struct ompi_datatype_t *sdtype,
+                                    void *rbuf, int rcount,
+                                    struct ompi_datatype_t *rdtype, 
+                                    int root,
+                                    struct ompi_communicator_t *comm,
+                                    mca_coll_base_module_t *module)
+{
+    mca_coll_han_module_t *han_module = (mca_coll_han_module_t*) module;
+    TOPO_LVL_T topo_lvl = han_module->topologic_level;
+    mca_coll_base_module_scatterv_fn_t scatterv;
+    mca_coll_base_module_t *sub_module;
+    int rank, verbosity = 0;
+
+    if (!han_module->enabled) {
+        return han_module->previous_scatterv(sbuf, scounts, displs, sdtype, rbuf, rcount, rdtype, 
+                                             root, comm, han_module->previous_scatterv_module);
+    }
+
+    /* v collectives do not support message-size based dynamic rules */
+    sub_module = get_module(SCATTERV,
+                            MCA_COLL_HAN_ANY_MESSAGE_SIZE,
+                            comm,
+                            han_module);
+
+    /* First errors are always printed by rank 0 */
+    rank = ompi_comm_rank(comm);
+    if( (0 == rank) && (han_module->dynamic_errors < mca_coll_han_component.max_dynamic_errors) ) {
+        verbosity = 30;
+    }
+
+    if(NULL == sub_module) {
+        /*
+         * No valid collective module from dynamic rules
+         * nor from mca parameter
+         */
+        han_module->dynamic_errors++;
+        opal_output_verbose(verbosity, mca_coll_han_component.han_output,
+                            "coll:han:mca_coll_han_scatterv_intra_dynamic "
+                            "HAN did not find any valid module for collective %d (%s) "
+                            "with topological level %d (%s) on communicator (%s/%s). "
+                            "Please check dynamic file/mca parameters\n",
+                            SCATTERV, mca_coll_base_colltype_to_str(SCATTERV),
+                            topo_lvl, mca_coll_han_topo_lvl_to_str(topo_lvl),
+                            ompi_comm_print_cid(comm), comm->c_name);
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "HAN/SCATTERV: No module found for the sub-communicator. "
+                             "Falling back to another component\n"));
+        scatterv = han_module->previous_scatterv;
+        sub_module = han_module->previous_scatterv_module;
+    } else if (NULL == sub_module->coll_scatterv) {
+        /*
+         * No valid collective from dynamic rules
+         * nor from mca parameter
+         */
+        han_module->dynamic_errors++;
+        opal_output_verbose(verbosity, mca_coll_han_component.han_output,
+                            "coll:han:mca_coll_han_scatterv_intra_dynamic "
+                            "HAN found valid module for collective %d (%s) "
+                            "with topological level %d (%s) on communicator (%s/%s) "
+                            "but this module cannot handle this collective. "
+                            "Please check dynamic file/mca parameters\n",
+                            SCATTERV, mca_coll_base_colltype_to_str(SCATTERV),
+                            topo_lvl, mca_coll_han_topo_lvl_to_str(topo_lvl),
+                            ompi_comm_print_cid(comm), comm->c_name);
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "HAN/SCATTERV: the module found for the sub-"
+                             "communicator cannot handle the SCATTERV operation. "
+                             "Falling back to another component\n"));
+        scatterv = han_module->previous_scatterv;
+        sub_module = han_module->previous_scatterv_module;
+    } else if (GLOBAL_COMMUNICATOR == topo_lvl && sub_module == module) {
+        /*
+         * No fallback mechanism activated for this configuration
+         * sub_module is valid
+         * sub_module->coll_scatterv is valid and point to this function
+         * Call han topological collective algorithm
+         */
+        int algorithm_id = get_algorithm(SCATTERV,
+                                         MCA_COLL_HAN_ANY_MESSAGE_SIZE,
+                                         comm,
+                                         han_module);
+        scatterv = (mca_coll_base_module_scatterv_fn_t)mca_coll_han_algorithm_id_to_fn(SCATTERV, algorithm_id);
+        if (NULL == scatterv) { /* default behaviour */
+            scatterv = mca_coll_han_scatterv_intra;
+        }
+    } else {
+        /*
+         * If we get here:
+         * sub_module is valid
+         * sub_module->coll_scatterv is valid
+         * They point to the collective to use, according to the dynamic rules
+         * Selector's job is done, call the collective
+         */
+        scatterv = sub_module->coll_scatterv;
+    }
+
+    return scatterv(sbuf, scounts, displs, sdtype, 
+                    rbuf, rcount, rdtype, 
+                    root, comm, sub_module);
 }

--- a/ompi/mca/coll/han/coll_han_gatherv.c
+++ b/ompi/mca/coll/han/coll_han_gatherv.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2018-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "coll_han.h"
+#include "coll_han_trigger.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/pml/pml.h"
+
+/*
+ * @file
+ *
+ * This files contains the hierarchical implementations of gatherv.
+ * Only work with regular situation (each node has equal number of processes).
+ */
+
+/*
+ * Implement hierarchical Gatherv to optimize large-scale communications where multiple nodes and
+ * multiple processes per node send non-zero sized messages to the root, i.e. high incast.
+ *
+ * In Gatherv, only the root(receiver) process has the information of the amount of data, i.e.
+ * datatype and count, from each sender process. Therefore node leaders need an additional step to
+ * collect the expected data from its local peers. In summary, the steps are:
+ * 1. Root
+ *      a. Receive data from local peers (Low Gatherv)
+ *      b. Receive data from other node leaders (Up Gatherv)
+ *      c. If necessary reorder data from node leaders(see discussion below)
+ * 2. Root's local peers
+ *      a. Send data to root. (Low Gatherv)
+ * 3. Node leaders:
+ *      a. Collect the data transfer sizes(in bytes) from local peers (Low Gather)
+ *      b. Receive data from local peers (Low Gatherv)
+ *      c. Send data to the root (Up Gatherv)
+ * 4. Node followers:
+ *      a. Send the data transfer size(in bytes) to the node leader (Low Gather)
+ *      b. Send data to the node leader (Low Gatherv)
+ *
+ * Note on reodering:
+ * In Up Gatherv, data from each node is stored in a contiguous buffer sorted by the sender's
+ * local rank, and MUST be reordered according to the root's displacement requirement on the output
+ * buffer. Concretely, reordering can avoided if and only if both of following conditions are met:
+ * 1. Data from processes on each node, other than the root's node, are placed in the output buffer
+ *    in the same **order** as their local ranks. Note, it is possible to receive the data in the
+ *    correct order even if the process are NOT mapped by core.
+ * 2. No **gap** exists between data from the same node, other than the root's node, in the output
+ *    buffer - it is ok if data from different nodes has gap.
+ */
+int mca_coll_han_gatherv_intra(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
+                               void *rbuf, const int *rcounts, const int *displs,
+                               struct ompi_datatype_t *rdtype, int root,
+                               struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
+{
+    mca_coll_han_module_t *han_module = (mca_coll_han_module_t *) module;
+    int w_rank, w_size;              /* information about the global communicator */
+    int root_low_rank, root_up_rank; /* root ranks for both sub-communicators */
+    int err, *vranks, low_rank, low_size, up_rank, up_size, *topo;
+    int *low_rcounts = NULL, *low_displs = NULL;
+
+    /* Create the subcommunicators */
+    err = mca_coll_han_comm_create(comm, han_module);
+    if (OMPI_SUCCESS != err) {
+        OPAL_OUTPUT_VERBOSE(
+            (30, mca_coll_han_component.han_output,
+             "han cannot handle gatherv with this communicator. Fall back on another component\n"));
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
+        return han_module->previous_gatherv(sbuf, scount, sdtype, rbuf, rcounts, displs, rdtype,
+                                            root, comm, han_module->previous_gatherv_module);
+    }
+
+    /* Topo must be initialized to know rank distribution which then is used to determine if han can
+     * be used */
+    topo = mca_coll_han_topo_init(comm, han_module, 2);
+    if (han_module->are_ppn_imbalanced) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle gatherv with this communicator (imbalance). Fall "
+                             "back on another component\n"));
+        /* Put back the fallback collective support and call it once. All
+         * future calls will then be automatically redirected.
+         */
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gatherv);
+        return han_module->previous_gatherv(sbuf, scount, sdtype, rbuf, rcounts, displs, rdtype,
+                                            root, comm, han_module->previous_gatherv_module);
+    }
+
+    w_rank = ompi_comm_rank(comm);
+    w_size = ompi_comm_size(comm);
+
+    /* create the subcommunicators */
+    ompi_communicator_t *low_comm
+        = han_module->cached_low_comms[mca_coll_han_component.han_gatherv_low_module];
+    ompi_communicator_t *up_comm
+        = han_module->cached_up_comms[mca_coll_han_component.han_gatherv_up_module];
+
+    /* Get the 'virtual ranks' mapping corresponding to the communicators */
+    vranks = han_module->cached_vranks;
+    /* information about sub-communicators */
+    low_rank = ompi_comm_rank(low_comm);
+    low_size = ompi_comm_size(low_comm);
+    up_rank = ompi_comm_rank(up_comm);
+    up_size = ompi_comm_size(up_comm);
+    /* Get root ranks for low and up comms */
+    mca_coll_han_get_ranks(vranks, root, low_size, &root_low_rank, &root_up_rank);
+
+    OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                         "[%d]: Han Gatherv root %d root_low_rank %d root_up_rank %d\n", w_rank,
+                         root, root_low_rank, root_up_rank));
+
+    err = OMPI_SUCCESS;
+    /* #################### Root ########################### */
+    if (root == w_rank) {
+        int need_bounce_buf = 0, total_up_rcounts = 0, *up_displs = NULL, *up_rcounts = NULL,
+            *up_peer_lb = NULL, *up_peer_ub = NULL;
+        char *bounce_buf = NULL;
+
+        low_rcounts = malloc(low_size * sizeof(int));
+        low_displs = malloc(low_size * sizeof(int));
+        if (!low_rcounts || !low_displs) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto root_out;
+        }
+
+        int low_peer, up_peer, w_peer;
+        for (w_peer = 0; w_peer < w_size; ++w_peer) {
+            mca_coll_han_get_ranks(vranks, w_peer, low_size, &low_peer, &up_peer);
+            if (root_up_rank != up_peer) {
+                /* Not a local peer */
+                continue;
+            }
+            low_displs[low_peer] = displs[w_peer];
+            low_rcounts[low_peer] = rcounts[w_peer];
+        }
+
+        /* Low Gatherv */
+        low_comm->c_coll->coll_gatherv(sbuf, scount, sdtype, rbuf, low_rcounts, low_displs, rdtype,
+                                       root_low_rank, low_comm,
+                                       low_comm->c_coll->coll_gatherv_module);
+
+        size_t rdsize;
+        char *tmp_rbuf = rbuf;
+
+        ompi_datatype_type_size(rdtype, &rdsize);
+
+        up_rcounts = calloc(up_size, sizeof(int));
+        up_displs = malloc(up_size * sizeof(int));
+        up_peer_ub = calloc(up_size, sizeof(int));
+        if (!up_rcounts || !up_displs || !up_peer_ub) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto root_out;
+        }
+
+        for (up_peer = 0; up_peer < up_size; ++up_peer) {
+            up_displs[up_peer] = INT_MAX;
+        }
+
+        /* Calculate recv counts for the inter-node gatherv - no need to gather
+         * from self again because the data is already in place */
+        for (w_peer = 0; w_peer < w_size; ++w_peer) {
+            mca_coll_han_get_ranks(vranks, w_peer, low_size, NULL, &up_peer);
+
+            if (!need_bounce_buf && root_up_rank != up_peer && 0 < rcounts[w_peer] && 0 < w_peer
+                && displs[w_peer] < displs[w_peer - 1]) {
+                /* Data is not placed in the rank order so reordering is needed */
+                need_bounce_buf = 1;
+            }
+
+            if (root_up_rank == up_peer) {
+                /* No need to gather data on the same node again */
+                continue;
+            }
+
+            up_peer_ub[up_peer] = 0 < rcounts[w_peer]
+                                          && displs[w_peer] + rcounts[w_peer] > up_peer_ub[up_peer]
+                                      ? displs[w_peer] + rcounts[w_peer]
+                                      : up_peer_ub[up_peer];
+
+            up_rcounts[up_peer] += rcounts[w_peer];
+            total_up_rcounts += rcounts[w_peer];
+
+            /* Optimize for the happy path */
+            up_displs[up_peer] = 0 < rcounts[w_peer] && displs[w_peer] < up_displs[up_peer]
+                                     ? displs[w_peer]
+                                     : up_displs[up_peer];
+        }
+
+        /* If the data is not placed contiguously on recv buf, then we will need temp buf to store
+         * the gap data and recover it later */
+        for (up_peer = 0; up_peer < up_size; ++up_peer) {
+            if (root_up_rank == up_peer) {
+                continue;
+            }
+            if (!need_bounce_buf && 0 < up_rcounts[up_peer]
+                && up_rcounts[up_peer] < up_peer_ub[up_peer] - up_displs[up_peer]) {
+                need_bounce_buf = 1;
+                break;
+            }
+        }
+
+        if (need_bounce_buf) {
+            bounce_buf = malloc(rdsize * total_up_rcounts);
+            if (!bounce_buf) {
+                err = OMPI_ERR_OUT_OF_RESOURCE;
+                goto root_out;
+            }
+
+            /* Calculate displacements for the inter-node gatherv */
+            for (up_peer = 0; up_peer < up_size; ++up_peer) {
+                up_displs[up_peer] = 0 < up_peer ? up_displs[up_peer - 1] + up_rcounts[up_peer - 1]
+                                                 : 0;
+            }
+
+            tmp_rbuf = bounce_buf;
+        }
+
+        /* Up Gatherv */
+        up_comm->c_coll->coll_gatherv(sbuf, 0, sdtype, tmp_rbuf, up_rcounts, up_displs, rdtype,
+                                      root_up_rank, up_comm, up_comm->c_coll->coll_gatherv_module);
+
+        /* Use a temp buffer to reorder the output buffer if needed */
+        if (need_bounce_buf) {
+            ptrdiff_t offset = 0;
+
+            for (int i = 0; i < w_size; ++i) {
+                up_peer = topo[2 * i];
+                if (root_up_rank == up_peer) {
+                    continue;
+                }
+
+                w_peer = topo[2 * i + 1];
+
+                ompi_datatype_copy_content_same_ddt(rdtype, (size_t) rcounts[w_peer],
+                                                    (char *) rbuf
+                                                        + (size_t) displs[w_peer] * rdsize,
+                                                    bounce_buf + offset);
+                offset += rdsize * (size_t) rcounts[w_peer];
+            }
+        }
+
+    root_out:
+        if (low_displs) {
+            free(low_displs);
+        }
+        if (low_rcounts) {
+            free(low_rcounts);
+        }
+        if (up_displs) {
+            free(up_displs);
+        }
+        if (up_rcounts) {
+            free(up_rcounts);
+        }
+        if (up_peer_lb) {
+            free(up_peer_lb);
+        }
+        if (up_peer_ub) {
+            free(up_peer_ub);
+        }
+        if (bounce_buf) {
+            free(bounce_buf);
+        }
+
+        return err;
+    }
+
+    /* #################### Root's local peers ########################### */
+    if (root_up_rank == up_rank) {
+        /* Low Gatherv */
+        low_comm->c_coll->coll_gatherv(sbuf, scount, sdtype, NULL, NULL, NULL, NULL, root_low_rank,
+                                       low_comm, low_comm->c_coll->coll_gatherv_module);
+        return OMPI_SUCCESS;
+    }
+
+    size_t sdsize = 0;
+    uint64_t send_size = 0;
+
+    ompi_datatype_type_size(sdtype, &sdsize);
+    send_size = (uint64_t) sdsize * (uint64_t) scount;
+
+    /* #################### Other node followers ########################### */
+    if (root_low_rank != low_rank) {
+        /* Low Gather - Gather each local peer's send data size */
+        low_comm->c_coll->coll_gather((const void *) &send_size, 1, MPI_UINT64_T, NULL, 1,
+                                      MPI_UINT64_T, root_low_rank, low_comm,
+                                      low_comm->c_coll->coll_gather_module);
+        /* Low Gatherv */
+        low_comm->c_coll->coll_gatherv(sbuf, scount, sdtype, NULL, NULL, NULL, NULL, root_low_rank,
+                                       low_comm, low_comm->c_coll->coll_gatherv_module);
+        return OMPI_SUCCESS;
+    }
+
+    /* #################### Node leaders ########################### */
+
+    uint64_t *low_data_size = NULL;
+    char *tmp_buf = NULL;
+    ompi_datatype_t *temptype = MPI_BYTE;
+
+    /* Allocate a temporary array to gather the data size, i.e. data type size x count,
+     * in bytes from local peers */
+    low_data_size = malloc(low_size * sizeof(uint64_t));
+    if (!low_data_size) {
+        err = OMPI_ERR_OUT_OF_RESOURCE;
+        goto node_leader_out;
+    }
+
+    /* Low Gather -  Gather local peers' send data sizes */
+    low_comm->c_coll->coll_gather((const void *) &send_size, 1, MPI_UINT64_T,
+                                  (void *) low_data_size, 1, MPI_UINT64_T, root_low_rank, low_comm,
+                                  low_comm->c_coll->coll_gather_module);
+
+    /* Determine if we need to create a custom datatype instead of MPI_BYTE,
+     * to avoid count(type int) overflow
+     * TODO: Remove this logic once we adopt large-count, i.e. count will become 64-bit.
+     */
+    int total_up_scount = 0;
+    size_t rsize = 0, datatype_size = 1, max_data_size = 0;
+    for (int i = 0; i < low_size; ++i) {
+        rsize += (size_t) low_data_size[i];
+        max_data_size = (size_t) low_data_size[i] > max_data_size ? (size_t) low_data_size[i]
+                                                                  : max_data_size;
+    }
+
+    if (max_data_size > (size_t) INT_MAX) {
+        datatype_size = coll_han_utils_gcd(low_data_size, low_size);
+    }
+
+    low_rcounts = malloc(low_size * sizeof(int));
+    low_displs = malloc(low_size * sizeof(int));
+    tmp_buf = (char *) malloc(rsize); /* tmp_buf is still valid if rsize is 0 */
+    if (!tmp_buf || !low_rcounts || !low_displs) {
+        err = OMPI_ERR_OUT_OF_RESOURCE;
+        goto node_leader_out;
+    }
+
+    for (int i = 0; i < low_size; ++i) {
+        low_rcounts[i] = (int) ((size_t) low_data_size[i] / datatype_size);
+        low_displs[i] = i > 0 ? low_displs[i - 1] + low_rcounts[i - 1] : 0;
+        total_up_scount += low_rcounts[i];
+    }
+
+    if (1 < datatype_size) {
+        coll_han_utils_create_contiguous_datatype(datatype_size, MPI_BYTE, &temptype);
+        ompi_datatype_commit(&temptype);
+    }
+
+    /* Low Gatherv */
+    low_comm->c_coll->coll_gatherv(sbuf, scount, sdtype, (void *) tmp_buf, low_rcounts, low_displs,
+                                   temptype, root_low_rank, low_comm,
+                                   low_comm->c_coll->coll_gatherv_module);
+
+    /* Up Gatherv */
+    up_comm->c_coll->coll_gatherv(tmp_buf, total_up_scount, temptype, NULL, NULL, NULL, NULL,
+                                  root_up_rank, up_comm, up_comm->c_coll->coll_gatherv_module);
+
+node_leader_out:
+    if (low_rcounts) {
+        free(low_rcounts);
+    }
+    if (low_displs) {
+        free(low_displs);
+    }
+    if (low_data_size) {
+        free(low_data_size);
+    }
+    if (tmp_buf) {
+        free(tmp_buf);
+    }
+    if (MPI_BYTE != temptype) {
+        ompi_datatype_destroy(&temptype);
+    }
+
+    return err;
+}

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -52,6 +52,7 @@ static void han_module_clear(mca_coll_han_module_t *han_module)
     CLEAN_PREV_COLL(han_module, bcast);
     CLEAN_PREV_COLL(han_module, reduce);
     CLEAN_PREV_COLL(han_module, gather);
+    CLEAN_PREV_COLL(han_module, gatherv);
     CLEAN_PREV_COLL(han_module, scatter);
 
     han_module->reproducible_reduce = NULL;
@@ -148,6 +149,7 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     OBJ_RELEASE_IF_NOT_NULL(module->previous_allreduce_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_bcast_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_gather_module);
+    OBJ_RELEASE_IF_NOT_NULL(module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_scatter_module);
 
@@ -250,7 +252,6 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
     han_module->super.coll_alltoallv  = NULL;
     han_module->super.coll_alltoallw  = NULL;
     han_module->super.coll_exscan     = NULL;
-    han_module->super.coll_gatherv    = NULL;
     han_module->super.coll_reduce_scatter = NULL;
     han_module->super.coll_scan       = NULL;
     han_module->super.coll_scatterv   = NULL;
@@ -258,6 +259,7 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
     han_module->super.coll_scatter    = mca_coll_han_scatter_intra_dynamic;
     han_module->super.coll_reduce     = mca_coll_han_reduce_intra_dynamic;
     han_module->super.coll_gather     = mca_coll_han_gather_intra_dynamic;
+    han_module->super.coll_gatherv    = mca_coll_han_gatherv_intra_dynamic;
     han_module->super.coll_bcast      = mca_coll_han_bcast_intra_dynamic;
     han_module->super.coll_allreduce  = mca_coll_han_allreduce_intra_dynamic;
     han_module->super.coll_allgather  = mca_coll_han_allgather_intra_dynamic;
@@ -311,6 +313,7 @@ han_module_enable(mca_coll_base_module_t * module,
     HAN_SAVE_PREV_COLL_API(barrier);
     HAN_SAVE_PREV_COLL_API(bcast);
     HAN_SAVE_PREV_COLL_API(gather);
+    HAN_SAVE_PREV_COLL_API(gatherv);
     HAN_SAVE_PREV_COLL_API(reduce);
     HAN_SAVE_PREV_COLL_API(scatter);
 
@@ -326,6 +329,7 @@ handle_error:
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_allreduce_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_bcast_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gather_module);
+    OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatter_module);
 
@@ -347,6 +351,7 @@ mca_coll_han_module_disable(mca_coll_base_module_t * module,
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_barrier_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_bcast_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gather_module);
+    OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatter_module);
 

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -54,6 +54,7 @@ static void han_module_clear(mca_coll_han_module_t *han_module)
     CLEAN_PREV_COLL(han_module, gather);
     CLEAN_PREV_COLL(han_module, gatherv);
     CLEAN_PREV_COLL(han_module, scatter);
+    CLEAN_PREV_COLL(han_module, scatterv);
 
     han_module->reproducible_reduce = NULL;
     han_module->reproducible_reduce_module = NULL;
@@ -152,6 +153,7 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     OBJ_RELEASE_IF_NOT_NULL(module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(module->previous_scatter_module);
+    OBJ_RELEASE_IF_NOT_NULL(module->previous_scatterv_module);
 
     han_module_clear(module);
 }
@@ -254,7 +256,7 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
     han_module->super.coll_exscan     = NULL;
     han_module->super.coll_reduce_scatter = NULL;
     han_module->super.coll_scan       = NULL;
-    han_module->super.coll_scatterv   = NULL;
+    han_module->super.coll_scatterv   = mca_coll_han_scatterv_intra_dynamic;
     han_module->super.coll_barrier    = mca_coll_han_barrier_intra_dynamic;
     han_module->super.coll_scatter    = mca_coll_han_scatter_intra_dynamic;
     han_module->super.coll_reduce     = mca_coll_han_reduce_intra_dynamic;
@@ -316,6 +318,7 @@ han_module_enable(mca_coll_base_module_t * module,
     HAN_SAVE_PREV_COLL_API(gatherv);
     HAN_SAVE_PREV_COLL_API(reduce);
     HAN_SAVE_PREV_COLL_API(scatter);
+    HAN_SAVE_PREV_COLL_API(scatterv);
 
     /* set reproducible algos */
     mca_coll_han_reduce_reproducible_decision(comm, module);
@@ -332,6 +335,7 @@ handle_error:
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatter_module);
+    OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatterv_module);
 
     return OMPI_ERROR;
 }
@@ -354,6 +358,7 @@ mca_coll_han_module_disable(mca_coll_base_module_t * module,
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_gatherv_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_reduce_module);
     OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatter_module);
+    OBJ_RELEASE_IF_NOT_NULL(han_module->previous_scatterv_module);
 
     han_module_clear(han_module);
 

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2018-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2020      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "coll_han.h"
+#include "coll_han_trigger.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/pml/pml.h"
+
+/*
+ * @file
+ *
+ * This files contains the hierarchical implementations of scatterv.
+ * Only work with regular situation (each node has equal number of processes).
+ */
+
+/*
+ * Implement hierarchical Scatterv to optimize large-scale communications where root sends
+ * non-zero sized messages to multiple nodes and multiple processes per node, i.e. high incast.
+ *
+ * In Scatterv, only the root(sender) process has the information of the amount of data, i.e.
+ * datatype and count, to each receiver process. Therefore node leaders need an additional step to
+ * collect the expected data from its local peers. In summary, the steps are:
+ * 1. Root:
+ *      a. If necessary, reorder and sort data (See discussion below)
+ *      b. Send data to other node leaders (Up Iscatterv)
+ *      c. Send data to local peers (Low Scatterv)
+ * 2. Root's local peers:
+ *      a. Receive data from root. (Low Scatterv)
+ * 3. Node leaders:
+ *      a. Collect the data transfer sizes(in bytes) from local peers (Low Gather)
+ *      b. Receive data from the root (Up Iscatterv)
+ *      c. Send data to local peers (Low Scatterv)
+ * 4. Node followers:
+ *      a. Send the data transfer size(in bytes) to the node leader (Low Gather)
+ *      b. Receive data from the node leader (Low Scatterv)
+ *
+ * Note on reordering:
+ * In Up Iscatterv, reordering the send buffer can be avoided if and only if both of following
+ * conditions are met:
+ * 1. The data for each node is sorted in the same order as peer local ranks. Note, it is possible
+ *    to send the data in the correct order even if the process are NOT mapped by core.
+ * 2. In the send buffer, other than the root's node, data destined to the same node are continuous
+ *    - it is ok if data to different nodes has gap.
+ */
+int mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts, const int *displs,
+                                struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+                                struct ompi_datatype_t *rdtype, int root,
+                                struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
+{
+    mca_coll_han_module_t *han_module = (mca_coll_han_module_t *) module;
+    int w_rank, w_size;              /* information about the global communicator */
+    int root_low_rank, root_up_rank; /* root ranks for both sub-communicators */
+    int err, *vranks, low_rank, low_size, up_rank, up_size, *topo;
+    int *low_scounts = NULL, *low_displs = NULL;
+    ompi_request_t *iscatterv_req = NULL;
+
+    /* Create the subcommunicators */
+    err = mca_coll_han_comm_create(comm, han_module);
+    if (OMPI_SUCCESS != err) {
+        OPAL_OUTPUT_VERBOSE((
+            30, mca_coll_han_component.han_output,
+            "han cannot handle scatterv with this communicator. Fall back on another component\n"));
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
+        return han_module->previous_scatterv(sbuf, scounts, displs, sdtype, rbuf, rcount, rdtype,
+                                             root, comm, han_module->previous_scatterv_module);
+    }
+
+    /* Topo must be initialized to know rank distribution which then is used to determine if han can
+     * be used */
+    topo = mca_coll_han_topo_init(comm, han_module, 2);
+    if (han_module->are_ppn_imbalanced) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle scatterv with this communicator (imbalance). Fall "
+                             "back on another component\n"));
+        /* Put back the fallback collective support and call it once. All
+         * future calls will then be automatically redirected.
+         */
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, scatterv);
+        return han_module->previous_scatterv(sbuf, scounts, displs, sdtype, rbuf, rcount, rdtype,
+                                             root, comm, han_module->previous_scatterv_module);
+    }
+
+    w_rank = ompi_comm_rank(comm);
+    w_size = ompi_comm_size(comm);
+
+    /* create the subcommunicators */
+    ompi_communicator_t *low_comm
+        = han_module->cached_low_comms[mca_coll_han_component.han_scatterv_low_module];
+    ompi_communicator_t *up_comm
+        = han_module->cached_up_comms[mca_coll_han_component.han_scatterv_up_module];
+
+    /* Get the 'virtual ranks' mapping corresponding to the communicators */
+    vranks = han_module->cached_vranks;
+    /* information about sub-communicators */
+    low_rank = ompi_comm_rank(low_comm);
+    low_size = ompi_comm_size(low_comm);
+    up_rank = ompi_comm_rank(up_comm);
+    up_size = ompi_comm_size(up_comm);
+    /* Get root ranks for low and up comms */
+    mca_coll_han_get_ranks(vranks, root, low_size, &root_low_rank, &root_up_rank);
+
+    OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                         "[%d]: Han scatterv root %d root_low_rank %d root_up_rank %d\n", w_rank,
+                         root, root_low_rank, root_up_rank));
+
+    err = OMPI_SUCCESS;
+    /* #################### Root ########################### */
+    if (root == w_rank) {
+        int low_peer, up_peer, w_peer;
+        int need_bounce_buf = 0, total_up_scounts = 0, *up_displs = NULL, *up_scounts = NULL,
+            *up_peer_lb = NULL, *up_peer_ub = NULL;
+        char *reorder_sbuf = (char *) sbuf, *bounce_buf = NULL;
+        size_t sdsize;
+
+        low_scounts = malloc(low_size * sizeof(int));
+        low_displs = malloc(low_size * sizeof(int));
+        if (!low_scounts || !low_displs) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto root_out;
+        }
+
+        for (w_peer = 0; w_peer < w_size; ++w_peer) {
+            mca_coll_han_get_ranks(vranks, w_peer, low_size, &low_peer, &up_peer);
+            if (root_up_rank != up_peer) {
+                /* Not a local peer */
+                continue;
+            }
+            low_displs[low_peer] = displs[w_peer];
+            low_scounts[low_peer] = scounts[w_peer];
+        }
+
+        ompi_datatype_type_size(sdtype, &sdsize);
+
+        up_scounts = calloc(up_size, sizeof(int));
+        up_displs = malloc(up_size * sizeof(int));
+        up_peer_ub = calloc(up_size, sizeof(int));
+        if (!up_scounts || !up_displs || !up_peer_ub) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto root_out;
+        }
+
+        for (up_peer = 0; up_peer < up_size; ++up_peer) {
+            up_displs[up_peer] = INT_MAX;
+        }
+
+        /* Calculate send counts for the inter-node scatterv */
+        for (w_peer = 0; w_peer < w_size; ++w_peer) {
+            mca_coll_han_get_ranks(vranks, w_peer, low_size, NULL, &up_peer);
+
+            if (!need_bounce_buf && root_up_rank != up_peer && 0 < scounts[w_peer] && 0 < w_peer
+                && displs[w_peer] < displs[w_peer - 1]) {
+                /* Data is not placed in the rank order so reordering is needed */
+                need_bounce_buf = 1;
+            }
+
+            if (root_up_rank == up_peer) {
+                /* No need to scatter data on the same node again */
+                continue;
+            }
+
+            up_peer_ub[up_peer] = 0 < scounts[w_peer]
+                                          && displs[w_peer] + scounts[w_peer] > up_peer_ub[up_peer]
+                                      ? displs[w_peer] + scounts[w_peer]
+                                      : up_peer_ub[up_peer];
+
+            up_scounts[up_peer] += scounts[w_peer];
+            total_up_scounts += scounts[w_peer];
+
+            /* Optimize for the happy path */
+            up_displs[up_peer] = 0 < scounts[w_peer] && displs[w_peer] < up_displs[up_peer]
+                                     ? displs[w_peer]
+                                     : up_displs[up_peer];
+        }
+
+        /* If the data is not placed contiguously on send buf without overlaping, then we need a
+         * temp buf without gaps */
+        for (up_peer = 0; up_peer < up_size; ++up_peer) {
+            if (root_up_rank == up_peer) {
+                continue;
+            }
+            if (!need_bounce_buf && 0 < up_scounts[up_peer]
+                && up_scounts[up_peer] != up_peer_ub[up_peer] - up_displs[up_peer]) {
+                need_bounce_buf = 1;
+                break;
+            }
+        }
+
+        if (need_bounce_buf) {
+            bounce_buf = malloc(sdsize * total_up_scounts);
+            if (!bounce_buf) {
+                err = OMPI_ERR_OUT_OF_RESOURCE;
+                goto root_out;
+            }
+
+            /* Calculate displacements for the inter-node scatterv */
+            for (up_peer = 0; up_peer < up_size; ++up_peer) {
+                up_displs[up_peer] = 0 < up_peer ? up_displs[up_peer - 1] + up_scounts[up_peer - 1]
+                                                 : 0;
+            }
+
+            /* Use a temp buffer to reorder the send buffer if needed */
+            ptrdiff_t offset = 0;
+
+            for (int i = 0; i < w_size; ++i) {
+                up_peer = topo[2 * i];
+                if (root_up_rank == up_peer) {
+                    continue;
+                }
+
+                w_peer = topo[2 * i + 1];
+
+                ompi_datatype_copy_content_same_ddt(sdtype, (size_t) scounts[w_peer],
+                                                    bounce_buf + offset,
+                                                    (char *) sbuf
+                                                        + (size_t) displs[w_peer] * sdsize);
+                offset += sdsize * (size_t) scounts[w_peer];
+            }
+
+            reorder_sbuf = bounce_buf;
+        }
+
+        /* Up Iscatterv */
+        up_comm->c_coll->coll_iscatterv((const char *) reorder_sbuf, up_scounts, up_displs, sdtype,
+                                        rbuf, rcount, rdtype, root_up_rank, up_comm, &iscatterv_req,
+                                        up_comm->c_coll->coll_iscatterv_module);
+
+        /* Low Scatterv */
+        low_comm->c_coll->coll_scatterv(sbuf, low_scounts, low_displs, sdtype, rbuf, rcount, rdtype,
+                                        root_low_rank, low_comm,
+                                        low_comm->c_coll->coll_scatterv_module);
+
+        ompi_request_wait(&iscatterv_req, MPI_STATUS_IGNORE);
+
+    root_out:
+        if (low_displs) {
+            free(low_displs);
+        }
+        if (low_scounts) {
+            free(low_scounts);
+        }
+        if (up_displs) {
+            free(up_displs);
+        }
+        if (up_scounts) {
+            free(up_scounts);
+        }
+        if (up_peer_lb) {
+            free(up_peer_lb);
+        }
+        if (up_peer_ub) {
+            free(up_peer_ub);
+        }
+        if (bounce_buf) {
+            free(bounce_buf);
+        }
+
+        return err;
+    }
+
+    /* #################### Root's local peers ########################### */
+    if (root_up_rank == up_rank) {
+        /* Low Scatterv */
+        low_comm->c_coll->coll_scatterv(NULL, NULL, NULL, NULL, rbuf, rcount, rdtype, root_low_rank,
+                                        low_comm, low_comm->c_coll->coll_scatterv_module);
+        return OMPI_SUCCESS;
+    }
+
+    size_t rdsize = 0;
+    uint64_t receive_size = 0;
+
+    ompi_datatype_type_size(rdtype, &rdsize);
+    receive_size = (uint64_t) rdsize * (uint64_t) rcount;
+
+    /* #################### Other node followers ########################### */
+    if (root_low_rank != low_rank) {
+        /* Low Gather - Gather each local peer's receive data size */
+        low_comm->c_coll->coll_gather((const void *) &receive_size, 1, MPI_UINT64_T, NULL, 1,
+                                      MPI_UINT64_T, root_low_rank, low_comm,
+                                      low_comm->c_coll->coll_gather_module);
+        /* Low Scatterv */
+        low_comm->c_coll->coll_scatterv(NULL, NULL, NULL, NULL, rbuf, rcount, rdtype, root_low_rank,
+                                        low_comm, low_comm->c_coll->coll_scatterv_module);
+        return OMPI_SUCCESS;
+    }
+
+    /* #################### Node leaders ########################### */
+
+    uint64_t *low_data_size = NULL;
+    char *tmp_buf = NULL;
+    ompi_datatype_t *temptype = MPI_BYTE;
+
+    /* Allocate a temporary array to gather the data size, i.e. data type size x count,
+     * in bytes from local peers */
+    low_data_size = malloc(low_size * sizeof(uint64_t));
+    if (!low_data_size) {
+        err = OMPI_ERR_OUT_OF_RESOURCE;
+        goto node_leader_out;
+    }
+
+    /* Low Gather -  Gather local peers' receive data sizes */
+    low_comm->c_coll->coll_gather((const void *) &receive_size, 1, MPI_UINT64_T,
+                                  (void *) low_data_size, 1, MPI_UINT64_T, root_low_rank, low_comm,
+                                  low_comm->c_coll->coll_gather_module);
+
+    /* Determine if we need to create a custom datatype instead of MPI_BYTE,
+     * to avoid count(type int) overflow
+     * TODO: Remove this logic once we adopt large-count, i.e. count will become 64-bit.
+     */
+    int total_up_scount = 0;
+    size_t rsize = 0, datatype_size = 1, max_data_size = 0;
+    for (int i = 0; i < low_size; ++i) {
+        rsize += (size_t) low_data_size[i];
+        max_data_size = (size_t) low_data_size[i] > max_data_size ? (size_t) low_data_size[i]
+                                                                  : max_data_size;
+    }
+
+    if (max_data_size > (size_t) INT_MAX) {
+        datatype_size = coll_han_utils_gcd(low_data_size, low_size);
+    }
+
+    low_scounts = malloc(low_size * sizeof(int));
+    low_displs = malloc(low_size * sizeof(int));
+    tmp_buf = (char *) malloc(rsize); /* tmp_buf is still valid if rsize is 0 */
+    if (!tmp_buf || !low_scounts || !low_displs) {
+        err = OMPI_ERR_OUT_OF_RESOURCE;
+        goto node_leader_out;
+    }
+
+    for (int i = 0; i < low_size; ++i) {
+        low_scounts[i] = (int) ((size_t) low_data_size[i] / datatype_size);
+        low_displs[i] = i > 0 ? low_displs[i - 1] + low_scounts[i - 1] : 0;
+        total_up_scount += low_scounts[i];
+    }
+
+    if (1 < datatype_size) {
+        coll_han_utils_create_contiguous_datatype(datatype_size, MPI_BYTE, &temptype);
+        ompi_datatype_commit(&temptype);
+    }
+
+    /* Up Iscatterv */
+    up_comm->c_coll->coll_iscatterv(NULL, NULL, NULL, NULL, (void *) tmp_buf, total_up_scount,
+                                    temptype, root_up_rank, up_comm, &iscatterv_req,
+                                    up_comm->c_coll->coll_iscatterv_module);
+
+    ompi_request_wait(&iscatterv_req, MPI_STATUS_IGNORE);
+
+    /* Low Scatterv */
+    low_comm->c_coll->coll_scatterv((void *) tmp_buf, low_scounts, low_displs, temptype, rbuf,
+                                    rcount, rdtype, root_low_rank, low_comm,
+                                    low_comm->c_coll->coll_scatterv_module);
+
+node_leader_out:
+    if (low_scounts) {
+        free(low_scounts);
+    }
+    if (low_displs) {
+        free(low_displs);
+    }
+    if (low_data_size) {
+        free(low_data_size);
+    }
+    if (tmp_buf) {
+        free(tmp_buf);
+    }
+    if (MPI_BYTE != temptype) {
+        ompi_datatype_destroy(&temptype);
+    }
+
+    return err;
+}

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -78,6 +78,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, bcast);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, reduce);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gather);
+    HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatter);
 
     /**
@@ -105,6 +106,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
         han_module->enabled = false;  /* entire module set to pass-through from now on */
         return OMPI_ERR_NOT_SUPPORTED;
@@ -181,6 +183,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+    HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
 
     OBJ_DESTRUCT(&comm_info);
@@ -236,6 +239,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, bcast);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, reduce);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gather);
+    HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatter);
 
     /**
@@ -260,6 +264,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
         han_module->enabled = false;  /* entire module set to pass-through from now on */
         return OMPI_ERR_NOT_SUPPORTED;
@@ -348,6 +353,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+    HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
 
     OBJ_DESTRUCT(&comm_info);

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -80,6 +80,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gather);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatter);
+    HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatterv);
 
     /**
      * HAN is not yet optimized for a single process per node case, we should
@@ -108,6 +109,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatterv);
         han_module->enabled = false;  /* entire module set to pass-through from now on */
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -185,6 +187,7 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
+    HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatterv);
 
     OBJ_DESTRUCT(&comm_info);
     return OMPI_SUCCESS;
@@ -241,6 +244,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gather);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatter);
+    HAN_SUBCOM_SAVE_COLLECTIVE(fallbacks, comm, han_module, scatterv);
 
     /**
      * HAN is not yet optimized for a single process per node case, we should
@@ -266,6 +270,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
         HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatterv);
         han_module->enabled = false;  /* entire module set to pass-through from now on */
         return OMPI_ERR_NOT_SUPPORTED;
     }
@@ -355,6 +360,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gatherv);
     HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
+    HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatterv);
 
     OBJ_DESTRUCT(&comm_info);
     return OMPI_SUCCESS;

--- a/ompi/mca/coll/han/coll_han_utils.c
+++ b/ompi/mca/coll/han/coll_han_utils.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Shared utility functions
+ */
+
+#include "ompi/mca/coll/base/coll_base_functions.h"
+#include "coll_han.h"
+
+/**
+ * Calculate the Greatest Common Denominator of a list of non-negative integers
+ *
+ * @param[in]   numerators      A list of numerators that should be divisible by
+ *                              the denominator
+ * @param[in]   size            Number of numerators
+ * @returns     The GCD, where 1 <= GCD
+ */
+size_t coll_han_utils_gcd(const size_t *numerators, const size_t size)
+{
+    size_t denominator = numerators[0], numerator, tmp;
+
+    for (size_t i = 1; i < size; ++i) {
+        numerator = numerators[i];
+
+        if (0 == denominator) {
+            denominator = numerator;
+            continue;
+        }
+
+        if (0 == numerator) {
+            continue;
+        }
+
+        while (0 < numerator % denominator && 0 < denominator % numerator) {
+            tmp = MIN(numerator, denominator);
+            denominator = MAX(numerator, denominator) - tmp;
+            numerator = tmp;
+        }
+    }
+
+    if (0 == denominator) {
+        denominator = 1;
+    }
+
+    return denominator;
+}
+
+int coll_han_utils_create_contiguous_datatype(size_t count, const ompi_datatype_t *oldType,
+                                                  ompi_datatype_t **newType)
+{
+    ompi_datatype_t *pdt;
+
+    if ((0 == count) || (0 == oldType->super.size)) {
+        return ompi_datatype_duplicate(&ompi_mpi_datatype_null.dt, newType);
+    }
+
+    pdt = ompi_datatype_create(oldType->super.desc.used + 2);
+    opal_datatype_add(&(pdt->super), &(oldType->super), count, 0,
+                      (oldType->super.ub - oldType->super.lb));
+    *newType = pdt;
+    return OMPI_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add gatherv and scatterv implementation to optimize large-scale communications on multiple nodes and multiple processes per node, by avoiding high-incast traffic on the root process.

Because *V collectives do not have equal datatype/count on every process, it does not natively support message-size based tuning without an additional global communication.

Similar to gather and allgather, the hierarchical gatherv requires a temporary buffer and memory copy to handle out-of-order data, or non-contiguous placement on the output buffer, which results in worse performance for large messages compared to the linear implementation.

<details>
<summary>OMB comparison between linear and hierarchical MPI_Gatherv</summary>




* Note: The following result has cherry picked https://github.com/open-mpi/ompi/pull/12305

## Happy Path Performance without reordering (`--rank-by slot`)
#### 2 nodes x 64ppn = 128 procs
**Default linear gatherv**
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                       4.64              0.35             49.63        1000
[1,0]<stdout>: 2                       4.67              0.35             47.83        1000
[1,0]<stdout>: 4                       4.40              0.35             46.51        1000
[1,0]<stdout>: 8                       4.48              0.34             47.04        1000
[1,0]<stdout>: 16                      4.46              0.35             47.13        1000
[1,0]<stdout>: 32                      4.50              0.35             47.31        1000
[1,0]<stdout>: 64                      5.84              0.35             53.00        1000
[1,0]<stdout>: 128                     5.60              0.35             52.76        1000
[1,0]<stdout>: 256                    12.01              0.35             77.85        1000
[1,0]<stdout>: 512                    11.66              0.35             76.06        1000
[1,0]<stdout>: 1024                   11.49              0.37             83.19        1000
[1,0]<stdout>: 2048                   11.35              0.38             88.96        1000
[1,0]<stdout>: 4096                   11.13              0.41             95.71        1000
[1,0]<stdout>: 8192                   60.45             13.57            216.82        1000
[1,0]<stdout>: 16384                  78.74             12.01            312.69         100
[1,0]<stdout>: 32768                 116.05             20.48            489.80         100
[1,0]<stdout>: 65536                 189.58             38.27            857.93         100
[1,0]<stdout>: 131072                742.51             48.57           1577.27         100
[1,0]<stdout>: 262144               1448.12             77.61           3137.05         100
[1,0]<stdout>: 524288               3041.88             78.65           6115.82         100
[1,0]<stdout>: 1048576              5046.68           1098.15           8445.72         100

real	0m7.592s
user	0m0.032s
sys	0m0.048s
```

**Hierarchical gatherv**

```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      13.24              0.62             57.08        1000
[1,0]<stdout>: 2                      13.58              0.55             59.21        1000
[1,0]<stdout>: 4                      13.63              0.53             59.58        1000
[1,0]<stdout>: 8                      13.65              0.53             59.65        1000
[1,0]<stdout>: 16                     13.63              0.54             60.32        1000
[1,0]<stdout>: 32                     13.62              0.53             60.47        1000
[1,0]<stdout>: 64                     13.69              0.54             61.90        1000
[1,0]<stdout>: 128                    13.47              0.60             61.72        1000
[1,0]<stdout>: 256                    30.31              0.86            119.91        1000
[1,0]<stdout>: 512                    29.73              0.80            121.20        1000
[1,0]<stdout>: 1024                   29.74              0.84            125.64        1000
[1,0]<stdout>: 2048                   30.49              0.83            162.71        1000
[1,0]<stdout>: 4096                   28.90              0.79            174.88        1000
[1,0]<stdout>: 8192                   85.67             25.98            282.71        1000
[1,0]<stdout>: 16384                 104.62             25.79            323.59         100
[1,0]<stdout>: 32768                 144.11             29.70            452.66         100
[1,0]<stdout>: 65536                 229.81             33.26            721.29         100
[1,0]<stdout>: 131072                383.63             40.88           1195.43         100
[1,0]<stdout>: 262144                751.58             63.67           2270.66         100
[1,0]<stdout>: 524288               2977.58            282.49          13139.84         100
[1,0]<stdout>: 1048576              5969.17            548.00          25890.52         100

real	0m10.551s
user	0m0.038s
sys	0m0.037s
```

#### 16 nodes x 64ppn = 1024 procs
**Default linear gatherv**
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                       1.68              0.34            634.42        1000
[1,0]<stdout>: 2                       1.69              0.34            638.99        1000
[1,0]<stdout>: 4                       1.69              0.34            642.46        1000
[1,0]<stdout>: 8                       1.70              0.25            652.73        1000
[1,0]<stdout>: 16                      1.71              0.32            653.11        1000
[1,0]<stdout>: 32                      1.72              0.26            654.13        1000
[1,0]<stdout>: 64                      1.76              0.27            679.29        1000
[1,0]<stdout>: 128                     1.78              0.25            681.59        1000
[1,0]<stdout>: 256                     1.97              0.34            693.36        1000
[1,0]<stdout>: 512                     2.02              0.34            717.60        1000
[1,0]<stdout>: 1024                    2.12              0.35            776.07        1000
[1,0]<stdout>: 2048                    2.25              0.37            898.00        1000
[1,0]<stdout>: 4096                    2.45              0.40           1054.73        1000
[1,0]<stdout>: 8192                  176.12             31.85           1413.68        1000
[1,0]<stdout>: 16384                 359.66             36.26           2521.24         100
[1,0]<stdout>: 32768                 722.06             40.71           4523.63         100
[1,0]<stdout>: 65536                1425.91             45.81           8647.08         100
[1,0]<stdout>: 131072               4968.47            185.44          15497.74         100
[1,0]<stdout>: 262144              16032.77            211.21          30089.29         100
[1,0]<stdout>: 524288              39176.47            272.97          58606.06         100

real	0m38.337s
user	0m0.079s
sys	0m0.088s
```

**Hierarchical gatherv**

```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      13.10              0.59             66.92        1000
[1,0]<stdout>: 2                      13.32              0.56             65.37        1000
[1,0]<stdout>: 4                      13.34              0.54             65.17        1000
[1,0]<stdout>: 8                      13.37              0.53             69.54        1000
[1,0]<stdout>: 16                     13.34              0.54             67.34        1000
[1,0]<stdout>: 32                     13.35              0.52             66.23        1000
[1,0]<stdout>: 64                     13.37              0.52             68.53        1000
[1,0]<stdout>: 128                    13.73              0.55             67.83        1000
[1,0]<stdout>: 256                    39.21              0.67            206.27        1000
[1,0]<stdout>: 512                    37.51              0.65            172.15        1000
[1,0]<stdout>: 1024                   37.38              0.70            216.41        1000
[1,0]<stdout>: 2048                   38.55              0.74            303.33        1000
[1,0]<stdout>: 4096                   35.55              0.77            480.86        1000
[1,0]<stdout>: 8192                  100.68             25.96            866.76        1000
[1,0]<stdout>: 16384                 125.71             24.17            933.73         100
[1,0]<stdout>: 32768                 177.80             26.00           2026.15         100
[1,0]<stdout>: 65536                 290.06             33.58           3702.86         100
[1,0]<stdout>: 131072                479.79             41.67           6243.50         100
[1,0]<stdout>: 262144                924.70             63.57          12132.51         100
[1,0]<stdout>: 524288               4508.58            278.82          32352.78         100

real	0m22.046s
user	0m0.163s
sys	0m0.130s
```

#### 64 nodes x 64ppn = 4096 procs(reduced message size due to memory limit)
**Default linear gatherv**
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                       1.57              0.34           3921.16        1000
[1,0]<stdout>: 2                       1.59              0.34           3937.05        1000
[1,0]<stdout>: 4                       1.59              0.33           3973.91        1000
[1,0]<stdout>: 8                       1.58              0.33           3920.90        1000
[1,0]<stdout>: 16                      1.58              0.33           3923.34        1000
[1,0]<stdout>: 32                      1.57              0.33           3879.77        1000
[1,0]<stdout>: 64                      1.57              0.33           3869.90        1000
[1,0]<stdout>: 128                     1.57              0.33           3892.23        1000
[1,0]<stdout>: 256                     1.57              0.33           3676.15        1000
[1,0]<stdout>: 512                     1.55              0.34           3527.66        1000
[1,0]<stdout>: 1024                    1.61              0.35           3735.54        1000

real	1m18.041s
user	0m0.688s
sys	0m0.827s
```
**Hierarchical gatherv**
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      12.96              0.67            122.70        1000
[1,0]<stdout>: 2                      13.28              0.55            138.74        1000
[1,0]<stdout>: 4                      13.30              0.50            119.33        1000
[1,0]<stdout>: 8                      13.33              0.50            124.42        1000
[1,0]<stdout>: 16                     13.31              0.49            124.79        1000
[1,0]<stdout>: 32                     13.31              0.49            121.69        1000
[1,0]<stdout>: 64                     13.33              0.49            124.90        1000
[1,0]<stdout>: 128                    13.69              0.49            120.31        1000
[1,0]<stdout>: 256                    38.85              0.63            238.08        1000
[1,0]<stdout>: 512                    37.89              0.64            336.00        1000
[1,0]<stdout>: 1024                   38.44              0.68            525.95        1000

real	0m32.456s
user	0m0.790s
sys	0m0.636s
```

## Worst Case Performance with Reordering (`--rank-by node`)
**Only show result for hierarchical gatherv - default linear algorithm is not affected by rank-by**
#### 2 nodes x 64ppn = 128 procs
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      12.93              1.04             57.49        1000
[1,0]<stdout>: 2                      13.34              0.59             59.37        1000
[1,0]<stdout>: 4                      13.36              0.51             59.89        1000
[1,0]<stdout>: 8                      13.43              0.53             60.05        1000
[1,0]<stdout>: 16                     13.37              0.51             59.77        1000
[1,0]<stdout>: 32                     13.39              0.51             60.57        1000
[1,0]<stdout>: 64                     13.43              0.53             64.19        1000
[1,0]<stdout>: 128                    13.09              0.53             61.37        1000
[1,0]<stdout>: 256                    36.45              0.76            142.11        1000
[1,0]<stdout>: 512                    35.59              0.66            142.69        1000
[1,0]<stdout>: 1024                   34.87              0.74            143.69        1000
[1,0]<stdout>: 2048                   35.39              0.75            182.90        1000
[1,0]<stdout>: 4096                   32.51              0.77            194.39        1000
[1,0]<stdout>: 8192                   87.38             11.71            307.09        1000
[1,0]<stdout>: 16384                 109.99             11.96            358.53         100
[1,0]<stdout>: 32768                 150.94             21.37            527.55         100
[1,0]<stdout>: 65536                 238.63             18.98            884.33         100
[1,0]<stdout>: 131072                400.55             25.91           1519.31         100
[1,0]<stdout>: 262144                773.05             52.27           2917.65         100
[1,0]<stdout>: 524288               3143.42             75.64          18756.92         100
[1,0]<stdout>: 1048576              6288.95            142.21          37001.20         100

real	0m13.099s
user	0m0.037s
sys	0m0.041s
```

#### 16 nodes x 64ppn = 1024 procs
```
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      12.97              0.99             85.45        1000
[1,0]<stdout>: 2                      13.21              0.62             85.09        1000
[1,0]<stdout>: 4                      13.22              0.53             84.87        1000
[1,0]<stdout>: 8                      13.24              0.55             86.50        1000
[1,0]<stdout>: 16                     13.22              0.52             84.07        1000
[1,0]<stdout>: 32                     13.25              0.53             85.32        1000
[1,0]<stdout>: 64                     13.25              0.52             90.10        1000
[1,0]<stdout>: 128                    13.57              0.55             69.28        1000
[1,0]<stdout>: 256                    37.74              0.63            173.56        1000
[1,0]<stdout>: 512                    36.96              0.66            190.24        1000
[1,0]<stdout>: 1024                   36.54              0.69            243.03        1000
[1,0]<stdout>: 2048                   37.76              0.73            377.21        1000
[1,0]<stdout>: 4096                   35.28              0.77            595.56        1000
[1,0]<stdout>: 8192                  100.17             25.75           1109.30        1000
[1,0]<stdout>: 16384                 127.45             26.63           1518.66         100
[1,0]<stdout>: 32768                 181.39             29.25           2992.01         100
[1,0]<stdout>: 65536                 566.74             25.20          23168.03         100
[1,0]<stdout>: 131072                931.37             46.47          39313.10         100
[1,0]<stdout>: 262144               1732.46             76.02          71912.28         100
[1,0]<stdout>: 524288               5978.15            161.02         144052.29         100

real	0m49.669s
user	0m0.100s
sys	0m0.199s
```
#### 64 nodes x 64ppn = 4096 procs
````
[1,0]<stdout>: # OSU MPI Gatherv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      12.88              0.94            167.05        1000
[1,0]<stdout>: 2                      13.15              0.55            167.64        1000
[1,0]<stdout>: 4                      13.17              0.49            170.75        1000
[1,0]<stdout>: 8                      13.18              0.49            167.91        1000
[1,0]<stdout>: 16                     13.18              0.49            163.97        1000
[1,0]<stdout>: 32                     13.19              0.49            182.50        1000
[1,0]<stdout>: 64                     13.21              0.49            169.98        1000
[1,0]<stdout>: 128                    13.59              0.49            188.04        1000
[1,0]<stdout>: 256                    40.82              0.64            299.74        1000
[1,0]<stdout>: 512                    40.03              0.66            426.60        1000
[1,0]<stdout>: 1024                   40.59              0.67            663.56        1000

real	0m33.257s
user	0m0.843s
sys	0m0.751s
````


</details>


<details>
<summary>OMB comparison between linear and hierarchical MPI_Scatterv</summary>

## Happy Path Performance without reordering (`--rank-by slot`)
#### 2 nodes x 64ppn = 128 procs
**Default linear scatterv**
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      16.52              1.35             62.98        1000
[1,0]<stdout>: 2                      17.07              1.36             63.90        1000
[1,0]<stdout>: 4                      17.11              1.34             63.99        1000
[1,0]<stdout>: 8                      17.21              1.26             64.46        1000
[1,0]<stdout>: 16                     17.26              1.28             64.58        1000
[1,0]<stdout>: 32                     17.20              1.31             64.48        1000
[1,0]<stdout>: 64                     17.23              1.25             64.44        1000
[1,0]<stdout>: 128                    17.74              1.36             65.36        1000
[1,0]<stdout>: 256                    21.51              1.60             70.10        1000
[1,0]<stdout>: 512                    22.20              1.67             71.19        1000
[1,0]<stdout>: 1024                   26.92              1.84             78.22        1000
[1,0]<stdout>: 2048                   30.35              1.95             84.08        1000
[1,0]<stdout>: 4096                   36.27              2.58             96.20        1000
[1,0]<stdout>: 8192                  531.94              3.30           1825.26        1000
[1,0]<stdout>: 16384                 570.35              3.26           1908.61         100
[1,0]<stdout>: 32768                 644.08              4.70           2055.98         100
[1,0]<stdout>: 65536                 793.32              7.12           2341.72         100
[1,0]<stdout>: 131072               1530.23             15.22           4681.64         100
[1,0]<stdout>: 262144               2040.22             27.88           5643.87         100
[1,0]<stdout>: 524288               3752.15             55.37           9855.75         100
[1,0]<stdout>: 1048576              5812.79            121.96          12268.16         100

real	0m13.233s
user	0m0.000s
sys	0m0.082s
```

**Hierarchical scatterv**

```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      23.93              1.86             46.99        1000
[1,0]<stdout>: 2                      23.98              1.95             47.00        1000
[1,0]<stdout>: 4                      24.08              1.94             47.24        1000
[1,0]<stdout>: 8                      24.21              2.00             47.43        1000
[1,0]<stdout>: 16                     24.29              1.90             47.70        1000
[1,0]<stdout>: 32                     24.36              1.94             47.80        1000
[1,0]<stdout>: 64                     25.11              2.02             49.11        1000
[1,0]<stdout>: 128                    25.88              2.12             50.39        1000
[1,0]<stdout>: 256                    29.04              2.28             56.47        1000
[1,0]<stdout>: 512                    30.98              2.50             60.44        1000
[1,0]<stdout>: 1024                   35.34              2.85             68.55        1000
[1,0]<stdout>: 2048                   55.07              2.73            107.68        1000
[1,0]<stdout>: 4096                   64.59              3.29            126.34        1000
[1,0]<stdout>: 8192                  159.80              4.10            335.16        1000
[1,0]<stdout>: 16384                 181.21              4.63            409.44         100
[1,0]<stdout>: 32768                 265.88              6.04            598.07         100
[1,0]<stdout>: 65536                 441.75              9.02            989.17         100
[1,0]<stdout>: 131072                720.13             15.06           1594.35         100
[1,0]<stdout>: 262144               1272.70             29.57           2743.94         100
[1,0]<stdout>: 524288               6852.35             63.08          15249.06         100
[1,0]<stdout>: 1048576             13692.94            138.20          30069.45         100

real	0m10.032s
user	0m0.049s
sys	0m0.097s
```

#### 16 nodes x 64ppn = 1024 procs
**Default linear scatterv**
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                     159.78              1.85            345.43        1000
[1,0]<stdout>: 2                     158.27              1.29            343.23        1000
[1,0]<stdout>: 4                     158.60              1.82            342.69        1000
[1,0]<stdout>: 8                     157.31              1.26            339.72        1000
[1,0]<stdout>: 16                    157.46              1.77            340.10        1000
[1,0]<stdout>: 32                    157.55              1.26            340.09        1000
[1,0]<stdout>: 64                    158.66              1.76            341.39        1000
[1,0]<stdout>: 128                   159.87              1.31            344.11        1000
[1,0]<stdout>: 256                   168.50              2.04            354.58        1000
[1,0]<stdout>: 512                   173.21              1.63            363.31        1000
[1,0]<stdout>: 1024                  185.34              2.26            384.19        1000
[1,0]<stdout>: 2048                  208.39              1.90            429.41        1000
[1,0]<stdout>: 4096                  245.61              2.77            501.90        1000
[1,0]<stdout>: 8192                11961.05              3.12          25562.80        1000
[1,0]<stdout>: 16384               12324.61              4.83          26333.23         100
[1,0]<stdout>: 32768               12902.40              5.46          27472.94         100
[1,0]<stdout>: 65536               13983.43              9.07          29607.63         100
[1,0]<stdout>: 131072              29112.35             14.61          61728.65         100
[1,0]<stdout>: 262144              32925.09             27.35          69120.39         100
[1,0]<stdout>: 524288              55311.94             55.04         115649.66         100

real	1m27.318s
user	0m0.053s
sys	0m0.115s
```

**Hierarchical scatterv**

```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      29.80             12.80             46.78        1000
[1,0]<stdout>: 2                      29.73             12.76             46.74        1000
[1,0]<stdout>: 4                      29.69             12.78             46.60        1000
[1,0]<stdout>: 8                      30.00             12.90             46.58        1000
[1,0]<stdout>: 16                     30.83             13.20             47.40        1000
[1,0]<stdout>: 32                     30.69             13.41             47.83        1000
[1,0]<stdout>: 64                     31.86             14.10             49.73        1000
[1,0]<stdout>: 128                    34.52             15.39             50.35        1000
[1,0]<stdout>: 256                    40.02             15.11             62.27        1000
[1,0]<stdout>: 512                    49.78             16.71             77.03        1000
[1,0]<stdout>: 1024                   69.12             20.27            111.07        1000
[1,0]<stdout>: 2048                  134.34             20.38            189.22        1000
[1,0]<stdout>: 4096                  205.15             21.96            284.62        1000
[1,0]<stdout>: 8192                  433.22             23.15            611.64        1000
[1,0]<stdout>: 16384                 764.50             17.42           1055.88         100
[1,0]<stdout>: 32768                1590.97             19.54           2028.55         100
[1,0]<stdout>: 65536                3008.15             23.42           3724.62         100
[1,0]<stdout>: 131072               5573.11             30.70           6614.90         100
[1,0]<stdout>: 262144              10475.43             43.00          12152.31         100
[1,0]<stdout>: 524288              27654.88             79.65          33890.64         100

real	0m13.903s
user	0m0.133s
sys	0m0.245s
```

#### 64 nodes x 64ppn = 4096 procs(reduced message size due to memory limit)
**Default linear scatterv**
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      63.43             10.58             92.32        1000
[1,0]<stdout>: 2                      63.92             10.69             92.41        1000
[1,0]<stdout>: 4                      63.29             10.61             92.22        1000
[1,0]<stdout>: 8                      63.53             10.59             93.07        1000
[1,0]<stdout>: 16                     63.92             10.76             93.06        1000
[1,0]<stdout>: 32                     63.88             10.61             94.49        1000
[1,0]<stdout>: 64                     65.36             10.81             98.71        1000
[1,0]<stdout>: 128                   835.28             10.80           1700.16        1000
[1,0]<stdout>: 256                   872.38             10.83           1762.42        1000
[1,0]<stdout>: 512                   911.33             10.94           1839.79        1000
[1,0]<stdout>: 1024                  982.67             10.97           1966.01        1000

real	0m39.731s
user	0m0.654s
sys	0m0.684s
```
**Hierarchical scatterv**
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      50.61             32.31             72.00        1000
[1,0]<stdout>: 2                      51.36             33.09             72.31        1000
[1,0]<stdout>: 4                      51.88             32.99             78.24        1000
[1,0]<stdout>: 8                      52.24             33.25             73.50        1000
[1,0]<stdout>: 16                     52.06             33.23             74.43        1000
[1,0]<stdout>: 32                     53.08             33.29             76.45        1000
[1,0]<stdout>: 64                     55.50             34.96             81.43        1000
[1,0]<stdout>: 128                    59.38             33.88             97.11        1000
[1,0]<stdout>: 256                    66.71             36.11             99.07        1000
[1,0]<stdout>: 512                    85.26             38.64            141.51        1000
[1,0]<stdout>: 1024                  140.49             46.03            228.36        1000

real	0m12.118s
user	0m0.821s
sys	0m0.877s
```

## Worst Case Performance with Reordering (`--rank-by node`)
**Only show result for hierarchical scatterv - default linear algorithm is not affected by rank-by**
#### 2 nodes x 64ppn = 128 procs
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      25.60              4.03             48.02        1000
[1,0]<stdout>: 2                      26.05              4.05             49.00        1000
[1,0]<stdout>: 4                      25.94              4.04             48.79        1000
[1,0]<stdout>: 8                      26.08              3.99             49.09        1000
[1,0]<stdout>: 16                     26.15              4.05             49.15        1000
[1,0]<stdout>: 32                     26.53              4.21             49.79        1000
[1,0]<stdout>: 64                     27.12              4.29             50.76        1000
[1,0]<stdout>: 128                    27.88              4.44             51.96        1000
[1,0]<stdout>: 256                    32.47              4.81             60.71        1000
[1,0]<stdout>: 512                    33.36              5.52             62.07        1000
[1,0]<stdout>: 1024                   39.12              6.80             72.22        1000
[1,0]<stdout>: 2048                   61.11              8.60            113.52        1000
[1,0]<stdout>: 4096                   76.31             13.76            137.90        1000
[1,0]<stdout>: 8192                  181.19             22.81            357.19        1000
[1,0]<stdout>: 16384                 217.13             43.21            437.48         100
[1,0]<stdout>: 32768                 336.13             78.06            671.74         100
[1,0]<stdout>: 65536                 580.73            148.29           1142.75         100
[1,0]<stdout>: 131072                986.48            289.44           1857.83         100
[1,0]<stdout>: 262144               1878.63            616.36           3279.75         100
[1,0]<stdout>: 524288              18502.51          11494.99          27117.56         100
[1,0]<stdout>: 1048576             36537.57          22721.70          53158.69         100

real	0m13.962s
user	0m0.057s
sys	0m0.088s
```

#### 16 nodes x 64ppn = 1024 procs
```
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                      56.74             40.34             74.19        1000
[1,0]<stdout>: 2                      56.53             40.20             74.12        1000
[1,0]<stdout>: 4                      56.78             40.15             73.90        1000
[1,0]<stdout>: 8                      56.73             40.36             74.07        1000
[1,0]<stdout>: 16                     57.96             40.96             75.21        1000
[1,0]<stdout>: 32                     58.12             41.36             75.79        1000
[1,0]<stdout>: 64                     59.50             42.23             77.72        1000
[1,0]<stdout>: 128                    63.65             44.93             80.03        1000
[1,0]<stdout>: 256                    71.07             47.87             90.31        1000
[1,0]<stdout>: 512                    95.40             65.06            120.45        1000
[1,0]<stdout>: 1024                  139.92             96.81            181.46        1000
[1,0]<stdout>: 2048                  250.04            129.94            310.99        1000
[1,0]<stdout>: 4096                  383.59            191.28            457.32        1000
[1,0]<stdout>: 8192                  737.86            326.46            925.51        1000
[1,0]<stdout>: 16384                1464.46            668.41           1716.35         100
[1,0]<stdout>: 32768                2933.77           1370.01           3353.69         100
[1,0]<stdout>: 65536               26660.53          24117.55          29337.44         100
[1,0]<stdout>: 131072              46952.71          43746.51          50632.84         100
[1,0]<stdout>: 262144              88646.68          81590.93          94318.28         100
[1,0]<stdout>: 524288             181359.35         163479.02         190249.45         100

real	0m49.024s
user	0m0.158s
sys	0m0.247s
```
#### 64 nodes x 64ppn = 4096 procs
````
[1,0]<stdout>: # OSU MPI Scatterv Latency Test v7.2
[1,0]<stdout>: # Datatype: MPI_CHAR.
[1,0]<stdout>: # Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
[1,0]<stdout>: 1                     167.34            147.75            190.17        1000
[1,0]<stdout>: 2                     167.45            148.12            190.65        1000
[1,0]<stdout>: 4                     168.58            149.19            191.40        1000
[1,0]<stdout>: 8                     167.53            147.38            200.54        1000
[1,0]<stdout>: 16                    170.57            150.43            196.34        1000
[1,0]<stdout>: 32                    178.27            152.16            202.29        1000
[1,0]<stdout>: 64                    174.22            151.39            207.85        1000
[1,0]<stdout>: 128                   185.17            158.47            234.55        1000
[1,0]<stdout>: 256                   219.19            188.50            278.50        1000
[1,0]<stdout>: 512                   304.37            260.04            367.82        1000
[1,0]<stdout>: 1024                  439.06            347.00            528.86        1000

real	0m14.463s
user	0m1.003s
sys	0m0.958s
````
</details>