### PR TITLE
Add an AARCH64 OP component.

### DIFF
--- a/ompi/mca/op/aarch64/Makefile.am
+++ b/ompi/mca/op/aarch64/Makefile.am
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2019      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is an aarch64 op component.  This Makefile.am is a typical
+# aarch64 of how to integrate into Open MPI's Automake-based build
+# system.
+#
+# See https://github.com/open-mpi/ompi/wiki/devel-CreateComponent
+# for more details on how to make Open MPI components.
+
+# First, list all .h and .c sources.  It is necessary to list all .h
+# files so that they will be picked up in the distribution tarball.
+
+sources = \
+    op_aarch64.h \
+    op_aarch64_component.c
+
+# Open MPI components can be compiled two ways:
+#
+# 1. As a standalone dynamic shared object (DSO), sometimes called a
+# dynamically loadable library (DLL).
+#
+# 2. As a static library that is slurped up into the upper-level
+# libmpi library (regardless of whether libmpi is a static or dynamic
+# library).  This is called a "Libtool convenience library".
+#
+# The component needs to create an output library in this top-level
+# component directory, and named either mca_<type>_<name>.la (for DSO
+# builds) or libmca_<type>_<name>.la (for static builds).  The OMPI
+# build system will have set the
+# MCA_BUILD_ompi_<framework>_<component>_DSO AM_CONDITIONAL to indicate
+# which way this component should be built.
+specialized_op_libs =
+if MCA_BUILD_ompi_op_has_neon_support
+specialized_op_libs += liblocal_ops_neon.la
+liblocal_ops_neon_la_SOURCES = op_aarch64_functions.c
+liblocal_ops_neon_la_CPPFLAGS = -DGENERATE_NEON_CODE
+endif
+if MCA_BUILD_ompi_op_has_sve_support
+specialized_op_libs += liblocal_ops_sve.la
+liblocal_ops_sve_la_SOURCES = op_aarch64_functions.c
+liblocal_ops_sve_la_CPPFLAGS = -DGENERATE_SVE_CODE
+endif
+
+component_noinst  = $(specialized_op_libs)
+if MCA_BUILD_ompi_op_aarch64_DSO
+component_install = mca_op_aarch64.la
+else
+component_install =
+component_noinst  += libmca_op_aarch64.la
+endif
+
+# Specific information for DSO builds.
+#
+# The DSO should install itself in $(ompilibdir) (by default,
+# $prefix/lib/openmpi).
+
+mcacomponentdir = $(ompilibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_op_aarch64_la_SOURCES = $(sources)
+mca_op_aarch64_la_LIBADD = $(specialized_op_libs)
+mca_op_aarch64_la_LDFLAGS = -module -avoid-version $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+
+
+# Specific information for static builds.
+#
+# Note that we *must* "noinst"; the upper-layer Makefile.am's will
+# slurp in the resulting .la library into libmpi.
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_op_aarch64_la_SOURCES = $(sources)
+libmca_op_aarch64_la_LIBADD = $(specialized_op_libs)
+libmca_op_aarch64_la_LDFLAGS = -module -avoid-version

--- a/ompi/mca/op/aarch64/configure.m4
+++ b/ompi/mca/op/aarch64/configure.m4
@@ -1,0 +1,119 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2019-2020 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ompi_op_arm_CONFIG([action-if-can-compile],
+#		         [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_op_aarch64_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/op/aarch64/Makefile])
+    case "${host}" in
+        aarch64*|arm64*)
+            op_aarch64_check="yes";;
+        *)
+            op_aarch64_check="no";;
+    esac
+    AS_IF([test "$op_aarch64_check" = "yes"],
+          [AC_LANG_PUSH([C])
+
+           #
+           # Check for NEON support
+           #
+           AC_CACHE_CHECK([for NEON support], op_cv_neon_support, 
+                [
+                  AC_LINK_IFELSE(
+                      [AC_LANG_PROGRAM([[
+#if defined(__aarch64__) && defined(__ARM_NEON)
+#include <arm_neon.h>
+#else
+#error "No support for __aarch64__"
+#endif
+                                       ]],
+                                       [[
+#if defined(__aarch64__) && defined(__ARM_NEON)
+    int32x4_t vA;
+    vA = vmovq_n_s32(0)
+#endif
+                                       ]])],
+                      [op_cv_neon_support=yes],
+                      [op_cv_neon_support=no])])
+
+           #
+           # Check for NEON FP support
+           #
+           AC_CACHE_CHECK([for NEON FP support], op_cv_neon_fp_support,
+                [AS_IF([test "$op_cv_neon_support" = "yes"],
+                        [
+                          AC_LINK_IFELSE(
+                              [AC_LANG_PROGRAM([[
+#if defined(__aarch64__) && defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP))
+#include <arm_neon.h>
+#else
+#error "No support for __aarch64__ or NEON FP"
+#endif
+                                             ]],
+                                             [[
+#if defined(__aarch64__) && defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP))
+    float32x4_t vA;
+    vA = vmovq_n_f32(0)
+#endif
+                                             ]])],
+                            [op_cv_neon_fp_support=yes],
+                            [op_cv_neon_fp_support=no])])])
+
+           #
+           # Check for SVE support
+           #
+           AC_CACHE_CHECK([for SVE support], op_cv_sve_support,
+                 [AS_IF([test "$op_cv_neon_support" = "yes"],
+                        [
+                          AC_LINK_IFELSE(
+                              [AC_LANG_PROGRAM([[
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
+#else
+#error "No support for __aarch64__ or SVE"
+#endif
+                                             ]],
+                                             [[
+#if defined(__aarch64__) && defined(_ARM_FEATURE_SVE)
+    svfloat32_t vA;
+    vA = svdup_n_f32(0)
+#endif
+                                             ]])],
+                      [op_cv_sve_support=yes],
+                      [op_cv_sve_support=no])])])
+          ])
+
+    AM_CONDITIONAL([MCA_BUILD_ompi_op_has_neon_support],
+                   [test "$op_cv_neon_support" = "yes"])
+    AM_CONDITIONAL([MCA_BUILD_ompi_op_has_neon_fp_support],
+                   [test "$op_cv_neon_fp_support" = "yes"])
+    AM_CONDITIONAL([MCA_BUILD_ompi_op_has_sve_support],
+                   [test "$op_cv_sve_support" = "yes"])
+    AC_SUBST(MCA_BUILD_ompi_op_has_neon_support)
+    AC_SUBST(MCA_BUILD_ompi_op_has_neon_fp_support)
+    AC_SUBST(MCA_BUILD_ompi_op_has_sve_support)
+
+    AS_IF([test "$op_cv_neon_support" = "yes"],
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON], [1],[NEON supported in the current build])])
+    AS_IF([test "$op_cv_neon_fp_support" = "yes"],
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON_FP], [1],[NEON FP supported in the current build])])
+    AS_IF([test "$op_cv_sve_support" = "yes"],
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_SVE], [1],[SVE supported in the current build])])
+
+    # If we have at least support for Neon
+    AS_IF([test "$op_cv_neon_support" = "yes"],
+          [$1],
+          [$2])
+])dnl

