### PR TITLE
Parameterize and move Fortran MPI bindings modulefiles install location

### DIFF
--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -166,6 +166,15 @@ case "x$enable_mpi_fortran" in
         ;;
 esac
 
+AC_MSG_CHECKING([where to install Fortran MPI modules])
+AC_ARG_WITH([mpi-moduledir],
+    [AS_HELP_STRING([--with-mpi-moduledir],
+                    [specify where to install Fortran MPI modules (default: $libdir)])],
+    [OMPI_FORTRAN_MODULEDIR=$withval],
+    [OMPI_FORTRAN_MODULEDIR=$libdir])
+AC_SUBST(OMPI_FORTRAN_MODULEDIR)
+AC_MSG_RESULT([$OMPI_FORTRAN_MODULEDIR])
+
 # Remove these when we finally kill them once and for all
 AC_ARG_ENABLE([mpi1-compatibility],
     [AS_HELP_STRING([--enable-mpi1-compatibility],

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -541,7 +541,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OMPI_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}"'${libdir}'
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OMPI_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OMPI_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_FCFLAGS])
@@ -780,7 +780,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OSHMEM_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}"'${libdir}'
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OSHMEM_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OSHMEM_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OSHMEM_WRAPPER_EXTRA_FCFLAGS])

--- a/docs/installing-open-mpi/configure-cli-options/mpi.rst
+++ b/docs/installing-open-mpi/configure-cli-options/mpi.rst
@@ -60,6 +60,11 @@ MPI API behaviors that can be used with ``configure``:
     ``--disable-mpi-fortran``).  This is mutually exclusive
     with building the OpenSHMEM Fortran interface.
 
+* ``--with-mpi-moduledir=DIR``:
+  Specify a specific ``DIR`` directory where to install the MPI
+  Fortran bindings modulefiles.  By default, Open MPI will install
+  Fortran modulefiles into ``$libdir``.
+
 * ``--enable-mpi-ext[=LIST]``:
   Enable Open MPI's non-portable API extensions.  ``LIST`` is a
   comma-delmited list of extensions.  If no ``LIST`` is specified, all

--- a/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
@@ -73,14 +73,14 @@ CLEANFILES += *.i90
 #
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 else

--- a/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
@@ -71,14 +71,14 @@ CLEANFILES += *.i90
 #
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 else

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -566,14 +566,14 @@ mpi-f08.lo: $(module_sentinel_files) $(SIZEOF_H)
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -102,14 +102,14 @@ pmpi-f08-interfaces.lo: mpi-f08-rename.h
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -136,14 +136,14 @@ CLEANFILES += *.i90
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -168,14 +168,14 @@ DISTCLEANFILES = $(nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES)
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 # if OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS

--- a/ompi/mpi/fortran/use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi/Makefile.am
@@ -55,13 +55,13 @@ mpi-types.lo: mpi-types.F90
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 endif


### PR DESCRIPTION
See individual commit messages for details.

This PR is split into 2 commits so that we can cherry-pick one of them to the v5.0.x branch and still leave the default install location as `$libdir`.

Refs #12600

FYI @minrk