### PR TITLE
pml/ucx: Propagate MPI serialized thread mode

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -283,6 +283,20 @@ int mca_pml_ucx_close(void)
     return OMPI_SUCCESS;
 }
 
+static ucs_thread_mode_t mca_pml_ucx_thread_mode(int ompi_mode)
+{
+    switch (ompi_mode) {
+    case MPI_THREAD_MULTIPLE:
+        return UCS_THREAD_MODE_MULTI;
+    case MPI_THREAD_SERIALIZED:
+        return UCS_THREAD_MODE_SERIALIZED;
+    case MPI_THREAD_FUNNELED:
+    case MPI_THREAD_SINGLE:
+    default:
+        return UCS_THREAD_MODE_SINGLE;
+    }
+}
+
 int mca_pml_ucx_init(int enable_mpi_threads)
 {
     ucp_worker_params_t params;
@@ -292,12 +306,11 @@ int mca_pml_ucx_init(int enable_mpi_threads)
 
     PML_UCX_VERBOSE(1, "mca_pml_ucx_init");
 
-    /* TODO check MPI thread mode */
     params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
     if (enable_mpi_threads) {
         params.thread_mode = UCS_THREAD_MODE_MULTI;
     } else {
-        params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        params.thread_mode = mca_pml_ucx_thread_mode(ompi_mpi_thread_provided);
     }
 
 #if HAVE_DECL_UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -322,6 +322,8 @@ static int spml_ucx_init(void)
     wkr_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
     if (oshmem_mpi_thread_requested == SHMEM_THREAD_MULTIPLE) {
         wkr_params.thread_mode = UCS_THREAD_MODE_MULTI;
+    } else if (oshmem_mpi_thread_requested == SHMEM_THREAD_SERIALIZED) {
+        wkr_params.thread_mode = UCS_THREAD_MODE_SERIALIZED;
     } else {
         wkr_params.thread_mode = UCS_THREAD_MODE_SINGLE;
     }


### PR DESCRIPTION
## What
The UCX PML needs to differentiate between mpi serialized and single thread mode according to MPI standard.

## Why
Using UCX with multiple threads, even when providing mutual exclusion, is not completely equivalent to only using UCX with one same thread.

To guarantee ordering and avoid corruption, some UCX transports need the cpu to flush stores to the devices, before another thread can progress the worker. For latency reasons, this needed flush is only performed in non single thread mode.

## Tested

### OMPI
```C
$ cat test.c
#include <stdio.h>
#include <mpi.h>

int main(void)
{
    int provided, requested = MPI_THREAD_SERIALIZED;
    MPI_Init_thread(NULL, NULL, requested, &provided);
    printf("Requested %d Provided %d\n", requested, provided);
    MPI_Finalize();
    return 0;
}

$ mpicc test.c
$ mpirun -mca pml ucx ./a.out
```

### OSHMEM
```
$ cat test_oshmem.c
#include <shmem.h>

int main(void)
{
    int provided, requested = SHMEM_THREAD_MULTIPLE;
    shmem_init_thread(requested, &provided);
    printf("Requested %d Provided %d\n", requested, provided);
    return 0;
}

$ oshcc test_oshmem.c
$ oshrun ./a.out
```