### PR TITLE
Topic/cuda ipc restore

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.h
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,15 +38,28 @@ struct opal_accelerator_cuda_event_t {
 typedef struct opal_accelerator_cuda_event_t opal_accelerator_cuda_event_t;
 OBJ_CLASS_DECLARATION(opal_accelerator_cuda_event_t);
 
+struct opal_accelerator_cuda_ipc_handle_t {
+    opal_accelerator_ipc_handle_t base;
+};
+typedef struct opal_accelerator_cuda_ipc_handle_t opal_accelerator_cuda_ipc_handle_t;
+OBJ_CLASS_DECLARATION(opal_accelerator_cuda_ipc_handle_t);
+
+struct opal_accelerator_cuda_ipc_event_handle_t {
+    opal_accelerator_ipc_event_handle_t base;
+};
+typedef struct opal_accelerator_cuda_ipc_event_handle_t opal_accelerator_cuda_ipc_event_handle_t;
+OBJ_CLASS_DECLARATION(opal_accelerator_cuda_ipc_event_handle_t);
+
 /* Declare extern variables, defined in accelerator_cuda_component.c */
-OPAL_DECLSPEC extern CUstream opal_accelerator_cuda_memcpy_stream;
-OPAL_DECLSPEC extern opal_mutex_t opal_accelerator_cuda_stream_lock;
+extern CUstream opal_accelerator_cuda_memcpy_stream;
+extern opal_mutex_t opal_accelerator_cuda_stream_lock;
+extern bool mca_accelerator_cuda_init_complete;
 
 OPAL_DECLSPEC extern opal_accelerator_cuda_component_t mca_accelerator_cuda_component;
 
-OPAL_DECLSPEC extern opal_accelerator_base_module_t opal_accelerator_cuda_module;
+extern opal_accelerator_base_module_t opal_accelerator_cuda_module;
 
-OPAL_DECLSPEC extern int opal_accelerator_cuda_delayed_init(void);
+extern int opal_accelerator_cuda_delayed_init(void);
 
 END_C_DECLS
 

--- a/opal/mca/accelerator/rocm/accelerator_rocm.h
+++ b/opal/mca/accelerator/rocm/accelerator_rocm.h
@@ -41,7 +41,7 @@ typedef struct {
 } opal_accelerator_rocm_component_t;
 
 OPAL_DECLSPEC extern opal_accelerator_rocm_component_t mca_accelerator_rocm_component;
-OPAL_DECLSPEC extern opal_accelerator_base_module_t opal_accelerator_rocm_module;
+extern opal_accelerator_base_module_t opal_accelerator_rocm_module;
 
 struct opal_accelerator_rocm_stream_t {
     opal_accelerator_stream_t base;
@@ -67,12 +67,12 @@ struct opal_accelerator_rocm_ipc_event_handle_t {
 typedef struct opal_accelerator_rocm_ipc_event_handle_t opal_accelerator_rocm_ipc_event_handle_t;
 OBJ_CLASS_DECLARATION(opal_accelerator_rocm_ipc_event_handle_t);
 
-OPAL_DECLSPEC extern hipStream_t opal_accelerator_rocm_MemcpyStream;
-OPAL_DECLSPEC extern int opal_accelerator_rocm_memcpy_async;
-OPAL_DECLSPEC extern int opal_accelerator_rocm_verbose;
-OPAL_DECLSPEC extern size_t opal_accelerator_rocm_memcpyH2D_limit;
-OPAL_DECLSPEC extern size_t opal_accelerator_rocm_memcpyD2H_limit;
+extern hipStream_t opal_accelerator_rocm_MemcpyStream;
+extern int opal_accelerator_rocm_memcpy_async;
+extern int opal_accelerator_rocm_verbose;
+extern size_t opal_accelerator_rocm_memcpyH2D_limit;
+extern size_t opal_accelerator_rocm_memcpyD2H_limit;
 
-OPAL_DECLSPEC extern int opal_accelerator_rocm_lazy_init(void);
+extern int opal_accelerator_rocm_lazy_init(void);
 
 #endif

--- a/opal/mca/accelerator/rocm/accelerator_rocm_component.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_component.c
@@ -176,6 +176,7 @@ int opal_accelerator_rocm_lazy_init()
 
     err = hipStreamCreate(&opal_accelerator_rocm_MemcpyStream);
     if (hipSuccess != err) {
+	err = OPAL_ERROR;  // we got hipErrorInvalidValue, pretty bad
         opal_output(0, "Could not create hipStream, err=%d %s\n",
                 err, hipGetErrorString(err));
         goto out;


### PR DESCRIPTION
Add support for CUDA IPC. The support is similar to ROCM.

For CUDA IPC support has a drastic impact on performance, significantly faster than before but not a good as the UCX PML.

![output](https://github.com/open-mpi/ompi/assets/642701/19c5f3ec-5227-4ea5-b995-ef69292f35bf)
