### PR TITLE
Fix a variety of typos in comments and strings

### DIFF
--- a/test/carto/carto-file
+++ b/test/carto/carto-file
@@ -21,7 +21,7 @@
 #
 #
 # Connection declaration  From node   To node:weight   To node:weight   ......
-# (Reserve word)          (declered   (declered        (declered
+# (Reserve word)          (declared   (declared        (declared
 #                          above)      above)           above)
 #===============================================================================================
   CONNECTION              slot0       mem0:0           slot1:1           slot2:1 mthca0:1 eth0:1

--- a/test/monitoring/check_monitoring.c
+++ b/test/monitoring/check_monitoring.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2017      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -503,7 +504,7 @@ int main(int argc, char *argv[])
         MPI_Abort(MPI_COMM_WORLD, -1);
 
     /* third phase: exchange size times data with everyone, including self, in
-       MPI_COMM_WORLD with RMA opertations */
+       MPI_COMM_WORLD with RMA operations */
     char win_buff[20];
     MPI_Win win;
     MPI_Win_create(win_buff, 20, sizeof(char), MPI_INFO_NULL, MPI_COMM_WORLD, &win);

--- a/test/simple/concurrent_spawn.c
+++ b/test/simple/concurrent_spawn.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     else {
         hostname = opal_gethostname();
         if (argc == 1) {
-            printf("ERROR: child did not receive exepcted argv!\n");
+            printf("ERROR: child did not receive expected argv!\n");
             i = -1;
         } else {
             i = atoi(argv[1]);

--- a/test/simple/hello_show_help.c
+++ b/test/simple/hello_show_help.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
         opal_output(
             0, "This test ensures that the aggregation functionality of the opal_show_help\nsystem "
                "is working properly.  It outputs a bogus warning about opal_init(),\nand contains "
-               "sleep statements to ensure that the timer is firiing properly\nin the HNP and "
+               "sleep statements to ensure that the timer is firing properly\nin the HNP and "
                "aggregates messages properly.  The total sleep time is\n(3 * num_procs).  You "
                "should see:\n\n - aggregation messages from the HNP every five seconds or so\n - a "
                "total of (2 * num_procs) messages");

--- a/test/simple/intercomm1.c
+++ b/test/simple/intercomm1.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
     MPI_Comm_split(MPI_COMM_WORLD, color, rank, &scomm);
     printf("%d Calling Intercomm_create\n", rank);
     MPI_Intercomm_create(scomm, 0, MPI_COMM_WORLD, 1 - color, 1, &comm);
-    printf("%d Completet\n", rank);
+    printf("%d Complete\n", rank);
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_remote_size(comm, &size);
     MPI_Comm_free(&scomm);

--- a/test/util/opal_error.c
+++ b/test/util/opal_error.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,7 +51,7 @@ int main(int argc, char *argv[])
         OPAL_ERR_NOT_FOUND,
         OPAL_ERR_BAD_PARAM,
         OPAL_ERR_MAX + 10, /* bad value */
-        1,                 /* sentinal */
+        1,                 /* sentinel */
     };
     char buf[1024];
 


### PR DESCRIPTION
No code or logic changes.

Thanks to @spaette for bringing these to our attention.

Refs #12738