### PR TITLE
coll/base: add support for component name in output

### DIFF
--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -41,6 +41,7 @@
 #include "opal/util/argv.h"
 #include "opal/util/show_help.h"
 #include "opal/class/opal_list.h"
+#include "opal/class/opal_hash_table.h"
 #include "opal/class/opal_object.h"
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
@@ -85,6 +86,135 @@ static int query_2_4_0(const mca_coll_base_component_2_4_0_t *
 
 #define CHECK_NULL(what, comm, func)                                    \
   ( (what) = # func , NULL == (comm)->c_coll->coll_ ## func)
+
+static void mca_coll_base_get_component_name(ompi_communicator_t *comm, void* module, char** name)
+{
+    mca_coll_base_avail_coll_t *avail;
+
+    *name = NULL;
+    OPAL_LIST_FOREACH(avail, comm->c_coll->module_list, mca_coll_base_avail_coll_t) {
+        if (avail->ac_module == module) {
+            *name = (char*) avail->ac_component_name;
+            break;
+        }
+    }
+}
+
+#define PRINT_NAME(comm, func, func_name)                 \
+    do {                                                  \
+        char *name;                                       \
+        mca_coll_base_get_component_name(comm, (void*)comm->c_coll->coll_ ## func ## _module, &name); \
+        opal_output_verbose(10, ompi_coll_base_framework.framework_output,                                                              \
+                            "coll:base:comm_select: communicator %s rank %d %s -> %s", comm->c_name, comm->c_my_rank, func_name, name); \
+    } while (0);
+
+#define PRINT_ALL_BLOCKING(comm)                     \
+    do {                                                 \
+        PRINT_NAME(comm,  allgather, "allgather");    \
+        PRINT_NAME(comm,  allgatherv, "allgatherv");  \
+        PRINT_NAME(comm,  allreduce, "allreduce");    \
+        PRINT_NAME(comm,  alltoall, "alltoall");      \
+        PRINT_NAME(comm,  alltoallv, "alltoallv");    \
+        PRINT_NAME(comm,  alltoallw, "alltoallw");    \
+        PRINT_NAME(comm,  barrier, "barrier");        \
+        PRINT_NAME(comm,  bcast, "bcast");            \
+        PRINT_NAME(comm,  exscan, "exscan");          \
+        PRINT_NAME(comm,  gather, "gather");          \
+        PRINT_NAME(comm,  gatherv, "gatherv");        \
+        PRINT_NAME(comm,  reduce, "reduce");          \
+        PRINT_NAME(comm,  reduce_scatter_block, "reduce_scatter_block");  \
+        PRINT_NAME(comm,  reduce_scatter, "reduce_scatter");              \
+        PRINT_NAME(comm,  scan, "scan");              \
+        PRINT_NAME(comm,  scatter, "scatter");        \
+        PRINT_NAME(comm,  scatterv, "scatterv");      \
+        PRINT_NAME(comm,  neighbor_allgather, "neighbor_allgather");     \
+        PRINT_NAME(comm,  neighbor_allgatherv, "neighbor_allgatherv");   \
+        PRINT_NAME(comm,  neighbor_alltoall, "neighbor_alltoall");       \
+        PRINT_NAME(comm,  neighbor_alltoallv, "neighbor_alltoallv");     \
+        PRINT_NAME(comm,  neighbor_alltoallw, "neighbor_alltoallw");     \
+        PRINT_NAME(comm,  reduce_local, "reduce_local");                 \
+    } while (0);
+
+#define PRINT_ALL_NB(comm)                            \
+    do {                                              \
+        PRINT_NAME(comm,  iallgather, "iallgather");  \
+        PRINT_NAME(comm,  iallgatherv, "iallgatherv");\
+        PRINT_NAME(comm,  iallreduce, "iallreduce");  \
+        PRINT_NAME(comm,  ialltoall, "ialltoall");    \
+        PRINT_NAME(comm,  ialltoallv, "ialltoallv");  \
+        PRINT_NAME(comm,  ialltoallw, "ialltoallw");  \
+        PRINT_NAME(comm,  ibarrier, "ibarrier");      \
+        PRINT_NAME(comm,  ibcast, "ibcast");          \
+        PRINT_NAME(comm,  iexscan, "iexscan");        \
+        PRINT_NAME(comm,  igather, "igather");        \
+        PRINT_NAME(comm,  igatherv, "igatherv");      \
+        PRINT_NAME(comm,  ireduce, "ireduce");        \
+        PRINT_NAME(comm,  ireduce_scatter_block, "ireduce_scatter_block"); \
+        PRINT_NAME(comm,  ireduce_scatter, "ireduce_scatter");             \
+        PRINT_NAME(comm,  iscan, "iscan");            \
+        PRINT_NAME(comm,  iscatter, "iscatter");      \
+        PRINT_NAME(comm,  iscatterv, "iscatterv");    \
+        PRINT_NAME(comm,  ineighbor_allgather, "ineighbor_allgather");     \
+        PRINT_NAME(comm,  ineighbor_allgatherv, "ineighbor_allgatherv");   \
+        PRINT_NAME(comm,  ineighbor_alltoall, "ineighbor_alltoall");       \
+        PRINT_NAME(comm,  ineighbor_alltoallv, "ineighbor_alltoallv");     \
+        PRINT_NAME(comm,  ineighbor_alltoallw, "ineighbor_alltoallw");     \
+    } while (0);
+
+#define PRINT_ALL_PERSISTENT(comm)                              \
+    do {                                                        \
+        PRINT_NAME(comm,  allgather_init, "allgather_init");    \
+        PRINT_NAME(comm,  allgatherv_init, "allgatherv_init");  \
+        PRINT_NAME(comm,  allreduce_init, "allreduce_init");    \
+        PRINT_NAME(comm,  alltoall_init, "alltoall_init");      \
+        PRINT_NAME(comm,  alltoallv_init, "alltoallv_init");    \
+        PRINT_NAME(comm,  alltoallw_init, "alltoallw_init");    \
+        PRINT_NAME(comm,  barrier_init, "barrier_init");        \
+        PRINT_NAME(comm,  bcast_init, "bcast_init");            \
+        PRINT_NAME(comm,  exscan_init, "exscan_init");          \
+        PRINT_NAME(comm,  gather_init, "gather_init");          \
+        PRINT_NAME(comm,  gatherv_init, "gatherv_init");        \
+        PRINT_NAME(comm,  reduce_init, "reduce_init");          \
+        PRINT_NAME(comm,  reduce_scatter_block_init, "reduce_scatter_block_init"); \
+        PRINT_NAME(comm,  reduce_scatter_init, "reduce_scatter_init");             \
+        PRINT_NAME(comm,  scan_init, "scan_init");              \
+        PRINT_NAME(comm,  scatter_init, "scatter_init");        \
+        PRINT_NAME(comm,  scatterv_init, "scatterv_init");      \
+        PRINT_NAME(comm,  neighbor_allgather_init, "neighbor_allgather_init");     \
+        PRINT_NAME(comm,  neighbor_allgatherv_init, "neighbor_allgatherv_init");   \
+        PRINT_NAME(comm,  neighbor_alltoall_init, "neighbor_alltoall_init");       \
+        PRINT_NAME(comm,  neighbor_alltoallv_init, "neighbor_alltoallv_init");     \
+        PRINT_NAME(comm,  neighbor_alltoallw_init, "neighbor_alltoallw_init");     \
+    } while (0);
+
+#define PRINT_ALL_FT(comm)                    \
+    do {                                      \
+        PRINT_NAME(comm,  agree, "agree");    \
+        PRINT_NAME(comm,  iagree, "iagree");  \
+    } while (0);
+
+static void mca_coll_base_print_component_names(ompi_communicator_t *comm)
+{
+    /*
+    ** Verbosity level 1 - 19 will only print the blocking and non-blocking collectives
+    ** assigned to MPI_COMM_WORLD, but not the persistent and ft ones.
+    **
+    ** Verbosity level 20 will print all blocking and non-blocking collectives for all communicators,
+    ** but not the persistent and ft ones.
+    **
+    ** Verbosity level > 20 will print all collectives for all communicators.
+    */
+    if ( (MPI_COMM_WORLD == comm) || (ompi_coll_base_framework.framework_verbose >= 20)) {
+        PRINT_ALL_BLOCKING (comm);
+        PRINT_ALL_NB (comm);
+        if (ompi_coll_base_framework.framework_verbose > 20) {
+            PRINT_ALL_PERSISTENT (comm);
+#if OPAL_ENABLE_FT_MPI
+            PRINT_ALL_FT (comm);
+#endif
+        }
+    }
+}
 
 /*
  * This function is called at the initialization time of every
@@ -134,7 +264,6 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
          NULL != item; item = opal_list_remove_first(selectable)) {
 
         mca_coll_base_avail_coll_t *avail = (mca_coll_base_avail_coll_t *) item;
-
         /* initialize the module */
         ret = avail->ac_module->coll_module_enable(avail->ac_module, comm);
 
@@ -235,7 +364,6 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
             OBJ_RELEASE(avail);
         }
     }
-
     /* Done with the list from the check_components() call so release it. */
     OBJ_RELEASE(selectable);
 
@@ -301,6 +429,11 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
          mca_coll_base_comm_unselect(comm);
         return OMPI_ERR_NOT_FOUND;
     }
