### PR TITLE
v4.1.x: Fix typo in LDFLAGS_save_xcode variable name

### DIFF
--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -210,13 +210,13 @@ end program
     LIBS=$LIBS_save_xcode
 
     AS_IF([test $xcode_happy -eq 1],
-          [ # Restore LDFLAFGS + the new flags (i.e., get rid of the
+          [ # Restore LDFLAGS + the new flags (i.e., get rid of the
             # "-L." we added for this test)
-           LDFLAGS="$LDFLAGS_xcode_save $1"
+           LDFLAGS="$LDFLAGS_save_xcode $1"
            $2],
           [ # If we failed the test, reset LDFLAGS back to its
             # original value.
-           LDFLAGS=$LDFLAGS_xcode_save
+           LDFLAGS=$LDFLAGS_save_xcode
            $3])
 
     OPAL_VAR_SCOPE_POP


### PR DESCRIPTION
resulted in effectively overriding LDFLAGS='' on mac because save and restore variable named did not match

Signed-off-by: Min RK <benjaminrk@gmail.com>
(cherry picked from commit 5d6026e041a76bfd11d22a0b12bf3476fc1f39a1)

This is a cherry pick of main PR #12720 
Refs #12719 

FYI @minrk 