### PR TITLE
Require C11

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -170,7 +170,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_REQUIRE([_OPAL_PROG_CC])
     AC_REQUIRE([AM_PROG_CC_C_O])
 
-    OPAL_VAR_SCOPE_PUSH([opal_prog_cc_c11_helper__Thread_local_available opal_prog_cc_c11_helper_atomic_var_available opal_prog_cc_c11_helper__Atomic_available opal_prog_cc_c11_helper__static_assert_available opal_prog_cc_c11_helper__Generic_available opal_prog_cc__thread_available opal_prog_cc_c11_helper_atomic_fetch_xor_explicit_available opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics])
+    OPAL_VAR_SCOPE_PUSH([opal_prog_cc_c11_helper__Thread_local_available opal_prog_cc_c11_helper_atomic_var_available opal_prog_cc_c11_helper__Atomic_available opal_prog_cc_c11_helper__static_assert_available opal_prog_cc_c11_helper__Generic_available opal_prog_cc_c11_helper_atomic_fetch_xor_explicit_available opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics])
 
     OPAL_PROG_CC_C11
 
@@ -179,32 +179,10 @@ AC_DEFUN([OPAL_SETUP_CC],[
     OPAL_C_COMPILER_VENDOR([opal_c_vendor])
 
     if test $opal_cv_c11_supported = no ; then
-        # It is not currently an error if C11 support is not available. Uncomment the
-        # following lines and update the warning when we require a C11 compiler.
-        # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
-        # AC_MSG_ERROR([Aborting.])
-        # From Open MPI 1.7 on we require a C99 compliant compiler
-        dnl with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
-        m4_version_prereq([2.70],
-            [],
-            [AC_PROG_CC_C99])
-        # The result of AC_PROG_CC_C99 is stored in ac_cv_prog_cc_c99
-        if test "x$ac_cv_prog_cc_c99" = xno ; then
-            AC_MSG_WARN([Open MPI requires a C99 (or newer) compiler. C11 is recommended.])
-            AC_MSG_ERROR([Aborting.])
-        fi
-
-        # Get the correct result for C11 support flags now that the compiler flags have
-        # changed
-        OPAL_PROG_CC_C11_HELPER([], [], [])
+        # C11 is required
+        AC_MSG_WARN([Open MPI requires a C11 (or newer) compiler. C11 is required.])
+        AC_MSG_ERROR([Aborting.])
     fi
-
-    # Check if compiler support __thread
-    OPAL_CC_HELPER([if $CC $1 supports __thread], [opal_prog_cc__thread_available],
-               [],[[static __thread int  foo = 1;++foo;]])
-
-    OPAL_CC_HELPER([if $CC $1 supports C11 _Thread_local], [opal_prog_cc_c11_helper__Thread_local_available],
-                   [],[[static _Thread_local int  foo = 1;++foo;]])
 
     dnl At this time Open MPI only needs thread local and the atomic convenience types for C11 support. These
     dnl will likely be required in the future.
@@ -222,9 +200,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
 
     AC_DEFINE_UNQUOTED([OPAL_C_HAVE__STATIC_ASSERT], [$opal_prog_cc_c11_helper__static_assert_available],
                        [Whether C compiler support _Static_assert keyword])
-
-    AC_DEFINE_UNQUOTED([OPAL_C_HAVE___THREAD], [$opal_prog_cc__thread_available],
-                       [Whether C compiler supports __thread])
 
     # Check for standard headers, needed here because needed before
     # the types checks.  This is only necessary for Autoconf < v2.70.

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -5,7 +5,7 @@ Compilers
 ---------
 
 Although it should probably be assumed, you'll need a C compiler that
-supports C99.
+supports C11.
 
 You'll also need a Fortran compiler if you want to build the Fortran
 MPI bindings (the more recent the Fortran compiler, the better), and a

--- a/docs/developers/source-code.rst
+++ b/docs/developers/source-code.rst
@@ -47,7 +47,7 @@ C / C++
      if (whatever)
         return OMPI_SUCCESS;
 
-* Starting with Open MPI 1.7, Open MPI requires a C99-compliant
+* Starting with Open MPI 6.0, Open MPI requires a C11-compliant
   compiler.
 
   * C++-style comments are now allowed (and preferred).

--- a/docs/release-notes/changelog/index.rst
+++ b/docs/release-notes/changelog/index.rst
@@ -8,6 +8,7 @@ since v1.0.0.
 .. toctree::
    :maxdepth: 1
 
+   v6.0.x
    v5.0.x
    v4.1.x
    v4.0.x

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -1,0 +1,11 @@
+Open MPI v6.0.x series
+======================
+
+This file contains all the NEWS updates for the Open MPI v6.0.x
+series, in reverse chronological order.
+
+Open MPI version v6.0.0
+--------------------------
+:Date: ...fill me in...
+
+- Open MPI now requires a C11-compliant compiler to build.

--- a/docs/release-notes/compilers.rst
+++ b/docs/release-notes/compilers.rst
@@ -3,7 +3,7 @@
 Compiler Notes
 ==============
 
-* Open MPI requires a C99-capable compiler to build.
+* Open MPI requires a C11-capable compiler to build.
 
 * On platforms other than x86-64, AArc64 (64-bit ARM), and PPC, Open
   MPI requires a compiler that either supports C11 atomics or the GCC

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_wait.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_wait.c
@@ -20,7 +20,7 @@ static int vprotocol_pessimist_request_no_free(ompi_request_t **req) {
 }
 
 #define PREPARE_REQUESTS_WITH_NO_FREE(count, requests) do { \
-    for (typeof(count) i = 0; i < count; i++)     \
+    for (size_t i = 0; i < count; i++)     \
     { \
         if(requests[i] == MPI_REQUEST_NULL) continue; \
         requests[i]->req_free = vprotocol_pessimist_request_no_free; \

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -224,7 +224,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic(opal_fifo_t *fifo)
         if (++attempt == 5) {
             /* deliberately suspend this thread to allow other threads to run. this should
              * only occur during periods of contention on the lifo. */
-            _opal_lifo_release_cpu();
+            opal_lifo_release_cpu();
             attempt = 0;
         }
 

--- a/opal/class/opal_lifo.c
+++ b/opal/class/opal_lifo.c
@@ -19,7 +19,11 @@
  * $HEADER$
  */
 
+/* needed for nanosleep() */
+#define _POSIX_C_SOURCE 200809L
+
 #include "opal_config.h"
+#include <time.h>
 #include "opal/class/opal_lifo.h"
 
 static void opal_lifo_construct(opal_lifo_t *lifo)
@@ -31,3 +35,16 @@ static void opal_lifo_construct(opal_lifo_t *lifo)
 }
 
 OBJ_CLASS_INSTANCE(opal_lifo_t, opal_object_t, opal_lifo_construct, NULL);
+
+
+void opal_lifo_release_cpu(void)
+{
+    /* NTH: there are many ways to cause the current thread to be suspended. This one
+     * should work well in most cases. Another approach would be to use poll (NULL, 0, ) but
+     * the interval will be forced to be in ms (instead of ns or us). Note that there
+     * is a performance improvement for the lifo test when this call is made on detection
+     * of contention but it may not translate into actually MPI or application performance
+     * improvements. */
+    static struct timespec interval = {.tv_sec = 0, .tv_nsec = 100};
+    nanosleep(&interval, NULL);
+}

--- a/opal/mca/threads/pthreads/threads_pthreads_module.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_module.c
@@ -23,7 +23,11 @@
  * $HEADER$
  */
 
+/* needed for pthread_mutexattr_settype */
+#define _GNU_SOURCE
+
 #include <unistd.h>
+#include <pthread.h>
 
 #include "opal/constants.h"
 #include "opal/mca/threads/threads.h"
@@ -37,4 +41,40 @@ int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
     int rc;
     rc = pthread_key_create(key, destructor);
     return 0 == rc ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
+}
+
+
+int opal_thread_internal_mutex_init_recursive(opal_thread_internal_mutex_t *p_mutex)
+{
+    int ret;
+#if OPAL_ENABLE_DEBUG
+    pthread_mutexattr_t mutex_attr;
+    ret = pthread_mutexattr_init(&mutex_attr);
+    if (0 != ret)
+        return OPAL_ERR_IN_ERRNO;
+    ret = pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+    if (0 != ret) {
+        ret = pthread_mutexattr_destroy(&mutex_attr);
+        assert(0 == ret);
+        return OPAL_ERR_IN_ERRNO;
+    }
+    ret = pthread_mutex_init(p_mutex, &mutex_attr);
+    if (0 != ret) {
+        ret = pthread_mutexattr_destroy(&mutex_attr);
+        assert(0 == ret);
+        return OPAL_ERR_IN_ERRNO;
+    }
+    ret = pthread_mutexattr_destroy(&mutex_attr);
+    assert(0 == ret);
+#else
+    pthread_mutexattr_t mutex_attr;
+    ret = pthread_mutexattr_init(&mutex_attr);
+    if (0 != ret) {
+        return OPAL_ERR_IN_ERRNO;
+    }
+    pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+    ret = pthread_mutex_init(p_mutex, &mutex_attr);
+    pthread_mutexattr_destroy(&mutex_attr);
+#endif
+    return 0 == ret ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
 }

--- a/opal/mca/threads/pthreads/threads_pthreads_mutex.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_mutex.h
@@ -61,48 +61,19 @@ typedef pthread_mutex_t opal_thread_internal_mutex_t;
 #    define OPAL_THREAD_INTERNAL_RECURSIVE_MUTEX_INITIALIZER PTHREAD_RECURSIVE_MUTEX_INITIALIZER
 #endif
 
+
+int opal_thread_internal_mutex_init_recursive(opal_thread_internal_mutex_t *p_mutex);
+
 static inline int opal_thread_internal_mutex_init(opal_thread_internal_mutex_t *p_mutex,
                                                   bool recursive)
 {
     int ret;
-#if OPAL_ENABLE_DEBUG
     if (recursive) {
-        pthread_mutexattr_t mutex_attr;
-        ret = pthread_mutexattr_init(&mutex_attr);
-        if (0 != ret)
-            return OPAL_ERR_IN_ERRNO;
-        ret = pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
-        if (0 != ret) {
-            ret = pthread_mutexattr_destroy(&mutex_attr);
-            assert(0 == ret);
-            return OPAL_ERR_IN_ERRNO;
-        }
-        ret = pthread_mutex_init(p_mutex, &mutex_attr);
-        if (0 != ret) {
-            ret = pthread_mutexattr_destroy(&mutex_attr);
-            assert(0 == ret);
-            return OPAL_ERR_IN_ERRNO;
-        }
-        ret = pthread_mutexattr_destroy(&mutex_attr);
-        assert(0 == ret);
+        return opal_thread_internal_mutex_init_recursive(p_mutex);
     } else {
         ret = pthread_mutex_init(p_mutex, NULL);
+        return 0 == ret ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
     }
-#else
-    if (recursive) {
-        pthread_mutexattr_t mutex_attr;
-        ret = pthread_mutexattr_init(&mutex_attr);
-        if (0 != ret) {
-            return OPAL_ERR_IN_ERRNO;
-        }
-        pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
-        ret = pthread_mutex_init(p_mutex, &mutex_attr);
-        pthread_mutexattr_destroy(&mutex_attr);
-    } else {
-        ret = pthread_mutex_init(p_mutex, NULL);
-    }
-#endif
-    return 0 == ret ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
 }
 
 static inline void opal_thread_internal_mutex_lock(opal_thread_internal_mutex_t *p_mutex)

--- a/opal/mca/threads/pthreads/threads_pthreads_yield.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_yield.c
@@ -10,6 +10,9 @@
  * $HEADER$
  */
 
+/* needed for nanosleep() */
+#define _POSIX_C_SOURCE 200809L
+
 #include "opal_config.h"
 #include <time.h>
 #ifdef HAVE_SCHED_H

--- a/opal/mca/threads/thread_usage.h
+++ b/opal/mca/threads/thread_usage.h
@@ -250,17 +250,7 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 #    define OPAL_ATOMIC_SWAP_64 opal_thread_swap_64
 
 /* thread local storage */
-#if OPAL_C_HAVE__THREAD_LOCAL
 #    define opal_thread_local      _Thread_local
 #    define OPAL_HAVE_THREAD_LOCAL 1
-
-#elif OPAL_C_HAVE___THREAD /* OPAL_C_HAVE__THREAD_LOCAL */
-#    define opal_thread_local      __thread
-#    define OPAL_HAVE_THREAD_LOCAL 1
-#endif /* OPAL_C_HAVE___THREAD */
-
-#if !defined(OPAL_HAVE_THREAD_LOCAL)
-#    define OPAL_HAVE_THREAD_LOCAL 0
-#endif /* !defined(OPAL_HAVE_THREAD_LOCAL) */
 
 #endif /* OPAL_MCA_THREADS_THREAD_USAGE_H */

--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -138,6 +138,12 @@ libopalutil_core_la_DEPENDENCIES = \
         json/libopalutil_json.la \
         keyval/libopalutilkeyval.la
 
+# flex prior to version 2.6.6 uses the POSIX extension fileno()
+# without providing the proper feature test macro, so
+# we add the _POSIX_C_SOURCE macro here.
+# See https://github.com/westes/flex/issues/263
+libopalutil_core_la_CFLAGS = -D_POSIX_C_SOURCE=200809L
+
 # Conditionally install the header files
 
 if WANT_INSTALL_HEADERS

--- a/opal/util/keyval/Makefile.am
+++ b/opal/util/keyval/Makefile.am
@@ -30,5 +30,11 @@ libopalutilkeyval_la_SOURCES = \
 	keyval_lex.h \
         keyval_lex.l
 
+# flex prior to version 2.6.6 uses the POSIX extension fileno()
+# without providing the proper feature test macro, so
+# we add the _POSIX_C_SOURCE macro here.
+# See https://github.com/westes/flex/issues/263
+libopalutilkeyval_la_CFLAGS = -D_POSIX_C_SOURCE=200809L
+
 maintainer-clean-local:
 	rm -f keyval_lex.c

--- a/test/datatype/reduce_local.c
+++ b/test/datatype/reduce_local.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2024      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,6 +13,14 @@
  * $HEADER$
  */
 
+/* needed for strsep() */
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+
+/* needed for posix_memalign() and getopt() */
+#define _POSIX_C_SOURCE 200809L
+
+#include "ompi_config.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -50,19 +59,9 @@ static int do_ops[12] = {
 static int verbose = 0;
 static int total_errors = 0;
 
-#define max(a, b)               \
-    ({                          \
-        __typeof__(a) _a = (a); \
-        __typeof__(b) _b = (b); \
-        _a > _b ? _a : _b;      \
-    })
+#define max(a, b) (a) > (b) ? (a) : (b)
 
-#define min(a, b)               \
-    ({                          \
-        __typeof__(a) _a = (a); \
-        __typeof__(b) _b = (b); \
-        _a < _b ? _a : _b;      \
-    })
+#define min(a, b) (a) < (b) ? (a) : (b)
 
 static void print_status(char *op, char *type, int type_size, int count, int max_shift,
                          double *duration, int repeats, int correct)


### PR DESCRIPTION
Error out if the compiler does not support C11 and limit the standard to C11 if the compiler accepts a standard flag. This limit prevents us from using features of newer standard versions.

Also removes support for `__thread` since we now rely on C11 `_Thread_local`.

Please check my m4 code, not an expert on this.

See https://github.com/open-mpi/ompi/pull/12658#pullrequestreview-2164230547 for notes from the RM discussion and the PR that initiated this.

There will likely be more changes over time replacing pre-C11 features with C11 features where possible but I wanted to keep this manageable. 

@jsquyres where should I put a note about this for users?