### PR TITLE
Add test for mpi_request_null to avoid error in wait[xxx]/test[xxx] when using sessions

### DIFF
--- a/ompi/mpi/c/testall.c
+++ b/ompi/mpi/c/testall.c
@@ -70,6 +70,8 @@ int MPI_Testall(int count, MPI_Request requests[], int *flag,
                 }
                 if (&ompi_request_empty == requests[i]) { 
                     continue;
+                } else if (&ompi_request_null == requests[i]) {
+                    continue;
                 } else if (NULL == requests[i]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {

--- a/ompi/mpi/c/testany.c
+++ b/ompi/mpi/c/testany.c
@@ -69,6 +69,8 @@ int MPI_Testany(int count, MPI_Request requests[], int *indx, int *completed, MP
                 }
                 if (&ompi_request_empty == requests[i]) {
                     continue;
+                } else if (&ompi_request_null == requests[i]) {
+                    continue;
                 } else if (NULL == requests[i]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {

--- a/ompi/mpi/c/testsome.c
+++ b/ompi/mpi/c/testsome.c
@@ -71,6 +71,8 @@ int MPI_Testsome(int incount, MPI_Request requests[],
                 }
                 if (&ompi_request_empty == requests[indx]) { 
                     continue;
+                } else if (&ompi_request_null == requests[indx]) {
+                    continue;
                 } else if (NULL == requests[indx]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {

--- a/ompi/mpi/c/waitall.c
+++ b/ompi/mpi/c/waitall.c
@@ -68,6 +68,8 @@ int MPI_Waitall(int count, MPI_Request requests[], MPI_Status statuses[])
                 }
                 if (&ompi_request_empty == requests[i]) {
                     continue;
+                } else if (&ompi_request_null == requests[i]) {
+                    continue;
                 } else if (NULL == requests[i]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {

--- a/ompi/mpi/c/waitany.c
+++ b/ompi/mpi/c/waitany.c
@@ -69,6 +69,8 @@ int MPI_Waitany(int count, MPI_Request requests[], int *indx, MPI_Status *status
                 }
                 if (requests[i] == &ompi_request_empty) {
                     continue;
+                } else if (&ompi_request_null == requests[i]) {
+                    continue;
                 } else if (NULL == requests[i]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {

--- a/ompi/mpi/c/waitsome.c
+++ b/ompi/mpi/c/waitsome.c
@@ -71,6 +71,8 @@ int MPI_Waitsome(int incount, MPI_Request requests[],
                 }
                 if (&ompi_request_empty == requests[indx]) {
                     continue;
+                } else if (&ompi_request_null == requests[indx]) {
+                    continue;
                 } else if (NULL == requests[indx]->req_mpi_object.comm) {
                     continue;
                 } else if (NULL == check_req) {


### PR DESCRIPTION
**Issue:**
The MPI Standard explicitly allows for `MPI_REQUEST_NULL` in the list of requests passed to `MPI_Wait[xxx]/MPI_Test[xxx]`.
However, using `MPI_Wait[xxx]/MPI_Test[xxx]` with a list containing _active_ requests together with _null_ requests leads to the following MPI error:
```
[n01:00000] *** An error occurred in MPI_Waitall
[n01:00000] *** reported by process [3991601153,3]
[n01:00000] *** on a NULL communicator
[n01:00000] *** Unknown error
[n01:00000] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[n01:00000] ***    and MPI will try to terminate your MPI job as well)
--------------------------------------------------------------------------
```

**Reproducer:**
The following code snippet is a minimal reproducer of the issue:
```
#include "mpi.h"
#include <stdio.h>

int main(int argc, char *argv[]){
    MPI_Request requests[] = {MPI_REQUEST_NULL, MPI_REQUEST_NULL, MPI_REQUEST_NULL};
    MPI_Session session;
    MPI_Group wgroup;
    MPI_Comm wcomm;
    int wrank, wsize;

    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);
    MPI_Group_from_session_pset(session, "mpi://WORLD", &wgroup);
    MPI_Comm_create_from_group(wgroup, "test", MPI_INFO_NULL, MPI_ERRORS_RETURN, &wcomm);
    MPI_Comm_size(wcomm, &wsize);
    MPI_Comm_rank(wcomm, &wrank);

    printf("Rank %d isend to rank %d and irecv from rank %d\n", wrank, (wrank + 1) % wsize, (wsize + wrank - 1) % wsize);
    MPI_Isend(&wrank, 1, MPI_INT, (wrank + 1) % wsize, 42, wcomm, &requests[0]);
    MPI_Irecv(&wrank, 1, MPI_INT, (wsize + wrank - 1) % wsize, 42, wcomm, &requests[1]);
    MPI_Waitall(3, requests, MPI_STATUSES_IGNORE); 

    MPI_Session_finalize(&session);

    return 0;
}
```


**Root Cause:**
The root cause of the issue is that `ompi_comm_instances_same()` fails, because `MPI_REQUEST_NULL` is not associated with a particular instance and therefore the instance is not the same for _null_ requests and _valid_ requests.

**Proposed Solution:**
This pull request adds a check for `ompi_request_null` in `MPI_Wait[xxx]/MPI_Test[xxx]` to avoid it being passed to the `ompi_comm_instances_same()` check.