### PR TITLE
MPIRUN: use PMIx hash gds component by default

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -171,6 +171,9 @@ int main(int argc, char *argv[])
     // to Open MPI.
     setup_mca_prefixes();
 
+    // Only use the hash PMIX GDS unless user requested a different one.
+    opal_setenv("PMIX_MCA_gds", "hash", false, &environ);
+
     /* calling mpirun (and now prterun) with a full path has a special
      * meaning in terms of -prefix behavior, so copy that behavior
      * into prterun */


### PR DESCRIPTION
The hash PMMIx gds component has proven to be the most robust component for Open MPI so ensure its used by default.

This should probably be documented.