### PR TITLE
coll/acoll: Remove use of cid as array index

### DIFF
--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -33,6 +33,7 @@ BEGIN_C_DECLS
 /* Globally exported variables */
 OMPI_DECLSPEC extern const mca_coll_base_component_3_0_0_t mca_coll_acoll_component;
 extern int mca_coll_acoll_priority;
+extern int mca_coll_acoll_max_comms;
 extern int mca_coll_acoll_sg_size;
 extern int mca_coll_acoll_sg_scale;
 extern int mca_coll_acoll_node_size;
@@ -75,7 +76,6 @@ int mca_coll_acoll_barrier_intra(struct ompi_communicator_t *comm, mca_coll_base
 
 END_C_DECLS
 
-#define MCA_COLL_ACOLL_MAX_CID            100
 #define MCA_COLL_ACOLL_ROOT_CHANGE_THRESH 10
 
 typedef enum MCA_COLL_ACOLL_SG_SIZES {
@@ -208,8 +208,10 @@ struct mca_coll_acoll_module_t {
     int mnode_log2_sg_size;
     int allg_lin;
     int allg_ring;
-    coll_acoll_subcomms_t subc[MCA_COLL_ACOLL_MAX_CID];
+    int max_comms;
+    coll_acoll_subcomms_t **subc;
     coll_acoll_reserve_mem_t reserve_mem_s;
+    int num_subc;
 };
 
 #ifdef HAVE_XPMEM_H

--- a/ompi/mca/coll/acoll/coll_acoll_module.c
+++ b/ompi/mca/coll/acoll/coll_acoll_module.c
@@ -77,6 +77,7 @@ mca_coll_base_module_t *mca_coll_acoll_comm_query(struct ompi_communicator_t *co
     *priority = mca_coll_acoll_priority;
 
     /* Set topology params */
+    acoll_module->max_comms = mca_coll_acoll_max_comms;
     acoll_module->sg_scale = mca_coll_acoll_sg_scale;
     acoll_module->sg_size = mca_coll_acoll_sg_size;
     acoll_module->sg_cnt = mca_coll_acoll_sg_size / mca_coll_acoll_sg_scale;


### PR DESCRIPTION
This PR removes the use of context id as array index in `mca_coll_acoll_module_t`. Previously, `coll_acoll_subcomms_t subc[]` was indexed through context id of the communicator. Now, `subc `is dynamically allocated for each new communicator (for up to 10 communicators), thereby eliminating the need to use context id as array index. 

There is no change in performance of the collective APIs with this change. 