### PR TITLE
OFI:  move OFI_RETRY_UNTIL_DONE to common

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019-2022 Triad National Security, LLC. All rights
+ * Copyright (c) 2019-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  *                         reserved.
@@ -265,25 +265,6 @@ ompi_mtl_ofi_progress(void)
 
     return count;
 }
-
-/**
- * When attempting to execute an OFI operation we need to handle
- * resource overrun cases. When a call to an OFI OP fails with -FI_EAGAIN
- * the OFI mtl will attempt to progress any pending Completion Queue
- * events that may prevent additional operations to be enqueued.
- * If the call to ofi progress is successful, then the function call
- * will be retried.
- */
-#define MTL_OFI_RETRY_UNTIL_DONE(FUNC, RETURN)         \
-    do {                                               \
-        do {                                           \
-            RETURN = FUNC;                             \
-            if (OPAL_LIKELY(0 == RETURN)) {break;}     \
-            if (OPAL_LIKELY(RETURN == -FI_EAGAIN)) {   \
-                ompi_mtl_ofi_progress();               \
-            }                                          \
-        } while (OPAL_LIKELY(-FI_EAGAIN == RETURN));   \
-    } while (0);
 
 #define MTL_OFI_LOG_FI_ERR(err, string)                                     \
     do {                                                                    \
@@ -631,12 +612,12 @@ ompi_mtl_ofi_post_recv_excid_buffer(bool blocking, struct ompi_communicator_t *c
     ofi_req->completion_count = 1;
     ofi_req->comm = comm;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_recv(ompi_mtl_ofi.ofi_ctxt[0].rx_ep,
-                                      start,
-                                      length,
-                                      NULL,
-                                      FI_ADDR_UNSPEC,
-                                      (void *)&ofi_req->ctx), ret);
+    OFI_RETRY_UNTIL_DONE(fi_recv(ompi_mtl_ofi.ofi_ctxt[0].rx_ep,
+                                 start,
+                                 length,
+                                 NULL,
+                                 FI_ADDR_UNSPEC,
+                                 (void *)&ofi_req->ctx), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         if (NULL != ofi_req->buffer) {
             free(ofi_req->buffer);
@@ -684,14 +665,14 @@ ompi_mtl_ofi_ssend_recv(ompi_mtl_ofi_request_t *ack_req,
 
     ofi_req->completion_count += 1;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_trecv(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep,
-                                      NULL,
-                                      0,
-                                      NULL,
-                                      *src_addr,
-                                      *match_bits | ompi_mtl_ofi.sync_send_ack,
-                                      0, /* Exact match, no ignore bits */
-                                      (void *) &ack_req->ctx), ret);
+    OFI_RETRY_UNTIL_DONE(fi_trecv(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep,
+                                  NULL,
+                                  0,
+                                  NULL,
+                                  *src_addr,
+                                  *match_bits | ompi_mtl_ofi.sync_send_ack,
+                                  0, /* Exact match, no ignore bits */
+                                  (void *) &ack_req->ctx), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         opal_output_verbose(1, opal_common_ofi.output,
                             "%s:%d: fi_trecv failed: %s(%zd)",
@@ -783,16 +764,16 @@ ompi_mtl_ofi_send_excid(struct mca_mtl_base_module_t *mtl,
 
     if (ompi_mtl_ofi.max_inject_size >= length) {
         if (ofi_cq_data) {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_injectdata(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
-                                            start,
-                                            length,
-                                            comm->c_my_rank,
-                                            sep_peer_fiaddr), ret);
+            OFI_RETRY_UNTIL_DONE(fi_injectdata(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
+                                               start,
+                                               length,
+                                               comm->c_my_rank,
+                                               sep_peer_fiaddr), ret);
         } else {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_inject(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
-                                            start,
-                                            length,
-                                            sep_peer_fiaddr), ret);
+            OFI_RETRY_UNTIL_DONE(fi_inject(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
+                                           start,
+                                           length,
+                                           sep_peer_fiaddr), ret);
         }
         if (OPAL_UNLIKELY(0 > ret)) {
             MTL_OFI_LOG_FI_ERR(ret,
@@ -803,20 +784,20 @@ ompi_mtl_ofi_send_excid(struct mca_mtl_base_module_t *mtl,
     } else {
         ofi_req->completion_count = 1;
         if (ofi_cq_data) {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_senddata(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
-                                          start,
-                                          length,
-                                          NULL,
-                                          comm->c_my_rank,
-                                          sep_peer_fiaddr,
-                                          (void *) &ofi_req->ctx), ret);
+            OFI_RETRY_UNTIL_DONE(fi_senddata(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
+                                             start,
+                                             length,
+                                             NULL,
+                                             comm->c_my_rank,
+                                             sep_peer_fiaddr,
+                                             (void *) &ofi_req->ctx), ret);
         } else {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_send(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
-                                          start,
-                                          length,
-                                          NULL,
-                                          sep_peer_fiaddr,
-                                          (void *) &ofi_req->ctx), ret);
+            OFI_RETRY_UNTIL_DONE(fi_send(ompi_mtl_ofi.ofi_ctxt[0].tx_ep,
+                                         start,
+                                         length,
+                                         NULL,
+                                         sep_peer_fiaddr,
+                                         (void *) &ofi_req->ctx), ret);
         }
         if (OPAL_UNLIKELY(0 > ret)) {
             MTL_OFI_LOG_FI_ERR(ret,
@@ -941,14 +922,14 @@ ompi_mtl_ofi_send_generic(struct mca_mtl_base_module_t *mtl,
     if (!(convertor->flags & CONVERTOR_ACCELERATOR)
         && (ompi_mtl_ofi.max_inject_size >= length)) {
         if (ofi_cq_data) {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_tinjectdata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
-                                            start,
-                                            length,
-                                            comm->c_my_rank,
-                                            sep_peer_fiaddr,
-                                            match_bits), ret);
+            OFI_RETRY_UNTIL_DONE(fi_tinjectdata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+                                                start,
+                                                length,
+                                                comm->c_my_rank,
+                                                sep_peer_fiaddr,
+                                                match_bits), ret);
         } else {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_tinject(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+            OFI_RETRY_UNTIL_DONE(fi_tinject(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
                                             start,
                                             length,
                                             sep_peer_fiaddr,
@@ -973,16 +954,16 @@ ompi_mtl_ofi_send_generic(struct mca_mtl_base_module_t *mtl,
         }
         ofi_req.completion_count += 1;
         if (ofi_cq_data) {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_tsenddata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
-                                          start,
-                                          length,
-                                          (NULL == ofi_req.mr) ? NULL : ofi_req.mr->mem_desc,
-                                          comm->c_my_rank,
-                                          sep_peer_fiaddr,
-                                          match_bits,
-                                          (void *) &ofi_req.ctx), ret);
+            OFI_RETRY_UNTIL_DONE(fi_tsenddata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+                                              start,
+                                              length,
+                                              (NULL == ofi_req.mr) ? NULL : ofi_req.mr->mem_desc,
+                                              comm->c_my_rank,
+                                              sep_peer_fiaddr,
+                                              match_bits,
+                                              (void *) &ofi_req.ctx), ret);
         } else {
-            MTL_OFI_RETRY_UNTIL_DONE(fi_tsend(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+            OFI_RETRY_UNTIL_DONE(fi_tsend(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
                                           start,
                                           length,
                                           (NULL == ofi_req.mr) ? NULL : ofi_req.mr->mem_desc,
@@ -1081,8 +1062,8 @@ ompi_mtl_ofi_gen_ssend_ack(struct fi_cq_tagged_entry *wc,
     tagged_msg.context = NULL;
     tagged_msg.data = 0;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_tsendmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
-                                &tagged_msg, 0), ret);
+    OFI_RETRY_UNTIL_DONE(fi_tsendmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+                                     &tagged_msg, 0), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         MTL_OFI_LOG_FI_ERR(ret, "fi_tsendmsg failed during ompi_mtl_ofi_gen_ssend_ack");
         ret = OMPI_ERROR;
@@ -1227,16 +1208,16 @@ ompi_mtl_ofi_isend_generic(struct mca_mtl_base_module_t *mtl,
 
 
     if (ofi_cq_data) {
-        MTL_OFI_RETRY_UNTIL_DONE(fi_tsenddata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
-                                      start,
-                                      length,
-                                      (NULL == ofi_req->mr) ? NULL : ofi_req->mr->mem_desc,
-                                      comm->c_my_rank,
-                                      sep_peer_fiaddr,
-                                      match_bits,
-                                      (void *) &ofi_req->ctx), ret);
+        OFI_RETRY_UNTIL_DONE(fi_tsenddata(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+                                          start,
+                                          length,
+                                          (NULL == ofi_req->mr) ? NULL : ofi_req->mr->mem_desc,
+                                          comm->c_my_rank,
+                                          sep_peer_fiaddr,
+                                          match_bits,
+                                          (void *) &ofi_req->ctx), ret);
     } else {
-        MTL_OFI_RETRY_UNTIL_DONE(fi_tsend(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
+        OFI_RETRY_UNTIL_DONE(fi_tsend(ompi_mtl_ofi.ofi_ctxt[ctxt_id].tx_ep,
                                       start,
                                       length,
                                       (NULL == ofi_req->mr) ? NULL : ofi_req->mr->mem_desc,
@@ -1445,7 +1426,7 @@ ompi_mtl_ofi_irecv_generic(struct mca_mtl_base_module_t *mtl,
         return ompi_ret;
     }
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_trecv(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep,
+    OFI_RETRY_UNTIL_DONE(fi_trecv(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep,
                                       start,
                                       length,
                                       (NULL == ofi_req->mr) ? NULL : ofi_req->mr->mem_desc,
@@ -1597,7 +1578,7 @@ ompi_mtl_ofi_imrecv(struct mca_mtl_base_module_t *mtl,
     msg.context = (void *)&ofi_req->ctx;
     msg.data = 0;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
+    OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         ompi_mtl_ofi_deregister_and_free_buffer(ofi_req);
         MTL_OFI_LOG_FI_ERR(ret, "fi_trecvmsg failed");
@@ -1729,7 +1710,7 @@ ompi_mtl_ofi_iprobe_generic(struct mca_mtl_base_module_t *mtl,
     ofi_req.completion_count = 1;
     ofi_req.match_state = 0;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
+    OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         MTL_OFI_LOG_FI_ERR(ret, "fi_trecvmsg failed");
         return ompi_mtl_ofi_get_error(ret);
@@ -1838,7 +1819,7 @@ ompi_mtl_ofi_improbe_generic(struct mca_mtl_base_module_t *mtl,
     ofi_req->match_state = 0;
     ofi_req->mask_bits = mask_bits;
 
-    MTL_OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
+    OFI_RETRY_UNTIL_DONE(fi_trecvmsg(ompi_mtl_ofi.ofi_ctxt[ctxt_id].rx_ep, &msg, msgflags), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
         MTL_OFI_LOG_FI_ERR(ret, "fi_trecvmsg failed");
         free(ofi_req);


### PR DESCRIPTION
In running some MPI stress tests on a HPE SS11 network we had to fall back to using the OFI BTL path.  That in turn revealed some places in the BTL where we need to use a function similar to the MTL_OFI_RETRY_UNTIL_DONE macro.

So as a first step move this macro to ofi common layer and invoke the more general opal_progress function.  That's the content of this PR

Additional changes needed to the OFI BTL will applied in subsequent PRs.

The OFI MTL will require more work as the situation hit with the HPE CXI provider indicates a need to implement some kind of send backlog queueing mechanism in the MTL rather than simply spinning on the OFI CQs hoping for progress at the OFI provider level.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit 9c54bb03fa0f920cf5eaaf0a8bd5f23e13144ffa)