### PR TITLE
Update collective framework for bigcount

### DIFF
--- a/ompi/mca/coll/accelerator/coll_accelerator.h
+++ b/ompi/mca/coll/accelerator/coll_accelerator.h
@@ -42,33 +42,33 @@ int mca_coll_accelerator_module_enable(mca_coll_base_module_t *module,
                                 struct ompi_communicator_t *comm);
 
 int
-mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
 int
-mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
@@ -124,7 +124,7 @@ OBJ_CLASS_DECLARATION(mca_coll_accelerator_module_t);
 /* Component */
 
 typedef struct mca_coll_accelerator_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     int priority; /* Priority of this component */
     int disable_accelerator_coll;  /* Force disable of the accelerator collective component */

--- a/ompi/mca/coll/accelerator/coll_accelerator_allreduce.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_allreduce.c
@@ -28,7 +28,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op,
                         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_component.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_component.c
@@ -44,7 +44,7 @@ mca_coll_accelerator_component_t mca_coll_accelerator_component = {
          * about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "accelerator",

--- a/ompi/mca/coll/accelerator/coll_accelerator_exscan.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_exscan.c
@@ -20,7 +20,7 @@
 #include "ompi/op/op.h"
 #include "opal/datatype/opal_convertor.h"
 
-int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce.c
@@ -28,7 +28,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, size_t count,
                      struct ompi_datatype_t *dtype,
                      struct ompi_op_t *op,
                      int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
@@ -32,7 +32,7 @@
  *     up at some point)
  */
 int
-mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_scan.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_scan.c
@@ -27,7 +27,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/adapt/coll_adapt.h
+++ b/ompi/mca/coll/adapt/coll_adapt.h
@@ -44,7 +44,7 @@ typedef enum {
  */
 typedef struct mca_coll_adapt_component_t {
     /* Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /* MCA parameter: Priority of this component */
     int adapt_priority;

--- a/ompi/mca/coll/adapt/coll_adapt_bcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_bcast.c
@@ -12,7 +12,7 @@
 #include "coll_adapt.h"
 #include "coll_adapt_algorithms.h"
 
-int ompi_coll_adapt_bcast(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_bcast(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                          struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
 {
     ompi_request_t *request = NULL;

--- a/ompi/mca/coll/adapt/coll_adapt_component.c
+++ b/ompi/mca/coll/adapt/coll_adapt_component.c
@@ -41,7 +41,7 @@ mca_coll_adapt_component_t mca_coll_adapt_component = {
         /* First, the mca_component_t struct containing meta
            information about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "adapt",

--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -319,7 +319,7 @@ static int recv_cb(ompi_request_t * req)
     return 1;
 }
 
-int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_ibcast(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                           mca_coll_base_module_t * module)
 {
@@ -341,7 +341,7 @@ int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *dataty
 }
 
 
-int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_ibcast_generic(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t * module, ompi_coll_tree_t * tree,
                                    size_t seg_size)
@@ -351,7 +351,7 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
     int min;
 
     /* Number of datatype in a segment */
-    int seg_count = count;
+    size_t seg_count = count;
     /* Size of a datatype */
     size_t type_size;
     /* Real size of a segment */

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -476,7 +476,7 @@ static int recv_cb(ompi_request_t * req)
     return 1;
 }
 
-int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
                            ompi_request_t ** request, mca_coll_base_module_t * module)
 {
@@ -513,7 +513,7 @@ int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi
 }
 
 
-int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
+int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype, struct ompi_op_t *op, int root,
                                     struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t * module, ompi_coll_tree_t * tree,
@@ -523,7 +523,8 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
     ptrdiff_t extent, lower_bound, segment_increment;
     ptrdiff_t true_lower_bound, true_extent, real_seg_size;
     size_t typelng;
-    int seg_count = count, num_segs, rank, recv_count, send_count, err, min;
+    size_t seg_count = count, recv_count, send_count;
+    int num_segs, rank, err, min;
     /* Used to store the accumuate result, pointer to every segment */
     char **accumbuf = NULL;
     opal_mutex_t *mutex_op_list;

--- a/ompi/mca/coll/adapt/coll_adapt_reduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_reduce.c
@@ -15,7 +15,7 @@
 #include "coll_adapt_algorithms.h"
 
 /* MPI_Reduce and MPI_Ireduce in the ADAPT module only work for commutative operations */
-int ompi_coll_adapt_reduce(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_adapt_reduce(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                           struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
                           mca_coll_base_module_t * module)
 {

--- a/ompi/mca/coll/base/coll_base_agree_noft.c
+++ b/ompi/mca/coll/base/coll_base_agree_noft.c
@@ -19,7 +19,7 @@
 
 int
 ompi_coll_base_agree_noft(void *contrib,
-                         int dt_count,
+                         size_t dt_count,
                          struct ompi_datatype_t *dt,
                          struct ompi_op_t *op,
                          struct ompi_group_t **group, bool update_grp,
@@ -33,7 +33,7 @@ ompi_coll_base_agree_noft(void *contrib,
 
 int
 ompi_coll_base_iagree_noft(void *contrib,
-                          int dt_count,
+                          size_t dt_count,
                           struct ompi_datatype_t *dt,
                           struct ompi_op_t *op,
                           struct ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -84,9 +84,9 @@
  *         [4]    [4]    [4]    [4]    [4]    [4]
  *         [5]    [5]    [5]    [5]    [5]    [5]
  */
-int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_bruck(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void* rbuf, int rcount,
+                                          void* rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
@@ -252,9 +252,9 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
  *          step, and send them appropriate messages.
  */
 int
-ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype,
-                                                  void* rbuf, int rcount,
+                                                  void* rbuf, size_t rcount,
                                                   struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module)
@@ -392,9 +392,9 @@ ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
  *         [5]    [5]    [5]    [5]    [5]    [5]
  */
 
-int ompi_coll_base_allgather_intra_sparbit(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_sparbit(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype,
-                                                  void* rbuf, int rcount,
+                                                  void* rbuf, size_t rcount,
                                                   struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module)
@@ -495,9 +495,9 @@ err_hndl:
  *               No additional memory requirements.
  *
  */
-int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_ring(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void* rbuf, int rcount,
+                                         void* rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
@@ -621,9 +621,9 @@ int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
  *         [5]    [5]    [5]    [5]    [5]    [5]
  */
 int
-ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, size_t scount,
                                                  struct ompi_datatype_t *sdtype,
-                                                 void* rbuf, int rcount,
+                                                 void* rbuf, size_t rcount,
                                                  struct ompi_datatype_t *rdtype,
                                                  struct ompi_communicator_t *comm,
                                                  mca_coll_base_module_t *module)
@@ -735,9 +735,9 @@ ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -818,10 +818,10 @@ int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
  *    Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
                                              void *rbuf,
-                                             int rcount,
+                                             size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/base/coll_base_allreduce.c
+++ b/ompi/mca/coll/base/coll_base_allreduce.c
@@ -54,7 +54,7 @@
  *
  */
 int
-ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, size_t count,
                                                struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op,
                                                struct ompi_communicator_t *comm,
@@ -131,7 +131,7 @@ ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, int 
  */
 int
 ompi_coll_base_allreduce_intra_recursivedoubling(const void *sbuf, void *rbuf,
-                                                  int count,
+                                                  size_t count,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
@@ -341,7 +341,7 @@ ompi_coll_base_allreduce_intra_recursivedoubling(const void *sbuf, void *rbuf,
  *
  */
 int
-ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
@@ -371,7 +371,7 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
     }
 
     /* Special case for count less than size - use recursive doubling */
-    if (count < size) {
+    if (count < (size_t) size) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring rank %d/%d, count %d, switching to recursive doubling", rank, size, count));
         return (ompi_coll_base_allreduce_intra_recursivedoubling(sbuf, rbuf,
                                                                   count,
@@ -618,7 +618,7 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
  *
  */
 int
-ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, size_t count,
                                                struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op,
                                                struct ompi_communicator_t *comm,
@@ -656,7 +656,7 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
     COLL_BASE_COMPUTED_SEGCOUNT(segsize, typelng, segcount)
 
         /* Special case for count less than size * segcount - use regular ring */
-        if (count < (size * segcount)) {
+        if (count < (size_t) (size * segcount)) {
             OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring_segmented rank %d/%d, count %d, switching to regular ring", rank, size, count));
             return (ompi_coll_base_allreduce_intra_ring(sbuf, rbuf, count, dtype, op,
                                                          comm, module));
@@ -664,8 +664,8 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
 
     /* Determine the number of phases of the algorithm */
     num_phases = count / (size * segcount);
-    if ((count % (size * segcount) >= size) &&
-        (count % (size * segcount) > ((size * segcount) / 2))) {
+    if ((count % (size * segcount) >= (size_t) size) &&
+        (count % (size * segcount) > (size_t) ((size * segcount) / 2))) {
         num_phases++;
     }
 
@@ -881,7 +881,7 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, size_t count,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -971,7 +971,7 @@ ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, int co
  *   count * typesize + 4 * \log_2(p) * sizeof(int) = O(count)
  */
 int ompi_coll_base_allreduce_intra_redscat_allgather(
-    const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -990,7 +990,7 @@ int ompi_coll_base_allreduce_intra_redscat_allgather(
     }
     int nprocs_pof2 = 1 << nsteps;                              /* flp2(comm_size) */
 
-    if (count < nprocs_pof2 || !ompi_op_is_commute(op)) {
+    if (count < (size_t) nprocs_pof2 || !ompi_op_is_commute(op)) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:allreduce_intra_redscat_allgather: rank %d/%d "
                      "count %d switching to basic linear allreduce",
@@ -1261,7 +1261,7 @@ int ompi_coll_base_allreduce_intra_redscat_allgather(
  * Caution is needed on larger communicators(n) and data sizes(m), which will
  * result in m*n^2 total traffic and potential network congestion.
  */
-int ompi_coll_base_allreduce_intra_allgather_reduce(const void *sbuf, void *rbuf, int count,
+int ompi_coll_base_allreduce_intra_allgather_reduce(const void *sbuf, void *rbuf, size_t count,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -48,7 +48,7 @@
  * and count) to send the data to the other.
  */
 int
-mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
+mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module)
@@ -177,9 +177,9 @@ mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
     return err;
 }
 
-int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -236,9 +236,9 @@ int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void* rbuf, int rcount,
+                                         void* rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
@@ -375,9 +375,9 @@ int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, int scount,
  *                    - wait for any request to complete
  *                    - replace that request by the new one of the same type.
  */
-int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module,
@@ -534,9 +534,9 @@ int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
@@ -613,9 +613,9 @@ int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, int scount,
 
 /* copied function (with appropriate renaming) starts here */
 
-int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -50,7 +50,7 @@
  * and count) to send the data to the other.
  */
 int
-mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts, const int *rdisps,
+mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -191,9 +191,9 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
 }
 
 int
-ompi_coll_base_alltoallv_intra_pairwise(const void *sbuf, const int *scounts, const int *sdisps,
+ompi_coll_base_alltoallv_intra_pairwise(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                          struct ompi_datatype_t *sdtype,
-                                         void* rbuf, const int *rcounts, const int *rdisps,
+                                         void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
@@ -280,9 +280,9 @@ ompi_coll_base_alltoallv_intra_pairwise(const void *sbuf, const int *scounts, co
  * differently and so will not have to duplicate code.
  */
 int
-ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts, const int *sdisps,
+ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                             struct ompi_datatype_t *sdtype,
-                                            void *rbuf, const int *rcounts, const int *rdisps,
+                                            void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -36,7 +36,7 @@
 
 int
 ompi_coll_base_bcast_intra_generic( void* buffer,
-                                     int original_count,
+                                     size_t original_count,
                                      struct ompi_datatype_t* datatype,
                                      int root,
                                      struct ompi_communicator_t* comm,
@@ -46,7 +46,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
 {
     int err = 0, line, i, rank, segindex, req_index;
     int num_segments; /* Number of segments */
-    int sendcount;    /* number of elements sent in this segment */
+    size_t sendcount;    /* number of elements sent in this segment */
     size_t realsegsize, type_size;
     char *tmpbuf;
     ptrdiff_t extent, lb;
@@ -247,14 +247,14 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_bintree ( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -275,14 +275,14 @@ ompi_coll_base_bcast_intra_bintree ( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_pipeline( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -303,14 +303,14 @@ ompi_coll_base_bcast_intra_pipeline( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_chain( void* buffer,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t* datatype,
                                    int root,
                                    struct ompi_communicator_t* comm,
                                    mca_coll_base_module_t *module,
                                    uint32_t segsize, int32_t chains )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -331,14 +331,14 @@ ompi_coll_base_bcast_intra_chain( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_binomial( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -359,7 +359,7 @@ ompi_coll_base_bcast_intra_binomial( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
-                                            int count,
+                                            size_t count,
                                             struct ompi_datatype_t* datatype,
                                             int root,
                                             struct ompi_communicator_t* comm,
@@ -367,10 +367,10 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
                                             uint32_t segsize )
 {
     int err=0, line, rank, size, segindex, i, lr, pair;
-    uint32_t counts[2];
-    int segcount[2];       /* Number of elements sent with each segment */
-    int num_segments[2];   /* Number of segments */
-    int sendcount[2];      /* the same like segcount, except for the last segment */
+    size_t counts[2];
+    size_t segcount[2];       /* Number of elements sent with each segment */
+    int num_segments[2];      /* Number of segments */
+    size_t sendcount[2];      /* the same like segcount, except for the last segment */
     size_t realsegsize[2], type_size;
     char *tmpbuf[2];
     ptrdiff_t type_extent, lb;
@@ -625,7 +625,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
+ompi_coll_base_bcast_intra_basic_linear(void *buff, size_t count,
                                         struct ompi_datatype_t *datatype, int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module)
@@ -718,7 +718,7 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
  *     7
  */
 int ompi_coll_base_bcast_intra_knomial(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize, int radix)
 {
@@ -772,7 +772,7 @@ int ompi_coll_base_bcast_intra_knomial(
  * 7:           <-+  [*******7]  <-+ [******67]  <--|-+ [****4567] <--------+
  */
 int ompi_coll_base_bcast_intra_scatter_allgather(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize)
 {
@@ -791,7 +791,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
     if (comm_size < 2 || datatype_size == 0)
         return MPI_SUCCESS;
 
-    if (count < comm_size) {
+    if (count < (size_t)comm_size) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:bcast_intra_scatter_allgather: rank %d/%d "
                      "count %d switching to basic linear bcast",
@@ -801,9 +801,9 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
     }
 
     int vrank = (rank - root + comm_size) % comm_size;
-    int recv_count = 0, send_count = 0;
-    int scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
-    int curr_count = (rank == root) ? count : 0;
+    size_t recv_count = 0, send_count = 0;
+    size_t scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
+    size_t curr_count = (rank == root) ? count : 0;
 
     /* Scatter by binomial tree: receive data from parent */
     int mask = 0x1;
@@ -850,7 +850,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
      * Allgather by recursive doubling
      * Each process has the curr_count elems in the buf[vrank * scatter_count, ...]
      */
-    int rem_count = count - vrank * scatter_count;
+    size_t rem_count = count - vrank * scatter_count;
     curr_count = (scatter_count < rem_count) ? scatter_count : rem_count;
     if (curr_count < 0)
         curr_count = 0;
@@ -888,7 +888,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
          */
         if (vremote_tree_root + mask > comm_size) {
             int nprocs_alldata = comm_size - vrank_tree_root - mask;
-            int offset = scatter_count * (vrank_tree_root + mask);
+            ptrdiff_t offset = scatter_count * (vrank_tree_root + mask);
             for (int rhalving_mask = mask >> 1; rhalving_mask > 0; rhalving_mask >>= 1) {
                 vremote = vrank ^ rhalving_mask;
                 remote = (vremote + root) % comm_size;
@@ -949,7 +949,7 @@ cleanup_and_return:
  * 7:           <-+  [*******7]  [******67] [*****567] [****4567] ... [01234567]
  */
 int ompi_coll_base_bcast_intra_scatter_allgather_ring(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize)
 {
@@ -968,7 +968,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather_ring(
     if (comm_size < 2 || datatype_size == 0)
         return MPI_SUCCESS;
 
-    if (count < comm_size) {
+    if (count < (size_t)comm_size) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:bcast_intra_scatter_allgather_ring: rank %d/%d "
                      "count %d switching to basic linear bcast",
@@ -978,9 +978,9 @@ int ompi_coll_base_bcast_intra_scatter_allgather_ring(
     }
 
     int vrank = (rank - root + comm_size) % comm_size;
-    int recv_count = 0, send_count = 0;
-    int scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
-    int curr_count = (rank == root) ? count : 0;
+    size_t recv_count = 0, send_count = 0;
+    size_t scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
+    size_t curr_count = (rank == root) ? count : 0;
 
     /* Scatter by binomial tree: receive data from parent */
     int mask = 1;

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -66,7 +66,7 @@ static int query(const mca_base_component_t * component,
                  ompi_communicator_t * comm, int *priority,
                  mca_coll_base_module_t ** module);
 
-static int query_2_4_0(const mca_coll_base_component_2_4_0_t *
+static int query_3_0_0(const mca_coll_base_component_3_0_0_t *
                        coll_component, ompi_communicator_t * comm,
                        int *priority,
                        mca_coll_base_module_t ** module);
@@ -520,11 +520,11 @@ static int query(const mca_base_component_t * component,
                  int *priority, mca_coll_base_module_t ** module)
 {
     *module = NULL;
-    if (2 == component->mca_type_major_version &&
-        4 == component->mca_type_minor_version &&
+    if (3 == component->mca_type_major_version &&
+        0 == component->mca_type_minor_version &&
         0 == component->mca_type_release_version) {
 
-        return query_2_4_0((const mca_coll_base_component_2_4_0_t *)component, comm, priority, module);
+        return query_3_0_0((const mca_coll_base_component_3_0_0_t *)component, comm, priority, module);
     }
 
     /* Unknown coll API version -- return error */
@@ -533,7 +533,7 @@ static int query(const mca_base_component_t * component,
 }
 
 
-static int query_2_4_0(const mca_coll_base_component_2_4_0_t * component,
+static int query_3_0_0(const mca_coll_base_component_3_0_0_t * component,
                        ompi_communicator_t * comm, int *priority,
                        mca_coll_base_module_t ** module)
 {

--- a/ompi/mca/coll/base/coll_base_exscan.c
+++ b/ompi/mca/coll/base/coll_base_exscan.c
@@ -32,7 +32,7 @@
  * Returns:   MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -140,7 +140,7 @@ ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, int count,
  * Limitations: intra-communicators only
  */
 int ompi_coll_base_exscan_intra_recursivedoubling(
-    const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype,
+    const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_find_available.c
+++ b/ompi/mca/coll/base/coll_base_find_available.c
@@ -107,12 +107,12 @@ int mca_coll_base_find_available(bool enable_progress_threads,
  * Query a specific component, coll v2.4.0
  */
 static inline int
-init_query_2_4_0(const mca_base_component_t * component,
+init_query_3_0_0(const mca_base_component_t * component,
                  bool enable_progress_threads,
                  bool enable_mpi_threads)
 {
-    mca_coll_base_component_2_4_0_t *coll =
-        (mca_coll_base_component_2_4_0_t *) component;
+    mca_coll_base_component_3_0_0_t *coll =
+        (mca_coll_base_component_3_0_0_t *) component;
 
     return coll->collm_init_query(enable_progress_threads,
                                   enable_mpi_threads);
@@ -133,10 +133,10 @@ static int init_query(const mca_base_component_t * component,
     /* This component has already been successfully opened.  So now
        query it. */
 
-    if (2 == component->mca_type_major_version &&
-        4 == component->mca_type_minor_version &&
+    if (3 == component->mca_type_major_version &&
+        0 == component->mca_type_minor_version &&
         0 == component->mca_type_release_version) {
-        ret = init_query_2_4_0(component, enable_progress_threads,
+        ret = init_query_3_0_0(component, enable_progress_threads,
                                enable_mpi_threads);
     } else {
         /* Unrecognized coll API version */

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -68,28 +68,28 @@ typedef enum COLLTYPE {
 } COLLTYPE_T;
 
 /* defined arg lists to simply auto inclusion of user overriding decision functions */
-#define ALLGATHER_BASE_ARGS           const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define ALLGATHERV_BASE_ARGS          const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define ALLREDUCE_BASE_ARGS           const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define ALLTOALL_BASE_ARGS            const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define ALLTOALLV_BASE_ARGS           const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define ALLTOALLW_BASE_ARGS           const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
+#define ALLGATHER_BASE_ARGS           const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLGATHERV_BASE_ARGS          const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const size_t recvcounts[], const ptrdiff_t displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLREDUCE_BASE_ARGS           const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define ALLTOALL_BASE_ARGS            const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLTOALLV_BASE_ARGS           const void *sendbuf, const size_t sendcounts[], const ptrdiff_t sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const size_t recvcounts[], const ptrdiff_t rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLTOALLW_BASE_ARGS           const void *sendbuf, const size_t sendcounts[], const ptrdiff_t sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const size_t recvcounts[], const ptrdiff_t rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
 #define BARRIER_BASE_ARGS             struct ompi_communicator_t *comm
-#define BCAST_BASE_ARGS               void *buffer, int count, struct ompi_datatype_t *datatype, int root, struct ompi_communicator_t *comm
-#define EXSCAN_BASE_ARGS              const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define GATHER_BASE_ARGS              const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define GATHERV_BASE_ARGS             const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define REDUCE_BASE_ARGS              const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, int root, struct ompi_communicator_t *comm
-#define REDUCESCATTER_BASE_ARGS       const void *sendbuf, void *recvbuf, const int recvcounts[], struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define REDUCESCATTERBLOCK_BASE_ARGS  const void *sendbuf, void *recvbuf, int recvcount, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define SCAN_BASE_ARGS                const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define SCATTER_BASE_ARGS             const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define SCATTERV_BASE_ARGS            const void *sendbuf, const int sendcounts[], const int displs[], struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLGATHER_BASE_ARGS  const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLGATHERV_BASE_ARGS const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLTOALL_BASE_ARGS   const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLTOALLV_BASE_ARGS  const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLTOALLW_BASE_ARGS  const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
+#define BCAST_BASE_ARGS               void *buffer, size_t count, struct ompi_datatype_t *datatype, int root, struct ompi_communicator_t *comm
+#define EXSCAN_BASE_ARGS              const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define GATHER_BASE_ARGS              const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define GATHERV_BASE_ARGS             const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const size_t recvcounts[], const ptrdiff_t displs[], struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define REDUCE_BASE_ARGS              const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, int root, struct ompi_communicator_t *comm
+#define REDUCESCATTER_BASE_ARGS       const void *sendbuf, void *recvbuf, const size_t recvcounts[], struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define REDUCESCATTERBLOCK_BASE_ARGS  const void *sendbuf, void *recvbuf, size_t recvcount, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define SCAN_BASE_ARGS                const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define SCATTER_BASE_ARGS             const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define SCATTERV_BASE_ARGS            const void *sendbuf, const size_t sendcounts[], const ptrdiff_t displs[], struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLGATHER_BASE_ARGS  const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLGATHERV_BASE_ARGS const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const size_t recvcounts[], const ptrdiff_t displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLTOALL_BASE_ARGS   const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLTOALLV_BASE_ARGS  const void *sendbuf, const size_t sendcounts[], const ptrdiff_t sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const size_t recvcounts[], const ptrdiff_t rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLTOALLW_BASE_ARGS  const void *sendbuf, const size_t sendcounts[], const MPI_Aint sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const size_t recvcounts[], const MPI_Aint rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
 
 #define ALLGATHER_ARGS           ALLGATHER_BASE_ARGS,           mca_coll_base_module_t *module
 #define ALLGATHERV_ARGS          ALLGATHERV_BASE_ARGS,          mca_coll_base_module_t *module
@@ -218,7 +218,7 @@ int ompi_coll_base_alltoall_intra_bruck(ALLTOALL_ARGS);
 int ompi_coll_base_alltoall_intra_basic_linear(ALLTOALL_ARGS);
 int ompi_coll_base_alltoall_intra_linear_sync(ALLTOALL_ARGS, int max_requests);
 int ompi_coll_base_alltoall_intra_two_procs(ALLTOALL_ARGS);
-int mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
+int mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module);  /* special version for INPLACE */
@@ -226,7 +226,7 @@ int mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
 /* AlltoAllV */
 int ompi_coll_base_alltoallv_intra_pairwise(ALLTOALLV_ARGS);
 int ompi_coll_base_alltoallv_intra_basic_linear(ALLTOALLV_ARGS);
-int mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                                 struct ompi_datatype_t *rdtype,
                                                 struct ompi_communicator_t *comm,
                                                 mca_coll_base_module_t *module);  /* special version for INPLACE */
@@ -266,7 +266,7 @@ int ompi_coll_base_gather_intra_linear_sync(GATHER_ARGS, int first_segment_size)
 /* GatherV */
 
 /* Reduce */
-int ompi_coll_base_reduce_generic(REDUCE_ARGS, ompi_coll_tree_t* tree, int count_by_segment, int max_outstanding_reqs);
+int ompi_coll_base_reduce_generic(REDUCE_ARGS, ompi_coll_tree_t* tree, size_t count_by_segment, int max_outstanding_reqs);
 int ompi_coll_base_reduce_intra_basic_linear(REDUCE_ARGS);
 int ompi_coll_base_reduce_intra_chain(REDUCE_ARGS, uint32_t segsize, int fanout, int max_outstanding_reqs );
 int ompi_coll_base_reduce_intra_pipeline(REDUCE_ARGS, uint32_t segsize, int max_outstanding_reqs );
@@ -300,21 +300,21 @@ int ompi_coll_base_scatter_intra_linear_nb(SCATTER_ARGS, int max_reqs);
 /* ScatterV */
 
 /* Reduce_local */
-int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
+int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, size_t count,
                                struct ompi_datatype_t * dtype, struct ompi_op_t * op,
                                mca_coll_base_module_t *module);
 
 #if OPAL_ENABLE_FT_MPI
 /* Agreement */
 int ompi_coll_base_agree_noft(void *contrib,
-                              int dt_count,
+                              size_t dt_count,
                               struct ompi_datatype_t *dt,
                               struct ompi_op_t *op,
                               struct ompi_group_t **group, bool update_grp,
                               struct ompi_communicator_t* comm,
                               mca_coll_base_module_t *module);
 int ompi_coll_base_iagree_noft(void *contrib,
-                               int dt_count,
+                               size_t dt_count,
                                struct ompi_datatype_t *dt,
                                struct ompi_op_t *op,
                                struct ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -38,15 +38,16 @@
 /* Todo: gather_intra_generic, gather_intra_binary, gather_intra_chain,
  * gather_intra_pipeline, segmentation? */
 int
-ompi_coll_base_gather_intra_binomial(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_binomial(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {
-    int line = -1, i, rank, vrank, size, total_recv = 0, err;
+    int line = -1, i, rank, vrank, size, err;
+    size_t total_recv = 0;
     char *ptmp     = NULL, *tempbuf  = NULL;
     ompi_coll_tree_t* bmtree;
     MPI_Status status;
@@ -205,9 +206,9 @@ ompi_coll_base_gather_intra_binomial(const void *sbuf, int scount,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_linear_sync(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          int root,
                                          struct ompi_communicator_t *comm,
@@ -367,9 +368,9 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_gather_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_basic_linear(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           int root,
                                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -40,7 +40,7 @@
 #include "coll_base_topo.h"
 #include "coll_base_util.h"
 
-int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
+int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, size_t count,
                                struct ompi_datatype_t * dtype, struct ompi_op_t * op,
                                mca_coll_base_module_t *module)
 {
@@ -60,11 +60,11 @@ int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
  * for the first block: thus we must copy sendbuf to accumbuf on intermediate
  * to keep the optimized loop happy.
  */
-int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int original_count,
+int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, size_t original_count,
                                     ompi_datatype_t* datatype, ompi_op_t* op,
                                     int root, ompi_communicator_t* comm,
                                     mca_coll_base_module_t *module,
-                                    ompi_coll_tree_t* tree, int count_by_segment,
+                                    ompi_coll_tree_t* tree, size_t count_by_segment,
                                     int max_outstanding_reqs )
 {
     char *inbuf[2] = {NULL, NULL}, *inbuf_free[2] = {NULL, NULL};
@@ -314,7 +314,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
                 ret = ompi_request_wait(&sreq[creq], MPI_STATUS_IGNORE);
                 if (ret != MPI_SUCCESS) { line = __LINE__; goto error_hndl;  }
 
-                if( original_count < count_by_segment ) {
+                if( original_count < (size_t) count_by_segment ) {
                     count_by_segment = original_count;
                 }
                 ret = MCA_PML_CALL( isend((char*)sendbuf +
@@ -381,7 +381,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
      meaning that at least one datatype must fit in the segment !
 */
 
-int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int count,
+int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, size_t count,
                                         ompi_datatype_t* datatype,
                                         ompi_op_t* op, int root,
                                         ompi_communicator_t* comm,
@@ -389,7 +389,7 @@ int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int c
                                         uint32_t segsize, int fanout,
                                         int max_outstanding_reqs )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -412,14 +412,14 @@ int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int c
 
 
 int ompi_coll_base_reduce_intra_pipeline( const void *sendbuf, void *recvbuf,
-                                           int count, ompi_datatype_t* datatype,
+                                           size_t count, ompi_datatype_t* datatype,
                                            ompi_op_t* op, int root,
                                            ompi_communicator_t* comm,
                                            mca_coll_base_module_t *module,
                                            uint32_t segsize,
                                            int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -443,14 +443,14 @@ int ompi_coll_base_reduce_intra_pipeline( const void *sendbuf, void *recvbuf,
 }
 
 int ompi_coll_base_reduce_intra_binary( const void *sendbuf, void *recvbuf,
-                                         int count, ompi_datatype_t* datatype,
+                                         size_t count, ompi_datatype_t* datatype,
                                          ompi_op_t* op, int root,
                                          ompi_communicator_t* comm,
                                          mca_coll_base_module_t *module,
                                          uint32_t segsize,
                                          int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -474,14 +474,14 @@ int ompi_coll_base_reduce_intra_binary( const void *sendbuf, void *recvbuf,
 }
 
 int ompi_coll_base_reduce_intra_binomial( const void *sendbuf, void *recvbuf,
-                                           int count, ompi_datatype_t* datatype,
+                                           size_t count, ompi_datatype_t* datatype,
                                            ompi_op_t* op, int root,
                                            ompi_communicator_t* comm,
                                            mca_coll_base_module_t *module,
                                            uint32_t segsize,
                                            int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -512,7 +512,7 @@ int ompi_coll_base_reduce_intra_binomial( const void *sendbuf, void *recvbuf,
  * Returns:       MPI_SUCCESS or error code
  */
 int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recvbuf,
-                                                  int count,
+                                                  size_t count,
                                                   ompi_datatype_t* datatype,
                                                   ompi_op_t* op, int root,
                                                   ompi_communicator_t* comm,
@@ -638,7 +638,7 @@ int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recv
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          int root,
@@ -809,7 +809,7 @@ ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count
  *                  in the root process.
  */
 int ompi_coll_base_reduce_intra_redscat_gather(
-    const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -827,7 +827,7 @@ int ompi_coll_base_reduce_intra_redscat_gather(
     }
     int nprocs_pof2 = 1 << nsteps;                              /* flp2(comm_size) */
 
-    if (nprocs_pof2 < 2 || count < nprocs_pof2 || !ompi_op_is_commute(op)) {
+    if (nprocs_pof2 < 2 || count < (size_t) nprocs_pof2 || !ompi_op_is_commute(op)) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:reduce_intra_redscat_gather: rank %d/%d count %d "
                      "switching to basic linear reduce", rank, comm_size, count));

--- a/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
@@ -54,7 +54,7 @@
  *     up at some point)
  */
 int
-ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, int rcount,
+ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, size_t rcount,
                                                  struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op,
                                                  struct ompi_communicator_t *comm,
@@ -195,14 +195,17 @@ ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, i
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
     struct ompi_datatype_t *dtypesend = NULL, *dtyperecv = NULL;
     char *tmprecv_raw = NULL, *tmpbuf_raw = NULL, *tmprecv, *tmpbuf;
-    ptrdiff_t span, gap, totalcount, extent;
-    int blocklens[2], displs[2];
+    ptrdiff_t span, gap, extent;
+    size_t totalcount;
+    size_t blocklens[2];
+    ptrdiff_t displs[2];
+    int tmp_blocklens[2], tmp_displs[2];
     int err = MPI_SUCCESS;
     int comm_size = ompi_comm_size(comm);
     int rank = ompi_comm_rank(comm);
@@ -270,7 +273,12 @@ ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
                        rcount * (comm_size - cur_tree_root - mask) : 0;
         displs[0] = 0;
         displs[1] = comm_size * rcount - blocklens[1];
-        err = ompi_datatype_create_indexed(2, blocklens, displs, dtype, &dtypesend);
+        /* TODO:BIGCOUNT: Remove temporaries when ompi_datatype interface is updated */
+        tmp_blocklens[0] = (int) blocklens[0];
+        tmp_blocklens[1] = (int) blocklens[1];
+        tmp_displs[0] = (int) displs[0];
+        tmp_displs[1] = (int) displs[1];
+        err = ompi_datatype_create_indexed(2, tmp_blocklens, tmp_displs, dtype, &dtypesend);
         if (MPI_SUCCESS != err) { goto cleanup_and_return; }
         err = ompi_datatype_commit(&dtypesend);
         if (MPI_SUCCESS != err) { goto cleanup_and_return; }
@@ -281,7 +289,12 @@ ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
                        rcount * (comm_size - remote_tree_root - mask) : 0;
         displs[0] = 0;
         displs[1] = comm_size * rcount - blocklens[1];
-        err = ompi_datatype_create_indexed(2, blocklens, displs, dtype, &dtyperecv);
+        /* TODO:BIGCOUNT: Remove temporaries when ompi_datatype interface is updated */
+        tmp_blocklens[0] = (int) blocklens[0];
+        tmp_blocklens[1] = (int) blocklens[1];
+        tmp_displs[0] = (int) displs[0];
+        tmp_displs[1] = (int) displs[1];
+        err = ompi_datatype_create_indexed(2, tmp_blocklens, tmp_displs, dtype, &dtyperecv);
         if (MPI_SUCCESS != err) { goto cleanup_and_return; }
         err = ompi_datatype_commit(&dtyperecv);
         if (MPI_SUCCESS != err) { goto cleanup_and_return; }
@@ -400,7 +413,7 @@ static int ompi_range_sum(int a, int b, int r)
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_recursivehalving(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -580,7 +593,7 @@ cleanup_and_return:
 }
 
 static int ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module);
 
@@ -642,7 +655,7 @@ static int ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_butterfly(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -889,7 +902,7 @@ cleanup_and_return:
  */
 static int
 ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_scan.c
+++ b/ompi/mca/coll/base/coll_base_scan.c
@@ -32,7 +32,7 @@
  * Returns:   MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,
@@ -155,7 +155,7 @@ ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, int count,
  * Limitations: intra-communicators only
  */
 int ompi_coll_base_scan_intra_recursivedoubling(
-    const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype,
+    const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_scatter.c
+++ b/ompi/mca/coll/base/coll_base_scatter.c
@@ -61,14 +61,15 @@
  */
 int
 ompi_coll_base_scatter_intra_binomial(
-    const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+    const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+    void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
     int root, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*)module;
     mca_coll_base_comm_t *data = base_module->base_data;
-    int line = -1, rank, vrank, size, err, packed_size, curr_count;
+    int line = -1, rank, vrank, size, err, packed_size;
+    size_t curr_count;
     char *ptmp, *tempbuf = NULL;
     size_t max_data, packed_sizet;
     opal_convertor_t convertor;
@@ -107,7 +108,7 @@ ompi_coll_base_scatter_intra_binomial(
             opal_convertor_copy_and_prepare_for_send( ompi_mpi_local_convertor, &(sdtype->super),
                                                       scount * size, sbuf, 0, &convertor );
             opal_convertor_get_packed_size( &convertor, &packed_sizet );
-            packed_size = (int)packed_sizet;
+            packed_size = packed_sizet;
             packed_sizet = packed_sizet / size;
             ptmp = tempbuf = (char *)malloc(packed_size);
             if (NULL == tempbuf) {
@@ -135,7 +136,7 @@ ompi_coll_base_scatter_intra_binomial(
         opal_convertor_copy_and_prepare_for_send( ompi_mpi_local_convertor, &(rdtype->super),
                                                   rcount, NULL, 0, &convertor );
         opal_convertor_get_packed_size( &convertor, &packed_sizet );
-        scount = (int)packed_sizet;
+        scount = packed_sizet;
 
         sdtype = MPI_PACKED;  /* default to MPI_PACKED as the send type */
 
@@ -157,7 +158,7 @@ ompi_coll_base_scatter_intra_binomial(
         if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
         /* Get received count */
-        curr_count = (int)status._ucount;  /* no need for conversion, work in bytes */
+        curr_count = status._ucount;  /* no need for conversion, work in bytes */
         sextent = 1;  /* bytes */
     }
 
@@ -219,9 +220,9 @@ ompi_coll_base_scatter_intra_binomial(
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           int root,
                                           struct ompi_communicator_t *comm,
@@ -286,9 +287,9 @@ ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, int scount,
  * progression until the message is sent/(copied to some sort of transmit buffer).
  */
 int
-ompi_coll_base_scatter_intra_linear_nb(const void *sbuf, int scount,
+ompi_coll_base_scatter_intra_linear_nb(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        int root,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic.h
+++ b/ompi/mca/coll/basic/coll_basic.h
@@ -39,7 +39,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-    OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+    OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t
         mca_coll_basic_component;
     extern int mca_coll_basic_priority;
     extern int mca_coll_basic_crossover;
@@ -55,61 +55,61 @@ BEGIN_C_DECLS
     int mca_coll_basic_module_enable(mca_coll_base_module_t *module,
                                      struct ompi_communicator_t *comm);
 
-    int mca_coll_basic_allgather_inter(const void *sbuf, int scount,
+    int mca_coll_basic_allgather_inter(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_allgatherv_inter(const void *sbuf, int scount,
+    int mca_coll_basic_allgatherv_inter(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, const int *rcounts,
-                                        const int *disps,
+                                        void *rbuf, const size_t *rcounts,
+                                        const ptrdiff_t *disps,
                                         struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
-    int mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-    int mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
+    int mca_coll_basic_alltoall_inter(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts,
-                                       const int *sdisps,
+    int mca_coll_basic_alltoallv_inter(const void *sbuf, const size_t *scounts,
+                                       const ptrdiff_t *sdisps,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, const int *rcounts,
-                                       const int *rdisps,
+                                       void *rbuf, const size_t *rcounts,
+                                       const ptrdiff_t *rdisps,
                                        struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_alltoallw_intra(const void *sbuf, const int *scounts,
-                                       const int *sdisps,
+    int mca_coll_basic_alltoallw_intra(const void *sbuf, const size_t *scounts,
+                                       const ptrdiff_t *sdisps,
                                        struct ompi_datatype_t * const *sdtypes,
-                                       void *rbuf, const int *rcounts,
-                                       const int *rdisps,
+                                       void *rbuf, const size_t *rcounts,
+                                       const ptrdiff_t *rdisps,
                                        struct ompi_datatype_t * const *rdtypes,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-    int mca_coll_basic_alltoallw_inter(const void *sbuf, const int *scounts,
-                                       const int *sdisps,
+    int mca_coll_basic_alltoallw_inter(const void *sbuf, const size_t *scounts,
+                                       const ptrdiff_t *sdisps,
                                        struct ompi_datatype_t * const *sdtypes,
-                                       void *rbuf, const int *rcounts,
-                                       const int *rdisps,
+                                       void *rbuf, const size_t *rcounts,
+                                       const ptrdiff_t *rdisps,
                                        struct ompi_datatype_t * const *rdtypes,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
@@ -120,74 +120,74 @@ BEGIN_C_DECLS
     int mca_coll_basic_barrier_intra_log(struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-    int mca_coll_basic_bcast_lin_inter(void *buff, int count,
+    int mca_coll_basic_bcast_lin_inter(void *buff, size_t count,
                                        struct ompi_datatype_t *datatype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_bcast_log_intra(void *buff, int count,
+    int mca_coll_basic_bcast_log_intra(void *buff, size_t count,
                                        struct ompi_datatype_t *datatype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_bcast_log_inter(void *buff, int count,
+    int mca_coll_basic_bcast_log_inter(void *buff, size_t count,
                                        struct ompi_datatype_t *datatype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_exscan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_basic_exscan_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_exscan_inter(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_basic_gather_inter(const void *sbuf, int scount,
+    int mca_coll_basic_gather_inter(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void *rbuf, int rcount,
+                                    void *rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
+    int mca_coll_basic_gatherv_intra(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, const int *rcounts, const int *disps,
+                                     void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-    int mca_coll_basic_gatherv_inter(const void *sbuf, int scount,
+    int mca_coll_basic_gatherv_inter(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, const int *rcounts, const int *disps,
+                                     void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-    int mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
-    int mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
-    int mca_coll_basic_reduce_log_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_reduce_log_inter(const void *sbuf, void *rbuf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         int root,
@@ -195,88 +195,88 @@ BEGIN_C_DECLS
                                         mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf,
-                                                  int rcount,
+                                                  size_t rcount,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf,
-                                                  int rcount,
+                                                  size_t rcount,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf,
-                                            const int *rcounts,
+                                            const size_t *rcounts,
                                             struct ompi_datatype_t *dtype,
                                             struct ompi_op_t *op,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_inter(const void *sbuf, void *rbuf,
-                                            const int *rcounts,
+                                            const size_t *rcounts,
                                             struct ompi_datatype_t *dtype,
                                             struct ompi_op_t *op,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module);
 
-    int mca_coll_basic_scan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_scan_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-    int mca_coll_basic_scan_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_scan_inter(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 
-    int mca_coll_basic_scatter_inter(const void *sbuf, int scount,
+    int mca_coll_basic_scatter_inter(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, int rcount,
+                                     void *rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-    int mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts, const int *disps,
+    int mca_coll_basic_scatterv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts, const int *disps,
+    int mca_coll_basic_scatterv_inter(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_allgather(const void *sbuf, int scount,
+     int mca_coll_basic_neighbor_allgather(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype, void *rbuf,
-                                           int rcount, struct ompi_datatype_t *rdtype,
+                                           size_t rcount, struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_allgatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                            void *rbuf, const int rcounts[], const int disps[], struct ompi_datatype_t *rdtype,
+     int mca_coll_basic_neighbor_allgatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                            void *rbuf, const size_t rcounts[], const ptrdiff_t disps[], struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                          int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+     int mca_coll_basic_neighbor_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                          size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_alltoallv(const void *sbuf, const int scounts[], const int sdisps[],
-                                           struct ompi_datatype_t *sdtype, void *rbuf, const int rcounts[],
-                                           const int rdisps[], struct ompi_datatype_t *rdtype,
+     int mca_coll_basic_neighbor_alltoallv(const void *sbuf, const size_t scounts[], const ptrdiff_t sdisps[],
+                                           struct ompi_datatype_t *sdtype, void *rbuf, const size_t rcounts[],
+                                           const ptrdiff_t rdisps[], struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_alltoallw(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],
-                                           struct ompi_datatype_t * const *sdtypes, void *rbuf, const int rcounts[],
+     int mca_coll_basic_neighbor_alltoallw(const void *sbuf, const size_t scounts[], const MPI_Aint sdisps[],
+                                           struct ompi_datatype_t * const *sdtypes, void *rbuf, const size_t rcounts[],
                                            const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                            struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 

--- a/ompi/mca/coll/basic/coll_basic_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_allgather.c
@@ -41,9 +41,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allgather_inter(const void *sbuf, int scount,
+mca_coll_basic_allgather_inter(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_allgatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_allgatherv.c
@@ -38,21 +38,22 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allgatherv_inter(const void *sbuf, int scount,
+mca_coll_basic_allgatherv_inter(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, const int *rcounts, const int *disps,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)
 {
     int rsize, err, i;
-    int *scounts, *sdisps;
+    size_t *scounts;
+    ptrdiff_t *sdisps;
 
     rsize = ompi_comm_remote_size(comm);
 
-    scounts = (int *) malloc(2 * rsize * sizeof(int));
-    sdisps = scounts + rsize;
-    if (NULL == scounts) {
+    scounts = malloc(rsize * sizeof(size_t));
+    sdisps = malloc(rsize * sizeof(ptrdiff_t));
+    if (NULL == scounts || NULL == sdisps) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
@@ -67,6 +68,9 @@ mca_coll_basic_allgatherv_inter(const void *sbuf, int scount,
 
     if (NULL != scounts) {
         free(scounts);
+    }
+    if (NULL != sdisps) {
+        free(sdisps);
     }
 
     return err;

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -41,7 +41,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
@@ -76,7 +76,7 @@ mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoall.c
@@ -41,9 +41,9 @@
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
+mca_coll_basic_alltoall_inter(const void *sbuf, size_t scount,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, int rcount,
+                              void *rbuf, size_t rcount,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoallv.c
@@ -42,9 +42,9 @@
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *sdisps,
+mca_coll_basic_alltoallv_inter(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                struct ompi_datatype_t *sdtype, void *rbuf,
-                               const int *rcounts, const int *rdisps,
+                               const size_t *rcounts, const ptrdiff_t *rdisps,
                                struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoallw.c
@@ -45,7 +45,7 @@
  * and count) to send the data to the other.
  */
 static int
-mca_coll_basic_alltoallw_intra_inplace(const void *rbuf, const int *rcounts, const int *rdisps,
+mca_coll_basic_alltoallw_intra_inplace(const void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                        struct ompi_datatype_t * const *rdtypes,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
@@ -163,9 +163,9 @@ mca_coll_basic_alltoallw_intra_inplace(const void *rbuf, const int *rcounts, con
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_basic_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
+mca_coll_basic_alltoallw_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                struct ompi_datatype_t * const *sdtypes,
-                               void *rbuf, const int *rcounts, const int *rdisps,
+                               void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                struct ompi_datatype_t * const *rdtypes,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -277,9 +277,9 @@ mca_coll_basic_alltoallw_intra(const void *sbuf, const int *scounts, const int *
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_basic_alltoallw_inter(const void *sbuf, const int *scounts, const int *sdisps,
+mca_coll_basic_alltoallw_inter(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                struct ompi_datatype_t * const *sdtypes,
-                               void *rbuf, const int *rcounts, const int *rdisps,
+                               void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                struct ompi_datatype_t * const *rdtypes,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_bcast.c
+++ b/ompi/mca/coll/basic/coll_basic_bcast.c
@@ -41,7 +41,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_bcast_log_intra(void *buff, int count,
+mca_coll_basic_bcast_log_intra(void *buff, size_t count,
                                struct ompi_datatype_t *datatype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -136,7 +136,7 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_bcast_lin_inter(void *buff, int count,
+mca_coll_basic_bcast_lin_inter(void *buff, size_t count,
                                struct ompi_datatype_t *datatype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -191,7 +191,7 @@ mca_coll_basic_bcast_lin_inter(void *buff, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_bcast_log_inter(void *buff, int count,
+mca_coll_basic_bcast_log_inter(void *buff, size_t count,
                                struct ompi_datatype_t *datatype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_component.c
+++ b/ompi/mca/coll/basic/coll_basic_component.c
@@ -55,13 +55,13 @@ static int basic_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_basic_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_basic_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "basic",

--- a/ompi/mca/coll/basic/coll_basic_exscan.c
+++ b/ompi/mca/coll/basic/coll_basic_exscan.c
@@ -42,7 +42,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_exscan_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
@@ -60,7 +60,7 @@ mca_coll_basic_exscan_intra(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_exscan_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_exscan_inter(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_gather.c
+++ b/ompi/mca/coll/basic/coll_basic_gather.c
@@ -38,9 +38,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_gather_inter(const void *sbuf, int scount,
+mca_coll_basic_gather_inter(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root, struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_gatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_gatherv.c
@@ -37,9 +37,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
+mca_coll_basic_gatherv_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, const int *rcounts, const int *disps,
+                             void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                              struct ompi_datatype_t *rdtype, int root,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)
@@ -146,9 +146,9 @@ mca_coll_basic_gatherv_intra(const void *sbuf, int scount,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_gatherv_inter(const void *sbuf, int scount,
+mca_coll_basic_gatherv_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, const int *rcounts, const int *disps,
+                             void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                              struct ompi_datatype_t *rdtype, int root,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
@@ -37,9 +37,9 @@
 #include "ompi/mca/topo/base/base.h"
 
 static int
-mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_cart(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype, void *rbuf,
-                                       int rcount, struct ompi_datatype_t *rdtype,
+                                       size_t rcount, struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
 {
@@ -117,9 +117,9 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
 }
 
 static int
-mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_graph(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype, void *rbuf,
-                                        int rcount, struct ompi_datatype_t *rdtype,
+                                        size_t rcount, struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module)
 {
@@ -170,9 +170,9 @@ mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
 }
 
 static int
-mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype, void *rbuf,
-                                             int rcount, struct ompi_datatype_t *rdtype,
+                                             size_t rcount, struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
 {
@@ -229,9 +229,9 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_basic_neighbor_allgather(const void *sbuf, int scount,
+int mca_coll_basic_neighbor_allgather(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype, void *rbuf,
-                                      int rcount, struct ompi_datatype_t *rdtype,
+                                      size_t rcount, struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
@@ -37,8 +37,8 @@
 #include "ompi/mca/topo/base/base.h"
 
 static int
-mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                        void *rbuf, const int rcounts[], const int disps[],
+mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                        void *rbuf, const size_t rcounts[], const ptrdiff_t disps[],
                                         struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module)
 {
@@ -108,8 +108,8 @@ mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, int scount, struct omp
 }
 
 static int
-mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                         void *rbuf, const int rcounts[], const int disps[],
+mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                         void *rbuf, const size_t rcounts[], const ptrdiff_t disps[],
                                          struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
 {
@@ -158,8 +158,8 @@ mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, int scount, struct om
 }
 
 static int
-mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                              void *rbuf, const int rcounts[], const int disps[],
+mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                              void *rbuf, const size_t rcounts[], const ptrdiff_t disps[],
                                               struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
 {
@@ -213,8 +213,8 @@ mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, stru
     return rc;
 }
 
-int mca_coll_basic_neighbor_allgatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                       void *rbuf, const int rcounts[], const int disps[], struct ompi_datatype_t *rdtype,
+int mca_coll_basic_neighbor_allgatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                       void *rbuf, const size_t rcounts[], const ptrdiff_t disps[], struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
     if (OMPI_COMM_IS_INTER(comm)) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
@@ -42,8 +42,8 @@
  * 512 dimensions.
  */
 static int
-mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                      int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                      size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
@@ -142,8 +142,8 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
 }
 
 static int
-mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                       int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                       size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_graph_2_2_0_t *graph = comm->c_topo->mtc.graph;
@@ -201,8 +201,8 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
 }
 
 static int
-mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct ompi_datatype_t *sdtype, void *rbuf,
-                                            int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                            size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
@@ -259,8 +259,8 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
     return rc;
 }
 
-int mca_coll_basic_neighbor_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                     int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+int mca_coll_basic_neighbor_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                     size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module)
 {
     if (OMPI_COMM_IS_INTER(comm)) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
@@ -37,9 +37,9 @@
 #include "ompi/mca/topo/base/base.h"
 
 static int
-mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], const int sdisps[],
-                                       struct ompi_datatype_t *sdtype, void *rbuf, const int rcounts[],
-                                       const int rdisps[], struct ompi_datatype_t *rdtype,
+mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const size_t scounts[], const ptrdiff_t sdisps[],
+                                       struct ompi_datatype_t *sdtype, void *rbuf, const size_t rcounts[],
+                                       const ptrdiff_t rdisps[], struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
@@ -123,9 +123,9 @@ mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], co
 }
 
 static int
-mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], const int sdisps[],
-                                        struct ompi_datatype_t *sdtype, void *rbuf, const int rcounts[],
-                                        const int rdisps[], struct ompi_datatype_t *rdtype,
+mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const size_t scounts[], const ptrdiff_t sdisps[],
+                                        struct ompi_datatype_t *sdtype, void *rbuf, const size_t rcounts[],
+                                        const ptrdiff_t rdisps[], struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_graph_2_2_0_t *graph = comm->c_topo->mtc.graph;
@@ -181,9 +181,9 @@ mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], c
 }
 
 static int
-mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts[], const int sdisps[],
-                                             struct ompi_datatype_t *sdtype, void *rbuf, const int rcounts[],
-                                             const int rdisps[], struct ompi_datatype_t *rdtype,
+mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const size_t scounts[], const ptrdiff_t sdisps[],
+                                             struct ompi_datatype_t *sdtype, void *rbuf, const size_t rcounts[],
+                                             const ptrdiff_t rdisps[], struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
@@ -237,9 +237,9 @@ mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts
     return rc;
 }
 
-int mca_coll_basic_neighbor_alltoallv(const void *sbuf, const int scounts[], const int sdisps[],
-                                      struct ompi_datatype_t *sdtype, void *rbuf, const int rcounts[],
-                                      const int rdisps[], struct ompi_datatype_t *rdtype,
+int mca_coll_basic_neighbor_alltoallv(const void *sbuf, const size_t scounts[], const ptrdiff_t sdisps[],
+                                      struct ompi_datatype_t *sdtype, void *rbuf, const size_t rcounts[],
+                                      const ptrdiff_t rdisps[], struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
     if (OMPI_COMM_IS_INTER(comm)) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
@@ -37,8 +37,8 @@
 #include "ompi/mca/topo/base/base.h"
 
 static int
-mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],
-                                       struct ompi_datatype_t * const *sdtypes, void *rbuf, const int rcounts[],
+mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const size_t scounts[], const MPI_Aint sdisps[],
+                                       struct ompi_datatype_t * const *sdtypes, void *rbuf, const size_t rcounts[],
                                        const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                        struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
@@ -120,8 +120,8 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
 }
 
 static int
-mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],
-                                        struct ompi_datatype_t * const sdtypes[], void *rbuf, const int rcounts[],
+mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const size_t scounts[], const MPI_Aint sdisps[],
+                                        struct ompi_datatype_t * const sdtypes[], void *rbuf, const size_t rcounts[],
                                         const MPI_Aint rdisps[], struct ompi_datatype_t * const rdtypes[],
                                         struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
@@ -175,8 +175,8 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
 }
 
 static int
-mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],
-                                             struct ompi_datatype_t * const *sdtypes, void *rbuf, const int rcounts[],
+mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const size_t scounts[], const MPI_Aint sdisps[],
+                                             struct ompi_datatype_t * const *sdtypes, void *rbuf, const size_t rcounts[],
                                              const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                              struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
@@ -230,8 +230,8 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
     return rc;
 }
 
-int mca_coll_basic_neighbor_alltoallw(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],
-                                      struct ompi_datatype_t * const *sdtypes, void *rbuf, const int rcounts[],
+int mca_coll_basic_neighbor_alltoallw(const void *sbuf, const size_t scounts[], const MPI_Aint sdisps[],
+                                      struct ompi_datatype_t * const *sdtypes, void *rbuf, const size_t rcounts[],
                                       const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                       struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/basic/coll_basic_reduce.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce.c
@@ -85,7 +85,7 @@
  *
  */
 int
-mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root, struct ompi_communicator_t *comm,
@@ -285,7 +285,7 @@ mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root, struct ompi_communicator_t *comm,
@@ -363,7 +363,7 @@ mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_log_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_reduce_log_inter(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
@@ -64,15 +64,16 @@
  * so this should be investigated further.
  */
 int
-mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rcounts,
+mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf, const size_t *rcounts,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module)
 {
-    int i, rank, size, count, err = OMPI_SUCCESS;
+    int i, rank, size, err = OMPI_SUCCESS;
+    size_t count;
     ptrdiff_t extent, buf_size, gap;
-    int *disps = NULL;
+    ptrdiff_t *disps = NULL;
     char *recv_buf = NULL, *recv_buf_free = NULL;
     char *result_buf = NULL, *result_buf_free = NULL;
     /* Initialize */
@@ -80,7 +81,7 @@ mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rco
     size = ompi_comm_size(comm);
 
     /* Find displacements and the like */
-    disps = (int*) malloc(sizeof(int) * size);
+    disps = malloc(sizeof(ptrdiff_t) * size);
     if (NULL == disps) return OMPI_ERR_OUT_OF_RESOURCE;
 
     disps[0] = 0;
@@ -359,17 +360,18 @@ mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rco
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_scatter_inter(const void *sbuf, void *rbuf, const int *rcounts,
+mca_coll_basic_reduce_scatter_inter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module)
 {
-    int err, i, rank, root = 0, rsize, lsize, totalcounts;
+    int err, i, rank, root = 0, rsize, lsize;
+    size_t totalcounts;
     char *tmpbuf = NULL, *tmpbuf2 = NULL, *lbuf = NULL, *buf;
     ptrdiff_t gap, span;
     ompi_request_t *req;
-    int *disps = NULL;
+    ptrdiff_t *disps = NULL;
 
     rank = ompi_comm_rank(comm);
     rsize = ompi_comm_remote_size(comm);
@@ -401,7 +403,7 @@ mca_coll_basic_reduce_scatter_inter(const void *sbuf, void *rbuf, const int *rco
         span = opal_datatype_span(&dtype->super, totalcounts, &gap);
 
         /* Generate displacements for the scatterv part */
-        disps = (int*) malloc(sizeof(int) * lsize);
+        disps = malloc(sizeof(ptrdiff_t) * lsize);
         if (NULL == disps) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
@@ -53,7 +53,7 @@
  *     up at some point)
  */
 int
-mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcount,
+mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -70,14 +70,14 @@ mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcou
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcount,
+mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
 {
     int err, i, rank, root = 0, rsize, lsize;
-    int totalcounts;
+    size_t totalcounts;
     ptrdiff_t gap, span;
     char *tmpbuf = NULL, *tmpbuf2 = NULL;
     char *lbuf = NULL, *buf;

--- a/ompi/mca/coll/basic/coll_basic_scan.c
+++ b/ompi/mca/coll/basic/coll_basic_scan.c
@@ -40,7 +40,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_scan_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_scan_intra(const void *sbuf, void *rbuf, size_t count,
                           struct ompi_datatype_t *dtype,
                           struct ompi_op_t *op,
                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_scatter.c
@@ -39,9 +39,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_scatter_inter(const void *sbuf, int scount,
+mca_coll_basic_scatter_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root, struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -39,9 +39,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
-                              const int *disps, struct ompi_datatype_t *sdtype,
-                              void *rbuf, int rcount,
+mca_coll_basic_scatterv_intra(const void *sbuf, const size_t *scounts,
+                              const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                              void *rbuf, size_t rcount,
                               struct ompi_datatype_t *rdtype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)
@@ -124,9 +124,9 @@ mca_coll_basic_scatterv_intra(const void *sbuf, const int *scounts,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
-                              const int *disps, struct ompi_datatype_t *sdtype,
-                              void *rbuf, int rcount,
+mca_coll_basic_scatterv_inter(const void *sbuf, const size_t *scounts,
+                              const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                              void *rbuf, size_t rcount,
                               struct ompi_datatype_t *rdtype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -119,7 +119,7 @@ struct ompi_group_t;
 typedef int (*mca_coll_base_component_init_query_fn_t)
      (bool enable_progress_threads, bool enable_mpi_threads);
 
-struct mca_coll_base_module_2_4_0_t;
+struct mca_coll_base_module_3_0_0_t;
 
 /**
  * Query whether a component is available for the given communicator
@@ -148,8 +148,8 @@ struct mca_coll_base_module_2_4_0_t;
  * provide a module with the requested functionality or NULL if the
  * component should not be used on the given communicator.
  */
-typedef struct mca_coll_base_module_2_4_0_t *
-  (*mca_coll_base_component_comm_query_2_4_0_fn_t)
+typedef struct mca_coll_base_module_3_0_0_t *
+  (*mca_coll_base_component_comm_query_3_0_0_fn_t)
     (struct ompi_communicator_t *comm, int *priority);
 
 
@@ -188,7 +188,7 @@ typedef struct mca_coll_base_module_2_4_0_t *
  * @param[in]     comm       Communicator being created
  */
 typedef int
-(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_2_4_0_t* module,
+(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_3_0_0_t* module,
                                           struct ompi_communicator_t *comm);
 
 /* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
@@ -210,15 +210,15 @@ typedef int
  * @param module: the MCA module that defines this agreement.
  */
 typedef int (*mca_coll_base_module_agree_fn_t)
- (void *contrib, int dt_count, struct ompi_datatype_t *dtype,
+ (void *contrib, size_t dt_count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_group_t **failedgroup, bool update_failedgroup,
    struct ompi_communicator_t *comm,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iagree_fn_t)
-  (void *contrib, int dt_count, struct ompi_datatype_t *dtype,
+  (void *contrib, size_t dt_count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_group_t **failedgroup, bool update_failedgroup,
    struct ompi_communicator_t *comm, ompi_request_t **request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 
 /**
@@ -232,243 +232,243 @@ typedef int (*mca_coll_base_module_iagree_fn_t)
  * @param[in]     comm       Communicator being disabled
  */
 typedef int
-(*mca_coll_base_module_disable_1_2_0_fn_t)(struct mca_coll_base_module_2_4_0_t* module,
+(*mca_coll_base_module_disable_1_2_0_fn_t)(struct mca_coll_base_module_3_0_0_t* module,
                                           struct ompi_communicator_t *comm);
 
 /* blocking collectives */
 typedef int (*mca_coll_base_module_allgather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allgatherv_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,  struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allreduce_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoall_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallv_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallw_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_barrier_fn_t)
-  (struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_bcast_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_exscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gatherv_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *disps, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_fn_t)
-  (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, const size_t *rcounts, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_block_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatter_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatterv_fn_t)
-  (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 
 /* nonblocking collectives */
 typedef int (*mca_coll_base_module_iallgather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iallgatherv_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,  struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iallreduce_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm,
-   ompi_request_t ** request, struct mca_coll_base_module_2_4_0_t *module);
+   ompi_request_t ** request, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoall_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallv_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallw_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ibarrier_fn_t)
   (struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ibcast_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iexscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_igather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_igatherv_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *disps, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_fn_t)
-  (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, const size_t *rcounts, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_block_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscatter_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscatterv_fn_t)
-  (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /* persistent collectives */
 typedef int (*mca_coll_base_module_allgather_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allgatherv_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,  struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allreduce_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info,
-   ompi_request_t ** request, struct mca_coll_base_module_2_4_0_t *module);
+   ompi_request_t ** request, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoall_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallv_init_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallw_init_fn_t)
-  (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_barrier_init_fn_t)
   (struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_bcast_init_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_exscan_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gather_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gatherv_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, const size_t *rcounts, const ptrdiff_t *disps, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_init_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_init_fn_t)
-  (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, const size_t *rcounts, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_block_init_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scan_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatter_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatterv_init_fn_t)
-  (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, const size_t *scounts, const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /*
  * The signature of the neighborhood alltoallw differs from alltoallw
  */
 typedef int (*mca_coll_base_module_neighbor_alltoallw_fn_t)
-  (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ineighbor_alltoallw_fn_t)
-  (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
+  (const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_neighbor_alltoallw_init_fn_t)
-  (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
-   void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
+  (const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
+   void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /*
  * reduce_local
@@ -477,9 +477,9 @@ typedef int (*mca_coll_base_module_neighbor_alltoallw_init_fn_t)
  * option of intercepting it, if desired.
  */
 typedef int (*mca_coll_base_module_reduce_local_fn_t)
-   (const void *inbuf, void *inoutbuf, int count,
+   (const void *inbuf, void *inoutbuf, size_t count,
     struct ompi_datatype_t * dtype, struct ompi_op_t * op,
-    struct mca_coll_base_module_2_4_0_t *module);
+    struct mca_coll_base_module_3_0_0_t *module);
 
 
 /* ******************************************************************** */
@@ -493,7 +493,7 @@ typedef int (*mca_coll_base_module_reduce_local_fn_t)
  * mca_coll_[component_name]_component, must exist in any collective
  * component.
  */
-struct mca_coll_base_component_2_4_0_t {
+struct mca_coll_base_component_3_0_0_t {
     /** Base component description */
     mca_base_component_t collm_version;
     /** Base component data block */
@@ -502,14 +502,14 @@ struct mca_coll_base_component_2_4_0_t {
     /** Component initialization function */
     mca_coll_base_component_init_query_fn_t collm_init_query;
     /** Query whether component is usable for given communicator */
-    mca_coll_base_component_comm_query_2_4_0_fn_t collm_comm_query;
+    mca_coll_base_component_comm_query_3_0_0_fn_t collm_comm_query;
 };
-typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_2_4_0_t;
+typedef struct mca_coll_base_component_3_0_0_t mca_coll_base_component_3_0_0_t;
 
 /** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
     interface. */
-typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
+typedef struct mca_coll_base_component_3_0_0_t mca_coll_base_component_t;
 
 
 /**
@@ -526,7 +526,7 @@ typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
  * function, so the component is free to create a structure that
  * inherits from this one for use as the module structure.
  */
-struct mca_coll_base_module_2_4_0_t {
+struct mca_coll_base_module_3_0_0_t {
     /** Collective modules all inherit from opal_object */
     opal_object_t super;
 
@@ -628,12 +628,12 @@ struct mca_coll_base_module_2_4_0_t {
         not be used by other modules */
     struct mca_coll_base_comm_t* base_data;
 };
-typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_2_4_0_t;
+typedef struct mca_coll_base_module_3_0_0_t mca_coll_base_module_3_0_0_t;
 
 /** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
     interface. */
-typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_t;
+typedef struct mca_coll_base_module_3_0_0_t mca_coll_base_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_module_t);
 
 /**
@@ -649,155 +649,155 @@ struct mca_coll_base_comm_coll_t {
 
     /* blocking collectives */
     mca_coll_base_module_allgather_fn_t coll_allgather;
-    mca_coll_base_module_2_4_0_t *coll_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_allgatherv_module;
     mca_coll_base_module_allreduce_fn_t coll_allreduce;
-    mca_coll_base_module_2_4_0_t *coll_allreduce_module;
+    mca_coll_base_module_3_0_0_t *coll_allreduce_module;
     mca_coll_base_module_alltoall_fn_t coll_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallv_module;
     mca_coll_base_module_alltoallw_fn_t coll_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallw_module;
     mca_coll_base_module_barrier_fn_t coll_barrier;
-    mca_coll_base_module_2_4_0_t *coll_barrier_module;
+    mca_coll_base_module_3_0_0_t *coll_barrier_module;
     mca_coll_base_module_bcast_fn_t coll_bcast;
-    mca_coll_base_module_2_4_0_t *coll_bcast_module;
+    mca_coll_base_module_3_0_0_t *coll_bcast_module;
     mca_coll_base_module_exscan_fn_t coll_exscan;
-    mca_coll_base_module_2_4_0_t *coll_exscan_module;
+    mca_coll_base_module_3_0_0_t *coll_exscan_module;
     mca_coll_base_module_gather_fn_t coll_gather;
-    mca_coll_base_module_2_4_0_t *coll_gather_module;
+    mca_coll_base_module_3_0_0_t *coll_gather_module;
     mca_coll_base_module_gatherv_fn_t coll_gatherv;
-    mca_coll_base_module_2_4_0_t *coll_gatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_gatherv_module;
     mca_coll_base_module_reduce_fn_t coll_reduce;
-    mca_coll_base_module_2_4_0_t *coll_reduce_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_module;
     mca_coll_base_module_reduce_scatter_fn_t coll_reduce_scatter;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_module;
     mca_coll_base_module_reduce_scatter_block_fn_t coll_reduce_scatter_block;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_block_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_block_module;
     mca_coll_base_module_scan_fn_t coll_scan;
-    mca_coll_base_module_2_4_0_t *coll_scan_module;
+    mca_coll_base_module_3_0_0_t *coll_scan_module;
     mca_coll_base_module_scatter_fn_t coll_scatter;
-    mca_coll_base_module_2_4_0_t *coll_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_scatter_module;
     mca_coll_base_module_scatterv_fn_t coll_scatterv;
-    mca_coll_base_module_2_4_0_t *coll_scatterv_module;
+    mca_coll_base_module_3_0_0_t *coll_scatterv_module;
 
     /* nonblocking collectives */
     mca_coll_base_module_iallgather_fn_t coll_iallgather;
-    mca_coll_base_module_2_4_0_t *coll_iallgather_module;
+    mca_coll_base_module_3_0_0_t *coll_iallgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_iallgatherv;
-    mca_coll_base_module_2_4_0_t *coll_iallgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_iallgatherv_module;
     mca_coll_base_module_iallreduce_fn_t coll_iallreduce;
-    mca_coll_base_module_2_4_0_t *coll_iallreduce_module;
+    mca_coll_base_module_3_0_0_t *coll_iallreduce_module;
     mca_coll_base_module_ialltoall_fn_t coll_ialltoall;
-    mca_coll_base_module_2_4_0_t *coll_ialltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ialltoallv;
-    mca_coll_base_module_2_4_0_t *coll_ialltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoallv_module;
     mca_coll_base_module_ialltoallw_fn_t coll_ialltoallw;
-    mca_coll_base_module_2_4_0_t *coll_ialltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoallw_module;
     mca_coll_base_module_ibarrier_fn_t coll_ibarrier;
-    mca_coll_base_module_2_4_0_t *coll_ibarrier_module;
+    mca_coll_base_module_3_0_0_t *coll_ibarrier_module;
     mca_coll_base_module_ibcast_fn_t coll_ibcast;
-    mca_coll_base_module_2_4_0_t *coll_ibcast_module;
+    mca_coll_base_module_3_0_0_t *coll_ibcast_module;
     mca_coll_base_module_iexscan_fn_t coll_iexscan;
-    mca_coll_base_module_2_4_0_t *coll_iexscan_module;
+    mca_coll_base_module_3_0_0_t *coll_iexscan_module;
     mca_coll_base_module_igather_fn_t coll_igather;
-    mca_coll_base_module_2_4_0_t *coll_igather_module;
+    mca_coll_base_module_3_0_0_t *coll_igather_module;
     mca_coll_base_module_igatherv_fn_t coll_igatherv;
-    mca_coll_base_module_2_4_0_t *coll_igatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_igatherv_module;
     mca_coll_base_module_ireduce_fn_t coll_ireduce;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_module;
     mca_coll_base_module_ireduce_scatter_fn_t coll_ireduce_scatter;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_scatter_module;
     mca_coll_base_module_ireduce_scatter_block_fn_t coll_ireduce_scatter_block;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_scatter_block_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_scatter_block_module;
     mca_coll_base_module_iscan_fn_t coll_iscan;
-    mca_coll_base_module_2_4_0_t *coll_iscan_module;
+    mca_coll_base_module_3_0_0_t *coll_iscan_module;
     mca_coll_base_module_iscatter_fn_t coll_iscatter;
-    mca_coll_base_module_2_4_0_t *coll_iscatter_module;
+    mca_coll_base_module_3_0_0_t *coll_iscatter_module;
     mca_coll_base_module_iscatterv_fn_t coll_iscatterv;
-    mca_coll_base_module_2_4_0_t *coll_iscatterv_module;
+    mca_coll_base_module_3_0_0_t *coll_iscatterv_module;
 
     /* persistent collectives */
     mca_coll_base_module_allgather_init_fn_t coll_allgather_init;
-    mca_coll_base_module_2_4_0_t *coll_allgather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allgather_init_module;
     mca_coll_base_module_allgatherv_init_fn_t coll_allgatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_allgatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allgatherv_init_module;
     mca_coll_base_module_allreduce_init_fn_t coll_allreduce_init;
-    mca_coll_base_module_2_4_0_t *coll_allreduce_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allreduce_init_module;
     mca_coll_base_module_alltoall_init_fn_t coll_alltoall_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoall_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoall_init_module;
     mca_coll_base_module_alltoallv_init_fn_t coll_alltoallv_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoallv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallv_init_module;
     mca_coll_base_module_alltoallw_init_fn_t coll_alltoallw_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoallw_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallw_init_module;
     mca_coll_base_module_barrier_init_fn_t coll_barrier_init;
-    mca_coll_base_module_2_4_0_t *coll_barrier_init_module;
+    mca_coll_base_module_3_0_0_t *coll_barrier_init_module;
     mca_coll_base_module_bcast_init_fn_t coll_bcast_init;
-    mca_coll_base_module_2_4_0_t *coll_bcast_init_module;
+    mca_coll_base_module_3_0_0_t *coll_bcast_init_module;
     mca_coll_base_module_exscan_init_fn_t coll_exscan_init;
-    mca_coll_base_module_2_4_0_t *coll_exscan_init_module;
+    mca_coll_base_module_3_0_0_t *coll_exscan_init_module;
     mca_coll_base_module_gather_init_fn_t coll_gather_init;
-    mca_coll_base_module_2_4_0_t *coll_gather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_gather_init_module;
     mca_coll_base_module_gatherv_init_fn_t coll_gatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_gatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_gatherv_init_module;
     mca_coll_base_module_reduce_init_fn_t coll_reduce_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_init_module;
     mca_coll_base_module_reduce_scatter_init_fn_t coll_reduce_scatter_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_init_module;
     mca_coll_base_module_reduce_scatter_block_init_fn_t coll_reduce_scatter_block_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_block_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_block_init_module;
     mca_coll_base_module_scan_init_fn_t coll_scan_init;
-    mca_coll_base_module_2_4_0_t *coll_scan_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scan_init_module;
     mca_coll_base_module_scatter_init_fn_t coll_scatter_init;
-    mca_coll_base_module_2_4_0_t *coll_scatter_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scatter_init_module;
     mca_coll_base_module_scatterv_init_fn_t coll_scatterv_init;
-    mca_coll_base_module_2_4_0_t *coll_scatterv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scatterv_init_module;
 
     /* blocking neighborhood collectives */
     mca_coll_base_module_allgather_fn_t coll_neighbor_allgather;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_neighbor_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgatherv_module;
     mca_coll_base_module_alltoall_fn_t coll_neighbor_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_neighbor_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallv_module;
     mca_coll_base_module_neighbor_alltoallw_fn_t coll_neighbor_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallw_module;
 
     /* nonblocking neighborhood collectives */
     mca_coll_base_module_iallgather_fn_t coll_ineighbor_allgather;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_allgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_ineighbor_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_allgatherv_module;
     mca_coll_base_module_ialltoall_fn_t coll_ineighbor_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ineighbor_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoallv_module;
     mca_coll_base_module_ineighbor_alltoallw_fn_t coll_ineighbor_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoallw_module;
 
     /* persistent neighborhood collectives */
     mca_coll_base_module_allgather_init_fn_t coll_neighbor_allgather_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgather_init_module;
     mca_coll_base_module_allgatherv_init_fn_t coll_neighbor_allgatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgatherv_init_module;
     mca_coll_base_module_alltoall_init_fn_t coll_neighbor_alltoall_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoall_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoall_init_module;
     mca_coll_base_module_alltoallv_init_fn_t coll_neighbor_alltoallv_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallv_init_module;
     mca_coll_base_module_neighbor_alltoallw_init_fn_t coll_neighbor_alltoallw_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallw_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallw_init_module;
 
     mca_coll_base_module_reduce_local_fn_t coll_reduce_local;
-    mca_coll_base_module_2_4_0_t *coll_reduce_local_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_local_module;
 
     mca_coll_base_module_agree_fn_t coll_agree;
-    mca_coll_base_module_2_4_0_t *coll_agree_module;
+    mca_coll_base_module_3_0_0_t *coll_agree_module;
     mca_coll_base_module_iagree_fn_t coll_iagree;
-    mca_coll_base_module_2_4_0_t *coll_iagree_module;
+    mca_coll_base_module_3_0_0_t *coll_iagree_module;
 
     /* List of modules initialized, queried and enabled */
     opal_list_t *module_list;
@@ -811,8 +811,8 @@ typedef struct mca_coll_base_comm_coll_t mca_coll_base_comm_coll_t;
 /*
  * Macro for use in components that are of type coll
  */
-#define MCA_COLL_BASE_VERSION_2_4_0 \
-    OMPI_MCA_BASE_VERSION_2_1_0("coll", 2, 4, 0)
+#define MCA_COLL_BASE_VERSION_3_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("coll", 3, 0, 0)
 
 
 /* ******************************************************************** */

--- a/ompi/mca/coll/demo/coll_demo.h
+++ b/ompi/mca/coll/demo/coll_demo.h
@@ -30,7 +30,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_demo_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_demo_component;
     extern int mca_coll_demo_priority;
     extern int mca_coll_demo_verbose;
 
@@ -47,78 +47,78 @@ mca_coll_demo_comm_query(struct ompi_communicator_t *comm, int *priority);
 int mca_coll_demo_module_enable(mca_coll_base_module_t *module,
                                 struct ompi_communicator_t *comm);
 
-    int mca_coll_demo_allgather_intra(void *sbuf, int scount,
+    int mca_coll_demo_allgather_intra(void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_allgather_inter(void *sbuf, int scount,
+    int mca_coll_demo_allgather_inter(void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_demo_allgatherv_intra(void *sbuf, int scount,
+    int mca_coll_demo_allgatherv_intra(void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void * rbuf, int *rcounts, int *disps,
+                                       void * rbuf, size_t *rcounts, ptrdiff_t *disps,
                                        struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-    int mca_coll_demo_allgatherv_inter(void *sbuf, int scount,
+    int mca_coll_demo_allgatherv_inter(void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void * rbuf, int *rcounts, int *disps,
+                                       void * rbuf, size_t *rcounts, ptrdiff_t *disps,
                                        struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_demo_allreduce_intra(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_allreduce_intra(void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_allreduce_inter(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_allreduce_inter(void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_demo_alltoall_intra(void *sbuf, int scount,
+    int mca_coll_demo_alltoall_intra(void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
-    int mca_coll_demo_alltoall_inter(void *sbuf, int scount,
+    int mca_coll_demo_alltoall_inter(void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-    int mca_coll_demo_alltoallv_intra(void *sbuf, int *scounts, int *sdisps,
+    int mca_coll_demo_alltoallv_intra(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int *rcounts, int *rdisps,
+                                      void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_alltoallv_inter(void *sbuf, int *scounts, int *sdisps,
+    int mca_coll_demo_alltoallv_inter(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int *rcounts, int *rdisps,
+                                      void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_demo_alltoallw_intra(void *sbuf, int *scounts, int *sdisps,
+    int mca_coll_demo_alltoallw_intra(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                       struct ompi_datatype_t **sdtypes,
-                                      void *rbuf, int *rcounts, int *rdisps,
+                                      void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                       struct ompi_datatype_t **rdtypes,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_alltoallw_inter(void *sbuf, int *scounts, int *sdisps,
+    int mca_coll_demo_alltoallw_inter(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                       struct ompi_datatype_t **sdtypes,
-                                      void *rbuf, int *rcounts, int *rdisps,
+                                      void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                       struct ompi_datatype_t **rdtypes,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
@@ -128,59 +128,59 @@ int mca_coll_demo_module_enable(mca_coll_base_module_t *module,
     int mca_coll_demo_barrier_inter(struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_demo_bcast_intra(void *buff, int count,
+    int mca_coll_demo_bcast_intra(void *buff, size_t count,
                                   struct ompi_datatype_t *datatype,
                                   int root,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-    int mca_coll_demo_bcast_inter(void *buff, int count,
+    int mca_coll_demo_bcast_inter(void *buff, size_t count,
                                   struct ompi_datatype_t *datatype,
                                   int root,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 
-    int mca_coll_demo_exscan_intra(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_exscan_intra(void *sbuf, void *rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_exscan_inter(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_exscan_inter(void *sbuf, void *rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
-    int mca_coll_demo_gather_intra(void *sbuf, int scount,
+    int mca_coll_demo_gather_intra(void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                   int rcount, struct ompi_datatype_t *rdtype,
+                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                    int root, struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_gather_inter(void *sbuf, int scount,
+    int mca_coll_demo_gather_inter(void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                   int rcount, struct ompi_datatype_t *rdtype,
+                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                    int root, struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
-    int mca_coll_demo_gatherv_intra(void *sbuf, int scount,
+    int mca_coll_demo_gatherv_intra(void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int *rcounts, int *disps,
+                                    size_t *rcounts, ptrdiff_t *disps,
                                     struct ompi_datatype_t *rdtype, int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-    int mca_coll_demo_gatherv_inter(void *sbuf, int scount,
+    int mca_coll_demo_gatherv_inter(void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int *rcounts, int *disps,
+                                    size_t *rcounts, ptrdiff_t *disps,
                                     struct ompi_datatype_t *rdtype, int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_demo_reduce_intra(void *sbuf, void* rbuf, int count,
+    int mca_coll_demo_reduce_intra(void *sbuf, void* rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    int root,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_reduce_inter(void *sbuf, void* rbuf, int count,
+    int mca_coll_demo_reduce_inter(void *sbuf, void* rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    int root,
@@ -188,49 +188,49 @@ int mca_coll_demo_module_enable(mca_coll_base_module_t *module,
                                    mca_coll_base_module_t *module);
 
     int mca_coll_demo_reduce_scatter_intra(void *sbuf, void *rbuf,
-                                           int *rcounts,
+                                           size_t *rcounts,
                                            struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module);
     int mca_coll_demo_reduce_scatter_inter(void *sbuf, void *rbuf,
-                                           int *rcounts,
+                                           size_t *rcounts,
                                            struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module);
 
-    int mca_coll_demo_scan_intra(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_scan_intra(void *sbuf, void *rbuf, size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-    int mca_coll_demo_scan_inter(void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_scan_inter(void *sbuf, void *rbuf, size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 
-    int mca_coll_demo_scatter_intra(void *sbuf, int scount,
+    int mca_coll_demo_scatter_intra(void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int rcount, struct ompi_datatype_t *rdtype,
+                                    size_t rcount, struct ompi_datatype_t *rdtype,
                                     int root, struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-    int mca_coll_demo_scatter_inter(void *sbuf, int scount,
+    int mca_coll_demo_scatter_inter(void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int rcount, struct ompi_datatype_t *rdtype,
+                                    size_t rcount, struct ompi_datatype_t *rdtype,
                                     int root, struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_demo_scatterv_intra(void *sbuf, int *scounts, int *disps,
+    int mca_coll_demo_scatterv_intra(void *sbuf, size_t *scounts, ptrdiff_t *disps,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype, int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
-    int mca_coll_demo_scatterv_inter(void *sbuf, int *scounts, int *disps,
+    int mca_coll_demo_scatterv_inter(void *sbuf, size_t *scounts, ptrdiff_t *disps,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype, int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);

--- a/ompi/mca/coll/demo/coll_demo_allgather.c
+++ b/ompi/mca/coll/demo/coll_demo_allgather.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgather_intra(void *sbuf, int scount,
+int mca_coll_demo_allgather_intra(void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                  int rcount, struct ompi_datatype_t *rdtype,
+                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
 {
@@ -54,9 +54,9 @@ int mca_coll_demo_allgather_intra(void *sbuf, int scount,
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgather_inter(void *sbuf, int scount,
+int mca_coll_demo_allgather_inter(void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_allgatherv.c
+++ b/ompi/mca/coll/demo/coll_demo_allgatherv.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Allgatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgatherv_intra(void *sbuf, int scount,
+int mca_coll_demo_allgatherv_intra(void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void * rbuf, int *rcounts, int *disps,
+                                   void * rbuf, size_t *rcounts, ptrdiff_t *disps,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_allgatherv_intra(void *sbuf, int scount,
  *	Accepts:	- same as MPI_Allgatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgatherv_inter(void *sbuf, int scount,
+int mca_coll_demo_allgatherv_inter(void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void * rbuf, int *rcounts, int *disps,
+                                    void * rbuf, size_t *rcounts, ptrdiff_t *disps,
                                     struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_allreduce.c
+++ b/ompi/mca/coll/demo/coll_demo_allreduce.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allreduce_intra(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_allreduce_intra(void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -54,7 +54,7 @@ int mca_coll_demo_allreduce_intra(void *sbuf, void *rbuf, int count,
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allreduce_inter(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_allreduce_inter(void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_alltoall.c
+++ b/ompi/mca/coll/demo/coll_demo_alltoall.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoall_intra(void *sbuf, int scount,
+int mca_coll_demo_alltoall_intra(void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_alltoall_intra(void *sbuf, int scount,
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoall_inter(void *sbuf, int scount,
+int mca_coll_demo_alltoall_inter(void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_alltoallv.c
+++ b/ompi/mca/coll/demo/coll_demo_alltoallv.c
@@ -34,9 +34,9 @@
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_demo_alltoallv_intra(void *sbuf, int *scounts, int *sdisps,
+mca_coll_demo_alltoallv_intra(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, int *rcounts, int *rdisps,
+                              void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)
@@ -58,9 +58,9 @@ mca_coll_demo_alltoallv_intra(void *sbuf, int *scounts, int *sdisps,
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_demo_alltoallv_inter(void *sbuf, int *scounts, int *sdisps,
+mca_coll_demo_alltoallv_inter(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                               struct ompi_datatype_t *sdtype, void *rbuf,
-                              int *rcounts, int *rdisps,
+                              size_t *rcounts, ptrdiff_t *rdisps,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_alltoallw.c
+++ b/ompi/mca/coll/demo/coll_demo_alltoallw.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Alltoallw()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoallw_intra(void *sbuf, int *scounts, int *sdisps,
+int mca_coll_demo_alltoallw_intra(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                   struct ompi_datatype_t **sdtypes,
-                                  void *rbuf, int *rcounts, int *rdisps,
+                                  void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                   struct ompi_datatype_t **rdtypes,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_alltoallw_intra(void *sbuf, int *scounts, int *sdisps,
  *	Accepts:	- same as MPI_Alltoallw()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoallw_inter(void *sbuf, int *scounts, int *sdisps,
+int mca_coll_demo_alltoallw_inter(void *sbuf, size_t *scounts, ptrdiff_t *sdisps,
                                   struct ompi_datatype_t **sdtypes,
-                                  void *rbuf, int *rcounts, int *rdisps,
+                                  void *rbuf, size_t *rcounts, ptrdiff_t *rdisps,
                                   struct ompi_datatype_t **rdtypes,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_bcast.c
+++ b/ompi/mca/coll/demo/coll_demo_bcast.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_bcast_intra(void *buff, int count,
+int mca_coll_demo_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)
@@ -53,7 +53,7 @@ int mca_coll_demo_bcast_intra(void *buff, int count,
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_bcast_inter(void *buff, int count,
+int mca_coll_demo_bcast_inter(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_component.c
+++ b/ompi/mca/coll/demo/coll_demo_component.c
@@ -55,7 +55,7 @@ static int demo_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_demo_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_demo_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */

--- a/ompi/mca/coll/demo/coll_demo_exscan.c
+++ b/ompi/mca/coll/demo/coll_demo_exscan.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same arguments as MPI_Exscan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_exscan_intra(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_exscan_intra(void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_gather.c
+++ b/ompi/mca/coll/demo/coll_demo_gather.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gather_intra(void *sbuf, int scount,
+int mca_coll_demo_gather_intra(void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -55,9 +55,9 @@ int mca_coll_demo_gather_intra(void *sbuf, int scount,
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gather_inter(void *sbuf, int scount,
+int mca_coll_demo_gather_inter(void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_gatherv.c
+++ b/ompi/mca/coll/demo/coll_demo_gatherv.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same arguments as MPI_Gatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gatherv_intra(void *sbuf, int scount,
+int mca_coll_demo_gatherv_intra(void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int *rcounts, int *disps,
+                                void *rbuf, size_t *rcounts, ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_gatherv_intra(void *sbuf, int scount,
  *	Accepts:	- same arguments as MPI_Gatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gatherv_inter(void *sbuf, int scount,
+int mca_coll_demo_gatherv_inter(void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int *rcounts, int *disps,
+                                void *rbuf, size_t *rcounts, ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_reduce.c
+++ b/ompi/mca/coll/demo/coll_demo_reduce.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_intra(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_reduce_intra(void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,
@@ -54,7 +54,7 @@ int mca_coll_demo_reduce_intra(void *sbuf, void *rbuf, int count,
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_inter(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_reduce_inter(void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_reduce_scatter.c
+++ b/ompi/mca/coll/demo/coll_demo_reduce_scatter.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_scatter_intra(void *sbuf, void *rbuf, int *rcounts,
+int mca_coll_demo_reduce_scatter_intra(void *sbuf, void *rbuf, size_t *rcounts,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
@@ -54,7 +54,7 @@ int mca_coll_demo_reduce_scatter_intra(void *sbuf, void *rbuf, int *rcounts,
  *	Accepts:	- same arguments as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_scatter_inter(void *sbuf, void *rbuf, int *rcounts,
+int mca_coll_demo_reduce_scatter_inter(void *sbuf, void *rbuf, size_t *rcounts,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_scan.c
+++ b/ompi/mca/coll/demo/coll_demo_scan.c
@@ -33,7 +33,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scan_intra(void *sbuf, void *rbuf, int count,
+int mca_coll_demo_scan_intra(void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_scatter.c
+++ b/ompi/mca/coll/demo/coll_demo_scatter.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatter_intra(void *sbuf, int scount,
+int mca_coll_demo_scatter_intra(void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,
@@ -57,9 +57,9 @@ int mca_coll_demo_scatter_intra(void *sbuf, int scount,
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatter_inter(void *sbuf, int scount,
+int mca_coll_demo_scatter_inter(void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_scatterv.c
+++ b/ompi/mca/coll/demo/coll_demo_scatterv.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatterv_intra(void *sbuf, int *scounts,
-                                 int *disps, struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+int mca_coll_demo_scatterv_intra(void *sbuf, size_t *scounts,
+                                 ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype, int root,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_scatterv_intra(void *sbuf, int *scounts,
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatterv_inter(void *sbuf, int *scounts,
-                                 int *disps, struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+int mca_coll_demo_scatterv_inter(void *sbuf, size_t *scounts,
+                                 ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype, int root,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ftagree/coll_ftagree.h
+++ b/ompi/mca/coll/ftagree/coll_ftagree.h
@@ -32,7 +32,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t
 mca_coll_ftagree_component;
 extern int mca_coll_ftagree_priority;
 
@@ -108,7 +108,7 @@ int mca_coll_ftagree_module_enable(mca_coll_base_module_t *module,
 /* Early termination algorithm */
 int
 mca_coll_ftagree_eta_intra(     void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
@@ -117,14 +117,14 @@ mca_coll_ftagree_eta_intra(     void* contrib,
 /* Early returning algorithm */
 int
 mca_coll_ftagree_era_intra(     void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
                                 ompi_communicator_t* comm,
                                 mca_coll_base_module_t *module);
 int mca_coll_ftagree_iera_intra(void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
@@ -132,7 +132,7 @@ int mca_coll_ftagree_iera_intra(void* contrib,
                                 ompi_request_t **request,
                                 mca_coll_base_module_t *module);
 int mca_coll_ftagree_era_inter( void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,

--- a/ompi/mca/coll/ftagree/coll_ftagree_component.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_component.c
@@ -48,13 +48,13 @@ static int ftagree_close(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_ftagree_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_ftagree_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     {
-     MCA_COLL_BASE_VERSION_2_4_0,
+     MCA_COLL_BASE_VERSION_3_0_0,
 
      /* Component name and version */
      "ftagree",

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -119,7 +119,7 @@ typedef struct {
                                               *   min over all ranks. */
     int      operand;                        /**< operand applied on bytes.
                                               *   One of OMPI_OP_BASE_FORTRAN_* values in mca/op/op.h */
-    int      dt_count;                       /**< The number of datatypes in bytes */
+    size_t   dt_count;                       /**< The number of datatypes in bytes */
     int      datatype;                       /**< Fortran index of predefined basic datatype in bytes */
     int      nb_new_dead;                    /**< Number of newly discovered dead */
 } era_value_header_t;
@@ -3018,7 +3018,7 @@ static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
                                                             ompi_group_t *group,
                                                             ompi_op_t *op,
                                                             ompi_datatype_t *dt,
-                                                            int dt_count,
+                                                            size_t dt_count,
                                                             void *contrib,
                                                             mca_coll_base_module_t *module,
                                                             era_identifier_t *paid,
@@ -3187,7 +3187,7 @@ static int mca_coll_ftagree_era_complete_agreement(era_identifier_t agreement_id
  * Returns:	- MPI_SUCCESS or an MPI error code
  */
 int mca_coll_ftagree_era_intra(void *contrib,
-                                         int dt_count,
+                                         size_t dt_count,
                                          ompi_datatype_t *dt,
                                          ompi_op_t *op,
                                          ompi_group_t **group, bool grp_update,
@@ -3214,7 +3214,7 @@ int mca_coll_ftagree_era_intra(void *contrib,
  * Returns:	- MPI_SUCCESS or an MPI error code
  */
 int mca_coll_ftagree_era_inter(void *contrib,
-                                         int dt_count,
+                                         size_t dt_count,
                                          ompi_datatype_t *dt,
                                          ompi_op_t *op,
                                          ompi_group_t **group, bool grp_update,
@@ -3310,7 +3310,7 @@ static int era_iagree_req_complete_cb(struct ompi_request_t* request)
 }
 
 int mca_coll_ftagree_iera_intra(void *contrib,
-                                          int dt_count,
+                                          size_t dt_count,
                                           ompi_datatype_t *dt,
                                           ompi_op_t *op,
                                           ompi_group_t **group, bool grp_update,

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
@@ -62,7 +62,7 @@ typedef struct {
 
 int
 mca_coll_ftagree_eta_intra(void *contrib,
-                           int dt_count,
+                           size_t dt_count,
                            ompi_datatype_t *dt,
                            ompi_op_t *op,
                            ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -122,8 +122,8 @@ struct mca_coll_han_scatter_args_s {
     void *rbuf;
     ompi_datatype_t *sdtype;
     ompi_datatype_t *rdtype;
-    int scount;
-    int rcount;
+    size_t scount;
+    size_t rcount;
     int root;
     int root_up_rank;
     int root_low_rank;
@@ -163,8 +163,8 @@ struct mca_coll_han_allgather_s {
     void *rbuf;
     ompi_datatype_t *sdtype;
     ompi_datatype_t *rdtype;
-    int scount;
-    int rcount;
+    size_t scount;
+    size_t rcount;
     int root_low_rank;
     int w_rank;
     bool noop;
@@ -204,7 +204,7 @@ typedef struct mca_coll_han_op_module_name_t {
  */
 typedef struct mca_coll_han_component_t {
     /** Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /** MCA parameter: Priority of this component */
     int han_priority;
@@ -516,7 +516,7 @@ int mca_coll_han_barrier_intra_simple(struct ompi_communicator_t *comm,
 /* reordering after gather, for unordered ranks */
 void
 ompi_coll_han_reorder_gather(const void *sbuf,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              int * topo);

--- a/ompi/mca/coll/han/coll_han_algorithms.h
+++ b/ompi/mca/coll/han/coll_han_algorithms.h
@@ -74,19 +74,19 @@ int mca_coll_han_barrier_intra_simple(struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 /* Bcast */
 int mca_coll_han_bcast_intra_simple(void *buff,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-int mca_coll_han_bcast_intra(void *buff, int count, struct ompi_datatype_t *dtype, int root,
+int mca_coll_han_bcast_intra(void *buff, size_t count, struct ompi_datatype_t *dtype, int root,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 
 /* Reduce */
 int
 mca_coll_han_reduce_intra_simple(const void *sbuf,
                                  void* rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  ompi_op_t *op,
                                  int root,
@@ -98,7 +98,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_reduce_reproducible(const void *sbuf,
                                  void *rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  int root,
@@ -107,7 +107,7 @@ mca_coll_han_reduce_reproducible(const void *sbuf,
 
 int mca_coll_han_reduce_intra(const void *sbuf,
                               void *rbuf,
-                              int count,
+                              size_t count,
                               struct ompi_datatype_t *dtype,
                               ompi_op_t* op,
                               int root,
@@ -118,7 +118,7 @@ int mca_coll_han_reduce_intra(const void *sbuf,
 int
 mca_coll_han_allreduce_intra_simple(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -129,7 +129,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_allreduce_reproducible(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -137,23 +137,23 @@ mca_coll_han_allreduce_reproducible(const void *sbuf,
 
 int mca_coll_han_allreduce_intra(const void *sbuf,
                                  void *rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 
 /* Scatter */
 int
-mca_coll_han_scatter_intra(const void *sbuf, int scount,
+mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,
                            struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,
@@ -161,9 +161,9 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
 
 /* Scatterv */
 int
-mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts,
-                            const int *displs, struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+mca_coll_han_scatterv_intra(const void *sbuf, const size_t *scounts,
+                            const ptrdiff_t *displs, struct ompi_datatype_t *sdtype,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype, 
                             int root,
                             struct ompi_communicator_t *comm,
@@ -171,16 +171,16 @@ mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts,
 
 /* Gather */
 int
-mca_coll_han_gather_intra(const void *sbuf, int scount,
+mca_coll_han_gather_intra(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -188,22 +188,22 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
 
 /* Gatherv */
 int
-mca_coll_han_gatherv_intra(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void *rbuf, const int *rcounts, const int *displs,
+mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void *rbuf, const size_t *rcounts, const ptrdiff_t *displs,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
 /* Allgather */
 int
-mca_coll_han_allgather_intra(const void *sbuf, int scount,
+mca_coll_han_allgather_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void* rbuf, int rcount,
+                                    void* rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -32,10 +32,10 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
                                 mca_coll_task_t * cur_task,
                                 void *sbuf,
                                 void *sbuf_inter_free,
-                                int scount,
+                                size_t scount,
                                 struct ompi_datatype_t *sdtype,
                                 void *rbuf,
-                                int rcount,
+                                size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root_low_rank,
                                 struct ompi_communicator_t *up_comm,
@@ -69,9 +69,9 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
  * Main function for taskified allgather: calls lg task, a gather on low comm
  */
 int
-mca_coll_han_allgather_intra(const void *sbuf, int scount,
+mca_coll_han_allgather_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t * module)
@@ -292,9 +292,9 @@ int mca_coll_han_allgather_lb_task(void *task_args)
  * communications without tasks.
  */
 int
-mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void* rbuf, int rcount,
+                                    void* rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module){

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -90,7 +90,7 @@ mca_coll_han_set_allreduce_args(mca_coll_han_allreduce_args_t * args,
 int
 mca_coll_han_allreduce_intra(const void *sbuf,
                              void *rbuf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -132,7 +132,7 @@ mca_coll_han_allreduce_intra(const void *sbuf,
 
     /* Determine number of elements sent per task. */
     OPAL_OUTPUT_VERBOSE((10, mca_coll_han_component.han_output,
-                         "In HAN Allreduce seg_size %d seg_count %d count %d\n",
+                         "In HAN Allreduce seg_size %d seg_count %d count %zu\n",
                          mca_coll_han_component.han_allreduce_segsize, seg_count, count));
     int num_segments = (count + seg_count - 1) / seg_count;
 
@@ -464,7 +464,7 @@ int mca_coll_han_allreduce_t3_task(void *task_args)
 int
 mca_coll_han_allreduce_intra_simple(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -611,7 +611,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_allreduce_reproducible(const void *sbuf,
                                     void *rbuf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -64,7 +64,7 @@ mca_coll_han_set_bcast_args(mca_coll_han_bcast_args_t * args, mca_coll_task_t * 
  */
 int
 mca_coll_han_bcast_intra(void *buf,
-                         int count,
+                         size_t count,
                          struct ompi_datatype_t *dtype,
                          int root,
                          struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -112,7 +112,7 @@ mca_coll_han_bcast_intra(void *buf,
 
     int num_segments = (count + seg_count - 1) / seg_count;
     OPAL_OUTPUT_VERBOSE((20, mca_coll_han_component.han_output,
-                         "In HAN seg_count %d count %d num_seg %d\n",
+                         "In HAN seg_count %d count %zu num_seg %d\n",
                          seg_count, count, num_segments));
 
     int *vranks = han_module->cached_vranks;
@@ -223,7 +223,7 @@ int mca_coll_han_bcast_t1_task(void *task_args)
  */
 int
 mca_coll_han_bcast_intra_simple(void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *dtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -65,7 +65,7 @@ mca_coll_han_component_t mca_coll_han_component = {
            information about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "han",

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -372,9 +372,9 @@ get_algorithm(COLLTYPE_T coll_id,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_allgather_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_dynamic(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, int rcount,
+                                     void *rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module)
@@ -486,10 +486,10 @@ mca_coll_han_allgather_intra_dynamic(const void *sbuf, int scount,
  * The allgatherv size is the size of the biggest segment
  */
 int
-mca_coll_han_allgatherv_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_allgatherv_intra_dynamic(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, const int *rcounts,
-                                      const int *displs,
+                                      void *rbuf, const size_t *rcounts,
+                                      const ptrdiff_t *displs,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
@@ -605,7 +605,7 @@ mca_coll_han_allgatherv_intra_dynamic(const void *sbuf, int scount,
 int
 mca_coll_han_allreduce_intra_dynamic(const void *sbuf,
                                      void *rbuf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
@@ -820,7 +820,7 @@ mca_coll_han_barrier_intra_dynamic(struct ompi_communicator_t *comm,
  */
 int
 mca_coll_han_bcast_intra_dynamic(void *buff,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -934,9 +934,9 @@ mca_coll_han_bcast_intra_dynamic(void *buff,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_gather_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_gather_intra_dynamic(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,
@@ -1055,8 +1055,10 @@ mca_coll_han_gather_intra_dynamic(const void *sbuf, int scount,
  * On the global communicator, calls the han collective implementation, or
  * calls the correct module if fallback mechanism is activated
  */
-int mca_coll_han_gatherv_intra_dynamic(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                       void *rbuf, const int *rcounts, const int *displs,
+int mca_coll_han_gatherv_intra_dynamic(const void *sbuf, size_t scount,
+                                       struct ompi_datatype_t *sdtype,
+                                       void *rbuf, const size_t *rcounts,
+                                       const ptrdiff_t *displs,
                                        struct ompi_datatype_t *rdtype, int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
@@ -1156,7 +1158,7 @@ int mca_coll_han_gatherv_intra_dynamic(const void *sbuf, int scount, struct ompi
 int
 mca_coll_han_reduce_intra_dynamic(const void *sbuf,
                                   void *rbuf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   int root,
@@ -1276,9 +1278,9 @@ mca_coll_han_reduce_intra_dynamic(const void *sbuf,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_scatter_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_dynamic(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void *rbuf, int rcount,
+                                   void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *rdtype,
                                    int root,
                                    struct ompi_communicator_t *comm,
@@ -1407,9 +1409,9 @@ mca_coll_han_scatter_intra_dynamic(const void *sbuf, int scount,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_scatterv_intra_dynamic(const void *sbuf, const int *scounts,
-                                    const int *displs, struct ompi_datatype_t *sdtype,
-                                    void *rbuf, int rcount,
+mca_coll_han_scatterv_intra_dynamic(const void *sbuf, const size_t *scounts,
+                                    const ptrdiff_t *displs, struct ompi_datatype_t *sdtype,
+                                    void *rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype, 
                                     int root,
                                     struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -35,10 +35,10 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
                              mca_coll_task_t * cur_task,
                              void *sbuf,
                              void *sbuf_inter_free,
-                             int scount,
+                             size_t scount,
                              struct ompi_datatype_t *sdtype,
                              void *rbuf,
-                             int rcount,
+                             size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root,
                              int root_up_rank,
@@ -71,9 +71,9 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
  * Main function for taskified gather: calls lg task, a gather on low comm
  */
 int
-mca_coll_han_gather_intra(const void *sbuf, int scount,
+mca_coll_han_gather_intra(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -302,9 +302,9 @@ int mca_coll_han_gather_ug_task(void *task_args)
 
 /* only work with regular situation (each node has equal number of processes) */
 int
-mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -452,7 +452,7 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
  */
 void
 ompi_coll_han_reorder_gather(const void *sbuf,
-                             void *rbuf, int count,
+                             void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_communicator_t *comm,
                              int * topo)

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -68,7 +68,7 @@ mca_coll_han_set_reduce_args(mca_coll_han_reduce_args_t * args, mca_coll_task_t 
 int
 mca_coll_han_reduce_intra(const void *sbuf,
                           void *rbuf,
-                          int count,
+                          size_t count,
                           struct ompi_datatype_t *dtype,
                           ompi_op_t* op,
                           int root,
@@ -126,13 +126,12 @@ mca_coll_han_reduce_intra(const void *sbuf,
 
     int num_segments = (count + seg_count - 1) / seg_count;
     OPAL_OUTPUT_VERBOSE((20, mca_coll_han_component.han_output,
-                         "In HAN seg_count %d count %d num_seg %d\n",
+                         "In HAN seg_count %d count %zu num_seg %d\n",
                          seg_count, count, num_segments));
 
     int *vranks = han_module->cached_vranks;
     int low_rank = ompi_comm_rank(low_comm);
     int low_size = ompi_comm_size(low_comm);
-    int up_rank  = ompi_comm_rank(up_comm);
 
     int root_low_rank;
     int root_up_rank;
@@ -284,7 +283,7 @@ int mca_coll_han_reduce_t1_task(void *task_args) {
 int
 mca_coll_han_reduce_intra_simple(const void *sbuf,
                                  void* rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  ompi_op_t *op,
                                  int root,
@@ -451,7 +450,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_reduce_reproducible(const void *sbuf,
                                  void *rbuf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   int root,

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -33,10 +33,10 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
                               void *sbuf,
                               void *sbuf_inter_free,
                               void *sbuf_reorder_free,
-                              int scount,
+                              size_t scount,
                               struct ompi_datatype_t *sdtype,
                               void *rbuf,
-                              int rcount,
+                              size_t rcount,
                               struct ompi_datatype_t *rdtype,
                               int root,
                               int root_up_rank,
@@ -69,9 +69,9 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
  * after data reordring, calls us task, a scatter on up communicator
  */
 int
-mca_coll_han_scatter_intra(const void *sbuf, int scount,
+mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,
                            struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -262,9 +262,9 @@ int mca_coll_han_scatter_ls_task(void *task_args)
 
 
 int
-mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -62,8 +62,8 @@
  * packed form of MPI_BYTE type. This works for Gatherv but NOT for Scatterv provided that the Root
  * has a different architecture, e.g. endianness, integer representation, etc.
  */
-int mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts, const int *displs,
-                                struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_han_scatterv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *displs,
+                                struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
@@ -71,7 +71,8 @@ int mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts, const int 
     int w_rank, w_size;              /* information about the global communicator */
     int root_low_rank, root_up_rank; /* root ranks for both sub-communicators */
     int err, *vranks, low_rank, low_size, up_rank, up_size, *topo;
-    int *low_scounts = NULL, *low_displs = NULL;
+    size_t *low_scounts = NULL;
+    ptrdiff_t *low_displs = NULL;
     ompi_request_t *iscatterv_req = NULL;
 
     /* Create the subcommunicators */
@@ -136,12 +137,13 @@ int mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts, const int 
     /* #################### Root ########################### */
     if (root == w_rank) {
         int low_peer, up_peer, w_peer;
-        int need_bounce_buf = 0, total_up_scounts = 0, *up_displs = NULL, *up_scounts = NULL,
-            *up_peer_lb = NULL, *up_peer_ub = NULL;
+        int need_bounce_buf = 0, total_up_scounts = 0;
+        ptrdiff_t *up_displs = NULL;
+        size_t *up_scounts = NULL, *up_peer_lb = NULL, *up_peer_ub = NULL;
         char *reorder_sbuf = (char *) sbuf, *bounce_buf = NULL;
 
-        low_scounts = malloc(low_size * sizeof(int));
-        low_displs = malloc(low_size * sizeof(int));
+        low_scounts = malloc(low_size * sizeof(size_t));
+        low_displs = malloc(low_size * sizeof(ptrdiff_t));
         if (!low_scounts || !low_displs) {
             err = OMPI_ERR_OUT_OF_RESOURCE;
             goto root_out;
@@ -157,16 +159,16 @@ int mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts, const int 
             low_scounts[low_peer] = scounts[w_peer];
         }
 
-        up_scounts = calloc(up_size, sizeof(int));
-        up_displs = malloc(up_size * sizeof(int));
-        up_peer_ub = calloc(up_size, sizeof(int));
+        up_scounts = calloc(up_size, sizeof(size_t));
+        up_displs = malloc(up_size * sizeof(ptrdiff_t));
+        up_peer_ub = calloc(up_size, sizeof(size_t));
         if (!up_scounts || !up_displs || !up_peer_ub) {
             err = OMPI_ERR_OUT_OF_RESOURCE;
             goto root_out;
         }
 
         for (up_peer = 0; up_peer < up_size; ++up_peer) {
-            up_displs[up_peer] = INT_MAX;
+            up_displs[up_peer] = SIZE_MAX;
         }
 
         /* Calculate send counts for the inter-node scatterv */

--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -58,7 +58,7 @@ OBJ_CLASS_DECLARATION(mca_coll_hcoll_dtype_t);
 extern mca_coll_hcoll_dtype_t zero_dte_mapping;
 struct mca_coll_hcoll_component_t {
     /** Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /** MCA parameter: Priority of this component */
     int hcoll_priority;
@@ -179,87 +179,87 @@ void hcoll_rte_fns_setup(void);
 int mca_coll_hcoll_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_bcast(void *buff, int count,
+int mca_coll_hcoll_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_allgather(const void *sbuf, int scount,
+int mca_coll_hcoll_allgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_allgatherv(const void *sbuf, int scount,
+int mca_coll_hcoll_allgatherv(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcount,
-                            const int *displs,
+                            void *rbuf, const size_t *rcount,
+                            const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_gather(const void *sbuf, int scount,
+int mca_coll_hcoll_gather(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
 #if HCOLL_API > HCOLL_VERSION(4,5)
-int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
-int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcounts,
+int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 #endif
-int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_alltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_alltoall(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount,
+                           void* rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_alltoallv(const void *sbuf, const int *scounts,
-                            const int *sdisps,
+int mca_coll_hcoll_alltoallv(const void *sbuf, const size_t *scounts,
+                            const ptrdiff_t *sdisps,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcounts,
-                            const int *rdisps,
+                            void *rbuf, const size_t *rcounts,
+                            const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_gatherv(const void* sbuf, int scount,
+int mca_coll_hcoll_gatherv(const void* sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *displs,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
 
-int mca_coll_hcoll_scatterv(const void* sbuf, const int *scounts, const int *displs,
+int mca_coll_hcoll_scatterv(const void* sbuf, const size_t *scounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount,
+                            void* rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,
@@ -269,37 +269,37 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ibcast(void *buff, int count,
+int mca_coll_hcoll_ibcast(void *buff, size_t count,
                             struct ompi_datatype_t *datatype, int root,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_iallgather(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgatherv(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcount,
-                            const int *displs,
+                            void *rbuf, const size_t *rcount,
+                            const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -307,29 +307,29 @@ int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ialltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_ialltoall(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount,
+                            void* rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t **req,
                             mca_coll_base_module_t *module);
 
 #if HCOLL_API >= HCOLL_VERSION(3,7)
-int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts,
-                            const int *sdisps,
+int mca_coll_hcoll_ialltoallv(const void *sbuf, const size_t *scounts,
+                            const ptrdiff_t *sdisps,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcounts,
-                            const int *rdisps,
+                            void *rbuf, const size_t *rcounts,
+                            const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t **req,
                             mca_coll_base_module_t *module);
 #endif
 
-int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
+int mca_coll_hcoll_igatherv(const void* sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *displs,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -36,7 +36,7 @@ mca_coll_hcoll_component_t mca_coll_hcoll_component = {
        about the component itfca */
     {
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "hcoll",

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -36,7 +36,7 @@ orig_barrier:
     return hcoll_module->previous_barrier(comm,hcoll_module->previous_barrier_module);
 }
 
-int mca_coll_hcoll_bcast(void *buff, int count,
+int mca_coll_hcoll_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)
@@ -65,9 +65,9 @@ int mca_coll_hcoll_bcast(void *buff, int count,
     return rc;
 }
 
-int mca_coll_hcoll_allgather(const void *sbuf, int scount,
+int mca_coll_hcoll_allgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)
@@ -106,10 +106,10 @@ int mca_coll_hcoll_allgather(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_hcoll_allgatherv(const void *sbuf, int scount,
+int mca_coll_hcoll_allgatherv(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcount,
-                            const int *displs,
+                            void *rbuf, const size_t *rcount,
+                            const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)
@@ -150,9 +150,9 @@ int mca_coll_hcoll_allgatherv(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_hcoll_gather(const void *sbuf, int scount,
+int mca_coll_hcoll_gather(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -196,7 +196,7 @@ int mca_coll_hcoll_gather(const void *sbuf, int scount,
 
 }
 
-int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
@@ -243,7 +243,7 @@ int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 
-int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -294,9 +294,9 @@ int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 
-int mca_coll_hcoll_alltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_alltoall(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount,
+                           void* rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
@@ -332,9 +332,9 @@ int mca_coll_hcoll_alltoall(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_hcoll_alltoallv(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_hcoll_alltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcounts, const int *rdisps,
+                            void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)
@@ -355,9 +355,9 @@ int mca_coll_hcoll_alltoallv(const void *sbuf, const int *scounts, const int *sd
                                             comm, hcoll_module->previous_alltoallv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_alltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
-                                            rbuf, (int *)rcounts, (int *)rdisps, rtype,
-                                                hcoll_module->hcoll_context);
+    rc = hcoll_collectives.coll_alltoallv(sbuf, scounts, sdisps, stype,
+                                          rbuf, rcounts, rdisps, rtype,
+                                          hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK ALLTOALLV");
         rc = hcoll_module->previous_alltoallv(sbuf, scounts, sdisps, sdtype,
@@ -367,9 +367,9 @@ int mca_coll_hcoll_alltoallv(const void *sbuf, const int *scounts, const int *sd
     return rc;
 }
 
-int mca_coll_hcoll_gatherv(const void* sbuf, int scount,
+int mca_coll_hcoll_gatherv(const void* sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *displs,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,
@@ -400,8 +400,8 @@ int mca_coll_hcoll_gatherv(const void* sbuf, int scount,
                                            comm, hcoll_module->previous_gatherv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_gatherv((void *)sbuf, scount, stype, rbuf,
-                                        (int *)rcounts, (int *)displs, rtype,
+    rc = hcoll_collectives.coll_gatherv(sbuf, scount, stype, rbuf,
+                                        rcounts, displs, rtype,
                                         root, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK GATHERV");
@@ -413,9 +413,9 @@ int mca_coll_hcoll_gatherv(const void* sbuf, int scount,
 
 }
 
-int mca_coll_hcoll_scatterv(const void* sbuf, const int *scounts, const int *displs,
+int mca_coll_hcoll_scatterv(const void* sbuf, const size_t *scounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount,
+                            void* rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,
@@ -451,7 +451,7 @@ int mca_coll_hcoll_scatterv(const void* sbuf, const int *scounts, const int *dis
                                            comm, hcoll_module->previous_scatterv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_scatterv((void *)sbuf, (int *)scounts, (int *)displs, stype, rbuf, rcount, rtype, root, hcoll_module->hcoll_context);
+    rc = hcoll_collectives.coll_scatterv(sbuf, scounts, displs, stype, rbuf, rcount, rtype, root, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK SCATTERV");
         rc = hcoll_module->previous_scatterv(sbuf, scounts, displs, sdtype,
@@ -478,7 +478,7 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
     return rc;
 }
 
-int mca_coll_hcoll_ibcast(void *buff, int count,
+int mca_coll_hcoll_ibcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         ompi_request_t ** request,
@@ -509,9 +509,9 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
     return rc;
 }
 
-int mca_coll_hcoll_iallgather(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t ** request,
@@ -552,10 +552,10 @@ int mca_coll_hcoll_iallgather(const void *sbuf, int scount,
     return rc;
 }
 #if HCOLL_API >= HCOLL_VERSION(3,5)
-int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgatherv(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, const int *rcount,
-                            const int *displs,
+                            void *rbuf, const size_t *rcount,
+                            const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t ** request,
@@ -600,7 +600,7 @@ int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
     return rc;
 }
 #endif
-int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
@@ -650,7 +650,7 @@ int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 #if HCOLL_API >= HCOLL_VERSION(3,5)
-int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -706,9 +706,9 @@ int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 #endif
-int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
+int mca_coll_hcoll_igatherv(const void* sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *displs,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *displs,
                             struct ompi_datatype_t *rdtype,
                             int root,
                             struct ompi_communicator_t *comm,
@@ -758,9 +758,9 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
 
 
 #if HCOLL_API >= HCOLL_VERSION(3,7)
-int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_hcoll_ialltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, const int *rcounts, const int *rdisps,
+                              void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               ompi_request_t ** request,
@@ -782,8 +782,8 @@ int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts, const int *s
                                                comm, request, hcoll_module->previous_alltoallv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_ialltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
-                                           rbuf, (int *)rcounts, (int *)rdisps, rtype,
+    rc = hcoll_collectives.coll_ialltoallv(sbuf, scounts, sdisps, stype,
+                                           rbuf, rcounts, rdisps, rtype,
                                            hcoll_module->hcoll_context, (void**)request);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK IALLTOALLV");
@@ -796,7 +796,7 @@ int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts, const int *s
 #endif
 
 #if HCOLL_API > HCOLL_VERSION(4,5)
-int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         struct ompi_communicator_t *comm,
@@ -837,7 +837,7 @@ int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount
     return rc;
 }
 
-int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcounts,
+int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -867,7 +867,7 @@ int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcoun
         goto fallback;
     }
 
-    rc = hcoll_collectives.coll_reduce_scatter((void*)sbuf, rbuf, (int*)rcounts,
+    rc = hcoll_collectives.coll_reduce_scatter(sbuf, rbuf, rcounts,
                                                Dtype, Op, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
     fallback:        

--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -51,7 +51,7 @@
 
 
 static int recv_nb(dte_data_representation_t data ,
-                   uint32_t count ,
+                   size_t count ,
                    void *buffer,
                    rte_ec_handle_t ,
                    rte_grp_handle_t ,
@@ -59,7 +59,7 @@ static int recv_nb(dte_data_representation_t data ,
                    rte_request_handle_t * req);
 
 static int send_nb(dte_data_representation_t data,
-                   uint32_t count,
+                   size_t count,
                    void *buffer,
                    rte_ec_handle_t ec_h,
                    rte_grp_handle_t grp_h,
@@ -161,7 +161,7 @@ void hcoll_rte_fns_setup(void)
 }
 
 static int recv_nb(struct dte_data_representation_t data,
-                   uint32_t count ,
+                   size_t count,
                    void *buffer,
                    rte_ec_handle_t ec_h,
                    rte_grp_handle_t grp_h,
@@ -187,8 +187,8 @@ static int recv_nb(struct dte_data_representation_t data,
     }
     size = (size_t)data.rep.in_line_rep.data_handle.in_line.packed_size*count/8;
 
-    HCOL_VERBOSE(30,"PML_IRECV: dest = %d: buf = %p: size = %u: comm = %p",
-                 ec_h.rank, buffer, (unsigned int)size, (void *)comm);
+    HCOL_VERBOSE(30,"PML_IRECV: dest = %d: buf = %p: size = %zu: comm = %p",
+                 ec_h.rank, buffer, size, (void *)comm);
     if (MCA_PML_CALL(irecv(buffer,size,&(ompi_mpi_unsigned_char.dt),ec_h.rank,
                            tag,comm,&ompi_req)))
     {
@@ -202,7 +202,7 @@ static int recv_nb(struct dte_data_representation_t data,
 
 
 static int send_nb( dte_data_representation_t data,
-                    uint32_t count,
+                    size_t count,
                     void *buffer,
                     rte_ec_handle_t ec_h,
                     rte_grp_handle_t grp_h,
@@ -226,8 +226,8 @@ static int send_nb( dte_data_representation_t data,
         return HCOLL_ERROR;
     }
     size = (size_t)data.rep.in_line_rep.data_handle.in_line.packed_size*count/8;
-    HCOL_VERBOSE(30,"PML_ISEND: dest = %d: buf = %p: size = %u: comm = %p",
-                 ec_h.rank, buffer, (unsigned int)size, (void *)comm);
+    HCOL_VERBOSE(30,"PML_ISEND: dest = %d: buf = %p: size = %zu: comm = %p",
+                 ec_h.rank, buffer, size, (void *)comm);
     if (MCA_PML_CALL(isend(buffer,size,&(ompi_mpi_unsigned_char.dt),ec_h.rank,
                            tag,MCA_PML_BASE_SEND_STANDARD,comm,&ompi_req)))
     {

--- a/ompi/mca/coll/inter/coll_inter.h
+++ b/ompi/mca/coll/inter/coll_inter.h
@@ -37,7 +37,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_inter_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_inter_component;
 extern int mca_coll_inter_priority_param;
 extern int mca_coll_inter_verbose_param;
 
@@ -53,56 +53,56 @@ mca_coll_inter_comm_query(struct ompi_communicator_t *comm, int *priority);
 int mca_coll_inter_module_enable(mca_coll_base_module_t *module,
                                  struct ompi_communicator_t *comm);
 
-int mca_coll_inter_allgather_inter(const void *sbuf, int scount,
+int mca_coll_inter_allgather_inter(const void *sbuf, size_t scount,
 				   struct ompi_datatype_t *sdtype,
-				   void *rbuf, int rcount,
+				   void *rbuf, size_t rcount,
 				   struct ompi_datatype_t *rdtype,
 				   struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-int mca_coll_inter_allgatherv_inter(const void *sbuf, int scount,
+int mca_coll_inter_allgatherv_inter(const void *sbuf, size_t scount,
 				    struct ompi_datatype_t *sdtype,
-				    void *rbuf, const int *rcounts, const int *disps,
+				    void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
 				    struct ompi_datatype_t *rdtype,
 				    struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-int mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
+int mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
 				   struct ompi_datatype_t *dtype,
 				   struct ompi_op_t *op,
 				   struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-int mca_coll_inter_bcast_inter(void *buff, int count,
+int mca_coll_inter_bcast_inter(void *buff, size_t count,
 			       struct ompi_datatype_t *datatype,
 			       int root,
 			       struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
-int mca_coll_inter_gather_inter(const void *sbuf, int scount,
+int mca_coll_inter_gather_inter(const void *sbuf, size_t scount,
 				struct ompi_datatype_t *sdtype,
-				void *rbuf, int rcount,
+				void *rbuf, size_t rcount,
 				struct ompi_datatype_t *rdtype,
 				int root,
 				struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
+int mca_coll_inter_gatherv_inter(const void *sbuf, size_t scount,
 				 struct ompi_datatype_t *sdtype,
-				 void *rbuf, const int *rcounts, const int *disps,
+				 void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
 				 struct ompi_datatype_t *rdtype,
 				 int root,
 				 struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-int mca_coll_inter_reduce_inter(const void *sbuf, void* rbuf, int count,
+int mca_coll_inter_reduce_inter(const void *sbuf, void* rbuf, size_t count,
 				struct ompi_datatype_t *dtype,
 				struct ompi_op_t *op,
 				int root,
 				struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_inter_scatter_inter(const void *sbuf, int scount,
+int mca_coll_inter_scatter_inter(const void *sbuf, size_t scount,
 				 struct ompi_datatype_t *sdtype, void *rbuf,
-				 int rcount, struct ompi_datatype_t *rdtype,
+				 size_t rcount, struct ompi_datatype_t *rdtype,
 				 int root, struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-int mca_coll_inter_scatterv_inter(const void *sbuf, const int *scounts, const int *disps,
+int mca_coll_inter_scatterv_inter(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
 				  struct ompi_datatype_t *sdtype,
-				  void* rbuf, int rcount,
+				  void* rbuf, size_t rcount,
 				  struct ompi_datatype_t *rdtype, int root,
 				  struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);

--- a/ompi/mca/coll/inter/coll_inter_allgather.c
+++ b/ompi/mca/coll/inter/coll_inter_allgather.c
@@ -42,9 +42,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_allgather_inter(const void *sbuf, int scount,
+mca_coll_inter_allgather_inter(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_allreduce.c
+++ b/ompi/mca/coll/inter/coll_inter_allreduce.c
@@ -42,7 +42,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/inter/coll_inter_bcast.c
+++ b/ompi/mca/coll/inter/coll_inter_bcast.c
@@ -37,7 +37,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_bcast_inter(void *buff, int count,
+mca_coll_inter_bcast_inter(void *buff, size_t count,
                            struct ompi_datatype_t *datatype, int root,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_component.c
+++ b/ompi/mca/coll/inter/coll_inter_component.c
@@ -56,13 +56,13 @@ static int inter_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_inter_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_inter_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "inter",

--- a/ompi/mca/coll/inter/coll_inter_gather.c
+++ b/ompi/mca/coll/inter/coll_inter_gather.c
@@ -39,9 +39,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_gather_inter(const void *sbuf, int scount,
+mca_coll_inter_gather_inter(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root, struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_gatherv.c
+++ b/ompi/mca/coll/inter/coll_inter_gatherv.c
@@ -38,18 +38,20 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
+mca_coll_inter_gatherv_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, const int *rcounts, const int *disps,
+                             void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                              struct ompi_datatype_t *rdtype, int root,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)
 {
     int i, rank, size, size_local, err;
     size_t total = 0;
-    int *count=NULL, *displace=NULL;
+    size_t *count=NULL;
+    ptrdiff_t *displace=NULL;
     char *ptmp_free=NULL, *ptmp=NULL;
     ompi_datatype_t *ndtype;
+    int *tmp_rcounts = NULL, *tmp_disps = NULL;
 
     if (MPI_PROC_NULL == root) { /* do nothing */
         return OMPI_SUCCESS;
@@ -59,7 +61,20 @@ mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
     size_local = ompi_comm_size(comm);
 
     if (MPI_ROOT == root) { /* I am the root, receiving the data from zero. */
-        ompi_datatype_create_indexed(size, rcounts, disps, rdtype, &ndtype);
+        /* TODO:BIGCOUNT: Remove these temporaries when the ompi_datatype
+         * interface is updated with size_t/ptrdiff_t
+         */
+        tmp_rcounts = (int *)malloc(2 * size * sizeof(int));
+        if (NULL == tmp_rcounts) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        tmp_disps = tmp_rcounts + size;
+        for (i = 0; i < size; i++) {
+            tmp_rcounts[i] = (int)rcounts[i];
+            tmp_disps[i] = (int)disps[i];
+        }
+        ompi_datatype_create_indexed(size, tmp_rcounts, tmp_disps, rdtype, &ndtype);
+        free(tmp_rcounts);
         ompi_datatype_commit(&ndtype);
 
         err = MCA_PML_CALL(recv(rbuf, 1, ndtype, 0,
@@ -70,16 +85,16 @@ mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
     }
 
     if (0 == rank) {
-        count = (int *)malloc(sizeof(int) * size_local);
-        displace = (int *)malloc(sizeof(int) * size_local);
+        count = (size_t *)malloc(sizeof(size_t) * size_local);
+        displace = (ptrdiff_t *)malloc(sizeof(ptrdiff_t) * size_local);
         if ((NULL == displace) || (NULL == count)) {
             err = OMPI_ERR_OUT_OF_RESOURCE;
             goto exit;
         }
     }
 
-    err = comm->c_local_comm->c_coll->coll_gather(&scount, 1, MPI_INT,
-                                                 count, 1, MPI_INT,
+    err = comm->c_local_comm->c_coll->coll_gather(&scount, sizeof(scount), MPI_BYTE,
+                                                 count, sizeof(*count), MPI_BYTE,
                                                  0, comm->c_local_comm,
                                                  comm->c_local_comm->c_coll->coll_gather_module);
     if (OMPI_SUCCESS != err) {

--- a/ompi/mca/coll/inter/coll_inter_reduce.c
+++ b/ompi/mca/coll/inter/coll_inter_reduce.c
@@ -40,7 +40,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_reduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_inter_reduce_inter(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/inter/coll_inter_scatter.c
+++ b/ompi/mca/coll/inter/coll_inter_scatter.c
@@ -38,9 +38,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_scatter_inter(const void *sbuf, int scount,
+mca_coll_inter_scatter_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root, struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -79,7 +79,7 @@ extern int libnbc_ireduce_algorithm;
 extern int libnbc_iscan_algorithm;
 
 struct ompi_coll_libnbc_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
     opal_free_list_t requests;
     opal_list_t active_requests;
     opal_atomic_int32_t active_comms;
@@ -161,258 +161,258 @@ int NBC_Init_comm(MPI_Comm comm, ompi_coll_libnbc_module_t *module);
 int NBC_Progress(NBC_Handle *handle);
 
 
-int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallgatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_iallgatherv(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallreduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iallreduce(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoallv(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_ialltoallv(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoallw(const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-                                void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+int ompi_coll_libnbc_ialltoallw(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
                                 struct ompi_communicator_t *comm, ompi_request_t **request,
                                 mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ibarrier(struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iexscan(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_iexscan(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t **request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_igather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_igatherv(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                            ompi_request_t **request,
                                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatterv(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatterv(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                               void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
 
 
-int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallreduce_inter(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iallreduce_inter(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoall_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoallv_inter(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_ialltoallv_inter(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoallw_inter(const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-                                      void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+int ompi_coll_libnbc_ialltoallw_inter(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+                                      void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
                                       struct ompi_communicator_t *comm, ompi_request_t **request,
                                       mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ibarrier_inter(struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast_inter(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_igather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_inter(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_inter(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter_inter(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_inter(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_ireduce_scatter_block_inter(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                                  ompi_request_t **request,
                                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatter_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                               void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
 
 
-int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                         size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                          ompi_request_t ** request, mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                          const int *rcounts, const int *displs, MPI_Datatype rtype,
+int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                          const size_t *rcounts, const ptrdiff_t *displs, MPI_Datatype rtype,
                                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                        int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                        size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                         ompi_request_t ** request, mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
-                                         void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
+int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdispls, MPI_Datatype stype,
+                                         void *rbuf, const size_t *rcounts, const ptrdiff_t *rdispls, MPI_Datatype rtype,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
-                                         void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
+int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
+                                         void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                      MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allreduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_allreduce_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                     struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                    MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                    mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoallv_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                    MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_alltoallv_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                    MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoallw_init(const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-                                    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+int ompi_coll_libnbc_alltoallw_init(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+                                    void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
                                     struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t **request,
                                     mca_coll_base_module_t *module);
 int ompi_coll_libnbc_barrier_init(struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
-int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_exscan_init(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_exscan_init(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op, struct ompi_communicator_t *comm, MPI_Info info,  ompi_request_t **request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                  MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_gatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                   int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                                  MPI_Op op, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                          MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info,  ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_block_init(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_reduce_scatter_block_init(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t **request,
                                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                   void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                   void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                    mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allgatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_allgatherv_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                            MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allreduce_inter_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_allreduce_inter_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                           struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoall_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                          MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoallv_inter_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                          MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_alltoallv_inter_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                          MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoallw_inter_init(const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
-                                          void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
+int ompi_coll_libnbc_alltoallw_inter_init(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps, struct ompi_datatype_t * const *sdtypes,
+                                          void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps, struct ompi_datatype_t * const *rdtypes,
                                           struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t **request,
                                           mca_coll_base_module_t *module);
 int ompi_coll_libnbc_barrier_inter_init(struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
-int ompi_coll_libnbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                       struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                       mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                        MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_gatherv_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                         int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_inter_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_inter_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                                        MPI_Op op, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_inter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_inter_init(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                      struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                                      MPI_Info info, ompi_request_t **request,
                                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                         struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                         void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                         void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                          struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                             int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                             size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                              MPI_Info info, ompi_request_t ** request, mca_coll_base_module_t *module);
-int ompi_coll_libnbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                              const int *rcounts, const int *displs, MPI_Datatype rtype,
+int ompi_coll_libnbc_neighbor_allgatherv_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                              const size_t *rcounts, const ptrdiff_t *displs, MPI_Datatype rtype,
                                               struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                            int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
+int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                            size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
                                             ompi_request_t ** request, mca_coll_base_module_t *module);
-int ompi_coll_libnbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
-                                             void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
+int ompi_coll_libnbc_neighbor_alltoallv_init(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdispls, MPI_Datatype stype,
+                                             void *rbuf, const size_t *rcounts, const ptrdiff_t *rdispls, MPI_Datatype rtype,
                                              struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
-                                             void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
+int ompi_coll_libnbc_neighbor_alltoallw_init(const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
+                                             void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
                                              struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                              mca_coll_base_module_t *module);
 

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -117,7 +117,7 @@ ompi_coll_libnbc_component_t mca_coll_libnbc_component = {
         /* First, the mca_component_t struct containing meta information
          * about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "libnbc",

--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -22,11 +22,11 @@
 
 static inline int allgather_sched_linear(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sendbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *recvbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *recvbuf, size_t rcount,
     struct ompi_datatype_t *rdtype);
 static inline int allgather_sched_recursivedoubling(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
     struct ompi_datatype_t *rdtype);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -49,7 +49,7 @@ int NBC_Allgather_args_compare(NBC_Allgather_args *a, NBC_Allgather_args *b, voi
 }
 #endif
 
-static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                               MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module, bool persistent)
 {
@@ -190,7 +190,7 @@ static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype s
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module)
 {
@@ -210,7 +210,7 @@ int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype
     return OMPI_SUCCESS;
 }
 
-static int nbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module, bool persistent)
 {
@@ -267,7 +267,7 @@ static int nbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Data
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				      mca_coll_base_module_t *module) {
     int res = nbc_allgather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -296,7 +296,7 @@ int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Da
  */
 static inline int allgather_sched_linear(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sendbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *recvbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *recvbuf, size_t rcount,
     struct ompi_datatype_t *rdtype)
 {
     int res = OMPI_SUCCESS;
@@ -354,7 +354,7 @@ cleanup_and_return:
  */
 static inline int allgather_sched_recursivedoubling(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
     struct ompi_datatype_t *rdtype)
 {
     int res = OMPI_SUCCESS;
@@ -389,7 +389,7 @@ cleanup_and_return:
     return res;
 }
 
-int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_allgather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -401,7 +401,7 @@ int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module) {
     int res = nbc_allgather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,

--- a/ompi/mca/coll/libnbc/nbc_iallgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgatherv.c
@@ -34,7 +34,7 @@
  * second round:
  *   each node sends to node (rank+2)%p sendcount elements
  *   each node receives from node (rank-2)%p recvcounts[(rank+2)%p] elements */
-static int nbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+static int nbc_allgatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module, bool persistent)
 {
@@ -119,7 +119,7 @@ static int nbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Datatype 
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_iallgatherv(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                  mca_coll_base_module_t *module) {
     int res = nbc_allgatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
@@ -138,7 +138,7 @@ int ompi_coll_libnbc_iallgatherv(const void* sendbuf, int sendcount, MPI_Datatyp
     return OMPI_SUCCESS;
 }
 
-static int nbc_allgatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+static int nbc_allgatherv_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module, bool persistent)
 {
@@ -198,7 +198,7 @@ static int nbc_allgatherv_inter_init(const void* sendbuf, int sendcount, MPI_Dat
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                        MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                        mca_coll_base_module_t *module) {
     int res = nbc_allgatherv_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
@@ -217,7 +217,7 @@ int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, int sendcount, MPI_D
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                      MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                      mca_coll_base_module_t *module) {
     int res = nbc_allgatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
@@ -229,7 +229,7 @@ int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Dat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_allgatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
+int ompi_coll_libnbc_allgatherv_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs,
                                            MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                            mca_coll_base_module_t *module) {
     int res = nbc_allgatherv_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,

--- a/ompi/mca/coll/libnbc/nbc_ialltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoall.c
@@ -22,15 +22,15 @@
 #include "nbc_internal.h"
 
 static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule *schedule,
-                                   const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                   int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+                                   const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                   size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm);
 static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule *schedule,
-                                     const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                     int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+                                     const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                     size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm);
 static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                 const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                 int recvcount, MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf);
-static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, int count,
+                                 const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                 size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf);
+static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, size_t count,
                                    MPI_Datatype type, MPI_Aint ext, ptrdiff_t gap, MPI_Comm comm);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -54,7 +54,7 @@ int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *
 #endif
 
 /* simple linear MPI_Ialltoall the (simple) algorithm just sends to all nodes */
-static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_alltoall_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module, bool persistent)
 {
@@ -289,7 +289,7 @@ static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype se
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -308,7 +308,7 @@ int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype 
     return OMPI_SUCCESS;
 }
 
-static int nbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_alltoall_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module, bool persistent)
 {
@@ -373,7 +373,7 @@ static int nbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Data
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				      mca_coll_base_module_t *module) {
     int res = nbc_alltoall_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -393,7 +393,7 @@ int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, int sendcount, MPI_Da
 }
 
 static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                     const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                     const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                      MPI_Datatype recvtype, MPI_Comm comm) {
   int res;
 
@@ -422,7 +422,7 @@ static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint 
 }
 
 static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                   const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                   const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                    MPI_Datatype recvtype, MPI_Comm comm) {
   int res;
 
@@ -449,7 +449,7 @@ static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rc
 }
 
 static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                 const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                 const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                  MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf) {
   int res, speer, rpeer, virtp;
   MPI_Aint datasize, offset;
@@ -542,7 +542,7 @@ static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcve
   return OMPI_SUCCESS;
 }
 
-static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, int count,
+static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, size_t count,
                                    MPI_Datatype type, MPI_Aint ext, ptrdiff_t gap, MPI_Comm comm) {
   int res;
 
@@ -599,7 +599,7 @@ static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, voi
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoall_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -611,7 +611,7 @@ int ompi_coll_libnbc_alltoall_init (const void* sendbuf, int sendcount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module) {
     int res = nbc_alltoall_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,

--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -21,19 +21,19 @@
 #include "nbc_internal.h"
 
 static inline int a2aw_sched_linear(int rank, int p, NBC_Schedule *schedule,
-                                    const void *sendbuf, const int *sendcounts, const int *sdispls,
+                                    const void *sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
                                     struct ompi_datatype_t * const * sendtypes,
-                                    void *recvbuf, const int *recvcounts, const int *rdispls,
+                                    void *recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                     struct ompi_datatype_t * const * recvtypes);
 
 static inline int a2aw_sched_pairwise(int rank, int p, NBC_Schedule *schedule,
-                                      const void *sendbuf, const int *sendcounts, const int *sdispls,
+                                      const void *sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
                                       struct ompi_datatype_t * const * sendtypes,
-                                      void *recvbuf, const int *recvcounts, const int *rdispls,
+                                      void *recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                       struct ompi_datatype_t * const * recvtypes);
 
 static inline int a2aw_sched_inplace(int rank, int p, NBC_Schedule *schedule,
-                                    void *buf, const int *counts, const int *displs,
+                                    void *buf, const size_t *counts, const ptrdiff_t *displs,
                                     struct ompi_datatype_t * const * types);
 
 /* an alltoallw schedule can not be cached easily because the contents
@@ -41,8 +41,8 @@ static inline int a2aw_sched_inplace(int rank, int p, NBC_Schedule *schedule,
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear Alltoallw */
-static int nbc_alltoallw_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                              struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+static int nbc_alltoallw_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                              struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                               struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module, bool persistent)
 {
@@ -132,8 +132,8 @@ static int nbc_alltoallw_init(const void* sendbuf, const int *sendcounts, const 
   return OMPI_SUCCESS;
 } 
 
-int ompi_coll_libnbc_ialltoallw(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_ialltoallw(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                 struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				mca_coll_base_module_t *module) {
     int res = nbc_alltoallw_init(sendbuf, sendcounts, sdispls, sendtypes,
@@ -154,8 +154,8 @@ int ompi_coll_libnbc_ialltoallw(const void* sendbuf, const int *sendcounts, cons
 }
 
 /* simple linear Alltoallw */
-static int nbc_alltoallw_inter_init (const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                     struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+static int nbc_alltoallw_inter_init (const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                     struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                      struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module, bool persistent)
 {
@@ -207,8 +207,8 @@ static int nbc_alltoallw_inter_init (const void* sendbuf, const int *sendcounts,
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ialltoallw_inter(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                      struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_ialltoallw_inter(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                      struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                       struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				      mca_coll_base_module_t *module) {
     int res = nbc_alltoallw_inter_init(sendbuf, sendcounts, sdispls, sendtypes,
@@ -229,9 +229,9 @@ int ompi_coll_libnbc_ialltoallw_inter(const void* sendbuf, const int *sendcounts
 }
 
 static inline int a2aw_sched_linear(int rank, int p, NBC_Schedule *schedule,
-                                    const void *sendbuf, const int *sendcounts, const int *sdispls,
+                                    const void *sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
                                     struct ompi_datatype_t * const * sendtypes,
-                                    void *recvbuf, const int *recvcounts, const int *rdispls,
+                                    void *recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                     struct ompi_datatype_t * const * recvtypes) {
   int res;
 
@@ -266,9 +266,9 @@ static inline int a2aw_sched_linear(int rank, int p, NBC_Schedule *schedule,
 
 __opal_attribute_unused__
 static inline int a2aw_sched_pairwise(int rank, int p, NBC_Schedule *schedule,
-                                      const void *sendbuf, const int *sendcounts, const int *sdispls,
+                                      const void *sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
                                       struct ompi_datatype_t * const * sendtypes,
-                                      void *recvbuf, const int *recvcounts, const int *rdispls,
+                                      void *recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                       struct ompi_datatype_t * const * recvtypes) {
   int res;
 
@@ -298,7 +298,7 @@ static inline int a2aw_sched_pairwise(int rank, int p, NBC_Schedule *schedule,
 }
 
 static inline int a2aw_sched_inplace(int rank, int p, NBC_Schedule *schedule,
-                                     void *buf, const int *counts, const int *displs,
+                                     void *buf, const size_t *counts, const ptrdiff_t *displs,
                                      struct ompi_datatype_t * const * types) {
   ptrdiff_t gap = 0;
   int res;
@@ -368,8 +368,8 @@ static inline int a2aw_sched_inplace(int rank, int p, NBC_Schedule *schedule,
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoallw_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                    struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_alltoallw_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                    struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                     struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_alltoallw_init(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes,
@@ -381,8 +381,8 @@ int ompi_coll_libnbc_alltoallw_init(const void* sendbuf, const int *sendcounts, 
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoallw_inter_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
-                                          struct ompi_datatype_t * const *sendtypes, void* recvbuf, const int *recvcounts, const int *rdispls,
+int ompi_coll_libnbc_alltoallw_inter_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *sdispls,
+                                          struct ompi_datatype_t * const *sendtypes, void* recvbuf, const size_t *recvcounts, const ptrdiff_t *rdispls,
                                           struct ompi_datatype_t * const *recvtypes, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module) {
     int res = nbc_alltoallw_inter_init(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes,

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -20,14 +20,14 @@
  */
 #include "nbc_internal.h"
 
-static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
+static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
                                        MPI_Datatype datatype);
-static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
+static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
                                      MPI_Datatype datatype);
-static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
-                                    MPI_Datatype datatype, int fragsize, size_t size);
+static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
+                                    MPI_Datatype datatype, size_t fragsize, size_t size);
 static inline int bcast_sched_knomial(int rank, int comm_size, int root, NBC_Schedule *schedule, void *buf,
-                                      int count, MPI_Datatype datatype, int knomial_radix);
+                                      size_t count, MPI_Datatype datatype, int knomial_radix);
 
 #ifdef NBC_CACHE_SCHEDULE
 /* tree comparison function for schedule cache */
@@ -47,7 +47,7 @@ int NBC_Bcast_args_compare(NBC_Bcast_args *a, NBC_Bcast_args *b, void *param) {
 }
 #endif
 
-static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+static int nbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                           mca_coll_base_module_t *module, bool persistent)
 {
@@ -191,7 +191,7 @@ static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int ro
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module)
 {
@@ -235,7 +235,7 @@ int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int 
   if (vrank == 0) rank = root; \
   if (vrank == root) rank = 0; \
 }
-static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype) {
+static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype) {
   int maxr, vrank, peer, res;
 
   maxr = ceil_of_log2(p);
@@ -275,7 +275,7 @@ static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *
 }
 
 /* simple linear MPI_Ibcast */
-static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype) {
+static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype) {
   int res;
 
   /* send to all others */
@@ -301,7 +301,7 @@ static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *sc
 }
 
 /* simple chained MPI_Ibcast */
-static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype, int fragsize, size_t size) {
+static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype, size_t fragsize, size_t size) {
   int res, vrank, rpeer, speer, numfrag, fragcount, thiscount;
   MPI_Aint ext;
   char *buf;
@@ -372,7 +372,7 @@ static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *sch
  */
 static inline int bcast_sched_knomial(
     int rank, int comm_size, int root, NBC_Schedule *schedule, void *buf,
-    int count, MPI_Datatype datatype, int knomial_radix)
+    size_t count, MPI_Datatype datatype, int knomial_radix)
 {
     int res = OMPI_SUCCESS;
 
@@ -408,7 +408,7 @@ cleanup_and_return:
     return res;
 }
 
-static int nbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+static int nbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module, bool persistent) {
   int res;
@@ -460,7 +460,7 @@ static int nbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, 
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast_inter(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                   struct ompi_communicator_t *comm, ompi_request_t ** request,
                                   mca_coll_base_module_t *module) {
     int res = nbc_bcast_inter_init(buffer, count, datatype, root,
@@ -479,7 +479,7 @@ int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                 mca_coll_base_module_t *module) {
     int res = nbc_bcast_init(buffer, count, datatype, root,
@@ -491,7 +491,7 @@ int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, 
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                       struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                       mca_coll_base_module_t *module) {
     int res = nbc_bcast_inter_init(buffer, count, datatype, root,

--- a/ompi/mca/coll/libnbc/nbc_iexscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iexscan.c
@@ -24,12 +24,12 @@
 #include "nbc_internal.h"
 
 static inline int exscan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf);
 static inline int exscan_sched_recursivedoubling(
     int rank, int comm_size, const void *sendbuf, void *recvbuf,
-    int count, MPI_Datatype datatype,  MPI_Op op, char inplace,
+    size_t count, MPI_Datatype datatype,  MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -51,7 +51,7 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
 }
 #endif
 
-static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+static int nbc_exscan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module, bool persistent) {
     int rank, p, res;
@@ -165,7 +165,7 @@ static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module) {
     int res = nbc_exscan_init(sendbuf, recvbuf, count, datatype, op,
@@ -184,7 +184,7 @@ int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, int count, MPI_
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                  struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module) {
     int res = nbc_exscan_init(sendbuf, recvbuf, count, datatype, op,
@@ -211,7 +211,7 @@ int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, int count, 
  * Schedule length: O(1)
  */
 static inline int exscan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf)
 {
@@ -293,7 +293,7 @@ cleanup_and_return:
  * Schedule length: O(log(p))
  */
 static inline int exscan_sched_recursivedoubling(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype, MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2)
 {

--- a/ompi/mca/coll/libnbc/nbc_igather.c
+++ b/ompi/mca/coll/libnbc/nbc_igather.c
@@ -44,8 +44,8 @@ int NBC_Gather_args_compare(NBC_Gather_args *a, NBC_Gather_args *b, void *param)
 }
 #endif
 
-static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                           int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                           size_t recvcount, MPI_Datatype recvtype, int root,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -173,8 +173,8 @@ static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype send
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                             int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_igather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                             size_t recvcount, MPI_Datatype recvtype, int root,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module) {
     int res = nbc_gather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -193,8 +193,8 @@ int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype se
     return OMPI_SUCCESS;
 }
 
-static int nbc_gather_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                  int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_gather_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                  size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, ompi_request_t ** request,
                                   mca_coll_base_module_t *module, bool persistent) {
     int res, rsize;
@@ -253,8 +253,8 @@ static int nbc_gather_inter_init (const void* sendbuf, int sendcount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                   int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_igather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                   size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module) {
     int res = nbc_gather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -273,8 +273,8 @@ int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                 int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                 size_t recvcount, MPI_Datatype recvtype, int root,
                                  struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module) {
     int res = nbc_gather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -286,8 +286,8 @@ int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatyp
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                       int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                       size_t recvcount, MPI_Datatype recvtype, int root,
                                        struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module) {
     int res = nbc_gather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,

--- a/ompi/mca/coll/libnbc/nbc_igatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_igatherv.c
@@ -29,8 +29,8 @@
  * would not be sufficient ... we simply do not cache it */
 
 
-static int nbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+static int nbc_gatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                            void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                             int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -105,8 +105,8 @@ static int nbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sen
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_igatherv(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module) {
     int res = nbc_gatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
@@ -125,8 +125,8 @@ int ompi_coll_libnbc_igatherv(const void* sendbuf, int sendcount, MPI_Datatype s
     return OMPI_SUCCESS;
 }
 
-static int nbc_gatherv_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+static int nbc_gatherv_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                   void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module, bool persistent) {
   int res, rsize;
@@ -185,8 +185,8 @@ static int nbc_gatherv_inter_init (const void* sendbuf, int sendcount, MPI_Datat
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                    void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                     int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_gatherv_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
@@ -205,8 +205,8 @@ int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, int sendcount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_gatherv_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                   int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module) {
     int res = nbc_gatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
@@ -218,8 +218,8 @@ int ompi_coll_libnbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
+int ompi_coll_libnbc_gatherv_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, const size_t *recvcounts, const ptrdiff_t *displs, MPI_Datatype recvtype,
                                         int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module) {
     int res = nbc_gatherv_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
@@ -44,8 +44,8 @@ int NBC_Ineighbor_allgather_args_compare(NBC_Ineighbor_allgather_args *a, NBC_In
 #endif
 
 
-static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                       int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+static int nbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                       size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -163,8 +163,8 @@ static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatyp
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                         size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                          ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgather_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                           comm, request, module, false);
@@ -182,8 +182,8 @@ int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datat
 }
 
 
-int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                             int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                             size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                              MPI_Info info, ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgather_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                           comm, request, module, true);

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
@@ -44,8 +44,8 @@ int NBC_Ineighbor_allgatherv_args_compare(NBC_Ineighbor_allgatherv_args *a, NBC_
 #endif
 
 
-static int nbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                        const int *rcounts, const int *displs, MPI_Datatype rtype,
+static int nbc_neighbor_allgatherv_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                        const size_t *rcounts, const ptrdiff_t *displs, MPI_Datatype rtype,
                                         struct ompi_communicator_t *comm, ompi_request_t ** request,
                                         mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -164,8 +164,8 @@ static int nbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Dataty
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-					  const int *rcounts, const int *displs, MPI_Datatype rtype,
+int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+					  const size_t *rcounts, const ptrdiff_t *displs, MPI_Datatype rtype,
 					  struct ompi_communicator_t *comm, ompi_request_t ** request,
 					  mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgatherv_init(sbuf, scount, stype, rbuf, rcounts, displs, rtype,
@@ -183,8 +183,8 @@ int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, int scount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                              const int *rcounts, const int *displs, MPI_Datatype rtype,
+int ompi_coll_libnbc_neighbor_allgatherv_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                              const size_t *rcounts, const ptrdiff_t *displs, MPI_Datatype rtype,
                                               struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                               mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgatherv_init(sbuf, scount, stype, rbuf, rcounts, displs, rtype,

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
@@ -41,8 +41,8 @@ int NBC_Ineighbor_alltoall_args_compare(NBC_Ineighbor_alltoall_args *a, NBC_Inei
 }
 #endif
 
-static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                      int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+static int nbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                      size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                       ompi_request_t ** request,
                                       mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -167,8 +167,8 @@ static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                        int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                        size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                         ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoall_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                          comm, request, module, false);
@@ -185,8 +185,8 @@ int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                            int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
+int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                            size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
                                             ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoall_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                          comm, request, module, true);

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
@@ -44,8 +44,8 @@ int NBC_Ineighbor_alltoallv_args_compare(NBC_Ineighbor_alltoallv_args *a, NBC_In
 #endif
 
 
-static int nbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
-                                       void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
+static int nbc_neighbor_alltoallv_init(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdispls, MPI_Datatype stype,
+                                       void *rbuf, const size_t *rcounts, const ptrdiff_t *rdispls, MPI_Datatype rtype,
                                        struct ompi_communicator_t *comm, ompi_request_t ** request,
                                        mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -171,8 +171,8 @@ static int nbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, con
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
-                                         void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
+int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdispls, MPI_Datatype stype,
+                                         void *rbuf, const size_t *rcounts, const ptrdiff_t *rdispls, MPI_Datatype rtype,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoallv_init(sbuf, scounts, sdispls, stype, rbuf, rcounts, rdispls, rtype,
@@ -190,8 +190,8 @@ int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const int *scounts, c
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
-                                             void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
+int ompi_coll_libnbc_neighbor_alltoallv_init(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdispls, MPI_Datatype stype,
+                                             void *rbuf, const size_t *rcounts, const ptrdiff_t *rdispls, MPI_Datatype rtype,
                                              struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                              mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoallv_init(sbuf, scounts, sdispls, stype, rbuf, rcounts, rdispls, rtype,

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
@@ -43,8 +43,8 @@ int NBC_Ineighbor_alltoallw_args_compare(NBC_Ineighbor_alltoallw_args *a, NBC_In
 }
 #endif
 
-static int nbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
-                                       void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
+static int nbc_neighbor_alltoallw_init(const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
+                                       void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
                                        struct ompi_communicator_t *comm, ompi_request_t ** request,
                                        mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -156,8 +156,8 @@ static int nbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, con
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
-                                         void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
+int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
+                                         void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoallw_init(sbuf, scounts, sdisps, stypes, rbuf, rcounts, rdisps, rtypes,
@@ -175,8 +175,8 @@ int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const int *scounts, c
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_neighbor_alltoallw_init(const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
-                                             void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
+int ompi_coll_libnbc_neighbor_alltoallw_init(const void *sbuf, const size_t *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *stypes,
+                                             void *rbuf, const size_t *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rtypes,
                                              struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                              mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoallw_init(sbuf, scounts, sdisps, stypes, rbuf, rcounts, rdisps, rtypes,

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -179,10 +179,10 @@ struct NBC_dummyarg {
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
 } NBC_Alltoall_args;
 int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *param);
@@ -190,10 +190,10 @@ int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
 } NBC_Allgather_args;
 int NBC_Allgather_args_compare(NBC_Allgather_args *a, NBC_Allgather_args *b, void *param);
@@ -202,7 +202,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
 } NBC_Allreduce_args;
@@ -211,7 +211,7 @@ int NBC_Allreduce_args_compare(NBC_Allreduce_args *a, NBC_Allreduce_args *b, voi
 typedef struct {
   NBC_Schedule *schedule;
   void *buffer;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   int root;
 } NBC_Bcast_args;
@@ -220,10 +220,10 @@ int NBC_Bcast_args_compare(NBC_Bcast_args *a, NBC_Bcast_args *b, void *param);
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
   int root;
 } NBC_Gather_args;
@@ -233,7 +233,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
   int root;
@@ -244,7 +244,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
 } NBC_Scan_args;
@@ -253,10 +253,10 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param);
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
   int root;
 } NBC_Scatter_args;
@@ -506,7 +506,7 @@ static inline int NBC_Type_intrinsic(MPI_Datatype type) {
 }
 
 /* let's give a try to inline functions */
-static inline int NBC_Copy(const void *src, int srccount, MPI_Datatype srctype, void *tgt, int tgtcount, MPI_Datatype tgttype, MPI_Comm comm) {
+static inline int NBC_Copy(const void *src, size_t srccount, MPI_Datatype srctype, void *tgt, size_t tgtcount, MPI_Datatype tgttype, MPI_Comm comm) {
   int res;
 
   res = ompi_datatype_sndrcv(src, srccount, srctype, tgt, tgtcount, tgttype);
@@ -518,7 +518,7 @@ static inline int NBC_Copy(const void *src, int srccount, MPI_Datatype srctype, 
   return OMPI_SUCCESS;
 }
 
-static inline int NBC_Unpack(void *src, int srccount, MPI_Datatype srctype, void *tgt, MPI_Comm comm) {
+static inline int NBC_Unpack(void *src, size_t srccount, MPI_Datatype srctype, void *tgt, MPI_Comm comm) {
   MPI_Aint size, pos;
   int res;
   ptrdiff_t ext, lb;

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
@@ -42,7 +42,7 @@
  *
  */
 
-static int nbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+static int nbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                    MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module, bool persistent) {
   int peer, rank, maxr, p, res;
@@ -211,7 +211,7 @@ static int nbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter (const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter (const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                       MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                       mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_init(sendbuf, recvbuf, recvcounts, datatype, op,
@@ -228,7 +228,7 @@ int ompi_coll_libnbc_ireduce_scatter (const void* sendbuf, void* recvbuf, const 
 
     return OMPI_SUCCESS;
 }
-static int nbc_reduce_scatter_inter_init (const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+static int nbc_reduce_scatter_inter_init (const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                           MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                           mca_coll_base_module_t *module, bool persistent) {
   int rank, res, lsize, rsize;
@@ -355,7 +355,7 @@ static int nbc_reduce_scatter_inter_init (const void* sendbuf, void* recvbuf, co
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter_inter (const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_inter (const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                             MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                             mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_inter_init(sendbuf, recvbuf, recvcounts, datatype, op,
@@ -373,7 +373,7 @@ int ompi_coll_libnbc_ireduce_scatter_inter (const void* sendbuf, void* recvbuf, 
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                          MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_init(sendbuf, recvbuf, recvcounts, datatype, op,
@@ -385,7 +385,7 @@ int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, con
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_inter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_inter_init(const void* sendbuf, void* recvbuf, const size_t *recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_inter_init(sendbuf, recvbuf, recvcounts, datatype, op,

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
@@ -40,7 +40,7 @@
  *
  */
 
-static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                          MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module, bool persistent) {
   int peer, rank, maxr, p, res;
@@ -209,7 +209,7 @@ static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                            MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                            mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -227,7 +227,7 @@ int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, i
     return OMPI_SUCCESS;
 }
 
-static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbuf, int rcount, struct ompi_datatype_t *dtype,
+static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t **request,
                                                mca_coll_base_module_t *module, bool persistent) {
   int rank, res, lsize, rsize;
@@ -349,7 +349,7 @@ static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbu
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                  MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                                  mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_inter_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -367,7 +367,7 @@ int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recv
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -379,7 +379,7 @@ int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbu
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                      MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                      mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_inter_init(sendbuf, recvbuf, recvcount, datatype, op,

--- a/ompi/mca/coll/libnbc/nbc_iscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iscan.c
@@ -24,12 +24,12 @@
 #include "nbc_internal.h"
 
 static inline int scan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf);
 static inline int scan_sched_recursivedoubling(
     int rank, int comm_size, const void *sendbuf, void *recvbuf,
-    int count, MPI_Datatype datatype,  MPI_Op op, char inplace,
+    size_t count, MPI_Datatype datatype,  MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -51,7 +51,7 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
 }
 #endif
 
-static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+static int nbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                          mca_coll_base_module_t *module, bool persistent) {
     int rank, p, res;
@@ -181,7 +181,7 @@ static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Data
  * Schedule length: O(1)
  */
 static inline int scan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf)
 {
@@ -251,7 +251,7 @@ cleanup_and_return:
  * Schedule length: O(log(p))
  */
 static inline int scan_sched_recursivedoubling(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype, MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2)
 {
@@ -312,7 +312,7 @@ static inline int scan_sched_recursivedoubling(
     return res;
 }
 
-int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module) {
     int res = nbc_scan_init(sendbuf, recvbuf, count, datatype, op,
@@ -330,7 +330,7 @@ int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Da
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_scan_init(sendbuf, recvbuf, count, datatype, op,

--- a/ompi/mca/coll/libnbc/nbc_iscatter.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatter.c
@@ -45,8 +45,8 @@ int NBC_Scatter_args_compare(NBC_Scatter_args *a, NBC_Scatter_args *b, void *par
 #endif
 
 /* simple linear MPI_Iscatter */
-static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                             void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -168,8 +168,8 @@ static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype se
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatter (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                               void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_scatter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -187,8 +187,8 @@ int ompi_coll_libnbc_iscatter (const void* sendbuf, int sendcount, MPI_Datatype 
     return OMPI_SUCCESS;
 }
 
-static int nbc_scatter_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatter_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                   void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module, bool persistent) {
     int res, rsize;
@@ -247,8 +247,8 @@ static int nbc_scatter_inter_init (const void* sendbuf, int sendcount, MPI_Datat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                     void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                      struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module) {
     int res = nbc_scatter_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -266,8 +266,8 @@ int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, int sendcount, MPI_Dat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module) {
     int res = nbc_scatter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -279,8 +279,8 @@ int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                         struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module) {
     int res = nbc_scatter_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,

--- a/ompi/mca/coll/libnbc/nbc_iscatterv.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatterv.c
@@ -28,8 +28,8 @@
  * would not be sufficient ... we simply do not cache it */
 
 /* simple linear MPI_Iscatterv */
-static int nbc_scatterv_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                             void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatterv_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                             void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -103,8 +103,8 @@ static int nbc_scatterv_init(const void* sendbuf, const int *sendcounts, const i
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatterv(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatterv(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                               void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_scatterv_init(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
@@ -122,8 +122,8 @@ int ompi_coll_libnbc_iscatterv(const void* sendbuf, const int *sendcounts, const
     return OMPI_SUCCESS;
 }
 
-static int nbc_scatterv_inter_init (const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                    void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatterv_inter_init (const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                    void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                     struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module, bool persistent) {
     int res, rsize;
@@ -181,8 +181,8 @@ static int nbc_scatterv_inter_init (const void* sendbuf, const int *sendcounts, 
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                     void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                     void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                      struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module) {
     int res = nbc_scatterv_inter_init(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
@@ -200,8 +200,8 @@ int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const int *sendcounts,
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                   void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                   void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                    mca_coll_base_module_t *module) {
     int res = nbc_scatterv_init(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
@@ -213,8 +213,8 @@ int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const int *sendcounts, c
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
-                                         void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const size_t *sendcounts, const ptrdiff_t *displs, MPI_Datatype sendtype,
+                                         void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                          struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module) {
     int res = nbc_scatterv_inter_init(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,

--- a/ompi/mca/coll/monitoring/coll_monitoring.h
+++ b/ompi/mca/coll/monitoring/coll_monitoring.h
@@ -46,48 +46,48 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_monitoring_module_t);
  */
 
 /* Blocking */
-extern int mca_coll_monitoring_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_allgather(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_allgatherv(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, const int *rcounts,
-                                          const int *disps,
+                                          void *rbuf, const size_t *rcounts,
+                                          const ptrdiff_t *disps,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_alltoall(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_alltoallv(const void *sbuf, const int *scounts,
-                                         const int *sdisps,
+extern int mca_coll_monitoring_alltoallv(const void *sbuf, const size_t *scounts,
+                                         const ptrdiff_t *sdisps,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, const int *rcounts,
-                                         const int *rdisps,
+                                         void *rbuf, const size_t *rcounts,
+                                         const ptrdiff_t *rdisps,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
-                                         const int *sdisps,
+extern int mca_coll_monitoring_alltoallw(const void *sbuf, const size_t *scounts,
+                                         const ptrdiff_t *sdisps,
                                          struct ompi_datatype_t * const *sdtypes,
-                                         void *rbuf, const int *rcounts,
-                                         const int *rdisps,
+                                         void *rbuf, const size_t *rcounts,
+                                         const ptrdiff_t *rdisps,
                                          struct ompi_datatype_t * const *rdtypes,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
@@ -95,33 +95,33 @@ extern int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
 extern int mca_coll_monitoring_barrier(struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_bcast(void *buff, int count,
+extern int mca_coll_monitoring_bcast(void *buff, size_t count,
                                      struct ompi_datatype_t *datatype,
                                      int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_gather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_gather(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                      void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                       int root, struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_gatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_gatherv(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, const int *rcounts, const int *disps,
+                                       void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                        struct ompi_datatype_t *rdtype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       int root,
@@ -129,89 +129,89 @@ extern int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
                                       mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,
-                                              const int *rcounts,
+                                              const size_t *rcounts,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
-                                                    int rcount,
+                                                    size_t rcount,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     struct ompi_communicator_t *comm,
                                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_scatter(const void *sbuf, int scount,
+extern int mca_coll_monitoring_scatter(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, const int *disps,
+extern int mca_coll_monitoring_scatterv(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
 /* Nonblocking */
-extern int mca_coll_monitoring_iallgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_iallgather(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iallgatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_iallgatherv(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void *rbuf, const int *rcounts,
-                                           const int *disps,
+                                           void *rbuf, const size_t *rcounts,
+                                           const ptrdiff_t *disps,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            ompi_request_t ** request,
                                            mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ialltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ialltoall(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ialltoallv(const void *sbuf, const int *scounts,
-                                          const int *sdisps,
+extern int mca_coll_monitoring_ialltoallv(const void *sbuf, const size_t *scounts,
+                                          const ptrdiff_t *sdisps,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, const int *rcounts,
-                                          const int *rdisps,
+                                          void *rbuf, const size_t *rcounts,
+                                          const ptrdiff_t *rdisps,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ialltoallw(const void *sbuf, const int *scounts,
-                                          const int *sdisps,
+extern int mca_coll_monitoring_ialltoallw(const void *sbuf, const size_t *scounts,
+                                          const ptrdiff_t *sdisps,
                                           struct ompi_datatype_t * const *sdtypes,
-                                          void *rbuf, const int *rcounts,
-                                          const int *rdisps,
+                                          void *rbuf, const size_t *rcounts,
+                                          const ptrdiff_t *rdisps,
                                           struct ompi_datatype_t * const *rdtypes,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
@@ -221,37 +221,37 @@ extern int mca_coll_monitoring_ibarrier(struct ompi_communicator_t *comm,
                                         ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ibcast(void *buff, int count,
+extern int mca_coll_monitoring_ibcast(void *buff, size_t count,
                                       struct ompi_datatype_t *datatype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       ompi_request_t ** request,
                                       mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_igather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_igather(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                       void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                        int root, struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_igatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_igatherv(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, const int *rcounts, const int *disps,
+                                        void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                         struct ompi_datatype_t *rdtype,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        int root,
@@ -260,7 +260,7 @@ extern int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
                                        mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_ireduce_scatter(const void *sbuf, void *rbuf,
-                                               const int *rcounts,
+                                               const size_t *rcounts,
                                                struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op,
                                                struct ompi_communicator_t *comm,
@@ -268,32 +268,32 @@ extern int mca_coll_monitoring_ireduce_scatter(const void *sbuf, void *rbuf,
                                                mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_ireduce_scatter_block(const void *sbuf, void *rbuf,
-                                                     int rcount,
+                                                     size_t rcount,
                                                      struct ompi_datatype_t *dtype,
                                                      struct ompi_op_t *op,
                                                      struct ompi_communicator_t *comm,
                                                      ompi_request_t ** request,
                                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
                                      ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iscatter(const void *sbuf, int scount,
+extern int mca_coll_monitoring_iscatter(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iscatterv(const void *sbuf, const int *scounts, const int *disps,
+extern int mca_coll_monitoring_iscatterv(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          int root,
                                          struct ompi_communicator_t *comm,
@@ -301,81 +301,81 @@ extern int mca_coll_monitoring_iscatterv(const void *sbuf, const int *scounts, c
                                          mca_coll_base_module_t *module);
 
 /* Neighbor */
-extern int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_neighbor_allgather(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                                  int rcount, struct ompi_datatype_t *rdtype,
+                                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, size_t scount,
                                                    struct ompi_datatype_t *sdtype, void * rbuf,
-                                                   const int *rcounts, const int *disps,
+                                                   const size_t *rcounts, const ptrdiff_t *disps,
                                                    struct ompi_datatype_t *rdtype,
                                                    struct ompi_communicator_t *comm,
                                                    mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, size_t scount,
                                                  struct ompi_datatype_t *sdtype,
-                                                 void *rbuf, int rcount,
+                                                 void *rbuf, size_t rcount,
                                                  struct ompi_datatype_t *rdtype,
                                                  struct ompi_communicator_t *comm,
                                                  mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,
-                                                  const int *sdisps,
+extern int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const size_t *scounts,
+                                                  const ptrdiff_t *sdisps,
                                                   struct ompi_datatype_t *sdtype,
-                                                  void *rbuf, const int *rcounts,
-                                                  const int *rdisps,
+                                                  void *rbuf, const size_t *rcounts,
+                                                  const ptrdiff_t *rdisps,
                                                   struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,
+extern int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const size_t *scounts,
                                                   const MPI_Aint *sdisps,
                                                   struct ompi_datatype_t * const *sdtypes,
-                                                  void *rbuf, const int *rcounts,
+                                                  void *rbuf, const size_t *rcounts,
                                                   const MPI_Aint *rdisps,
                                                   struct ompi_datatype_t * const *rdtypes,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, size_t scount,
                                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                                   int rcount, struct ompi_datatype_t *rdtype,
+                                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                                    struct ompi_communicator_t *comm,
                                                    ompi_request_t ** request,
                                                    mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, size_t scount,
                                                     struct ompi_datatype_t *sdtype,
-                                                    void * rbuf, const int *rcounts,
-                                                    const int *disps,
+                                                    void * rbuf, const size_t *rcounts,
+                                                    const ptrdiff_t *disps,
                                                     struct ompi_datatype_t *rdtype,
                                                     struct ompi_communicator_t *comm,
                                                     ompi_request_t ** request,
                                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                                  int rcount, struct ompi_datatype_t *rdtype,
+                                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   ompi_request_t ** request,
                                                   mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const int *scounts,
-                                                   const int *sdisps,
+extern int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const size_t *scounts,
+                                                   const ptrdiff_t *sdisps,
                                                    struct ompi_datatype_t *sdtype,
-                                                   void *rbuf, const int *rcounts,
-                                                   const int *rdisps,
+                                                   void *rbuf, const size_t *rcounts,
+                                                   const ptrdiff_t *rdisps,
                                                    struct ompi_datatype_t *rdtype,
                                                    struct ompi_communicator_t *comm,
                                                    ompi_request_t ** request,
                                                    mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const int *scounts,
+extern int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const size_t *scounts,
                                                    const MPI_Aint *sdisps,
                                                    struct ompi_datatype_t * const *sdtypes,
-                                                   void *rbuf, const int *rcounts,
+                                                   void *rbuf, const size_t *rcounts,
                                                    const MPI_Aint *rdisps,
                                                    struct ompi_datatype_t * const *rdtypes,
                                                    struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_allgather(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
@@ -43,9 +43,9 @@ int mca_coll_monitoring_allgather(const void *sbuf, int scount,
     return monitoring_module->real.coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_allgather_module);
 }
 
-int mca_coll_monitoring_iallgather(const void *sbuf, int scount,
+int mca_coll_monitoring_iallgather(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void *rbuf, int rcount,
+                                   void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_allgatherv(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void * rbuf, const int *rcounts, const int *disps,
+                                   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module)
@@ -43,9 +43,9 @@ int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,
     return monitoring_module->real.coll_allgatherv(sbuf, scount, sdtype, rbuf, rcounts, disps, rdtype, comm, monitoring_module->real.coll_allgatherv_module);
 }
 
-int mca_coll_monitoring_iallgatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_iallgatherv(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void * rbuf, const int *rcounts, const int *disps,
+                                    void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -43,7 +43,7 @@ int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_allreduce(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_allreduce_module);
 }
 
-int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
@@ -15,8 +15,8 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_monitoring_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                 void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
 {
@@ -41,9 +41,9 @@ int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datat
     return monitoring_module->real.coll_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_alltoall_module);
 }
 
-int mca_coll_monitoring_ialltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_ialltoall(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_alltoallv(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_monitoring_alltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, const int *rcounts, const int *rdisps,
+                                  void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
@@ -44,11 +44,11 @@ int mca_coll_monitoring_alltoallv(const void *sbuf, const int *scounts, const in
     return monitoring_module->real.coll_alltoallv(sbuf, scounts, sdisps, sdtype, rbuf, rcounts, rdisps, rdtype, comm, monitoring_module->real.coll_alltoallv_module);
 }
 
-int mca_coll_monitoring_ialltoallv(const void *sbuf, const int *scounts,
-                                   const int *sdisps,
+int mca_coll_monitoring_ialltoallv(const void *sbuf, const size_t *scounts,
+                                   const ptrdiff_t *sdisps,
                                    struct ompi_datatype_t *sdtype,
-                                   void *rbuf, const int *rcounts,
-                                   const int *rdisps,
+                                   void *rbuf, const size_t *rcounts,
+                                   const ptrdiff_t *rdisps,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
@@ -15,11 +15,11 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
-                                  const int *sdisps,
+int mca_coll_monitoring_alltoallw(const void *sbuf, const size_t *scounts,
+                                  const ptrdiff_t *sdisps,
                                   struct ompi_datatype_t * const *sdtypes,
-                                  void *rbuf, const int *rcounts,
-                                  const int *rdisps,
+                                  void *rbuf, const size_t *rcounts,
+                                  const ptrdiff_t *rdisps,
                                   struct ompi_datatype_t * const *rdtypes,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
@@ -46,11 +46,11 @@ int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
     return monitoring_module->real.coll_alltoallw(sbuf, scounts, sdisps, sdtypes, rbuf, rcounts, rdisps, rdtypes, comm, monitoring_module->real.coll_alltoallw_module);
 }
 
-int mca_coll_monitoring_ialltoallw(const void *sbuf, const int *scounts,
-                                   const int *sdisps,
+int mca_coll_monitoring_ialltoallw(const void *sbuf, const size_t *scounts,
+                                   const ptrdiff_t *sdisps,
                                    struct ompi_datatype_t * const *sdtypes,
-                                   void *rbuf, const int *rcounts,
-                                   const int *rdisps,
+                                   void *rbuf, const size_t *rcounts,
+                                   const ptrdiff_t *rdisps,
                                    struct ompi_datatype_t * const *rdtypes,
                                    struct ompi_communicator_t *comm,
                                    ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
@@ -15,7 +15,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_bcast(void *buff, int count,
+int mca_coll_monitoring_bcast(void *buff, size_t count,
                               struct ompi_datatype_t *datatype,
                               int root,
                               struct ompi_communicator_t *comm,
@@ -43,7 +43,7 @@ int mca_coll_monitoring_bcast(void *buff, int count,
     return monitoring_module->real.coll_bcast(buff, count, datatype, root, comm, monitoring_module->real.coll_bcast_module);
 }
 
-int mca_coll_monitoring_ibcast(void *buff, int count,
+int mca_coll_monitoring_ibcast(void *buff, size_t count,
                                struct ompi_datatype_t *datatype,
                                int root,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_component.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_component.c
@@ -221,7 +221,7 @@ mca_coll_monitoring_component_t mca_coll_monitoring_component = {
         /* First, the mca_base_component_t struct containing meta
            information about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             .mca_component_name = "monitoring", /* MCA component name */
             MCA_MONITORING_MAKE_VERSION,

--- a/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
@@ -42,7 +42,7 @@ int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_exscan(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_exscan_module);
 }
 
-int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_gather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gather.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_gather(const void *sbuf, int scount,
+int mca_coll_monitoring_gather(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                               void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
 {
@@ -43,9 +43,9 @@ int mca_coll_monitoring_gather(const void *sbuf, int scount,
     return monitoring_module->real.coll_gather(sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm, monitoring_module->real.coll_gather_module);
 }
 
-int mca_coll_monitoring_igather(const void *sbuf, int scount,
+int mca_coll_monitoring_igather(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                 int root, struct ompi_communicator_t *comm,
                                 ompi_request_t ** request,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_gatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_gatherv(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, const int *rcounts, const int *disps,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,
@@ -46,9 +46,9 @@ int mca_coll_monitoring_gatherv(const void *sbuf, int scount,
     return monitoring_module->real.coll_gatherv(sbuf, scount, sdtype, rbuf, rcounts, disps, rdtype, root, comm, monitoring_module->real.coll_gatherv_module);
 }
 
-int mca_coll_monitoring_igatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_igatherv(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, const int *rcounts, const int *disps,
+                                 void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_neighbor_allgather(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype, void *rbuf,
-                                           int rcount, struct ompi_datatype_t *rdtype,
+                                           size_t rcount, struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module)
 {
@@ -68,9 +68,9 @@ int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
     return monitoring_module->real.coll_neighbor_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_neighbor_allgather_module);
 }
 
-int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype, void *rbuf,
-                                            int rcount, struct ompi_datatype_t *rdtype,
+                                            size_t rcount, struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             ompi_request_t ** request,
                                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void * rbuf, const int *rcounts, const int *disps,
+                                            void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -69,9 +69,9 @@ int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
     return monitoring_module->real.coll_neighbor_allgatherv(sbuf, scount, sdtype, rbuf, rcounts, disps, rdtype, comm, monitoring_module->real.coll_neighbor_allgatherv_module);
 }
 
-int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, int scount,
+int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void * rbuf, const int *rcounts, const int *disps,
+                                             void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void* rbuf, int rcount,
+                                          void* rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
@@ -69,9 +69,9 @@ int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
     return monitoring_module->real.coll_neighbor_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_neighbor_alltoall_module);
 }
 
-int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void *rbuf, int rcount,
+                                           void *rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,
-                                           const int *sdisps, struct ompi_datatype_t *sdtype,
-                                           void *rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const size_t *scounts,
+                                           const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+                                           void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module)
@@ -72,11 +72,11 @@ int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,
     return monitoring_module->real.coll_neighbor_alltoallv(sbuf, scounts, sdisps, sdtype, rbuf, rcounts, rdisps, rdtype, comm, monitoring_module->real.coll_neighbor_alltoallv_module);
 }
 
-int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const int *scounts,
-                                            const int *sdisps,
+int mca_coll_monitoring_ineighbor_alltoallv(const void *sbuf, const size_t *scounts,
+                                            const ptrdiff_t *sdisps,
                                             struct ompi_datatype_t *sdtype,
-                                            void *rbuf, const int *rcounts,
-                                            const int *rdisps,
+                                            void *rbuf, const size_t *rcounts,
+                                            const ptrdiff_t *rdisps,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
@@ -16,10 +16,10 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,
+int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const size_t *scounts,
                                            const MPI_Aint *sdisps,
                                            struct ompi_datatype_t * const *sdtypes,
-                                           void *rbuf, const int *rcounts,
+                                           void *rbuf, const size_t *rcounts,
                                            const MPI_Aint *rdisps,
                                            struct ompi_datatype_t * const *rdtypes,
                                            struct ompi_communicator_t *comm,
@@ -74,10 +74,10 @@ int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,
     return monitoring_module->real.coll_neighbor_alltoallw(sbuf, scounts, sdisps, sdtypes, rbuf, rcounts, rdisps, rdtypes, comm, monitoring_module->real.coll_neighbor_alltoallw_module);
 }
 
-int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const int *scounts,
+int mca_coll_monitoring_ineighbor_alltoallw(const void *sbuf, const size_t *scounts,
                                             const MPI_Aint *sdisps,
                                             struct ompi_datatype_t * const *sdtypes,
-                                            void *rbuf, const int *rcounts,
+                                            void *rbuf, const size_t *rcounts,
                                             const MPI_Aint *rdisps,
                                             struct ompi_datatype_t * const *rdtypes,
                                             struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root,
@@ -45,7 +45,7 @@ int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_reduce(sbuf, rbuf, count, dtype, op, root, comm, monitoring_module->real.coll_reduce_module);
 }
 
-int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
@@ -17,7 +17,7 @@
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,
-                                       const int *rcounts,
+                                       const size_t *rcounts,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
@@ -46,7 +46,7 @@ int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,
 }
 
 int mca_coll_monitoring_ireduce_scatter(const void *sbuf, void *rbuf,
-                                        const int *rcounts,
+                                        const size_t *rcounts,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
@@ -17,7 +17,7 @@
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
-                                             int rcount,
+                                             size_t rcount,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -45,7 +45,7 @@ int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
 }
 
 int mca_coll_monitoring_ireduce_scatter_block(const void *sbuf, void *rbuf,
-                                              int rcount,
+                                              size_t rcount,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op,
                                               struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scan.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,
@@ -42,7 +42,7 @@ int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_scan(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_scan_module);
 }
 
-int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, size_t count,
                               struct ompi_datatype_t *dtype,
                               struct ompi_op_t *op,
                               struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_scatter(const void *sbuf, int scount,
+int mca_coll_monitoring_scatter(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,
@@ -47,9 +47,9 @@ int mca_coll_monitoring_scatter(const void *sbuf, int scount,
 }
 
 
-int mca_coll_monitoring_iscatter(const void *sbuf, int scount,
+int mca_coll_monitoring_iscatter(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, const int *disps,
+int mca_coll_monitoring_scatterv(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                  struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                 void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                  int root, struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
 {
@@ -44,9 +44,9 @@ int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, const int
     return monitoring_module->real.coll_scatterv(sbuf, scounts, disps, sdtype, rbuf, rcount, rdtype, root, comm, monitoring_module->real.coll_scatterv_module);
 }
 
-int mca_coll_monitoring_iscatterv(const void *sbuf, const int *scounts, const int *disps,
+int mca_coll_monitoring_iscatterv(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                  void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                   int root, struct ompi_communicator_t *comm,
                                   ompi_request_t ** request,
                                   mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self.h
+++ b/ompi/mca/coll/self/coll_self.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_self_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_self_component;
 extern int ompi_coll_self_priority;
 
 /*
@@ -53,89 +53,89 @@ mca_coll_self_comm_query(struct ompi_communicator_t *comm, int *priority);
 int mca_coll_self_module_enable(mca_coll_base_module_t *module,
                                 struct ompi_communicator_t *comm);
 
-int mca_coll_self_allgather_intra(const void *sbuf, int scount,
+int mca_coll_self_allgather_intra(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-int mca_coll_self_allgatherv_intra(const void *sbuf, int scount,
+int mca_coll_self_allgatherv_intra(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void * rbuf, const int *rcounts, const int *disps,
+                                   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-int mca_coll_self_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_self_alltoall_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount,
+                                 void* rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-int mca_coll_self_alltoallv_intra(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_self_alltoallv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, const int *rcounts, const int *rdisps,
+                                  void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-int mca_coll_self_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_self_alltoallw_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                   struct ompi_datatype_t * const *sdtypes,
-                                  void *rbuf, const int *rcounts, const int *rdisps,
+                                  void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                   struct ompi_datatype_t * const *rdtypes,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 int mca_coll_self_barrier_intra(struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_self_bcast_intra(void *buff, int count,
+int mca_coll_self_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype,
                               int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module);
-int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
-int mca_coll_self_gather_intra(const void *sbuf, int scount,
+int mca_coll_self_gather_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype, void *rbuf,
-                               int rcount, struct ompi_datatype_t *rdtype,
+                               size_t rcount, struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
-int mca_coll_self_gatherv_intra(const void *sbuf, int scount,
+int mca_coll_self_gatherv_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype, void *rbuf,
-                                const int *rcounts, const int *disps,
+                                const size_t *rcounts, const ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_self_reduce_intra(const void *sbuf, void* rbuf, int count,
+int mca_coll_self_reduce_intra(const void *sbuf, void* rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
 int mca_coll_self_reduce_scatter_intra(const void *sbuf, void *rbuf,
-                                       const int *rcounts,
+                                       const size_t *rcounts,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module);
-int mca_coll_self_scatter_intra(const void *sbuf, int scount,
+int mca_coll_self_scatter_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype, void *rbuf,
-                                int rcount, struct ompi_datatype_t *rdtype,
+                                size_t rcount, struct ompi_datatype_t *rdtype,
                                 int root, struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_self_scatterv_intra(const void *sbuf, const int *scounts, const int *disps,
+int mca_coll_self_scatterv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                                  struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount,
+                                 void* rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype, int root,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);

--- a/ompi/mca/coll/self/coll_self_allgather.c
+++ b/ompi/mca/coll/self/coll_self_allgather.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS, or error code
  */
-int mca_coll_self_allgather_intra(const void *sbuf, int scount,
+int mca_coll_self_allgather_intra(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                  int rcount, struct ompi_datatype_t *rdtype,
+                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/self/coll_self_allgatherv.c
+++ b/ompi/mca/coll/self/coll_self_allgatherv.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same as MPI_Allgatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_allgatherv_intra(const void *sbuf, int scount,
+int mca_coll_self_allgatherv_intra(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void * rbuf, const int *rcounts, const int *disps,
+                                   void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_allreduce.c
+++ b/ompi/mca/coll/self/coll_self_allreduce.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_alltoall.c
+++ b/ompi/mca/coll/self/coll_self_alltoall.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_self_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_self_alltoall_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_alltoallv.c
+++ b/ompi/mca/coll/self/coll_self_alltoallv.c
@@ -34,9 +34,9 @@
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_self_alltoallv_intra(const void *sbuf, const int *scounts, const int *sdisps,
+mca_coll_self_alltoallv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, const int *rcounts, const int *rdisps,
+                              void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_alltoallw.c
+++ b/ompi/mca/coll/self/coll_self_alltoallw.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Alltoallw()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_self_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_self_alltoallw_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                   struct ompi_datatype_t * const *sdtypes,
-                                  void *rbuf, const int *rcounts, const int *rdisps,
+                                  void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                   struct ompi_datatype_t * const *rdtypes,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_bcast.c
+++ b/ompi/mca/coll/self/coll_self_bcast.c
@@ -30,7 +30,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS
  */
-int mca_coll_self_bcast_intra(void *buff, int count,
+int mca_coll_self_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_component.c
+++ b/ompi/mca/coll/self/coll_self_component.c
@@ -55,13 +55,13 @@ static int self_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_self_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_self_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "self",

--- a/ompi/mca/coll/self/coll_self_exscan.c
+++ b/ompi/mca/coll/self/coll_self_exscan.c
@@ -31,7 +31,7 @@
  *	Accepts:	- same arguments as MPI_Exccan()
  *	Returns:	- MPI_SUCCESS
  */
-int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_gather.c
+++ b/ompi/mca/coll/self/coll_self_gather.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_gather_intra(const void *sbuf, int scount,
+int mca_coll_self_gather_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_gatherv.c
+++ b/ompi/mca/coll/self/coll_self_gatherv.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Gatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_gatherv_intra(const void *sbuf, int scount,
+int mca_coll_self_gatherv_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, const int *rcounts, const int *disps,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_reduce.c
+++ b/ompi/mca/coll/self/coll_self_reduce.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_reduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_reduce_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_reduce_scatter.c
+++ b/ompi/mca/coll/self/coll_self_reduce_scatter.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_self_reduce_scatter_intra(const void *sbuf, void *rbuf, const size_t *rcounts,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_scan.c
+++ b/ompi/mca/coll/self/coll_self_scan.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_scatter.c
+++ b/ompi/mca/coll/self/coll_self_scatter.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_scatter_intra(const void *sbuf, int scount,
+int mca_coll_self_scatter_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_scatterv.c
+++ b/ompi/mca/coll/self/coll_self_scatterv.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_scatterv_intra(const void *sbuf, const int *scounts,
-                                 const int *disps, struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+int mca_coll_self_scatterv_intra(const void *sbuf, const size_t *scounts,
+                                 const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype, int root,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm.h
+++ b/ompi/mca/coll/sm/coll_sm.h
@@ -55,7 +55,7 @@ BEGIN_C_DECLS
      */
     typedef struct mca_coll_sm_component_t {
         /** Base coll component */
-        mca_coll_base_component_2_4_0_t super;
+        mca_coll_base_component_3_0_0_t super;
 
         /** MCA parameter: Priority of this component */
         int sm_priority;
@@ -217,101 +217,101 @@ BEGIN_C_DECLS
     int ompi_coll_sm_lazy_enable(mca_coll_base_module_t *module,
                                  struct ompi_communicator_t *comm);
 
-    int mca_coll_sm_allgather_intra(const void *sbuf, int scount,
+    int mca_coll_sm_allgather_intra(const void *sbuf, size_t scount,
 				    struct ompi_datatype_t *sdtype,
-				    void *rbuf, int rcount,
+				    void *rbuf, size_t rcount,
 				    struct ompi_datatype_t *rdtype,
 				    struct ompi_communicator_t *comm,
 				    mca_coll_base_module_t *module);
 
-    int mca_coll_sm_allgatherv_intra(const void *sbuf, int scount,
+    int mca_coll_sm_allgatherv_intra(const void *sbuf, size_t scount,
 				     struct ompi_datatype_t *sdtype,
-				     void * rbuf, const int *rcounts, const int *disps,
+				     void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
 				     struct ompi_datatype_t *rdtype,
 				     struct ompi_communicator_t *comm,
 				     mca_coll_base_module_t *module);
-    int mca_coll_sm_allreduce_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_sm_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
 				    struct ompi_datatype_t *dtype,
 				    struct ompi_op_t *op,
 				    struct ompi_communicator_t *comm,
 				    mca_coll_base_module_t *module);
-    int mca_coll_sm_alltoall_intra(const void *sbuf, int scount,
+    int mca_coll_sm_alltoall_intra(const void *sbuf, size_t scount,
 				   struct ompi_datatype_t *sdtype,
-				   void* rbuf, int rcount,
+				   void* rbuf, size_t rcount,
 				   struct ompi_datatype_t *rdtype,
 				   struct ompi_communicator_t *comm,
 				   mca_coll_base_module_t *module);
-    int mca_coll_sm_alltoallv_intra(const void *sbuf, const int *scounts, const int *sdisps,
+    int mca_coll_sm_alltoallv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
 				    struct ompi_datatype_t *sdtype,
-				    void *rbuf, const int *rcounts, const int *rdisps,
+				    void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
 				    struct ompi_datatype_t *rdtype,
 				    struct ompi_communicator_t *comm,
 				    mca_coll_base_module_t *module);
-    int mca_coll_sm_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
+    int mca_coll_sm_alltoallw_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
 				    struct ompi_datatype_t * const *sdtypes,
-				    void *rbuf, const int *rcounts, const int *rdisps,
+				    void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
 				    struct ompi_datatype_t * const *rdtypes,
 				    struct ompi_communicator_t *comm,
 				    mca_coll_base_module_t *module);
     int mca_coll_sm_barrier_intra(struct ompi_communicator_t *comm,
 				  mca_coll_base_module_t *module);
-    int mca_coll_sm_bcast_intra(void *buff, int count,
+    int mca_coll_sm_bcast_intra(void *buff, size_t count,
 				struct ompi_datatype_t *datatype,
 				int root,
 				struct ompi_communicator_t *comm,
 				mca_coll_base_module_t *module);
-    int mca_coll_sm_bcast_log_intra(void *buff, int count,
+    int mca_coll_sm_bcast_log_intra(void *buff, size_t count,
 				    struct ompi_datatype_t *datatype,
 				    int root,
 				    struct ompi_communicator_t *comm,
 				    mca_coll_base_module_t *module);
-    int mca_coll_sm_exscan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_sm_exscan_intra(const void *sbuf, void *rbuf, size_t count,
 				 struct ompi_datatype_t *dtype,
 				 struct ompi_op_t *op,
 				 struct ompi_communicator_t *comm,
 				 mca_coll_base_module_t *module);
-    int mca_coll_sm_gather_intra(void *sbuf, int scount,
+    int mca_coll_sm_gather_intra(void *sbuf, size_t scount,
 				 struct ompi_datatype_t *sdtype, void *rbuf,
-				 int rcount, struct ompi_datatype_t *rdtype,
+				 size_t rcount, struct ompi_datatype_t *rdtype,
 				 int root, struct ompi_communicator_t *comm,
 				 mca_coll_base_module_t *module);
-    int mca_coll_sm_gatherv_intra(void *sbuf, int scount,
+    int mca_coll_sm_gatherv_intra(void *sbuf, size_t scount,
 				  struct ompi_datatype_t *sdtype, void *rbuf,
-				  int *rcounts, int *disps,
+				  size_t *rcounts, ptrdiff_t *disps,
 				  struct ompi_datatype_t *rdtype, int root,
 				  struct ompi_communicator_t *comm,
 				  mca_coll_base_module_t *module);
-    int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, int count,
+    int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, size_t count,
 				 struct ompi_datatype_t *dtype,
 				 struct ompi_op_t *op,
 				 int root,
 				 struct ompi_communicator_t *comm,
 				 mca_coll_base_module_t *module);
-    int mca_coll_sm_reduce_log_intra(const void *sbuf, void* rbuf, int count,
+    int mca_coll_sm_reduce_log_intra(const void *sbuf, void* rbuf, size_t count,
 				     struct ompi_datatype_t *dtype,
 				     struct ompi_op_t *op,
 				     int root,
 				     struct ompi_communicator_t *comm,
 				     mca_coll_base_module_t *module);
     int mca_coll_sm_reduce_scatter_intra(const void *sbuf, void *rbuf,
-					 int *rcounts,
+					 size_t *rcounts,
 					 struct ompi_datatype_t *dtype,
 					 struct ompi_op_t *op,
 					 struct ompi_communicator_t *comm,
 					 mca_coll_base_module_t *module);
-    int mca_coll_sm_scan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_sm_scan_intra(const void *sbuf, void *rbuf, size_t count,
 			       struct ompi_datatype_t *dtype,
 			       struct ompi_op_t *op,
 			       struct ompi_communicator_t *comm,
 			       mca_coll_base_module_t *module);
-    int mca_coll_sm_scatter_intra(const void *sbuf, int scount,
+    int mca_coll_sm_scatter_intra(const void *sbuf, size_t scount,
 				  struct ompi_datatype_t *sdtype, void *rbuf,
-				  int rcount, struct ompi_datatype_t *rdtype,
+				  size_t rcount, struct ompi_datatype_t *rdtype,
 				  int root, struct ompi_communicator_t *comm,
 				  mca_coll_base_module_t *module);
-    int mca_coll_sm_scatterv_intra(const void *sbuf, const int *scounts, const int *disps,
+    int mca_coll_sm_scatterv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
 				   struct ompi_datatype_t *sdtype,
-				   void* rbuf, int rcount,
+				   void* rbuf, size_t rcount,
 				   struct ompi_datatype_t *rdtype, int root,
 				   struct ompi_communicator_t *comm,
 				   mca_coll_base_module_t *module);

--- a/ompi/mca/coll/sm/coll_sm_allgather.c
+++ b/ompi/mca/coll/sm/coll_sm_allgather.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_allgather_intra(const void *sbuf, int scount,
+int mca_coll_sm_allgather_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype, void *rbuf,
-                                int rcount, struct ompi_datatype_t *rdtype,
+                                size_t rcount, struct ompi_datatype_t *rdtype,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/sm/coll_sm_allgatherv.c
+++ b/ompi/mca/coll/sm/coll_sm_allgatherv.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same as MPI_Allgatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_allgatherv_intra(const void *sbuf, int scount,
+int mca_coll_sm_allgatherv_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void * rbuf, const int *rcounts, const int *disps,
+                                 void * rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm_allreduce.c
+++ b/ompi/mca/coll/sm/coll_sm_allreduce.c
@@ -33,7 +33,7 @@
  * For the moment, all we're doing is a reduce to root==0 and then a
  * broadcast.  It is possible that we'll do something better someday.
  */
-int mca_coll_sm_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_sm_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sm/coll_sm_alltoall.c
+++ b/ompi/mca/coll/sm/coll_sm_alltoall.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_sm_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_sm_alltoall_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype, void *rbuf,
-                               int rcount, struct ompi_datatype_t *rdtype,
+                               size_t rcount, struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/sm/coll_sm_alltoallv.c
+++ b/ompi/mca/coll/sm/coll_sm_alltoallv.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same as MPI_Alltoallv()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_sm_alltoallv_intra(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_sm_alltoallv_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, const int *rcounts, const int *rdisps,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                 struct ompi_datatype_t *rdtype,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm_alltoallw.c
+++ b/ompi/mca/coll/sm/coll_sm_alltoallw.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same as MPI_Alltoallw()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_sm_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
+int mca_coll_sm_alltoallw_intra(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                 struct ompi_datatype_t * const *sdtypes,
-                                void *rbuf, const int *rcounts, const int *rdisps,
+                                void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                 struct ompi_datatype_t * const *rdtypes,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm_bcast.c
+++ b/ompi/mca/coll/sm/coll_sm_bcast.c
@@ -53,7 +53,7 @@
  * have children, they copy the data directly from the parent's shared
  * data segment into the user's output buffer.
  */
-int mca_coll_sm_bcast_intra(void *buff, int count,
+int mca_coll_sm_bcast_intra(void *buff, size_t count,
                             struct ompi_datatype_t *datatype, int root,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm_component.c
+++ b/ompi/mca/coll/sm/coll_sm_component.c
@@ -66,7 +66,7 @@ mca_coll_sm_component_t mca_coll_sm_component = {
            information about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "sm",

--- a/ompi/mca/coll/sm/coll_sm_exscan.c
+++ b/ompi/mca/coll/sm/coll_sm_exscan.c
@@ -31,7 +31,7 @@
  *	Accepts:	- same arguments as MPI_Exscan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_sm_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sm/coll_sm_gather.c
+++ b/ompi/mca/coll/sm/coll_sm_gather.c
@@ -31,9 +31,9 @@
  *      Accepts:        - same as MPI_Gather()
  *      Returns:        - MPI_SUCCESS or error code
  */
-int mca_coll_sm_gather_intra(const void *sbuf, int scount,
+int mca_coll_sm_gather_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype, void *rbuf,
-                             int rcount, struct ompi_datatype_t *rdtype,
+                             size_t rcount, struct ompi_datatype_t *rdtype,
                              int root, struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/sm/coll_sm_gatherv.c
+++ b/ompi/mca/coll/sm/coll_sm_gatherv.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same arguments as MPI_Gatherb()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_gatherv_intra(const void *sbuf, int scount,
+int mca_coll_sm_gatherv_intra(const void *sbuf, size_t scount,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, const int *rcounts, const int *disps,
+                              void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                               struct ompi_datatype_t *rdtype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sm/coll_sm_reduce.c
+++ b/ompi/mca/coll/sm/coll_sm_reduce.c
@@ -35,14 +35,14 @@
 /*
  * Local functions
  */
-static int reduce_inorder(const void *sbuf, void* rbuf, int count,
+static int reduce_inorder(const void *sbuf, void* rbuf, size_t count,
                           struct ompi_datatype_t *dtype,
                           struct ompi_op_t *op,
                           int root, struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 #define WANT_REDUCE_NO_ORDER 0
 #if WANT_REDUCE_NO_ORDER
-static int reduce_no_order(const void *sbuf, void* rbuf, int count,
+static int reduce_no_order(const void *sbuf, void* rbuf, size_t count,
                            struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op,
                            int root, struct ompi_communicator_t *comm,
@@ -64,7 +64,7 @@ static inline int min(int a, int b)
  *
  * Simply farms out to the associative or non-associative functions.
  */
-int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, int count,
+int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              int root, struct ompi_communicator_t *comm,
@@ -173,7 +173,7 @@ int mca_coll_sm_reduce_intra(const void *sbuf, void* rbuf, int count,
  */
 
 
-static int reduce_inorder(const void *sbuf, void* rbuf, int count,
+static int reduce_inorder(const void *sbuf, void* rbuf, size_t count,
                           struct ompi_datatype_t *dtype,
                           struct ompi_op_t *op,
                           int root, struct ompi_communicator_t *comm,
@@ -557,7 +557,7 @@ static int reduce_inorder(const void *sbuf, void* rbuf, int count,
  * This function performs the reduction in whatever order the operands
  * arrive.
  */
-static int reduce_no_order(const void *sbuf, void* rbuf, int count,
+static int reduce_no_order(const void *sbuf, void* rbuf, size_t count,
                            struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op,
                            int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sm/coll_sm_reduce_scatter.c
+++ b/ompi/mca/coll/sm/coll_sm_reduce_scatter.c
@@ -31,7 +31,7 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_sm_reduce_scatter_intra(const void *sbuf, void *rbuf, const size_t *rcounts,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sm/coll_sm_scan.c
+++ b/ompi/mca/coll/sm/coll_sm_scan.c
@@ -31,7 +31,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_sm_scan_intra(const void *sbuf, void *rbuf, size_t count,
                            struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op,
                            struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sm/coll_sm_scatter.c
+++ b/ompi/mca/coll/sm/coll_sm_scatter.c
@@ -31,9 +31,9 @@
  *      Accepts:        - same as MPI_Scatter()
  *      Returns:        - MPI_SUCCESS or error code
  */
-int mca_coll_sm_scatter_intra(const void *sbuf, int scount,
+int mca_coll_sm_scatter_intra(const void *sbuf, size_t scount,
                               struct ompi_datatype_t *sdtype, void *rbuf,
-                              int rcount, struct ompi_datatype_t *rdtype,
+                              size_t rcount, struct ompi_datatype_t *rdtype,
                               int root, struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/sm/coll_sm_scatterv.c
+++ b/ompi/mca/coll/sm/coll_sm_scatterv.c
@@ -31,9 +31,9 @@
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sm_scatterv_intra(const void *sbuf, const int *scounts,
-                               const int *disps, struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+int mca_coll_sm_scatterv_intra(const void *sbuf, const size_t *scounts,
+                               const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -49,35 +49,35 @@ int mca_coll_sync_module_enable(mca_coll_base_module_t *module,
 int mca_coll_sync_barrier(struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_bcast(void *buff, int count,
+int mca_coll_sync_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype,
                         int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_sync_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_sync_gather(const void *sbuf, int scount,
+int mca_coll_sync_gather(const void *sbuf, size_t scount,
                          struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount,
+                         void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype,
                          int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_sync_gatherv(const void *sbuf, int scount,
+int mca_coll_sync_gatherv(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, const int *rcounts, const int *disps,
+                          void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root,
@@ -85,29 +85,29 @@ int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
                          mca_coll_base_module_t *module);
 
 int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
-                                 const int *rcounts,
+                                 const size_t *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 
-int mca_coll_sync_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
-int mca_coll_sync_scatter(const void *sbuf, int scount,
+int mca_coll_sync_scatter(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_scatterv(const void *sbuf, const int *scounts, const int *disps,
+int mca_coll_sync_scatterv(const void *sbuf, const size_t *scounts, const ptrdiff_t *disps,
                            struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,
                            struct ompi_communicator_t *comm,
@@ -137,7 +137,7 @@ OBJ_CLASS_DECLARATION(mca_coll_sync_module_t);
 /* Component */
 
 typedef struct mca_coll_sync_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /* Priority of this component */
     int priority;

--- a/ompi/mca/coll/sync/coll_sync_bcast.c
+++ b/ompi/mca/coll/sync/coll_sync_bcast.c
@@ -30,7 +30,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_bcast(void *buff, int count,
+int mca_coll_sync_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_component.c
+++ b/ompi/mca/coll/sync/coll_sync_component.c
@@ -49,7 +49,7 @@ mca_coll_sync_component_t mca_coll_sync_component = {
          * about the component itself */
 
        .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "sync",

--- a/ompi/mca/coll/sync/coll_sync_exscan.c
+++ b/ompi/mca/coll/sync/coll_sync_exscan.c
@@ -29,7 +29,7 @@
  *	Accepts:	- same arguments as MPI_Exscan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_gather.c
+++ b/ompi/mca/coll/sync/coll_sync_gather.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_gather(const void *sbuf, int scount,
+int mca_coll_sync_gather(const void *sbuf, size_t scount,
                          struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount,
+                         void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_gatherv.c
+++ b/ompi/mca/coll/sync/coll_sync_gatherv.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Gatherv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_gatherv(const void *sbuf, int scount,
+int mca_coll_sync_gatherv(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, const int *rcounts, const int *disps,
+                          void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_reduce.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce.c
@@ -28,7 +28,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
@@ -30,7 +30,7 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scan.c
+++ b/ompi/mca/coll/sync/coll_sync_scan.c
@@ -28,7 +28,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_scatter.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scatter(const void *sbuf, int scount,
+int mca_coll_sync_scatter(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root, struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_scatterv.c
+++ b/ompi/mca/coll/sync/coll_sync_scatterv.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
-                           const int *disps, struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+int mca_coll_sync_scatterv(const void *sbuf, const size_t *scounts,
+                           const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)

--- a/ompi/mca/coll/tuned/coll_tuned.h
+++ b/ompi/mca/coll/tuned/coll_tuned.h
@@ -184,7 +184,7 @@ int ompi_coll_tuned_scan_intra_check_forced_init (coll_tuned_force_algorithm_mca
 
 struct mca_coll_tuned_component_t {
 	/** Base coll component */
-	mca_coll_base_component_2_4_0_t super;
+	mca_coll_base_component_3_0_0_t super;
 
 	/** MCA parameter: Priority of this component */
 	int tuned_priority;

--- a/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
@@ -123,9 +123,9 @@ ompi_coll_tuned_allgather_intra_check_forced_init(coll_tuned_force_algorithm_mca
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_allgather_intra_do_this(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_do_this(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgatherv_decision.c
@@ -122,10 +122,10 @@ ompi_coll_tuned_allgatherv_intra_check_forced_init(coll_tuned_force_algorithm_mc
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_allgatherv_intra_do_this(const void *sbuf, int scount,
+int ompi_coll_tuned_allgatherv_intra_do_this(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void *rbuf, const int *rcounts,
-                                             const int *rdispls,
+                                             void *rbuf, const size_t *rcounts,
+                                             const ptrdiff_t *rdispls,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
@@ -122,7 +122,7 @@ int ompi_coll_tuned_allreduce_intra_check_forced_init (coll_tuned_force_algorith
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_allreduce_intra_do_this(const void *sbuf, void *rbuf, int count,
+int ompi_coll_tuned_allreduce_intra_do_this(const void *sbuf, void *rbuf, size_t count,
                                             struct ompi_datatype_t *dtype,
                                             struct ompi_op_t *op,
                                             struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
@@ -153,9 +153,9 @@ int ompi_coll_tuned_alltoall_intra_check_forced_init (coll_tuned_force_algorithm
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_alltoall_intra_do_this(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_do_this(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void* rbuf, int rcount,
+                                           void* rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoallv_decision.c
@@ -88,9 +88,9 @@ int ompi_coll_tuned_alltoallv_intra_check_forced_init(coll_tuned_force_algorithm
 
 /* If the user selects dynamic rules and specifies the algorithm to
  * use, then this function is called.  */
-int ompi_coll_tuned_alltoallv_intra_do_this(const void *sbuf, const int *scounts, const int *sdisps,
+int ompi_coll_tuned_alltoallv_intra_do_this(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, const int *rcounts, const int *rdisps,
+                                            void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
@@ -132,7 +132,7 @@ int ompi_coll_tuned_bcast_intra_check_forced_init (coll_tuned_force_algorithm_mc
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_bcast_intra_do_this(void *buf, int count,
+int ompi_coll_tuned_bcast_intra_do_this(void *buf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         int root,
                                         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_component.c
+++ b/ompi/mca/coll/tuned/coll_tuned_component.c
@@ -95,7 +95,7 @@ mca_coll_tuned_component_t mca_coll_tuned_component = {
         /* First, the mca_component_t struct containing meta information
            about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "tuned",

--- a/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
@@ -52,7 +52,7 @@
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int count,
+ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, size_t count,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -102,9 +102,9 @@ ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int c
  *    Returns:    - MPI_SUCCESS or error code (passed from the alltoall implementation)
  */
 
-int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)
@@ -158,9 +158,9 @@ int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
  *    Returns:    - MPI_SUCCESS or error code
  */
 
-int ompi_coll_tuned_alltoallv_intra_dec_dynamic(const void *sbuf, const int *scounts, const int *sdisps,
+int ompi_coll_tuned_alltoallv_intra_dec_dynamic(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                                 struct ompi_datatype_t *sdtype,
-                                                void* rbuf, const int *rcounts, const int *rdisps,
+                                                void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                                 struct ompi_datatype_t *rdtype,
                                                 struct ompi_communicator_t *comm,
                                                 mca_coll_base_module_t *module)
@@ -250,7 +250,7 @@ int ompi_coll_tuned_barrier_intra_dec_dynamic(struct ompi_communicator_t *comm,
  *   Accepts:   - same arguments as MPI_Bcast()
  *   Returns:   - MPI_SUCCESS or error code (passed from the bcast implementation)
  */
-int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
+int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, size_t count,
                                             struct ompi_datatype_t *dtype, int root,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -302,7 +302,7 @@ int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
  *
  */
 int ompi_coll_tuned_reduce_intra_dec_dynamic( const void *sbuf, void *rbuf,
-                                              int count, struct ompi_datatype_t* dtype,
+                                              size_t count, struct ompi_datatype_t* dtype,
                                               struct ompi_op_t* op, int root,
                                               struct ompi_communicator_t* comm,
                                               mca_coll_base_module_t *module)
@@ -357,7 +357,7 @@ int ompi_coll_tuned_reduce_intra_dec_dynamic( const void *sbuf, void *rbuf,
  *
  */
 int ompi_coll_tuned_reduce_scatter_intra_dec_dynamic(const void *sbuf, void *rbuf,
-                                                     const int *rcounts,
+                                                     const size_t *rcounts,
                                                      struct ompi_datatype_t *dtype,
                                                      struct ompi_op_t *op,
                                                      struct ompi_communicator_t *comm,
@@ -412,7 +412,7 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_dynamic(const void *sbuf, void *rbu
  *
  */
 int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, void *rbuf,
-                                                           int rcount,
+                                                           size_t rcount,
                                                            struct ompi_datatype_t *dtype,
                                                            struct ompi_op_t *op,
                                                            struct ompi_communicator_t *comm,
@@ -465,9 +465,9 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, voi
  *                        allgather function).
  */
 
-int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, size_t scount,
                                                 struct ompi_datatype_t *sdtype,
-                                                void* rbuf, int rcount,
+                                                void* rbuf, size_t rcount,
                                                 struct ompi_datatype_t *rdtype,
                                                 struct ompi_communicator_t *comm,
                                                 mca_coll_base_module_t *module)
@@ -526,10 +526,10 @@ int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, int scount,
  *                        allgatherv function).
  */
 
-int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, size_t scount,
                                                  struct ompi_datatype_t *sdtype,
-                                                 void* rbuf, const int *rcounts,
-                                                 const int *rdispls,
+                                                 void* rbuf, const size_t *rcounts,
+                                                 const ptrdiff_t *rdispls,
                                                  struct ompi_datatype_t *rdtype,
                                                  struct ompi_communicator_t *comm,
                                                  mca_coll_base_module_t *module)
@@ -583,9 +583,9 @@ int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, int scount,
                                                        comm, module);
 }
 
-int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              int root,
                                              struct ompi_communicator_t *comm,
@@ -634,9 +634,9 @@ int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
                                                    root, comm, module);
 }
 
-int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               int root, struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -684,7 +684,7 @@ int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
                                                     root, comm, module);
 }
 
-int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, size_t count,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op,
                                               struct ompi_communicator_t *comm,
@@ -728,7 +728,7 @@ int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int c
                                               op, comm, module);
 }
 
-int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, size_t count,
                                            struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op,
                                            struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -52,7 +52,7 @@
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int count,
+ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -225,9 +225,9 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int coun
  *	Returns:	- MPI_SUCCESS or error code
  */
 
-int ompi_coll_tuned_alltoall_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_dec_fixed(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
@@ -415,9 +415,9 @@ int ompi_coll_tuned_alltoall_intra_dec_fixed(const void *sbuf, int scount,
  *      Accepts:        - same arguments as MPI_Alltoallv()
  *      Returns:        - MPI_SUCCESS or error code
  */
-int ompi_coll_tuned_alltoallv_intra_dec_fixed(const void *sbuf, const int *scounts, const int *sdisps,
+int ompi_coll_tuned_alltoallv_intra_dec_fixed(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdisps,
                                               struct ompi_datatype_t *sdtype,
-                                              void *rbuf, const int *rcounts, const int *rdisps,
+                                              void *rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -509,7 +509,7 @@ int ompi_coll_tuned_barrier_intra_dec_fixed(struct ompi_communicator_t *comm,
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code (passed from the bcast implementation)
  */
-int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
+int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, size_t count,
                                           struct ompi_datatype_t *datatype, int root,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
@@ -660,7 +660,7 @@ int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
  *
  */
 int ompi_coll_tuned_reduce_intra_dec_fixed( const void *sendbuf, void *recvbuf,
-                                            int count, struct ompi_datatype_t* datatype,
+                                            size_t count, struct ompi_datatype_t* datatype,
                                             struct ompi_op_t* op, int root,
                                             struct ompi_communicator_t* comm,
                                             mca_coll_base_module_t *module)
@@ -822,7 +822,7 @@ int ompi_coll_tuned_reduce_intra_dec_fixed( const void *sendbuf, void *recvbuf,
  *                        the reduce scatter implementation)
  */
 int ompi_coll_tuned_reduce_scatter_intra_dec_fixed( const void *sbuf, void *rbuf,
-                                                    const int *rcounts,
+                                                    const size_t *rcounts,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     struct ompi_communicator_t *comm,
@@ -970,7 +970,7 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_fixed( const void *sbuf, void *rbuf
  *                        the reduce scatter implementation)
  */
 int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void *rbuf,
-                                                         int rcount,
+                                                         size_t rcount,
                                                          struct ompi_datatype_t *dtype,
                                                          struct ompi_op_t *op,
                                                          struct ompi_communicator_t *comm,
@@ -1090,9 +1090,9 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void 
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -1236,10 +1236,10 @@ int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
  *                        internal allgatherv function.
  */
 
-int ompi_coll_tuned_allgatherv_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_allgatherv_intra_dec_fixed(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, const int *rcounts,
-                                               const int *rdispls,
+                                               void* rbuf, const size_t *rcounts,
+                                               const ptrdiff_t *rdispls,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)
@@ -1376,9 +1376,9 @@ int ompi_coll_tuned_allgatherv_intra_dec_fixed(const void *sbuf, int scount,
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void* rbuf, int rcount,
+                                           void* rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            int root,
                                            struct ompi_communicator_t *comm,
@@ -1465,9 +1465,9 @@ int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, int scount,
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_scatter_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_scatter_intra_dec_fixed(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             int root, struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
@@ -85,7 +85,7 @@ int ompi_coll_tuned_exscan_intra_check_forced_init (coll_tuned_force_algorithm_m
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_exscan_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_exscan_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
@@ -120,9 +120,9 @@ ompi_coll_tuned_gather_intra_check_forced_init(coll_tuned_force_algorithm_mca_pa
 }
 
 int
-ompi_coll_tuned_gather_intra_do_this(const void *sbuf, int scount,
+ompi_coll_tuned_gather_intra_do_this(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
@@ -144,7 +144,7 @@ int ompi_coll_tuned_reduce_intra_check_forced_init (coll_tuned_force_algorithm_m
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_reduce_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_reduce_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op, int root,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
@@ -115,7 +115,7 @@ int ompi_coll_tuned_reduce_scatter_block_intra_check_forced_init (coll_tuned_for
 }
 
 int ompi_coll_tuned_reduce_scatter_block_intra_do_this(const void *sbuf, void *rbuf,
-                                                       int rcount,
+                                                       size_t rcount,
                                                        struct ompi_datatype_t *dtype,
                                                        struct ompi_op_t *op,
                                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_decision.c
@@ -122,7 +122,7 @@ int ompi_coll_tuned_reduce_scatter_intra_check_forced_init (coll_tuned_force_alg
 }
 
 int ompi_coll_tuned_reduce_scatter_intra_do_this(const void *sbuf, void* rbuf,
-                                                 const int *rcounts,
+                                                 const size_t *rcounts,
                                                  struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op,
                                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
@@ -85,7 +85,7 @@ int ompi_coll_tuned_scan_intra_check_forced_init (coll_tuned_force_algorithm_mca
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_scan_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_scan_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
@@ -153,9 +153,9 @@ ompi_coll_tuned_scatter_intra_check_forced_init(coll_tuned_force_algorithm_mca_p
 }
 
 int
-ompi_coll_tuned_scatter_intra_do_this(const void *sbuf, int scount,
+ompi_coll_tuned_scatter_intra_do_this(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void* rbuf, int rcount,
+                                      void* rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ucc/coll_ucc.h
+++ b/ompi/mca/coll/ucc/coll_ucc.h
@@ -47,7 +47,7 @@ typedef struct mca_coll_ucc_req {
 OBJ_CLASS_DECLARATION(mca_coll_ucc_req_t);
 
 struct mca_coll_ucc_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
     int                             ucc_priority;
     int                             ucc_verbose;
     int                             ucc_enable;
@@ -139,27 +139,27 @@ OBJ_CLASS_DECLARATION(mca_coll_ucc_module_t);
 int mca_coll_ucc_init_query(bool enable_progress_threads, bool enable_mpi_threads);
 mca_coll_base_module_t *mca_coll_ucc_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, size_t count,
                            struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, size_t count,
                         struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                         int root, struct ompi_communicator_t *comm,
-                        struct mca_coll_base_module_2_4_0_t *module);
+                        struct mca_coll_base_module_3_0_0_t *module);
 
-int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, size_t count,
                          struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
-                         struct mca_coll_base_module_2_4_0_t *module);
+                         struct mca_coll_base_module_3_0_0_t *module);
 
 int mca_coll_ucc_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
@@ -168,138 +168,138 @@ int mca_coll_ucc_ibarrier(struct ompi_communicator_t *comm,
                           ompi_request_t** request,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_bcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_bcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                        int root, struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ibcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_ibcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                         int root, struct ompi_communicator_t *comm,
                         ompi_request_t** request,
                         mca_coll_base_module_t *module);
 
-int mca_coll_ucc_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ialltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_ialltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_alltoallv(const void *sbuf, const int *scounts, const int *sdips,
+int mca_coll_ucc_alltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdips,
                            struct ompi_datatype_t *sdtype,
-                           void* rbuf, const int *rcounts, const int *rdisps,
+                           void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ialltoallv(const void *sbuf, const int *scounts, const int *sdips,
+int mca_coll_ucc_ialltoallv(const void *sbuf, const size_t *scounts, const ptrdiff_t *sdips,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *rdisps,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_allgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_allgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iallgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_iallgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                            void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_allgatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_ucc_allgatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iallgatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                             void* rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_ucc_iallgatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                             void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              ompi_request_t** request,
                              mca_coll_base_module_t *module);
 
-int mca_coll_ucc_gather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                        void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_gather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                        void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                         int root, struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_ucc_igather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_igather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
                          mca_coll_base_module_t *module);
 
-int mca_coll_ucc_gatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, const int *rcounts, const int *disps,
+int mca_coll_ucc_gatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_ucc_igatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void *rbuf, const int *rcounts, const int *disps,
+int mca_coll_ucc_igatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           ompi_request_t** request,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        ompi_request_t** request,
                                        mca_coll_base_module_t *module);
 
-int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ireduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_ucc_ireduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,
                                 ompi_request_t** request,
                                 mca_coll_base_module_t *module);
 
-int mca_coll_ucc_scatterv(const void *sbuf, const int *scounts,
-                          const int *disps, struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+int mca_coll_ucc_scatterv(const void *sbuf, const size_t *scounts,
+                          const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iscatterv(const void *sbuf, const int *scounts,
-                           const int *disps, struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+int mca_coll_ucc_iscatterv(const void *sbuf, const size_t *scounts,
+                           const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_scatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_scatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iscatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_iscatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                       void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                       void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                        mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
                                                        mca_coll_ucc_req_t *coll_req)
@@ -59,8 +59,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_allgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_allgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
 {
@@ -80,8 +80,8 @@ fallback:
                                           comm, ucc_module->previous_allgather_module);
 }
 
-int mca_coll_ucc_iallgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_iallgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                            void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
@@ -9,9 +9,9 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allgatherv_init(const void *sbuf, int scount,
+static inline ucc_status_t mca_coll_ucc_allgatherv_init(const void *sbuf, size_t scount,
                                                         struct ompi_datatype_t *sdtype,
-                                                        void* rbuf, const int *rcounts, const int *rdisps,
+                                                        void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                                         struct ompi_datatype_t *rdtype,
                                                         mca_coll_ucc_module_t *ucc_module,
                                                         ucc_coll_req_h *req,
@@ -57,9 +57,9 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_allgatherv(const void *sbuf, int scount,
+int mca_coll_ucc_allgatherv(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *rdisps,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)
@@ -82,9 +82,9 @@ fallback:
                                            comm, ucc_module->previous_allgatherv_module);
 }
 
-int mca_coll_ucc_iallgatherv(const void *sbuf, int scount,
+int mca_coll_ucc_iallgatherv(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void* rbuf, const int *rcounts, const int *rdisps,
+                             void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -9,7 +9,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, size_t count,
                                                        struct ompi_datatype_t *dtype,
                                                        struct ompi_op_t *op, mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
@@ -57,7 +57,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, size_t count,
                            struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op, struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
@@ -77,7 +77,7 @@ fallback:
                                           comm, ucc_module->previous_allreduce_module);
 }
 
-int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op, struct ompi_communicator_t *comm,
                             ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                      void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                      void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                       mca_coll_ucc_module_t *ucc_module,
                                                       ucc_coll_req_h *req,
                                                       mca_coll_ucc_req_t *coll_req)
@@ -59,8 +59,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)
 {
@@ -80,8 +80,8 @@ fallback:
                                           comm, ucc_module->previous_alltoall_module);
 }
 
-int mca_coll_ucc_ialltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_ialltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
@@ -9,9 +9,9 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_alltoallv_init(const void *sbuf, const int *scounts,
-                                                       const int *sdisps, struct ompi_datatype_t *sdtype,
-                                                       void* rbuf, const int *rcounts, const int *rdisps,
+static inline ucc_status_t mca_coll_ucc_alltoallv_init(const void *sbuf, const size_t *scounts,
+                                                       const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+                                                       void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                                                        struct ompi_datatype_t *rdtype,
                                                        mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
@@ -58,9 +58,9 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_alltoallv(const void *sbuf, const int *scounts,
-                           const int *sdisps, struct ompi_datatype_t *sdtype,
-                           void* rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_ucc_alltoallv(const void *sbuf, const size_t *scounts,
+                           const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+                           void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
@@ -83,9 +83,9 @@ fallback:
                                           comm, ucc_module->previous_alltoallv_module);
 }
 
-int mca_coll_ucc_ialltoallv(const void *sbuf, const int *scounts,
-                            const int *sdisps, struct ompi_datatype_t *sdtype,
-                            void* rbuf, const int *rcounts, const int *rdisps,
+int mca_coll_ucc_ialltoallv(const void *sbuf, const size_t *scounts,
+                            const ptrdiff_t *sdisps, struct ompi_datatype_t *sdtype,
+                            void* rbuf, const size_t *rcounts, const ptrdiff_t *rdisps,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, int count, struct ompi_datatype_t *dtype,
+static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, size_t count, struct ompi_datatype_t *dtype,
                                                    int root, mca_coll_ucc_module_t *ucc_module,
                                                    ucc_coll_req_h *req,
                                                    mca_coll_ucc_req_t *coll_req)
@@ -36,7 +36,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_bcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_bcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                        int root, struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module)
 {
@@ -54,7 +54,7 @@ fallback:
                                        comm, ucc_module->previous_bcast_module);
 }
 
-int mca_coll_ucc_ibcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_ibcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                         int root, struct ompi_communicator_t *comm,
                         ompi_request_t** request,
                         mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -24,7 +24,7 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
        about the component  */
     {
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "ucc",

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -11,8 +11,8 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                      void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                       int root, mca_coll_ucc_module_t *ucc_module,
                                       ucc_coll_req_h *req,
                                       mca_coll_ucc_req_t *coll_req)
@@ -73,8 +73,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_gather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                        void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_gather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                        void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                         int root, struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)
 {
@@ -95,8 +95,8 @@ fallback:
                                        ucc_module->previous_gather_module);
 }
 
-int mca_coll_ucc_igather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_igather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
                          mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -10,8 +10,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                     void *rbuf, const int *rcounts, const int *disps,
+static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                     void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                                                      struct ompi_datatype_t *rdtype, int root,
                                                      mca_coll_ucc_module_t *ucc_module,
                                                      ucc_coll_req_h *req,
@@ -68,8 +68,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_gatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, const int *rcounts, const int *disps,
+int mca_coll_ucc_gatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module)
@@ -91,8 +91,8 @@ fallback:
                                         ucc_module->previous_gatherv_module);
 }
 
-int mca_coll_ucc_igatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void *rbuf, const int *rcounts, const int *disps,
+int mca_coll_ucc_igatherv(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void *rbuf, const size_t *rcounts, const ptrdiff_t *disps,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, size_t count,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op, int root,
                                                     mca_coll_ucc_module_t *ucc_module,
@@ -58,11 +58,11 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op, int root,
                         struct ompi_communicator_t *comm,
-                        struct mca_coll_base_module_2_4_0_t *module)
+                        struct mca_coll_base_module_3_0_0_t *module)
 {
     mca_coll_ucc_module_t *ucc_module = (mca_coll_ucc_module_t*)module;
     ucc_coll_req_h         req;
@@ -79,12 +79,12 @@ fallback:
                                        comm, ucc_module->previous_reduce_module);
 }
 
-int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,
-                         struct mca_coll_base_module_2_4_0_t *module)
+                         struct mca_coll_base_module_3_0_0_t *module)
 {
     mca_coll_ucc_module_t *ucc_module = (mca_coll_ucc_module_t*)module;
     ucc_coll_req_h         req;

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
@@ -10,7 +10,7 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_reduce_scatter_init(const void *sbuf, void *rbuf, const int *rcounts,
+ucc_status_t mca_coll_ucc_reduce_scatter_init(const void *sbuf, void *rbuf, const size_t *rcounts,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op, mca_coll_ucc_module_t *ucc_module,
                                               ucc_coll_req_h *req,
@@ -69,7 +69,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,
@@ -91,7 +91,7 @@ fallback:
                                                ucc_module->previous_reduce_scatter_module);
 }
 
-int mca_coll_ucc_ireduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
+int mca_coll_ucc_ireduce_scatter(const void *sbuf, void *rbuf, const size_t *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -11,7 +11,7 @@
 
 static inline
 ucc_status_t mca_coll_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf,
-                                                    int rcount,
+                                                    size_t rcount,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     mca_coll_ucc_module_t *ucc_module,
@@ -45,7 +45,7 @@ ucc_status_t mca_coll_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf
         .coll_type = UCC_COLL_TYPE_REDUCE_SCATTER,
         .src.info = {
             .buffer   = (void*)sbuf,
-            .count    = ((size_t)rcount) * comm_size,
+            .count    = rcount * comm_size,
             .datatype = ucc_dt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
@@ -63,7 +63,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
@@ -86,7 +86,7 @@ fallback:
                                                      ucc_module->previous_reduce_scatter_block_module);
 }
 
-int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -10,9 +10,9 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, int scount,
+ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype, int root,
                                        mca_coll_ucc_module_t *ucc_module,
                                        ucc_coll_req_h *req,
@@ -46,7 +46,7 @@ ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, int scount,
         .root      = root,
         .src.info  = {
             .buffer   = (void*)sbuf,
-            .count    = ((size_t)scount) * comm_size,
+            .count    = scount * comm_size,
             .datatype = ucc_sdt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
@@ -68,8 +68,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_scatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_scatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module)
@@ -92,8 +92,8 @@ fallback:
 
 }
 
-int mca_coll_ucc_iscatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_iscatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -10,9 +10,9 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const int *scounts,
-                                        const int *disps, struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const size_t *scounts,
+                                        const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype, int root,
                                         mca_coll_ucc_module_t *ucc_module,
                                         ucc_coll_req_h *req,
@@ -70,9 +70,9 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_scatterv(const void *sbuf, const int *scounts,
-                          const int *disps, struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+int mca_coll_ucc_scatterv(const void *sbuf, const size_t *scounts,
+                          const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)
@@ -94,9 +94,9 @@ fallback:
                                          ucc_module->previous_scatterv_module);
 }
 
-int mca_coll_ucc_iscatterv(const void *sbuf, const int *scounts,
-                           const int *disps, struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+int mca_coll_ucc_iscatterv(const void *sbuf, const size_t *scounts,
+                           const ptrdiff_t *disps, struct ompi_datatype_t *sdtype,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -120,6 +120,7 @@ static int mca_fcoll_vulcan_minmax ( ompio_file_t *fh, struct iovec *iov, int io
                                      long *new_stripe_size);
 
 
+
 int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
                                       const void *buf,
                                       size_t count,
@@ -153,7 +154,8 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     int write_synch_type = 2;
     int write_chunksize, *result_counts=NULL;
 
-    int *temp_displs = NULL, *temp_counts = NULL;
+    ptrdiff_t *temp_displs = NULL;
+    size_t *temp_counts = NULL;
     
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     double write_time = 0.0, start_write_time = 0.0, end_write_time = 0.0;
@@ -421,7 +423,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         if ( 1 == mca_fcoll_vulcan_num_groups ) {
             /* TODO:BIGCOUNT: Remove temporary variables when coll framework is
              * udpated to use size_t/ptrdiff_t */
-            temp_counts = (int *)malloc (2 * fh->f_procs_per_group * sizeof(int));
+            temp_counts = (size_t *)malloc (2 * fh->f_procs_per_group * sizeof(size_t));
             if (NULL == temp_counts) {
                 opal_output (1, "OUT OF MEMORY\n");
                 ret = OMPI_ERR_OUT_OF_RESOURCE;

--- a/ompi/mca/io/ompio/io_ompio.c
+++ b/ompi/mca/io/ompio/io_ompio.c
@@ -119,7 +119,7 @@ int ompi_io_ompio_generate_current_file_view (struct ompio_file_t *fh,
 
     if (mca_io_ompio_record_offset_info){
 
-	int tot_entries=0, *recvcounts=NULL, *displs=NULL;
+	int tot_entries=0;
 	mca_io_ompio_offlen_array_t *per_process=NULL;
 	mca_io_ompio_offlen_array_t  *all_process=NULL;
 	int *sorted=NULL, *column_list=NULL, *values=NULL;
@@ -131,13 +131,15 @@ int ompi_io_ompio_generate_current_file_view (struct ompio_file_t *fh,
 	ompi_datatype_t *io_array_type=MPI_DATATYPE_NULL;
 	int **adj_matrix=NULL;
 	FILE *fp;
+	size_t *recvcounts=NULL;
+	ptrdiff_t *displs=NULL;
 
 
-        recvcounts = (int *) malloc (fh->f_size * sizeof(int));
+        recvcounts = malloc (fh->f_size * sizeof(size_t));
         if (NULL == recvcounts){
             return OMPI_ERR_OUT_OF_RESOURCE;
 	}
-        displs = (int *) malloc (fh->f_size * sizeof(int));
+        displs = malloc (fh->f_size * sizeof(ptrdiff_t));
         if (NULL == displs){
             free(recvcounts);
             return OMPI_ERR_OUT_OF_RESOURCE;

--- a/ompi/mpi/c/allgatherv.c
+++ b/ompi/mpi/c/allgatherv.c
@@ -50,6 +50,7 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                    const int displs[], MPI_Datatype recvtype, MPI_Comm comm)
 {
     int i, size, err;
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, displs);
 
     SPC_RECORD(OMPI_SPC_ALLGATHERV, 1);
 
@@ -57,8 +58,8 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         int rank;
         ptrdiff_t ext;
 
-        rank = ompi_comm_rank(comm);
         size = ompi_comm_size(comm);
+        rank = ompi_comm_rank(comm);
         ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_datatype(recvtype);
@@ -103,12 +104,12 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
 
-      /* We always define the remote group to be the same as the local
-         group in the case of an intracommunicator, so it's safe to
-         get the size of the remote group here for both intra- and
-         intercommunicators */
+        if ( OMPI_COMM_IS_INTER(comm) ) {
+            size = ompi_comm_remote_size(comm);
+	} else {
+            size = ompi_comm_size(comm);
+        }
 
-        size = ompi_comm_remote_size(comm);
         for (i = 0; i < size; ++i) {
           if (recvcounts[i] < 0) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
@@ -136,6 +137,7 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
        sum(recvounts) > 0 if there's anything to do. */
 
     if ( OMPI_COMM_IS_INTRA( comm) ) {
+        size = ompi_comm_size(comm);
 	for (i = 0; i < ompi_comm_size(comm); ++i) {
 	    if (0 != recvcounts[i]) {
 		break;
@@ -144,7 +146,10 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 	if (i >= ompi_comm_size(comm)) {
 	    return MPI_SUCCESS;
 	}
+    } else {
+        size = ompi_comm_remote_size(comm);
     }
+
     /* There is no rule that can be applied for inter-communicators, since
        recvcount(s)=0 only indicates that the processes in the other group
        do not send anything, sendcount=0 only indicates that I do not send
@@ -152,10 +157,12 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
        something */
 
     /* Invoke the coll component to perform the back-end operation */
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, displs, i, size);
     err = comm->c_coll->coll_allgatherv(sendbuf, sendcount, sendtype,
-                                       recvbuf, (int *) recvcounts,
-                                       (int *) displs, recvtype, comm,
+                                       recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                       OMPI_TEMP_ARRAY_NAME_CONVERT(displs), recvtype, comm,
                                        comm->c_coll->coll_allgatherv_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, displs);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/alltoallv.c
+++ b/ompi/mpi/c/alltoallv.c
@@ -50,9 +50,12 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
                   MPI_Datatype recvtype, MPI_Comm comm)
 {
     int i, size, err;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, rdispls);
 
     SPC_RECORD(OMPI_SPC_ALLTOALLV, 1);
 
+    size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
     MEMCHECKER(
         ptrdiff_t recv_ext;
         ptrdiff_t send_ext;
@@ -66,7 +69,6 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
 
         memchecker_comm(comm);
 
-        size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
         for ( i = 0; i < size; i++ ) {
             if (MPI_IN_PLACE != sendbuf) {
                 /* check if send chunks are defined. */
@@ -136,9 +138,15 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
 #endif
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
-                                      recvbuf, recvcounts, rdispls, recvtype,
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, sdispls, i, size);
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, rdispls, i, size);
+    err = comm->c_coll->coll_alltoallv(sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                      OMPI_TEMP_ARRAY_NAME_CONVERT(sdispls), sendtype,
+                                      recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                      OMPI_TEMP_ARRAY_NAME_CONVERT(rdispls), recvtype,
                                       comm, comm->c_coll->coll_alltoallv_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, rdispls);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/alltoallv_init.c
+++ b/ompi/mpi/c/alltoallv_init.c
@@ -50,9 +50,12 @@ int MPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sd
                        MPI_Info info, MPI_Request *request)
 {
     int i, size, err;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, rdispls);
 
     SPC_RECORD(OMPI_SPC_ALLTOALLV_INIT, 1);
 
+    size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
     MEMCHECKER(
         ptrdiff_t recv_ext;
         ptrdiff_t send_ext;
@@ -67,7 +70,6 @@ int MPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sd
         memchecker_datatype(recvtype);
         ompi_datatype_type_extent(recvtype, &recv_ext);
 
-        size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
         for ( i = 0; i < size; i++ ) {
             if (MPI_IN_PLACE != sendbuf) {
                 /* check if send chunks are defined. */
@@ -126,9 +128,15 @@ int MPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sd
     }
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_alltoallv_init(sendbuf, sendcounts, sdispls,
-                                            sendtype, recvbuf, recvcounts, rdispls,
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, sdispls, i, size);
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, rdispls, i, size);
+    err = comm->c_coll->coll_alltoallv_init(sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                            OMPI_TEMP_ARRAY_NAME_CONVERT(sdispls),
+                                            sendtype, recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                            OMPI_TEMP_ARRAY_NAME_CONVERT(rdispls),
                                             recvtype, comm, info, request, comm->c_coll->coll_alltoallv_init_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, rdispls);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         ompi_coll_base_retain_datatypes(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtype, recvtype);
     }

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -47,14 +47,15 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 void *recvbuf, const int recvcounts[], const int displs[],
                 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
-    int i, size, err;
+    int i, size, tmp_size, err;
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, displs);
 
     SPC_RECORD(OMPI_SPC_GATHERV, 1);
 
+    size = OMPI_COMM_IS_INTER(comm) ? ompi_comm_remote_size(comm) : ompi_comm_size(comm);
     MEMCHECKER(
         ptrdiff_t ext;
 
-        size = ompi_comm_remote_size(comm);
         ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
@@ -140,8 +141,8 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                 }
 
-                size = ompi_comm_size(comm);
-                for (i = 0; i < size; ++i) {
+                tmp_size = ompi_comm_size(comm);
+                for (i = 0; i < tmp_size; ++i) {
                     if (recvcounts[i] < 0) {
                         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                     } else if (MPI_DATATYPE_NULL == recvtype || NULL == recvtype) {
@@ -179,8 +180,8 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                 }
 
-                size = ompi_comm_remote_size(comm);
-                for (i = 0; i < size; ++i) {
+                tmp_size = ompi_comm_remote_size(comm);
+                for (i = 0; i < tmp_size; ++i) {
                     if (recvcounts[i] < 0) {
                         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                     } else if (MPI_DATATYPE_NULL == recvtype || NULL == recvtype) {
@@ -210,9 +211,16 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     }
 
     /* Invoke the coll component to perform the back-end operation */
+    if (NULL != recvcounts) {
+        OMPI_TEMP_ARRAYS_PREPARE(recvcounts, displs, i, size);
+    }
     err = comm->c_coll->coll_gatherv(sendbuf, sendcount, sendtype, updated_recvbuf,
-                                    recvcounts, displs,
+                                    OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                    OMPI_TEMP_ARRAY_NAME_CONVERT(displs),
                                     recvtype, root, comm,
                                     comm->c_coll->coll_gatherv_module);
+    if (NULL != recvcounts) {
+        OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, displs);
+    }
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/gatherv_init.c
+++ b/ompi/mpi/c/gatherv_init.c
@@ -48,14 +48,15 @@ int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                      MPI_Datatype recvtype, int root, MPI_Comm comm,
                      MPI_Info info, MPI_Request *request)
 {
-    int i, size, err;
+    int i, size, tmp_size, err;
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, displs);
 
     SPC_RECORD(OMPI_SPC_GATHERV_INIT, 1);
 
+    size = OMPI_COMM_IS_INTER(comm) ? ompi_comm_remote_size(comm) : ompi_comm_size(comm);
     MEMCHECKER(
         ptrdiff_t ext;
 
-        size = ompi_comm_remote_size(comm);
         ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
@@ -141,8 +142,8 @@ int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                 }
 
-                size = ompi_comm_size(comm);
-                for (i = 0; i < size; ++i) {
+                tmp_size = ompi_comm_size(comm);
+                for (i = 0; i < tmp_size; ++i) {
                     if (recvcounts[i] < 0) {
                         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                     } else if (MPI_DATATYPE_NULL == recvtype || NULL == recvtype) {
@@ -180,8 +181,8 @@ int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                 }
 
-                size = ompi_comm_remote_size(comm);
-                for (i = 0; i < size; ++i) {
+                tmp_size = ompi_comm_remote_size(comm);
+                for (i = 0; i < tmp_size; ++i) {
                     if (recvcounts[i] < 0) {
                         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COUNT, FUNC_NAME);
                     } else if (MPI_DATATYPE_NULL == recvtype || NULL == recvtype) {
@@ -200,10 +201,17 @@ int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     }
 
     /* Invoke the coll component to perform the back-end operation */
+    if (NULL != recvcounts) {
+        OMPI_TEMP_ARRAYS_PREPARE(recvcounts, displs, i, size);
+    }
     err = comm->c_coll->coll_gatherv_init(sendbuf, sendcount, sendtype, updated_recvbuf,
-                                          recvcounts, displs, recvtype,
+                                          OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                          OMPI_TEMP_ARRAY_NAME_CONVERT(displs), recvtype,
                                           root, comm, info, request,
                                           comm->c_coll->coll_gatherv_init_module);
+    if (NULL != recvcounts) {
+        OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, displs);
+    }
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         if (OMPI_COMM_IS_INTRA(comm)) {
             if (MPI_IN_PLACE == sendbuf) {

--- a/ompi/mpi/c/ialltoallv.c
+++ b/ompi/mpi/c/ialltoallv.c
@@ -50,9 +50,12 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
                    MPI_Request *request)
 {
     int i, size, err;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, rdispls);
 
     SPC_RECORD(OMPI_SPC_IALLTOALLV, 1);
 
+    size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
     MEMCHECKER(
         ptrdiff_t recv_ext;
         ptrdiff_t send_ext;
@@ -67,7 +70,6 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
         memchecker_datatype(recvtype);
         ompi_datatype_type_extent(recvtype, &recv_ext);
 
-        size = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
         for ( i = 0; i < size; i++ ) {
             if (MPI_IN_PLACE != sendbuf) {
                 /* check if send chunks are defined. */
@@ -126,9 +128,15 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
     }
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_ialltoallv(sendbuf, sendcounts, sdispls,
-                                       sendtype, recvbuf, recvcounts, rdispls,
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, sdispls, i, size);
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, rdispls, i, size);
+    err = comm->c_coll->coll_ialltoallv(sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                       OMPI_TEMP_ARRAY_NAME_CONVERT(sdispls),
+                                       sendtype, recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                       OMPI_TEMP_ARRAY_NAME_CONVERT(rdispls),
                                        recvtype, comm, request, comm->c_coll->coll_ialltoallv_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, rdispls);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         ompi_coll_base_retain_datatypes(*request, (MPI_IN_PLACE==sendbuf)?NULL:sendtype, recvtype);
     }

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -54,37 +54,37 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
 {
     int i, err;
     int indegree, outdegree;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, rdispls);
 
     SPC_RECORD(OMPI_SPC_INEIGHBOR_ALLTOALLW, 1);
 
+    mca_topo_base_neighbor_count (comm, &indegree, &outdegree);
     MEMCHECKER(
         ptrdiff_t recv_ext;
         ptrdiff_t send_ext;
 
         memchecker_comm(comm);
 
-        err = mca_topo_base_neighbor_count (comm, &indegree, &outdegree);
-        if (MPI_SUCCESS == err) {
-            if (MPI_IN_PLACE != sendbuf) {
-                for ( i = 0; i < outdegree; i++ ) {
-                    memchecker_datatype(sendtypes[i]);
+        if (MPI_IN_PLACE != sendbuf) {
+            for ( i = 0; i < outdegree; i++ ) {
+                memchecker_datatype(sendtypes[i]);
 
-                    ompi_datatype_type_extent(sendtypes[i], &send_ext);
+                ompi_datatype_type_extent(sendtypes[i], &send_ext);
 
-                    memchecker_call(&opal_memchecker_base_isdefined,
-                                    (char *)(sendbuf)+sdispls[i]*send_ext,
-                                    sendcounts[i], sendtypes[i]);
-                }
+                memchecker_call(&opal_memchecker_base_isdefined,
+                                (char *)(sendbuf)+sdispls[i]*send_ext,
+                                sendcounts[i], sendtypes[i]);
             }
-            for ( i = 0; i < indegree; i++ ) {
-                memchecker_datatype(recvtypes[i]);
+        }
+        for ( i = 0; i < indegree; i++ ) {
+            memchecker_datatype(recvtypes[i]);
 
-                ompi_datatype_type_extent(recvtypes[i], &recv_ext);
+            ompi_datatype_type_extent(recvtypes[i], &recv_ext);
 
-                memchecker_call(&opal_memchecker_base_isaddressable,
-                                (char *)(recvbuf)+sdispls[i]*recv_ext,
-                                recvcounts[i], recvtypes[i]);
-            }
+            memchecker_call(&opal_memchecker_base_isaddressable,
+                            (char *)(recvbuf)+sdispls[i]*recv_ext,
+                            recvcounts[i], recvtypes[i]);
         }
     );
 
@@ -102,7 +102,6 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
                                           FUNC_NAME);
         }
 
-        err = mca_topo_base_neighbor_count (comm, &indegree, &outdegree);
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         if (((0 < outdegree) && ((NULL == sendcounts) || (NULL == sdispls) || (NULL == sendtypes))) ||
             ((0 < indegree) && ((NULL == recvcounts) || (NULL == rdispls) || (NULL == recvtypes))) ||
@@ -142,9 +141,15 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
     }
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
-                                                recvbuf, recvcounts, rdispls, recvtypes, comm, request,
-                                                comm->c_coll->coll_ineighbor_alltoallw_module);
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, sdispls, i, outdegree);
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, rdispls, i, indegree);
+    err = comm->c_coll->coll_ineighbor_alltoallw(sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                                OMPI_TEMP_ARRAY_NAME_CONVERT(sdispls), sendtypes,
+                                                recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                                OMPI_TEMP_ARRAY_NAME_CONVERT(rdispls), recvtypes, comm,
+                                                request, comm->c_coll->coll_ineighbor_alltoallw_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, rdispls);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         ompi_coll_base_retain_datatypes_w(*request, sendtypes, recvtypes, true);
     }

--- a/ompi/mpi/c/iscatterv.c
+++ b/ompi/mpi/c/iscatterv.c
@@ -48,13 +48,14 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                   MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request)
 {
     int i, size, err;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, displs);
 
     SPC_RECORD(OMPI_SPC_ISCATTERV, 1);
 
+    size = ompi_comm_remote_size(comm);
     MEMCHECKER(
         ptrdiff_t ext;
 
-        size = ompi_comm_remote_size(comm);
         ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
@@ -202,9 +203,12 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
     }
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_iscatterv(updated_sendbuf, sendcounts, displs,
-                                       sendtype, updated_recvbuf, recvcount, recvtype, root, comm,
-                                       request, comm->c_coll->coll_iscatterv_module);
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, displs, i, size);
+    err = comm->c_coll->coll_iscatterv(updated_sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                      OMPI_TEMP_ARRAY_NAME_CONVERT(displs),
+                                      sendtype, updated_recvbuf, recvcount, recvtype, root, comm,
+                                      request, comm->c_coll->coll_iscatterv_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, displs);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         if (OMPI_COMM_IS_INTRA(comm)) {
             if (MPI_IN_PLACE == recvbuf) {

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -53,35 +53,35 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
 {
     int i, err;
     int indegree, outdegree;
+    OMPI_TEMP_ARRAYS_DECL(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_DECL(recvcounts, rdispls);
 
     SPC_RECORD(OMPI_SPC_NEIGHBOR_ALLTOALLW, 1);
 
+    mca_topo_base_neighbor_count (comm, &indegree, &outdegree);
     MEMCHECKER(
         ptrdiff_t recv_ext;
         ptrdiff_t send_ext;
 
         memchecker_comm(comm);
 
-        err = mca_topo_base_neighbor_count (comm, &indegree, &outdegree);
-        if (MPI_SUCCESS == err) {
-            if (MPI_IN_PLACE != sendbuf) {
-                for ( i = 0; i < outdegree; i++ ) {
-                    memchecker_datatype(sendtypes[i]);
+        if (MPI_IN_PLACE != sendbuf) {
+            for ( i = 0; i < outdegree; i++ ) {
+                memchecker_datatype(sendtypes[i]);
 
-                    ompi_datatype_type_extent(sendtypes[i], &send_ext);
+                ompi_datatype_type_extent(sendtypes[i], &send_ext);
 
-                    memchecker_call(&opal_memchecker_base_isdefined,
-                                    (char *)(sendbuf)+sdispls[i]*send_ext,
-                                    sendcounts[i], sendtypes[i]);
-                }
+                memchecker_call(&opal_memchecker_base_isdefined,
+                                (char *)(sendbuf)+sdispls[i]*send_ext,
+                                sendcounts[i], sendtypes[i]);
             }
-            for ( i = 0; i < indegree; i++ ) {
-                memchecker_datatype(recvtypes[i]);
-                ompi_datatype_type_extent(recvtypes[i], &recv_ext);
-                memchecker_call(&opal_memchecker_base_isaddressable,
-                                (char *)(recvbuf)+sdispls[i]*recv_ext,
-                                recvcounts[i], recvtypes[i]);
-            }
+        }
+        for ( i = 0; i < indegree; i++ ) {
+            memchecker_datatype(recvtypes[i]);
+            ompi_datatype_type_extent(recvtypes[i], &recv_ext);
+            memchecker_call(&opal_memchecker_base_isaddressable,
+                            (char *)(recvbuf)+sdispls[i]*recv_ext,
+                            recvcounts[i], recvtypes[i]);
         }
     );
 
@@ -150,9 +150,15 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
 #endif
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll->coll_neighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
-                                               recvbuf, recvcounts, rdispls, recvtypes,
+    OMPI_TEMP_ARRAYS_PREPARE(sendcounts, sdispls, i, outdegree);
+    OMPI_TEMP_ARRAYS_PREPARE(recvcounts, rdispls, i, indegree);
+    err = comm->c_coll->coll_neighbor_alltoallw(sendbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(sendcounts),
+                                               OMPI_TEMP_ARRAY_NAME_CONVERT(sdispls), sendtypes,
+                                               recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
+                                               OMPI_TEMP_ARRAY_NAME_CONVERT(rdispls), recvtypes,
                                                comm, comm->c_coll->coll_neighbor_alltoallw_module);
+    OMPI_TEMP_ARRAYS_CLEANUP(sendcounts, sdispls);
+    OMPI_TEMP_ARRAYS_CLEANUP(recvcounts, rdispls);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/reduce_scatter_init.c
+++ b/ompi/mpi/c/reduce_scatter_init.c
@@ -50,6 +50,7 @@ int MPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvco
                             MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request)
 {
     int i, err, size, count;
+    OMPI_TEMP_ARRAY_DECL(recvcounts);
 
     SPC_RECORD(OMPI_SPC_REDUCE_SCATTER_INIT, 1);
 
@@ -133,9 +134,11 @@ int MPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvco
 
     /* Invoke the coll component to perform the back-end operation */
 
-    err = comm->c_coll->coll_reduce_scatter_init(sendbuf, recvbuf, recvcounts,
+    OMPI_TEMP_ARRAY_PREPARE(recvcounts, i, size);
+    err = comm->c_coll->coll_reduce_scatter_init(sendbuf, recvbuf, OMPI_TEMP_ARRAY_NAME_CONVERT(recvcounts),
                                                  datatype, op, comm, info, request,
                                                  comm->c_coll->coll_reduce_scatter_init_module);
+    OMPI_TEMP_ARRAY_CLEANUP(recvcounts);
     if (OPAL_LIKELY(OMPI_SUCCESS == err)) {
         ompi_coll_base_retain_op(*request, op, datatype);
     }


### PR DESCRIPTION
This should update the collective framework to use size_t/ptrdiff_t for counts/displacements. There are a few places that will need to be changed once other components are updated for bigcount (such as the opal/ompi datatype code) and these are indicated with `TODO:BIGCOUNT` comments.