### PR TITLE
Make sure a PSCW epoch is active on MPI_Win_complete calls

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -429,14 +429,14 @@ int ompi_osc_rdma_complete_atomic (ompi_win_t *win)
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "complete: %s", win->w_name);
 
     OPAL_THREAD_LOCK(&module->lock);
-    if (0 == sync->num_peers) {
-        OPAL_THREAD_UNLOCK(&module->lock);
-        return OMPI_SUCCESS;
-    }
-
     if (OMPI_OSC_RDMA_SYNC_TYPE_PSCW != sync->type) {
         OPAL_THREAD_UNLOCK(&module->lock);
         return OMPI_ERR_RMA_SYNC;
+    }
+
+    if (0 == sync->num_peers) {
+        OPAL_THREAD_UNLOCK(&module->lock);
+        return OMPI_SUCCESS;
     }
 
     /* phase 1 cleanup sync object */


### PR DESCRIPTION
The [test case](https://github.com/pmodels/mpich/blob/v4.2.1/test/mpi/errors/rma/win_sync_complete.c) in mpich test suite v4.2.1 is failing due to MPI_Win_Complete returning with no failures when it should be failing with MPI_ERR_RMA_SYNC. Simple fix included in this PR to make sure that a check is done for an active pscw epoch before further actions are taken.

[config.log](https://github.com/user-attachments/files/16880651/config.log)

Script to generate the failure:
```
#! /usr/bin/env bash
export MPI_PATH="/home/cmann/builds/ompi.debug"
export MPI_LIB_PATH="$MPI_PATH/lib"
export MPI_BIN_PATH="$MPI_PATH/bin"

export LIBFAB_PATH="/home/cmann/builds/libfabric.debug"
export LIBFAB_LIB_PATH="$LIBFAB_PATH/lib"
export LIBFAB_BIN_PATH="$LIBFAB_PATH/bin"

./configure --enable-strictmpi --with-mpi=$MPI_PATH --disable-dtpools

 if [[ $? -ne 0 ]]
 then
    echo "Configure failure"
    exit 1
fi


HOSTS="phwtstl005,phwtstl006"
export RUNTESTS_SHOWPROGRESS=1
# export MPITEST_PPNARG="-N %d"
export VERBOSE=1
export MPITEST_PPNMAX=36
export MPITEST_TIMEOUT=300
export MPITEST_PROGRAM_WRAPPER="--host $HOSTS --mca btl_ofi_disable_sep 1 --mca btl_ofi_disable_hmem 1  --mca osc ^ucx --mca pml ^ucx --mca btl ofi --mca mtl_ofi_enable_sep 0 --mca mtl ofi --map-by :OVERSUBSCRIBE -x FI_OPX_UUID=$RANDOM -x FI_PROVIDER=opx -x LD_PRELOAD=/home/cmann/code/libfabric-devel/debug/handlers/segfault_abort_handler.so -x LD_LIBRARY_PATH=$LIBFAB_LIB_PATH:$MPI_LIB_PATH:$LD_LIBRARY_PATH -x PATH=$MPI_BIN_PATH:$PATH"
make testing
```

Test output:

```
/home/cmann/builds/ompi.debug/bin/mpiexec -n 2   --host phwtstl005,phwtstl006 --mca btl_ofi_disable_sep 1 --mca btl_ofi_disable_hmem 1  --mca osc ^ucx --mca pml ^ucx --mca btl ofi --mca mtl_ofi_enable_sep 0 --mca mtl ofi --map-by :OVERSUBSCRIBE -x FI_OPX_UUID=7553 -x FI_PROVIDER=opx -x LD_PRELOAD=/home/cmann/code/libfabric-devel/debug/handlers/segfault_abort_handler.so -x LD_LIBRARY_PATH=/home/cmann/builds/libfabric.debug/lib:/home/cmann/builds/ompi.debug/lib: -x PATH=/home/cmann/builds/ompi.debug/bin:/home/cmann/.vscode-server/cli/servers/Stable-fee1edb8d6d72a0ddff41e5f71a671c23ed924b9/server/bin/remote-cli:/home/cmann/.local/bin:/usr/share/Modules/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin ./win_sync_complete 
0: Operation succeeded, when it should have failed
1: Operation succeeded, when it should have failed
 Found 2 errors
```
