### PR TITLE
man pages: fix typos in MPI_Pready* man pages

### DIFF
--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -21,7 +21,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Parrived(MPI_Request *request, int partition, int *flag)
+   int MPI_Parrived(MPI_Request request, int partition, int *flag)
 
 
 Fortran Syntax

--- a/docs/man-openmpi/man3/MPI_Pready.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready.3.rst
@@ -21,7 +21,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Pready(int partition, MPI_Request *request)
+   int MPI_Pready(int partition, MPI_Request request)
 
 
 Fortran Syntax

--- a/docs/man-openmpi/man3/MPI_Pready_list.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready_list.3.rst
@@ -21,7 +21,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Pready_list(int length, int *partitions, MPI_Request *request)
+   int MPI_Pready_list(int length, int *partitions, MPI_Request request)
 
 
 Fortran Syntax

--- a/docs/man-openmpi/man3/MPI_Pready_range.3.rst
+++ b/docs/man-openmpi/man3/MPI_Pready_range.3.rst
@@ -21,7 +21,7 @@ C Syntax
 
    #include <mpi.h>
 
-   int MPI_Pready_range(int partition_low, int partition_high, MPI_Request *request)
+   int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request)
 
 
 Fortran Syntax


### PR DESCRIPTION
Thanks to @jprotze for notifying us of the issue.

refs #12704