### PR TITLE
oshmem/shmem: Fix sshmem start address and warn if inside data region

### DIFF
--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -15,6 +15,7 @@
 #include "oshmem/proc/proc.h"
 #include "oshmem/mca/memheap/memheap.h"
 #include "oshmem/mca/memheap/base/base.h"
+#include "oshmem/mca/sshmem/base/base.h"
 #include "oshmem/util/oshmem_util.h"
 #include "opal/util/minmax.h"
 
@@ -52,6 +53,14 @@ int mca_memheap_base_static_init(mca_memheap_map_t *map)
         MEMHEAP_ERROR("Failed to open /proc/self/maps");
         return OSHMEM_ERROR;
     }
+
+#ifdef __linux__
+    extern unsigned _end;
+    if (mca_sshmem_base_start_address < (uintptr_t)&_end) {
+        MEMHEAP_WARN("sshmem base start address is inside data region"
+                     " (%p < %p)", mca_sshmem_base_start_address, &_end);
+    }
+#endif
 
     while (NULL != fgets(line, sizeof(line), fp)) {
         if (3 > sscanf(line,

--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
@@ -37,6 +37,8 @@
  */
 #if UINTPTR_MAX == 0xFFFFFFFF
 void *mca_sshmem_base_start_address = (void*)0;
+#elif defined(__aarch64__)
+void* mca_sshmem_base_start_address = (void*)0xAB0000000000;
 #else
 void* mca_sshmem_base_start_address = (void*)0xFF000000;
 #endif


### PR DESCRIPTION
On some platforms, the end of the data region is above our shared memory region. We end-up erroneously adding the UCX segment a second time as a static segment, causing corruption.

Possible workaround option: `-mca sshmem_base_start_address 0xbaaaab2c0000`
Internal: [3995436](https://redmine.mellanox.com/issues/3995436)