### PR TITLE
v5.0.x: Get rid of local copy of ompi_mpi_thread_multiple.

### DIFF
--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -137,7 +137,6 @@ int mca_pml_base_bsend_attach(void* addr, int size)
 {
     int align;
 
-    bool thread_safe = ompi_mpi_thread_multiple;
     if(NULL == addr || size <= 0) {
         return OMPI_ERR_BUFFER;
     }
@@ -150,7 +149,7 @@ int mca_pml_base_bsend_attach(void* addr, int size)
     }
 
     /* try to create an instance of the allocator - to determine thread safety level */
-    mca_pml_bsend_allocator = mca_pml_bsend_allocator_component->allocator_init(thread_safe, mca_pml_bsend_alloc_segment, NULL, NULL);
+    mca_pml_bsend_allocator = mca_pml_bsend_allocator_component->allocator_init(ompi_mpi_thread_multiple, mca_pml_bsend_alloc_segment, NULL, NULL);
     if(NULL == mca_pml_bsend_allocator) {
         OPAL_THREAD_UNLOCK(&mca_pml_bsend_mutex);
         return OMPI_ERR_BUFFER;


### PR DESCRIPTION
The global variable is set once in ompi_init, it's safe to read it within the lock region.

Signed-off-by: Rainer Keller <rainer.keller@hs-esslingen.de>
(cherry picked from commit 667536d394b21f59daa8111f2a6d519a8dffe6ce)

This is the v5.0.x PR corresponding to main PR #12432 
FYI @hpcraink 