### PR TITLE
Fix MPI function names in error output

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1618,7 +1618,7 @@ int ompi_comm_create_from_group (ompi_group_t *group, const char *tag, opal_info
 
     /*
      * setup predefined keyvals - see MPI Standard for predefined keyvals cached on 
-     * communicators created via MPI_Comm_from_group or MPI_Intercomm_create_from_groups
+     * communicators created via MPI_Comm_create_from_group or MPI_Intercomm_create_from_groups
      */
     ompi_attr_hash_init(&newcomp->c_keyhash);
     ompi_attr_set_int(COMM_ATTR,

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -366,7 +366,7 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
             opal_show_help("help-comm.txt",
                            "MPI function not supported",
                            true,
-                           "MPI_Comm_from_group/MPI_Intercomm_from_groups",
+                           "MPI_Comm_create_from_group/MPI_Intercomm_create_from_groups",
                            msg_string);
             ret = MPI_ERR_UNSUPPORTED_OPERATION;
             break;
@@ -496,7 +496,7 @@ int ompi_comm_nextcid_nb (ompi_communicator_t *newcomm, ompi_communicator_t *com
 
     /* old CID algorighm */
 
-    /* if we got here and comm is NULL then that means the app is  invoking MPI-4 Sessions or later
+    /* if we got here and comm is NULL then that means the app is invoking MPI-4 Sessions or later
        functions but the pml does not support these functions so return not supported */
     if (NULL == comm) {
        char msg_string[1024];
@@ -505,7 +505,7 @@ int ompi_comm_nextcid_nb (ompi_communicator_t *newcomm, ompi_communicator_t *com
        opal_show_help("help-comm.txt",
                       "MPI function not supported",
                       true,
-                      "MPI_Comm_from_group/MPI_Intercomm_from_groups",
+                      "MPI_Comm_create_from_group/MPI_Intercomm_create_from_groups",
                       msg_string);
 
         return MPI_ERR_UNSUPPORTED_OPERATION;


### PR DESCRIPTION
Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>
(cherry picked from commit 8cdb8cc618a81dc8f1b2013f7429ff1d1ce760cd)