### PR TITLE
Identify requests from the same instance.

### DIFF
--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -253,7 +253,8 @@ int ompi_request_persistent_noop_create(ompi_request_t** request)
 bool ompi_request_check_same_instance(ompi_request_t** requests,
                                       int count)
 {
-    ompi_request_t *req, *base = NULL;
+    ompi_instance_t* base_instance = NULL;
+    ompi_request_t *req;
 
     for(int idx = 0; idx < count; idx++ ) {
         req = requests[idx];
@@ -262,11 +263,11 @@ bool ompi_request_check_same_instance(ompi_request_t** requests,
         /* Only PML requests have support for MPI sessions */
         if(OMPI_REQUEST_PML != req->req_type)
             continue;
-        if(NULL == base) {
-            base = req;
+        if(NULL == base_instance) {
+            base_instance = req->req_mpi_object.comm->instance;
             continue;
         }
-        if(base->req_mpi_object.comm != req->req_mpi_object.comm)
+        if(base_instance != req->req_mpi_object.comm->instance)
             return false;
     }
     return true;


### PR DESCRIPTION
The prior version identified requests from the same communicator instead of instance.

Signed-off-by: George Bosilca <gbosilca@nvidia.com>
(cherry picked from commit 1b7215a5f5632694f1f8003c253871e84a853c22)