### PR TITLE
mpi4py: Run accept/connect tests unconditionally

### DIFF
--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -136,17 +136,3 @@ jobs:
     with:
       # Enable the spawn tests
       env_name: MPI4PY_TEST_SPAWN
-
-  #==============================================
-
-  run_dynamic:
-    # This whole set of tests runs explicitly with setting "enable the
-    # spawn tests".  As of March 2024, we know that Open MPI is
-    # failing these tests.
-    needs: [ build ]
-    # Only run if the label "mpi4py" is set on this PR.
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'mpi4py-all') }}
-    uses: ./.github/workflows/ompi_mpi4py_tests.yaml
-    with:
-      # Enable the dynamic process tests
-      env_name: MPI4PY_TEST_DYNPROC


### PR DESCRIPTION
It looks like recent fixes from @hppritcha solved outstanding mpi4py testing issues related to accept/connect.
Here you have fresh runs to confirm: https://github.com/mpi4py/mpi4py-testing/actions/runs/8759119662

This PR removes the conditional run of accept/connect. However, note that I have not yet pushed to mpi4py/mpi4py@master the required changes https://github.com/mpi4py/mpi4py/commit/24ba042c0ee08fc324a04c5190d5dbc41d32e023 .

cc @jsquyres