### PR TITLE
v5.0x: OSHMEM/SHMEM: fix warnings regarding types and unused variables in shmem

### DIFF
--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -597,12 +597,11 @@ typedef int (*mca_spml_base_module_test_all_vector_fn_t)(void *ivars,
  *
  *  @return             OSHMEM_SUCCESS or failure status.
  */
-typedef int (*mca_spml_base_module_test_any_vector_fn_t)(void *ivars,
-                                                    int cmp,
-                                                    void *cmp_values,
-                                                    size_t nelems,
-                                                    const int *status,
-                                                    int datatype);
+typedef size_t (*mca_spml_base_module_test_any_vector_fn_t)(void *ivars, int cmp,
+                                                            void *cmp_values,
+                                                            size_t nelems,
+                                                            const int *status,
+                                                            int datatype);
 
 /*
  *  Indicate whether at least one variable within an array of variables on the local PE meets
@@ -624,13 +623,13 @@ typedef int (*mca_spml_base_module_test_any_vector_fn_t)(void *ivars,
  *
  *  @return             OSHMEM_SUCCESS or failure status.
  */
-typedef int (*mca_spml_base_module_test_some_vector_fn_t)(void *ivars,
-                                                    int cmp,
-                                                    void *cmp_values,
-                                                    size_t nelems,
-                                                    size_t *indices,
-                                                    const int *status,
-                                                    int datatype);
+typedef size_t (*mca_spml_base_module_test_some_vector_fn_t)(void *ivars,
+                                                             int cmp,
+                                                             void *cmp_values,
+                                                             size_t nelems,
+                                                             size_t *indices,
+                                                             const int *status,
+                                                             int datatype);
 
 /*
  *  Registers the arrival of a PE at a synchronization point.

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -1663,14 +1663,14 @@ int mca_spml_ucx_put_signal_nb(shmem_ctx_t ctx, void* dst_addr, size_t size,
 void mca_spml_ucx_wait_until_all(void *ivars, int cmp, void
         *cmp_value, size_t nelems, const int *status, int datatype)
 {
-    return ;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT();
 }
 
 /* This routine is not implemented */
 size_t mca_spml_ucx_wait_until_any(void *ivars, int cmp, void
         *cmp_value, size_t nelems, const int *status, int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
@@ -1678,21 +1678,21 @@ size_t mca_spml_ucx_wait_until_some(void *ivars, int cmp, void
         *cmp_value, size_t nelems, size_t *indices, const int *status, int
         datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */ 
 void mca_spml_ucx_wait_until_all_vector(void *ivars, int cmp, void
         *cmp_values, size_t nelems, const int *status, int datatype)
 {
-    return ;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT();
 }
 
 /* This routine is not implemented */
 size_t mca_spml_ucx_wait_until_any_vector(void *ivars, int cmp, void
         *cmp_value, size_t nelems, const int *status, int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
@@ -1700,7 +1700,7 @@ size_t mca_spml_ucx_wait_until_some_vector(void *ivars, int cmp, void
         *cmp_value, size_t nelems, size_t *indices, const int *status, int
         datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
@@ -1714,36 +1714,39 @@ int mca_spml_ucx_test_all(void *ivars, int cmp, void *cmp_value,
 size_t mca_spml_ucx_test_any(void *ivars, int cmp, void *cmp_value,
         size_t nelems, const int *status, int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
 size_t mca_spml_ucx_test_some(void *ivars, int cmp, void *cmp_value,
         size_t nelems, size_t *indices, const int *status, int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
-int mca_spml_ucx_test_all_vector(void *ivars, int cmp, void
-        *cmp_values, size_t nelems, const int *status, int datatype)
+int mca_spml_ucx_test_all_vector(void *ivars, int cmp, void *cmp_values,
+                                 size_t nelems, const int *status,
+                                 int datatype)
 {
     return OSHMEM_ERR_NOT_IMPLEMENTED;
 }
 
 /* This routine is not implemented */
-int mca_spml_ucx_test_any_vector(void *ivars, int cmp, void
-        *cmp_values, size_t nelems, const int *status, int datatype)
+size_t mca_spml_ucx_test_any_vector(void *ivars, int cmp,
+                                    void *cmp_values, size_t nelems,
+                                    const int *status, int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
-int mca_spml_ucx_test_some_vector(void *ivars, int cmp, void
-        *cmp_values, size_t nelems, size_t *indices, const int *status, int
-        datatype)
+size_t mca_spml_ucx_test_some_vector(void *ivars, int cmp,
+                                     void *cmp_values, size_t nelems,
+                                     size_t *indices, const int *status,
+                                     int datatype)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T();
 }
 
 /* This routine is not implemented */
@@ -1855,5 +1858,3 @@ int mca_spml_ucx_team_reduce(shmem_team_t team, void
 {
     return OSHMEM_ERR_NOT_IMPLEMENTED;
 }
-
-

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -259,11 +259,10 @@ extern size_t mca_spml_ucx_test_some(void *ivars, int cmp, void *cmp_value,
         size_t nelems, size_t *indices, const int *status, int datatype);
 extern int mca_spml_ucx_test_all_vector(void *ivars, int cmp, void
         *cmp_values, size_t nelems, const int *status, int datatype);
-extern int mca_spml_ucx_test_any_vector(void *ivars, int cmp, void
-        *cmp_values, size_t nelems, const int *status, int datatype);
-extern int mca_spml_ucx_test_some_vector(void *ivars, int cmp, void
-        *cmp_values, size_t nelems, size_t *indices, const int *status, int
-        datatype);
+extern size_t mca_spml_ucx_test_any_vector(void *ivars, int cmp, void *cmp_values, size_t nelems,
+                                           const int *status, int datatype);
+extern size_t mca_spml_ucx_test_some_vector(void *ivars, int cmp, void *cmp_values, size_t nelems,
+                                            size_t *indices, const int *status, int datatype);
 extern int mca_spml_ucx_team_sync(shmem_team_t team);
 extern int mca_spml_ucx_team_my_pe(shmem_team_t team);
 extern int mca_spml_ucx_team_n_pes(shmem_team_t team);

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -463,7 +463,6 @@ static int mca_spml_ucx_component_fini(void)
     volatile int fenced = 0;
     int i;
     int ret = OSHMEM_SUCCESS;
-    mca_spml_ucx_ctx_t *ctx;
 
     opal_progress_unregister(spml_ucx_default_progress);
     if (mca_spml_ucx.active_array.ctxs_count) {

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
@@ -181,12 +181,11 @@ segment_create(map_segment_t *ds_buf,
 {
     mca_spml_ucx_t *spml = (mca_spml_ucx_t*)mca_spml.self;
     unsigned flags       = UCP_MEM_MAP_ALLOCATE;
-    int status;
 
     if (hint & SHMEM_HINT_DEVICE_NIC_MEM) {
 #if HAVE_DECL_UCS_MEMORY_TYPE_RDMA
-        status = segment_create_internal(ds_buf, NULL, size, flags,
-                                         UCS_MEMORY_TYPE_RDMA, 3);
+        int status = segment_create_internal(ds_buf, NULL, size,
+                                             flags, UCS_MEMORY_TYPE_RDMA, 3);
         if (status == OSHMEM_SUCCESS) {
             ds_buf->alloc_hints = hint;
             ds_buf->allocator   = &sshmem_ucx_allocator;

--- a/oshmem/runtime/runtime.h
+++ b/oshmem/runtime/runtime.h
@@ -237,6 +237,18 @@ OSHMEM_DECLSPEC int oshmem_shmem_register_params(void);
 
 #endif  /* OSHMEM_PARAM_CHECK */
 
+#define RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT()                    \
+    do {                                                             \
+        SHMEM_API_ERROR("Called non-implemented API: %s", __func__); \
+        oshmem_shmem_abort(OSHMEM_ERR_NOT_IMPLEMENTED);              \
+    } while (0)
+
+#define RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT_RET_SIZE_T() \
+    do {                                                     \
+        RUNTIME_SHMEM_NOT_IMPLEMENTED_API_ABORT();           \
+        return SIZE_MAX;                                     \
+    } while (0)
+
 END_C_DECLS
 
 #endif /* OSHMEM_SHMEM_RUNTIME_H */

--- a/oshmem/shmem/c/shmem_test_ivars.c
+++ b/oshmem/shmem/c/shmem_test_ivars.c
@@ -124,7 +124,7 @@
 #define SHMEM_TYPE_TEST_ALL(type_name, type, code, prefix)          \
     int prefix##type_name##_test_all(volatile type *ivars, size_t nelems, const int *status, int cmp, type value)   \
     {                                                               \
-        int rc = OSHMEM_SUCCESS;                                    \
+        int rc;                                                     \
                                                                     \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
@@ -138,81 +138,60 @@
         return rc;                                                  \
     }
 
-
 #define SHMEM_TYPE_TEST_ANY(type_name, type, code, prefix)          \
     size_t prefix##type_name##_test_any(volatile type *ivars, size_t nelems, const int *status, int cmp, type value)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(test_any(                                \
-            (void*)ivars,                                           \
-            cmp,                                                    \
-            (void*)&value,                                          \
-            nelems, status, code));                                 \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
+        return MCA_SPML_CALL(test_any(                              \
+                                      (void*)ivars,                 \
+                                      cmp,                          \
+                                      (void*)&value,                \
+                                      nelems, status, code));       \
     }
 
 
 #define SHMEM_TYPE_TEST_SOME(type_name, type, code, prefix)         \
     size_t  prefix##type_name##_test_some(volatile type *ivars, size_t nelems, size_t *indices, const int *status, int cmp, type value)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(test_some(                               \
+        return MCA_SPML_CALL(test_some(                             \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)&value,                                          \
             nelems, indices, status, code));                        \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 #define SHMEM_TYPE_TEST_ANY_VECTOR(type_name, type, code, prefix)   \
     size_t prefix##type_name##_test_any_vector(volatile type *ivars, size_t nelems, const int *status, int cmp, type *values)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(test_any_vector(                         \
+        return MCA_SPML_CALL(test_any_vector(                       \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)values,                                          \
             nelems, status, code));                                 \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 #define SHMEM_TYPE_TEST_SOME_VECTOR(type_name, type, code, prefix)  \
     size_t prefix##type_name##_test_some_vector(volatile type *ivars, size_t nelems, size_t *indices, const int *status, int cmp, type *values)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(test_some_vector(                        \
+        return MCA_SPML_CALL(test_some_vector(                      \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)values,                                          \
             nelems, indices, status, code));                        \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 
 #define SHMEM_TYPE_TEST_ALL_VECTOR(type_name, type, code, prefix)   \
-    int prefix##type_name##_test_all_vector(volatile type *ivars, size_t nelems, const int *status, int cmp, type *values)   \
+   int prefix##type_name##_test_all_vector(volatile type *ivars, size_t nelems, const int *status, int cmp, type *values)   \
     {                                                               \
-        int rc = OSHMEM_SUCCESS;                                    \
+        int rc;                                                     \
                                                                     \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \

--- a/oshmem/shmem/c/shmem_wait_ivars.c
+++ b/oshmem/shmem/c/shmem_wait_ivars.c
@@ -124,7 +124,6 @@
 #define SHMEM_TYPE_WAIT_UNTIL_ALL(type_name, type, code, prefix)    \
     void prefix##type_name##_wait_until_all(volatile type *ivars, size_t nelems, const int *status, int cmp, type value)   \
     {                                                               \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
         MCA_SPML_CALL(wait_until_all(                               \
@@ -132,94 +131,67 @@
             cmp,                                                    \
             (void*)&value,                                          \
             nelems, status, code));                                 \
-                                                                    \
-        return ;                                                    \
     }
 
 
 #define SHMEM_TYPE_WAIT_UNTIL_ANY(type_name, type, code, prefix)    \
     size_t prefix##type_name##_wait_until_any(volatile type *ivars, size_t nelems, const int *status, int cmp, type value)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(wait_until_any(                          \
+        return MCA_SPML_CALL(wait_until_any(                        \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)&value,                                          \
             nelems, status, code));                                 \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 
 #define SHMEM_TYPE_WAIT_UNTIL_SOME(type_name, type, code, prefix)   \
     size_t  prefix##type_name##_wait_until_some(volatile type *ivars, size_t nelems, size_t *indices, const int *status, int cmp, type value)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(wait_until_some(                         \
+        return MCA_SPML_CALL(wait_until_some(                       \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)&value,                                          \
             nelems, indices, status, code));                        \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 #define SHMEM_TYPE_WAIT_UNTIL_ANY_VECTOR(type_name, type, code, prefix)    \
     size_t prefix##type_name##_wait_until_any_vector(volatile type *ivars, size_t nelems, const int *status, int cmp, type *values)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(wait_until_any_vector(                   \
+        return MCA_SPML_CALL(wait_until_any_vector(                 \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)values,                                          \
             nelems, status, code));                                 \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 #define SHMEM_TYPE_WAIT_UNTIL_SOME_VECTOR(type_name, type, code, prefix)    \
     size_t prefix##type_name##_wait_until_some_vector(volatile type *ivars, size_t nelems, size_t *indices, const int *status, int cmp, type *values)   \
     {                                                               \
-        size_t rc = 0;                                              \
-                                                                    \
         RUNTIME_CHECK_INIT();                                       \
                                                                     \
-        rc = MCA_SPML_CALL(wait_until_some_vector(                  \
+        return MCA_SPML_CALL(wait_until_some_vector(                \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)values,                                          \
             nelems, indices, status, code));                        \
-        RUNTIME_CHECK_IMPL_RC(rc);                                  \
-                                                                    \
-        return rc;                                                  \
     }
 
 
 #define SHMEM_TYPE_WAIT_UNTIL_ALL_VECTOR(type_name, type, code, prefix)    \
     void prefix##type_name##_wait_until_all_vector(volatile type *ivars, size_t nelems, const int *status, int cmp, type *values)   \
     {                                                               \
-        int rc = OSHMEM_SUCCESS;                                    \
-                                                                    \
-                                                                    \
         MCA_SPML_CALL(wait_until_all_vector(                        \
             (void*)ivars,                                           \
             cmp,                                                    \
             (void*)values,                                          \
             nelems, status, code));                                 \
-                                                                    \
-        return ;                                                    \
     }
 
 


### PR DESCRIPTION
Signed-off-by: Roie Danino <rdanino@nvidia.com>
(cherry picked from commit 093900d455aab733426dee4e1df7f452a6548ddb)