### PR TITLE
v5.0.x: fcoll/vulcan: fix memory leak

### DIFF
--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -728,8 +728,10 @@ exit :
     }
     free(broken_iov_arrays);
     free(fh->f_procs_in_group);
+    free(fh->f_aggr_list);
     fh->f_procs_in_group=NULL;
     fh->f_procs_per_group=0;
+    fh->f_aggr_list=NULL;
     free(result_counts);
     free(reqs);
      


### PR DESCRIPTION
we didn't correctly free the fh->f_aggr_list array in the vulcan file_write_all file. Thanks @andymwood for reporting the issue and @ggouaillardet for identifying the cause for the leak.

Fixes Issue #12677 (at least partially)

Signed-off-by: Edgar Gabriel <edgar.gabriel@amd.com>
(cherry picked from commit 3fde6af4ac598a95db5b05c21b689e12fb507790)