### PR TITLE
Make datatype copy stream-aware

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
@@ -275,8 +275,9 @@ ompi_datatype_set_element_count( const ompi_datatype_t* type, size_t count, size
 }
 
 static inline int32_t
-ompi_datatype_copy_content_same_ddt( const ompi_datatype_t* type, size_t count,
-                                     char* pDestBuf, char* pSrcBuf )
+ompi_datatype_copy_content_same_ddt_stream( const ompi_datatype_t* type, size_t count,
+                                            char* pDestBuf, char* pSrcBuf,
+                                            opal_accelerator_stream_t *stream )
 {
     int32_t length, rc;
     ptrdiff_t extent;
@@ -285,14 +286,21 @@ ompi_datatype_copy_content_same_ddt( const ompi_datatype_t* type, size_t count,
     while( 0 != count ) {
         length = INT_MAX;
         if( ((size_t)length) > count ) length = (int32_t)count;
-        rc = opal_datatype_copy_content_same_ddt( &type->super, length,
-                                                  pDestBuf, pSrcBuf );
+        rc = opal_datatype_copy_content_same_ddt_stream( &type->super, length,
+                                                  pDestBuf, pSrcBuf, stream );
         if( 0 != rc ) return rc;
         pDestBuf += ((ptrdiff_t)length) * extent;
         pSrcBuf  += ((ptrdiff_t)length) * extent;
         count -= (size_t)length;
     }
     return 0;
+}
+
+static inline int32_t
+ompi_datatype_copy_content_same_ddt( const ompi_datatype_t* type, size_t count,
+                                     char* pDestBuf, char* pSrcBuf )
+{
+    return ompi_datatype_copy_content_same_ddt_stream(type, count, pDestBuf, pSrcBuf, NULL);
 }
 
 OMPI_DECLSPEC const ompi_datatype_t* ompi_datatype_match_size( int size, uint16_t datakind, uint16_t datalang );

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -42,6 +42,7 @@
 #include <stddef.h>
 
 #include "opal/class/opal_object.h"
+#include "opal/mca/accelerator/accelerator.h"
 
 BEGIN_C_DECLS
 
@@ -308,6 +309,10 @@ OPAL_DECLSPEC int32_t opal_datatype_set_element_count(const opal_datatype_t *pDa
 OPAL_DECLSPEC int32_t opal_datatype_copy_content_same_ddt(const opal_datatype_t *pData,
                                                           int32_t count, char *pDestBuf,
                                                           char *pSrcBuf);
+
+OPAL_DECLSPEC int32_t opal_datatype_copy_content_same_ddt_stream(const opal_datatype_t *datatype, int32_t count,
+                                                                 char *destination_base, char *source_base,
+                                                                 opal_accelerator_stream_t *stream);
 
 OPAL_DECLSPEC int opal_datatype_compute_ptypes(opal_datatype_t *datatype);
 

--- a/opal/datatype/opal_datatype_copy.h
+++ b/opal/datatype/opal_datatype_copy.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; -*- */
 /*
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
@@ -44,7 +44,7 @@
 static inline void _predefined_data(const dt_elem_desc_t *ELEM, const opal_datatype_t *DATATYPE,
                                     unsigned char *SOURCE_BASE, size_t TOTAL_COUNT, size_t COUNT,
                                     unsigned char *SOURCE, unsigned char *DESTINATION,
-                                    size_t *SPACE)
+                                    size_t *SPACE, opal_accelerator_stream_t *stream)
 {
     const ddt_elem_desc_t *_elem = &((ELEM)->elem);
     unsigned char *_source = (SOURCE) + _elem->disp;
@@ -69,7 +69,7 @@ static inline void _predefined_data(const dt_elem_desc_t *ELEM, const opal_datat
         DO_DEBUG(opal_output(0, "copy %s( %p, %p, %" PRIsize_t " ) => space %" PRIsize_t "\n",
                              STRINGIFY(MEM_OP_NAME), (void *) _destination, (void *) _source,
                              do_now_bytes, *(SPACE) -_i * do_now_bytes););
-        MEM_OP(_destination, _source, do_now_bytes);
+        MEM_OP(_destination, _source, do_now_bytes, stream);
         _destination += _elem->extent;
         _source += _elem->extent;
     }
@@ -79,7 +79,7 @@ static inline void _predefined_data(const dt_elem_desc_t *ELEM, const opal_datat
 static inline void _contiguous_loop(const dt_elem_desc_t *ELEM, const opal_datatype_t *DATATYPE,
                                     unsigned char *SOURCE_BASE, size_t TOTAL_COUNT, size_t COUNT,
                                     unsigned char *SOURCE, unsigned char *DESTINATION,
-                                    size_t *SPACE)
+                                    size_t *SPACE, opal_accelerator_stream_t *stream)
 {
     ddt_loop_desc_t *_loop = (ddt_loop_desc_t *) (ELEM);
     ddt_endloop_desc_t *_end_loop = (ddt_endloop_desc_t *) ((ELEM) + _loop->items);
@@ -91,7 +91,7 @@ static inline void _contiguous_loop(const dt_elem_desc_t *ELEM, const opal_datat
         _copy_loops *= _end_loop->size;
         OPAL_DATATYPE_SAFEGUARD_POINTER(_source, _copy_loops, (SOURCE_BASE), (DATATYPE),
                                         (TOTAL_COUNT));
-        MEM_OP(_destination, _source, _copy_loops);
+        MEM_OP(_destination, _source, _copy_loops, stream);
     } else {
         for (size_t _i = 0; _i < _copy_loops; _i++) {
             OPAL_DATATYPE_SAFEGUARD_POINTER(_source, _end_loop->size, (SOURCE_BASE), (DATATYPE),
@@ -100,7 +100,7 @@ static inline void _contiguous_loop(const dt_elem_desc_t *ELEM, const opal_datat
                                  "copy 3. %s( %p, %p, %" PRIsize_t " ) => space %" PRIsize_t "\n",
                                  STRINGIFY(MEM_OP_NAME), (void *) _destination, (void *) _source,
                                  _end_loop->size, *(SPACE) -_i * _end_loop->size););
-            MEM_OP(_destination, _source, _end_loop->size);
+            MEM_OP(_destination, _source, _end_loop->size, stream);
             _source += _loop->extent;
             _destination += _loop->extent;
         }
@@ -110,7 +110,8 @@ static inline void _contiguous_loop(const dt_elem_desc_t *ELEM, const opal_datat
 }
 
 static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, int32_t count,
-                                             char *destination_base, char *source_base)
+                                             char *destination_base, char *source_base,
+                                             opal_accelerator_stream_t *stream)
 {
     dt_stack_t *pStack;  /* pointer to the position on the stack */
     int32_t stack_pos;   /* index of the stack level */
@@ -148,12 +149,19 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
                 DO_DEBUG(opal_output(0, "copy c1. %s( %p, %p, %lu ) => space %lu\n",
                                      STRINGIFY(MEM_OP_NAME), (void *) destination, (void *) source,
                                      (unsigned long) memop_chunk, (unsigned long) total_length););
-                MEM_OP(destination, source, memop_chunk);
+                MEM_OP(destination, source, memop_chunk, stream);
                 destination += memop_chunk;
                 source += memop_chunk;
                 total_length -= memop_chunk;
             }
             return 0; /* completed */
+        }
+        opal_accelerator_stream_t *actual_stream = stream;
+        bool flush_stream = false;
+        if (NULL == stream) {
+            /* use the default stream to enqueue multiple ops before sync'ing */
+            actual_stream = MCA_ACCELERATOR_STREAM_DEFAULT;
+            flush_stream = true;
         }
         for (pos_desc = 0; (int32_t) pos_desc < count; pos_desc++) {
             OPAL_DATATYPE_SAFEGUARD_POINTER(destination, datatype->size,
@@ -164,9 +172,12 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
                                  STRINGIFY(MEM_OP_NAME), (void *) destination, (void *) source,
                                  (unsigned long) datatype->size,
                                  (unsigned long) (iov_len_local - (pos_desc * datatype->size))););
