### PR TITLE
v5.0.x: DOCS: minor fix to autogen.pl related page

### DIFF
--- a/docs/developers/autogen.rst
+++ b/docs/developers/autogen.rst
@@ -20,7 +20,7 @@ shell startup files)::
    export AUTOMAKE_JOBS=4
 
    # For csh/tcsh:
-   set AUTOMAKE_JOBS 4
+   setenv AUTOMAKE_JOBS 4
 
 .. important:: You generally need to run ``autogen.pl`` whenever the
    top-level file ``configure.ac`` changes, or any files in the


### PR DESCRIPTION
tcsh/csh use setenv not set for environment variables

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 7f9dfda377829743adb89fa2ef88bd1c471c0112)