### PR TITLE
dist/buildrpm: fix incorrect test, which passed even with an empty path

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -253,7 +253,7 @@ echo "--> Found specfile: $specfile"
 #
 # try to find Libfabric lib subir
 #
-if test -n $libfabric_path; then
+if test -n "$libfabric_path"; then
     # does lib64 exist?
     if test -d $libfabric_path/lib64; then
         # yes, so I will use lib64 as include dir


### PR DESCRIPTION
Stumbled on this by accident - turns out this condition is true and proceeds the `then` clause even if the `libfabric_path` was never set and remained empty. Adding the quotes fixes this, so that only non-empty string (set by passing `-f` to `buildrpm.sh`) would trigger the rest of libfabric detection logic (as probably intended originally).

As the code runs today - every build adds these (libfabric-specific?) flags to the configure phase of the build -  for no apparent reason: `LDFLAGS=-Wl,--build-id -Wl,-rpath -Wl,/lib64 -Wl,--enable-new-dtags`