### PR TITLE
ulfm: Fix use-after-free in ishrink implementation

### DIFF
--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -489,8 +489,8 @@ int ompi_comm_ishrink_internal(ompi_communicator_t* comm, ompi_communicator_t** 
                                     subreq,
                                     comm->c_coll->coll_iagree_module );
     if( OMPI_SUCCESS != rc ) {
-        ompi_comm_request_return(request);
         OBJ_RELEASE(context->failed_group);
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -523,8 +523,8 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
     rc = request->super.req_status.MPI_ERROR;
     if( (OMPI_SUCCESS != rc) && (MPI_ERR_PROC_FAILED != rc) ) {
         opal_output(0, "%s:%d Agreement failure: %d\n", __FILE__, __LINE__, rc);
-        ompi_comm_request_return(request);
         OBJ_RELEASE(context->failed_group);
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -542,8 +542,8 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
                                         subreq,
                                         comm->c_coll->coll_iagree_module );
         if( OMPI_SUCCESS != rc ) {
-            ompi_comm_request_return(request);
             OBJ_RELEASE(context->failed_group);
+            ompi_comm_request_return(request);
             return rc;
         }
         ompi_comm_request_schedule_append(request, ompi_comm_ishrink_check_agree, subreq, 1);
@@ -565,17 +565,17 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
     comm_group = comm->c_local_group;
     rc = ompi_group_difference(comm_group, context->failed_group, &context->alive_group);
     if( OMPI_SUCCESS != rc ) {
-        ompi_comm_request_return(request);
         OBJ_RELEASE(context->failed_group);
+        ompi_comm_request_return(request);
         return rc;
     }
     if( OMPI_COMM_IS_INTER(comm) ) {
         comm_group = comm->c_remote_group;
         rc = ompi_group_difference(comm_group, context->failed_group, &context->alive_rgroup);
         if( OMPI_SUCCESS != rc ) {
-            ompi_comm_request_return(request);
             OBJ_RELEASE(context->alive_group);
             OBJ_RELEASE(context->failed_group);
+            ompi_comm_request_return(request);
             return rc;
         }
     }
@@ -595,11 +595,11 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
                            subreq
                          );
     if( OMPI_SUCCESS != rc ) {
-        ompi_comm_request_return(request);
         OBJ_RELEASE(context->alive_group);
         if( NULL != context->alive_rgroup ) {
             OBJ_RELEASE(context->alive_rgroup);
         }
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -628,8 +628,8 @@ static int ompi_comm_ishrink_check_setrank(ompi_comm_request_t *request) {
         opal_output_verbose(1, ompi_ftmpi_output_handle,
                             "%s ompi: comm_ishrink: Construction failed with error %d",
                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), rc);
-        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -663,8 +663,8 @@ static int ompi_comm_ishrink_check_setrank(ompi_comm_request_t *request) {
                                mode,              /* mode */
                                subreq );
     if( OMPI_SUCCESS != rc ) {
-        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -687,8 +687,8 @@ static int ompi_comm_ishrink_check_cid(ompi_comm_request_t *request) {
         opal_output_verbose(1, ompi_ftmpi_output_handle,
                             "%s ompi: comm_ishrink: Determine context id failed with error %d",
                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), rc);
-        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
+        ompi_comm_request_return(request);
         return rc;
     }
 #if OPAL_ENABLE_DEBUG
@@ -724,8 +724,8 @@ static int ompi_comm_ishrink_check_cid(ompi_comm_request_t *request) {
                                 mode,
                                 subreq );
     if( OMPI_SUCCESS != rc ) {
-        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
+        ompi_comm_request_return(request);
         return rc;
     }
 
@@ -747,8 +747,8 @@ static int ompi_comm_ishrink_check_activate(ompi_comm_request_t *request) {
         opal_output_verbose(1, ompi_ftmpi_output_handle,
                             "%s ompi: comm_ishrink: Activation failed with error %d",
                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), rc);
-        ompi_comm_request_return(request);
         OBJ_RELEASE(*context->newcomm);
+        ompi_comm_request_return(request);
         return rc;
     }
 #if OPAL_ENABLE_DEBUG


### PR DESCRIPTION
`ompi_comm_request_return(req)` releases the internal `req->context`. Therefore, any `OBJ_RELEASE(context->xxx)` **MUST** be called **BEFORE** `ompi_comm_request_return()`, otherwise it is a use-after-free.

Follow up of #12384.

cc @bosilca @abouteiller 