### PR TITLE
Big Count: first pass for coll framework bc

### DIFF
--- a/ompi/mca/coll/accelerator/coll_accelerator.h
+++ b/ompi/mca/coll/accelerator/coll_accelerator.h
@@ -39,33 +39,33 @@ mca_coll_base_module_t
                           int *priority);
 
 int
-mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
 int
-mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
@@ -121,7 +121,7 @@ OBJ_CLASS_DECLARATION(mca_coll_accelerator_module_t);
 /* Component */
 
 typedef struct mca_coll_accelerator_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     int priority; /* Priority of this component */
     int disable_accelerator_coll;  /* Force disable of the accelerator collective component */

--- a/ompi/mca/coll/accelerator/coll_accelerator_allreduce.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_allreduce.c
@@ -28,7 +28,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_allreduce(const void *sbuf, void *rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op,
                         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_component.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_component.c
@@ -44,7 +44,7 @@ mca_coll_accelerator_component_t mca_coll_accelerator_component = {
          * about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "accelerator",

--- a/ompi/mca/coll/accelerator/coll_accelerator_exscan.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_exscan.c
@@ -20,7 +20,7 @@
 #include "ompi/op/op.h"
 #include "opal/datatype/opal_convertor.h"
 
-int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce.c
@@ -28,7 +28,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, int count,
+mca_coll_accelerator_reduce(const void *sbuf, void *rbuf, size_t count,
                      struct ompi_datatype_t *dtype,
                      struct ompi_op_t *op,
                      int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
@@ -32,7 +32,7 @@
  *     up at some point)
  */
 int
-mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/accelerator/coll_accelerator_scan.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_scan.c
@@ -27,7 +27,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_accelerator_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/adapt/coll_adapt.h
+++ b/ompi/mca/coll/adapt/coll_adapt.h
@@ -44,7 +44,7 @@ typedef enum {
  */
 typedef struct mca_coll_adapt_component_t {
     /* Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /* MCA parameter: Priority of this component */
     int adapt_priority;

--- a/ompi/mca/coll/adapt/coll_adapt_bcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_bcast.c
@@ -12,7 +12,7 @@
 #include "coll_adapt.h"
 #include "coll_adapt_algorithms.h"
 
-int ompi_coll_adapt_bcast(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_bcast(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                          struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
 {
     ompi_request_t *request = NULL;

--- a/ompi/mca/coll/adapt/coll_adapt_component.c
+++ b/ompi/mca/coll/adapt/coll_adapt_component.c
@@ -41,7 +41,7 @@ mca_coll_adapt_component_t mca_coll_adapt_component = {
         /* First, the mca_component_t struct containing meta
            information about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "adapt",

--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -319,7 +319,7 @@ static int recv_cb(ompi_request_t * req)
     return 1;
 }
 
-int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_ibcast(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                           mca_coll_base_module_t * module)
 {
@@ -341,7 +341,7 @@ int ompi_coll_adapt_ibcast(void *buff, int count, struct ompi_datatype_t *dataty
 }
 
 
-int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t *datatype, int root,
+int ompi_coll_adapt_ibcast_generic(void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t * module, ompi_coll_tree_t * tree,
                                    size_t seg_size)
@@ -351,7 +351,7 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
     int min;
 
     /* Number of datatype in a segment */
-    int seg_count = count;
+    size_t seg_count = count;
     /* Size of a datatype */
     size_t type_size;
     /* Real size of a segment */
@@ -446,7 +446,7 @@ int ompi_coll_adapt_ibcast_generic(void *buff, int count, struct ompi_datatype_t
                          "[%d]: Ibcast, root %d, tag %d\n", rank, root,
                          con->ibcast_tag));
     OPAL_OUTPUT_VERBOSE((30, mca_coll_adapt_component.adapt_output,
-                         "[%d]: con->mutex = %p, num_children = %d, num_segs = %d, real_seg_size = %d, seg_count = %d, tree_adreess = %p\n",
+                         "[%d]: con->mutex = %p, num_children = %d, num_segs = %d, real_seg_size = %d, seg_count = %zu, tree_adreess = %p\n",
                          rank, (void *) con->mutex, tree->tree_nextsize, num_segs,
                          (int) real_seg_size, seg_count, (void *) con->tree));
 

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -476,7 +476,7 @@ static int recv_cb(ompi_request_t * req)
     return 1;
 }
 
-int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
                            ompi_request_t ** request, mca_coll_base_module_t * module)
 {
@@ -513,7 +513,7 @@ int ompi_coll_adapt_ireduce(const void *sbuf, void *rbuf, int count, struct ompi
 }
 
 
-int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
+int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype, struct ompi_op_t *op, int root,
                                     struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t * module, ompi_coll_tree_t * tree,
@@ -523,7 +523,8 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
     ptrdiff_t extent, lower_bound, segment_increment;
     ptrdiff_t true_lower_bound, true_extent, real_seg_size;
     size_t typelng;
-    int seg_count = count, num_segs, rank, recv_count, send_count, err, min;
+    size_t seg_count = count, recv_count, send_count;
+    int num_segs, rank, err, min;
     /* Used to store the accumuate result, pointer to every segment */
     char **accumbuf = NULL;
     opal_mutex_t *mutex_op_list;
@@ -696,7 +697,7 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
                 context->inbuf = inbuf;
 
                 OPAL_OUTPUT_VERBOSE((30, mca_coll_adapt_component.adapt_output,
-                                      "[%d]: In ireduce, create irecv for seg %d, peer %d, recv_count %d, inbuf %p tag %d\n",
+                                      "[%d]: In ireduce, create irecv for seg %d, peer %d, recv_count %zu, inbuf %p tag %d\n",
                                       context->con->rank, context->seg_index, context->peer,
                                       recv_count, (void *) inbuf,
                                       con->ireduce_tag - seg_index));
@@ -747,7 +748,7 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
             context->inbuf = NULL;
 
             OPAL_OUTPUT_VERBOSE((30, mca_coll_adapt_component.adapt_output,
-                                  "[%d]: In ireduce, create isend to seg %d, peer %d, send_count %d tag %d\n",
+                                  "[%d]: In ireduce, create isend to seg %d, peer %d, send_count %zu tag %d\n",
                                   context->con->rank, context->seg_index, context->peer,
                                   send_count, con->ireduce_tag - context->seg_index));
 

--- a/ompi/mca/coll/adapt/coll_adapt_reduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_reduce.c
@@ -15,7 +15,7 @@
 #include "coll_adapt_algorithms.h"
 
 /* MPI_Reduce and MPI_Ireduce in the ADAPT module only work for commutative operations */
-int ompi_coll_adapt_reduce(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_adapt_reduce(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                           struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
                           mca_coll_base_module_t * module)
 {

--- a/ompi/mca/coll/base/coll_base_agree_noft.c
+++ b/ompi/mca/coll/base/coll_base_agree_noft.c
@@ -19,7 +19,7 @@
 
 int
 ompi_coll_base_agree_noft(void *contrib,
-                         int dt_count,
+                         size_t dt_count,
                          struct ompi_datatype_t *dt,
                          struct ompi_op_t *op,
                          struct ompi_group_t **group, bool update_grp,
@@ -33,7 +33,7 @@ ompi_coll_base_agree_noft(void *contrib,
 
 int
 ompi_coll_base_iagree_noft(void *contrib,
-                          int dt_count,
+                          size_t dt_count,
                           struct ompi_datatype_t *dt,
                           struct ompi_op_t *op,
                           struct ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -82,9 +82,9 @@
  *          step, and send them appropriate messages.
  */
 int
-ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype,
-                                                  void* rbuf, int rcount,
+                                                  void* rbuf, size_t rcount,
                                                   struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module)
@@ -224,9 +224,9 @@ ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
  *         [5]    [5]    [5]    [5]    [5]    [5]
  */
 
-int ompi_coll_base_allgather_intra_sparbit(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_sparbit(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype,
-                                                  void* rbuf, int rcount,
+                                                  void* rbuf, size_t rcount,
                                                   struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module)
@@ -327,9 +327,9 @@ err_hndl:
  *               No additional memory requirements.
  *
  */
-int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_ring(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void* rbuf, int rcount,
+                                         void* rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
@@ -453,9 +453,9 @@ int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
  *         [5]    [5]    [5]    [5]    [5]    [5]
  */
 int
-ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, size_t scount,
                                                  struct ompi_datatype_t *sdtype,
-                                                 void* rbuf, int rcount,
+                                                 void* rbuf, size_t rcount,
                                                  struct ompi_datatype_t *rdtype,
                                                  struct ompi_communicator_t *comm,
                                                  mca_coll_base_module_t *module)
@@ -567,9 +567,9 @@ ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -650,10 +650,10 @@ int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
  *    Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
                                              void *rbuf,
-                                             int rcount,
+                                             size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
@@ -764,9 +764,9 @@ ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, int scount,
  *         [8]    [8]    [8]    [8]    [8]    [8]    [8]    [8]    [8]    [8]
  *         [9]    [9]    [9]    [9]    [9]    [9]    [9]    [9]    [9]    [9]
  */
-int ompi_coll_base_allgather_intra_k_bruck(const void *sbuf, int scount,
+int ompi_coll_base_allgather_intra_k_bruck(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void* rbuf, int rcount,
+                                          void* rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module,
@@ -927,9 +927,9 @@ err_hndl:
  * Caution is needed on larger communicators(n) and data sizes(m), which will
  * result in m*n^2 total traffic and potential network congestion.
  */
-int ompi_coll_base_allgather_direct_messaging(const void *sbuf, int scount,
+int ompi_coll_base_allgather_direct_messaging(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/base/coll_base_allreduce.c
+++ b/ompi/mca/coll/base/coll_base_allreduce.c
@@ -54,7 +54,7 @@
  *
  */
 int
-ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, size_t count,
                                                struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op,
                                                struct ompi_communicator_t *comm,
@@ -131,7 +131,7 @@ ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, int 
  */
 int
 ompi_coll_base_allreduce_intra_recursivedoubling(const void *sbuf, void *rbuf,
-                                                  int count,
+                                                  size_t count,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
@@ -341,7 +341,7 @@ ompi_coll_base_allreduce_intra_recursivedoubling(const void *sbuf, void *rbuf,
  *
  */
 int
-ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
@@ -359,7 +359,7 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
     rank = ompi_comm_rank(comm);
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                 "coll:base:allreduce_intra_ring rank %d, count %d", rank, count));
+                 "coll:base:allreduce_intra_ring rank %d, count %zu", rank, count));
 
     /* Special case for size == 1 */
     if (1 == size) {
@@ -371,8 +371,8 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
     }
 
     /* Special case for count less than size - use recursive doubling */
-    if (count < size) {
-        OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring rank %d/%d, count %d, switching to recursive doubling", rank, size, count));
+    if (count < (size_t) size) {
+        OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring rank %d/%d, count %zu, switching to recursive doubling", rank, size, count));
         return (ompi_coll_base_allreduce_intra_recursivedoubling(sbuf, rbuf,
                                                                   count,
                                                                   dtype, op,
@@ -618,7 +618,7 @@ ompi_coll_base_allreduce_intra_ring(const void *sbuf, void *rbuf, int count,
  *
  */
 int
-ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, size_t count,
                                                struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op,
                                                struct ompi_communicator_t *comm,
@@ -627,8 +627,8 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
 {
     int ret, line, rank, size, k, recv_from, send_to;
     int early_blockcount, late_blockcount, split_rank;
-    int segcount, max_segcount, num_phases, phase, block_count, inbi;
-    size_t typelng;
+    int num_phases, phase, block_count, inbi;
+    size_t typelng, segcount, max_segcount;
     char *tmpsend = NULL, *tmprecv = NULL, *inbuf[2] = {NULL, NULL};
     ptrdiff_t block_offset, max_real_segsize;
     ompi_request_t *reqs[2] = {MPI_REQUEST_NULL, MPI_REQUEST_NULL};
@@ -638,7 +638,7 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
     rank = ompi_comm_rank(comm);
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                 "coll:base:allreduce_intra_ring_segmented rank %d, count %d", rank, count));
+                 "coll:base:allreduce_intra_ring_segmented rank %d, count %zu", rank, count));
 
     /* Special case for size == 1 */
     if (1 == size) {
@@ -656,16 +656,16 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
     COLL_BASE_COMPUTED_SEGCOUNT(segsize, typelng, segcount)
 
         /* Special case for count less than size * segcount - use regular ring */
-        if (count < (size * segcount)) {
-            OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring_segmented rank %d/%d, count %d, switching to regular ring", rank, size, count));
+        if (count < (size_t) (size * segcount)) {
+            OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:allreduce_ring_segmented rank %d/%d, count %zu, switching to regular ring", rank, size, count));
             return (ompi_coll_base_allreduce_intra_ring(sbuf, rbuf, count, dtype, op,
                                                          comm, module));
         }
 
     /* Determine the number of phases of the algorithm */
     num_phases = count / (size * segcount);
-    if ((count % (size * segcount) >= size) &&
-        (count % (size * segcount) > ((size * segcount) / 2))) {
+    if ((count % (size * segcount) >= (size_t) size) &&
+        (count % (size * segcount) > (size_t) ((size * segcount) / 2))) {
         num_phases++;
     }
 
@@ -881,7 +881,7 @@ ompi_coll_base_allreduce_intra_ring_segmented(const void *sbuf, void *rbuf, int 
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, size_t count,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -971,7 +971,7 @@ ompi_coll_base_allreduce_intra_basic_linear(const void *sbuf, void *rbuf, int co
  *   count * typesize + 4 * \log_2(p) * sizeof(int) = O(count)
  */
 int ompi_coll_base_allreduce_intra_redscat_allgather(
-    const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -990,10 +990,10 @@ int ompi_coll_base_allreduce_intra_redscat_allgather(
     }
     int nprocs_pof2 = 1 << nsteps;                              /* flp2(comm_size) */
 
-    if (count < nprocs_pof2 || !ompi_op_is_commute(op)) {
+    if (count < (size_t) nprocs_pof2 || !ompi_op_is_commute(op)) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:allreduce_intra_redscat_allgather: rank %d/%d "
-                     "count %d switching to basic linear allreduce",
+                     "count %zu switching to basic linear allreduce",
                      rank, comm_size, count));
         return ompi_coll_base_allreduce_intra_basic_linear(sbuf, rbuf, count, dtype,
                                                            op, comm, module);
@@ -1264,7 +1264,7 @@ int ompi_coll_base_allreduce_intra_redscat_allgather(
  *                   is not efficient in terms of network bandwidth comparing
  *                   to gather/reduce/bcast type of approach.
  */
-int ompi_coll_base_allreduce_intra_allgather_reduce(const void *sbuf, void *rbuf, int count,
+int ompi_coll_base_allreduce_intra_allgather_reduce(const void *sbuf, void *rbuf, size_t count,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -48,7 +48,7 @@
  * and count) to send the data to the other.
  */
 int
-mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
+mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module)
@@ -177,9 +177,9 @@ mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
     return err;
 }
 
-int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -236,9 +236,9 @@ int ompi_coll_base_alltoall_intra_pairwise(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void* rbuf, int rcount,
+                                         void* rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module)
@@ -375,9 +375,9 @@ int ompi_coll_base_alltoall_intra_bruck(const void *sbuf, int scount,
  *                    - wait for any request to complete
  *                    - replace that request by the new one of the same type.
  */
-int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module,
@@ -534,9 +534,9 @@ int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
 }
 
 
-int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
@@ -613,9 +613,9 @@ int ompi_coll_base_alltoall_intra_two_procs(const void *sbuf, int scount,
 
 /* copied function (with appropriate renaming) starts here */
 
-int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
+int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -36,7 +36,7 @@
 
 int
 ompi_coll_base_bcast_intra_generic( void* buffer,
-                                     int original_count,
+                                     size_t original_count,
                                      struct ompi_datatype_t* datatype,
                                      int root,
                                      struct ompi_communicator_t* comm,
@@ -46,7 +46,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
 {
     int err = 0, line, i, rank, segindex, req_index;
     int num_segments; /* Number of segments */
-    int sendcount;    /* number of elements sent in this segment */
+    size_t sendcount;    /* number of elements sent in this segment */
     size_t realsegsize, type_size;
     char *tmpbuf;
     ptrdiff_t extent, lb;
@@ -247,14 +247,14 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_bintree ( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -266,7 +266,7 @@ ompi_coll_base_bcast_intra_bintree ( void* buffer,
     ompi_datatype_type_size( datatype, &typelng );
     COLL_BASE_COMPUTED_SEGCOUNT( segsize, typelng, segcount );
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_binary rank %d ss %5d typelng %lu segcount %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_binary rank %d ss %5d typelng %zu segcount %zu",
                  ompi_comm_rank(comm), segsize, (unsigned long)typelng, segcount));
 
     return ompi_coll_base_bcast_intra_generic( buffer, count, datatype, root, comm, module,
@@ -275,14 +275,14 @@ ompi_coll_base_bcast_intra_bintree ( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_pipeline( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -294,7 +294,7 @@ ompi_coll_base_bcast_intra_pipeline( void* buffer,
     ompi_datatype_type_size( datatype, &typelng );
     COLL_BASE_COMPUTED_SEGCOUNT( segsize, typelng, segcount );
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_pipeline rank %d ss %5d typelng %lu segcount %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_pipeline rank %d ss %5d typelng %zu segcount %zu",
                  ompi_comm_rank(comm), segsize, (unsigned long)typelng, segcount));
 
     return ompi_coll_base_bcast_intra_generic( buffer, count, datatype, root, comm, module,
@@ -303,14 +303,14 @@ ompi_coll_base_bcast_intra_pipeline( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_chain( void* buffer,
-                                   int count,
+                                   size_t count,
                                    struct ompi_datatype_t* datatype,
                                    int root,
                                    struct ompi_communicator_t* comm,
                                    mca_coll_base_module_t *module,
                                    uint32_t segsize, int32_t chains )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -322,7 +322,7 @@ ompi_coll_base_bcast_intra_chain( void* buffer,
     ompi_datatype_type_size( datatype, &typelng );
     COLL_BASE_COMPUTED_SEGCOUNT( segsize, typelng, segcount );
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_chain rank %d fo %d ss %5d typelng %lu segcount %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_chain rank %d fo %d ss %5d typelng %zu segcount %zu",
                  ompi_comm_rank(comm), chains, segsize, (unsigned long)typelng, segcount));
 
     return ompi_coll_base_bcast_intra_generic( buffer, count, datatype, root, comm, module,
@@ -331,14 +331,14 @@ ompi_coll_base_bcast_intra_chain( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_binomial( void* buffer,
-                                      int count,
+                                      size_t count,
                                       struct ompi_datatype_t* datatype,
                                       int root,
                                       struct ompi_communicator_t* comm,
                                       mca_coll_base_module_t *module,
                                       uint32_t segsize )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_comm_t *data = module->base_data;
 
@@ -350,7 +350,7 @@ ompi_coll_base_bcast_intra_binomial( void* buffer,
     ompi_datatype_type_size( datatype, &typelng );
     COLL_BASE_COMPUTED_SEGCOUNT( segsize, typelng, segcount );
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_binomial rank %d ss %5d typelng %lu segcount %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"coll:base:bcast_intra_binomial rank %d ss %5d typelng %zu segcount %zu",
                  ompi_comm_rank(comm), segsize, (unsigned long)typelng, segcount));
 
     return ompi_coll_base_bcast_intra_generic( buffer, count, datatype, root, comm, module,
@@ -359,7 +359,7 @@ ompi_coll_base_bcast_intra_binomial( void* buffer,
 
 int
 ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
-                                            int count,
+                                            size_t count,
                                             struct ompi_datatype_t* datatype,
                                             int root,
                                             struct ompi_communicator_t* comm,
@@ -367,10 +367,10 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
                                             uint32_t segsize )
 {
     int err=0, line, rank, size, segindex, i, lr, pair;
-    uint32_t counts[2];
-    int segcount[2];       /* Number of elements sent with each segment */
-    int num_segments[2];   /* Number of segments */
-    int sendcount[2];      /* the same like segcount, except for the last segment */
+    size_t counts[2];
+    size_t segcount[2];       /* Number of elements sent with each segment */
+    int num_segments[2];      /* Number of segments */
+    size_t sendcount[2];      /* the same like segcount, except for the last segment */
     size_t realsegsize[2], type_size;
     char *tmpbuf[2];
     ptrdiff_t type_extent, lb;
@@ -625,7 +625,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
+ompi_coll_base_bcast_intra_basic_linear(void *buff, size_t count,
                                         struct ompi_datatype_t *datatype, int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module)
@@ -718,7 +718,7 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
  *     7
  */
 int ompi_coll_base_bcast_intra_knomial(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize, int radix)
 {
@@ -740,7 +740,7 @@ int ompi_coll_base_bcast_intra_knomial(
     COLL_BASE_COMPUTED_SEGCOUNT(segsize, typesize, segcount);
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                 "coll:base:bcast_intra_knomial rank %d segsize %5d typesize %lu segcount %d",
+                 "coll:base:bcast_intra_knomial rank %d segsize %5d typesize %zu segcount %d",
                  ompi_comm_rank(comm), segsize, (unsigned long)typesize, segcount));
 
     return ompi_coll_base_bcast_intra_generic(buf, count, datatype, root, comm, module,
@@ -772,7 +772,7 @@ int ompi_coll_base_bcast_intra_knomial(
  * 7:           <-+  [*******7]  <-+ [******67]  <--|-+ [****4567] <--------+
  */
 int ompi_coll_base_bcast_intra_scatter_allgather(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize)
 {
@@ -791,19 +791,19 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
     if (comm_size < 2 || datatype_size == 0)
         return MPI_SUCCESS;
 
-    if (count < comm_size) {
+    if (count < (size_t)comm_size) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:bcast_intra_scatter_allgather: rank %d/%d "
-                     "count %d switching to basic linear bcast",
+                     "count %zu switching to basic linear bcast",
                      rank, comm_size, count));
         return ompi_coll_base_bcast_intra_basic_linear(buf, count, datatype,
                                                        root, comm, module);
     }
 
     int vrank = (rank - root + comm_size) % comm_size;
-    int recv_count = 0, send_count = 0;
-    int scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
-    int curr_count = (rank == root) ? count : 0;
+    size_t recv_count = 0, send_count = 0;
+    size_t scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
+    size_t curr_count = (rank == root) ? count : 0;
 
     /* Scatter by binomial tree: receive data from parent */
     int mask = 0x1;
@@ -850,7 +850,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
      * Allgather by recursive doubling
      * Each process has the curr_count elems in the buf[vrank * scatter_count, ...]
      */
-    int rem_count = count - vrank * scatter_count;
+    size_t rem_count = count - vrank * scatter_count;
     curr_count = (scatter_count < rem_count) ? scatter_count : rem_count;
     if (curr_count < 0)
         curr_count = 0;
@@ -888,7 +888,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
          */
         if (vremote_tree_root + mask > comm_size) {
             int nprocs_alldata = comm_size - vrank_tree_root - mask;
-            int offset = scatter_count * (vrank_tree_root + mask);
+            ptrdiff_t offset = scatter_count * (vrank_tree_root + mask);
             for (int rhalving_mask = mask >> 1; rhalving_mask > 0; rhalving_mask >>= 1) {
                 vremote = vrank ^ rhalving_mask;
                 remote = (vremote + root) % comm_size;
@@ -949,7 +949,7 @@ cleanup_and_return:
  * 7:           <-+  [*******7]  [******67] [*****567] [****4567] ... [01234567]
  */
 int ompi_coll_base_bcast_intra_scatter_allgather_ring(
-    void *buf, int count, struct ompi_datatype_t *datatype, int root,
+    void *buf, size_t count, struct ompi_datatype_t *datatype, int root,
     struct ompi_communicator_t *comm, mca_coll_base_module_t *module,
     uint32_t segsize)
 {
@@ -968,19 +968,19 @@ int ompi_coll_base_bcast_intra_scatter_allgather_ring(
     if (comm_size < 2 || datatype_size == 0)
         return MPI_SUCCESS;
 
-    if (count < comm_size) {
+    if (count < (size_t)comm_size) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                      "coll:base:bcast_intra_scatter_allgather_ring: rank %d/%d "
-                     "count %d switching to basic linear bcast",
+                     "count %zu switching to basic linear bcast",
                      rank, comm_size, count));
         return ompi_coll_base_bcast_intra_basic_linear(buf, count, datatype,
                                                        root, comm, module);
     }
 
     int vrank = (rank - root + comm_size) % comm_size;
-    int recv_count = 0, send_count = 0;
-    int scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
-    int curr_count = (rank == root) ? count : 0;
+    size_t recv_count = 0, send_count = 0;
+    size_t scatter_count = (count + comm_size - 1) / comm_size; /* ceil(count / comm_size) */
+    size_t curr_count = (rank == root) ? count : 0;
 
     /* Scatter by binomial tree: receive data from parent */
     int mask = 1;

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -68,7 +68,7 @@ static int query(const mca_base_component_t * component,
                  ompi_communicator_t * comm, int *priority,
                  mca_coll_base_module_t ** module);
 
-static int query_2_4_0(const mca_coll_base_component_2_4_0_t *
+static int query_3_0_0(const mca_coll_base_component_3_0_0_t *
                        coll_component, ompi_communicator_t * comm,
                        int *priority,
                        mca_coll_base_module_t ** module);
@@ -564,11 +564,11 @@ static int query(const mca_base_component_t * component,
                  int *priority, mca_coll_base_module_t ** module)
 {
     *module = NULL;
-    if (2 == component->mca_type_major_version &&
-        4 == component->mca_type_minor_version &&
+    if (3 == component->mca_type_major_version &&
+        0 == component->mca_type_minor_version &&
         0 == component->mca_type_release_version) {
 
-        return query_2_4_0((const mca_coll_base_component_2_4_0_t *)component, comm, priority, module);
+        return query_3_0_0((const mca_coll_base_component_3_0_0_t *)component, comm, priority, module);
     }
 
     /* Unknown coll API version -- return error */
@@ -577,7 +577,7 @@ static int query(const mca_base_component_t * component,
 }
 
 
-static int query_2_4_0(const mca_coll_base_component_2_4_0_t * component,
+static int query_3_0_0(const mca_coll_base_component_3_0_0_t * component,
                        ompi_communicator_t * comm, int *priority,
                        mca_coll_base_module_t ** module)
 {

--- a/ompi/mca/coll/base/coll_base_exscan.c
+++ b/ompi/mca/coll/base/coll_base_exscan.c
@@ -32,7 +32,7 @@
  * Returns:   MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -140,7 +140,7 @@ ompi_coll_base_exscan_intra_linear(const void *sbuf, void *rbuf, int count,
  * Limitations: intra-communicators only
  */
 int ompi_coll_base_exscan_intra_recursivedoubling(
-    const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype,
+    const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_find_available.c
+++ b/ompi/mca/coll/base/coll_base_find_available.c
@@ -107,12 +107,12 @@ int mca_coll_base_find_available(bool enable_progress_threads,
  * Query a specific component, coll v2.4.0
  */
 static inline int
-init_query_2_4_0(const mca_base_component_t * component,
+init_query_3_0_0(const mca_base_component_t * component,
                  bool enable_progress_threads,
                  bool enable_mpi_threads)
 {
-    mca_coll_base_component_2_4_0_t *coll =
-        (mca_coll_base_component_2_4_0_t *) component;
+    mca_coll_base_component_3_0_0_t *coll =
+        (mca_coll_base_component_3_0_0_t *) component;
 
     return coll->collm_init_query(enable_progress_threads,
                                   enable_mpi_threads);
@@ -133,10 +133,10 @@ static int init_query(const mca_base_component_t * component,
     /* This component has already been successfully opened.  So now
        query it. */
 
-    if (2 == component->mca_type_major_version &&
-        4 == component->mca_type_minor_version &&
+    if (3 == component->mca_type_major_version &&
+        0 == component->mca_type_minor_version &&
         0 == component->mca_type_release_version) {
-        ret = init_query_2_4_0(component, enable_progress_threads,
+        ret = init_query_3_0_0(component, enable_progress_threads,
                                enable_mpi_threads);
     } else {
         /* Unrecognized coll API version */

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -68,26 +68,26 @@ typedef enum COLLTYPE {
 } COLLTYPE_T;
 
 /* defined arg lists to simply auto inclusion of user overriding decision functions */
-#define ALLGATHER_BASE_ARGS           const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLGATHER_BASE_ARGS           const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define ALLGATHERV_BASE_ARGS          const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define ALLREDUCE_BASE_ARGS           const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define ALLTOALL_BASE_ARGS            const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define ALLREDUCE_BASE_ARGS           const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define ALLTOALL_BASE_ARGS            const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define ALLTOALLV_BASE_ARGS           const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define ALLTOALLW_BASE_ARGS           const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
 #define BARRIER_BASE_ARGS             struct ompi_communicator_t *comm
-#define BCAST_BASE_ARGS               void *buffer, int count, struct ompi_datatype_t *datatype, int root, struct ompi_communicator_t *comm
-#define EXSCAN_BASE_ARGS              const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define GATHER_BASE_ARGS              const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define BCAST_BASE_ARGS               void *buffer, size_t count, struct ompi_datatype_t *datatype, int root, struct ompi_communicator_t *comm
+#define EXSCAN_BASE_ARGS              const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define GATHER_BASE_ARGS              const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
 #define GATHERV_BASE_ARGS             const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define REDUCE_BASE_ARGS              const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, int root, struct ompi_communicator_t *comm
+#define REDUCE_BASE_ARGS              const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, int root, struct ompi_communicator_t *comm
 #define REDUCESCATTER_BASE_ARGS       const void *sendbuf, void *recvbuf, const int recvcounts[], struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define REDUCESCATTERBLOCK_BASE_ARGS  const void *sendbuf, void *recvbuf, int recvcount, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define SCAN_BASE_ARGS                const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
-#define SCATTER_BASE_ARGS             const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
+#define REDUCESCATTERBLOCK_BASE_ARGS  const void *sendbuf, void *recvbuf, size_t recvcount, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define SCAN_BASE_ARGS                const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype, struct ompi_op_t *op, struct ompi_communicator_t *comm
+#define SCATTER_BASE_ARGS             const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
 #define SCATTERV_BASE_ARGS            const void *sendbuf, const int sendcounts[], const int displs[], struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, int root, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLGATHER_BASE_ARGS  const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLGATHER_BASE_ARGS  const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define NEIGHBOR_ALLGATHERV_BASE_ARGS const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int displs[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
-#define NEIGHBOR_ALLTOALL_BASE_ARGS   const void *sendbuf, int sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, int recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
+#define NEIGHBOR_ALLTOALL_BASE_ARGS   const void *sendbuf, size_t sendcount, struct ompi_datatype_t *sendtype, void *recvbuf, size_t recvcount, struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define NEIGHBOR_ALLTOALLV_BASE_ARGS  const void *sendbuf, const int sendcounts[], const int sdispls[], struct ompi_datatype_t *sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], struct ompi_datatype_t *recvtype, struct ompi_communicator_t *comm
 #define NEIGHBOR_ALLTOALLW_BASE_ARGS  const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], struct ompi_datatype_t * const sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], struct ompi_datatype_t * const recvtypes[], struct ompi_communicator_t *comm
 
@@ -219,7 +219,7 @@ int ompi_coll_base_alltoall_intra_bruck(ALLTOALL_ARGS);
 int ompi_coll_base_alltoall_intra_basic_linear(ALLTOALL_ARGS);
 int ompi_coll_base_alltoall_intra_linear_sync(ALLTOALL_ARGS, int max_requests);
 int ompi_coll_base_alltoall_intra_two_procs(ALLTOALL_ARGS);
-int mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, int rcount,
+int mca_coll_base_alltoall_intra_basic_inplace(const void *rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module);  /* special version for INPLACE */
@@ -267,7 +267,7 @@ int ompi_coll_base_gather_intra_linear_sync(GATHER_ARGS, int first_segment_size)
 /* GatherV */
 
 /* Reduce */
-int ompi_coll_base_reduce_generic(REDUCE_ARGS, ompi_coll_tree_t* tree, int count_by_segment, int max_outstanding_reqs);
+int ompi_coll_base_reduce_generic(REDUCE_ARGS, ompi_coll_tree_t* tree, size_t count_by_segment, int max_outstanding_reqs);
 int ompi_coll_base_reduce_intra_basic_linear(REDUCE_ARGS);
 int ompi_coll_base_reduce_intra_chain(REDUCE_ARGS, uint32_t segsize, int fanout, int max_outstanding_reqs );
 int ompi_coll_base_reduce_intra_pipeline(REDUCE_ARGS, uint32_t segsize, int max_outstanding_reqs );
@@ -302,21 +302,21 @@ int ompi_coll_base_scatter_intra_linear_nb(SCATTER_ARGS, int max_reqs);
 /* ScatterV */
 
 /* Reduce_local */
-int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
+int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, size_t count,
                                struct ompi_datatype_t * dtype, struct ompi_op_t * op,
                                mca_coll_base_module_t *module);
 
 #if OPAL_ENABLE_FT_MPI
 /* Agreement */
 int ompi_coll_base_agree_noft(void *contrib,
-                              int dt_count,
+                              size_t dt_count,
                               struct ompi_datatype_t *dt,
                               struct ompi_op_t *op,
                               struct ompi_group_t **group, bool update_grp,
                               struct ompi_communicator_t* comm,
                               mca_coll_base_module_t *module);
 int ompi_coll_base_iagree_noft(void *contrib,
-                               int dt_count,
+                               size_t dt_count,
                                struct ompi_datatype_t *dt,
                                struct ompi_op_t *op,
                                struct ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -38,15 +38,16 @@
 /* Todo: gather_intra_generic, gather_intra_binary, gather_intra_chain,
  * gather_intra_pipeline, segmentation? */
 int
-ompi_coll_base_gather_intra_binomial(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_binomial(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {
-    int line = -1, i, rank, vrank, size, total_recv = 0, err;
+    int line = -1, i, rank, vrank, size, err;
+    size_t total_recv = 0;
     char *ptmp     = NULL, *tempbuf  = NULL;
     ompi_coll_tree_t* bmtree;
     MPI_Status status;
@@ -157,7 +158,7 @@ ompi_coll_base_gather_intra_binomial(const void *sbuf, int scount,
     if (rank != root) {
         /* all nodes except root send to parents */
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                     "ompi_coll_base_gather_intra_binomial rank %d send %d count %d\n",
+                     "ompi_coll_base_gather_intra_binomial rank %d send %d count %lu\n",
                      rank, bmtree->tree_prev, total_recv));
 
         err = MCA_PML_CALL(send(ptmp, total_recv, sdtype,
@@ -205,9 +206,9 @@ ompi_coll_base_gather_intra_binomial(const void *sbuf, int scount,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_linear_sync(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          int root,
                                          struct ompi_communicator_t *comm,
@@ -367,9 +368,9 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_gather_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_gather_intra_basic_linear(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           int root,
                                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -40,7 +40,7 @@
 #include "coll_base_topo.h"
 #include "coll_base_util.h"
 
-int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
+int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, size_t count,
                                struct ompi_datatype_t * dtype, struct ompi_op_t * op,
                                mca_coll_base_module_t *module)
 {
@@ -60,11 +60,11 @@ int mca_coll_base_reduce_local(const void *inbuf, void *inoutbuf, int count,
  * for the first block: thus we must copy sendbuf to accumbuf on intermediate
  * to keep the optimized loop happy.
  */
-int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int original_count,
+int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, size_t original_count,
                                     ompi_datatype_t* datatype, ompi_op_t* op,
                                     int root, ompi_communicator_t* comm,
                                     mca_coll_base_module_t *module,
-                                    ompi_coll_tree_t* tree, int count_by_segment,
+                                    ompi_coll_tree_t* tree, size_t count_by_segment,
                                     int max_outstanding_reqs )
 {
     char *inbuf[2] = {NULL, NULL}, *inbuf_free[2] = {NULL, NULL};
@@ -88,7 +88,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
         sendtmpbuf = (char *)recvbuf;
     }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:reduce_generic count %d, msg size %ld, segsize %ld, max_requests %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:reduce_generic count %zu, msg size %ld, segsize %ld, max_requests %d",
                  original_count, (unsigned long)((ptrdiff_t)num_segments * (ptrdiff_t)segment_increment),
                  (unsigned long)segment_increment, max_outstanding_reqs));
 
@@ -314,7 +314,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
                 ret = ompi_request_wait(&sreq[creq], MPI_STATUS_IGNORE);
                 if (ret != MPI_SUCCESS) { line = __LINE__; goto error_hndl;  }
 
-                if( original_count < count_by_segment ) {
+                if( original_count < (size_t) count_by_segment ) {
                     count_by_segment = original_count;
                 }
                 ret = MCA_PML_CALL( isend((char*)sendbuf +
@@ -381,7 +381,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
      meaning that at least one datatype must fit in the segment !
 */
 
-int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int count,
+int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, size_t count,
                                         ompi_datatype_t* datatype,
                                         ompi_op_t* op, int root,
                                         ompi_communicator_t* comm,
@@ -389,7 +389,7 @@ int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int c
                                         uint32_t segsize, int fanout,
                                         int max_outstanding_reqs )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -412,14 +412,14 @@ int ompi_coll_base_reduce_intra_chain( const void *sendbuf, void *recvbuf, int c
 
 
 int ompi_coll_base_reduce_intra_pipeline( const void *sendbuf, void *recvbuf,
-                                           int count, ompi_datatype_t* datatype,
+                                           size_t count, ompi_datatype_t* datatype,
                                            ompi_op_t* op, int root,
                                            ompi_communicator_t* comm,
                                            mca_coll_base_module_t *module,
                                            uint32_t segsize,
                                            int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -443,14 +443,14 @@ int ompi_coll_base_reduce_intra_pipeline( const void *sendbuf, void *recvbuf,
 }
 
 int ompi_coll_base_reduce_intra_binary( const void *sendbuf, void *recvbuf,
-                                         int count, ompi_datatype_t* datatype,
+                                         size_t count, ompi_datatype_t* datatype,
                                          ompi_op_t* op, int root,
                                          ompi_communicator_t* comm,
                                          mca_coll_base_module_t *module,
                                          uint32_t segsize,
                                          int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -474,14 +474,14 @@ int ompi_coll_base_reduce_intra_binary( const void *sendbuf, void *recvbuf,
 }
 
 int ompi_coll_base_reduce_intra_binomial( const void *sendbuf, void *recvbuf,
-                                           int count, ompi_datatype_t* datatype,
+                                           size_t count, ompi_datatype_t* datatype,
                                            ompi_op_t* op, int root,
                                            ompi_communicator_t* comm,
                                            mca_coll_base_module_t *module,
                                            uint32_t segsize,
                                            int max_outstanding_reqs  )
 {
-    int segcount = count;
+    size_t segcount = count;
     size_t typelng;
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*) module;
     mca_coll_base_comm_t *data = base_module->base_data;
@@ -512,7 +512,7 @@ int ompi_coll_base_reduce_intra_binomial( const void *sendbuf, void *recvbuf,
  * Returns:       MPI_SUCCESS or error code
  */
 int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recvbuf,
-                                                  int count,
+                                                  size_t count,
                                                   ompi_datatype_t* datatype,
                                                   ompi_op_t* op, int root,
                                                   ompi_communicator_t* comm,
@@ -638,7 +638,7 @@ int ompi_coll_base_reduce_intra_in_order_binary( const void *sendbuf, void *recv
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          int root,
@@ -809,7 +809,7 @@ ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count
  *                  in the root process.
  */
 int ompi_coll_base_reduce_intra_redscat_gather(
-    const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, int root, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -827,9 +827,9 @@ int ompi_coll_base_reduce_intra_redscat_gather(
     }
     int nprocs_pof2 = 1 << nsteps;                              /* flp2(comm_size) */
 
-    if (nprocs_pof2 < 2 || count < nprocs_pof2 || !ompi_op_is_commute(op)) {
+    if (nprocs_pof2 < 2 || count < (size_t) nprocs_pof2 || !ompi_op_is_commute(op)) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
-                     "coll:base:reduce_intra_redscat_gather: rank %d/%d count %d "
+                     "coll:base:reduce_intra_redscat_gather: rank %d/%d count %zu"
                      "switching to basic linear reduce", rank, comm_size, count));
         return ompi_coll_base_reduce_intra_basic_linear(sbuf, rbuf, count, dtype,
                                                         op, root, comm, module);
@@ -1164,7 +1164,7 @@ int ompi_coll_base_reduce_intra_redscat_gather(
  *     7
  */
 int ompi_coll_base_reduce_intra_knomial( const void *sendbuf, void *recvbuf,
-                                           int count, ompi_datatype_t* datatype,
+                                           size_t count, ompi_datatype_t* datatype,
                                            ompi_op_t* op, int root,
                                            ompi_communicator_t* comm,
                                            mca_coll_base_module_t *module,
@@ -1188,7 +1188,7 @@ int ompi_coll_base_reduce_intra_knomial( const void *sendbuf, void *recvbuf,
     int max_reqs = 0, num_reqs;
     ompi_request_t **reqs;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:ompi_coll_base_reduce_intra_knomial msg size %d, max_requests %d",
+    OPAL_OUTPUT((ompi_coll_base_framework.framework_output, "coll:base:ompi_coll_base_reduce_intra_knomial msg size %zu, max_requests %d",
                  count, max_outstanding_reqs));
 
     rank = ompi_comm_rank(comm);

--- a/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
@@ -54,7 +54,7 @@
  *     up at some point)
  */
 int
-ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, int rcount,
+ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, size_t rcount,
                                                  struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op,
                                                  struct ompi_communicator_t *comm,
@@ -195,7 +195,7 @@ ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, i
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -400,7 +400,7 @@ static int ompi_range_sum(int a, int b, int r)
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_recursivehalving(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -580,7 +580,7 @@ cleanup_and_return:
 }
 
 static int ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module);
 
@@ -642,7 +642,7 @@ static int ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
  */
 int
 ompi_coll_base_reduce_scatter_block_intra_butterfly(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
@@ -889,7 +889,7 @@ cleanup_and_return:
  */
 static int
 ompi_coll_base_reduce_scatter_block_intra_butterfly_pof2(
-    const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+    const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_scan.c
+++ b/ompi/mca/coll/base/coll_base_scan.c
@@ -32,7 +32,7 @@
  * Returns:   MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, int count,
+ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,
@@ -155,7 +155,7 @@ ompi_coll_base_scan_intra_linear(const void *sbuf, void *rbuf, int count,
  * Limitations: intra-communicators only
  */
 int ompi_coll_base_scan_intra_recursivedoubling(
-    const void *sendbuf, void *recvbuf, int count, struct ompi_datatype_t *datatype,
+    const void *sendbuf, void *recvbuf, size_t count, struct ompi_datatype_t *datatype,
     struct ompi_op_t *op, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/base/coll_base_scatter.c
+++ b/ompi/mca/coll/base/coll_base_scatter.c
@@ -61,14 +61,15 @@
  */
 int
 ompi_coll_base_scatter_intra_binomial(
-    const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+    const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+    void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
     int root, struct ompi_communicator_t *comm,
     mca_coll_base_module_t *module)
 {
     mca_coll_base_module_t *base_module = (mca_coll_base_module_t*)module;
     mca_coll_base_comm_t *data = base_module->base_data;
-    int line = -1, rank, vrank, size, err, packed_size, curr_count;
+    int line = -1, rank, vrank, size, err, packed_size;
+    size_t curr_count;
     char *ptmp, *tempbuf = NULL;
     size_t max_data, packed_sizet;
     opal_convertor_t convertor;
@@ -107,7 +108,7 @@ ompi_coll_base_scatter_intra_binomial(
             opal_convertor_copy_and_prepare_for_send( ompi_mpi_local_convertor, &(sdtype->super),
                                                       scount * size, sbuf, 0, &convertor );
             opal_convertor_get_packed_size( &convertor, &packed_sizet );
-            packed_size = (int)packed_sizet;
+            packed_size = packed_sizet;
             packed_sizet = packed_sizet / size;
             ptmp = tempbuf = (char *)malloc(packed_size);
             if (NULL == tempbuf) {
@@ -135,7 +136,7 @@ ompi_coll_base_scatter_intra_binomial(
         opal_convertor_copy_and_prepare_for_send( ompi_mpi_local_convertor, &(rdtype->super),
                                                   rcount, NULL, 0, &convertor );
         opal_convertor_get_packed_size( &convertor, &packed_sizet );
-        scount = (int)packed_sizet;
+        scount = packed_sizet;
 
         sdtype = MPI_PACKED;  /* default to MPI_PACKED as the send type */
 
@@ -157,7 +158,7 @@ ompi_coll_base_scatter_intra_binomial(
         if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
         /* Get received count */
-        curr_count = (int)status._ucount;  /* no need for conversion, work in bytes */
+        curr_count = status._ucount;  /* no need for conversion, work in bytes */
         sextent = 1;  /* bytes */
     }
 
@@ -219,9 +220,9 @@ ompi_coll_base_scatter_intra_binomial(
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, int scount,
+ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           int root,
                                           struct ompi_communicator_t *comm,
@@ -286,9 +287,9 @@ ompi_coll_base_scatter_intra_basic_linear(const void *sbuf, int scount,
  * progression until the message is sent/(copied to some sort of transmit buffer).
  */
 int
-ompi_coll_base_scatter_intra_linear_nb(const void *sbuf, int scount,
+ompi_coll_base_scatter_intra_linear_nb(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        int root,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic.h
+++ b/ompi/mca/coll/basic/coll_basic.h
@@ -40,7 +40,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-    OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+    OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t
         mca_coll_basic_component;
     extern int mca_coll_basic_priority;
     extern int mca_coll_basic_crossover;
@@ -53,9 +53,9 @@ BEGIN_C_DECLS
         *mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
                                    int *priority);
 
-    int mca_coll_basic_allgather_inter(const void *sbuf, int scount,
+    int mca_coll_basic_allgather_inter(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
@@ -68,20 +68,20 @@ BEGIN_C_DECLS
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
-    int mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-    int mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
+    int mca_coll_basic_alltoall_inter(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
@@ -118,21 +118,21 @@ BEGIN_C_DECLS
     int mca_coll_basic_barrier_intra_log(struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-    int mca_coll_basic_bcast_lin_inter(void *buff, int count,
+    int mca_coll_basic_bcast_lin_inter(void *buff, size_t count,
                                        struct ompi_datatype_t *datatype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_bcast_log_intra(void *buff, int count,
+    int mca_coll_basic_bcast_log_intra(void *buff, size_t count,
                                        struct ompi_datatype_t *datatype,
                                        int root,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_basic_gather_inter(const void *sbuf, int scount,
+    int mca_coll_basic_gather_inter(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void *rbuf, int rcount,
+                                    void *rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     int root,
                                     struct ompi_communicator_t *comm,
@@ -154,14 +154,14 @@ BEGIN_C_DECLS
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-    int mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         int root,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
 
-    int mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         int root,
@@ -169,14 +169,14 @@ BEGIN_C_DECLS
                                         mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf,
-                                                  int rcount,
+                                                  size_t rcount,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
     int mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf,
-                                                  int rcount,
+                                                  size_t rcount,
                                                   struct ompi_datatype_t *dtype,
                                                   struct ompi_op_t *op,
                                                   struct ompi_communicator_t *comm,
@@ -196,15 +196,15 @@ BEGIN_C_DECLS
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module);
 
-    int mca_coll_basic_scan_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_basic_scan_inter(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 
-    int mca_coll_basic_scatter_inter(const void *sbuf, int scount,
+    int mca_coll_basic_scatter_inter(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, int rcount,
+                                     void *rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,
@@ -225,9 +225,9 @@ BEGIN_C_DECLS
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_allgather(const void *sbuf, int scount,
+     int mca_coll_basic_neighbor_allgather(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype, void *rbuf,
-                                           int rcount, struct ompi_datatype_t *rdtype,
+                                           size_t rcount, struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module);
 
@@ -235,8 +235,8 @@ BEGIN_C_DECLS
                                             void *rbuf, const int rcounts[], const int disps[], struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
-     int mca_coll_basic_neighbor_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                          int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+     int mca_coll_basic_neighbor_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                          size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module);
 
      int mca_coll_basic_neighbor_alltoallv(const void *sbuf, const int scounts[], const int sdisps[],

--- a/ompi/mca/coll/basic/coll_basic_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_allgather.c
@@ -41,9 +41,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allgather_inter(const void *sbuf, int scount,
+mca_coll_basic_allgather_inter(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -41,7 +41,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
@@ -76,7 +76,7 @@ mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoall.c
@@ -41,9 +41,9 @@
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
 int
-mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
+mca_coll_basic_alltoall_inter(const void *sbuf, size_t scount,
                               struct ompi_datatype_t *sdtype,
-                              void *rbuf, int rcount,
+                              void *rbuf, size_t rcount,
                               struct ompi_datatype_t *rdtype,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_bcast.c
+++ b/ompi/mca/coll/basic/coll_basic_bcast.c
@@ -41,7 +41,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_bcast_log_intra(void *buff, int count,
+mca_coll_basic_bcast_log_intra(void *buff, size_t count,
                                struct ompi_datatype_t *datatype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -136,7 +136,7 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_bcast_lin_inter(void *buff, int count,
+mca_coll_basic_bcast_lin_inter(void *buff, size_t count,
                                struct ompi_datatype_t *datatype, int root,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_component.c
+++ b/ompi/mca/coll/basic/coll_basic_component.c
@@ -55,13 +55,13 @@ static int basic_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_basic_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_basic_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "basic",

--- a/ompi/mca/coll/basic/coll_basic_gather.c
+++ b/ompi/mca/coll/basic/coll_basic_gather.c
@@ -38,9 +38,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_gather_inter(const void *sbuf, int scount,
+mca_coll_basic_gather_inter(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root, struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
@@ -37,9 +37,9 @@
 #include "ompi/mca/topo/base/base.h"
 
 static int
-mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_cart(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype, void *rbuf,
-                                       int rcount, struct ompi_datatype_t *rdtype,
+                                       size_t rcount, struct ompi_datatype_t *rdtype,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
 {
@@ -117,9 +117,9 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
 }
 
 static int
-mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_graph(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype, void *rbuf,
-                                        int rcount, struct ompi_datatype_t *rdtype,
+                                        size_t rcount, struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module)
 {
@@ -170,9 +170,9 @@ mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
 }
 
 static int
-mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
+mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype, void *rbuf,
-                                             int rcount, struct ompi_datatype_t *rdtype,
+                                             size_t rcount, struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
 {
@@ -229,9 +229,9 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_basic_neighbor_allgather(const void *sbuf, int scount,
+int mca_coll_basic_neighbor_allgather(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype, void *rbuf,
-                                      int rcount, struct ompi_datatype_t *rdtype,
+                                      size_t rcount, struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
@@ -42,8 +42,8 @@
  * 512 dimensions.
  */
 static int
-mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                      int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                      size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
@@ -142,8 +142,8 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
 }
 
 static int
-mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                       int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                       size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_graph_2_2_0_t *graph = comm->c_topo->mtc.graph;
@@ -201,8 +201,8 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
 }
 
 static int
-mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct ompi_datatype_t *sdtype, void *rbuf,
-                                            int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                            size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
 {
     const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
@@ -259,8 +259,8 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
     return rc;
 }
 
-int mca_coll_basic_neighbor_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype, void *rbuf,
-                                     int rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
+int mca_coll_basic_neighbor_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype, void *rbuf,
+                                     size_t rcount, struct ompi_datatype_t *rdtype, struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module)
 {
     if (OMPI_COMM_IS_INTER(comm)) {

--- a/ompi/mca/coll/basic/coll_basic_reduce.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce.c
@@ -86,7 +86,7 @@
  *
  */
 int
-mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root, struct ompi_communicator_t *comm,
@@ -286,7 +286,7 @@ mca_coll_basic_reduce_log_intra(const void *sbuf, void *rbuf, int count,
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_basic_reduce_lin_inter(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
@@ -53,7 +53,7 @@
  *     up at some point)
  */
 int
-mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcount,
+mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -70,7 +70,7 @@ mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcou
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcount,
+mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/basic/coll_basic_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_scatter.c
@@ -40,9 +40,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_basic_scatter_inter(const void *sbuf, int scount,
+mca_coll_basic_scatter_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root, struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -121,7 +121,7 @@ struct ompi_group_t;
 typedef int (*mca_coll_base_component_init_query_fn_t)
      (bool enable_progress_threads, bool enable_mpi_threads);
 
-struct mca_coll_base_module_2_4_0_t;
+struct mca_coll_base_module_3_0_0_t;
 
 /**
  * Query whether a component is available for the given communicator
@@ -150,8 +150,8 @@ struct mca_coll_base_module_2_4_0_t;
  * provide a module with the requested functionality or NULL if the
  * component should not be used on the given communicator.
  */
-typedef struct mca_coll_base_module_2_4_0_t *
-  (*mca_coll_base_component_comm_query_2_4_0_fn_t)
+typedef struct mca_coll_base_module_3_0_0_t *
+  (*mca_coll_base_component_comm_query_3_0_0_fn_t)
     (struct ompi_communicator_t *comm, int *priority);
 
 
@@ -190,7 +190,7 @@ typedef struct mca_coll_base_module_2_4_0_t *
  * @param[in]     comm       Communicator being created
  */
 typedef int
-(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_2_4_0_t* module,
+(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_3_0_0_t* module,
                                           struct ompi_communicator_t *comm);
 
 /* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
@@ -212,15 +212,15 @@ typedef int
  * @param module: the MCA module that defines this agreement.
  */
 typedef int (*mca_coll_base_module_agree_fn_t)
- (void *contrib, int dt_count, struct ompi_datatype_t *dtype,
+ (void *contrib, size_t dt_count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_group_t **failedgroup, bool update_failedgroup,
    struct ompi_communicator_t *comm,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iagree_fn_t)
-  (void *contrib, int dt_count, struct ompi_datatype_t *dtype,
+  (void *contrib, size_t dt_count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_group_t **failedgroup, bool update_failedgroup,
    struct ompi_communicator_t *comm, ompi_request_t **request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 
 /**
@@ -234,225 +234,225 @@ typedef int (*mca_coll_base_module_iagree_fn_t)
  * @param[in]     comm       Communicator being disabled
  */
 typedef int
-(*mca_coll_base_module_disable_1_2_0_fn_t)(struct mca_coll_base_module_2_4_0_t* module,
+(*mca_coll_base_module_disable_1_2_0_fn_t)(struct mca_coll_base_module_3_0_0_t* module,
                                           struct ompi_communicator_t *comm);
 
 /* blocking collectives */
 typedef int (*mca_coll_base_module_allgather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allgatherv_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allreduce_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoall_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallv_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallw_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_barrier_fn_t)
-  (struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_bcast_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_exscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gatherv_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_fn_t)
   (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_block_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatter_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatterv_fn_t)
   (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 
 /* nonblocking collectives */
 typedef int (*mca_coll_base_module_iallgather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iallgatherv_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iallreduce_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm,
-   ompi_request_t ** request, struct mca_coll_base_module_2_4_0_t *module);
+   ompi_request_t ** request, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoall_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallv_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallw_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ibarrier_fn_t)
   (struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ibcast_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iexscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_igather_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_igatherv_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_fn_t)
   (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_block_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscan_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscatter_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_iscatterv_fn_t)
   (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /* persistent collectives */
 typedef int (*mca_coll_base_module_allgather_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allgatherv_init_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void * rbuf, const int *rcounts, const int *disps,  struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_allreduce_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info,
-   ompi_request_t ** request, struct mca_coll_base_module_2_4_0_t *module);
+   ompi_request_t ** request, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoall_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallv_init_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_alltoallw_init_fn_t)
   (const void *sbuf, const int *scounts, const int *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const int *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_barrier_init_fn_t)
   (struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_bcast_init_fn_t)
-  (void *buff, int count, struct ompi_datatype_t *datatype, int root,
+  (void *buff, size_t count, struct ompi_datatype_t *datatype, int root,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_exscan_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gather_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_gatherv_init_fn_t)
   (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, const int *rcounts, const int *disps, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_init_fn_t)
-  (const void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void* rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_init_fn_t)
   (const void *sbuf, void *rbuf, const int *rcounts, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_block_init_fn_t)
-  (const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scan_init_fn_t)
-  (const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+  (const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatter_init_fn_t)
-  (const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-   void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+  (const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+   void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_scatterv_init_fn_t)
   (const void *sbuf, const int *scounts, const int *disps, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /*
  * The signature of the neighborhood alltoallw differs from alltoallw
@@ -460,17 +460,17 @@ typedef int (*mca_coll_base_module_scatterv_init_fn_t)
 typedef int (*mca_coll_base_module_neighbor_alltoallw_fn_t)
   (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_4_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_ineighbor_alltoallw_fn_t)
   (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 typedef int (*mca_coll_base_module_neighbor_alltoallw_init_fn_t)
   (const void *sbuf, const int *scounts, const MPI_Aint *sdisps, struct ompi_datatype_t * const *sdtypes,
    void *rbuf, const int *rcounts, const MPI_Aint *rdisps, struct ompi_datatype_t * const *rdtypes,
    struct ompi_communicator_t *comm, struct ompi_info_t *info, ompi_request_t ** request,
-   struct mca_coll_base_module_2_4_0_t *module);
+   struct mca_coll_base_module_3_0_0_t *module);
 
 /*
  * reduce_local
@@ -479,9 +479,9 @@ typedef int (*mca_coll_base_module_neighbor_alltoallw_init_fn_t)
  * option of intercepting it, if desired.
  */
 typedef int (*mca_coll_base_module_reduce_local_fn_t)
-   (const void *inbuf, void *inoutbuf, int count,
+   (const void *inbuf, void *inoutbuf, size_t count,
     struct ompi_datatype_t * dtype, struct ompi_op_t * op,
-    struct mca_coll_base_module_2_4_0_t *module);
+    struct mca_coll_base_module_3_0_0_t *module);
 
 
 /* ******************************************************************** */
@@ -495,7 +495,7 @@ typedef int (*mca_coll_base_module_reduce_local_fn_t)
  * mca_coll_[component_name]_component, must exist in any collective
  * component.
  */
-struct mca_coll_base_component_2_4_0_t {
+struct mca_coll_base_component_3_0_0_t {
     /** Base component description */
     mca_base_component_t collm_version;
     /** Base component data block */
@@ -504,14 +504,14 @@ struct mca_coll_base_component_2_4_0_t {
     /** Component initialization function */
     mca_coll_base_component_init_query_fn_t collm_init_query;
     /** Query whether component is usable for given communicator */
-    mca_coll_base_component_comm_query_2_4_0_fn_t collm_comm_query;
+    mca_coll_base_component_comm_query_3_0_0_fn_t collm_comm_query;
 };
-typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_2_4_0_t;
+typedef struct mca_coll_base_component_3_0_0_t mca_coll_base_component_3_0_0_t;
 
 /** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
     interface. */
-typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
+typedef struct mca_coll_base_component_3_0_0_t mca_coll_base_component_t;
 
 
 /**
@@ -528,7 +528,7 @@ typedef struct mca_coll_base_component_2_4_0_t mca_coll_base_component_t;
  * function, so the component is free to create a structure that
  * inherits from this one for use as the module structure.
  */
-struct mca_coll_base_module_2_4_0_t {
+struct mca_coll_base_module_3_0_0_t {
     /** Collective modules all inherit from opal_object */
     opal_object_t super;
 
@@ -630,12 +630,12 @@ struct mca_coll_base_module_2_4_0_t {
         not be used by other modules */
     struct mca_coll_base_comm_t* base_data;
 };
-typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_2_4_0_t;
+typedef struct mca_coll_base_module_3_0_0_t mca_coll_base_module_3_0_0_t;
 
 /** Per guidance in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
     interface. */
-typedef struct mca_coll_base_module_2_4_0_t mca_coll_base_module_t;
+typedef struct mca_coll_base_module_3_0_0_t mca_coll_base_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_module_t);
 
 /**
@@ -651,155 +651,155 @@ struct mca_coll_base_comm_coll_t {
 
     /* blocking collectives */
     mca_coll_base_module_allgather_fn_t coll_allgather;
-    mca_coll_base_module_2_4_0_t *coll_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_allgatherv_module;
     mca_coll_base_module_allreduce_fn_t coll_allreduce;
-    mca_coll_base_module_2_4_0_t *coll_allreduce_module;
+    mca_coll_base_module_3_0_0_t *coll_allreduce_module;
     mca_coll_base_module_alltoall_fn_t coll_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallv_module;
     mca_coll_base_module_alltoallw_fn_t coll_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallw_module;
     mca_coll_base_module_barrier_fn_t coll_barrier;
-    mca_coll_base_module_2_4_0_t *coll_barrier_module;
+    mca_coll_base_module_3_0_0_t *coll_barrier_module;
     mca_coll_base_module_bcast_fn_t coll_bcast;
-    mca_coll_base_module_2_4_0_t *coll_bcast_module;
+    mca_coll_base_module_3_0_0_t *coll_bcast_module;
     mca_coll_base_module_exscan_fn_t coll_exscan;
-    mca_coll_base_module_2_4_0_t *coll_exscan_module;
+    mca_coll_base_module_3_0_0_t *coll_exscan_module;
     mca_coll_base_module_gather_fn_t coll_gather;
-    mca_coll_base_module_2_4_0_t *coll_gather_module;
+    mca_coll_base_module_3_0_0_t *coll_gather_module;
     mca_coll_base_module_gatherv_fn_t coll_gatherv;
-    mca_coll_base_module_2_4_0_t *coll_gatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_gatherv_module;
     mca_coll_base_module_reduce_fn_t coll_reduce;
-    mca_coll_base_module_2_4_0_t *coll_reduce_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_module;
     mca_coll_base_module_reduce_scatter_fn_t coll_reduce_scatter;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_module;
     mca_coll_base_module_reduce_scatter_block_fn_t coll_reduce_scatter_block;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_block_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_block_module;
     mca_coll_base_module_scan_fn_t coll_scan;
-    mca_coll_base_module_2_4_0_t *coll_scan_module;
+    mca_coll_base_module_3_0_0_t *coll_scan_module;
     mca_coll_base_module_scatter_fn_t coll_scatter;
-    mca_coll_base_module_2_4_0_t *coll_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_scatter_module;
     mca_coll_base_module_scatterv_fn_t coll_scatterv;
-    mca_coll_base_module_2_4_0_t *coll_scatterv_module;
+    mca_coll_base_module_3_0_0_t *coll_scatterv_module;
 
     /* nonblocking collectives */
     mca_coll_base_module_iallgather_fn_t coll_iallgather;
-    mca_coll_base_module_2_4_0_t *coll_iallgather_module;
+    mca_coll_base_module_3_0_0_t *coll_iallgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_iallgatherv;
-    mca_coll_base_module_2_4_0_t *coll_iallgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_iallgatherv_module;
     mca_coll_base_module_iallreduce_fn_t coll_iallreduce;
-    mca_coll_base_module_2_4_0_t *coll_iallreduce_module;
+    mca_coll_base_module_3_0_0_t *coll_iallreduce_module;
     mca_coll_base_module_ialltoall_fn_t coll_ialltoall;
-    mca_coll_base_module_2_4_0_t *coll_ialltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ialltoallv;
-    mca_coll_base_module_2_4_0_t *coll_ialltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoallv_module;
     mca_coll_base_module_ialltoallw_fn_t coll_ialltoallw;
-    mca_coll_base_module_2_4_0_t *coll_ialltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_ialltoallw_module;
     mca_coll_base_module_ibarrier_fn_t coll_ibarrier;
-    mca_coll_base_module_2_4_0_t *coll_ibarrier_module;
+    mca_coll_base_module_3_0_0_t *coll_ibarrier_module;
     mca_coll_base_module_ibcast_fn_t coll_ibcast;
-    mca_coll_base_module_2_4_0_t *coll_ibcast_module;
+    mca_coll_base_module_3_0_0_t *coll_ibcast_module;
     mca_coll_base_module_iexscan_fn_t coll_iexscan;
-    mca_coll_base_module_2_4_0_t *coll_iexscan_module;
+    mca_coll_base_module_3_0_0_t *coll_iexscan_module;
     mca_coll_base_module_igather_fn_t coll_igather;
-    mca_coll_base_module_2_4_0_t *coll_igather_module;
+    mca_coll_base_module_3_0_0_t *coll_igather_module;
     mca_coll_base_module_igatherv_fn_t coll_igatherv;
-    mca_coll_base_module_2_4_0_t *coll_igatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_igatherv_module;
     mca_coll_base_module_ireduce_fn_t coll_ireduce;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_module;
     mca_coll_base_module_ireduce_scatter_fn_t coll_ireduce_scatter;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_scatter_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_scatter_module;
     mca_coll_base_module_ireduce_scatter_block_fn_t coll_ireduce_scatter_block;
-    mca_coll_base_module_2_4_0_t *coll_ireduce_scatter_block_module;
+    mca_coll_base_module_3_0_0_t *coll_ireduce_scatter_block_module;
     mca_coll_base_module_iscan_fn_t coll_iscan;
-    mca_coll_base_module_2_4_0_t *coll_iscan_module;
+    mca_coll_base_module_3_0_0_t *coll_iscan_module;
     mca_coll_base_module_iscatter_fn_t coll_iscatter;
-    mca_coll_base_module_2_4_0_t *coll_iscatter_module;
+    mca_coll_base_module_3_0_0_t *coll_iscatter_module;
     mca_coll_base_module_iscatterv_fn_t coll_iscatterv;
-    mca_coll_base_module_2_4_0_t *coll_iscatterv_module;
+    mca_coll_base_module_3_0_0_t *coll_iscatterv_module;
 
     /* persistent collectives */
     mca_coll_base_module_allgather_init_fn_t coll_allgather_init;
-    mca_coll_base_module_2_4_0_t *coll_allgather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allgather_init_module;
     mca_coll_base_module_allgatherv_init_fn_t coll_allgatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_allgatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allgatherv_init_module;
     mca_coll_base_module_allreduce_init_fn_t coll_allreduce_init;
-    mca_coll_base_module_2_4_0_t *coll_allreduce_init_module;
+    mca_coll_base_module_3_0_0_t *coll_allreduce_init_module;
     mca_coll_base_module_alltoall_init_fn_t coll_alltoall_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoall_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoall_init_module;
     mca_coll_base_module_alltoallv_init_fn_t coll_alltoallv_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoallv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallv_init_module;
     mca_coll_base_module_alltoallw_init_fn_t coll_alltoallw_init;
-    mca_coll_base_module_2_4_0_t *coll_alltoallw_init_module;
+    mca_coll_base_module_3_0_0_t *coll_alltoallw_init_module;
     mca_coll_base_module_barrier_init_fn_t coll_barrier_init;
-    mca_coll_base_module_2_4_0_t *coll_barrier_init_module;
+    mca_coll_base_module_3_0_0_t *coll_barrier_init_module;
     mca_coll_base_module_bcast_init_fn_t coll_bcast_init;
-    mca_coll_base_module_2_4_0_t *coll_bcast_init_module;
+    mca_coll_base_module_3_0_0_t *coll_bcast_init_module;
     mca_coll_base_module_exscan_init_fn_t coll_exscan_init;
-    mca_coll_base_module_2_4_0_t *coll_exscan_init_module;
+    mca_coll_base_module_3_0_0_t *coll_exscan_init_module;
     mca_coll_base_module_gather_init_fn_t coll_gather_init;
-    mca_coll_base_module_2_4_0_t *coll_gather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_gather_init_module;
     mca_coll_base_module_gatherv_init_fn_t coll_gatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_gatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_gatherv_init_module;
     mca_coll_base_module_reduce_init_fn_t coll_reduce_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_init_module;
     mca_coll_base_module_reduce_scatter_init_fn_t coll_reduce_scatter_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_init_module;
     mca_coll_base_module_reduce_scatter_block_init_fn_t coll_reduce_scatter_block_init;
-    mca_coll_base_module_2_4_0_t *coll_reduce_scatter_block_init_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_scatter_block_init_module;
     mca_coll_base_module_scan_init_fn_t coll_scan_init;
-    mca_coll_base_module_2_4_0_t *coll_scan_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scan_init_module;
     mca_coll_base_module_scatter_init_fn_t coll_scatter_init;
-    mca_coll_base_module_2_4_0_t *coll_scatter_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scatter_init_module;
     mca_coll_base_module_scatterv_init_fn_t coll_scatterv_init;
-    mca_coll_base_module_2_4_0_t *coll_scatterv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_scatterv_init_module;
 
     /* blocking neighborhood collectives */
     mca_coll_base_module_allgather_fn_t coll_neighbor_allgather;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_neighbor_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgatherv_module;
     mca_coll_base_module_alltoall_fn_t coll_neighbor_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_neighbor_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallv_module;
     mca_coll_base_module_neighbor_alltoallw_fn_t coll_neighbor_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallw_module;
 
     /* nonblocking neighborhood collectives */
     mca_coll_base_module_iallgather_fn_t coll_ineighbor_allgather;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_allgather_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_allgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_ineighbor_allgatherv;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_allgatherv_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_allgatherv_module;
     mca_coll_base_module_ialltoall_fn_t coll_ineighbor_alltoall;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoall_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ineighbor_alltoallv;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoallv_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoallv_module;
     mca_coll_base_module_ineighbor_alltoallw_fn_t coll_ineighbor_alltoallw;
-    mca_coll_base_module_2_4_0_t *coll_ineighbor_alltoallw_module;
+    mca_coll_base_module_3_0_0_t *coll_ineighbor_alltoallw_module;
 
     /* persistent neighborhood collectives */
     mca_coll_base_module_allgather_init_fn_t coll_neighbor_allgather_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgather_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgather_init_module;
     mca_coll_base_module_allgatherv_init_fn_t coll_neighbor_allgatherv_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_allgatherv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_allgatherv_init_module;
     mca_coll_base_module_alltoall_init_fn_t coll_neighbor_alltoall_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoall_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoall_init_module;
     mca_coll_base_module_alltoallv_init_fn_t coll_neighbor_alltoallv_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallv_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallv_init_module;
     mca_coll_base_module_neighbor_alltoallw_init_fn_t coll_neighbor_alltoallw_init;
-    mca_coll_base_module_2_4_0_t *coll_neighbor_alltoallw_init_module;
+    mca_coll_base_module_3_0_0_t *coll_neighbor_alltoallw_init_module;
 
     mca_coll_base_module_reduce_local_fn_t coll_reduce_local;
-    mca_coll_base_module_2_4_0_t *coll_reduce_local_module;
+    mca_coll_base_module_3_0_0_t *coll_reduce_local_module;
 
     mca_coll_base_module_agree_fn_t coll_agree;
-    mca_coll_base_module_2_4_0_t *coll_agree_module;
+    mca_coll_base_module_3_0_0_t *coll_agree_module;
     mca_coll_base_module_iagree_fn_t coll_iagree;
-    mca_coll_base_module_2_4_0_t *coll_iagree_module;
+    mca_coll_base_module_3_0_0_t *coll_iagree_module;
 
     /* List of modules initialized, queried and enabled */
     opal_list_t *module_list;
@@ -813,8 +813,8 @@ typedef struct mca_coll_base_comm_coll_t mca_coll_base_comm_coll_t;
 /*
  * Macro for use in components that are of type coll
  */
-#define MCA_COLL_BASE_VERSION_2_4_0 \
-    OMPI_MCA_BASE_VERSION_2_1_0("coll", 2, 4, 0)
+#define MCA_COLL_BASE_VERSION_3_0_0 \
+    OMPI_MCA_BASE_VERSION_2_1_0("coll", 3, 0, 0)
 
 
 /* ******************************************************************** */

--- a/ompi/mca/coll/demo/coll_demo.h
+++ b/ompi/mca/coll/demo/coll_demo.h
@@ -31,7 +31,7 @@ BEGIN_C_DECLS
 
     /* Globally exported variables */
 
-    OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_demo_component;
+    OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_demo_component;
     extern int mca_coll_demo_priority;
     extern int mca_coll_demo_verbose;
 
@@ -45,20 +45,20 @@ BEGIN_C_DECLS
 
     /* Module functions */
 
-    int mca_coll_demo_allgather_intra(const void *sbuf, int scount,
+    int mca_coll_demo_allgather_intra(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_allgather_inter(const void *sbuf, int scount,
+    int mca_coll_demo_allgather_inter(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount,
+                                      void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_demo_allgatherv_intra(const void *sbuf, int scount,
+    int mca_coll_demo_allgatherv_intra(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
                                        void * rbuf, const int *rcounts, const int *disps,
                                        struct ompi_datatype_t *rdtype,
@@ -71,26 +71,26 @@ BEGIN_C_DECLS
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-    int mca_coll_demo_allreduce_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_allreduce_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-    int mca_coll_demo_alltoall_intra(const void *sbuf, int scount,
+    int mca_coll_demo_alltoall_intra(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
-    int mca_coll_demo_alltoall_inter(const void *sbuf, int scount,
+    int mca_coll_demo_alltoall_inter(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
@@ -109,15 +109,15 @@ BEGIN_C_DECLS
                                       mca_coll_base_module_t *module);
 
     int mca_coll_demo_alltoallw_intra(const void *sbuf, const int *scounts, const int *sdisps,
-                                      struct ompi_datatype_t *const *sdtypes,
+                                      struct ompi_datatype_t **sdtypes,
                                       void *rbuf, const int *rcounts, const int *rdisps,
-                                      struct ompi_datatype_t *const *rdtypes,
+                                      struct ompi_datatype_t **rdtypes,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
-    int mca_coll_demo_alltoallw_inter(const void *sbuf, const int *scounts, const int *sdisps,
-                                      struct ompi_datatype_t *const *sdtypes,
+    int mca_coll_demo_alltoallw_inter(void *sbuf, const int *scounts, const int *sdisps,
+                                      struct ompi_datatype_t **sdtypes,
                                       void *rbuf, const int *rcounts, const int *rdisps,
-                                      struct ompi_datatype_t *const *rdtypes,
+                                      struct ompi_datatype_t **rdtypes,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
@@ -126,36 +126,36 @@ BEGIN_C_DECLS
     int mca_coll_demo_barrier_inter(struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_demo_bcast_intra(void *buff, int count,
+    int mca_coll_demo_bcast_intra(void *buff, size_t count,
                                   struct ompi_datatype_t *datatype,
                                   int root,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-    int mca_coll_demo_bcast_inter(void *buff, int count,
+    int mca_coll_demo_bcast_inter(void *buff, size_t count,
                                   struct ompi_datatype_t *datatype,
                                   int root,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 
-    int mca_coll_demo_exscan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_exscan_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_exscan_inter(const void *sbuf, void *rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
-    int mca_coll_demo_gather_intra(const void *sbuf, int scount,
+    int mca_coll_demo_gather_intra(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                   int rcount, struct ompi_datatype_t *rdtype,
+                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                    int root, struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_gather_inter(const void *sbuf, int scount,
+    int mca_coll_demo_gather_inter(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                   int rcount, struct ompi_datatype_t *rdtype,
+                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                    int root, struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
@@ -165,20 +165,20 @@ BEGIN_C_DECLS
                                     struct ompi_datatype_t *rdtype, int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-    int mca_coll_demo_gatherv_inter(const void *sbuf, int scount,
+    int mca_coll_demo_gatherv_inter(void *sbuf, int scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
                                     const int *rcounts, const int *disps,
                                     struct ompi_datatype_t *rdtype, int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-    int mca_coll_demo_reduce_intra(const void *sbuf, void* rbuf, int count,
+    int mca_coll_demo_reduce_intra(const void *sbuf, void* rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    int root,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-    int mca_coll_demo_reduce_inter(const void *sbuf, void* rbuf, int count,
+    int mca_coll_demo_reduce_inter(const void *sbuf, void* rbuf, size_t count,
                                    struct ompi_datatype_t *dtype,
                                    struct ompi_op_t *op,
                                    int root,
@@ -198,37 +198,37 @@ BEGIN_C_DECLS
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module);
 
-    int mca_coll_demo_scan_intra(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_scan_intra(const void *sbuf, void *rbuf, size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-    int mca_coll_demo_scan_inter(const void *sbuf, void *rbuf, int count,
+    int mca_coll_demo_scan_inter(const void *sbuf, void *rbuf, size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 
-    int mca_coll_demo_scatter_intra(const void *sbuf, int scount,
+    int mca_coll_demo_scatter_intra(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int rcount, struct ompi_datatype_t *rdtype,
+                                    size_t rcount, struct ompi_datatype_t *rdtype,
                                     int root, struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-    int mca_coll_demo_scatter_inter(const void *sbuf, int scount,
+    int mca_coll_demo_scatter_inter(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype, void *rbuf,
-                                    int rcount, struct ompi_datatype_t *rdtype,
+                                    size_t rcount, struct ompi_datatype_t *rdtype,
                                     int root, struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
     int mca_coll_demo_scatterv_intra(const void *sbuf, const int *scounts, const int *disps,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype, int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
     int mca_coll_demo_scatterv_inter(const void *sbuf, const int *scounts, const int *disps,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype, int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);

--- a/ompi/mca/coll/demo/coll_demo_allgather.c
+++ b/ompi/mca/coll/demo/coll_demo_allgather.c
@@ -34,9 +34,9 @@
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgather_intra(const void *sbuf, int scount,
+int mca_coll_demo_allgather_intra(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                  int rcount, struct ompi_datatype_t *rdtype,
+                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
 {
@@ -55,9 +55,9 @@ int mca_coll_demo_allgather_intra(const void *sbuf, int scount,
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allgather_inter(const void *sbuf, int scount,
+int mca_coll_demo_allgather_inter(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_allreduce.c
+++ b/ompi/mca/coll/demo/coll_demo_allreduce.c
@@ -34,7 +34,7 @@
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -55,7 +55,7 @@ int mca_coll_demo_allreduce_intra(const void *sbuf, void *rbuf, int count,
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_allreduce_inter(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_alltoall.c
+++ b/ompi/mca/coll/demo/coll_demo_alltoall.c
@@ -34,9 +34,9 @@
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_demo_alltoall_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
@@ -57,9 +57,9 @@ int mca_coll_demo_alltoall_intra(const void *sbuf, int scount,
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_demo_alltoall_inter(const void *sbuf, int scount,
+int mca_coll_demo_alltoall_inter(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_bcast.c
+++ b/ompi/mca/coll/demo/coll_demo_bcast.c
@@ -34,7 +34,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_bcast_intra(void *buff, int count,
+int mca_coll_demo_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)
@@ -54,7 +54,7 @@ int mca_coll_demo_bcast_intra(void *buff, int count,
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_bcast_inter(void *buff, int count,
+int mca_coll_demo_bcast_inter(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_component.c
+++ b/ompi/mca/coll/demo/coll_demo_component.c
@@ -56,7 +56,7 @@ static int demo_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_demo_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_demo_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */

--- a/ompi/mca/coll/demo/coll_demo_exscan.c
+++ b/ompi/mca/coll/demo/coll_demo_exscan.c
@@ -34,7 +34,7 @@
  *	Accepts:	- same arguments as MPI_Exscan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_gather.c
+++ b/ompi/mca/coll/demo/coll_demo_gather.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gather_intra(const void *sbuf, int scount,
+int mca_coll_demo_gather_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
@@ -56,9 +56,9 @@ int mca_coll_demo_gather_intra(const void *sbuf, int scount,
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_gather_inter(const void *sbuf, int scount,
+int mca_coll_demo_gather_inter(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/demo/coll_demo_reduce.c
+++ b/ompi/mca/coll/demo/coll_demo_reduce.c
@@ -34,7 +34,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_reduce_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,
@@ -55,7 +55,7 @@ int mca_coll_demo_reduce_intra(const void *sbuf, void *rbuf, int count,
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_reduce_inter(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_reduce_inter(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_scan.c
+++ b/ompi/mca/coll/demo/coll_demo_scan.c
@@ -34,7 +34,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_demo_scan_intra(void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/demo/coll_demo_scatter.c
+++ b/ompi/mca/coll/demo/coll_demo_scatter.c
@@ -34,9 +34,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatter_intra(const void *sbuf, int scount,
+int mca_coll_demo_scatter_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,
@@ -58,9 +58,9 @@ int mca_coll_demo_scatter_intra(const void *sbuf, int scount,
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_demo_scatter_inter(const void *sbuf, int scount,
+int mca_coll_demo_scatter_inter(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ftagree/coll_ftagree.h
+++ b/ompi/mca/coll/ftagree/coll_ftagree.h
@@ -33,7 +33,7 @@ BEGIN_C_DECLS
 
 /* Globally exported variables */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t
 mca_coll_ftagree_component;
 extern int mca_coll_ftagree_priority;
 
@@ -106,7 +106,7 @@ mca_coll_base_module_t
 /* Early termination algorithm */
 int
 mca_coll_ftagree_eta_intra(     void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
@@ -115,14 +115,14 @@ mca_coll_ftagree_eta_intra(     void* contrib,
 /* Early returning algorithm */
 int
 mca_coll_ftagree_era_intra(     void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
                                 ompi_communicator_t* comm,
                                 mca_coll_base_module_t *module);
 int mca_coll_ftagree_iera_intra(void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,
@@ -130,7 +130,7 @@ int mca_coll_ftagree_iera_intra(void* contrib,
                                 ompi_request_t **request,
                                 mca_coll_base_module_t *module);
 int mca_coll_ftagree_era_inter( void* contrib,
-                                int dt_count,
+                                size_t dt_count,
                                 ompi_datatype_t *dt,
                                 ompi_op_t *op,
                                 ompi_group_t **group, bool grp_update,

--- a/ompi/mca/coll/ftagree/coll_ftagree_component.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_component.c
@@ -48,13 +48,13 @@ static int ftagree_close(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_ftagree_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_ftagree_component = {
 
     /* First, the mca_component_t struct containing meta information
      * about the component itself */
 
     {
-     MCA_COLL_BASE_VERSION_2_4_0,
+     MCA_COLL_BASE_VERSION_3_0_0,
 
      /* Component name and version */
      "ftagree",

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -119,7 +119,7 @@ typedef struct {
                                               *   min over all ranks. */
     int      operand;                        /**< operand applied on bytes.
                                               *   One of OMPI_OP_BASE_FORTRAN_* values in mca/op/op.h */
-    int      dt_count;                       /**< The number of datatypes in bytes */
+    size_t   dt_count;                       /**< The number of datatypes in bytes */
     int      datatype;                       /**< Fortran index of predefined basic datatype in bytes */
     int      nb_new_dead;                    /**< Number of newly discovered dead */
 } era_value_header_t;
@@ -3018,7 +3018,7 @@ static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
                                                             ompi_group_t *group,
                                                             ompi_op_t *op,
                                                             ompi_datatype_t *dt,
-                                                            int dt_count,
+                                                            size_t dt_count,
                                                             void *contrib,
                                                             mca_coll_base_module_t *module,
                                                             era_identifier_t *paid,
@@ -3187,7 +3187,7 @@ static int mca_coll_ftagree_era_complete_agreement(era_identifier_t agreement_id
  * Returns:	- MPI_SUCCESS or an MPI error code
  */
 int mca_coll_ftagree_era_intra(void *contrib,
-                                         int dt_count,
+                                         size_t dt_count,
                                          ompi_datatype_t *dt,
                                          ompi_op_t *op,
                                          ompi_group_t **group, bool grp_update,
@@ -3214,7 +3214,7 @@ int mca_coll_ftagree_era_intra(void *contrib,
  * Returns:	- MPI_SUCCESS or an MPI error code
  */
 int mca_coll_ftagree_era_inter(void *contrib,
-                                         int dt_count,
+                                         size_t dt_count,
                                          ompi_datatype_t *dt,
                                          ompi_op_t *op,
                                          ompi_group_t **group, bool grp_update,
@@ -3310,7 +3310,7 @@ static int era_iagree_req_complete_cb(struct ompi_request_t* request)
 }
 
 int mca_coll_ftagree_iera_intra(void *contrib,
-                                          int dt_count,
+                                          size_t dt_count,
                                           ompi_datatype_t *dt,
                                           ompi_op_t *op,
                                           ompi_group_t **group, bool grp_update,

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
@@ -62,7 +62,7 @@ typedef struct {
 
 int
 mca_coll_ftagree_eta_intra(void *contrib,
-                           int dt_count,
+                           size_t dt_count,
                            ompi_datatype_t *dt,
                            ompi_op_t *op,
                            ompi_group_t **group, bool update_grp,

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -125,8 +125,8 @@ struct mca_coll_han_scatter_args_s {
     void *rbuf;
     ompi_datatype_t *sdtype;
     ompi_datatype_t *rdtype;
-    int scount;
-    int rcount;
+    size_t scount;
+    size_t rcount;
     int root;
     int root_up_rank;
     int root_low_rank;
@@ -166,8 +166,8 @@ struct mca_coll_han_allgather_s {
     void *rbuf;
     ompi_datatype_t *sdtype;
     ompi_datatype_t *rdtype;
-    int scount;
-    int rcount;
+    size_t scount;
+    size_t rcount;
     int root_low_rank;
     int w_rank;
     bool noop;
@@ -207,7 +207,7 @@ typedef struct mca_coll_han_op_module_name_t {
  */
 typedef struct mca_coll_han_component_t {
     /** Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /** MCA parameter: Priority of this component */
     int han_priority;
@@ -521,7 +521,7 @@ int mca_coll_han_barrier_intra_simple(struct ompi_communicator_t *comm,
 /* reordering after gather, for unordered ranks */
 void
 ompi_coll_han_reorder_gather(const void *sbuf,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              int * topo);

--- a/ompi/mca/coll/han/coll_han_algorithms.h
+++ b/ompi/mca/coll/han/coll_han_algorithms.h
@@ -74,19 +74,19 @@ int mca_coll_han_barrier_intra_simple(struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 /* Bcast */
 int mca_coll_han_bcast_intra_simple(void *buff,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     int root,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-int mca_coll_han_bcast_intra(void *buff, int count, struct ompi_datatype_t *dtype, int root,
+int mca_coll_han_bcast_intra(void *buff, size_t count, struct ompi_datatype_t *dtype, int root,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 
 /* Reduce */
 int
 mca_coll_han_reduce_intra_simple(const void *sbuf,
                                  void* rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  ompi_op_t *op,
                                  int root,
@@ -98,7 +98,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_reduce_reproducible(const void *sbuf,
                                  void *rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  int root,
@@ -107,7 +107,7 @@ mca_coll_han_reduce_reproducible(const void *sbuf,
 
 int mca_coll_han_reduce_intra(const void *sbuf,
                               void *rbuf,
-                              int count,
+                              size_t count,
                               struct ompi_datatype_t *dtype,
                               ompi_op_t* op,
                               int root,
@@ -118,7 +118,7 @@ int mca_coll_han_reduce_intra(const void *sbuf,
 int
 mca_coll_han_allreduce_intra_simple(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -129,7 +129,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_allreduce_reproducible(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -137,23 +137,23 @@ mca_coll_han_allreduce_reproducible(const void *sbuf,
 
 int mca_coll_han_allreduce_intra(const void *sbuf,
                                  void *rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 
 /* Scatter */
 int
-mca_coll_han_scatter_intra(const void *sbuf, int scount,
+mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,
                            struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,
@@ -171,16 +171,16 @@ mca_coll_han_scatterv_intra(const void *sbuf, const int *scounts,
 
 /* Gather */
 int
-mca_coll_han_gather_intra(const void *sbuf, int scount,
+mca_coll_han_gather_intra(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -195,15 +195,15 @@ mca_coll_han_gatherv_intra(const void *sbuf, int scount, struct ompi_datatype_t 
 
 /* Allgather */
 int
-mca_coll_han_allgather_intra(const void *sbuf, int scount,
+mca_coll_han_allgather_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module);
 int
-mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void* rbuf, int rcount,
+                                    void* rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -33,10 +33,10 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
                                 mca_coll_task_t * cur_task,
                                 void *sbuf,
                                 void *sbuf_inter_free,
-                                int scount,
+                                size_t scount,
                                 struct ompi_datatype_t *sdtype,
                                 void *rbuf,
-                                int rcount,
+                                size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root_low_rank,
                                 struct ompi_communicator_t *up_comm,
@@ -70,9 +70,9 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
  * Main function for taskified allgather: calls lg task, a gather on low comm
  */
 int
-mca_coll_han_allgather_intra(const void *sbuf, int scount,
+mca_coll_han_allgather_intra(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t * module)
@@ -293,9 +293,9 @@ int mca_coll_han_allgather_lb_task(void *task_args)
  * communications without tasks.
  */
 int
-mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *sdtype,
-                                    void* rbuf, int rcount,
+                                    void* rbuf, size_t rcount,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module){

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -91,7 +91,7 @@ mca_coll_han_set_allreduce_args(mca_coll_han_allreduce_args_t * args,
 int
 mca_coll_han_allreduce_intra(const void *sbuf,
                              void *rbuf,
-                             int count,
+                             size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -133,7 +133,7 @@ mca_coll_han_allreduce_intra(const void *sbuf,
 
     /* Determine number of elements sent per task. */
     OPAL_OUTPUT_VERBOSE((10, mca_coll_han_component.han_output,
-                         "In HAN Allreduce seg_size %d seg_count %d count %d\n",
+                         "In HAN Allreduce seg_size %d seg_count %d count %zu\n",
                          mca_coll_han_component.han_allreduce_segsize, seg_count, count));
     int num_segments = (count + seg_count - 1) / seg_count;
 
@@ -465,7 +465,7 @@ int mca_coll_han_allreduce_t3_task(void *task_args)
 int
 mca_coll_han_allreduce_intra_simple(const void *sbuf,
                                     void *rbuf,
-                                    int count,
+                                    size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
@@ -612,7 +612,7 @@ mca_coll_han_allreduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_allreduce_reproducible(const void *sbuf,
                                     void *rbuf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -65,7 +65,7 @@ mca_coll_han_set_bcast_args(mca_coll_han_bcast_args_t * args, mca_coll_task_t * 
  */
 int
 mca_coll_han_bcast_intra(void *buf,
-                         int count,
+                         size_t count,
                          struct ompi_datatype_t *dtype,
                          int root,
                          struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -113,7 +113,7 @@ mca_coll_han_bcast_intra(void *buf,
 
     int num_segments = (count + seg_count - 1) / seg_count;
     OPAL_OUTPUT_VERBOSE((20, mca_coll_han_component.han_output,
-                         "In HAN seg_count %d count %d num_seg %d\n",
+                         "In HAN seg_count %d count %zu num_seg %d\n",
                          seg_count, count, num_segments));
 
     int *vranks = han_module->cached_vranks;
@@ -224,7 +224,7 @@ int mca_coll_han_bcast_t1_task(void *task_args)
  */
 int
 mca_coll_han_bcast_intra_simple(void *buf,
-                                int count,
+                                size_t count,
                                 struct ompi_datatype_t *dtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -68,7 +68,7 @@ mca_coll_han_component_t mca_coll_han_component = {
            information about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "han",

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -372,9 +372,9 @@ get_algorithm(COLLTYPE_T coll_id,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_allgather_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_allgather_intra_dynamic(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void *rbuf, int rcount,
+                                     void *rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module)
@@ -605,7 +605,7 @@ mca_coll_han_allgatherv_intra_dynamic(const void *sbuf, int scount,
 int
 mca_coll_han_allreduce_intra_dynamic(const void *sbuf,
                                      void *rbuf,
-                                     int count,
+                                     size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
@@ -820,7 +820,7 @@ mca_coll_han_barrier_intra_dynamic(struct ompi_communicator_t *comm,
  */
 int
 mca_coll_han_bcast_intra_dynamic(void *buff,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -934,9 +934,9 @@ mca_coll_han_bcast_intra_dynamic(void *buff,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_gather_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_gather_intra_dynamic(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,
@@ -1156,7 +1156,7 @@ int mca_coll_han_gatherv_intra_dynamic(const void *sbuf, int scount, struct ompi
 int
 mca_coll_han_reduce_intra_dynamic(const void *sbuf,
                                   void *rbuf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   int root,
@@ -1276,9 +1276,9 @@ mca_coll_han_reduce_intra_dynamic(const void *sbuf,
  * calls the correct module if fallback mechanism is activated
  */
 int
-mca_coll_han_scatter_intra_dynamic(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_dynamic(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void *rbuf, int rcount,
+                                   void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *rdtype,
                                    int root,
                                    struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -36,10 +36,10 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
                              mca_coll_task_t * cur_task,
                              void *sbuf,
                              void *sbuf_inter_free,
-                             int scount,
+                             size_t scount,
                              struct ompi_datatype_t *sdtype,
                              void *rbuf,
-                             int rcount,
+                             size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root,
                              int root_up_rank,
@@ -72,9 +72,9 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
  * Main function for taskified gather: calls lg task, a gather on low comm
  */
 int
-mca_coll_han_gather_intra(const void *sbuf, int scount,
+mca_coll_han_gather_intra(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -301,9 +301,9 @@ int mca_coll_han_gather_ug_task(void *task_args)
 
 /* only work with regular situation (each node has equal number of processes) */
 int
-mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
+mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,
@@ -449,7 +449,7 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
  */
 void
 ompi_coll_han_reorder_gather(const void *sbuf,
-                             void *rbuf, int count,
+                             void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_communicator_t *comm,
                              int * topo)

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -69,7 +69,7 @@ mca_coll_han_set_reduce_args(mca_coll_han_reduce_args_t * args, mca_coll_task_t 
 int
 mca_coll_han_reduce_intra(const void *sbuf,
                           void *rbuf,
-                          int count,
+                          size_t count,
                           struct ompi_datatype_t *dtype,
                           ompi_op_t* op,
                           int root,
@@ -127,7 +127,7 @@ mca_coll_han_reduce_intra(const void *sbuf,
 
     int num_segments = (count + seg_count - 1) / seg_count;
     OPAL_OUTPUT_VERBOSE((20, mca_coll_han_component.han_output,
-                         "In HAN seg_count %d count %d num_seg %d\n",
+                         "In HAN seg_count %d count %zu num_seg %d\n",
                          seg_count, count, num_segments));
 
     int *vranks = han_module->cached_vranks;
@@ -284,7 +284,7 @@ int mca_coll_han_reduce_t1_task(void *task_args) {
 int
 mca_coll_han_reduce_intra_simple(const void *sbuf,
                                  void* rbuf,
-                                 int count,
+                                 size_t count,
                                  struct ompi_datatype_t *dtype,
                                  ompi_op_t *op,
                                  int root,
@@ -451,7 +451,7 @@ mca_coll_han_reduce_reproducible_decision(struct ompi_communicator_t *comm,
 int
 mca_coll_han_reduce_reproducible(const void *sbuf,
                                  void *rbuf,
-                                  int count,
+                                  size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   int root,

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -34,10 +34,10 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
                               void *sbuf,
                               void *sbuf_inter_free,
                               void *sbuf_reorder_free,
-                              int scount,
+                              size_t scount,
                               struct ompi_datatype_t *sdtype,
                               void *rbuf,
-                              int rcount,
+                              size_t rcount,
                               struct ompi_datatype_t *rdtype,
                               int root,
                               int root_up_rank,
@@ -70,9 +70,9 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
  * after data reordring, calls us task, a scatter on up communicator
  */
 int
-mca_coll_han_scatter_intra(const void *sbuf, int scount,
+mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void *rbuf, int rcount,
+                           void *rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,
                            struct ompi_communicator_t *comm, mca_coll_base_module_t * module)
@@ -263,9 +263,9 @@ int mca_coll_han_scatter_ls_task(void *task_args)
 
 
 int
-mca_coll_han_scatter_intra_simple(const void *sbuf, int scount,
+mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   int root,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -58,7 +58,7 @@ OBJ_CLASS_DECLARATION(mca_coll_hcoll_dtype_t);
 extern mca_coll_hcoll_dtype_t zero_dte_mapping;
 struct mca_coll_hcoll_component_t {
     /** Base coll component */
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /** MCA parameter: Priority of this component */
     int hcoll_priority;
@@ -179,14 +179,14 @@ void hcoll_rte_fns_setup(void);
 int mca_coll_hcoll_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_bcast(void *buff, int count,
+int mca_coll_hcoll_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_allgather(const void *sbuf, int scount,
+int mca_coll_hcoll_allgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
@@ -199,22 +199,22 @@ int mca_coll_hcoll_allgatherv(const void *sbuf, int scount,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_gather(const void *sbuf, int scount,
+int mca_coll_hcoll_gather(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
 #if HCOLL_API > HCOLL_VERSION(4,5)
-int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         struct ompi_communicator_t *comm,
@@ -225,16 +225,16 @@ int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcoun
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
 #endif
-int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_alltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_alltoall(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount,
+                           void* rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
@@ -269,15 +269,15 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ibcast(void *buff, int count,
+int mca_coll_hcoll_ibcast(void *buff, size_t count,
                             struct ompi_datatype_t *datatype, int root,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_iallgather(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
@@ -292,14 +292,14 @@ int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -307,9 +307,9 @@ int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_hcoll_ialltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_ialltoall(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount,
+                            void* rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t **req,

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -36,7 +36,7 @@ mca_coll_hcoll_component_t mca_coll_hcoll_component = {
        about the component itfca */
     {
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "hcoll",

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -36,7 +36,7 @@ orig_barrier:
     return hcoll_module->previous_barrier(comm,hcoll_module->previous_barrier_module);
 }
 
-int mca_coll_hcoll_bcast(void *buff, int count,
+int mca_coll_hcoll_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)
@@ -65,9 +65,9 @@ int mca_coll_hcoll_bcast(void *buff, int count,
     return rc;
 }
 
-int mca_coll_hcoll_allgather(const void *sbuf, int scount,
+int mca_coll_hcoll_allgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)
@@ -150,9 +150,9 @@ int mca_coll_hcoll_allgatherv(const void *sbuf, int scount,
     return rc;
 }
 
-int mca_coll_hcoll_gather(const void *sbuf, int scount,
+int mca_coll_hcoll_gather(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -196,7 +196,7 @@ int mca_coll_hcoll_gather(const void *sbuf, int scount,
 
 }
 
-int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
@@ -243,7 +243,7 @@ int mca_coll_hcoll_allreduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 
-int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -294,9 +294,9 @@ int mca_coll_hcoll_reduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 
-int mca_coll_hcoll_alltoall(const void *sbuf, int scount,
+int mca_coll_hcoll_alltoall(const void *sbuf, size_t scount,
                            struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount,
+                           void* rbuf, size_t rcount,
                            struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
@@ -355,9 +355,9 @@ int mca_coll_hcoll_alltoallv(const void *sbuf, const int *scounts, const int *sd
                                             comm, hcoll_module->previous_alltoallv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_alltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
-                                            rbuf, (int *)rcounts, (int *)rdisps, rtype,
-                                                hcoll_module->hcoll_context);
+    rc = hcoll_collectives.coll_alltoallv(sbuf, scounts, sdisps, stype,
+                                          rbuf, rcounts, rdisps, rtype,
+                                          hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK ALLTOALLV");
         rc = hcoll_module->previous_alltoallv(sbuf, scounts, sdisps, sdtype,
@@ -400,8 +400,8 @@ int mca_coll_hcoll_gatherv(const void* sbuf, int scount,
                                            comm, hcoll_module->previous_gatherv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_gatherv((void *)sbuf, scount, stype, rbuf,
-                                        (int *)rcounts, (int *)displs, rtype,
+    rc = hcoll_collectives.coll_gatherv(sbuf, scount, stype, rbuf,
+                                        rcounts, displs, rtype,
                                         root, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK GATHERV");
@@ -451,7 +451,7 @@ int mca_coll_hcoll_scatterv(const void* sbuf, const int *scounts, const int *dis
                                            comm, hcoll_module->previous_scatterv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_scatterv((void *)sbuf, (int *)scounts, (int *)displs, stype, rbuf, rcount, rtype, root, hcoll_module->hcoll_context);
+    rc = hcoll_collectives.coll_scatterv(sbuf, scounts, displs, stype, rbuf, rcount, rtype, root, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK SCATTERV");
         rc = hcoll_module->previous_scatterv(sbuf, scounts, displs, sdtype,
@@ -478,7 +478,7 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
     return rc;
 }
 
-int mca_coll_hcoll_ibcast(void *buff, int count,
+int mca_coll_hcoll_ibcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         ompi_request_t ** request,
@@ -509,9 +509,9 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
     return rc;
 }
 
-int mca_coll_hcoll_iallgather(const void *sbuf, int scount,
+int mca_coll_hcoll_iallgather(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t ** request,
@@ -600,7 +600,7 @@ int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
     return rc;
 }
 #endif
-int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
@@ -650,7 +650,7 @@ int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
     return rc;
 }
 #if HCOLL_API >= HCOLL_VERSION(3,5)
-int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root,
@@ -782,8 +782,8 @@ int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts, const int *s
                                                comm, request, hcoll_module->previous_alltoallv_module);
         return rc;
     }
-    rc = hcoll_collectives.coll_ialltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
-                                           rbuf, (int *)rcounts, (int *)rdisps, rtype,
+    rc = hcoll_collectives.coll_ialltoallv(sbuf, scounts, sdisps, stype,
+                                           rbuf, rcounts, rdisps, rtype,
                                            hcoll_module->hcoll_context, (void**)request);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK IALLTOALLV");
@@ -796,7 +796,7 @@ int mca_coll_hcoll_ialltoallv(const void *sbuf, const int *scounts, const int *s
 #endif
 
 #if HCOLL_API > HCOLL_VERSION(4,5)
-int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *dtype,
                                         struct ompi_op_t *op,
                                         struct ompi_communicator_t *comm,
@@ -837,7 +837,7 @@ int mca_coll_hcoll_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount
     return rc;
 }
 
-int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcounts,
+int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
@@ -867,7 +867,7 @@ int mca_coll_hcoll_reduce_scatter(const void *sbuf, void *rbuf, const int* rcoun
         goto fallback;
     }
 
-    rc = hcoll_collectives.coll_reduce_scatter((void*)sbuf, rbuf, (int*)rcounts,
+    rc = hcoll_collectives.coll_reduce_scatter(sbuf, rbuf, rcounts,
                                                Dtype, Op, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
     fallback:        

--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -51,7 +51,7 @@
 
 
 static int recv_nb(dte_data_representation_t data ,
-                   uint32_t count ,
+                   size_t count ,
                    void *buffer,
                    rte_ec_handle_t ,
                    rte_grp_handle_t ,
@@ -59,7 +59,7 @@ static int recv_nb(dte_data_representation_t data ,
                    rte_request_handle_t * req);
 
 static int send_nb(dte_data_representation_t data,
-                   uint32_t count,
+                   size_t count,
                    void *buffer,
                    rte_ec_handle_t ec_h,
                    rte_grp_handle_t grp_h,
@@ -161,7 +161,7 @@ void hcoll_rte_fns_setup(void)
 }
 
 static int recv_nb(struct dte_data_representation_t data,
-                   uint32_t count ,
+                   size_t count,
                    void *buffer,
                    rte_ec_handle_t ec_h,
                    rte_grp_handle_t grp_h,
@@ -187,8 +187,8 @@ static int recv_nb(struct dte_data_representation_t data,
     }
     size = (size_t)data.rep.in_line_rep.data_handle.in_line.packed_size*count/8;
 
-    HCOL_VERBOSE(30,"PML_IRECV: dest = %d: buf = %p: size = %u: comm = %p",
-                 ec_h.rank, buffer, (unsigned int)size, (void *)comm);
+    HCOL_VERBOSE(30,"PML_IRECV: dest = %d: buf = %p: size = %zu: comm = %p",
+                 ec_h.rank, buffer, size, (void *)comm);
     if (MCA_PML_CALL(irecv(buffer,size,&(ompi_mpi_unsigned_char.dt),ec_h.rank,
                            tag,comm,&ompi_req)))
     {
@@ -202,7 +202,7 @@ static int recv_nb(struct dte_data_representation_t data,
 
 
 static int send_nb( dte_data_representation_t data,
-                    uint32_t count,
+                    size_t count,
                     void *buffer,
                     rte_ec_handle_t ec_h,
                     rte_grp_handle_t grp_h,
@@ -226,8 +226,8 @@ static int send_nb( dte_data_representation_t data,
         return HCOLL_ERROR;
     }
     size = (size_t)data.rep.in_line_rep.data_handle.in_line.packed_size*count/8;
-    HCOL_VERBOSE(30,"PML_ISEND: dest = %d: buf = %p: size = %u: comm = %p",
-                 ec_h.rank, buffer, (unsigned int)size, (void *)comm);
+    HCOL_VERBOSE(30,"PML_ISEND: dest = %d: buf = %p: size = %zu: comm = %p",
+                 ec_h.rank, buffer, size, (void *)comm);
     if (MCA_PML_CALL(isend(buffer,size,&(ompi_mpi_unsigned_char.dt),ec_h.rank,
                            tag,MCA_PML_BASE_SEND_STANDARD,comm,&ompi_req)))
     {

--- a/ompi/mca/coll/inter/coll_inter.h
+++ b/ompi/mca/coll/inter/coll_inter.h
@@ -38,7 +38,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_inter_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_inter_component;
 extern int mca_coll_inter_priority_param;
 extern int mca_coll_inter_verbose_param;
 
@@ -51,9 +51,9 @@ int mca_coll_inter_init_query(bool allow_inter_user_threads,
 mca_coll_base_module_t *
 mca_coll_inter_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int mca_coll_inter_allgather_inter(const void *sbuf, int scount,
+int mca_coll_inter_allgather_inter(const void *sbuf, size_t scount,
 				   struct ompi_datatype_t *sdtype,
-				   void *rbuf, int rcount,
+				   void *rbuf, size_t rcount,
 				   struct ompi_datatype_t *rdtype,
 				   struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
@@ -63,19 +63,19 @@ int mca_coll_inter_allgatherv_inter(const void *sbuf, int scount,
 				    struct ompi_datatype_t *rdtype,
 				    struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
-int mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
+int mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
 				   struct ompi_datatype_t *dtype,
 				   struct ompi_op_t *op,
 				   struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-int mca_coll_inter_bcast_inter(void *buff, int count,
+int mca_coll_inter_bcast_inter(void *buff, size_t count,
 			       struct ompi_datatype_t *datatype,
 			       int root,
 			       struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
-int mca_coll_inter_gather_inter(const void *sbuf, int scount,
+int mca_coll_inter_gather_inter(const void *sbuf, size_t scount,
 				struct ompi_datatype_t *sdtype,
-				void *rbuf, int rcount,
+				void *rbuf, size_t rcount,
 				struct ompi_datatype_t *rdtype,
 				int root,
 				struct ompi_communicator_t *comm,
@@ -87,15 +87,15 @@ int mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
 				 int root,
 				 struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
-int mca_coll_inter_reduce_inter(const void *sbuf, void* rbuf, int count,
+int mca_coll_inter_reduce_inter(const void *sbuf, void* rbuf, size_t count,
 				struct ompi_datatype_t *dtype,
 				struct ompi_op_t *op,
 				int root,
 				struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_inter_scatter_inter(const void *sbuf, int scount,
+int mca_coll_inter_scatter_inter(const void *sbuf, size_t scount,
 				 struct ompi_datatype_t *sdtype, void *rbuf,
-				 int rcount, struct ompi_datatype_t *rdtype,
+				 size_t rcount, struct ompi_datatype_t *rdtype,
 				 int root, struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 int mca_coll_inter_scatterv_inter(const void *sbuf, const int *scounts, const int *disps,

--- a/ompi/mca/coll/inter/coll_inter_allgather.c
+++ b/ompi/mca/coll/inter/coll_inter_allgather.c
@@ -43,9 +43,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_allgather_inter(const void *sbuf, int scount,
+mca_coll_inter_allgather_inter(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_allreduce.c
+++ b/ompi/mca/coll/inter/coll_inter_allreduce.c
@@ -42,7 +42,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/inter/coll_inter_bcast.c
+++ b/ompi/mca/coll/inter/coll_inter_bcast.c
@@ -37,7 +37,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_bcast_inter(void *buff, int count,
+mca_coll_inter_bcast_inter(void *buff, size_t count,
                            struct ompi_datatype_t *datatype, int root,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_component.c
+++ b/ompi/mca/coll/inter/coll_inter_component.c
@@ -57,13 +57,13 @@ static int inter_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_inter_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_inter_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "inter",

--- a/ompi/mca/coll/inter/coll_inter_gather.c
+++ b/ompi/mca/coll/inter/coll_inter_gather.c
@@ -39,9 +39,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_gather_inter(const void *sbuf, int scount,
+mca_coll_inter_gather_inter(const void *sbuf, size_t scount,
                             struct ompi_datatype_t *sdtype,
-                            void *rbuf, int rcount,
+                            void *rbuf, size_t rcount,
                             struct ompi_datatype_t *rdtype,
                             int root, struct ompi_communicator_t *comm,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/inter/coll_inter_reduce.c
+++ b/ompi/mca/coll/inter/coll_inter_reduce.c
@@ -40,7 +40,7 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_reduce_inter(const void *sbuf, void *rbuf, int count,
+mca_coll_inter_reduce_inter(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op,
                             int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/inter/coll_inter_scatter.c
+++ b/ompi/mca/coll/inter/coll_inter_scatter.c
@@ -38,9 +38,9 @@
  *	Returns:	- MPI_SUCCESS or error code
  */
 int
-mca_coll_inter_scatter_inter(const void *sbuf, int scount,
+mca_coll_inter_scatter_inter(const void *sbuf, size_t scount,
                              struct ompi_datatype_t *sdtype,
-                             void *rbuf, int rcount,
+                             void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              int root, struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module)

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -79,7 +79,7 @@ extern int libnbc_ireduce_algorithm;
 extern int libnbc_iscan_algorithm;
 
 struct ompi_coll_libnbc_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
     opal_free_list_t requests;
     opal_list_t active_requests;
     opal_atomic_int32_t active_comms;
@@ -161,16 +161,16 @@ int NBC_Init_comm(MPI_Comm comm, ompi_coll_libnbc_module_t *module);
 int NBC_Progress(NBC_Handle *handle);
 
 
-int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
 int ompi_coll_libnbc_iallgatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallreduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iallreduce(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ialltoallv(const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -183,34 +183,34 @@ int ompi_coll_libnbc_ialltoallw(const void *sbuf, const int *scounts, const int 
                                 mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ibarrier(struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iexscan(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_iexscan(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t **request,
                              mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_igather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
 int ompi_coll_libnbc_igatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                               void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ireduce_scatter(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                            ompi_request_t **request,
                                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
 int ompi_coll_libnbc_iscatterv(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
@@ -219,16 +219,16 @@ int ompi_coll_libnbc_iscatterv(const void* sendbuf, const int *sendcounts, const
                                mca_coll_base_module_t *module);
 
 
-int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
 int ompi_coll_libnbc_iallgatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iallreduce_inter(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iallreduce_inter(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ialltoall_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ialltoallv_inter(const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -241,28 +241,28 @@ int ompi_coll_libnbc_ialltoallw_inter(const void *sbuf, const int *scounts, cons
                                       mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ibarrier_inter(struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast_inter(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module);
-int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_igather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
 int ompi_coll_libnbc_igatherv_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                               void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_inter(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_inter(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ireduce_scatter_inter(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ireduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_ireduce_scatter_block_inter(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                                  ompi_request_t **request,
                                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_iscatter_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module);
 int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
@@ -271,15 +271,15 @@ int ompi_coll_libnbc_iscatterv_inter(const void* sendbuf, const int *sendcounts,
                                mca_coll_base_module_t *module);
 
 
-int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                         size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                          ompi_request_t ** request, mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ineighbor_allgatherv(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                           const int *rcounts, const int *displs, MPI_Datatype rtype,
                                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                        int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                        size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                         ompi_request_t ** request, mca_coll_base_module_t *module);
 int ompi_coll_libnbc_ineighbor_alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
                                          void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,
@@ -290,16 +290,16 @@ int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const int *scounts, c
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module);
 int ompi_coll_libnbc_allgatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
                                      MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allreduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_allreduce_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                     struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                    MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                    mca_coll_base_module_t *module);
 int ompi_coll_libnbc_alltoallv_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -312,33 +312,33 @@ int ompi_coll_libnbc_alltoallw_init(const void *sbuf, const int *scounts, const 
                                     mca_coll_base_module_t *module);
 int ompi_coll_libnbc_barrier_init(struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
-int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                 mca_coll_base_module_t *module);
-int ompi_coll_libnbc_exscan_init(const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_exscan_init(const void *sbuf, void *rbuf, size_t count, struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op, struct ompi_communicator_t *comm, MPI_Info info,  ompi_request_t **request,
                                  mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                  MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
 int ompi_coll_libnbc_gatherv_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
                                   int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                                  MPI_Op op, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module);
 int ompi_coll_libnbc_reduce_scatter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
                                          MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info,  ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_block_init(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_reduce_scatter_block_init(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t **request,
                                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module);
 int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
@@ -346,16 +346,16 @@ int ompi_coll_libnbc_scatterv_init(const void* sendbuf, const int *sendcounts, c
                                    struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                    mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
 int ompi_coll_libnbc_allgatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *displs,
                                            MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                            mca_coll_base_module_t *module);
-int ompi_coll_libnbc_allreduce_inter_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_allreduce_inter_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                           struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
-int ompi_coll_libnbc_alltoall_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                          MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 int ompi_coll_libnbc_alltoallv_inter_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -368,28 +368,28 @@ int ompi_coll_libnbc_alltoallw_inter_init(const void *sbuf, const int *scounts, 
                                           mca_coll_base_module_t *module);
 int ompi_coll_libnbc_barrier_inter_init(struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
-int ompi_coll_libnbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                       struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                       mca_coll_base_module_t *module);
-int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                        MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
 int ompi_coll_libnbc_gatherv_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void* recvbuf, const int *recvcounts, const int *displs, MPI_Datatype recvtype,
                                         int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_inter_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_inter_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype,
                                        MPI_Op op, int root, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
 int ompi_coll_libnbc_reduce_scatter_inter_init(const void* sendbuf, void* recvbuf, const int *recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                mca_coll_base_module_t *module);
-int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
+int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void *sbuf, void *rbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                      struct ompi_op_t *op, struct ompi_communicator_t *comm,
                                                      MPI_Info info, ompi_request_t **request,
                                                      mca_coll_base_module_t *module);
-int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                         struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const int *sendcounts, const int *displs, MPI_Datatype sendtype,
@@ -397,15 +397,15 @@ int ompi_coll_libnbc_scatterv_inter_init(const void* sendbuf, const int *sendcou
                                          struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                          mca_coll_base_module_t *module);
 
-int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                             int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                             size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                              MPI_Info info, ompi_request_t ** request, mca_coll_base_module_t *module);
 int ompi_coll_libnbc_neighbor_allgatherv_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                               const int *rcounts, const int *displs, MPI_Datatype rtype,
                                               struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                               mca_coll_base_module_t *module);
-int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                            int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
+int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                            size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
                                             ompi_request_t ** request, mca_coll_base_module_t *module);
 int ompi_coll_libnbc_neighbor_alltoallv_init(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype stype,
                                              void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rtype,

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -120,7 +120,7 @@ ompi_coll_libnbc_component_t mca_coll_libnbc_component = {
         /* First, the mca_component_t struct containing meta information
          * about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "libnbc",

--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -22,11 +22,11 @@
 
 static inline int allgather_sched_linear(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sendbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *recvbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *recvbuf, size_t rcount,
     struct ompi_datatype_t *rdtype);
 static inline int allgather_sched_recursivedoubling(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
     struct ompi_datatype_t *rdtype);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -49,7 +49,7 @@ int NBC_Allgather_args_compare(NBC_Allgather_args *a, NBC_Allgather_args *b, voi
 }
 #endif
 
-static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                               MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                               mca_coll_base_module_t *module, bool persistent)
 {
@@ -190,7 +190,7 @@ static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype s
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module)
 {
@@ -210,7 +210,7 @@ int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype
     return OMPI_SUCCESS;
 }
 
-static int nbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module, bool persistent)
 {
@@ -267,7 +267,7 @@ static int nbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Data
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				      mca_coll_base_module_t *module) {
     int res = nbc_allgather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -296,7 +296,7 @@ int ompi_coll_libnbc_iallgather_inter(const void* sendbuf, int sendcount, MPI_Da
  */
 static inline int allgather_sched_linear(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sendbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *recvbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *recvbuf, size_t rcount,
     struct ompi_datatype_t *rdtype)
 {
     int res = OMPI_SUCCESS;
@@ -354,7 +354,7 @@ cleanup_and_return:
  */
 static inline int allgather_sched_recursivedoubling(
     int rank, int comm_size, NBC_Schedule *schedule, const void *sbuf,
-    int scount, struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+    size_t scount, struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
     struct ompi_datatype_t *rdtype)
 {
     int res = OMPI_SUCCESS;
@@ -389,7 +389,7 @@ cleanup_and_return:
     return res;
 }
 
-int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_allgather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -401,7 +401,7 @@ int ompi_coll_libnbc_allgather_init(const void* sendbuf, int sendcount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_allgather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module) {
     int res = nbc_allgather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,

--- a/ompi/mca/coll/libnbc/nbc_ialltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoall.c
@@ -22,15 +22,15 @@
 #include "nbc_internal.h"
 
 static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule *schedule,
-                                   const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                   int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+                                   const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                   size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm);
 static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule *schedule,
-                                     const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                     int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+                                     const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                     size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm);
 static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                 const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                 int recvcount, MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf);
-static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, int count,
+                                 const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                 size_t recvcount, MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf);
+static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, size_t count,
                                    MPI_Datatype type, MPI_Aint ext, ptrdiff_t gap, MPI_Comm comm);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -54,7 +54,7 @@ int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *
 #endif
 
 /* simple linear MPI_Ialltoall the (simple) algorithm just sends to all nodes */
-static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_alltoall_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                              MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module, bool persistent)
 {
@@ -289,7 +289,7 @@ static int nbc_alltoall_init(const void* sendbuf, int sendcount, MPI_Datatype se
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -308,7 +308,7 @@ int ompi_coll_libnbc_ialltoall(const void* sendbuf, int sendcount, MPI_Datatype 
     return OMPI_SUCCESS;
 }
 
-static int nbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+static int nbc_alltoall_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                     mca_coll_base_module_t *module, bool persistent)
 {
@@ -373,7 +373,7 @@ static int nbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Data
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
 				      mca_coll_base_module_t *module) {
     int res = nbc_alltoall_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -393,7 +393,7 @@ int ompi_coll_libnbc_ialltoall_inter (const void* sendbuf, int sendcount, MPI_Da
 }
 
 static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                     const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                     const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                      MPI_Datatype recvtype, MPI_Comm comm) {
   int res;
 
@@ -422,7 +422,7 @@ static inline int a2a_sched_pairwise(int rank, int p, MPI_Aint sndext, MPI_Aint 
 }
 
 static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                   const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                   const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                    MPI_Datatype recvtype, MPI_Comm comm) {
   int res;
 
@@ -449,7 +449,7 @@ static inline int a2a_sched_linear(int rank, int p, MPI_Aint sndext, MPI_Aint rc
 }
 
 static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcvext, NBC_Schedule* schedule,
-                                 const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+                                 const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                  MPI_Datatype recvtype, MPI_Comm comm, void* tmpbuf) {
   int res, speer, rpeer, virtp;
   MPI_Aint datasize, offset;
@@ -542,7 +542,7 @@ static inline int a2a_sched_diss(int rank, int p, MPI_Aint sndext, MPI_Aint rcve
   return OMPI_SUCCESS;
 }
 
-static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, int count,
+static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, void* buf, size_t count,
                                    MPI_Datatype type, MPI_Aint ext, ptrdiff_t gap, MPI_Comm comm) {
   int res;
 
@@ -599,7 +599,7 @@ static inline int a2a_sched_inplace(int rank, int p, NBC_Schedule* schedule, voi
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoall_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                     MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                     mca_coll_base_module_t *module) {
     int res = nbc_alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
@@ -611,7 +611,7 @@ int ompi_coll_libnbc_alltoall_init (const void* sendbuf, int sendcount, MPI_Data
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_alltoall_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+int ompi_coll_libnbc_alltoall_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf, size_t recvcount,
                                           MPI_Datatype recvtype, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                           mca_coll_base_module_t *module) {
     int res = nbc_alltoall_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -20,14 +20,14 @@
  */
 #include "nbc_internal.h"
 
-static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
+static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
                                        MPI_Datatype datatype);
-static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
+static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
                                      MPI_Datatype datatype);
-static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count,
-                                    MPI_Datatype datatype, int fragsize, size_t size);
+static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count,
+                                    MPI_Datatype datatype, size_t fragsize, size_t size);
 static inline int bcast_sched_knomial(int rank, int comm_size, int root, NBC_Schedule *schedule, void *buf,
-                                      int count, MPI_Datatype datatype, int knomial_radix);
+                                      size_t count, MPI_Datatype datatype, int knomial_radix);
 
 #ifdef NBC_CACHE_SCHEDULE
 /* tree comparison function for schedule cache */
@@ -47,7 +47,7 @@ int NBC_Bcast_args_compare(NBC_Bcast_args *a, NBC_Bcast_args *b, void *param) {
 }
 #endif
 
-static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+static int nbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                           struct ompi_communicator_t *comm, ompi_request_t ** request,
                           mca_coll_base_module_t *module, bool persistent)
 {
@@ -191,7 +191,7 @@ static int nbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int ro
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast(void *buffer, size_t count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
                             mca_coll_base_module_t *module)
 {
@@ -235,7 +235,7 @@ int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int 
   if (vrank == 0) rank = root; \
   if (vrank == root) rank = 0; \
 }
-static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype) {
+static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype) {
   int maxr, vrank, peer, res;
 
   maxr = ceil_of_log2(p);
@@ -275,7 +275,7 @@ static inline int bcast_sched_binomial(int rank, int p, int root, NBC_Schedule *
 }
 
 /* simple linear MPI_Ibcast */
-static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype) {
+static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype) {
   int res;
 
   /* send to all others */
@@ -301,7 +301,7 @@ static inline int bcast_sched_linear(int rank, int p, int root, NBC_Schedule *sc
 }
 
 /* simple chained MPI_Ibcast */
-static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, int count, MPI_Datatype datatype, int fragsize, size_t size) {
+static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *schedule, void *buffer, size_t count, MPI_Datatype datatype, size_t fragsize, size_t size) {
   int res, vrank, rpeer, speer, numfrag, fragcount, thiscount;
   MPI_Aint ext;
   char *buf;
@@ -372,7 +372,7 @@ static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *sch
  */
 static inline int bcast_sched_knomial(
     int rank, int comm_size, int root, NBC_Schedule *schedule, void *buf,
-    int count, MPI_Datatype datatype, int knomial_radix)
+    size_t count, MPI_Datatype datatype, int knomial_radix)
 {
     int res = OMPI_SUCCESS;
 
@@ -408,7 +408,7 @@ cleanup_and_return:
     return res;
 }
 
-static int nbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+static int nbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
                                 mca_coll_base_module_t *module, bool persistent) {
   int res;
@@ -460,7 +460,7 @@ static int nbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, 
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_ibcast_inter(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                   struct ompi_communicator_t *comm, ompi_request_t ** request,
                                   mca_coll_base_module_t *module) {
     int res = nbc_bcast_inter_init(buffer, count, datatype, root,
@@ -479,7 +479,7 @@ int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                 struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                 mca_coll_base_module_t *module) {
     int res = nbc_bcast_init(buffer, count, datatype, root,
@@ -491,7 +491,7 @@ int ompi_coll_libnbc_bcast_init(void *buffer, int count, MPI_Datatype datatype, 
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_bcast_inter_init(void *buffer, int count, MPI_Datatype datatype, int root,
+int ompi_coll_libnbc_bcast_inter_init(void *buffer, size_t count, MPI_Datatype datatype, int root,
                                       struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                       mca_coll_base_module_t *module) {
     int res = nbc_bcast_inter_init(buffer, count, datatype, root,

--- a/ompi/mca/coll/libnbc/nbc_iexscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iexscan.c
@@ -24,12 +24,12 @@
 #include "nbc_internal.h"
 
 static inline int exscan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf);
 static inline int exscan_sched_recursivedoubling(
     int rank, int comm_size, const void *sendbuf, void *recvbuf,
-    int count, MPI_Datatype datatype,  MPI_Op op, char inplace,
+    size_t count, MPI_Datatype datatype,  MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -51,7 +51,7 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
 }
 #endif
 
-static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+static int nbc_exscan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module, bool persistent) {
     int rank, p, res;
@@ -165,7 +165,7 @@ static int nbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Da
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module) {
     int res = nbc_exscan_init(sendbuf, recvbuf, count, datatype, op,
@@ -184,7 +184,7 @@ int ompi_coll_libnbc_iexscan(const void* sendbuf, void* recvbuf, int count, MPI_
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                  struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module) {
     int res = nbc_exscan_init(sendbuf, recvbuf, count, datatype, op,
@@ -211,7 +211,7 @@ int ompi_coll_libnbc_exscan_init(const void* sendbuf, void* recvbuf, int count, 
  * Schedule length: O(1)
  */
 static inline int exscan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf)
 {
@@ -293,7 +293,7 @@ cleanup_and_return:
  * Schedule length: O(log(p))
  */
 static inline int exscan_sched_recursivedoubling(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype, MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2)
 {

--- a/ompi/mca/coll/libnbc/nbc_igather.c
+++ b/ompi/mca/coll/libnbc/nbc_igather.c
@@ -44,8 +44,8 @@ int NBC_Gather_args_compare(NBC_Gather_args *a, NBC_Gather_args *b, void *param)
 }
 #endif
 
-static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                           int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                           size_t recvcount, MPI_Datatype recvtype, int root,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -173,8 +173,8 @@ static int nbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype send
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                             int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_igather(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                             size_t recvcount, MPI_Datatype recvtype, int root,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module) {
     int res = nbc_gather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -193,8 +193,8 @@ int ompi_coll_libnbc_igather(const void* sendbuf, int sendcount, MPI_Datatype se
     return OMPI_SUCCESS;
 }
 
-static int nbc_gather_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                  int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_gather_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                  size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, ompi_request_t ** request,
                                   mca_coll_base_module_t *module, bool persistent) {
     int res, rsize;
@@ -253,8 +253,8 @@ static int nbc_gather_inter_init (const void* sendbuf, int sendcount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                   int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_igather_inter(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                   size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module) {
     int res = nbc_gather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -273,8 +273,8 @@ int ompi_coll_libnbc_igather_inter(const void* sendbuf, int sendcount, MPI_Datat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                 int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_gather_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                 size_t recvcount, MPI_Datatype recvtype, int root,
                                  struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                  mca_coll_base_module_t *module) {
     int res = nbc_gather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -286,8 +286,8 @@ int ompi_coll_libnbc_gather_init(const void* sendbuf, int sendcount, MPI_Datatyp
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-                                       int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_gather_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype, void* recvbuf,
+                                       size_t recvcount, MPI_Datatype recvtype, int root,
                                        struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                        mca_coll_base_module_t *module) {
     int res = nbc_gather_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
@@ -44,8 +44,8 @@ int NBC_Ineighbor_allgather_args_compare(NBC_Ineighbor_allgather_args *a, NBC_In
 #endif
 
 
-static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                       int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+static int nbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                       size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -163,8 +163,8 @@ static int nbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatyp
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                         size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                          ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgather_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                           comm, request, module, false);
@@ -182,8 +182,8 @@ int ompi_coll_libnbc_ineighbor_allgather(const void *sbuf, int scount, MPI_Datat
 }
 
 
-int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                             int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_neighbor_allgather_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                             size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                              MPI_Info info, ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_allgather_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                           comm, request, module, true);

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
@@ -41,8 +41,8 @@ int NBC_Ineighbor_alltoall_args_compare(NBC_Ineighbor_alltoall_args *a, NBC_Inei
 }
 #endif
 
-static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                      int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+static int nbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                      size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                       ompi_request_t ** request,
                                       mca_coll_base_module_t *module, bool persistent) {
   int res, indegree, outdegree, *srcs, *dsts;
@@ -167,8 +167,8 @@ static int nbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                        int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
+int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                        size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
                                         ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoall_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                          comm, request, module, false);
@@ -185,8 +185,8 @@ int ompi_coll_libnbc_ineighbor_alltoall(const void *sbuf, int scount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
-                                            int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
+int ompi_coll_libnbc_neighbor_alltoall_init(const void *sbuf, size_t scount, MPI_Datatype stype, void *rbuf,
+                                            size_t rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm, MPI_Info info,
                                             ompi_request_t ** request, mca_coll_base_module_t *module) {
     int res = nbc_neighbor_alltoall_init(sbuf, scount, stype, rbuf, rcount, rtype,
                                          comm, request, module, true);

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -179,10 +179,10 @@ struct NBC_dummyarg {
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
 } NBC_Alltoall_args;
 int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *param);
@@ -190,10 +190,10 @@ int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
 } NBC_Allgather_args;
 int NBC_Allgather_args_compare(NBC_Allgather_args *a, NBC_Allgather_args *b, void *param);
@@ -202,7 +202,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
 } NBC_Allreduce_args;
@@ -211,7 +211,7 @@ int NBC_Allreduce_args_compare(NBC_Allreduce_args *a, NBC_Allreduce_args *b, voi
 typedef struct {
   NBC_Schedule *schedule;
   void *buffer;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   int root;
 } NBC_Bcast_args;
@@ -220,10 +220,10 @@ int NBC_Bcast_args_compare(NBC_Bcast_args *a, NBC_Bcast_args *b, void *param);
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
   int root;
 } NBC_Gather_args;
@@ -233,7 +233,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
   int root;
@@ -244,7 +244,7 @@ typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
   void* recvbuf;
-  int count;
+  size_t count;
   MPI_Datatype datatype;
   MPI_Op op;
 } NBC_Scan_args;
@@ -253,10 +253,10 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param);
 typedef struct {
   NBC_Schedule *schedule;
   void *sendbuf;
-  int sendcount;
+  size_t sendcount;
   MPI_Datatype sendtype;
   void* recvbuf;
-  int recvcount;
+  size_t recvcount;
   MPI_Datatype recvtype;
   int root;
 } NBC_Scatter_args;
@@ -506,7 +506,7 @@ static inline int NBC_Type_intrinsic(MPI_Datatype type) {
 }
 
 /* let's give a try to inline functions */
-static inline int NBC_Copy(const void *src, int srccount, MPI_Datatype srctype, void *tgt, int tgtcount, MPI_Datatype tgttype, MPI_Comm comm) {
+static inline int NBC_Copy(const void *src, size_t srccount, MPI_Datatype srctype, void *tgt, size_t tgtcount, MPI_Datatype tgttype, MPI_Comm comm) {
   int res;
 
   res = ompi_datatype_sndrcv(src, srccount, srctype, tgt, tgtcount, tgttype);
@@ -518,7 +518,7 @@ static inline int NBC_Copy(const void *src, int srccount, MPI_Datatype srctype, 
   return OMPI_SUCCESS;
 }
 
-static inline int NBC_Unpack(void *src, int srccount, MPI_Datatype srctype, void *tgt, MPI_Comm comm) {
+static inline int NBC_Unpack(void *src, size_t srccount, MPI_Datatype srctype, void *tgt, MPI_Comm comm) {
   MPI_Aint size, pos;
   int res;
   ptrdiff_t ext, lb;

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter_block.c
@@ -209,7 +209,7 @@ static int nbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                            MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                            mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -227,7 +227,7 @@ int ompi_coll_libnbc_ireduce_scatter_block(const void* sendbuf, void* recvbuf, i
     return OMPI_SUCCESS;
 }
 
-static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbuf, int rcount, struct ompi_datatype_t *dtype,
+static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbuf, size_t rcount, struct ompi_datatype_t *dtype,
                                                struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t **request,
                                                mca_coll_base_module_t *module, bool persistent) {
   int rank, res, lsize, rsize;
@@ -349,7 +349,7 @@ static int nbc_reduce_scatter_block_inter_init(const void *sendbuf, void *recvbu
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                  MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
                                                  mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_inter_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -367,7 +367,7 @@ int ompi_coll_libnbc_ireduce_scatter_block_inter(const void* sendbuf, void* recv
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_init(sendbuf, recvbuf, recvcount, datatype, op,
@@ -379,7 +379,7 @@ int ompi_coll_libnbc_reduce_scatter_block_init(const void* sendbuf, void* recvbu
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype,
+int ompi_coll_libnbc_reduce_scatter_block_inter_init(const void* sendbuf, void* recvbuf, size_t recvcount, MPI_Datatype datatype,
                                                      MPI_Op op, struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                                      mca_coll_base_module_t *module) {
     int res = nbc_reduce_scatter_block_inter_init(sendbuf, recvbuf, recvcount, datatype, op,

--- a/ompi/mca/coll/libnbc/nbc_iscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iscan.c
@@ -24,12 +24,12 @@
 #include "nbc_internal.h"
 
 static inline int scan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf);
 static inline int scan_sched_recursivedoubling(
     int rank, int comm_size, const void *sendbuf, void *recvbuf,
-    int count, MPI_Datatype datatype,  MPI_Op op, char inplace,
+    size_t count, MPI_Datatype datatype,  MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2);
 
 #ifdef NBC_CACHE_SCHEDULE
@@ -51,7 +51,7 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
 }
 #endif
 
-static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+static int nbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                          struct ompi_communicator_t *comm, ompi_request_t ** request,
                          mca_coll_base_module_t *module, bool persistent) {
     int rank, p, res;
@@ -181,7 +181,7 @@ static int nbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Data
  * Schedule length: O(1)
  */
 static inline int scan_sched_linear(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype,  MPI_Op op, char inplace, NBC_Schedule *schedule,
     void *tmpbuf)
 {
@@ -251,7 +251,7 @@ cleanup_and_return:
  * Schedule length: O(log(p))
  */
 static inline int scan_sched_recursivedoubling(
-    int rank, int comm_size, const void *sendbuf, void *recvbuf, int count,
+    int rank, int comm_size, const void *sendbuf, void *recvbuf, size_t count,
     MPI_Datatype datatype, MPI_Op op, char inplace,
     NBC_Schedule *schedule, void *tmpbuf1, void *tmpbuf2)
 {
@@ -312,7 +312,7 @@ static inline int scan_sched_recursivedoubling(
     return res;
 }
 
-int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
                            mca_coll_base_module_t *module) {
     int res = nbc_scan_init(sendbuf, recvbuf, count, datatype, op,
@@ -330,7 +330,7 @@ int ompi_coll_libnbc_iscan(const void* sendbuf, void* recvbuf, int count, MPI_Da
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
+int ompi_coll_libnbc_scan_init(const void* sendbuf, void* recvbuf, size_t count, MPI_Datatype datatype, MPI_Op op,
                                struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_scan_init(sendbuf, recvbuf, count, datatype, op,

--- a/ompi/mca/coll/libnbc/nbc_iscatter.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatter.c
@@ -45,8 +45,8 @@ int NBC_Scatter_args_compare(NBC_Scatter_args *a, NBC_Scatter_args *b, void *par
 #endif
 
 /* simple linear MPI_Iscatter */
-static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                             void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
                              mca_coll_base_module_t *module, bool persistent) {
   int rank, p, res;
@@ -168,8 +168,8 @@ static int nbc_scatter_init (const void* sendbuf, int sendcount, MPI_Datatype se
   return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatter (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                               void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
                                mca_coll_base_module_t *module) {
     int res = nbc_scatter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -187,8 +187,8 @@ int ompi_coll_libnbc_iscatter (const void* sendbuf, int sendcount, MPI_Datatype 
     return OMPI_SUCCESS;
 }
 
-static int nbc_scatter_inter_init (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+static int nbc_scatter_inter_init (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                   void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                    struct ompi_communicator_t *comm, ompi_request_t ** request,
                                    mca_coll_base_module_t *module, bool persistent) {
     int res, rsize;
@@ -247,8 +247,8 @@ static int nbc_scatter_inter_init (const void* sendbuf, int sendcount, MPI_Datat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                     void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                      struct ompi_communicator_t *comm, ompi_request_t ** request,
                                      mca_coll_base_module_t *module) {
     int res = nbc_scatter_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -266,8 +266,8 @@ int ompi_coll_libnbc_iscatter_inter (const void* sendbuf, int sendcount, MPI_Dat
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                  void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                   struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                   mca_coll_base_module_t *module) {
     int res = nbc_scatter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
@@ -279,8 +279,8 @@ int ompi_coll_libnbc_scatter_init(const void* sendbuf, int sendcount, MPI_Dataty
     return OMPI_SUCCESS;
 }
 
-int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+int ompi_coll_libnbc_scatter_inter_init(const void* sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                                        void* recvbuf, size_t recvcount, MPI_Datatype recvtype, int root,
                                         struct ompi_communicator_t *comm, MPI_Info info, ompi_request_t ** request,
                                         mca_coll_base_module_t *module) {
     int res = nbc_scatter_inter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,

--- a/ompi/mca/coll/monitoring/coll_monitoring.h
+++ b/ompi/mca/coll/monitoring/coll_monitoring.h
@@ -46,9 +46,9 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_monitoring_module_t);
  */
 
 /* Blocking */
-extern int mca_coll_monitoring_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_allgather(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
@@ -61,15 +61,15 @@ extern int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,
                                          mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_alltoall(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype,
                                         struct ompi_communicator_t *comm,
                                         mca_coll_base_module_t *module);
@@ -95,21 +95,21 @@ extern int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,
 extern int mca_coll_monitoring_barrier(struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_bcast(void *buff, int count,
+extern int mca_coll_monitoring_bcast(void *buff, size_t count,
                                      struct ompi_datatype_t *datatype,
                                      int root,
                                      struct ompi_communicator_t *comm,
                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_gather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_gather(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                      void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                       int root, struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
@@ -121,7 +121,7 @@ extern int mca_coll_monitoring_gatherv(const void *sbuf, int scount,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, size_t count,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       int root,
@@ -136,21 +136,21 @@ extern int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,
                                               mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
-                                                    int rcount,
+                                                    size_t rcount,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     struct ompi_communicator_t *comm,
                                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, size_t count,
                                     struct ompi_datatype_t *dtype,
                                     struct ompi_op_t *op,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_scatter(const void *sbuf, int scount,
+extern int mca_coll_monitoring_scatter(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype,
                                        int root,
                                        struct ompi_communicator_t *comm,
@@ -165,9 +165,9 @@ extern int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, co
                                         mca_coll_base_module_t *module);
 
 /* Nonblocking */
-extern int mca_coll_monitoring_iallgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_iallgather(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void *rbuf, int rcount,
+                                          void *rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
@@ -182,16 +182,16 @@ extern int mca_coll_monitoring_iallgatherv(const void *sbuf, int scount,
                                            ompi_request_t ** request,
                                            mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
                                           ompi_request_t ** request,
                                           mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ialltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ialltoall(const void *sbuf, size_t scount,
                                          struct ompi_datatype_t *sdtype,
-                                         void *rbuf, int rcount,
+                                         void *rbuf, size_t rcount,
                                          struct ompi_datatype_t *rdtype,
                                          struct ompi_communicator_t *comm,
                                          ompi_request_t ** request,
@@ -221,23 +221,23 @@ extern int mca_coll_monitoring_ibarrier(struct ompi_communicator_t *comm,
                                         ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ibcast(void *buff, int count,
+extern int mca_coll_monitoring_ibcast(void *buff, size_t count,
                                       struct ompi_datatype_t *datatype,
                                       int root,
                                       struct ompi_communicator_t *comm,
                                       ompi_request_t ** request,
                                       mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_igather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_igather(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                       void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                        int root, struct ompi_communicator_t *comm,
                                        ompi_request_t ** request,
                                        mca_coll_base_module_t *module);
@@ -251,7 +251,7 @@ extern int mca_coll_monitoring_igatherv(const void *sbuf, int scount,
                                         ompi_request_t ** request,
                                         mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, size_t count,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        int root,
@@ -268,23 +268,23 @@ extern int mca_coll_monitoring_ireduce_scatter(const void *sbuf, void *rbuf,
                                                mca_coll_base_module_t *module);
 
 extern int mca_coll_monitoring_ireduce_scatter_block(const void *sbuf, void *rbuf,
-                                                     int rcount,
+                                                     size_t rcount,
                                                      struct ompi_datatype_t *dtype,
                                                      struct ompi_op_t *op,
                                                      struct ompi_communicator_t *comm,
                                                      ompi_request_t ** request,
                                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, int count,
+extern int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, size_t count,
                                      struct ompi_datatype_t *dtype,
                                      struct ompi_op_t *op,
                                      struct ompi_communicator_t *comm,
                                      ompi_request_t ** request,
                                      mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_iscatter(const void *sbuf, int scount,
+extern int mca_coll_monitoring_iscatter(const void *sbuf, size_t scount,
                                         struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype,
                                         int root,
                                         struct ompi_communicator_t *comm,
@@ -301,9 +301,9 @@ extern int mca_coll_monitoring_iscatterv(const void *sbuf, const int *scounts, c
                                          mca_coll_base_module_t *module);
 
 /* Neighbor */
-extern int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_neighbor_allgather(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                                  int rcount, struct ompi_datatype_t *rdtype,
+                                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
@@ -314,9 +314,9 @@ extern int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,
                                                    struct ompi_communicator_t *comm,
                                                    mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, size_t scount,
                                                  struct ompi_datatype_t *sdtype,
-                                                 void *rbuf, int rcount,
+                                                 void *rbuf, size_t rcount,
                                                  struct ompi_datatype_t *rdtype,
                                                  struct ompi_communicator_t *comm,
                                                  mca_coll_base_module_t *module);
@@ -339,9 +339,9 @@ extern int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *s
                                                   struct ompi_communicator_t *comm,
                                                   mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, size_t scount,
                                                    struct ompi_datatype_t *sdtype, void *rbuf,
-                                                   int rcount, struct ompi_datatype_t *rdtype,
+                                                   size_t rcount, struct ompi_datatype_t *rdtype,
                                                    struct ompi_communicator_t *comm,
                                                    ompi_request_t ** request,
                                                    mca_coll_base_module_t *module);
@@ -355,9 +355,9 @@ extern int mca_coll_monitoring_ineighbor_allgatherv(const void *sbuf, int scount
                                                     ompi_request_t ** request,
                                                     mca_coll_base_module_t *module);
 
-extern int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
+extern int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, size_t scount,
                                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                                  int rcount, struct ompi_datatype_t *rdtype,
+                                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                                   struct ompi_communicator_t *comm,
                                                   ompi_request_t ** request,
                                                   mca_coll_base_module_t *module);

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_allgather(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
@@ -43,9 +43,9 @@ int mca_coll_monitoring_allgather(const void *sbuf, int scount,
     return monitoring_module->real.coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_allgather_module);
 }
 
-int mca_coll_monitoring_iallgather(const void *sbuf, int scount,
+int mca_coll_monitoring_iallgather(const void *sbuf, size_t scount,
                                    struct ompi_datatype_t *sdtype,
-                                   void *rbuf, int rcount,
+                                   void *rbuf, size_t rcount,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -43,7 +43,7 @@ int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_allreduce(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_allreduce_module);
 }
 
-int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iallreduce(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
@@ -15,8 +15,8 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_monitoring_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                 void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)
 {
@@ -41,9 +41,9 @@ int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datat
     return monitoring_module->real.coll_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_alltoall_module);
 }
 
-int mca_coll_monitoring_ialltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_ialltoall(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
@@ -15,7 +15,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_bcast(void *buff, int count,
+int mca_coll_monitoring_bcast(void *buff, size_t count,
                               struct ompi_datatype_t *datatype,
                               int root,
                               struct ompi_communicator_t *comm,
@@ -43,7 +43,7 @@ int mca_coll_monitoring_bcast(void *buff, int count,
     return monitoring_module->real.coll_bcast(buff, count, datatype, root, comm, monitoring_module->real.coll_bcast_module);
 }
 
-int mca_coll_monitoring_ibcast(void *buff, int count,
+int mca_coll_monitoring_ibcast(void *buff, size_t count,
                                struct ompi_datatype_t *datatype,
                                int root,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_component.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_component.c
@@ -213,7 +213,7 @@ mca_coll_monitoring_component_t mca_coll_monitoring_component = {
         /* First, the mca_base_component_t struct containing meta
            information about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             .mca_component_name = "monitoring", /* MCA component name */
             MCA_MONITORING_MAKE_VERSION,

--- a/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
@@ -42,7 +42,7 @@ int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_exscan(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_exscan_module);
 }
 
-int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iexscan(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_gather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gather.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_gather(const void *sbuf, int scount,
+int mca_coll_monitoring_gather(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                               void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)
 {
@@ -43,9 +43,9 @@ int mca_coll_monitoring_gather(const void *sbuf, int scount,
     return monitoring_module->real.coll_gather(sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm, monitoring_module->real.coll_gather_module);
 }
 
-int mca_coll_monitoring_igather(const void *sbuf, int scount,
+int mca_coll_monitoring_igather(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+                                void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                 int root, struct ompi_communicator_t *comm,
                                 ompi_request_t ** request,
                                 mca_coll_base_module_t *module)

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_neighbor_allgather(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype, void *rbuf,
-                                           int rcount, struct ompi_datatype_t *rdtype,
+                                           size_t rcount, struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module)
 {
@@ -68,9 +68,9 @@ int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,
     return monitoring_module->real.coll_neighbor_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_neighbor_allgather_module);
 }
 
-int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, int scount,
+int mca_coll_monitoring_ineighbor_allgather(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype, void *rbuf,
-                                            int rcount, struct ompi_datatype_t *rdtype,
+                                            size_t rcount, struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             ompi_request_t ** request,
                                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
@@ -16,9 +16,9 @@
 #include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, size_t scount,
                                           struct ompi_datatype_t *sdtype,
-                                          void* rbuf, int rcount,
+                                          void* rbuf, size_t rcount,
                                           struct ompi_datatype_t *rdtype,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
@@ -69,9 +69,9 @@ int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,
     return monitoring_module->real.coll_neighbor_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, monitoring_module->real.coll_neighbor_alltoall_module);
 }
 
-int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, int scount,
+int mca_coll_monitoring_ineighbor_alltoall(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void *rbuf, int rcount,
+                                           void *rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            ompi_request_t ** request,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root,
@@ -45,7 +45,7 @@ int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_reduce(sbuf, rbuf, count, dtype, op, root, comm, monitoring_module->real.coll_reduce_module);
 }
 
-int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_ireduce(const void *sbuf, void *rbuf, size_t count,
                                 struct ompi_datatype_t *dtype,
                                 struct ompi_op_t *op,
                                 int root,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
@@ -17,7 +17,7 @@
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
-                                             int rcount,
+                                             size_t rcount,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -45,7 +45,7 @@ int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,
 }
 
 int mca_coll_monitoring_ireduce_scatter_block(const void *sbuf, void *rbuf,
-                                              int rcount,
+                                              size_t rcount,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op,
                                               struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scan.c
@@ -16,7 +16,7 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,
@@ -42,7 +42,7 @@ int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,
     return monitoring_module->real.coll_scan(sbuf, rbuf, count, dtype, op, comm, monitoring_module->real.coll_scan_module);
 }
 
-int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_monitoring_iscan(const void *sbuf, void *rbuf, size_t count,
                               struct ompi_datatype_t *dtype,
                               struct ompi_op_t *op,
                               struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
@@ -15,9 +15,9 @@
 #include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
-int mca_coll_monitoring_scatter(const void *sbuf, int scount,
+int mca_coll_monitoring_scatter(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,
@@ -47,9 +47,9 @@ int mca_coll_monitoring_scatter(const void *sbuf, int scount,
 }
 
 
-int mca_coll_monitoring_iscatter(const void *sbuf, int scount,
+int mca_coll_monitoring_iscatter(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  int root,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self.h
+++ b/ompi/mca/coll/self/coll_self.h
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-OMPI_DECLSPEC extern const mca_coll_base_component_2_4_0_t mca_coll_self_component;
+OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_self_component;
 extern int ompi_coll_self_priority;
 
 /*
@@ -51,9 +51,9 @@ int mca_coll_self_init_query(bool enable_progress_threads,
 mca_coll_base_module_t *
 mca_coll_self_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int mca_coll_self_allgather_intra(const void *sbuf, int scount,
+int mca_coll_self_allgather_intra(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype,
-                                  void *rbuf, int rcount,
+                                  void *rbuf, size_t rcount,
                                   struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
@@ -63,14 +63,14 @@ int mca_coll_self_allgatherv_intra(const void *sbuf, int scount,
                                    struct ompi_datatype_t *rdtype,
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
-int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module);
-int mca_coll_self_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_self_alltoall_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void* rbuf, int rcount,
+                                 void* rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
@@ -88,19 +88,19 @@ int mca_coll_self_alltoallw_intra(const void *sbuf, const int *scounts, const in
                                   mca_coll_base_module_t *module);
 int mca_coll_self_barrier_intra(struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_self_bcast_intra(void *buff, int count,
+int mca_coll_self_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype,
                               int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module);
-int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
-int mca_coll_self_gather_intra(const void *sbuf, int scount,
+int mca_coll_self_gather_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype, void *rbuf,
-                               int rcount, struct ompi_datatype_t *rdtype,
+                               size_t rcount, struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module);
 int mca_coll_self_gatherv_intra(const void *sbuf, int scount,
@@ -109,7 +109,7 @@ int mca_coll_self_gatherv_intra(const void *sbuf, int scount,
                                 struct ompi_datatype_t *rdtype, int root,
                                 struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
-int mca_coll_self_reduce_intra(const void *sbuf, void* rbuf, int count,
+int mca_coll_self_reduce_intra(const void *sbuf, void* rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root,
@@ -121,14 +121,14 @@ int mca_coll_self_reduce_scatter_intra(const void *sbuf, void *rbuf,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
                                        mca_coll_base_module_t *module);
-int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,
                              mca_coll_base_module_t *module);
-int mca_coll_self_scatter_intra(const void *sbuf, int scount,
+int mca_coll_self_scatter_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype, void *rbuf,
-                                int rcount, struct ompi_datatype_t *rdtype,
+                                size_t rcount, struct ompi_datatype_t *rdtype,
                                 int root, struct ompi_communicator_t *comm,
                                 mca_coll_base_module_t *module);
 int mca_coll_self_scatterv_intra(const void *sbuf, const int *scounts, const int *disps,

--- a/ompi/mca/coll/self/coll_self_allgather.c
+++ b/ompi/mca/coll/self/coll_self_allgather.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same as MPI_Allgather()
  *	Returns:	- MPI_SUCCESS, or error code
  */
-int mca_coll_self_allgather_intra(const void *sbuf, int scount,
+int mca_coll_self_allgather_intra(const void *sbuf, size_t scount,
                                   struct ompi_datatype_t *sdtype, void *rbuf,
-                                  int rcount, struct ompi_datatype_t *rdtype,
+                                  size_t rcount, struct ompi_datatype_t *rdtype,
                                   struct ompi_communicator_t *comm,
                                   mca_coll_base_module_t *module)
 {

--- a/ompi/mca/coll/self/coll_self_allreduce.c
+++ b/ompi/mca/coll/self/coll_self_allreduce.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same as MPI_Allreduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                                   struct ompi_datatype_t *dtype,
                                   struct ompi_op_t *op,
                                   struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_alltoall.c
+++ b/ompi/mca/coll/self/coll_self_alltoall.c
@@ -33,9 +33,9 @@
  *	Accepts:	- same as MPI_Alltoall()
  *	Returns:	- MPI_SUCCESS or an MPI error code
  */
-int mca_coll_self_alltoall_intra(const void *sbuf, int scount,
+int mca_coll_self_alltoall_intra(const void *sbuf, size_t scount,
                                  struct ompi_datatype_t *sdtype,
-                                 void *rbuf, int rcount,
+                                 void *rbuf, size_t rcount,
                                  struct ompi_datatype_t *rdtype,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_bcast.c
+++ b/ompi/mca/coll/self/coll_self_bcast.c
@@ -30,7 +30,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS
  */
-int mca_coll_self_bcast_intra(void *buff, int count,
+int mca_coll_self_bcast_intra(void *buff, size_t count,
                               struct ompi_datatype_t *datatype, int root,
                               struct ompi_communicator_t *comm,
                               mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_component.c
+++ b/ompi/mca/coll/self/coll_self_component.c
@@ -55,13 +55,13 @@ static int self_register(void);
  * and pointers to our public functions in it
  */
 
-const mca_coll_base_component_2_4_0_t mca_coll_self_component = {
+const mca_coll_base_component_3_0_0_t mca_coll_self_component = {
 
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
     .collm_version = {
-        MCA_COLL_BASE_VERSION_2_4_0,
+        MCA_COLL_BASE_VERSION_3_0_0,
 
         /* Component name and version */
         .mca_component_name = "self",

--- a/ompi/mca/coll/self/coll_self_exscan.c
+++ b/ompi/mca/coll/self/coll_self_exscan.c
@@ -31,7 +31,7 @@
  *	Accepts:	- same arguments as MPI_Exccan()
  *	Returns:	- MPI_SUCCESS
  */
-int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_exscan_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_gather.c
+++ b/ompi/mca/coll/self/coll_self_gather.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_gather_intra(const void *sbuf, int scount,
+int mca_coll_self_gather_intra(const void *sbuf, size_t scount,
                                struct ompi_datatype_t *sdtype,
-                               void *rbuf, int rcount,
+                               void *rbuf, size_t rcount,
                                struct ompi_datatype_t *rdtype,
                                int root, struct ompi_communicator_t *comm,
                                mca_coll_base_module_t *module)

--- a/ompi/mca/coll/self/coll_self_reduce.c
+++ b/ompi/mca/coll/self/coll_self_reduce.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_reduce_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_reduce_intra(const void *sbuf, void *rbuf, size_t count,
                                struct ompi_datatype_t *dtype,
                                struct ompi_op_t *op,
                                int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_scan.c
+++ b/ompi/mca/coll/self/coll_self_scan.c
@@ -32,7 +32,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, int count,
+int mca_coll_self_scan_intra(const void *sbuf, void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_op_t *op,
                              struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/self/coll_self_scatter.c
+++ b/ompi/mca/coll/self/coll_self_scatter.c
@@ -32,9 +32,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_self_scatter_intra(const void *sbuf, int scount,
+int mca_coll_self_scatter_intra(const void *sbuf, size_t scount,
                                 struct ompi_datatype_t *sdtype,
-                                void *rbuf, int rcount,
+                                void *rbuf, size_t rcount,
                                 struct ompi_datatype_t *rdtype,
                                 int root,
                                 struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -47,21 +47,21 @@ mca_coll_base_module_t
 int mca_coll_sync_barrier(struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_bcast(void *buff, int count,
+int mca_coll_sync_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype,
                         int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_sync_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_sync_gather(const void *sbuf, int scount,
+int mca_coll_sync_gather(const void *sbuf, size_t scount,
                          struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount,
+                         void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype,
                          int root,
                          struct ompi_communicator_t *comm,
@@ -75,7 +75,7 @@ int mca_coll_sync_gatherv(const void *sbuf, int scount,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root,
@@ -89,15 +89,15 @@ int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
                                  struct ompi_communicator_t *comm,
                                  mca_coll_base_module_t *module);
 
-int mca_coll_sync_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
-int mca_coll_sync_scatter(const void *sbuf, int scount,
+int mca_coll_sync_scatter(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -135,7 +135,7 @@ OBJ_CLASS_DECLARATION(mca_coll_sync_module_t);
 /* Component */
 
 typedef struct mca_coll_sync_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
 
     /* Priority of this component */
     int priority;

--- a/ompi/mca/coll/sync/coll_sync_bcast.c
+++ b/ompi/mca/coll/sync/coll_sync_bcast.c
@@ -30,7 +30,7 @@
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_bcast(void *buff, int count,
+int mca_coll_sync_bcast(void *buff, size_t count,
                         struct ompi_datatype_t *datatype, int root,
                         struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_component.c
+++ b/ompi/mca/coll/sync/coll_sync_component.c
@@ -49,7 +49,7 @@ mca_coll_sync_component_t mca_coll_sync_component = {
          * about the component itself */
 
        .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "sync",

--- a/ompi/mca/coll/sync/coll_sync_exscan.c
+++ b/ompi/mca/coll/sync/coll_sync_exscan.c
@@ -29,7 +29,7 @@
  *	Accepts:	- same arguments as MPI_Exscan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_exscan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_exscan(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_gather.c
+++ b/ompi/mca/coll/sync/coll_sync_gather.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Gather()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_gather(const void *sbuf, int scount,
+int mca_coll_sync_gather(const void *sbuf, size_t scount,
                          struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount,
+                         void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_reduce.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce.c
@@ -28,7 +28,7 @@
  *	Accepts:	- same as MPI_Reduce()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_reduce(const void *sbuf, void *rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op,
                          int root, struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scan.c
+++ b/ompi/mca/coll/sync/coll_sync_scan.c
@@ -28,7 +28,7 @@
  *	Accepts:	- same arguments as MPI_Scan()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scan(const void *sbuf, void *rbuf, int count,
+int mca_coll_sync_scan(const void *sbuf, void *rbuf, size_t count,
                        struct ompi_datatype_t *dtype,
                        struct ompi_op_t *op,
                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_scatter.c
@@ -29,9 +29,9 @@
  *	Accepts:	- same arguments as MPI_Scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scatter(const void *sbuf, int scount,
+int mca_coll_sync_scatter(const void *sbuf, size_t scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int rcount,
+                          void *rbuf, size_t rcount,
                           struct ompi_datatype_t *rdtype,
                           int root, struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)

--- a/ompi/mca/coll/tuned/coll_tuned.h
+++ b/ompi/mca/coll/tuned/coll_tuned.h
@@ -184,7 +184,7 @@ int ompi_coll_tuned_scan_intra_check_forced_init (coll_tuned_force_algorithm_mca
 
 struct mca_coll_tuned_component_t {
 	/** Base coll component */
-	mca_coll_base_component_2_4_0_t super;
+	mca_coll_base_component_3_0_0_t super;
 
 	/** MCA parameter: Priority of this component */
 	int tuned_priority;

--- a/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allgather_decision.c
@@ -124,9 +124,9 @@ ompi_coll_tuned_allgather_intra_check_forced_init(coll_tuned_force_algorithm_mca
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_allgather_intra_do_this(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_do_this(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_allreduce_decision.c
@@ -122,7 +122,7 @@ int ompi_coll_tuned_allreduce_intra_check_forced_init (coll_tuned_force_algorith
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_allreduce_intra_do_this(const void *sbuf, void *rbuf, int count,
+int ompi_coll_tuned_allreduce_intra_do_this(const void *sbuf, void *rbuf, size_t count,
                                             struct ompi_datatype_t *dtype,
                                             struct ompi_op_t *op,
                                             struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_alltoall_decision.c
@@ -153,9 +153,9 @@ int ompi_coll_tuned_alltoall_intra_check_forced_init (coll_tuned_force_algorithm
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_alltoall_intra_do_this(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_do_this(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void* rbuf, int rcount,
+                                           void* rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            struct ompi_communicator_t *comm,
                                            mca_coll_base_module_t *module,

--- a/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_bcast_decision.c
@@ -132,7 +132,7 @@ int ompi_coll_tuned_bcast_intra_check_forced_init (coll_tuned_force_algorithm_mc
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_bcast_intra_do_this(void *buf, int count,
+int ompi_coll_tuned_bcast_intra_do_this(void *buf, size_t count,
                                         struct ompi_datatype_t *dtype,
                                         int root,
                                         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_component.c
+++ b/ompi/mca/coll/tuned/coll_tuned_component.c
@@ -95,7 +95,7 @@ mca_coll_tuned_component_t mca_coll_tuned_component = {
         /* First, the mca_component_t struct containing meta information
            about the component itself */
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "tuned",

--- a/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_dynamic.c
@@ -52,7 +52,7 @@
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int count,
+ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, size_t count,
                                              struct ompi_datatype_t *dtype,
                                              struct ompi_op_t *op,
                                              struct ompi_communicator_t *comm,
@@ -102,9 +102,9 @@ ompi_coll_tuned_allreduce_intra_dec_dynamic (const void *sbuf, void *rbuf, int c
  *    Returns:    - MPI_SUCCESS or error code (passed from the alltoall implementation)
  */
 
-int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_dec_dynamic(const void *sbuf, size_t scount,
                                                struct ompi_datatype_t *sdtype,
-                                               void* rbuf, int rcount,
+                                               void* rbuf, size_t rcount,
                                                struct ompi_datatype_t *rdtype,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)
@@ -250,7 +250,7 @@ int ompi_coll_tuned_barrier_intra_dec_dynamic(struct ompi_communicator_t *comm,
  *   Accepts:   - same arguments as MPI_Bcast()
  *   Returns:   - MPI_SUCCESS or error code (passed from the bcast implementation)
  */
-int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
+int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, size_t count,
                                             struct ompi_datatype_t *dtype, int root,
                                             struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)
@@ -302,7 +302,7 @@ int ompi_coll_tuned_bcast_intra_dec_dynamic(void *buf, int count,
  *
  */
 int ompi_coll_tuned_reduce_intra_dec_dynamic( const void *sbuf, void *rbuf,
-                                              int count, struct ompi_datatype_t* dtype,
+                                              size_t count, struct ompi_datatype_t* dtype,
                                               struct ompi_op_t* op, int root,
                                               struct ompi_communicator_t* comm,
                                               mca_coll_base_module_t *module)
@@ -412,7 +412,7 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_dynamic(const void *sbuf, void *rbu
  *
  */
 int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, void *rbuf,
-                                                           int rcount,
+                                                           size_t rcount,
                                                            struct ompi_datatype_t *dtype,
                                                            struct ompi_op_t *op,
                                                            struct ompi_communicator_t *comm,
@@ -465,9 +465,9 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_dynamic(const void *sbuf, voi
  *                        allgather function).
  */
 
-int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_dec_dynamic(const void *sbuf, size_t scount,
                                                 struct ompi_datatype_t *sdtype,
-                                                void* rbuf, int rcount,
+                                                void* rbuf, size_t rcount,
                                                 struct ompi_datatype_t *rdtype,
                                                 struct ompi_communicator_t *comm,
                                                 mca_coll_base_module_t *module)
@@ -583,9 +583,9 @@ int ompi_coll_tuned_allgatherv_intra_dec_dynamic(const void *sbuf, int scount,
                                                        comm, module);
 }
 
-int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              int root,
                                              struct ompi_communicator_t *comm,
@@ -634,9 +634,9 @@ int ompi_coll_tuned_gather_intra_dec_dynamic(const void *sbuf, int scount,
                                                    root, comm, module);
 }
 
-int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
+int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               int root, struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -684,7 +684,7 @@ int ompi_coll_tuned_scatter_intra_dec_dynamic(const void *sbuf, int scount,
                                                     root, comm, module);
 }
 
-int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, size_t count,
                                               struct ompi_datatype_t *dtype,
                                               struct ompi_op_t *op,
                                               struct ompi_communicator_t *comm,
@@ -728,7 +728,7 @@ int ompi_coll_tuned_exscan_intra_dec_dynamic(const void *sbuf, void* rbuf, int c
                                               op, comm, module);
 }
 
-int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_scan_intra_dec_dynamic(const void *sbuf, void* rbuf, size_t count,
                                            struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op,
                                            struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -52,7 +52,7 @@
  *  Returns:    - MPI_SUCCESS or error code
  */
 int
-ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int count,
+ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, size_t count,
                                           struct ompi_datatype_t *dtype,
                                           struct ompi_op_t *op,
                                           struct ompi_communicator_t *comm,
@@ -225,9 +225,9 @@ ompi_coll_tuned_allreduce_intra_dec_fixed(const void *sbuf, void *rbuf, int coun
  *	Returns:	- MPI_SUCCESS or error code
  */
 
-int ompi_coll_tuned_alltoall_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_alltoall_intra_dec_fixed(const void *sbuf, size_t scount,
                                              struct ompi_datatype_t *sdtype,
-                                             void* rbuf, int rcount,
+                                             void* rbuf, size_t rcount,
                                              struct ompi_datatype_t *rdtype,
                                              struct ompi_communicator_t *comm,
                                              mca_coll_base_module_t *module)
@@ -509,7 +509,7 @@ int ompi_coll_tuned_barrier_intra_dec_fixed(struct ompi_communicator_t *comm,
  *	Accepts:	- same arguments as MPI_Bcast()
  *	Returns:	- MPI_SUCCESS or error code (passed from the bcast implementation)
  */
-int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
+int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, size_t count,
                                           struct ompi_datatype_t *datatype, int root,
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
@@ -660,7 +660,7 @@ int ompi_coll_tuned_bcast_intra_dec_fixed(void *buff, int count,
  *
  */
 int ompi_coll_tuned_reduce_intra_dec_fixed( const void *sendbuf, void *recvbuf,
-                                            int count, struct ompi_datatype_t* datatype,
+                                            size_t count, struct ompi_datatype_t* datatype,
                                             struct ompi_op_t* op, int root,
                                             struct ompi_communicator_t* comm,
                                             mca_coll_base_module_t *module)
@@ -971,7 +971,7 @@ int ompi_coll_tuned_reduce_scatter_intra_dec_fixed( const void *sbuf, void *rbuf
  *                        the reduce scatter implementation)
  */
 int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void *rbuf,
-                                                         int rcount,
+                                                         size_t rcount,
                                                          struct ompi_datatype_t *dtype,
                                                          struct ompi_op_t *op,
                                                          struct ompi_communicator_t *comm,
@@ -1091,9 +1091,9 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void 
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_allgather_intra_dec_fixed(const void *sbuf, size_t scount,
                                               struct ompi_datatype_t *sdtype,
-                                              void* rbuf, int rcount,
+                                              void* rbuf, size_t rcount,
                                               struct ompi_datatype_t *rdtype,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
@@ -1378,9 +1378,9 @@ int ompi_coll_tuned_allgatherv_intra_dec_fixed(const void *sbuf, int scount,
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, size_t scount,
                                            struct ompi_datatype_t *sdtype,
-                                           void* rbuf, int rcount,
+                                           void* rbuf, size_t rcount,
                                            struct ompi_datatype_t *rdtype,
                                            int root,
                                            struct ompi_communicator_t *comm,
@@ -1467,9 +1467,9 @@ int ompi_coll_tuned_gather_intra_dec_fixed(const void *sbuf, int scount,
  *                        internal allgather function.
  */
 
-int ompi_coll_tuned_scatter_intra_dec_fixed(const void *sbuf, int scount,
+int ompi_coll_tuned_scatter_intra_dec_fixed(const void *sbuf, size_t scount,
                                             struct ompi_datatype_t *sdtype,
-                                            void* rbuf, int rcount,
+                                            void* rbuf, size_t rcount,
                                             struct ompi_datatype_t *rdtype,
                                             int root, struct ompi_communicator_t *comm,
                                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_exscan_decision.c
@@ -85,7 +85,7 @@ int ompi_coll_tuned_exscan_intra_check_forced_init (coll_tuned_force_algorithm_m
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_exscan_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_exscan_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_gather_decision.c
@@ -120,9 +120,9 @@ ompi_coll_tuned_gather_intra_check_forced_init(coll_tuned_force_algorithm_mca_pa
 }
 
 int
-ompi_coll_tuned_gather_intra_do_this(const void *sbuf, int scount,
+ompi_coll_tuned_gather_intra_do_this(const void *sbuf, size_t scount,
                                      struct ompi_datatype_t *sdtype,
-                                     void* rbuf, int rcount,
+                                     void* rbuf, size_t rcount,
                                      struct ompi_datatype_t *rdtype,
                                      int root,
                                      struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_decision.c
@@ -145,7 +145,7 @@ int ompi_coll_tuned_reduce_intra_check_forced_init (coll_tuned_force_algorithm_m
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_reduce_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_reduce_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op, int root,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
@@ -115,7 +115,7 @@ int ompi_coll_tuned_reduce_scatter_block_intra_check_forced_init (coll_tuned_for
 }
 
 int ompi_coll_tuned_reduce_scatter_block_intra_do_this(const void *sbuf, void *rbuf,
-                                                       int rcount,
+                                                       size_t rcount,
                                                        struct ompi_datatype_t *dtype,
                                                        struct ompi_op_t *op,
                                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scan_decision.c
@@ -85,7 +85,7 @@ int ompi_coll_tuned_scan_intra_check_forced_init (coll_tuned_force_algorithm_mca
     return (MPI_SUCCESS);
 }
 
-int ompi_coll_tuned_scan_intra_do_this(const void *sbuf, void* rbuf, int count,
+int ompi_coll_tuned_scan_intra_do_this(const void *sbuf, void* rbuf, size_t count,
                                          struct ompi_datatype_t *dtype,
                                          struct ompi_op_t *op,
                                          struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_scatter_decision.c
@@ -153,9 +153,9 @@ ompi_coll_tuned_scatter_intra_check_forced_init(coll_tuned_force_algorithm_mca_p
 }
 
 int
-ompi_coll_tuned_scatter_intra_do_this(const void *sbuf, int scount,
+ompi_coll_tuned_scatter_intra_do_this(const void *sbuf, size_t scount,
                                       struct ompi_datatype_t *sdtype,
-                                      void* rbuf, int rcount,
+                                      void* rbuf, size_t rcount,
                                       struct ompi_datatype_t *rdtype,
                                       int root,
                                       struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ucc/coll_ucc.h
+++ b/ompi/mca/coll/ucc/coll_ucc.h
@@ -47,7 +47,7 @@ typedef struct mca_coll_ucc_req {
 OBJ_CLASS_DECLARATION(mca_coll_ucc_req_t);
 
 struct mca_coll_ucc_component_t {
-    mca_coll_base_component_2_4_0_t super;
+    mca_coll_base_component_3_0_0_t super;
     int                             ucc_priority;
     int                             ucc_verbose;
     int                             ucc_enable;
@@ -139,27 +139,27 @@ OBJ_CLASS_DECLARATION(mca_coll_ucc_module_t);
 int mca_coll_ucc_init_query(bool enable_progress_threads, bool enable_mpi_threads);
 mca_coll_base_module_t *mca_coll_ucc_comm_query(struct ompi_communicator_t *comm, int *priority);
 
-int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, size_t count,
                            struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, size_t count,
                         struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                         int root, struct ompi_communicator_t *comm,
-                        struct mca_coll_base_module_2_4_0_t *module);
+                        struct mca_coll_base_module_3_0_0_t *module);
 
-int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, size_t count,
                          struct ompi_datatype_t *dtype, struct ompi_op_t *op,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
-                         struct mca_coll_base_module_2_4_0_t *module);
+                         struct mca_coll_base_module_3_0_0_t *module);
 
 int mca_coll_ucc_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
@@ -168,22 +168,22 @@ int mca_coll_ucc_ibarrier(struct ompi_communicator_t *comm,
                           ompi_request_t** request,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_bcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_bcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                        int root, struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ibcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_ibcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                         int root, struct ompi_communicator_t *comm,
                         ompi_request_t** request,
                         mca_coll_base_module_t *module);
 
-int mca_coll_ucc_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ialltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_ialltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module);
@@ -203,13 +203,13 @@ int mca_coll_ucc_ialltoallv(const void *sbuf, const int *scounts, const int *sdi
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
 
-int mca_coll_ucc_allgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_allgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iallgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_iallgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                            void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module);
@@ -227,13 +227,13 @@ int mca_coll_ucc_iallgatherv(const void *sbuf, int scount, struct ompi_datatype_
                              ompi_request_t** request,
                              mca_coll_base_module_t *module);
 
-int mca_coll_ucc_gather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                        void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_gather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                        void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                         int root, struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module);
 
-int mca_coll_ucc_igather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_igather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
                          mca_coll_base_module_t *module);
@@ -251,13 +251,13 @@ int mca_coll_ucc_igatherv(const void *sbuf, int scount, struct ompi_datatype_t *
                           ompi_request_t** request,
                           mca_coll_base_module_t *module);
 
-int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
                                       mca_coll_base_module_t *module);
 
-int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,
@@ -292,14 +292,14 @@ int mca_coll_ucc_iscatterv(const void *sbuf, const int *scounts,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module);
 
-int mca_coll_ucc_scatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_scatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module);
 
-int mca_coll_ucc_iscatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_iscatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                       void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                       void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                        mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
                                                        mca_coll_ucc_req_t *coll_req)
@@ -59,8 +59,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_allgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_allgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
 {
@@ -80,8 +80,8 @@ fallback:
                                           comm, ucc_module->previous_allgather_module);
 }
 
-int mca_coll_ucc_iallgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                            void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_iallgather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                            void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                             struct ompi_communicator_t *comm,
                             ompi_request_t** request,
                             mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -9,7 +9,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, size_t count,
                                                        struct ompi_datatype_t *dtype,
                                                        struct ompi_op_t *op, mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
@@ -57,7 +57,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, size_t count,
                            struct ompi_datatype_t *dtype,
                            struct ompi_op_t *op, struct ompi_communicator_t *comm,
                            mca_coll_base_module_t *module)
@@ -77,7 +77,7 @@ fallback:
                                           comm, ucc_module->previous_allreduce_module);
 }
 
-int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, int count,
+int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, size_t count,
                             struct ompi_datatype_t *dtype,
                             struct ompi_op_t *op, struct ompi_communicator_t *comm,
                             ompi_request_t** request,

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                      void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                      void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                       mca_coll_ucc_module_t *ucc_module,
                                                       ucc_coll_req_h *req,
                                                       mca_coll_ucc_req_t *coll_req)
@@ -59,8 +59,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                          void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                          void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)
 {
@@ -80,8 +80,8 @@ fallback:
                                           comm, ucc_module->previous_alltoall_module);
 }
 
-int mca_coll_ucc_ialltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                           void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_ialltoall(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                           void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                            struct ompi_communicator_t *comm,
                            ompi_request_t** request,
                            mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, int count, struct ompi_datatype_t *dtype,
+static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, size_t count, struct ompi_datatype_t *dtype,
                                                    int root, mca_coll_ucc_module_t *ucc_module,
                                                    ucc_coll_req_h *req,
                                                    mca_coll_ucc_req_t *coll_req)
@@ -36,7 +36,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_bcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_bcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                        int root, struct ompi_communicator_t *comm,
                        mca_coll_base_module_t *module)
 {
@@ -54,7 +54,7 @@ fallback:
                                        comm, ucc_module->previous_bcast_module);
 }
 
-int mca_coll_ucc_ibcast(void *buf, int count, struct ompi_datatype_t *dtype,
+int mca_coll_ucc_ibcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
                         int root, struct ompi_communicator_t *comm,
                         ompi_request_t** request,
                         mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -24,7 +24,7 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
        about the component  */
     {
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "ucc",

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -11,8 +11,8 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                      void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                       int root, mca_coll_ucc_module_t *ucc_module,
                                       ucc_coll_req_h *req,
                                       mca_coll_ucc_req_t *coll_req)
@@ -73,8 +73,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_gather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                        void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_gather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                        void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                         int root, struct ompi_communicator_t *comm,
                         mca_coll_base_module_t *module)
 {
@@ -95,8 +95,8 @@ fallback:
                                        ucc_module->previous_gather_module);
 }
 
-int mca_coll_ucc_igather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                         void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+int mca_coll_ucc_igather(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                         void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                          int root, struct ompi_communicator_t *comm,
                          ompi_request_t** request,
                          mca_coll_base_module_t *module)

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, size_t count,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op, int root,
                                                     mca_coll_ucc_module_t *ucc_module,
@@ -58,11 +58,11 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, size_t count,
                         struct ompi_datatype_t *dtype,
                         struct ompi_op_t *op, int root,
                         struct ompi_communicator_t *comm,
-                        struct mca_coll_base_module_2_4_0_t *module)
+                        struct mca_coll_base_module_3_0_0_t *module)
 {
     mca_coll_ucc_module_t *ucc_module = (mca_coll_ucc_module_t*)module;
     ucc_coll_req_h         req;
@@ -79,12 +79,12 @@ fallback:
                                        comm, ucc_module->previous_reduce_module);
 }
 
-int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, int count,
+int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, size_t count,
                          struct ompi_datatype_t *dtype,
                          struct ompi_op_t *op, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,
-                         struct mca_coll_base_module_2_4_0_t *module)
+                         struct mca_coll_base_module_3_0_0_t *module)
 {
     mca_coll_ucc_module_t *ucc_module = (mca_coll_ucc_module_t*)module;
     ucc_coll_req_h         req;

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -11,7 +11,7 @@
 
 static inline
 ucc_status_t mca_coll_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf,
-                                                    int rcount,
+                                                    size_t rcount,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     mca_coll_ucc_module_t *ucc_module,
@@ -63,7 +63,7 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                       struct ompi_datatype_t *dtype,
                                       struct ompi_op_t *op,
                                       struct ompi_communicator_t *comm,
@@ -86,7 +86,7 @@ fallback:
                                                      ucc_module->previous_reduce_scatter_block_module);
 }
 
-int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
+int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *dtype,
                                        struct ompi_op_t *op,
                                        struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -10,9 +10,9 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, int scount,
+ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype, int root,
                                        mca_coll_ucc_module_t *ucc_module,
                                        ucc_coll_req_h *req,
@@ -46,7 +46,7 @@ ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, int scount,
         .root      = root,
         .src.info  = {
             .buffer   = (void*)sbuf,
-            .count    = ((size_t)scount) * comm_size,
+            .count    = scount * comm_size,
             .datatype = ucc_sdt,
             .mem_type = UCC_MEMORY_TYPE_UNKNOWN
         },
@@ -68,8 +68,8 @@ fallback:
     return UCC_ERR_NOT_SUPPORTED;
 }
 
-int mca_coll_ucc_scatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_scatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module)
@@ -92,8 +92,8 @@ fallback:
 
 }
 
-int mca_coll_ucc_iscatter(const void *sbuf, int scount,
-                         struct ompi_datatype_t *sdtype, void *rbuf, int rcount,
+int mca_coll_ucc_iscatter(const void *sbuf, size_t scount,
+                         struct ompi_datatype_t *sdtype, void *rbuf, size_t rcount,
                          struct ompi_datatype_t *rdtype, int root,
                          struct ompi_communicator_t *comm,
                          ompi_request_t** request,

--- a/ompi/mca/coll/xhc/coll_xhc.h
+++ b/ompi/mca/coll/xhc/coll_xhc.h
@@ -253,17 +253,17 @@ struct xhc_comm_t {
      *    recalculate `elem_chunk`, so that all workers will perform
      *    equal work. */
     struct xhc_reduce_area_t {
-        int start; // where the area begins
-        int len; // the size of the area
+        size_t start; // where the area begins
+        size_t len; // the size of the area
         int workers; // how many processes perform reductions in the area
-        int stride; /* how much to advance inside the area after
+        size_t stride; /* how much to advance inside the area after
                      * each reduction, unused for non-combo areas */
 
         // local process settings
-        int work_begin; // where to begin the first reduction from
-        int work_end; // up to where to reduce
-        int work_chunk; // how much to reduce each time
-        int work_leftover; /* assigned leftover elements to include as
+        size_t work_begin; // where to begin the first reduction from
+        size_t work_end; // up to where to reduce
+        size_t work_chunk; // how much to reduce each time
+        size_t work_leftover; /* assigned leftover elements to include as
                             * part of the last reduction in the area */
     } reduce_area[3];
     int n_reduce_areas;
@@ -341,14 +341,14 @@ struct xhc_member_ctrl_t {
     volatile int cico_id;
 
     // reduction progress counters, written by member
-    volatile xf_int_t reduce_ready;
-    volatile xf_int_t reduce_done;
+    volatile xf_size_t reduce_ready;
+    volatile xf_size_t reduce_done;
 } __attribute__((aligned(OMPI_XHC_ALIGN)));
 
 struct xhc_reduce_queue_item_t {
     opal_list_item_t super;
     int member; // ID of member
-    int count; // current reduction progress for member
+    size_t count; // current reduction progress for member
     int area_id; // current reduce area
 };
 
@@ -446,18 +446,18 @@ void mca_coll_xhc_return_registration(xhc_reg_t *reg);
 // Primitives (respective file)
 // ----------------------------
 
-int mca_coll_xhc_bcast(void *buf, int count, ompi_datatype_t *datatype,
+int mca_coll_xhc_bcast(void *buf, size_t count, ompi_datatype_t *datatype,
     int root, ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
 int mca_coll_xhc_barrier(ompi_communicator_t *ompi_comm,
     mca_coll_base_module_t *module);
 
 int mca_coll_xhc_reduce(const void *sbuf, void *rbuf,
-    int count, ompi_datatype_t *datatype, ompi_op_t *op, int root,
+    size_t count, ompi_datatype_t *datatype, ompi_op_t *op, int root,
     ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
 int mca_coll_xhc_allreduce(const void *sbuf, void *rbuf,
-    int count, ompi_datatype_t *datatype, ompi_op_t *op,
+    size_t count, ompi_datatype_t *datatype, ompi_op_t *op,
     ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
 // Miscellaneous
@@ -465,7 +465,7 @@ int mca_coll_xhc_allreduce(const void *sbuf, void *rbuf,
 
 #define xhc_allreduce_internal(...) mca_coll_xhc_allreduce_internal(__VA_ARGS__)
 
-int mca_coll_xhc_allreduce_internal(const void *sbuf, void *rbuf, int count,
+int mca_coll_xhc_allreduce_internal(const void *sbuf, void *rbuf, size_t count,
     ompi_datatype_t *datatype, ompi_op_t *op, ompi_communicator_t *ompi_comm,
     mca_coll_base_module_t *module, bool require_bcast);
 

--- a/ompi/mca/coll/xhc/coll_xhc_bcast.c
+++ b/ompi/mca/coll/xhc/coll_xhc_bcast.c
@@ -178,7 +178,7 @@ static xhc_comm_t *xhc_bcast_src_comm(xhc_comm_t *comms, int comm_count) {
     return s;
 }
 
-int mca_coll_xhc_bcast(void *buf, int count, ompi_datatype_t *datatype, int root,
+int mca_coll_xhc_bcast(void *buf, size_t count, ompi_datatype_t *datatype, int root,
         ompi_communicator_t *ompi_comm, mca_coll_base_module_t *ompi_module) {
 
     xhc_module_t *module = (xhc_module_t *) ompi_module;

--- a/ompi/mca/coll/xhc/coll_xhc_component.c
+++ b/ompi/mca/coll/xhc/coll_xhc_component.c
@@ -52,7 +52,7 @@ static const xhc_loc_t hwloc_topo_val[] = {
 mca_coll_xhc_component_t mca_coll_xhc_component = {
     .super = {
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             .mca_component_name = "xhc",
             MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION,

--- a/ompi/mca/coll/xhc/coll_xhc_reduce.c
+++ b/ompi/mca/coll/xhc/coll_xhc_reduce.c
@@ -23,7 +23,7 @@
 #include "coll_xhc.h"
 
 int mca_coll_xhc_reduce(const void *sbuf, void *rbuf,
-        int count, ompi_datatype_t *datatype, ompi_op_t *op, int root,
+        size_t count, ompi_datatype_t *datatype, ompi_op_t *op, int root,
         ompi_communicator_t *ompi_comm, mca_coll_base_module_t *ompi_module) {
 
     xhc_module_t *module = (xhc_module_t *) ompi_module;


### PR DESCRIPTION
This commit adds only those functions which make use of C integer promotion. So none of the 'v,w' and reduce_scatter related methods are added in this PR.

Related to #12336
Pieces of #12478 were taken out to make this PR.