### PR TITLE
Differentiate blocking unblocking collectives in UCC

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -34,6 +34,7 @@ static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, size_t 
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_ALLGATHER,
         .src.info = {
             .buffer   = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
@@ -31,6 +31,7 @@ static inline ucc_status_t mca_coll_ucc_allgatherv_init(const void *sbuf, int sc
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_ALLGATHERV,
         .src.info = {
             .buffer        = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -32,6 +32,7 @@ static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *r
     }
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_ALLREDUCE,
         .src.info = {
             .buffer   = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -34,6 +34,7 @@ static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, size_t s
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_ALLTOALL,
         .src.info = {
             .buffer   = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
@@ -31,6 +31,7 @@ static inline ucc_status_t mca_coll_ucc_alltoallv_init(const void *sbuf, const i
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_ALLTOALLV,
         .src.info_v = {
             .buffer        = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_barrier.c
+++ b/ompi/mca/coll/ucc/coll_ucc_barrier.c
@@ -14,6 +14,7 @@ static inline ucc_status_t mca_coll_ucc_barrier_init(mca_coll_ucc_module_t *ucc_
 {
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_BARRIER
     };
     COLL_UCC_REQ_INIT(coll_req, req, coll, ucc_module);

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -21,6 +21,7 @@ static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, size_t count, stru
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_BCAST,
         .root = root,
         .src.info = {

--- a/ompi/mca/coll/ucc/coll_ucc_common.h
+++ b/ompi/mca/coll/ucc/coll_ucc_common.h
@@ -47,6 +47,9 @@
             _coll.mask   |= UCC_COLL_ARGS_FIELD_CB;                     \
             _coll.cb.cb   = mca_coll_ucc_completion;                    \
             _coll.cb.data = (void*)_coll_req;                           \
+        } else {                                                        \
+            _coll.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;                   \
+            _coll.flags |= UCC_COLL_ARGS_HINT_OPTIMIZE_LATENCY;         \
         }                                                               \
         COLL_UCC_CHECK(ucc_collective_init(&_coll, _req,                \
                                            _module->ucc_team));         \

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -47,6 +47,7 @@ ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, size_t scount, struct om
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_GATHER,
         .root      = root,
         .src.info = {

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -19,7 +19,6 @@ static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, int scoun
 {
     ucc_datatype_t ucc_sdt, ucc_rdt;
     int comm_rank = ompi_comm_rank(ucc_module->comm);
-    int comm_size = ompi_comm_size(ucc_module->comm);
 
     ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
     if (comm_rank == root) {
@@ -41,6 +40,7 @@ static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, int scoun
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_GATHERV,
         .root      = root,
         .src.info = {

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -93,7 +93,7 @@ static void mca_coll_ucc_module_construct(mca_coll_ucc_module_t *ucc_module)
     mca_coll_ucc_module_clear(ucc_module);
 }
 
-int mca_coll_ucc_progress(void)
+static int mca_coll_ucc_progress(void)
 {
     ucc_context_progress(mca_coll_ucc_component.ucc_context);
     return OPAL_SUCCESS;

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -31,7 +31,8 @@ static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf
         goto fallback;
     }
     ucc_coll_args_t coll = {
-        .mask = 0,
+        .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_REDUCE,
         .root = root,
         .src.info = {

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
@@ -48,6 +48,7 @@ ucc_status_t mca_coll_ucc_reduce_scatter_init(const void *sbuf, void *rbuf, cons
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_REDUCE_SCATTERV,
         .src.info = {
             .buffer   = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -42,6 +42,7 @@ ucc_status_t mca_coll_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf
     }
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_REDUCE_SCATTER,
         .src.info = {
             .buffer   = (void*)sbuf,

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -42,6 +42,7 @@ ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, size_t scount,
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_SCATTER,
         .root      = root,
         .src.info  = {

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -43,6 +43,7 @@ ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const int *scounts,
 
     ucc_coll_args_t coll = {
         .mask      = 0,
+        .flags     = 0,
         .coll_type = UCC_COLL_TYPE_SCATTERV,
         .root      = root,
         .src.info_v = {


### PR DESCRIPTION
Provide a hint to UCC collective init to know it is dealing with a blocking collective.