### PR TITLE
autogen.pl: put in a helpful git submodule message

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1429,7 +1429,12 @@ if (-f ".gitmodules") {
         }
 
         if (!$happy) {
-            print("    ==> ERROR: Missing submodule\n\nThe submodule \"$path\" is missing.\n\n");
+                print("    ==> ERROR: Missing
+
+The submodule \"$path\" is missing.
+
+Perhaps you forgot to \"git clone --recursive ...\", or you need to
+\"git submodule update --init --recursive\"...?\n\n");
             exit(1);
         }
     }


### PR DESCRIPTION
We have two places where we check for expected git submodules.  One of them printed a helpful message describing how to fix the error, the other didn't.  This commit simply makes both places print the helpful message.