-            MEM_OP(destination, source, datatype->size);
+            MEM_OP(destination, source, datatype->size, actual_stream);
             destination += extent;
             source += extent;
+        }
+        if (flush_stream) {
+            opal_accelerator.sync_stream(actual_stream);
         }
         return 0; /* completed */
     }
@@ -185,11 +196,18 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
 
     UPDATE_INTERNAL_COUNTERS(description, 0, pElem, count_desc);
 
+    opal_accelerator_stream_t *actual_stream = stream;
+    bool flush_stream = false;
+    if (NULL == stream) {
+        /* use the default stream to enqueue multiple ops before sync'ing */
+        actual_stream = MCA_ACCELERATOR_STREAM_DEFAULT;
+        flush_stream = true;
+    }
     while (1) {
         while (OPAL_LIKELY(pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA)) {
             /* now here we have a basic datatype */
             _predefined_data(pElem, datatype, (unsigned char *) source_base, count, count_desc,
-                             source, destination, &iov_len_local);
+                             source, destination, &iov_len_local, stream);
             pos_desc++; /* advance to the next data */
             UPDATE_INTERNAL_COUNTERS(description, pos_desc, pElem, count_desc);
         }
@@ -202,6 +220,9 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
             if (--(pStack->count) == 0) { /* end of loop */
                 if (stack_pos == 0) {
                     assert(iov_len_local == 0);
+                    if (flush_stream) {
+                        opal_accelerator.sync_stream(actual_stream);
+                    }
                     return 0; /* completed */
                 }
                 stack_pos--;
@@ -229,7 +250,7 @@ static inline int32_t _copy_content_same_ddt(const opal_datatype_t *datatype, in
             ptrdiff_t local_disp = (ptrdiff_t) source;
             if (pElem->loop.common.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) {
                 _contiguous_loop(pElem, datatype, (unsigned char *) source_base, count, count_desc,
-                                 source, destination, &iov_len_local);
+                                 source, destination, &iov_len_local, actual_stream);
                 pos_desc += pElem->loop.items + 1;
                 goto update_loop_description;
             }


### PR DESCRIPTION
This is the third chunk of #12318, which makes datatype copying stream-aware. This will be needed in the coll components to order data movement with kernel invocations.

Adds `ompi_datatype_copy_content_same_ddt_stream` (and opal equivalent), which takes a stream that is used to submit a series of stream-aware memcpy/memmove operations. If no stream is provided, the default stream is used and synchronized at the end.

Requires #12356, will rebase once that's merged.