### PR TITLE
configury: harden IGNORE_TKR check

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -200,12 +200,12 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   end subroutine force_assumed_shape
 
   module check_ignore_tkr
-  interface
-     subroutine foobar(buffer, count)
+  interface foobar
+     subroutine foobar_x(buffer, count)
        $1 buffer
        $2, intent(in) :: buffer
        integer, intent(in) :: count
-     end subroutine foobar
+     end subroutine foobar_x
   end interface
   end module
 


### PR DESCRIPTION
NVIDIA HPC Compiler (e.g. nvfortran) incorrectly selected the GCC style pragmas to support IGNORE_TKR. Harden the test by mimicking exactly the mpi f08 bindings in order to fix that false positive.

Thanks Chris Parrot for the report.

Refs. open-mpi/ompi#11582