### PR TITLE
Add accelerator-awareness to most allreduce implementations

### DIFF
--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -40,6 +40,8 @@
 /* need to include our own topo prototypes so we can malloc data on the comm correctly */
 #include "coll_base_topo.h"
 
+#include "opal/mca/allocator/allocator.h"
+
 /* some fixed value index vars to simplify certain operations */
 typedef enum COLLTYPE {
     ALLGATHER = 0,       /*  0 */
@@ -516,6 +518,10 @@ struct mca_coll_base_comm_t {
 
     /* in-order binary tree (root of the in-order binary tree is rank 0) */
     ompi_coll_tree_t *cached_in_order_bintree;
+
+    /* pointer to per-device memory cache */
+    mca_allocator_base_module_t **device_allocators;
+    int num_device_allocators;
 };
 typedef struct mca_coll_base_comm_t mca_coll_base_comm_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_comm_t);

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -31,6 +31,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "coll_base_util.h"
 #include "coll_base_functions.h"
+#include "opal/mca/allocator/base/base.h"
 #include <ctype.h>
 
 int ompi_coll_base_sendrecv_actual( const void* sendbuf, size_t scount,
@@ -602,4 +603,59 @@ const char* mca_coll_base_colltype_to_str(int collid)
         return NULL;
     }
     return colltype_translation_table[collid];
+}
+
+static void* ompi_coll_base_device_allocate_cb(void *ctx, size_t *size) {
+    int dev_id = (intptr_t)ctx;
+    void *ptr = NULL;
+    opal_accelerator.mem_alloc(dev_id, &ptr, *size);
+    return ptr;
+}
+
+static void ompi_coll_base_device_release_cb(void *ctx, void* ptr) {
+    int dev_id = (intptr_t)ctx;
+    opal_accelerator.mem_release(dev_id, ptr);
+}
+
+void *ompi_coll_base_allocate_on_device(int device, size_t size,
+                                        mca_coll_base_module_t *module)
+{
+    mca_allocator_base_module_t *allocator_module;
+    if (device < 0) {
+        return malloc(size);
+    }
+
+    if (module->base_data->num_device_allocators <= device) {
+        int num_dev;
+        opal_accelerator.num_devices(&num_dev);
+        if (num_dev < device+1) num_dev = device+1;
+        module->base_data->device_allocators = realloc(module->base_data->device_allocators, num_dev * sizeof(mca_allocator_base_module_t *));
+        for (int i = module->base_data->num_device_allocators; i < num_dev; ++i) {
+            module->base_data->device_allocators[i] = NULL;
+        }
+        module->base_data->num_device_allocators = num_dev;
+    }
+    if (NULL == (allocator_module = module->base_data->device_allocators[device])) {
+        mca_allocator_base_component_t *allocator_component;
+        allocator_component = mca_allocator_component_lookup("devicebucket");
+        assert(allocator_component != NULL);
+        allocator_module = allocator_component->allocator_init(false, ompi_coll_base_device_allocate_cb,
+                                                               ompi_coll_base_device_release_cb,
+                                                               (void*)(intptr_t)device);
+        assert(allocator_module != NULL);
+        module->base_data->device_allocators[device] = allocator_module;
+    }
+    return allocator_module->alc_alloc(allocator_module, size, 0);
+}
+
+void ompi_coll_base_free_on_device(int device, void *ptr, mca_coll_base_module_t *module)
+{
+    mca_allocator_base_module_t *allocator_module;
+    if (device < 0) {
+        free(ptr);
+    } else {
+        assert(NULL != module->base_data->device_allocators);
+        allocator_module = module->base_data->device_allocators[device];
+        allocator_module->alc_free(allocator_module, ptr);
+    }
 }


### PR DESCRIPTION
This is the fifth patch based on #12318 and introduces accelerator-awareness for the most of the allreduce implementations in `coll/base`. There were changes introduced to `ompi_coll_base_allreduce_intra_allgather_reduce`, which led to conflicts. These implementations will still need to be adapted.

This PR relies on the following PRs:

- #12356 
- #12569
- #12570  
- #12610 

Adding accelerator-awareness requires allocation of temporary memory on the a device selected based on the input buffer (possibly cached by the allocator) and reintroduces the use of 3buff reductions to combine copy and operator application. This change also improves performance on CPU for larger operations. Where possible