### PR TITLE
ci: always run configury build tests on Amazon Linux 2

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -71,7 +71,7 @@ def prepare_check_stages() {
 
       for (configure_option in configure_options) {
         def name = "Configure: ${configure_option}".replaceAll("-", "")
-        build_parallel_map.put(name, prepare_build(name, "(ec2&&linux)", "--configure-args \\\"${configure_option}\\\""))
+        build_parallel_map.put(name, prepare_build(name, "amazon_linux_2", "--configure-args \\\"${configure_option}\\\""))
     }
 
     build_parallel_map.put("distcheck", prepare_build("distcheck", "tarball_build", "--distcheck"))


### PR DESCRIPTION
This patch fixes 2 issues:
- CI configury test is currently non-deterministic since the job can be placed on an arbitrary node.
- RHEL7 node is still alive but we don't want to test main on it due to old gcc