### PR TITLE
configury: patch configure to support nvfortran

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -5,7 +5,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2015-2021 Research Organization for Information Science
+# Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2015-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
@@ -891,9 +891,9 @@ sub patch_autotools_output {
     # source tree); we can't fix it.  So all we can do is patch the
     # resulting configure script.  :-(
     push(@verbose_out, $indent_str . "Patching configure for Libtool PGI 10 fortran compiler name\n");
-    $c =~ s/gfortran g95 xlf95 f95 fort ifort ifc efc pgf95 lf95 ftn/gfortran g95 xlf95 f95 fort ifort ifc efc pgfortran pgf95 lf95 ftn/g;
-    $c =~ s/pgcc\* \| pgf77\* \| pgf90\* \| pgf95\*\)/pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)/g;
-    $c =~ s/pgf77\* \| pgf90\* \| pgf95\*\)/pgf77* | pgf90* | pgf95* | pgfortran*)/g;
+    $c =~ s/gfortran g95 xlf95 f95 fort ifort ifc efc pgf95 lf95 ftn/gfortran g95 xlf95 f95 fort ifort ifc efc pgfortran nvfortran pgf95 lf95 ftn/g;
+    $c =~ s/pgcc\* \| pgf77\* \| pgf90\* \| pgf95\*\)/pgcc* | pgf77* | pgf90* | pgf95* | pgfortran* | nvfortran*)/g;
+    $c =~ s/pgf77\* \| pgf90\* \| pgf95\*\)/pgf77* | pgf90* | pgf95* | pgfortran* | nvfortran*)/g;
 
     # Similar issue as above -- the PGI 10 version number broke <=LT
     # 2.2.6b's version number checking regexps.  Again, we can't fix the
@@ -1084,6 +1084,30 @@ sub patch_autotools_output {
         lt_prog_compiler_static_FC='-Bstatic'
         ;;";
     $c =~ s/$search_string/$replace_string/g;
+
+    $c =~ s/for ac_prog in gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor/for ac_prog in gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor nvfortran/g;
+    foreach my $tag (("", "_FC")) {
+        $search_string = 'tcc\*\)
+	# Fabrice Bellard et al\'s Tiny C Compiler
+	lt_prog_compiler_wl'."${tag}".'=\'-Wl,\'
+	lt_prog_compiler_pic'."${tag}".'=\'-fPIC\'
+	lt_prog_compiler_static'."${tag}".'=\'-static\'
+	;;';
+        $replace_string = "tcc*)
+        # Fabrice Bellard et al's Tiny C Compiler
+        lt_prog_compiler_wl${tag}='-Wl,'
+        lt_prog_compiler_pic${tag}='-fPIC'
+        lt_prog_compiler_static${tag}='-static'
+        ;;
+    nvc* | nvcc* | nvfortran*)
+	# NVIDIA Fortran compiler
+        lt_prog_compiler_wl${tag}='-Wl,'
+        lt_prog_compiler_pic${tag}='-fPIC'
+        lt_prog_compiler_static${tag}='-Bstatic'
+        ;;";
+        push(@verbose_out, $indent_str . "Patching configure for NVIDIA Fortran compiler (${tag})\n");
+        $c =~ s/$search_string/$replace_string/g;
+    }
 
     # Only write out verbose statements and a new configure if the
     # configure content actually changed

--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -43,7 +43,7 @@ AC_DEFUN_ONCE([_OMPI_SETUP_FC_COMPILER],[
     # Fortran compilers (excluding the f77 compiler names) from AC's
     # default list of compilers and use it here.  This is the main
     # reason we have an OMPI-ized version of the PROG_FC macro.
-    AC_PROG_FC([gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor])
+    AC_PROG_FC([gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor nvfortran])
     FCFLAGS="$ompi_fcflags_save"
     OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
nvfortran needs to be passed -fPIC when building shared libraries, so patch the generated configure script in order to properly handle nvfortran:
- add nvfortran to the list of known fortran compilers
- pass -fPIC to the compiler

Refs. #8919