### PR TITLE
Fix some compiler warnings

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1509,10 +1509,7 @@ static int ompi_comm_idup_with_info_activate (ompi_comm_request_t *request)
 
 static int ompi_comm_idup_with_info_finish (ompi_comm_request_t *request)
 {
-    ompi_comm_idup_with_info_context_t *context =
-        (ompi_comm_idup_with_info_context_t *) request->context;
-
-    /* done */
+    /* nothing to be done */
     return MPI_SUCCESS;
 }
 

--- a/ompi/mca/coll/base/coll_base_allreduce.c
+++ b/ompi/mca/coll/base/coll_base_allreduce.c
@@ -1281,7 +1281,6 @@ int ompi_coll_base_allreduce_intra_allgather_reduce(const void *sbuf, void *rbuf
     ptrdiff_t extent, lb;
     ompi_datatype_get_extent(dtype, &lb, &extent);
 
-    int rank = ompi_comm_rank(comm);
     int size = ompi_comm_size(comm);
 
     sendtmpbuf = (char*) sbuf;
@@ -1337,7 +1336,7 @@ err_hndl:
         tmpsend_start = NULL;
     }
    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,  "%s:%4d\tError occurred %d, rank %2d",
-                 __FILE__, line, err, rank));
+                 __FILE__, line, err, ompi_comm_rank(comm)));
     (void)line;  // silence compiler warning
     return err;
 

--- a/ompi/mpi/fortran/base/fint_2_int.h
+++ b/ompi/mpi/fortran/base/fint_2_int.h
@@ -33,7 +33,7 @@
  */
 
 #if OMPI_SIZEOF_FORTRAN_INTEGER == SIZEOF_INT
-  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a
+  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a = NULL
   #define OMPI_2_DIM_ARRAY_NAME_DECL(a, dim2) int (*c_##a)[dim2]
   #define OMPI_SINGLE_NAME_DECL(a)
   #define OMPI_ARRAY_NAME_CONVERT(a) c_##a
@@ -50,7 +50,7 @@
   #define OMPI_ARRAY_INT_2_FINT(in, n)
 
 #elif OMPI_SIZEOF_FORTRAN_INTEGER > SIZEOF_INT
-  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a
+  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a = NULL
   #define OMPI_2_DIM_ARRAY_NAME_DECL(a, dim2) int (*c_##a)[dim2], dim2_index
   #define OMPI_SINGLE_NAME_DECL(a) int c_##a
   #define OMPI_ARRAY_NAME_CONVERT(a) c_##a
@@ -107,7 +107,7 @@
       free(OMPI_ARRAY_NAME_CONVERT(in)); \
     } while (0)
 #else /* int > MPI_Fint  */
-  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a
+  #define OMPI_ARRAY_NAME_DECL(a) int *c_##a = NULL
   #define OMPI_2_DIM_ARRAY_NAME_DECL(a, dim2) int (*c_##a)[dim2], dim2_index
   #define OMPI_SINGLE_NAME_DECL(a) int c_##a
   #define OMPI_ARRAY_NAME_CONVERT(a) c_##a

--- a/opal/mca/smsc/xpmem/smsc_xpmem_component.c
+++ b/opal/mca/smsc/xpmem/smsc_xpmem_component.c
@@ -116,10 +116,10 @@ static int mca_smsc_xpmem_component_query(void)
     char buffer[1024];
     uintptr_t address_max = 0;
     while (fgets(buffer, sizeof(buffer), fh)) {
-        uintptr_t low, high;
+        uintptr_t high;
         char *tmp;
         /* each line of /proc/self/maps starts with low-high in hexadecimal (without a 0x) */
-        low = strtoul(buffer, &tmp, 16);
+        strtoul(buffer, &tmp, 16);
         high = strtoul(tmp + 1, NULL, 16);
         if (address_max < high) {
             address_max = high;


### PR DESCRIPTION
Random selection of compiler warnings found with Clang 17. 


The warnings addressed here:

```
pialltoallw_f.c: In function ‘ompi_ialltoallw_f’:
pialltoallw_f.c:110:12: warning: ‘c_sdispls’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     c_ierr = PMPI_Ialltoallw(sendbuf,
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
                              OMPI_ARRAY_NAME_CONVERT(sendcounts),
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              OMPI_ARRAY_NAME_CONVERT(sdispls),
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              c_sendtypes,
                              ~~~~~~~~~~~~
                              recvbuf,
                              ~~~~~~~~
                              OMPI_ARRAY_NAME_CONVERT(recvcounts),
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              OMPI_ARRAY_NAME_CONVERT(rdispls),
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              c_recvtypes, c_comm, &c_request);
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pialltoallw_f.c:110:12: warning: ‘c_sendcounts’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```

```
../../../../ompi/mca/coll/base/coll_base_allreduce.c: In function ‘ompi_coll_base_allreduce_intra_allgather_reduce’:
../../../../ompi/mca/coll/base/coll_base_allreduce.c:1284:9: warning: unused variable ‘rank’ [-Wunused-variable]
     int rank = ompi_comm_rank(comm);
         ^~~~
```

```
../../../../../opal/mca/smsc/xpmem/smsc_xpmem_component.c: In function ‘mca_smsc_xpmem_component_query’:
../../../../../opal/mca/smsc/xpmem/smsc_xpmem_component.c:119:19: warning: variable ‘low’ set but not used [-Wunused-but-set-variable]
         uintptr_t low, high;
                   ^~~
```