### PR TITLE
v5.0.x: configure: Add --with-mpi-moduledir configure CLI option

### DIFF
--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -166,6 +166,15 @@ case "x$enable_mpi_fortran" in
         ;;
 esac
 
+AC_MSG_CHECKING([where to install Fortran MPI modules])
+AC_ARG_WITH([mpi-moduledir],
+    [AS_HELP_STRING([--with-mpi-moduledir],
+                    [specify where to install Fortran MPI modules (default: $libdir)])],
+    [OMPI_FORTRAN_MODULEDIR=$withval],
+    [OMPI_FORTRAN_MODULEDIR=$libdir])
+AC_SUBST(OMPI_FORTRAN_MODULEDIR)
+AC_MSG_RESULT([$OMPI_FORTRAN_MODULEDIR])
+
 # Remove these when we finally kill them once and for all
 AC_ARG_ENABLE([mpi1-compatibility],
     [AS_HELP_STRING([--enable-mpi1-compatibility],

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -541,7 +541,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OMPI_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}"'${libdir}'
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OMPI_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OMPI_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_FCFLAGS])
@@ -780,7 +780,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OSHMEM_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}"'${libdir}'
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OSHMEM_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OSHMEM_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OSHMEM_WRAPPER_EXTRA_FCFLAGS])

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -541,7 +541,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OMPI_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OMPI_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OMPI_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_FCFLAGS])
@@ -780,7 +780,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        OSHMEM_WRAPPER_FCFLAGS='-I${includedir}'" ${wrapper_extra_fcflags} ${with_wrapper_fcflags}"
        AS_IF([test -n "${OMPI_FC_MODULE_FLAG}"],
              [dnl deal with some interesting expansion behavior in OPAL_APPEND
-              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG} ${OMPI_FORTRAN_MODULEDIR}"
+              wrapper_tmp_arg="${OMPI_FC_MODULE_FLAG}${OMPI_FORTRAN_MODULEDIR}"
               OPAL_APPEND([OSHMEM_WRAPPER_FCFLAGS], [${wrapper_tmp_arg}])])
        AC_SUBST([OSHMEM_WRAPPER_FCFLAGS])
        AC_MSG_RESULT([$OSHMEM_WRAPPER_EXTRA_FCFLAGS])

--- a/docs/installing-open-mpi/configure-cli-options/misc.rst
+++ b/docs/installing-open-mpi/configure-cli-options/misc.rst
@@ -63,3 +63,35 @@ above categories that can be used with ``configure``:
   See the section on :ref:`customizing wrapper compiler behavior
   <label-customizing-wrapper-compiler>` to see how to alter the
   wrapper compiler behavior at run time.
+
+* ``--with-mpi-moduledir``: Specify the directory where the Fortran
+  MPI module files are installed.
+
+  For historical reasons, Open MPI's Fortran MPI modulefiles are
+  installed into ``$libdir`` by default.  This option lets you change
+  where they are installed; some users prefer Fortran module files
+  installed into ``$installdir``, for example.
+
+  .. note:: If you intend to make your Open MPI installation
+            relocatable :ref:`via the OPAL_PREFIX mechanism
+            <install-location-opal-prefix>`, you will want to ensure
+            to specify the module directory relative to the
+            ``prefix``.  For example:
+
+            .. code-block::
+
+               $ ./configure --prefix=/opt/openmpi --with-mpi-moduledir='${includedir}/modules`...
+
+            Note the additional shell quoting that is likely necessary
+            to prevent shell variable expansion, and the additional
+            ``${}`` around ``includedir`` that is necessary for Open MPI
+            to recognize that it is a special name that needs to be
+            expanded.
+
+            Finally, note that the Fortran module installation
+            directory is *not* one of the :ref:`recognized directories
+            that can be specified via environment variable at run time
+            <install-location-overriding-individual-directories>`.
+            Instead, to make the Fortran module directory relocatable,
+            it needs to be relative to one of the other recognized
+            directories.

--- a/docs/installing-open-mpi/configure-cli-options/mpi.rst
+++ b/docs/installing-open-mpi/configure-cli-options/mpi.rst
@@ -60,6 +60,11 @@ MPI API behaviors that can be used with ``configure``:
     ``--disable-mpi-fortran``).  This is mutually exclusive
     with building the OpenSHMEM Fortran interface.
 