+
+    if (ompi_coll_base_framework.framework_verbose > 0) {
+        mca_coll_base_print_component_names(comm);
+    }
+
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
add the ability to output which component provides which collective operation. The feature is controlled by the mca_coll_base_verbose variable. Specifically

mca_coll_base_verbose > 0 and < 20:
  - output will be provided for MPI_COMM_WORLD only, and only for the blocking and non-blocking collectives

mca_coll_base_verbose = 20:
  - output will be provided for all communicators, but only for blocking and non-blocking collectives

mca_coll_base_verbose > 20:
  - output will be provided for all communicators and all collectives (including persistent and ft)

Note that the values are up for negotiation. I am also open to use an entirely new mca parameter that would allow for more natural specification of which communicator/operation we want the output for.

The output looks as follows (small sample):

```
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 alltoallv -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 alltoallw -> basic
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 barrier -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 bcast -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 exscan -> accelerator
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 gather -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 gatherv -> basic
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 reduce -> accelerator
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 reduce_scatter -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 scan -> accelerator
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 scatter -> tuned
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 scatterv -> basic
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 neighbor_allgather -> basic
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 reduce_local -> basic
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 iallgather -> libnbc
coll:base:comm_select: communicator MPI_COMM_WORLD rank 0 iallgatherv -> libnbc
...
```
