### PR TITLE
v4.1.x: docs/conf.py: updates per RTD docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -44,6 +44,23 @@ for ompi_line in ompi_lines:
 series = f"{ompi_data['major']}.{ompi_data['minor']}.x"
 release = f"{ompi_data['major']}.{ompi_data['minor']}.{ompi_data['release']}{ompi_data['greek']}"
 
+# If we are building in a ReadTheDocs.io environment, there will be
+# READTHEDOCS environment variables.
+#
+# Relevant RTD env variables (documented
+# https://docs.readthedocs.io/en/stable/builds.html#build-environment):
+key = 'READTHEDOCS'
+if key in os.environ and os.environ[key] == 'True':
+    print("OMPI: found ReadTheDocs build environment")
+
+    # Tell Jinja2 templates the build is running on Read the Docs
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
+    # Define the canonical URL if you are using a custom domain on
+    # Read the Docs
+    html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
RTD is rolling out some changes.  Per
https://about.readthedocs.com/blog/2024/07/addons-by-default/, these are the changes we need to make.

This is a manual backport of git commit db7ff49 from main PR #12687.  The other commits on that PR are not relevant to the v4.1.x branch.

bot:notacherrypick