### PR TITLE
portals4: update the coll-portals4 component to be Big Count compliant

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -95,10 +95,30 @@ struct mca_coll_portals4_module_t {
     opal_atomic_size_t coll_count;
 
     /* record handlers dedicated to fallback if offloaded operations are not supported */
+    mca_coll_base_module_barrier_fn_t previous_barrier;
+    mca_coll_base_module_t *previous_barrier_module;
+    mca_coll_base_module_ibarrier_fn_t previous_ibarrier;
+    mca_coll_base_module_t *previous_ibarrier_module;
+
+    mca_coll_base_module_bcast_fn_t previous_bcast;
+    mca_coll_base_module_t *previous_bcast_module;
+    mca_coll_base_module_ibcast_fn_t previous_ibcast;
+    mca_coll_base_module_t *previous_ibcast_module;
+
+    mca_coll_base_module_gather_fn_t previous_gather;
+    mca_coll_base_module_t *previous_gather_module;
+    mca_coll_base_module_igather_fn_t previous_igather;
+    mca_coll_base_module_t *previous_igather_module;
+
     mca_coll_base_module_reduce_fn_t previous_reduce;
     mca_coll_base_module_t *previous_reduce_module;
     mca_coll_base_module_ireduce_fn_t previous_ireduce;
     mca_coll_base_module_t *previous_ireduce_module;
+
+    mca_coll_base_module_scatter_fn_t previous_scatter;
+    mca_coll_base_module_t *previous_scatter_module;
+    mca_coll_base_module_iscatter_fn_t previous_iscatter;
+    mca_coll_base_module_t *previous_iscatter_module;
 
     mca_coll_base_module_allreduce_fn_t previous_allreduce;
     mca_coll_base_module_t *previous_allreduce_module;
@@ -187,22 +207,22 @@ int ompi_coll_portals4_ibarrier_intra(struct ompi_communicator_t *comm,
         mca_coll_base_module_t *module);
 int ompi_coll_portals4_ibarrier_intra_fini(struct ompi_coll_portals4_request_t *request);
 
-int ompi_coll_portals4_bcast_intra(void *buff, int count,
+int ompi_coll_portals4_bcast_intra(void *buff, size_t count,
         struct ompi_datatype_t *datatype, int root,
         struct ompi_communicator_t *comm,mca_coll_base_module_t *module);
-int ompi_coll_portals4_ibcast_intra(void *buff, int count,
+int ompi_coll_portals4_ibcast_intra(void *buff, size_t count,
         struct ompi_datatype_t *datatype, int root,
         struct ompi_communicator_t *comm,
         ompi_request_t **request,
         mca_coll_base_module_t *module);
 int ompi_coll_portals4_ibcast_intra_fini(struct ompi_coll_portals4_request_t *request);
 
-int ompi_coll_portals4_reduce_intra(const void *sbuf, void *rbuf, int count,
+int ompi_coll_portals4_reduce_intra(const void *sbuf, void *rbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         int root,
         struct ompi_communicator_t *comm,
         mca_coll_base_module_t *module);
-int ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, int count,
+int ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dype, MPI_Op op,
         int root,
         struct ompi_communicator_t *comm,
@@ -210,11 +230,11 @@ int ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, int cou
         mca_coll_base_module_t *module);
 int ompi_coll_portals4_ireduce_intra_fini(struct ompi_coll_portals4_request_t *request);
 
-int ompi_coll_portals4_allreduce_intra(const void* sendbuf, void* recvbuf, int count,
+int ompi_coll_portals4_allreduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         struct ompi_communicator_t *comm,
         mca_coll_base_module_t *module);
-int ompi_coll_portals4_iallreduce_intra(const void* sendbuf, void* recvbuf, int count,
+int ompi_coll_portals4_iallreduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         struct ompi_communicator_t *comm,
         ompi_request_t ** ompi_request,

--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -32,7 +32,7 @@
 #define COLL_PORTALS4_ALLREDUCE_MAX_CHILDREN	2
 
 static int
-allreduce_kary_tree_top(const void *sendbuf, void *recvbuf, int count,
+allreduce_kary_tree_top(const void *sendbuf, void *recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         struct ompi_communicator_t *comm,
         ompi_coll_portals4_request_t *request,
@@ -380,7 +380,7 @@ allreduce_kary_tree_bottom(ompi_coll_portals4_request_t *request)
     return (OMPI_SUCCESS);
 }
 
-int ompi_coll_portals4_allreduce_intra(const void* sendbuf, void* recvbuf, int count,
+int ompi_coll_portals4_allreduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         struct ompi_communicator_t *comm,
         mca_coll_base_module_t *module)
@@ -409,7 +409,7 @@ int ompi_coll_portals4_allreduce_intra(const void* sendbuf, void* recvbuf, int c
 }
 
 
-int ompi_coll_portals4_iallreduce_intra(const void* sendbuf, void* recvbuf, int count,
+int ompi_coll_portals4_iallreduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         struct ompi_communicator_t *comm,
         ompi_request_t ** ompi_request,

--- a/ompi/mca/coll/portals4/coll_portals4_bcast.c
+++ b/ompi/mca/coll/portals4/coll_portals4_bcast.c
@@ -834,7 +834,7 @@ bcast_pipeline_bottom(ompi_coll_portals4_request_t *request)
 
 
 int
-ompi_coll_portals4_bcast_intra(void *buff, int count,
+ompi_coll_portals4_bcast_intra(void *buff, size_t count,
         struct ompi_datatype_t *datatype, int root,
         struct ompi_communicator_t *comm,
         mca_coll_base_module_t *module)
@@ -878,7 +878,7 @@ ompi_coll_portals4_bcast_intra(void *buff, int count,
 
 
 int
-ompi_coll_portals4_ibcast_intra(void *buff, int count,
+ompi_coll_portals4_ibcast_intra(void *buff, size_t count,
         struct ompi_datatype_t *datatype, int root,
         struct ompi_communicator_t *comm,
         ompi_request_t **ompi_request,

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -135,7 +135,7 @@ ptl_datatype_t ompi_coll_portals4_atomic_datatype [OMPI_DATATYPE_MPI_MAX_PREDEFI
         {                                                                                                                 \
             opal_output_verbose(1, ompi_coll_base_framework.framework_output,                                             \
                                 "(%d/%s): no underlying " #__api "; disqualifying myself",                                \
-                                __comm->c_contextid, __comm->c_name);                                                     \
+                                ompi_comm_get_local_cid(__comm), __comm->c_name); \
             __module->previous_##__api = NULL;                                                                            \
             __module->previous_##__api##_module = NULL;                                                                   \
         }                                                                                                                 \
@@ -144,7 +144,7 @@ ptl_datatype_t ompi_coll_portals4_atomic_datatype [OMPI_DATATYPE_MPI_MAX_PREDEFI
             /* save the current selected collective */                                                                    \
             MCA_COLL_SAVE_API(__comm, __api, __module->previous_##__api, __module->previous_##__api##_module, "portals"); \
             /* install our own */                                                                                         \
-            MCA_COLL_INSTALL_API(__comm, __api, __module->super.coll##__api, &__module->super, "portals");                \
+            MCA_COLL_INSTALL_API(__comm, __api, __module->super.coll_##__api, &__module->super, "portals");                \
         }                                                                                                                 \
     } while (0)
 
@@ -187,7 +187,7 @@ mca_coll_portals4_component_t mca_coll_portals4_component = {
          * about the component itself */
 
         .collm_version = {
-            MCA_COLL_BASE_VERSION_2_4_0,
+            MCA_COLL_BASE_VERSION_3_0_0,
 
             /* Component name and version */
             .mca_component_name = "portals4",

--- a/ompi/mca/coll/portals4/coll_portals4_gather.c
+++ b/ompi/mca/coll/portals4/coll_portals4_gather.c
@@ -215,7 +215,7 @@ setup_gather_buffers_binomial(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:vrank(%d): root - gather_buf(%p) - gather_bytes(%lu)=packed_size(%ld) * size(%d)",
                             __FILE__, __LINE__, vrank,
-                            request->u.gather.gather_buf, request->u.gather.gather_bytes,
+                            (void*)request->u.gather.gather_buf, request->u.gather.gather_bytes,
                             request->u.gather.packed_size, request->u.gather.size);
     } else if (bmtree->tree_nextsize) {
         /*
@@ -238,7 +238,7 @@ setup_gather_buffers_binomial(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:vrank(%d): nonleaf - gather_buf(%p) - gather_bytes(%lu)=packed_size(%ld) * (bmtree->tree_numdescendants(%d) + 1)",
                             __FILE__, __LINE__, vrank,
-                            request->u.gather.gather_buf, request->u.gather.gather_bytes,
+                            (void*)request->u.gather.gather_buf, request->u.gather.gather_bytes,
                             request->u.gather.packed_size, bmtree->tree_numdescendants);
     } else {
         /* leaf nodes, allocate space to pack into and put from */
@@ -257,7 +257,7 @@ setup_gather_buffers_binomial(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:vrank(%d): leaf - gather_buf(%p) - gather_bytes(%lu)=packed_size(%ld)",
                             __FILE__, __LINE__, vrank,
-                            request->u.gather.gather_buf, request->u.gather.gather_bytes,
+                            (void*)request->u.gather.gather_buf, request->u.gather.gather_bytes,
                             request->u.gather.packed_size);
     }
 
@@ -316,7 +316,7 @@ setup_gather_buffers_linear(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:rank(%d): root - gather_buf(%p) - gather_bytes(%lu)=packed_size(%ld) * size(%d)",
                             __FILE__, __LINE__, request->u.gather.my_rank,
-                            request->u.gather.gather_buf, request->u.gather.gather_bytes,
+                            (void*)request->u.gather.gather_buf, request->u.gather.gather_bytes,
                             request->u.gather.packed_size, request->u.gather.size);
     } else {
         /* non-root nodes, allocate space to pack into and put from */
@@ -334,7 +334,7 @@ setup_gather_buffers_linear(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:rank(%d): leaf - gather_buf(%p) - gather_bytes(%lu)=packed_size(%ld)",
                             __FILE__, __LINE__, request->u.gather.my_rank,
-                            request->u.gather.gather_buf, request->u.gather.gather_bytes,
+                            (void*)request->u.gather.gather_buf, request->u.gather.gather_bytes,
                             request->u.gather.packed_size);
     }
 

--- a/ompi/mca/coll/portals4/coll_portals4_reduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_reduce.c
@@ -32,7 +32,7 @@
 
 
 static int
-reduce_kary_tree_top(const void *sendbuf, void *recvbuf, int count,
+reduce_kary_tree_top(const void *sendbuf, void *recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         int root,
         struct ompi_communicator_t *comm,
@@ -377,7 +377,7 @@ err_hdlr:
 
 
 int
-ompi_coll_portals4_reduce_intra(const void *sendbuf, void *recvbuf, int count,
+ompi_coll_portals4_reduce_intra(const void *sendbuf, void *recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         int root,
         struct ompi_communicator_t *comm,
@@ -412,7 +412,7 @@ ompi_coll_portals4_reduce_intra(const void *sendbuf, void *recvbuf, int count,
 
 
 int
-ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, int count,
+ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, size_t count,
         MPI_Datatype dtype, MPI_Op op,
         int root,
         struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/portals4/coll_portals4_scatter.c
+++ b/ompi/mca/coll/portals4/coll_portals4_scatter.c
@@ -91,7 +91,7 @@ setup_scatter_buffers_linear(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:rank(%d): root - scatter_buf(%p) - scatter_bytes(%lu)=packed_size(%ld) * size(%d)",
                             __FILE__, __LINE__, request->u.scatter.my_rank,
-                            request->u.scatter.scatter_buf, request->u.scatter.scatter_bytes,
+                            (void*)request->u.scatter.scatter_buf, request->u.scatter.scatter_bytes,
                             request->u.scatter.packed_size, request->u.scatter.size);
     } else {
         request->u.scatter.scatter_bytes=request->u.scatter.packed_size;
@@ -104,7 +104,7 @@ setup_scatter_buffers_linear(struct ompi_communicator_t   *comm,
         opal_output_verbose(30, ompi_coll_base_framework.framework_output,
                             "%s:%d:rank(%d): leaf - scatter_buf(%p) - scatter_bytes(%lu)=packed_size(%ld)",
                             __FILE__, __LINE__, request->u.scatter.my_rank,
-                            request->u.scatter.scatter_buf, request->u.scatter.scatter_bytes,
+                            (void*)request->u.scatter.scatter_buf, request->u.scatter.scatter_bytes,
                             request->u.scatter.packed_size);
     }
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -49,7 +49,7 @@ read_msg(void *start, ptl_size_t length, ptl_process_t target,
          ompi_mtl_portals4_recv_request_t *request)
 {
     int ret, i;
-    ptl_size_t rest = length, asked = 0;
+    ptl_size_t rest = length;
     int32_t frag_count;
 
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
@@ -102,7 +102,6 @@ read_msg(void *start, ptl_size_t length, ptl_process_t target,
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         rest -= frag->frag_length;
-        asked += frag->frag_length;
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -418,7 +418,7 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, uint32_t contextid, int
 
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
 void
-ompi_mtl_portals4_pending_list_progress()
+ompi_mtl_portals4_pending_list_progress(void)
 {
     int ret, val;
     opal_list_item_t *item;

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -2245,7 +2245,8 @@ ompi_osc_portals4_raccumulate(const void *origin_addr,
     size_t offset, size;
     ptl_op_t ptl_op;
     ptl_datatype_t ptl_dt;
-    ptrdiff_t sent, length, origin_lb, target_lb, extent;
+    ptl_size_t sent, length;
+    ptrdiff_t origin_lb, target_lb, extent;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "raccumulate: 0x%lx, %zu, %s, %d, %lu, %zu, %s, %s 0x%lx",
@@ -2998,7 +2999,8 @@ ompi_osc_portals4_accumulate(const void *origin_addr,
     size_t offset, size;
     ptl_op_t ptl_op;
     ptl_datatype_t ptl_dt;
-    ptrdiff_t sent, length, origin_lb, target_lb, extent;
+    ptl_size_t sent, length;
+    ptrdiff_t origin_lb, target_lb, extent;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "accumulate: 0x%lx, %zu, %s, %d, %lu, %zu, %s, %s, 0x%lx",

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -115,18 +115,18 @@ static bool
 check_config_value_bool(char *key, opal_info_t *info)
 {
     int ret, flag, param;
-    const bool *flag_value;
-    bool result;
+    bool result = false;
+    const bool *flag_value = &result;
+
     ret = opal_info_get_bool(info, key, &result, &flag);
-    if (OMPI_SUCCESS != ret || !flag) goto info_not_found;
-    return result;
+    if (OMPI_SUCCESS == ret && flag) {
+        return result;
+    }
 
- info_not_found:
     param = mca_base_var_find("ompi", "osc", "portals4", key);
-    if (0 > param) return false;
-
-    ret = mca_base_var_get_value(param, &flag_value, NULL, NULL);
-    if (OMPI_SUCCESS != ret) return false;
+    if (0 <= param) {
+        (void) mca_base_var_get_value(param, &flag_value, NULL, NULL);
+    }
 
     return flag_value[0];
 }


### PR DESCRIPTION
The Big Count implementation bumped the coll base struct version to 3.0.0.  This PR updates the coll-portals4 component to use coll base 3.0.0, updates function signatures to be Big Count compliant and fixes some compiler warnings.