--- a/ompi/mca/op/aarch64/op_aarch64.h
+++ b/ompi/mca/op/aarch64/op_aarch64.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      Arm Ltd.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_OP_AARCH64_EXPORT_H
+#define MCA_OP_AARCH64_EXPORT_H
+
+#include "ompi_config.h"
+
+#include "ompi/mca/mca.h"
+#include "opal/class/opal_object.h"
+
+#include "ompi/mca/op/op.h"
+
+BEGIN_C_DECLS
+
+/**
+ * Derive a struct from the base op component struct, allowing us to
+ * cache some component-specific information on our well-known
+ * component struct.
+ */
+typedef struct {
+    /** The base op component struct */
+    ompi_op_base_component_1_0_0_t super;
+
+    /* What follows is aarch64-component-specific cached information.  We
+       tend to use this scheme (caching information on the aarch64
+       component itself) instead of lots of individual global
+       variables for the component.  */
+
+    /** A simple boolean indicating that the hardware is available. */
+    uint32_t hardware_available;
+
+    /** A simple boolean indicating whether double precision is
+        supported. */
+    bool double_supported;
+} ompi_op_aarch64_component_t;
+
+/**
+ * Globally exported variable.  Note that it is a *aarch64* component
+ * (defined above), which has the ompi_op_base_component_t as its
+ * first member.  Hence, the MCA/op framework will find the data that
+ * it expects in the first memory locations, but then the component
+ * itself can cache additional information after that that can be used
+ * by both the component and modules.
+ */
+OMPI_DECLSPEC extern ompi_op_aarch64_component_t
+    mca_op_aarch64_component;
+
+END_C_DECLS
+
+#endif /* MCA_OP_AARCH64_EXPORT_H */

