### PR TITLE
v5.0.x: gcc 14 and clang 18 compiler warning fixes

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016-2022 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +16,7 @@
 #include <dlfcn.h>
 #endif
 
+#include "opal/util/string_copy.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/pml/pml.h"
 #include "opal/mca/btl/btl.h"
@@ -105,21 +107,21 @@ comm_method_string(MPI_Comm comm, int rank, int *comm_mode) {
             if (comm_mode) { *comm_mode = MODE_IS_BTL; }
             btl = lookup_btl_name_for_send(comm, rank);
             if (NULL == btl) {
-                strncpy(string, "n/a", COMM_METHOD_STRING_SIZE);
+                opal_string_copy(string, "n/a", COMM_METHOD_STRING_SIZE);
             } else {
-                strncpy(string, btl, COMM_METHOD_STRING_SIZE);
+                opal_string_copy(string, btl, COMM_METHOD_STRING_SIZE);
             }
         }
         else if (p && 0==strncmp("cm", p, 3)) {  // MTL
             if (comm_mode) { *comm_mode = MODE_IS_MTL; }
-            strncpy(string, lookup_mtl_name(), COMM_METHOD_STRING_SIZE);
+            opal_string_copy(string, lookup_mtl_name(), COMM_METHOD_STRING_SIZE);
         } else {                        // PML
             if (comm_mode) { *comm_mode = MODE_IS_PML; }
             if (p) {
-                strncpy(string, p, COMM_METHOD_STRING_SIZE);
+                opal_string_copy(string, p, COMM_METHOD_STRING_SIZE);
             }
             else {
-                strncpy(string, "n/a", COMM_METHOD_STRING_SIZE);
+                opal_string_copy(string, "n/a", COMM_METHOD_STRING_SIZE);
             }
         }
     }
@@ -691,7 +693,7 @@ ompi_report_comm_methods(int called_from_location)
                 p = str;
                 for (k=0; k<nleaderranks; ++k) {
                     char *method_string;
-                    char ucx_label[10];
+                    char ucx_label[20];
                     
                     method_string = comm_method_to_string(method[i * nleaderranks + k]);
                     if (0 == strncmp(method_string, UCX_TAG, strlen(UCX_TAG))) {

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -234,7 +234,7 @@ mca_part_persist_progress(void)
 
             if(done) {
                 size_t dt_size_;
-                int32_t dt_size;
+                uint32_t dt_size;
 
                 if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
                     /* parse message */
@@ -242,8 +242,8 @@ mca_part_persist_progress(void)
 
                     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
                     if(OMPI_SUCCESS != err) return OMPI_ERROR;
-                    dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
-                    int32_t bytes = req->real_count * dt_size;
+                    dt_size = (dt_size_ > (size_t) UINT_MAX) ? MPI_UNDEFINED : (uint32_t) dt_size_;
+                    uint32_t bytes = req->real_count * dt_size;
 
                     /* Set up persistent sends */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
@@ -261,8 +261,8 @@ mca_part_persist_progress(void)
 
                     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
                     if(OMPI_SUCCESS != err) return OMPI_ERROR;
-                    dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
-                    int32_t bytes = req->real_count * dt_size;
+                    dt_size = (dt_size_ > (size_t) UINT_MAX) ? MPI_UNDEFINED : (uint32_t) dt_size_;
+                    uint32_t bytes = req->real_count * dt_size;
 
                     /* Set up persistent sends */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
@@ -337,7 +337,7 @@ mca_part_persist_precv_init(void *buf,
 {
     int err = OMPI_SUCCESS;
     size_t dt_size_;
-    int dt_size;
+    uint32_t dt_size;
     mca_part_persist_list_t* new_progress_elem = NULL;
 
     mca_part_persist_precv_request_t *recvreq;
@@ -369,7 +369,7 @@ mca_part_persist_precv_init(void *buf,
     /* Compute total number of bytes */
     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
-    dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
+    dt_size = (dt_size_ > (size_t) UINT_MAX) ? MPI_UNDEFINED : (uint32_t) dt_size_;
     req->req_bytes = parts * count * dt_size;
 
 
@@ -405,7 +405,7 @@ mca_part_persist_psend_init(const void* buf,
 {
     int err = OMPI_SUCCESS;
     size_t dt_size_;
-    int dt_size;
+    uint32_t dt_size;
     mca_part_persist_list_t* new_progress_elem = NULL;
     mca_part_persist_psend_request_t *sendreq;
 
@@ -430,7 +430,7 @@ mca_part_persist_psend_init(const void* buf,
     /* Determine total bytes to send. */
     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
-    dt_size = (dt_size_ > (size_t) INT_MAX) ? MPI_UNDEFINED : (int) dt_size_;
+    dt_size = (dt_size_ > (size_t) UINT_MAX) ? MPI_UNDEFINED : (uint32_t) dt_size_;
     req->req_bytes = parts * count * dt_size;
 
 
@@ -494,11 +494,11 @@ mca_part_persist_start(size_t count, ompi_request_t** requests)
         {
             if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
                 req->done_count = 0;
-                memset((void*)req->flags,0,sizeof(int32_t)*req->real_parts);
+                memset((void*)req->flags,0,sizeof(uint32_t)*req->real_parts);
             } else {
                 req->done_count = 0;
                 err = req->persist_reqs[0]->req_start(req->real_parts, req->persist_reqs);
-                memset((void*)req->flags,0,sizeof(int32_t)*req->real_parts);
+                memset((void*)req->flags,0,sizeof(uint32_t)*req->real_parts);
             } 
         } else {
             if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {

--- a/opal/datatype/opal_copy_functions_heterogeneous.c
+++ b/opal/datatype/opal_copy_functions_heterogeneous.c
@@ -8,6 +8,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -492,7 +493,7 @@ f128_to_f80(unsigned char *f80_buf_to, const unsigned char *f128_buf_from, ssize
  */
 static inline
 size_t
-alignment_of_long_double() {
+alignment_of_long_double(void) {
     static size_t val = 0;
 
     if (val == 0) {

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -22,6 +22,7 @@
  *                         reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -572,6 +573,13 @@ static int do_open(int output_id, opal_output_stream_t *lds)
 
     if (!initialized) {
         opal_output_init();
+    }
+
+    /* Bozo check */
+
+    if (output_id >= OPAL_OUTPUT_MAX_STREAMS ||
+        output_id < -1) {
+        return OPAL_ERR_BAD_PARAM;
     }
 
     str = getenv("OPAL_OUTPUT_REDIRECT");


### PR DESCRIPTION
This is a partial cherry pick from main PR #12743 (only 4 out of the 9 commits from #12743 apply to the v5.0.x branch).

See individual commit messages for details.