### PR TITLE
Bump workflow actions to node20 [v5.0.x]

### DIFF
--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -18,7 +18,7 @@ jobs:
         sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt update
         sudo apt install -y cuda-toolkit
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -21,7 +21,7 @@ jobs:
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
         sudo apt update
         sudo apt install -y rocm-hip-runtime
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -7,11 +7,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Checkout CI scripts
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Mellanox/jenkins_scripts
         path: ompi_ci


### PR DESCRIPTION
Workflows should transition to node20 actions by Spring 2024.

See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Backport of https://github.com/open-mpi/ompi/pull/12651 to v5.0.x

Signed-off-by: Joseph Schuchart <joseph.schuchart@stonybrook.edu>
(cherry picked from commit a72921e79271867615b010e951b367ba6f37690e)