### PR TITLE
ULFM: Support for intercomm [i]agree and [i]shrink

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -1578,14 +1578,17 @@ static int ompi_comm_ft_allreduce_intra_nb(int *inbuf, int *outbuf, int count,
 static int ompi_comm_ft_allreduce_inter_nb(int *inbuf, int *outbuf, int count,
                                            struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
                                            ompi_request_t **req) {
-    return MPI_ERR_UNSUPPORTED_OPERATION;
+    //TODO: CID_INTER_FT needs an implementation, using the non-ft for now...
+    int rc = ompi_comm_allreduce_inter_nb(inbuf, outbuf, count, op, cid_context, req);
+    return (rc == MPI_ERR_REVOKED  || rc == MPI_ERR_PROC_FAILED) ? MPI_ERR_UNSUPPORTED_OPERATION: rc;
 }
 
 static int ompi_comm_ft_allreduce_intra_pmix_nb(int *inbuf, int *outbuf, int count,
                                                 struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
                                                 ompi_request_t **req) {
     //TODO: CID_INTRA_PMIX_FT needs an implementation, using the non-ft for now...
-    return ompi_comm_allreduce_intra_pmix_nb(inbuf, outbuf, count, op, cid_context, req);
+    int rc = ompi_comm_allreduce_intra_pmix_nb(inbuf, outbuf, count, op, cid_context, req);
+    return (rc == MPI_ERR_REVOKED || rc == MPI_ERR_PROC_FAILED) ? MPI_ERR_UNSUPPORTED_OPERATION: rc;
 }
 
 #endif /* OPAL_ENABLE_FT_MPI */

--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -416,6 +416,7 @@ struct ompi_comm_ishrink_context_t {
     ompi_group_t *failed_group;
     ompi_group_t *alive_group;
     ompi_group_t *alive_rgroup;
+    int flag;
     double start;
 };
 typedef struct ompi_comm_ishrink_context_t ompi_comm_ishrink_context_t;
@@ -429,7 +430,6 @@ static int ompi_comm_ishrink_check_activate(ompi_comm_request_t *request);
 int ompi_comm_ishrink_internal(ompi_communicator_t* comm, ompi_communicator_t** newcomm, ompi_request_t** req)
 {
     int rc;
-    int flag = 1;
 #if OPAL_ENABLE_DEBUG
     double stop;
 #endif
@@ -479,7 +479,8 @@ int ompi_comm_ishrink_internal(ompi_communicator_t* comm, ompi_communicator_t** 
      * the value of flag, instead we are only using the globally consistent
      * return value.
      */
-    rc = comm->c_coll->coll_iagree( &flag,
+    context->flag = 1;
+    rc = comm->c_coll->coll_iagree( &context->flag,
                                     1,
                                     &ompi_mpi_int.dt,
                                     &ompi_mpi_op_band.op,
@@ -508,7 +509,7 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
     ompi_communicator_t *comm = context->comm;
     ompi_request_t *subreq[1];
     ompi_group_t *comm_group = NULL;
-    int rc, flag = 1;
+    int rc;
 #if OPAL_ENABLE_DEBUG
     double stop;
 #endif
@@ -522,13 +523,17 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
     rc = request->super.req_status.MPI_ERROR;
     if( (OMPI_SUCCESS != rc) && (MPI_ERR_PROC_FAILED != rc) ) {
         opal_output(0, "%s:%d Agreement failure: %d\n", __FILE__, __LINE__, rc);
+        ompi_comm_request_return(request);
+        OBJ_RELEASE(context->failed_group);
         return rc;
     }
 
     if( MPI_ERR_PROC_FAILED == rc ) {
         /* previous round found more failures, redo */
+        OBJ_RELEASE(context->failed_group);
         request->super.req_status.MPI_ERROR = MPI_SUCCESS;
-        rc = comm->c_coll->coll_iagree( &flag,
+        context->flag = 1;
+        rc = comm->c_coll->coll_iagree( &context->flag,
                                         1,
                                         &ompi_mpi_int.dt,
                                         &ompi_mpi_op_band.op,
@@ -575,7 +580,6 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
         }
     }
     OBJ_RELEASE(context->failed_group);
-    context->failed_group = NULL;
 
     rc = ompi_comm_set_nb( context->newcomm,         /* new comm */
                            comm,                     /* old comm */
@@ -614,15 +618,16 @@ static int ompi_comm_ishrink_check_setrank(ompi_comm_request_t *request) {
 
     /* cleanup temporary groups */
     OBJ_RELEASE(context->alive_group);
-    context->alive_group = NULL;
     if( NULL != context->alive_rgroup ) {
         OBJ_RELEASE(context->alive_rgroup);
     }
-    context->alive_rgroup = NULL;
 
     /* check errors in prior step */
-    if( NULL == *context->newcomm ) {
-        rc = MPI_ERR_INTERN;
+    rc = request->super.req_status.MPI_ERROR;
+    if( OMPI_SUCCESS != rc ) {
+        opal_output_verbose(1, ompi_ftmpi_output_handle,
+                            "%s ompi: comm_ishrink: Construction failed with error %d",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), rc);
         ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
         return rc;
@@ -719,6 +724,7 @@ static int ompi_comm_ishrink_check_cid(ompi_comm_request_t *request) {
                                 mode,
                                 subreq );
     if( OMPI_SUCCESS != rc ) {
+        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
         return rc;
     }
@@ -729,6 +735,8 @@ static int ompi_comm_ishrink_check_cid(ompi_comm_request_t *request) {
 }
 
 static int ompi_comm_ishrink_check_activate(ompi_comm_request_t *request) {
+    ompi_comm_ishrink_context_t *context =
+        (ompi_comm_ishrink_context_t *)request->context;
     int rc;
 #if OPAL_ENABLE_DEBUG
     double stop;
@@ -736,11 +744,14 @@ static int ompi_comm_ishrink_check_activate(ompi_comm_request_t *request) {
 
     rc = request->super.req_status.MPI_ERROR;
     if( OMPI_SUCCESS != rc ) {
+        opal_output_verbose(1, ompi_ftmpi_output_handle,
+                            "%s ompi: comm_ishrink: Activation failed with error %d",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), rc);
+        ompi_comm_request_return(request);
+        OBJ_RELEASE(*context->newcomm);
         return rc;
     }
 #if OPAL_ENABLE_DEBUG
-    ompi_comm_ishrink_context_t *context =
-        (ompi_comm_ishrink_context_t *)request->context;
     stop = MPI_Wtime();
     OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
                          "%s ompi: comm_ishrink: COLL SELECT: %g seconds\n",

--- a/ompi/mca/coll/base/coll_base_agree_noft.c
+++ b/ompi/mca/coll/base/coll_base_agree_noft.c
@@ -26,7 +26,8 @@ ompi_coll_base_agree_noft(void *contrib,
                          struct ompi_communicator_t* comm,
                          mca_coll_base_module_t *module)
 {
-    return comm->c_coll->coll_allreduce(MPI_IN_PLACE, contrib, dt_count, dt, op,
+    void *sendbuf = OMPI_COMM_IS_INTER(comm) ? contrib : MPI_IN_PLACE;
+    return comm->c_coll->coll_allreduce(sendbuf, contrib, dt_count, dt, op,
                                        comm, comm->c_coll->coll_allreduce_module);
 }
 
@@ -40,6 +41,7 @@ ompi_coll_base_iagree_noft(void *contrib,
                           ompi_request_t **request,
                           mca_coll_base_module_t *module)
 {
-    return comm->c_coll->coll_iallreduce(MPI_IN_PLACE, contrib, dt_count, dt, op,
+    void *sendbuf = OMPI_COMM_IS_INTER(comm) ? contrib : MPI_IN_PLACE;
+    return comm->c_coll->coll_iallreduce(sendbuf, contrib, dt_count, dt, op,
                                         comm, request, comm->c_coll->coll_iallreduce_module);
 }


### PR DESCRIPTION
This PR is a bit of cheating, as it implements ULFM for  intercomm [i]agree and [i]shrink using the non-ft implementation of allreduce. There was already a precedent for such approach, and it is arguably better for the thing to work in the non-failure path rather than segfaulting bad as currently happening.

Refs. #12260 and [mpi4py tests](https://github.com/mpi4py/mpi4py-testing/actions/runs/8097420010).