--- a/ompi/mca/op/aarch64/op_aarch64_component.c
+++ b/ompi/mca/op/aarch64/op_aarch64_component.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2019      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      ARM Ltd.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file
+ *
+ * This is the "AARCH64" component source code.
+ *
+ */
+
+#include "ompi_config.h"
+
+#include "opal/util/printf.h"
+
+#include "ompi/constants.h"
+#include "ompi/mca/op/aarch64/op_aarch64.h"
+#include "ompi/mca/op/base/base.h"
+#include "ompi/mca/op/op.h"
+#include "ompi/op/op.h"
+
+static int mca_op_aarch64_component_open(void);
+static int mca_op_aarch64_component_close(void);
+static int mca_op_aarch64_component_init_query(bool enable_progress_threads,
+                                     bool enable_mpi_thread_multiple);
+static struct ompi_op_base_module_1_0_0_t *
+    mca_op_aarch64_component_op_query(struct ompi_op_t *op, int *priority);
+static int mca_op_aarch64_component_register(void);
+
+ompi_op_aarch64_component_t mca_op_aarch64_component = {
+    /* First, the mca_base_component_t struct containing meta
+       information about the component itself */
+    {
+        .opc_version = {
+            OMPI_OP_BASE_VERSION_1_0_0,
+
+            .mca_component_name = "aarch64",
+            MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
+                                  OMPI_RELEASE_VERSION),
+            .mca_open_component = mca_op_aarch64_component_open,
+            .mca_close_component = mca_op_aarch64_component_close,
+            .mca_register_component_params = mca_op_aarch64_component_register,
+        },
+        .opc_data = {
+            /* The component is checkpoint ready */
+            MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
+
+        .opc_init_query = mca_op_aarch64_component_init_query,
+        .opc_op_query = mca_op_aarch64_component_op_query,
+    },
+};
+
+/*
+ * Component open
+ */
+static int mca_op_aarch64_component_open(void)
+{
+
+    /* A first level check to see if NEON or SVE ISA is even available in this
+       process.  E.g., you may want to do a first-order check to see
+       if hardware is available.  If so, return OMPI_SUCCESS.  If not,
+       return anything other than OMPI_SUCCESS and the component will
+       silently be ignored.
+
+       Note that if this function returns non-OMPI_SUCCESS, then this
+       component won't even be shown in ompi_info output (which is
+       probably not what you want).
+    */
+
+    return OMPI_SUCCESS;
+}
+
+/*
+ * Component close
+ */
+static int mca_op_aarch64_component_close(void)
+{
+
+    /* If the aarch64 was opened successfully, close it (i.e., release any
+       resources that may have been allocated on this component).
+       Note that _component_close() will always be called at the end
+       of the process, so it may have been after any/all of the other
+       component functions have been invoked (and possibly even after
+       modules have been created and/or destroyed). */
+
+    return OMPI_SUCCESS;
+}
+
+/*
+ * Register MCA params.
+ */
+static int mca_op_aarch64_component_register(void)
+{
+
+    mca_op_aarch64_component.hardware_available = 1;  /* Check for Neon */
+#if defined(OMPI_MCA_OP_HAVE_SVE)
+    uint64_t id_aa64pfr0_el1 = (1UL << 32);
+    __asm__("mrs %0, ID_AA64PFR0_EL1" : "=r"(id_aa64pfr0_el1) : :);
+    /* Check for SVE support */
+    mca_op_aarch64_component.hardware_available |= ((id_aa64pfr0_el1 & (1UL << 32)) ? 2 : 0);
+#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+    (void) mca_base_component_var_register(&mca_op_aarch64_component.super.opc_version,
+                                           "hardware_available",
+                                           "Whether the Neon (1) or SVE (2) hardware is available",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_op_aarch64_component.hardware_available);
+    uint64_t id_aa64zfr0_el1 = 0;
+#if defined(OMPI_MCA_OP_HAVE_SVE)
+    __asm__("mrs %0, ID_AA64ZFR0_EL1" : "=r"(id_aa64zfr0_el1) : :);
+#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+    mca_op_aarch64_component.double_supported = id_aa64zfr0_el1 & (1UL << 56);
+    /* Bit 1: mandatory SVE2 instructions */
+    /* Bit 2: mandatory SVE2.1 instructions */
+    (void) mca_base_component_var_register(&mca_op_aarch64_component.super.opc_version,
+                                           "double_supported",
+                                           "Whether the double precision data types are supported or not",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_op_aarch64_component.double_supported);
+
+    return OMPI_SUCCESS;
+}
+
+/*
+ * Query whether this component wants to be used in this process.
+ */
+static int mca_op_aarch64_component_init_query(bool enable_progress_threads,
+                                               bool enable_mpi_thread_multiple)
+{
+    if (mca_op_aarch64_component.hardware_available) {
+        return OMPI_SUCCESS;
+    }
+    return OMPI_ERR_NOT_SUPPORTED;
+}
+
+#if defined(OMPI_MCA_OP_HAVE_NEON)
+extern ompi_op_base_handler_fn_t
+ompi_op_aarch64_functions_neon[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
+extern ompi_op_base_3buff_handler_fn_t
+ompi_op_aarch64_3buff_functions_neon[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
+#endif  /* defined(OMPI_MCA_OP_HAVE_NEON) */
+#if defined(OMPI_MCA_OP_HAVE_SVE)
+extern ompi_op_base_handler_fn_t
+ompi_op_aarch64_functions_sve[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
+extern ompi_op_base_3buff_handler_fn_t
+ompi_op_aarch64_3buff_functions_sve[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
+#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+
+/*
+ * Query whether this component can be used for a specific op
+ */
+static struct ompi_op_base_module_1_0_0_t *
+    mca_op_aarch64_component_op_query(struct ompi_op_t *op, int *priority)
+{
+    ompi_op_base_module_t *module = OBJ_NEW(ompi_op_base_module_t);
+    /* Sanity check -- although the framework should never invoke the
+       _component_op_query() on non-intrinsic MPI_Op's, we'll put a
+       check here just to be sure. */
+    if (0 == (OMPI_OP_FLAGS_INTRINSIC & op->o_flags)) {
+        return NULL;
+    }
+
+    switch (op->o_f_to_c_index) {
+    case OMPI_OP_BASE_FORTRAN_MAX:
+    case OMPI_OP_BASE_FORTRAN_MIN:
+    case OMPI_OP_BASE_FORTRAN_SUM:
+    case OMPI_OP_BASE_FORTRAN_PROD:
+    case OMPI_OP_BASE_FORTRAN_BOR:
+    case OMPI_OP_BASE_FORTRAN_BAND:
+    case OMPI_OP_BASE_FORTRAN_BXOR:
+        for (int i = 0; i < OMPI_OP_BASE_TYPE_MAX; ++i) {
+            module->opm_fns[i] = NULL;
+            module->opm_3buff_fns[i] = NULL;
+#if defined(OMPI_MCA_OP_HAVE_SVE)
+            if( mca_op_aarch64_component.hardware_available & 2 ) {
+                module->opm_fns[i] = ompi_op_aarch64_functions_sve[op->o_f_to_c_index][i];
+                module->opm_3buff_fns[i] = ompi_op_aarch64_3buff_functions_sve[op->o_f_to_c_index][i];
+            }
+#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+#if defined(OMPI_MCA_OP_HAVE_NEON)
+            if( mca_op_aarch64_component.hardware_available & 1 ) {
+                if( NULL == module->opm_fns[i] ) {
+                    module->opm_fns[i] = ompi_op_aarch64_functions_neon[op->o_f_to_c_index][i];
+                }
+                if( NULL == module->opm_3buff_fns[i] ) {
+                    module->opm_3buff_fns[i] = ompi_op_aarch64_3buff_functions_neon[op->o_f_to_c_index][i];
+                }
+            }
+#endif  /* defined(OMPI_MCA_OP_HAVE_NEON) */
+            if( NULL != module->opm_fns[i] ) {
+                OBJ_RETAIN(module);
+            }
+            if( NULL != module->opm_3buff_fns[i] ) {
+                OBJ_RETAIN(module);
+            }
+        }
+        break;
+    case OMPI_OP_BASE_FORTRAN_LAND:
+        module = NULL;
+        break;
+    case OMPI_OP_BASE_FORTRAN_LOR:
+        module = NULL;
+        break;
+    case OMPI_OP_BASE_FORTRAN_LXOR:
+        module = NULL;
+        break;
+    case OMPI_OP_BASE_FORTRAN_MAXLOC:
+        module = NULL;
+        break;
+    case OMPI_OP_BASE_FORTRAN_MINLOC:
+        module= NULL;
+        break;
+    default:
+        module= NULL;
+    }
+    /* If we got a module from above, we'll return it.  Otherwise,
+       we'll return NULL, indicating that this component does not want
+       to be considered for selection for this MPI_Op.  Note that the
+       functions each returned a *aarch64* component pointer
+       (vs. a *base* component pointer -- where an *aarch64* component
+       is a base component plus some other module-specific cached
+       information), so we have to cast it to the right pointer type
+       before returning. */
+    if (NULL != module) {
+        *priority = 50;
+    }
+    return (ompi_op_base_module_1_0_0_t *) module;
+}

--- a/ompi/mca/op/aarch64/op_aarch64_functions.c
+++ b/ompi/mca/op/aarch64/op_aarch64_functions.c
@@ -1,0 +1,624 @@
+/*
+ * Copyright (c) 2019      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      Arm Ltd.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#include "opal/util/output.h"
+
+#include "ompi/op/op.h"
+#include "ompi/mca/op/op.h"
+#include "ompi/mca/op/base/base.h"
+#include "ompi/mca/op/aarch64/op_aarch64.h"
+
+#if defined(GENERATE_SVE_CODE)
+#    include <arm_sve.h>
+#define OMPI_OP_TYPE_PREPEND sv
+#define OMPI_OP_OP_PREPEND sv
+#define APPEND   _sve
+#elif defined(GENERATE_NEON_CODE)
+#    include <arm_neon.h>
+#define OMPI_OP_TYPE_PREPEND
+#define OMPI_OP_OP_PREPEND v
+#define APPEND   _neon
+#else
+#error we should not reach this
+#endif /* OMPI_MCA_OP_HAVE_SVE */
+
+/*
+ * Concatenate preprocessor tokens A and B without expanding macro definitions
+ * (however, if invoked from a macro, macro arguments are expanded).
+ */
+#define OP_CONCAT_NX(A, B) A ## B
+
+/*
+ * Concatenate preprocessor tokens A and B after macro-expanding them.
+ */
+#define OP_CONCAT(A, B) OP_CONCAT_NX(A, B)
+
+#if defined(GENERATE_SVE_CODE)
+#    define svcnt(X)           \
+        _Generic((X),          \
+            int8_t: svcntb,    \
+            uint8_t: svcntb,   \
+            int16_t: svcnth,   \
+            uint16_t: svcnth,  \
+            int32_t: svcntw,   \
+            uint32_t: svcntw,  \
+            int64_t: svcntd,   \
+            uint64_t: svcntd,  \
+            float32_t: svcntw, \
+            float64_t: svcntd)()
+#else
+#define DUMP2(out, in1, in2) \
+        case 2: (out)[1] = current_func((in1)[1], (in2)[1]); \
+        case 1: (out)[0] = current_func((in1)[0], (in2)[0]);
+#define DUMP4(out, in1, in2) \
+        case 4: (out)[3] = current_func((in1)[3], (in2)[3]); \
+        case 3: (out)[2] = current_func((in1)[2], (in2)[2]); \
+        DUMP2(out, in1, in2)
+#define DUMP8(out, in1, in2) \
+        case 8: (out)[7] = current_func((in1)[7], (in2)[7]); \
+        case 7: (out)[6] = current_func((in1)[6], (in2)[6]); \
+        case 6: (out)[5] = current_func((in1)[5], (in2)[5]); \
+        case 5: (out)[4] = current_func((in1)[4], (in2)[4]); \
+        DUMP4(out, in1, in2)
+#define DUMP16(out, in1, in2) \
+        case 16: (out)[15] = current_func((in1)[15], (in2)[15]); \
+        case 15: (out)[14] = current_func((in1)[14], (in2)[14]); \
+        case 14: (out)[13] = current_func((in1)[13], (in2)[13]); \
+        case 13: (out)[12] = current_func((in1)[12], (in2)[12]); \
+        case 12: (out)[11] = current_func((in1)[11], (in2)[11]); \
+        case 11: (out)[10] = current_func((in1)[10], (in2)[10]); \
+        case 10: (out)[ 9] = current_func((in1)[ 9], (in2)[ 9]); \
+        case  9: (out)[ 8] = current_func((in1)[ 8], (in2)[ 8]); \
+        DUMP8(out, in1, in2)
+
+#    define neon_loop(how_much, out, in1, in2)   \
+_Generic((*(out)), \
+         int8_t:    __extension__({ switch ((how_much)) { DUMP16(out, in1, in2) }}), \
+         uint8_t:   __extension__({ switch ((how_much)) { DUMP16(out, in1, in2) }}), \
+         int16_t:   __extension__({ switch ((how_much)) { DUMP8(out, in1, in2) }}), \
+         uint16_t:  __extension__({ switch ((how_much)) { DUMP8(out, in1, in2) }}), \
+         int32_t:   __extension__({ switch ((how_much)) { DUMP4(out, in1, in2) }}), \
+         uint32_t:  __extension__({ switch ((how_much)) { DUMP4(out, in1, in2) }}), \
+         int64_t:   __extension__({ switch ((how_much)) { DUMP2(out, in1, in2) }}), \
+         uint64_t:  __extension__({ switch ((how_much)) { DUMP2(out, in1, in2) }}), \
+         float32_t: __extension__({ switch ((how_much)) { DUMP4(out, in1, in2) }}), \
+         float64_t: __extension__({ switch ((how_much)) { DUMP2(out, in1, in2) }}))
+#endif /* defined(GENERATE_SVE_CODE) */
+
+/*
+ * Since all the functions in this file are essentially identical, we
+ * use a macro to substitute in names and types.  The core operation
+ * in all functions that use this macro is the same.
+ *
+ * This macro is for (out op in).
+ *
+ */
+#if defined(GENERATE_NEON_CODE)
+#define OP_AARCH64_FUNC(name, type_name, type_size, type_cnt, type, op)                       \
+    static void OP_CONCAT(ompi_op_aarch64_2buff_##name##_##type##type_size##_t,               \
+                          APPEND)(const void *_in, void *_out, int *count,                    \
+                                  struct ompi_datatype_t **dtype,                             \
+                                  struct ompi_op_base_module_1_0_0_t *module)                 \
+    {                                                                                         \
+        int left_over = *count;                                                               \
+        type##type_size##_t *in = (type##type_size##_t *) _in,                                \
+                            *out = (type##type_size##_t *) _out;                              \
+        OP_CONCAT(OMPI_OP_TYPE_PREPEND, type##type_size####x##type_cnt##_t) vsrc, vdst;       \
+        for (; left_over >= type_cnt; left_over -= type_cnt) {                                \
+            vsrc = vld1q##_##type_name##type_size(in);                                        \
+            vdst = vld1q##_##type_name##type_size(out);                                       \
+            in += type_cnt;                                                                   \
+            vdst = OP_CONCAT(OMPI_OP_OP_PREPEND, op##q##_##type_name##type_size)(vdst, vsrc); \
+            vst1q##_##type_name##type_size(out, vdst);                                        \
+            out += type_cnt;                                                                  \
+        }                                                                                     \
+                                                                                              \
+        if(left_over > 0) {                                                                   \
+            neon_loop(left_over, out, out, in);                                               \
+        }                                                                                     \
+    }
+#elif defined(GENERATE_SVE_CODE)
+#define OP_AARCH64_FUNC(name, type_name, type_size, type_cnt, type, op)           \
+    static void OP_CONCAT(ompi_op_aarch64_2buff_##name##_##type##type_size##_t, APPEND) \
+                            (const void *_in, void *_out, int *count,             \
+                             struct ompi_datatype_t **dtype,                      \
+                             struct ompi_op_base_module_1_0_0_t *module)          \
+    {                                                                             \
+        int types_per_step = svcnt(*((type##type_size##_t *) _in));               \
+        size_t idx = 0, left_over = *count;                                       \
+        type##type_size##_t *in = (type##type_size##_t *) _in,                    \
+                            *out = (type##type_size##_t *) _out;                  \
+        OP_CONCAT(OMPI_OP_TYPE_PREPEND, type##type_size##_t) vsrc, vdst;          \
+        svbool_t pred = svwhilelt_b##type_size(idx, left_over);                   \
+        do {                                                                      \
+            vsrc = svld1(pred, &in[idx]);                                         \
+            vdst = svld1(pred, &out[idx]);                                        \
+            vdst = OP_CONCAT(OMPI_OP_OP_PREPEND, op##_x)(pred, vdst, vsrc);       \
+            OP_CONCAT(OMPI_OP_OP_PREPEND, st1)(pred, &out[idx], vdst);            \
+            idx += types_per_step;                                                \
+            pred = svwhilelt_b##type_size(idx, left_over);                        \
+        } while (svptest_any(svptrue_b##type_size(), pred));                      \
+    }
+#endif
+
+/*************************************************************************
+ * Max
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) > (b) ? (a) : (b))
+    OP_AARCH64_FUNC(max, s,  8, 16,   int, max)
+    OP_AARCH64_FUNC(max, u,  8, 16,  uint, max)
+    OP_AARCH64_FUNC(max, s, 16,  8,   int, max)
+    OP_AARCH64_FUNC(max, u, 16,  8,  uint, max)
+    OP_AARCH64_FUNC(max, s, 32,  4,   int, max)
+    OP_AARCH64_FUNC(max, u, 32,  4,  uint, max)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC(max, s, 64,  2,   int, max)
+    OP_AARCH64_FUNC(max, u, 64,  2,  uint, max)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC(max, f, 32,  4, float, max)
+    OP_AARCH64_FUNC(max, f, 64,  2, float, max)
+
+/*************************************************************************
+ * Min
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) < (b) ? (a) : (b))
+    OP_AARCH64_FUNC(min, s,  8, 16,   int, min)
+    OP_AARCH64_FUNC(min, u,  8, 16,  uint, min)
+    OP_AARCH64_FUNC(min, s, 16,  8,   int, min)
+    OP_AARCH64_FUNC(min, u, 16,  8,  uint, min)
+    OP_AARCH64_FUNC(min, s, 32,  4,   int, min)
+    OP_AARCH64_FUNC(min, u, 32,  4,  uint, min)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC(min, s, 64,  2,   int, min)
+    OP_AARCH64_FUNC(min, u, 64,  2,  uint, min)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC(min, f, 32,  4, float, min)
+    OP_AARCH64_FUNC(min, f, 64,  2, float, min)
+    /*************************************************************************
+     * Sum
+     ************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) + (b))
+    OP_AARCH64_FUNC(sum, s,  8, 16,   int, add)
+    OP_AARCH64_FUNC(sum, u,  8, 16,  uint, add)
+    OP_AARCH64_FUNC(sum, s, 16,  8,   int, add)
+    OP_AARCH64_FUNC(sum, u, 16,  8,  uint, add)
+    OP_AARCH64_FUNC(sum, s, 32,  4,   int, add)
+    OP_AARCH64_FUNC(sum, u, 32,  4,  uint, add)
+    OP_AARCH64_FUNC(sum, s, 64,  2,   int, add)
+    OP_AARCH64_FUNC(sum, u, 64,  2,  uint, add)
+
+    OP_AARCH64_FUNC(sum, f, 32,  4, float, add)
+    OP_AARCH64_FUNC(sum, f, 64,  2, float, add)
+
+/*************************************************************************
+ * Product
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) * (b))
+    OP_AARCH64_FUNC(prod, s,  8, 16,   int, mul)
+    OP_AARCH64_FUNC(prod, u,  8, 16,  uint, mul)
+    OP_AARCH64_FUNC(prod, s, 16,  8,   int, mul)
+    OP_AARCH64_FUNC(prod, u, 16,  8,  uint, mul)
+    OP_AARCH64_FUNC(prod, s, 32,  4,   int, mul)
+    OP_AARCH64_FUNC(prod, u, 32,  4,  uint, mul)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC(prod, s, 64,  2,   int, mul)
+    OP_AARCH64_FUNC(prod, u, 64,  2,  uint, mul)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC(prod, f, 32,  4, float, mul)
+    OP_AARCH64_FUNC(prod, f, 64,  2, float, mul)
+
+/*************************************************************************
+ * Bitwise AND
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) & (b))
+    OP_AARCH64_FUNC(band, s,  8, 16,  int, and)
+    OP_AARCH64_FUNC(band, u,  8, 16, uint, and)
+    OP_AARCH64_FUNC(band, s, 16,  8,  int, and)
+    OP_AARCH64_FUNC(band, u, 16,  8, uint, and)
+    OP_AARCH64_FUNC(band, s, 32,  4,  int, and)
+    OP_AARCH64_FUNC(band, u, 32,  4, uint, and)
+    OP_AARCH64_FUNC(band, s, 64,  2,  int, and)
+    OP_AARCH64_FUNC(band, u, 64,  2, uint, and)
+
+ /*************************************************************************
+ * Bitwise OR
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) | (b))
+    OP_AARCH64_FUNC(bor, s,  8, 16,  int, orr)
+    OP_AARCH64_FUNC(bor, u,  8, 16, uint, orr)
+    OP_AARCH64_FUNC(bor, s, 16,  8,  int, orr)
+    OP_AARCH64_FUNC(bor, u, 16,  8, uint, orr)
+    OP_AARCH64_FUNC(bor, s, 32,  4,  int, orr)
+    OP_AARCH64_FUNC(bor, u, 32,  4, uint, orr)
+    OP_AARCH64_FUNC(bor, s, 64,  2,  int, orr)
+    OP_AARCH64_FUNC(bor, u, 64,  2, uint, orr)
+
+/*************************************************************************
+ * Bitwise XOR
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) ^ (b))
+    OP_AARCH64_FUNC(bxor, s,  8, 16,  int, eor)
+    OP_AARCH64_FUNC(bxor, u,  8, 16, uint, eor)
+    OP_AARCH64_FUNC(bxor, s, 16,  8,  int, eor)
+    OP_AARCH64_FUNC(bxor, u, 16,  8, uint, eor)
+    OP_AARCH64_FUNC(bxor, s, 32,  4,  int, eor)
+    OP_AARCH64_FUNC(bxor, u, 32,  4, uint, eor)
+    OP_AARCH64_FUNC(bxor, s, 64,  2,  int, eor)
+    OP_AARCH64_FUNC(bxor, u, 64,  2, uint, eor)
+
+    /*
+     *  This is a three buffer (2 input and 1 output) version of the reduction
+     *  routines, needed for some optimizations.
+     */
+#if defined(GENERATE_NEON_CODE)
+#define OP_AARCH64_FUNC_3BUFF(name, type_name, type_size, type_cnt, type, op)                 \
+static void OP_CONCAT(ompi_op_aarch64_3buff_##name##_##type##type_size##_t, APPEND)       \
+                             (const void *_in1, const void *_in2, void *_out, int *count, \
+                              struct ompi_datatype_t **dtype,                             \
+                              struct ompi_op_base_module_1_0_0_t *module)                 \
+{                                                                                         \
+    int left_over = *count;                                                               \
+    type##type_size##_t *in1 = (type##type_size##_t *) _in1,                              \
+                        *in2 = (type##type_size##_t *) _in2,                              \
+                        *out = (type##type_size##_t *) _out;                              \
+    OP_CONCAT(OMPI_OP_TYPE_PREPEND, type##type_size##x##type_cnt##_t) vsrc, vdst;         \
+    for (; left_over >= type_cnt; left_over -= type_cnt) {                                \
+        vsrc = vld1q##_##type_name##type_size(in1);                                       \
+        vdst = vld1q##_##type_name##type_size(in2);                                       \
+        in1 += type_cnt;                                                                  \
+        in2 += type_cnt;                                                                  \
+        vdst = OP_CONCAT(OMPI_OP_OP_PREPEND, op##q##_##type_name##type_size)(vdst, vsrc); \
+        vst1q##_##type_name##type_size(out, vdst);                                        \
+        out += type_cnt;                                                                  \
+    }                                                                                     \
+    if (left_over > 0) {                                                                  \
+        neon_loop(left_over, out, in1, in2);                                              \
+    }                                                                                     \
+}
+#elif defined(GENERATE_SVE_CODE)
+#define OP_AARCH64_FUNC_3BUFF(name, type_name, type_size, type_cnt, type, op)             \
+static void OP_CONCAT(ompi_op_aarch64_3buff_##name##_##type##type_size##_t, APPEND)       \
+                             (const void *_in1, const void *_in2, void *_out, int *count, \
+                              struct ompi_datatype_t **dtype,                             \
+                              struct ompi_op_base_module_1_0_0_t *module)                 \
+{                                                                                         \
+    int types_per_step = svcnt(*((type##type_size##_t *) _in1));                          \
+    type##type_size##_t *in1 = (type##type_size##_t *) _in1,                              \
+                        *in2 = (type##type_size##_t *) _in2,                              \
+                        *out = (type##type_size##_t *) _out;                              \
+    size_t idx = 0, left_over = *count;                                                   \
+    OP_CONCAT(OMPI_OP_TYPE_PREPEND, type##type_size##_t) vsrc, vdst;                      \
+    svbool_t pred = svwhilelt_b##type_size(idx, left_over);                               \
+    do {                                                                                  \
+        vsrc = svld1(pred, &in1[idx]);                                                    \
+        vdst = svld1(pred, &in2[idx]);                                                    \
+        vdst = OP_CONCAT(OMPI_OP_OP_PREPEND, op##_x)(pred, vdst, vsrc);                   \
+        OP_CONCAT(OMPI_OP_OP_PREPEND, st1)(pred, &out[idx], vdst);                        \
+        idx += types_per_step;                                                            \
+        pred = svwhilelt_b##type_size(idx, left_over);                                    \
+    } while (svptest_any(svptrue_b##type_size(), pred));                                  \
+}
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+/*************************************************************************
+ * Max
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) > (b) ? (a) : (b))
+    OP_AARCH64_FUNC_3BUFF(max, s,  8, 16,   int, max)
+    OP_AARCH64_FUNC_3BUFF(max, u,  8, 16,  uint, max)
+    OP_AARCH64_FUNC_3BUFF(max, s, 16,  8,   int, max)
+    OP_AARCH64_FUNC_3BUFF(max, u, 16,  8,  uint, max)
+    OP_AARCH64_FUNC_3BUFF(max, s, 32,  4,   int, max)
+    OP_AARCH64_FUNC_3BUFF(max, u, 32,  4,  uint, max)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC_3BUFF(max, s, 64,  2,   int, max)
+    OP_AARCH64_FUNC_3BUFF(max, u, 64,  2,  uint, max)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC_3BUFF(max, f, 32,  4, float, max)
+    OP_AARCH64_FUNC_3BUFF(max, f, 64,  2, float, max)
+
+    /*************************************************************************
+     * Min
+     *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) < (b) ? (a) : (b))
+    OP_AARCH64_FUNC_3BUFF(min, s,  8, 16,   int, min)
+    OP_AARCH64_FUNC_3BUFF(min, u,  8, 16,  uint, min)
+    OP_AARCH64_FUNC_3BUFF(min, s, 16,  8,   int, min)
+    OP_AARCH64_FUNC_3BUFF(min, u, 16,  8,  uint, min)
+    OP_AARCH64_FUNC_3BUFF(min, s, 32,  4,   int, min)
+    OP_AARCH64_FUNC_3BUFF(min, u, 32,  4,  uint, min)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC_3BUFF(min, s, 64,  2,   int, min)
+    OP_AARCH64_FUNC_3BUFF(min, u, 64,  2,  uint, min)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC_3BUFF(min, f, 32,  4, float, min)
+    OP_AARCH64_FUNC_3BUFF(min, f, 64,  2, float, min)
+
+ /*************************************************************************
+ * Sum
+ ************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) + (b))
+    OP_AARCH64_FUNC_3BUFF(sum, s,  8, 16,  int, add)
+    OP_AARCH64_FUNC_3BUFF(sum, u,  8, 16, uint, add)
+    OP_AARCH64_FUNC_3BUFF(sum, s, 16,  8,  int, add)
+    OP_AARCH64_FUNC_3BUFF(sum, u, 16,  8, uint, add)
+    OP_AARCH64_FUNC_3BUFF(sum, s, 32,  4,  int, add)
+    OP_AARCH64_FUNC_3BUFF(sum, u, 32,  4, uint, add)
+    OP_AARCH64_FUNC_3BUFF(sum, s, 64,  2,  int, add)
+    OP_AARCH64_FUNC_3BUFF(sum, u, 64,  2, uint, add)
+
+    OP_AARCH64_FUNC_3BUFF(sum, f, 32,  4, float, add)
+    OP_AARCH64_FUNC_3BUFF(sum, f, 64,  2, float, add)
+
+/*************************************************************************
+ * Product
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) * (b))
+    OP_AARCH64_FUNC_3BUFF(prod, s,  8, 16,   int, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, u,  8, 16,  uint, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, s, 16,  8,   int, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, u, 16,  8,  uint, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, s, 32,  4,   int, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, u, 32,  4,  uint, mul)
+#if defined(GENERATE_SVE_CODE)
+    OP_AARCH64_FUNC_3BUFF(prod, s, 64,  2,   int, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, u, 64,  2,  uint, mul)
+#endif  /* defined(GENERATE_SVE_CODE) */
+
+    OP_AARCH64_FUNC_3BUFF(prod, f, 32,  4, float, mul)
+    OP_AARCH64_FUNC_3BUFF(prod, f, 64,  2, float, mul)
+
+/*************************************************************************
+ * Bitwise AND
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) & (b))
+    OP_AARCH64_FUNC_3BUFF(band, s,  8, 16,  int, and)
+    OP_AARCH64_FUNC_3BUFF(band, u,  8, 16, uint, and)
+    OP_AARCH64_FUNC_3BUFF(band, s, 16,  8,  int, and)
+    OP_AARCH64_FUNC_3BUFF(band, u, 16,  8, uint, and)
+    OP_AARCH64_FUNC_3BUFF(band, s, 32,  4,  int, and)
+    OP_AARCH64_FUNC_3BUFF(band, u, 32,  4, uint, and)
+    OP_AARCH64_FUNC_3BUFF(band, s, 64,  2,  int, and)
+    OP_AARCH64_FUNC_3BUFF(band, u, 64,  2, uint, and)
+
+ /*************************************************************************
+ * Bitwise OR
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) | (b))
+    OP_AARCH64_FUNC_3BUFF(bor, s,  8, 16,  int, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, u,  8, 16, uint, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, s, 16,  8,  int, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, u, 16,  8, uint, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, s, 32,  4,  int, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, u, 32,  4, uint, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, s, 64,  2,  int, orr)
+    OP_AARCH64_FUNC_3BUFF(bor, u, 64,  2, uint, orr)
+
+/*************************************************************************
+ * Bitwise XOR
+ *************************************************************************/
+#undef current_func
+#define current_func(a, b) ((a) ^ (b))
+    OP_AARCH64_FUNC_3BUFF(bxor, s,  8, 16,  int, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, u,  8, 16, uint, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, s, 16,  8,  int, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, u, 16,  8, uint, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, s, 32,  4,  int, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, u, 32,  4, uint, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, s, 64,  2,  int, eor)
+    OP_AARCH64_FUNC_3BUFF(bxor, u, 64,  2, uint, eor)
+
+    /** C integer ***********************************************************/
+#define C_INTEGER_BASE(name, ftype)                                         \
+    [OMPI_OP_BASE_TYPE_INT8_T]   = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_int8_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_UINT8_T]  = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_uint8_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_INT16_T]  = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_int16_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_UINT16_T] = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_uint16_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_INT32_T]  = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_int32_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_UINT32_T] = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_uint32_t, APPEND)
+#define C_INTEGER_EX(name, ftype)                                         \
+    [OMPI_OP_BASE_TYPE_INT64_T]  = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_int64_t, APPEND), \
+    [OMPI_OP_BASE_TYPE_UINT64_T] = OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_uint64_t, APPEND)
+
+    /** Floating point, including all the Fortran reals *********************/
+#define FLOAT(name, ftype)  OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_float32_t, APPEND)
+#define DOUBLE(name, ftype) OP_CONCAT(ompi_op_aarch64_##ftype##_##name##_float64_t, APPEND)
+
+#define FLOATING_POINT(name, ftype)                                    \
+    [OMPI_OP_BASE_TYPE_FLOAT] = FLOAT(name, ftype),                    \
+    [OMPI_OP_BASE_TYPE_DOUBLE] = DOUBLE(name, ftype)
+
+/*
+ * MPI_OP_NULL
+ * All types
+ */
+#define FLAGS_NO_FLOAT \
+        (OMPI_OP_FLAGS_INTRINSIC | OMPI_OP_FLAGS_ASSOC | OMPI_OP_FLAGS_COMMUTE)
+#define FLAGS \
+        (OMPI_OP_FLAGS_INTRINSIC | OMPI_OP_FLAGS_ASSOC | \
+         OMPI_OP_FLAGS_FLOAT_ASSOC | OMPI_OP_FLAGS_COMMUTE)
+
+    ompi_op_base_handler_fn_t OP_CONCAT(ompi_op_aarch64_functions, APPEND) [OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX] =
+{
+    /* Corresponds to MPI_OP_NULL */
+    [OMPI_OP_BASE_FORTRAN_NULL] = {
+        /* Leaving this empty puts in NULL for all entries */
+        NULL,
+    },
+    /* Corresponds to MPI_MAX */
+    [OMPI_OP_BASE_FORTRAN_MAX] = {
+        C_INTEGER_BASE(max, 2buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(max, 2buff),
+#endif /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(max, 2buff),
+    },
+    /* Corresponds to MPI_MIN */
+    [OMPI_OP_BASE_FORTRAN_MIN] = {
+        C_INTEGER_BASE(min, 2buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(min, 2buff),
+#endif /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(min, 2buff),
+    },
+    /* Corresponds to MPI_SUM */
+    [OMPI_OP_BASE_FORTRAN_SUM] = {
+        C_INTEGER_BASE(sum, 2buff),
+        C_INTEGER_EX(sum, 2buff),
+        FLOATING_POINT(sum, 2buff),
+    },
+    /* Corresponds to MPI_PROD */
+    [OMPI_OP_BASE_FORTRAN_PROD] = {
+        C_INTEGER_BASE(prod, 2buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(prod, 2buff),
+#endif /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(prod, 2buff),
+    },
+    /* Corresponds to MPI_LAND */
+    [OMPI_OP_BASE_FORTRAN_LAND] = {
+        NULL,
+    },
+    /* Corresponds to MPI_BAND */
+    [OMPI_OP_BASE_FORTRAN_BAND] = {
+        C_INTEGER_BASE(band, 2buff),
+        C_INTEGER_EX(band, 2buff),
+    },
+    /* Corresponds to MPI_LOR */
+    [OMPI_OP_BASE_FORTRAN_LOR] = {
+        NULL,
+    },
+    /* Corresponds to MPI_BOR */
+    [OMPI_OP_BASE_FORTRAN_BOR] = {
+        C_INTEGER_BASE(bor, 2buff),
+        C_INTEGER_EX(bor, 2buff),
+    },
+    /* Corresponds to MPI_LXOR */
+    [OMPI_OP_BASE_FORTRAN_LXOR] = {
+        NULL,
+    },
+    /* Corresponds to MPI_BXOR */
+    [OMPI_OP_BASE_FORTRAN_BXOR] = {
+        C_INTEGER_BASE(bxor, 2buff),
+        C_INTEGER_EX(bxor, 2buff),
+    },
+    /* Corresponds to MPI_REPLACE */
+    [OMPI_OP_BASE_FORTRAN_REPLACE] = {
+        /* (MPI_ACCUMULATE is handled differently than the other
+           reductions, so just zero out its function
+           implementations here to ensure that users don't invoke
+           MPI_REPLACE with any reduction operations other than
+           ACCUMULATE) */
+        NULL,
+    },
+
+};
+
+    ompi_op_base_3buff_handler_fn_t OP_CONCAT(ompi_op_aarch64_3buff_functions, APPEND)[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX] =
+{
+    /* Corresponds to MPI_OP_NULL */
+    [OMPI_OP_BASE_FORTRAN_NULL] = {
+        /* Leaving this empty puts in NULL for all entries */
+        NULL,
+    },
+    /* Corresponds to MPI_MAX */
+    [OMPI_OP_BASE_FORTRAN_MAX] = {
+        C_INTEGER_BASE(max, 3buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(max, 3buff),
+#endif  /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(max, 3buff),
+    },
+    /* Corresponds to MPI_MIN */
+    [OMPI_OP_BASE_FORTRAN_MIN] = {
+        C_INTEGER_BASE(min, 3buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(min, 3buff),
+#endif  /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(min, 3buff),
+    },
+    /* Corresponds to MPI_SUM */
+    [OMPI_OP_BASE_FORTRAN_SUM] = {
+        C_INTEGER_BASE(sum, 3buff),
+        C_INTEGER_EX(sum, 3buff),
+        FLOATING_POINT(sum, 3buff),
+    },
+    /* Corresponds to MPI_PROD */
+    [OMPI_OP_BASE_FORTRAN_PROD] = {
+        C_INTEGER_BASE(prod, 3buff),
+#if defined(GENERATE_SVE_CODE)
+        C_INTEGER_EX(prod, 3buff),
+#endif /* defined(GENERATE_SVE_CODE) */
+        FLOATING_POINT(prod, 3buff),
+    },
+    /* Corresponds to MPI_LAND */
+    [OMPI_OP_BASE_FORTRAN_LAND] ={
+        NULL,
+    },
+    /* Corresponds to MPI_BAND */
+    [OMPI_OP_BASE_FORTRAN_BAND] = {
+        C_INTEGER_BASE(band, 3buff),
+        C_INTEGER_EX(band, 3buff),
+    },
+    /* Corresponds to MPI_LOR */
+    [OMPI_OP_BASE_FORTRAN_LOR] = {
+        NULL,
+    },
+    /* Corresponds to MPI_BOR */
+    [OMPI_OP_BASE_FORTRAN_BOR] = {
+        C_INTEGER_BASE(bor, 3buff),
+        C_INTEGER_EX(bor, 3buff),
+    },
+    /* Corresponds to MPI_LXOR */
+    [OMPI_OP_BASE_FORTRAN_LXOR] = {
+        NULL,
+    },
+    /* Corresponds to MPI_BXOR */
+    [OMPI_OP_BASE_FORTRAN_BXOR] = {
+        C_INTEGER_BASE(bxor, 3buff),
+        C_INTEGER_EX(bxor, 3buff),
+    },
+    /* Corresponds to MPI_REPLACE */
+    [OMPI_OP_BASE_FORTRAN_REPLACE] = {
+        /* MPI_ACCUMULATE is handled differently than the other
+           reductions, so just zero out its function
+           implementations here to ensure that users don't invoke
+           MPI_REPLACE with any reduction operations other than
+           ACCUMULATE */
+        NULL,
+    },
+};

--- a/test/datatype/reduce_local.c
+++ b/test/datatype/reduce_local.c
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
     double *duration, tstart, tend;
     bool check = true;
     char type[5] = "uifd", *op = "sum", *mpi_type;
-    int lower = 1, upper = 1000000, skip_op_type;
+    int lower = 1, upper = 16*1024*1024, skip_op_type;
     MPI_Op mpi_op;
 
     while( -1 != (c = getopt(argc, argv, "l:u:r:t:o:i:s:n:1:2:vfh")) ) {


### PR DESCRIPTION
It provides support for NEON and SVE ISA.

Bring #12559 to the 5.x.

Signed-off-by: George Bosilca <gbosilca@nvidia.com>
(cherry picked from commit 3e02132d1aec8791da556764cb4535a9ef55e92e)