### PR TITLE
v5.0.x: file.c: fix uninitialized mutex in MPI_File handle

### DIFF
--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -131,9 +131,6 @@ int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    /* Create the mutex */
-    OBJ_CONSTRUCT(&file->f_lock, opal_mutex_t);
-
     /* Select a module and actually open the file */
 
     if (OMPI_SUCCESS != (ret = mca_io_base_file_select(file, NULL))) {
@@ -156,9 +153,6 @@ int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
  */
 int ompi_file_close(ompi_file_t **file)
 {
-
-    OBJ_DESTRUCT(&(*file)->f_lock);
-
     (*file)->f_flags |= OMPI_FILE_ISCLOSED;
     OBJ_RELEASE(*file);
     *file = &ompi_mpi_file_null.file;
@@ -241,6 +235,7 @@ static void file_constructor(ompi_file_t *file)
     file->f_comm = NULL;
     file->f_filename = NULL;
     file->f_amode = 0;
+    OBJ_CONSTRUCT(&file->f_lock, opal_mutex_t);
 
     /* Initialize flags */
 
@@ -335,4 +330,6 @@ static void file_destructor(ompi_file_t *file)
         opal_pointer_array_set_item(&ompi_file_f_to_c_table,
                                     file->f_f_to_c_index, NULL);
     }
+
+    OBJ_DESTRUCT(&(file->f_lock));
 }


### PR DESCRIPTION
We were initializing the mutex in file_open, but that didn't handle MPI_FILE_NULL.  So we move it to the constructor, and therefore it's always initialized for all file handles -- even MPI_FILE_NULL.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 2118615645ddee5d211855b710f87c7221de1722)

This is the v5.0.x PR corresponding to main PR #12416 