### PR TITLE
fortran: do not link Fortran libs with unnecessary libraries

### DIFF
--- a/.github/workflows/riscv64-qemu-test.yaml
+++ b/.github/workflows/riscv64-qemu-test.yaml
@@ -18,6 +18,14 @@ jobs:
         wget ${riscv_gnu_toolchain_download_path}
         tar -xvf riscv64-glibc-ubuntu-24.04-gcc-nightly-2025.07.03-nightly.tar.xz -C /opt
         sed -i "s|libdir='/mnt/riscv/riscv64-unknown-linux-gnu/lib'|libdir='/opt/riscv/riscv64-unknown-linux-gnu/lib'|g" /opt/riscv/riscv64-unknown-linux-gnu/lib/libatomic.la
+        echo "Bootstrap: docker" > rockylinux.def
+        echo "From: rockylinux:9" >> rockylinux.def
+        echo "" >> rockylinux.def
+        echo "%post" >> rockylinux.def
+        echo "dnf install -y libtool autoconf automake git python3" >> rockylinux.def
+        sudo apt install -y singularity-container
+        sudo -E singularity build rockylinux.sif rockylinux.def
+        sudo mv rockylinux.sif /opt
 
     - name: Checkout Open MPI
       uses: actions/checkout@v4
@@ -26,7 +34,7 @@ jobs:
     
     - name: Bootstrap Open MPI
       run: |
-        ./autogen.pl
+        singularity exec /opt/rockylinux.sif ./autogen.pl
         sed -i '/^func_exec_program_core ()/,/^}/ s/\<exec\>/exec qemu-riscv64 -cpu rv64,v=true,vext_spec=v1.0,vlen=128 -L \/opt\/riscv\/sysroot/g' config/ltmain.sh
 
     - name: Config Open MPI

--- a/config/opal_config_hwloc.m4
+++ b/config/opal_config_hwloc.m4
@@ -1,7 +1,7 @@
 dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
-dnl Copyright (c) 2014-2018 Research Organization for Information Science
+dnl Copyright (c) 2014-2024 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2020-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
@@ -270,5 +270,6 @@ dnl configure, to avoid pulling it into other configure tests.
 AC_DEFUN([OPAL_CONFIG_HWLOC_INTERNAL_LIBS_HANDLER], [
     OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${opal_hwloc_CPPFLAGS}])
     OPAL_FLAGS_APPEND_UNIQ([LDFLAGS], [$opal_hwloc_LDFLAGS])
-    OPAL_FLAGS_APPEND_MOVE([LIBS], [${opal_hwloc_BUILD_LIBS}])
+    opal_hwloc_LIBS=${opal_hwloc_BUILD_LIBS}
+    AC_SUBST([opal_hwloc_LIBS])
 ])

--- a/config/opal_config_libevent.m4
+++ b/config/opal_config_libevent.m4
@@ -269,5 +269,6 @@ dnl configure, to avoid pulling it into other configure tests.
 AC_DEFUN([OPAL_CONFIG_LIBEVENT_INTERNAL_LIBS_HANDLER], [
     OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${opal_libevent_CPPFLAGS}])
     OPAL_FLAGS_APPEND_UNIQ([LDFLAGS], [${opal_libevent_LDFLAGS}])
-    OPAL_FLAGS_APPEND_MOVE([LIBS], [${opal_libevent_BUILD_LIBS}])
+    opal_libevent_LIBS=${opal_libevent_BUILD_LIBS}
+    AC_SUBST([opal_libevent_LIBS])
 ])

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -297,5 +297,6 @@ dnl configure, to avoid pulling it into other configure tests.
 AC_DEFUN([OPAL_CONFIG_PMIX_INTERNAL_LIBS_HANDLER], [
     OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${opal_pmix_CPPFLAGS}])
     OPAL_FLAGS_APPEND_UNIQ([LDFLAGS], [${opal_pmix_LDFLAGS}])
