### PR TITLE
Fix typo in LDFLAGS_save_xcode variable name

### DIFF
--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -210,13 +210,13 @@ end program
     LIBS=$LIBS_save_xcode
 
     AS_IF([test $xcode_happy -eq 1],
-          [ # Restore LDFLAFGS + the new flags (i.e., get rid of the
+          [ # Restore LDFLAGS + the new flags (i.e., get rid of the
             # "-L." we added for this test)
-           LDFLAGS="$LDFLAGS_xcode_save $1"
+           LDFLAGS="$LDFLAGS_save_xcode $1"
            $2],
           [ # If we failed the test, reset LDFLAGS back to its
             # original value.
-           LDFLAGS=$LDFLAGS_xcode_save
+           LDFLAGS=$LDFLAGS_save_xcode
            $3])
 
     OPAL_VAR_SCOPE_POP


### PR DESCRIPTION
Fixes regression in #12650 where variable names [LDFLAGS_save_xcode](https://github.com/open-mpi/ompi/pull/12650/files#diff-1c99f5e2cd917e7209494f11f1a7195b836aa5e456058169ba90b4242277daafR136) and [LDFLAGS_xcode_save](https://github.com/open-mpi/ompi/pull/12650/files#diff-1c99f5e2cd917e7209494f11f1a7195b836aa5e456058169ba90b4242277daafR215) do not match, so LDFLAGS wasn't saved.

closes #12719
