### PR TITLE
pml/cm,ob1: pack data from application buffer in successive MPI_Start calls

### DIFF
--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -376,7 +376,7 @@ do {                                                                    \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
             opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
-                                             sendreq->req_send.req_base.req_datatype,   \
+                                             &sendreq->req_send.req_base.req_datatype->super,   \
                                              max_data,                  \
                                              sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -375,6 +375,10 @@ do {                                                                    \
             iov.iov_base = (IOVBASE_TYPE*)sendreq->req_buff;            \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
+            opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
+                                             sendreq->req_send.req_base.req_datatype,   \
+                                             max_data,                  \
+                                             sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \
                                  &iov,                                  \
                                  &iov_count,                            \

--- a/ompi/mca/pml/ob1/pml_ob1_start.c
+++ b/ompi/mca/pml/ob1/pml_ob1_start.c
@@ -84,13 +84,16 @@ int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
                     sendreq = (mca_pml_ob1_send_request_t *) request;
                     requests[i] = request;
                 } else if (sendreq->req_send.req_bytes_packed != 0) {
-                    size_t offset = 0;
                     /**
                      * Reset the convertor in case we're dealing with the original
-                     * request, which when completed do not reset the convertor.
+                     * request, which when completed do not reset the convertor but
+                     * leaves it pointing to the buffered send location, with the
+                     * packed datatype and count.
                      */
-                    opal_convertor_set_position (&sendreq->req_send.req_base.req_convertor,
-                                                 &offset);
+                    opal_convertor_prepare_for_send(&sendreq->req_send.req_base.req_convertor,
+                                                    &sendreq->req_send.req_base.req_datatype->super,
+                                                    sendreq->req_send.req_base.req_count,
+                                                    sendreq->req_send.req_base.req_addr);
                 }
 
                 /* reset the completion flag */


### PR DESCRIPTION
This patch fixes a bug exposed by MTT MPI_Bsend_init_overtake_c, where
- MPI_Bsend_init(buf, ..., req)
- MPI_Start(req)
- MPI_Wait(req, stat)
- modify(buf)
- MPI_Start(req) // this does not send the updated data
- MPI_Wait(buf)

This is because PML/CM uses a bounce buffer send_req.req_buff to pack data from  the application buffer in MPI_Bsend_int but not MPI_Start.

This patch adds a step to pack data from the application buffer in each MPI_Start call.