### PR TITLE
use-mpi-f08: add missing subroutines in the mpi_f08 module

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -3035,7 +3035,7 @@ subroutine ompi_query_thread_f(provided,ierror) &
 end subroutine ompi_query_thread_f
 
 subroutine ompi_status_f082f_f(f08_status,f_status,ierror) &
-   BIND(C, name="ompi_status_f2f08_f")
+   BIND(C, name="ompi_status_f082f_f")
    use :: mpi_f08_types, only : MPI_Status, MPI_STATUS_SIZE
    implicit none
    TYPE(MPI_Status), INTENT(IN) :: f08_status
@@ -3044,7 +3044,7 @@ subroutine ompi_status_f082f_f(f08_status,f_status,ierror) &
 end subroutine ompi_status_f082f_f
 
 subroutine ompi_status_f2f08_f(f_status,f08_status,ierror) &
-   BIND(C, name="ompi_status_f082f_f")
+   BIND(C, name="ompi_status_f2f08_f")
    use :: mpi_f08_types, only : MPI_Status, MPI_STATUS_SIZE
    implicit none
    INTEGER, INTENT(IN) :: f_status(MPI_STATUS_SIZE)

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
@@ -4891,3 +4891,23 @@ subroutine MPI_Neighbor_alltoallw_init_f08(sendbuf,sendcounts,sdispls,sendtypes,
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Neighbor_alltoallw_init_f08
 end interface  MPI_Neighbor_alltoallw_init
+
+interface MPI_Status_f2f08
+subroutine MPI_Status_f2f08_f08(f_status,f08_status,ierror)
+   use :: mpi_f08_types, only : MPI_Status, MPI_STATUS_SIZE
+   implicit none
+   INTEGER, INTENT(IN) :: f_status(MPI_STATUS_SIZE)
+   TYPE(MPI_Status), INTENT(OUT) :: f08_status
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Status_f2f08_f08
+end interface MPI_Status_f2f08
+
+interface MPI_Status_f082f
+subroutine MPI_Status_f082f_f08(f08_status,f_status,ierror)
+   use :: mpi_f08_types, only : MPI_Status, MPI_STATUS_SIZE
+   implicit none
+   TYPE(MPI_Status), INTENT(IN) :: f08_status
+   INTEGER, INTENT(OUT) :: f_status(MPI_STATUS_SIZE)
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Status_f082f_f08
+end interface MPI_Status_f082f

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-rename.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-rename.h
@@ -624,7 +624,9 @@
 #define MPI_Is_thread_main_f08 PMPI_Is_thread_main_f08
 #define MPI_Query_thread PMPI_Query_thread
 #define MPI_Query_thread_f08 PMPI_Query_thread_f08
+#define MPI_Status_f082f PMPI_Status_f082f
 #define MPI_Status_f082f_f08 PMPI_Status_f082f_f08
+#define MPI_Status_f2f08 PMPI_Status_f2f08
 #define MPI_Status_f2f08_f08 PMPI_Status_f2f08_f08
 #define MPI_Status_set_cancelled PMPI_Status_set_cancelled
 #define MPI_Status_set_cancelled_f08 PMPI_Status_set_cancelled_f08


### PR DESCRIPTION
 - MPI_Status_f082f
 - MPI_Status_f2f08

related to #12587

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit 83eb116f88f190c33ac6ddc67b8959fabc07d356)