### PR TITLE
fcoll/vulcan: fix memory leak

### DIFF
--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -768,8 +768,10 @@ exit :
     }
     free(broken_iov_arrays);
     free(fh->f_procs_in_group);
+    free(fh->f_aggr_list);
     fh->f_procs_in_group=NULL;
     fh->f_procs_per_group=0;
+    fh->f_aggr_list=NULL;
     free(result_counts);
     free(reqs);
      


### PR DESCRIPTION
we didn't free the fh->f_aggr_list array in the vulcan file_write_all file. Thanks @andymwood for reporting the issue and @ggouaillardet for identifying the cause of the leak. I followed in this pr the pattern that we used for the other variables (i.e. free the array and set the pointer to NULL) to have some uniformity.

Tested on main with the ompi-tests file testsuite, and through a manual backport to 5.0.3 with the hdf5 testsuite (current main does not work for hdf5 because of issue https://github.com/open-mpi/ompi/issues/12742)

Will have to be backported to 4.1.x and 5.0.x branches.

Fixes Issue #12677 (at least partially)