### PR TITLE
mtl/ofi: Remove dependence on libfabric's definition of container_of macro

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_request.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_request.h
@@ -13,8 +13,6 @@
 #ifndef OMPI_MTL_OFI_REQUEST_H
 #define OMPI_MTL_OFI_REQUEST_H
 
-#include "mtl_ofi.h"
-
 #ifndef container_of
 #    define container_of(ptr, type, member) ((type *) (((char *) (ptr)) - offsetof(type, member)))
 #endif

--- a/ompi/mca/mtl/ofi/mtl_ofi_request.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_request.h
@@ -15,6 +15,10 @@
 
 #include "mtl_ofi.h"
 
+#ifndef container_of
+#    define container_of(ptr, type, member) ((type *) (((char *) (ptr)) - offsetof(type, member)))
+#endif
+
 #define TO_OFI_REQ(_ptr_ctx) \
     container_of((_ptr_ctx), struct ompi_mtl_ofi_request_t, ctx)
 


### PR DESCRIPTION
Two commits:
 - Remove dependence on libfabric's definition of container_of macro.  They plan to remove it from libfabric's main-branch with https://github.com/ofiwg/libfabric/pull/10250.
 - Remove a useless circular include I saw while in that code.