### PR TITLE
v5.0.x: Fix compiler warning

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -313,7 +313,8 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
     opal_process_name_t *name_array = NULL;
     char *tag = NULL;
     size_t proc_count;
-    size_t cid_base;
+    size_t cid_base = 0;
+    bool cid_base_set = false;
     int rc, leader_rank;
     int ret = OMPI_SUCCESS;
     pmix_proc_t *procs = NULL;
@@ -383,6 +384,7 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
                 ret = opal_pmix_convert_status(rc);
                 goto fn_exit;
             }
+            cid_base_set = true;
             break;
         }
     }
@@ -390,6 +392,12 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
     rc = PMIx_Group_destruct (tag, NULL, 0);
     if(PMIX_SUCCESS != rc) {
         ret = opal_pmix_convert_status(rc);
+        goto fn_exit;
+    }
+
+    if (!cid_base_set) {
+        opal_show_help("help-comm.txt", "cid-base-not-set", true);
+        ret = OMPI_ERROR;
         goto fn_exit;
     }
 

--- a/ompi/communicator/help-comm.txt
+++ b/ompi/communicator/help-comm.txt
@@ -34,3 +34,12 @@ in a call to MPI_Comm_split_type between peers in the communicator.
 [unexpected-split-type]
 Detected an unexpected split type in a call to MPI_Comm_split_type.
   split_type:  %s (%d)
+[cid-base-not-set]
+An internal error has occurred when creating a new communicator.  This
+should probably never happen:
+
+* cid_base is not set.  Either nresults
+  is zero or no returned info matches PMIX_GROUP_CONTEXT_ID.
+
+Please contact the Open MPI developer community with this message and
+a small example code that reproduces the issue.


### PR DESCRIPTION
The compiler warned that 'cid_base' may be used uninitialized

Signed-off-by: Jessie Yang <jiaxiyan@amazon.com>
(cherry picked from commit e87a17b8e948d7121e3c054c65058eba71c69d49)

This is the v5.0.x PR corresponding to main PR #12389