### PR TITLE
configury: fix IGNORE_TKR check

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -214,7 +214,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
     implicit none
     real, intent(inout) :: var(:, :, :)
 
-    call foobar(var(1,1,1), 1)
+    call foobar(var, 1)
 ! Autoconf puts "end" after the last line
 ]]),
                     [msg=yes


### PR DESCRIPTION
As reported by Chris Parrott in #12681, the enhanced test was buggy. Pass the expected argument to make it Fortran compliant and LLVM 17 and above happy compilers