### PR TITLE
Added a partcomm fix for mismatched types

### DIFF
--- a/ompi/mca/part/persist/part_persist_request.h
+++ b/ompi/mca/part/persist/part_persist_request.h
@@ -40,6 +40,7 @@ struct ompi_mca_persist_setup_t {
    int start_tag;
    int setup_tag;
    size_t num_parts;
+   size_t dt_size;
    size_t count;
 };
 
@@ -71,6 +72,7 @@ struct mca_part_persist_request_t {
 
     size_t real_parts;                   /**< internal number of partitions */
     size_t real_count;
+    size_t real_dt_size;                 /**< receiver needs to know how large the sender's datatype is. */
     size_t part_size; 
 
     ompi_request_t** persist_reqs;            /**< requests for persistent sends/recvs */


### PR DESCRIPTION
This fixes a bug identified in the partitioned tests test_datatype[1..3] where a mismatched type in a partitioned create would results in wrong lengths and offsets being used on the receiver. 