### PR TITLE
btl/smcuda: reduce priority

### DIFF
--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -198,8 +198,7 @@ static int smcuda_register(void)
 
     /* Lower priority when CUDA support is not requested */
     if (0 != strcmp(opal_accelerator_base_selected_component.base_version.mca_component_name, "null")) {
-
-        mca_btl_smcuda.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH + 1;
+        mca_btl_smcuda.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_DEFAULT;
     } else {
         mca_btl_smcuda.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_LOW;
     }


### PR DESCRIPTION
reduce the smcuda priority value to be lower than btl/sm, but higher than btl/tcp.

A user can still explicitely request the btl/smcuda component e.g. for GPU use-cases. It doesn't make sense however for btl/smcuda to have a higher priority than btl/sm for non-GPU applications, since it doesn't support single-copy mechanisms (e.g. xpmem).