### PR TITLE
Minor improvements to cuda.rst

### DIFF
--- a/docs/tuning-apps/networking/cuda.rst
+++ b/docs/tuning-apps/networking/cuda.rst
@@ -76,12 +76,15 @@ How do I verify that Open MPI has been built with CUDA support?
 ---------------------------------------------------------------
 
 Verify that Open MPI has been built with cuda using ``ompi_info``
+with one of the following commands.
 
 .. code-block:: sh
 
    # Use ompi_info to verify cuda support in Open MPI
-   shell$ ./ompi_info |grep "MPI extensions"
+   shell$ ompi_info | grep "MPI extensions"
           MPI extensions: affinity, cuda, pcollreq
+   shell$ ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
+          mca:mpi:base:param:mpi_built_with_cuda_support:value:true
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -187,19 +190,6 @@ Libfabric's API after registering the memory. If there are no
 CUDA-capable providers available, the buffers will automatically
 be copied to host buffers before being transferred through
 Libfabric's API.
-
-/////////////////////////////////////////////////////////////////////////
-
-
-How can I tell if Open MPI was built with CUDA support?
--------------------------------------------------------
-
-Use the ``ompi_info`` command:
-
-.. code-block::
-
-   shell$ ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
-   mca:mpi:base:param:mpi_built_with_cuda_support:value:true
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -580,6 +570,8 @@ example of using the CUDA-aware macro and run-time check.
 
    int main(int argc, char *argv[])
    {
+       MPI_Init(&argc, &argv);
+
        printf("Compile time check:\n");
    #if defined(MPIX_CUDA_AWARE_SUPPORT) && MPIX_CUDA_AWARE_SUPPORT
        printf("This MPI library has CUDA-aware support.\n", MPIX_CUDA_AWARE_SUPPORT);
@@ -589,7 +581,7 @@ example of using the CUDA-aware macro and run-time check.
        printf("This MPI library cannot determine if there is CUDA-aware support.\n");
    #endif /* MPIX_CUDA_AWARE_SUPPORT */
 
-       printf("Run time check:n");
+       printf("Run time check:\n");
    #if defined(MPIX_CUDA_AWARE_SUPPORT)
        if (1 == MPIX_Query_cuda_support()) {
            printf("This MPI library has CUDA-aware support.\n");
@@ -599,6 +591,8 @@ example of using the CUDA-aware macro and run-time check.
    #else /* !defined(MPIX_CUDA_AWARE_SUPPORT) */
        printf("This MPI library cannot determine if there is CUDA-aware support.\n");
    #endif /* MPIX_CUDA_AWARE_SUPPORT */
+
+       MPI_Finalize();
 
        return 0;
    }


### PR DESCRIPTION
Hi,

When I compile and run the provided script to detect support for CUDA-aware functionality I used get:

```
Compile time check:
This MPI library has CUDA-aware support.
Run time check:
This MPI library does not have CUDA-aware support.
```

I've now fixed the script by adding calls to `MPI_Init()` and `MPI_Finalize()`.

-Nuno