### PR TITLE
Check that requests belong to similar sessions

### DIFF
--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -25,6 +25,7 @@
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -611,11 +612,6 @@ static inline struct ompi_proc_t* ompi_comm_peer_lookup (const ompi_communicator
 #endif
     /*return comm->c_remote_group->grp_proc_pointers[peer_id];*/
     return ompi_group_peer_lookup(comm->c_remote_group,peer_id);
-}
-
-static inline bool ompi_comm_instances_same(const ompi_communicator_t *comm1, const ompi_communicator_t *comm2)
-{
-    return comm1->instance == comm2->instance;
 }
 
 #if OPAL_ENABLE_FT_MPI

--- a/ompi/mpi/c/testall.c
+++ b/ompi/mpi/c/testall.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,31 +58,13 @@ int MPI_Testall(int count, MPI_Request requests[], int *flag,
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int i, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if( (NULL == requests) && (0 != count) ) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (i = 0; i < count; i++) {
-                if (NULL == requests[i]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (&ompi_request_empty == requests[i]) { 
-                    continue;
-                } else if (NULL == requests[i]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[i];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[i]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, count) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if ((NULL == flag) || (count < 0)) {

--- a/ompi/mpi/c/testany.c
+++ b/ompi/mpi/c/testany.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,31 +57,13 @@ int MPI_Testany(int count, MPI_Request requests[], int *indx, int *completed, MP
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int i, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if ((NULL == requests) && (0 != count)) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (i = 0; i < count; i++) {
-                if (NULL == requests[i]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (&ompi_request_empty == requests[i]) {
-                    continue;
-                } else if (NULL == requests[i]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[i];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[i]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, count) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if (((NULL == indx || NULL == completed) && count > 0) ||

--- a/ompi/mpi/c/testsome.c
+++ b/ompi/mpi/c/testsome.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,31 +59,13 @@ int MPI_Testsome(int incount, MPI_Request requests[],
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int indx, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if ((NULL == requests) && (0 != incount)) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (indx = 0; indx < incount; ++indx) {
-                if (NULL == requests[indx]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (&ompi_request_empty == requests[indx]) { 
-                    continue;
-                } else if (NULL == requests[indx]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[indx];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[indx]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, incount) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if (((NULL == outcount || NULL == indices) && incount > 0) ||

--- a/ompi/mpi/c/waitall.c
+++ b/ompi/mpi/c/waitall.c
@@ -16,6 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,31 +56,13 @@ int MPI_Waitall(int count, MPI_Request requests[], MPI_Status statuses[])
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int i, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if( (NULL == requests) && (0 != count) ) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (i = 0; i < count; i++) {
-                if (NULL == requests[i]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (&ompi_request_empty == requests[i]) {
-                    continue;
-                } else if (NULL == requests[i]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[i];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[i]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, count) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if (count < 0) {

--- a/ompi/mpi/c/waitany.c
+++ b/ompi/mpi/c/waitany.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,31 +57,13 @@ int MPI_Waitany(int count, MPI_Request requests[], int *indx, MPI_Status *status
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int i, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if ((NULL == requests) && (0 != count)) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (i = 0; i < count; i++) {
-                if (NULL == requests[i]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (requests[i] == &ompi_request_empty) {
-                    continue;
-                } else if (NULL == requests[i]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[i];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[i]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, count) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if ((NULL == indx && count > 0) ||

--- a/ompi/mpi/c/waitsome.c
+++ b/ompi/mpi/c/waitsome.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,31 +59,13 @@ int MPI_Waitsome(int incount, MPI_Request requests[],
     );
 
     if ( MPI_PARAM_CHECK ) {
-        int indx, rc = MPI_SUCCESS;
-        MPI_Request check_req = NULL;
+        int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if ((NULL == requests) && (0 != incount)) {
             rc = MPI_ERR_REQUEST;
         } else {
-            for (indx = 0; indx < incount; ++indx) {
-                if (NULL == requests[indx]) {
-                    rc = MPI_ERR_REQUEST;
-                    break;
-                }
-                if (&ompi_request_empty == requests[indx]) {
-                    continue;
-                } else if (NULL == requests[indx]->req_mpi_object.comm) {
-                    continue;
-                } else if (NULL == check_req) {
-                    check_req = requests[indx];
-                }
-                else {
-                    if (!ompi_comm_instances_same(requests[indx]->req_mpi_object.comm,
-                                                     check_req->req_mpi_object.comm)) {
-                        rc = MPI_ERR_REQUEST;
-                        break;
-                    }
-                }
+            if(!ompi_request_check_same_instance(requests, incount) ) {
+                rc = MPI_ERR_REQUEST;
             }
         }
         if (((NULL == outcount || NULL == indices) && incount > 0) ||

--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -21,6 +21,7 @@
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -247,4 +248,26 @@ int ompi_request_persistent_noop_create(ompi_request_t** request)
 
     *request = req;
     return OMPI_SUCCESS;
+}
+
+bool ompi_request_check_same_instance(ompi_request_t** requests,
+                                      int count)
+{
+    ompi_request_t *req, *base = NULL;
+
+    for(int idx = 0; idx < count; idx++ ) {
+        req = requests[idx];
+        if(OMPI_REQUEST_NULL == req->req_type)  /* predefined requests are generic */
+            continue;
+        /* Only PML requests have support for MPI sessions */
+        if(OMPI_REQUEST_PML != req->req_type)
+            continue;
+        if(NULL == base) {
+            base = req;
+            continue;
+        }
+        if(base->req_mpi_object.comm != req->req_mpi_object.comm)
+            return false;
+    }
+    return true;
 }

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -19,6 +19,7 @@
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -557,6 +558,22 @@ static inline int ompi_request_set_callback(ompi_request_t* request,
     }
     return OMPI_SUCCESS;
 }
+
+/**
+ * Check if an array of requests contains only requests that belong to the same
+ * instance or MPI Session. Exclude predefined requests, that are generic and part
+ * of all instances.
+ * Right now, only tests for PML requests as they are the only requests that have
+ * support for MPI Sessions.
+ *
+ * @param requests (IN)   Array of requests
+ * @param count (IN)      Number of requests
+ * @return                true if all requests are part of the same instance
+ *                        or MPI Session, false otherwise.
+ *
+ */
+bool ompi_request_check_same_instance(ompi_request_t** requests,
+                                      int count);
 
 END_C_DECLS
 


### PR DESCRIPTION
Consistent way to check that an array of requests belong to the same session or are predefined. Skip all requests generated by components that do not support instances (generalized requests, file, win).

Replaces #12525.