### PR TITLE
Fix compiler warning: declaration of i

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_gatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_gatherv.c
@@ -107,13 +107,13 @@ mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
         err = ompi_request_wait_all(nrecv, reqs, MPI_STATUSES_IGNORE);
 
         if (MPI_ERR_IN_STATUS == err) {
-            for (int i = 0; i < nrecv; i++) {
-                if (MPI_REQUEST_NULL == reqs[i])
+            for (size_t j = 0; j < nrecv; j++) {
+                if (MPI_REQUEST_NULL == reqs[j])
                     continue;
-                if (MPI_ERR_PENDING == reqs[i]->req_status.MPI_ERROR)
+                if (MPI_ERR_PENDING == reqs[j]->req_status.MPI_ERROR)
                     continue;
-                if (MPI_SUCCESS != reqs[i]->req_status.MPI_ERROR) {
-                    err = reqs[i]->req_status.MPI_ERROR;
+                if (MPI_SUCCESS != reqs[j]->req_status.MPI_ERROR) {
+                    err = reqs[j]->req_status.MPI_ERROR;
                     break;
                 }
             }


### PR DESCRIPTION
Fix the following compiler warning
```
coll_basic_gatherv.c: In function ‘mca_coll_basic_gatherv_intra’:
coll_basic_gatherv.c:110:22: warning: declaration of ‘i’ shadows a previous local [-Wshadow]
             for (int i = 0; i < nrecv; i++) {
                      ^
coll_basic_gatherv.c:47:14: note: shadowed declaration is here
     int err, i, peer, rank, size;
              ^
coll_basic_gatherv.c:110:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             for (int i = 0; i < nrecv; i++) {
                               ^
```