-    OPAL_FLAGS_APPEND_MOVE([LIBS], [${opal_pmix_BUILD_LIBS}])
+    opal_pmix_LIBS=${opal_pmix_BUILD_LIBS}
+    AC_SUBST([opal_pmix_LIBS])
 ])

--- a/ompi/Makefile.am
+++ b/ompi/Makefile.am
@@ -144,7 +144,8 @@ lib@OMPI_LIBMPI_NAME@_la_LIBADD = \
 
 
 lib@OMPI_LIBMPI_NAME@_la_LIBADD += \
-        $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_NAME@.la
+        $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_NAME@.la \
+        $(opal_pmix_LIBS)
 lib@OMPI_LIBMPI_NAME@_la_DEPENDENCIES = $(lib@OMPI_LIBMPI_NAME@_la_LIBADD)
 lib@OMPI_LIBMPI_NAME@_la_LDFLAGS = \
        -version-info $(libmpi_so_version) \

--- a/ompi/mca/topo/treematch/Makefile.am
+++ b/ompi/mca/topo/treematch/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2011-2015 INRIA.  All rights reserved.
 # Copyright (c) 2011-2015 Université Bordeaux 1
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2019      Research Organization for Information Science
+# Copyright (c) 2019-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2021      Google, LLC. All rights reserved.
 # $COPYRIGHT$
@@ -43,11 +43,16 @@ mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_topo_treematch_la_SOURCES = $(component_sources)
 mca_topo_treematch_la_LDFLAGS = -module -avoid-version $(topo_treematch_LDFLAGS)