+* ``--with-mpi-moduledir=DIR``:
+  Specify a specific ``DIR`` directory where to install the MPI
+  Fortran bindings modulefiles.  By default, Open MPI will install
+  Fortran modulefiles into ``$libdir``.
+
 * ``--enable-mpi-ext[=LIST]``:
   Enable Open MPI's non-portable API extensions.  ``LIST`` is a
   comma-delmited list of extensions.  If no ``LIST`` is specified, all

--- a/docs/installing-open-mpi/installation-location.rst
+++ b/docs/installing-open-mpi/installation-location.rst
@@ -162,6 +162,8 @@ variables to the new location where Open MPI now resides).
 
 There are three methods.
 
+.. _install-location-opal-prefix:
+
 Move an existing Open MPI installation to a new prefix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -170,6 +172,41 @@ MPI.  For example, if Open MPI had initially been installed to
 ``/opt/openmpi`` and the entire ``openmpi`` tree was later moved to
 ``/home/openmpi``, setting ``OPAL_PREFIX`` to ``/home/openmpi`` will
 enable Open MPI to function properly.
+
+.. note:: The ``OPAL_PREFIX`` mechanism relies on all installation
+          directories being specified as relative to the ``prefix``
+          directory specified during ``configure``.
+
+          For example, if Open MPI is configured the following way:
+
+          .. code-block::
+
+             $ ./configure --prefix=/opt/openmpi --libdir=/usr/lib ...
+
+          Then setting ``OPAL_PREFIX`` will not affect the run-time
+          implications of ``libdir``, since ``/usr/lib`` is not
+          specified as relative to ``/opt/openmpi``.
+
+          Instead of specifying absolute directories, you can make
+          them relative to other ``configure``-recognized directories.
+          For example:
+
+          .. code-block::
+
+             $ ./configure --prefix=/opt/openmpi --libdir='${exec_prefix}/x86_64/lib' ...
+
+          Note the additional shell quoting that is likely necessary
+          to prevent shell variable expansion, and the additional
+          ``${}`` around ``exec_prefix`` that is necessary for Open MPI
+          to recognize that it is a special name that needs to be
+          expanded.
+
+          The directory names recognized by Open MPI are listed in the
+          :ref:`Overriding individual directories
+          <install-location-overriding-individual-directories>`
+          section (below), without the ``OPAL_`` prefix, and in lower
+          case.  For example, the ``OPAL_SYSCONFDIR`` environment
+          variable corresponds to ``${sysconfdir}``.
 
 "Stage" an Open MPI installation in a temporary location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,6 +225,8 @@ MPI while it is installed in this staging area, the ``OPAL_DESTDIR``
 environment variable can be used; setting ``OPAL_DESTDIR`` to
 ``/var/rpm/build.1234`` will automatically prefix every directory such
 that Open MPI can function properly.
+
+.. _install-location-overriding-individual-directories:
 
 Overriding individual directories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
@@ -73,14 +73,14 @@ CLEANFILES += *.i90
 #
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 else

--- a/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
@@ -71,14 +71,14 @@ CLEANFILES += *.i90
 #
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 else

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -566,14 +566,14 @@ mpi-f08.lo: $(module_sentinel_files) $(SIZEOF_H)
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -102,14 +102,14 @@ pmpi-f08-interfaces.lo: mpi-f08-rename.h
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -136,14 +136,14 @@ CLEANFILES += *.i90
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 endif

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -168,14 +168,14 @@ DISTCLEANFILES = $(nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES)
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 
 # if OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS

--- a/ompi/mpi/fortran/use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi/Makefile.am
@@ -55,13 +55,13 @@ mpi-types.lo: mpi-types.F90
 
 install-exec-hook:
 	@ for file in `ls *.mod`; do \
-	  echo $(INSTALL) $$file $(DESTDIR)$(libdir); \
-	  $(INSTALL) $$file $(DESTDIR)$(libdir); \
+	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
+	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	done
 
 uninstall-local:
 	@ for file in `ls *.mod`; do \
-	  echo rm -f $(DESTDIR)$(libdir)/$$file; \
-	  rm -f $(DESTDIR)$(libdir)/$$file; \
+	  echo rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
+	  rm -f $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)/$$file; \
 	done
 endif


### PR DESCRIPTION
Parameterize the install location of Fortran MPI bindings modulefiles via the configure --with-mpi-moduledir CLI option (default to $libdir, per all prior versions of Open MPI).

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 73385943a72413b29b8cd71ee7774fad2a98eb6a)

This is the v5.0.x PR corresponding to main PRs #12649 and https://github.com/open-mpi/ompi/pull/12667.

Fixes https://github.com/open-mpi/ompi/issues/12600

FYI @minrk @dalcinl @jeffhammond 