### PR TITLE
romio,hwloc: fix type errors for x86

### DIFF
--- a/ompi/mca/io/romio321/romio/adio/include/adio.h
+++ b/ompi/mca/io/romio321/romio/adio/include/adio.h
@@ -97,6 +97,9 @@
 #ifdef MPI_OFFSET_IS_INT
    typedef int ADIO_Offset;
 #  define ADIO_OFFSET MPI_INT
+#elif __SIZEOF_SIZE_T__ == 4
+   typedef long ADIO_Offset;
+#  define ADIO_OFFSET MPI_LONG
 #elif defined(HAVE_LONG_LONG_64)
    typedef long long ADIO_Offset;
 #  ifdef HAVE_MPI_LONG_LONG_INT

--- a/opal/mca/pmix/pmix3x/pmix/src/hwloc/hwloc.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/hwloc/hwloc.c
@@ -48,7 +48,7 @@ static bool external_topology = false;
 
 #if HWLOC_API_VERSION >= 0x20000
 static size_t shmemsize = 0;
-static size_t shmemaddr;
+static uintptr_t shmemaddr;
 static char *shmemfile = NULL;
 static int shmemfd = -1;
 
@@ -58,10 +58,10 @@ static int parse_map_line(const char *line,
                           pmix_hwloc_vm_map_kind_t *kindp);
 static int use_hole(unsigned long holebegin,
                     unsigned long holesize,
-                    unsigned long *addrp,
+                    uintptr_t *addrp,
                     unsigned long size);
 static int find_hole(pmix_hwloc_vm_hole_kind_t hkind,
-                     size_t *addrp,
+                     uintptr_t *addrp,
                      size_t size);
 static int enough_space(const char *filename,
                         size_t space_req,
@@ -584,7 +584,7 @@ static int parse_map_line(const char *line,
 
 static int use_hole(unsigned long holebegin,
                     unsigned long holesize,
-                    unsigned long *addrp,
+                    uintptr_t *addrp,
                     unsigned long size)
 {
     unsigned long aligned;
@@ -615,7 +615,7 @@ static int use_hole(unsigned long holebegin,
 }
 
 static int find_hole(pmix_hwloc_vm_hole_kind_t hkind,
-                     size_t *addrp, size_t size)
+                     uintptr_t *addrp, size_t size)
 {
     unsigned long biggestbegin = 0;
     unsigned long biggestsize = 0;

--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -67,7 +67,7 @@ orte_rtc_base_module_t orte_rtc_hwloc_module = {
 
 #if HWLOC_API_VERSION >= 0x20000
 static size_t shmemsize = 0;
-static size_t shmemaddr;
+static uintptr_t shmemaddr;
 static char *shmemfile = NULL;
 static int shmemfd = -1;
 
@@ -77,10 +77,10 @@ static int parse_map_line(const char *line,
                           orte_rtc_hwloc_vm_map_kind_t *kindp);
 static int use_hole(unsigned long holebegin,
                     unsigned long holesize,
-                    unsigned long *addrp,
+                    uintptr_t *addrp,
                     unsigned long size);
 static int find_hole(orte_rtc_hwloc_vm_hole_kind_t hkind,
-                     size_t *addrp,
+                     uintptr_t *addrp,
                      size_t size);
 static int enough_space(const char *filename,
                         size_t space_req,
@@ -524,7 +524,7 @@ static int parse_map_line(const char *line,
 
 static int use_hole(unsigned long holebegin,
                     unsigned long holesize,
-                    unsigned long *addrp,
+                    uintptr_t *addrp,
                     unsigned long size)
 {
     unsigned long aligned;
@@ -576,7 +576,7 @@ static int use_hole(unsigned long holebegin,
 }
 
 static int find_hole(orte_rtc_hwloc_vm_hole_kind_t hkind,
-                     size_t *addrp, size_t size)
+                     uintptr_t *addrp, size_t size)
 {
     unsigned long biggestbegin = 0;
     unsigned long biggestsize = 0;


### PR DESCRIPTION
Fix the most egregious type violations that not only prevent with GCC 14 on i586 but that are just bugs too.