### PR TITLE
Fix man pages persistent collectives

### DIFF
--- a/docs/man-openmpi/man3/MPI_Allgather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgather.3.rst
@@ -111,7 +111,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
@@ -116,7 +116,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Allreduce.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allreduce.3.rst
@@ -104,7 +104,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Starting address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Alltoall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoall.3.rst
@@ -116,7 +116,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Starting address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Alltoallv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoallv.3.rst
@@ -130,7 +130,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer.
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status.
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Alltoallw.3.rst
+++ b/docs/man-openmpi/man3/MPI_Alltoallw.3.rst
@@ -133,7 +133,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer.
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status.
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Barrier.3.rst
+++ b/docs/man-openmpi/man3/MPI_Barrier.3.rst
@@ -64,7 +64,7 @@ INPUT PARAMETER
 OUTPUT PARAMETERS
 -----------------
 
-* ``request`` : Request (handle, non-blocking only).
+* ``request`` : Request (handle, non-blocking and persistent only).
 * ``ierror`` : Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Bcast.3.rst
+++ b/docs/man-openmpi/man3/MPI_Bcast.3.rst
@@ -24,6 +24,9 @@ C Syntax
    int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
        int root, MPI_Comm comm, MPI_Request *request)
 
+   int MPI_Bcast_init(void *buffer, int count, MPI_Datatype datatype,
+       int root, MPI_Comm comm, MPI_Info info, MPI_Request *request)
+
 Fortran Syntax
 ^^^^^^^^^^^^^^
 
@@ -38,6 +41,10 @@ Fortran Syntax
    MPI_IBCAST(BUFFER, COUNT, DATATYPE, ROOT, COMM, REQUEST, IERROR)
        <type>  BUFFER(*)
        INTEGER COUNT, DATATYPE, ROOT, COMM, REQUEST, IERROR
+
+   MPI_BCAST_INIT(BUFFER, COUNT, DATATYPE, ROOT, COMM, REQUEST, IERROR)
+       <type>  BUFFER(*)
+       INTEGER COUNT, DATATYPE, ROOT, COMM, INFO, REQUEST, IERROR
 
 Fortran 2008 Syntax
 ^^^^^^^^^^^^^^^^^^^
@@ -60,6 +67,15 @@ Fortran 2008 Syntax
        TYPE(MPI_Request), INTENT(OUT) :: request
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
+   MPI_Bcast_init(buffer, count, datatype, root, comm, request, ierror)
+       TYPE(*), DIMENSION(..), ASYNCHRONOUS :: buffer
+       INTEGER, INTENT(IN) :: count, root
+       TYPE(MPI_Datatype), INTENT(IN) :: datatype
+       TYPE(MPI_Comm), INTENT(IN) :: comm
+       TYPE(MPI_Info), INTENT(IN) :: info
+       TYPE(MPI_Request), INTENT(OUT) :: request
+       INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
 INPUT/OUTPUT PARAMETERS
 -----------------------
 
@@ -68,11 +84,12 @@ INPUT/OUTPUT PARAMETERS
 * ``datatype``: Data type of buffer (handle).
 * ``root``: Rank of broadcast root (integer).
 * ``comm``: Communicator (handle).
+* ``info``: Info (handle, persistent only).
 
 OUTPUT PARAMETERS
 -----------------
 
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Exscan.3.rst
+++ b/docs/man-openmpi/man3/MPI_Exscan.3.rst
@@ -101,7 +101,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Gather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gather.3.rst
@@ -112,7 +112,7 @@ OUTPUT PARAMETERS
 
 * ``recvbuf`` : Address of receive buffer (choice, significant only at
    root).
-* ``request`` : Request (handle, non-blocking only).
+* ``request`` : Request (handle, non-blocking and persistent only).
 * ``ierror`` : Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Gatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Gatherv.3.rst
@@ -118,7 +118,7 @@ OUTPUT PARAMETERS
 
 * ``recvbuf`` : Address of receive buffer (choice, significant only at
    root).
-* ``request`` : Request (handle, non-blocking only).
+* ``request`` : Request (handle, non-blocking and persistent only).
 * ``ierror`` : Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Neighbor_allgather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_allgather.3.rst
@@ -111,7 +111,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Neighbor_allgatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_allgatherv.3.rst
@@ -117,7 +117,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoall.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoall.3.rst
@@ -115,7 +115,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Starting address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoallv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoallv.3.rst
@@ -130,7 +130,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer.
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status.
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Neighbor_alltoallw.3.rst
+++ b/docs/man-openmpi/man3/MPI_Neighbor_alltoallw.3.rst
@@ -135,7 +135,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer.
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status.
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Reduce.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce.3.rst
@@ -106,12 +106,12 @@ INPUT PARAMETERS
 * ``op``: Reduce operation (handle).
 * ``root``: Rank of root process (integer).
 * ``comm``: Communicator (handle).
-* ``info``: Info (handle, persistent).
+* ``info``: Info (handle, persistent only).
 
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice, significant only at root).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Reduce_scatter.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce_scatter.3.rst
@@ -102,12 +102,12 @@ INPUT PARAMETERS
 * ``datatype``: Datatype of elements of input buffer (handle).
 * ``op``: Operation (handle).
 * ``comm``: Communicator (handle).
-* ``info``: Info (handle, persistent).
+* ``info``: Info (handle, persistent only).
 
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Starting address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Reduce_scatter_block.3.rst
+++ b/docs/man-openmpi/man3/MPI_Reduce_scatter_block.3.rst
@@ -109,7 +109,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Starting address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Scan.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scan.3.rst
@@ -102,7 +102,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Scatter.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scatter.3.rst
@@ -106,12 +106,12 @@ INPUT PARAMETERS
 * ``recvtype``: Datatype of receive buffer elements (handle).
 * ``root``: Rank of sending process (integer).
 * ``comm``: Communicator (handle).
-* ``info``: Info (handle, persistent).
+* ``info``: Info (handle, persistent only).
 
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION

--- a/docs/man-openmpi/man3/MPI_Scatterv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Scatterv.3.rst
@@ -114,7 +114,7 @@ INPUT PARAMETERS
 OUTPUT PARAMETERS
 -----------------
 * ``recvbuf``: Address of receive buffer (choice).
-* ``request``: Request (handle, non-blocking only).
+* ``request``: Request (handle, non-blocking and persistent only).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION


### PR DESCRIPTION
Adds the missing  API definitions for `MPI_Bcast_init ` and fixes descriptions for request and info arguments in the rest of the persistent collective documentations.