### PR TITLE
[5.0.x] Disable devel checks for PRRTE/PMIx

### DIFF
--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -164,6 +164,8 @@ AC_DEFUN([_OMPI_SETUP_PRRTE_INTERNAL], [
 
     internal_prrte_CPPFLAGS=
     internal_prrte_args="--with-proxy-version-string=$OPAL_VERSION --with-proxy-package-name=\"Open MPI\" --with-proxy-bugreport=\"https://www.open-mpi.org/community/help/\""
+    # PRRTE sets -Werror on devel builds so avoid buid breaks caused by 3rd-party codes
+    internal_prrte_args="$internal_prrte_args --disable-devel-check"
 
     # Set --enable-prte-prefix-by-default to the deprecated options,
     # if they were specified.  Otherwise, set it to enabled if the

--- a/config/opal_config_pmix.m4
+++ b/config/opal_config_pmix.m4
@@ -78,6 +78,8 @@ AC_DEFUN([OPAL_CONFIG_PMIX], [
                 # desired.
 
                 internal_pmix_args="--without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility"
+                # Open PMIx sets -Werror on devel builds so avoid buid breaks caused by 3rd-party codes
+                internal_pmix_args="$internal_pmix_args --disable-devel-check"
                 internal_pmix_wrapper_libs=
                 internal_pmix_CPPFLAGS=
 


### PR DESCRIPTION
The PRRTE and PMIx modules set `-Werror`, which has repeatedly led to builds of Open MPI breaking due to mere warnings that have otherwise no impact on correctness or performance. Warnings are tricky to catch since different compilers detect these minor issues with different precision.
We do not control these code base and are merely consumers, so we should not accept third-party projects inhibiting our ability to build code inside a git repository.

Cherry-pick of #12523 to v5.0.x

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>
(cherry picked from commit 86f2f42ef21c7abef7a99e98b4df67aa0821c637)