### PR TITLE
fix explanation of in-place option for MPI_Allgather(v)

### DIFF
--- a/docs/man-openmpi/man3/MPI_Allgather.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgather.3.rst
@@ -134,7 +134,7 @@ executed n calls to
      MPI_Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                 recvtype, root, comm);
 
-     // for root = 0 , ..., n-1.
+     // for root = 0, ..., n-1.
 
 The rules for correct usage of :ref:`MPI_Allgather`
 are easily found from the corresponding rules for :ref:`MPI_Gather`.
@@ -171,10 +171,10 @@ identical to the case in which all processes executed *n* calls to
 
 .. code-block:: c
 
-      MPI_Allgather( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, recvbuf,
-                     recvcount, recvtype, root, comm )
+      MPI_Gather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, recvbuf,
+                 recvcount, recvtype, root, comm);
 
-      // for root =0, ... , n-1.
+      // for root = 0, ..., n-1.
 
 Note that MPI_IN_PLACE is a special kind of value; it has the same
 restrictions on its use as MPI_BOTTOM.

--- a/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
+++ b/docs/man-openmpi/man3/MPI_Allgatherv.3.rst
@@ -136,10 +136,10 @@ The outcome is as if all processes executed calls to
 
 .. code-block:: c
 
-   MPI_Allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                 displs,recvtype,root,comm);
+   MPI_Gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+               displs, recvtype, root, comm);
 
-   // for root = 0 , ..., n-1.
+   // for root = 0, ..., n-1.
 
 The rules for correct usage of :ref:`MPI_Allgatherv`
 are easily found from the corresponding rules for :ref:`MPI_Gatherv`.
@@ -159,10 +159,10 @@ identical to the case in which all processes executed *n* calls to
 
 .. code-block:: c
 
-      MPI_Allgatherv ( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, recvbuf,
-                       recvcounts, displs, recvtype, root, comm );
+      MPI_Gatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, recvbuf,
+                  recvcounts, displs, recvtype, root, comm);
 
-      // for root =0, ... , n-1.
+      // for root = 0, ..., n-1.
 
 Note that MPI_IN_PLACE is a special kind of value; it has the same
 restrictions on its use as MPI_BOTTOM.


### PR DESCRIPTION
These man pages (for `MPI_Allgather` and `MPI_Allgatherv` when using `MPI_IN_PLACE`) were wrong (intended to call `MPI_Gather(v)`). The example is a bit confusing because `recvbuf` is modified in a loop of repeat calls, but I think the loop is still correct because the subset of `recvbuf` that acts as send area when using `MPI_IN_PLACE` should be invariant. I don't know if you want to keep this explanation; it certainly can't be used to explain sibling collectives that support `MPI_IN_PLACE`.

(Apologies for the incorrect explanation prior to edit.)