### PR TITLE
Han gatherv noncontiguous datatype fix

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -331,6 +331,7 @@ typedef struct mca_coll_han_module_t {
     int *cached_topo;
     bool is_mapbycore;
     bool are_ppn_imbalanced;
+    bool is_heterogeneous;
 
     /* To be able to fallback when the cases are not supported */
     struct mca_coll_han_collectives_fallback_s fallback;


### PR DESCRIPTION
This is a bugfix for derived datatypes with gaps. The reorder buffer should match the type signature and be large enough to hold gaps in addition to the actual entries.

Fixes #12438 