-mca_topo_treematch_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la $(topo_treematch_LIBS)
+mca_topo_treematch_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(topo_treematch_LIBS) \
+    $(opal_hwloc_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_topo_treematch_la_SOURCES = $(lib_sources)
-libmca_topo_treematch_la_LIBADD = $(topo_treematch_LIBS)
+libmca_topo_treematch_la_LIBADD = \
+    $(topo_treematch_LIBS) \
+    $(opal_hwloc_LIBS)
 libmca_topo_treematch_la_LDFLAGS = -module -avoid-version $(topo_treematch_LDFLAGS)
 
 distclean-local:

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -47,9 +47,11 @@ lib_LTLIBRARIES = lib@OPAL_LIB_NAME@.la
 
 libopen_pal_core_la_SOURCES =
 libopen_pal_core_la_LIBADD = \
-        mca/base/libmca_base.la \
-        util/libopalutil_core.la \
-	$(MCA_opal_FRAMEWORK_CORE_LIBS)
+	mca/base/libmca_base.la \
+	util/libopalutil_core.la \
+	$(MCA_opal_FRAMEWORK_CORE_LIBS) \
+	$(opal_pmix_LIBS) \
+	$(opal_libevent_LIBS)
 libopen_pal_core_la_DEPENDENCIES = \
         mca/base/libmca_base.la \
         util/libopalutil_core.la \
@@ -58,9 +60,11 @@ libopen_pal_core_la_DEPENDENCIES = \
 lib@OPAL_LIB_NAME@_la_SOURCES =
 lib@OPAL_LIB_NAME@_la_LIBADD = \
 	libopen-pal_core.la \
-        datatype/libdatatype.la \
-        util/libopalutil.la \
-	$(MCA_opal_FRAMEWORK_LIBS)
+	datatype/libdatatype.la \
+	util/libopalutil.la \
+	$(MCA_opal_FRAMEWORK_LIBS) \
+	$(opal_pmix_LIBS) \
+	$(opal_libevent_LIBS)
 lib@OPAL_LIB_NAME@_la_DEPENDENCIES = \
 	libopen-pal_core.la \
         datatype/libdatatype.la \

--- a/opal/mca/btl/smcuda/Makefile.am
+++ b/opal/mca/btl/smcuda/Makefile.am
@@ -14,6 +14,8 @@
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2024-2026 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -53,13 +55,17 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
 mca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
-mca_btl_smcuda_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+mca_btl_smcuda_la_LIBADD = \
+     $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/sm/lib@OPAL_LIB_NAME@mca_common_sm.la \
-    $(btl_smcuda_LIBS)
+    $(btl_smcuda_LIBS) \
+    $(opal_hwloc_LIBS)
 mca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
 libmca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
 libmca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
-libmca_btl_smcuda_la_LIBADD = $(btl_smcuda_LIBS)
+libmca_btl_smcuda_la_LIBADD = \
+    $(btl_smcuda_LIBS) \
+    $(opal_hwloc_LIBS)

--- a/opal/mca/btl/usnic/Makefile.am
+++ b/opal/mca/btl/usnic/Makefile.am
@@ -16,7 +16,7 @@
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
-# Copyright (c) 2019      Research Organization for Information Science
+# Copyright (c) 2019-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
@@ -93,8 +93,10 @@ mca_btl_usnic_la_LDFLAGS = \
         $(opal_btl_usnic_LDFLAGS) \
         $(btl_usnic_LDFLAGS) \
         -module -avoid-version
-mca_btl_usnic_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(btl_usnic_LIBS)
+mca_btl_usnic_la_LIBADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+        $(btl_usnic_LIBS) \
+        $(opal_hwloc_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_btl_usnic_la_SOURCES = $(lib_sources)
@@ -102,7 +104,9 @@ libmca_btl_usnic_la_LDFLAGS = \
         $(opal_btl_usnic_LDFLAGS) \
         $(btl_usnic_LDFLAGS) \
         -module -avoid-version
-libmca_btl_usnic_la_LIBADD = $(btl_usnic_LIBS)
+libmca_btl_usnic_la_LIBADD = \
+        $(btl_usnic_LIBS) \
+        $(opal_hwloc_LIBS)
 
 if OPAL_BTL_USNIC_BUILD_UNIT_TESTS
 usnic_btl_run_tests_CPPFLAGS = $(AM_CPPFLAGS) \

--- a/opal/mca/common/ofi/Makefile.am
+++ b/opal/mca/common/ofi/Makefile.am
@@ -17,6 +17,8 @@
 # Copyright (c) 2019      Hewlett Packard Enterprise. All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2024-2026 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -76,11 +78,15 @@ lib@OPAL_LIB_NAME@mca_common_ofi_la_SOURCES = $(headers) $(sources)
 lib@OPAL_LIB_NAME@mca_common_ofi_la_LDFLAGS = \
         $(common_ofi_LDFLAGS) \
         -version-info $(libmca_opal_common_ofi_so_version)
-lib@OPAL_LIB_NAME@mca_common_ofi_la_LIBADD = $(common_ofi_LIBS)
+lib@OPAL_LIB_NAME@mca_common_ofi_la_LIBADD = \
+        $(common_ofi_LIBS) \
+        $(opal_hwloc_LIBS)
 
 lib@OPAL_LIB_NAME@mca_common_ofi_noinst_la_SOURCES = $(headers) $(sources)
 lib@OPAL_LIB_NAME@mca_common_ofi_noinst_la_LDFLAGS = $(common_ofi_LDFLAGS)
-lib@OPAL_LIB_NAME@mca_common_ofi_noinst_la_LIBADD = $(common_ofi_LIBS)
+lib@OPAL_LIB_NAME@mca_common_ofi_noinst_la_LIBADD = \
+        $(common_ofi_LIBS) \
+        $(opal_hwloc_LIBS)
 
 # Conditionally install the header files
 

--- a/oshmem/Makefile.am
+++ b/oshmem/Makefile.am
@@ -9,6 +9,8 @@
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2024-2026 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,7 +57,8 @@ liboshmem_la_LIBADD = \
 	shmem/c/liboshmem_c.la \
 	$(fortran_oshmem_lib) \
 	$(MCA_oshmem_FRAMEWORK_LIBS) \
-	$(OSHMEM_TOP_BUILDDIR)/ompi/lib@OMPI_LIBMPI_NAME@.la
+	$(OSHMEM_TOP_BUILDDIR)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(opal_pmix_LIBS)
 liboshmem_la_DEPENDENCIES = $(liboshmem_la_LIBADD)
 liboshmem_la_LDFLAGS = \
         -version-info $(liboshmem_so_version) \

--- a/test/asm/Makefile.am
+++ b/test/asm/Makefile.am
@@ -9,6 +9,8 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2026      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,47 +41,49 @@ AM_CFLAGS = $(THREAD_CFLAGS)
 ######################################################################
 
 atomic_barrier_SOURCES = atomic_barrier.c
+atomic_barrier_LDADD = $(top_builddir)/opal/libopen-pal.la
 
 atomic_barrier_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_barrier.c atomic_barrier_noinline.c
 atomic_barrier_noinline_SOURCES = atomic_barrier_noinline.c
 atomic_barrier_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
+atomic_barrier_noinline_LDADD = $(top_builddir)/opal/libopen-pal.la
 
 ######################################################################
 
 atomic_spinlock_SOURCES = atomic_spinlock.c
 atomic_spinlock_CFLAGS = $(AM_CFLAGS)
-atomic_spinlock_LDADD = $(libs)
+atomic_spinlock_LDADD = $(top_builddir)/opal/libopen-pal.la $(libs)
 
 atomic_spinlock_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_spinlock.c atomic_spinlock_noinline.c
 atomic_spinlock_noinline_SOURCES = atomic_spinlock_noinline.c
 atomic_spinlock_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_spinlock_noinline_LDADD = $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
+atomic_spinlock_noinline_LDADD = $(top_builddir)/opal/libopen-pal.la $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
 
 ######################################################################
 
 atomic_math_SOURCES = atomic_math.c
 atomic_math_CFLAGS = $(AM_CFLAGS)
-atomic_math_LDADD = $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
+atomic_math_LDADD = $(top_builddir)/opal/libopen-pal.la $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
 
 atomic_math_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_math.c atomic_math_noinline.c
 atomic_math_noinline_SOURCES = atomic_math_noinline.c
 atomic_math_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_math_noinline_LDADD = $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
+atomic_math_noinline_LDADD = $(top_builddir)/opal/libopen-pal.la $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
 
 ######################################################################
 
 atomic_cmpset_SOURCES = atomic_cmpset.c
 atomic_cmpset_CFLAGS = $(AM_CFLAGS)
-atomic_cmpset_LDADD = $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
+atomic_cmpset_LDADD = $(top_builddir)/opal/libopen-pal.la $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
 
 atomic_cmpset_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_cmpset.c atomic_cmpset_noinline.c
 atomic_cmpset_noinline_SOURCES = atomic_cmpset_noinline.c
 atomic_cmpset_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_cmpset_noinline_LDADD = $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
+atomic_cmpset_noinline_LDADD = $(top_builddir)/opal/libopen-pal.la $(THREAD_LDFLAGS) $(THREAD_LIBS) $(libs)
 
 ######################################################################
 


### PR DESCRIPTION
Fortran libraries do not need to be linked with PMIx, hwloc nor libevent. That can cause some issues with incompatible flags are pulled from the .la files.
For example, when the NAG Fortran compiler is used, libmpi_mpifh_sizeof.la pulls the -pthread flag, that is translated into -Wl,-pthread.
Then when libmpi_mpifh.la is linked with gcc but pulls -Wl,-pthread that causes the build to fail since -pthread is not a valid ld option. Not depending on these libraries is enough to avoid the above issue.

Refs #12413

Thanks to Matthew Thompson for reporting this issue and helping with the diagnostic.