### PR TITLE
Find libcuda.so automatically if --with-cuda-lib is not passed.

### DIFF
--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -50,9 +50,18 @@ AC_ARG_WITH([cuda],
             [AS_HELP_STRING([--with-cuda(=DIR)],
             [Build cuda support, optionally adding DIR/include])])
 AC_MSG_CHECKING([if --with-cuda is set])
+
+# Search for libcuda.so in $with_cuda if the user didn't pass --with-cuda-libdir
+# Otherwise check for cuda in the default path, /usr/local/cuda. If the default
+# path doesn't exist, set with_cuda_libdir to empty.
 AC_ARG_WITH([cuda-libdir],
             [AS_HELP_STRING([--with-cuda-libdir=DIR],
-                            [Search for CUDA libraries in DIR])])
+                            [Search for CUDA libraries in DIR])],
+            [],
+            [AS_IF([test -d "$with_cuda"],
+             [with_cuda_libdir=$(dirname $(find $with_cuda -name libcuda.so) 2> /dev/null)],
+             [with_cuda_libdir=$(dirname $(find /usr/local/cuda -name libcuda.so) 2> /dev/null)])
+            ])
 
 # Note that CUDA support is off by default.  To turn it on, the user has to
 # request it.  The user can just ask for --with-cuda and it that case we

--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -59,8 +59,8 @@ AC_ARG_WITH([cuda-libdir],
                             [Search for CUDA libraries in DIR])],
             [],
             [AS_IF([test -d "$with_cuda"],
-             [with_cuda_libdir=$(dirname $(find $with_cuda -name libcuda.so) 2> /dev/null)],
-             [with_cuda_libdir=$(dirname $(find /usr/local/cuda -name libcuda.so) 2> /dev/null)])
+             [with_cuda_libdir=$(dirname $(find $with_cuda -name libcuda.so 2> /dev/null) 2> /dev/null)],
+             [with_cuda_libdir=$(dirname $(find /usr/local/cuda -name libcuda.so 2> /dev/null) 2> /dev/null)])
             ])
 
 # Note that CUDA support is off by default.  To turn it on, the user has to

--- a/docs/tuning-apps/networking/cuda.rst
+++ b/docs/tuning-apps/networking/cuda.rst
@@ -41,14 +41,16 @@ Open MPI offers two flavors of CUDA support:
       shell$ ./configure --prefix=/path/to/ucx-cuda-install --with-cuda=/usr/local/cuda --with-gdrcopy=/usr
 
       # Configure Open MPI this way
-      shell$ ./configure --with-cuda=/usr/local/cuda --with-cuda-libdir=/usr/local/cuda/lib64/stubs/ --with-ucx=/path/to/ucx-cuda-install <other configure params>
+      shell$ ./configure --with-cuda=/usr/local/cuda --with-ucx=/path/to/ucx-cuda-install <other configure params>
 
 #. Via internal Open MPI CUDA support
 
 Regardless of which flavor of CUDA support (or both) you plan to use,
 Open MPI should be configured using the ``--with-cuda=<path-to-cuda>``
-and ``--with-cuda-libdir=<path-to-libcuda.so>`` configure options to
-build CUDA support into Open MPI.
+configure option to build CUDA support into Open MPI. The configure
+script will automatically search the path given for ``libcuda.so``. If it cannot
+be found, please also pass ``--with-cuda-libdir``. For example:
+``--with-cuda=<path-to-cuda> --with-cuda-libdir=/usr/local/cuda/lib64/stubs``.
 
 Open MPI supports building with CUDA libraries and running on systems
 without CUDA libraries or hardware. In order to take advantage of
@@ -65,7 +67,7 @@ An example configure command would look like the following:
    .. code-block:: sh
 
       # Configure Open MPI this way
-      shell$ ./configure --with-cuda=/usr/local/cuda --with-cuda-libdir=/usr/local/cuda/lib64/stubs \
+      shell$ ./configure --with-cuda=/usr/local/cuda \
              --enable-mca-dso=btl-smcuda,rcache-rgpusm,rcache-gpusm,accelerator-cuda <other configure params>
 
 /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Finding CUDA libraries without having to specify both --with-cuda and --with-cuda-lib was requested in github issue
https://github.com/open-mpi/ompi/issues/12264

Signed-off-by: Nick Sarkauskas <nsarkauskas@nvidia.com>
(cherry picked from commit cad3d9a9ebc4c23981a82c2ca918a6c6ca29d274)