### PR TITLE
portals4: use PtlHandleIsEqual() to compare handles

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4_cancel.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_cancel.c
@@ -45,7 +45,7 @@ ompi_mtl_portals4_cancel(struct mca_mtl_base_module_t* mtl,
                receive completion event... */
             ompi_mtl_portals4_progress();
 
-            if (PTL_INVALID_HANDLE != recvreq->me_h) {
+            if (!PtlHandleIsEqual(recvreq->me_h, PTL_INVALID_HANDLE)) {
                 ret = PtlMEUnlink(recvreq->me_h);
                 if (PTL_OK == ret) {
                     recvreq->super.super.ompi_req->req_status._cancelled = true;

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
@@ -162,7 +162,7 @@ ompi_mtl_portals4_recv_short_block_alloc(bool release_on_free)
 static int
 ompi_mtl_portals4_recv_short_block_free(ompi_mtl_portals4_recv_short_block_t *block)
 {
-    if (PTL_INVALID_HANDLE != block->me_h) {
+    if (!PtlHandleIsEqual(block->me_h, PTL_INVALID_HANDLE)) {
         PtlMEUnlink(block->me_h);
         block->me_h = PTL_INVALID_HANDLE;
     }

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -496,7 +496,7 @@ get_to_iovec(ompi_osc_portals4_module_t *module,
     ptrdiff_t length, origin_lb, target_lb, extent;
     ptl_md_t md;
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -583,7 +583,7 @@ atomic_get_to_iovec(ompi_osc_portals4_module_t *module,
     ptrdiff_t length, origin_lb, target_lb, extent;
     ptl_md_t md;
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -665,7 +665,7 @@ put_from_iovec(ompi_osc_portals4_module_t *module,
     ptrdiff_t length, origin_lb, target_lb, extent;
     ptl_md_t md;
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -754,7 +754,7 @@ atomic_put_from_iovec(ompi_osc_portals4_module_t *module,
     ptrdiff_t length, origin_lb, target_lb, extent;
     ptl_md_t md;
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -841,7 +841,7 @@ atomic_from_iovec(ompi_osc_portals4_module_t *module,
     ptl_op_t ptl_op;
     ptl_datatype_t ptl_dt;
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -940,7 +940,7 @@ swap_to_iovec(ompi_osc_portals4_module_t *module,
     ptl_md_t md;
     ptl_datatype_t ptl_dt;
 
-    if (module->result_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->result_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->result_iovec_md_h);
         free(module->result_iovec_list);
         module->result_iovec_md_h = PTL_INVALID_HANDLE;
@@ -971,7 +971,7 @@ swap_to_iovec(ompi_osc_portals4_module_t *module,
         return ret;
     }
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;
@@ -1066,7 +1066,7 @@ fetch_atomic_to_iovec(ompi_osc_portals4_module_t *module,
     ptl_op_t ptl_op;
     ptl_datatype_t ptl_dt;
 
-    if (module->result_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->result_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->result_iovec_md_h);
         free(module->result_iovec_list);
         module->result_iovec_md_h = PTL_INVALID_HANDLE;
@@ -1097,7 +1097,7 @@ fetch_atomic_to_iovec(ompi_osc_portals4_module_t *module,
         return ret;
     }
 
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
         module->origin_iovec_md_h = PTL_INVALID_HANDLE;

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -615,10 +615,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
  error:
     /* BWB: FIX ME: This is all wrong... */
-    if (0 != module->ct_h) PtlCTFree(module->ct_h);
-    if (0 != module->data_me_h) PtlMEUnlink(module->data_me_h);
-    if (0 != module->req_md_h) PtlMDRelease(module->req_md_h);
-    if (0 != module->md_h) PtlMDRelease(module->md_h);
+    if (!PtlHandleIsEqual(module->ct_h, PTL_INVALID_HANDLE)) PtlCTFree(module->ct_h);
+    if (!PtlHandleIsEqual(module->data_me_h, PTL_INVALID_HANDLE)) PtlMEUnlink(module->data_me_h);
+    if (!PtlHandleIsEqual(module->req_md_h, PTL_INVALID_HANDLE)) PtlMDRelease(module->req_md_h);
+    if (!PtlHandleIsEqual(module->md_h, PTL_INVALID_HANDLE)) PtlMDRelease(module->md_h);
     if (NULL != module->comm) ompi_comm_free(&module->comm);
     if (NULL != module) free(module);
 
@@ -655,11 +655,11 @@ ompi_osc_portals4_free(struct ompi_win_t *win)
     PtlMEUnlink(module->control_me_h);
     PtlMEUnlink(module->data_me_h);
     PtlMDRelease(module->md_h);
-    if (module->origin_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->origin_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->origin_iovec_md_h);
         free(module->origin_iovec_list);
     }
-    if (module->result_iovec_md_h != PTL_INVALID_HANDLE) {
+    if (!PtlHandleIsEqual(module->result_iovec_md_h,PTL_INVALID_HANDLE)) {
         PtlMDRelease(module->result_iovec_md_h);
         free(module->result_iovec_list);
     }

--- a/opal/mca/btl/portals4/btl_portals4.c
+++ b/opal/mca/btl/portals4/btl_portals4.c
@@ -487,13 +487,13 @@ int mca_btl_portals4_free(struct mca_btl_base_module_t *btl_base, mca_btl_base_d
         OPAL_BTL_PORTALS4_FRAG_RETURN_EAGER(portals4_btl, frag);
 
     } else if (BTL_PORTALS4_FRAG_TYPE_MAX == frag->type) {
-        if (frag->me_h != PTL_INVALID_HANDLE) {
+        if (!PtlHandleIsEqual(frag->me_h,PTL_INVALID_HANDLE)) {
             frag->me_h = PTL_INVALID_HANDLE;
         }
         OPAL_BTL_PORTALS4_FRAG_RETURN_MAX(portals4_btl, frag);
 
     } else if (BTL_PORTALS4_FRAG_TYPE_USER == frag->type) {
-        if (frag->me_h != PTL_INVALID_HANDLE) {
+        if (!PtlHandleIsEqual(frag->me_h,PTL_INVALID_HANDLE)) {
             frag->me_h = PTL_INVALID_HANDLE;
         }
         OPAL_THREAD_ADD_FETCH32(&portals4_btl->portals_outstanding_ops, -1);

--- a/opal/mca/btl/portals4/btl_portals4_frag.c
+++ b/opal/mca/btl/portals4/btl_portals4_frag.c
@@ -45,7 +45,7 @@ static void mca_btl_portals4_frag_eager_constructor(mca_btl_portals4_frag_t *fra
 
 static void mca_btl_portals4_frag_eager_destructor(mca_btl_portals4_frag_t *frag)
 {
-    if (PTL_INVALID_HANDLE != frag->me_h) {
+    if (!PtlHandleIsEqual(frag->me_h, PTL_INVALID_HANDLE)) {
         PtlMEUnlink(frag->me_h);
         frag->me_h = PTL_INVALID_HANDLE;
     }


### PR DESCRIPTION
The Portals4 standard requires the use of PtlHandleIsEqual() instead of the (in)equality operatror, because a handle may be a compound data type that cannot be directly compared.

Thanks to @nbartelheimer for the bug report.
