### PR TITLE
coll/han: fix intra-node MPI_Scatter data count and type

### DIFF
--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -187,7 +187,7 @@ mca_coll_han_scatter_intra(const void *sbuf, int scount,
 
 }
 
-/* us: upper level (intra-node) scatter task */
+/* us: upper level (inter-node) scatter task */
 int mca_coll_han_scatter_us_task(void *task_args)
 {
     mca_coll_han_scatter_args_t *t = (mca_coll_han_scatter_args_t *) task_args;
@@ -218,6 +218,8 @@ int mca_coll_han_scatter_us_task(void *task_args)
                                          t->up_comm, t->up_comm->c_coll->coll_scatter_module);
         t->sbuf = tmp_rbuf;
         t->sbuf_inter_free = tmp_buf;
+        t->sdtype = dtype;
+        t->scount = count;
     }
 
     if (t->sbuf_reorder_free != NULL && t->root == t->w_rank) {


### PR DESCRIPTION
Fixes #12383

Thanks to Christoph van Wüllen for reporting the issue.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit a58e88472e9e2926d5302cb0820ad02486bacd18)