### PR TITLE
btl/uct: fix fetching atomics support for osc/rdma

### DIFF
--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -337,7 +337,8 @@ mca_btl_uct_module_t mca_btl_uct_module_template = {
 
         /* set the default flags for this btl. uct provides us with rdma and both
          * fetching and non-fetching atomics (though limited to add and cswap) */
-        .btl_flags = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS | MCA_BTL_FLAGS_ATOMIC_OPS,
+        .btl_flags = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS | MCA_BTL_FLAGS_ATOMIC_OPS
+                     | MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION,
         .btl_atomic_flags = MCA_BTL_ATOMIC_SUPPORTS_ADD | MCA_BTL_ATOMIC_SUPPORTS_CSWAP
                             | MCA_BTL_ATOMIC_SUPPORTS_SWAP | MCA_BTL_ATOMIC_SUPPORTS_32BIT,
 

--- a/opal/mca/btl/uct/btl_uct_tl.c
+++ b/opal/mca/btl/uct/btl_uct_tl.c
@@ -78,11 +78,10 @@ static void mca_btl_uct_module_set_atomic_flags(mca_btl_uct_module_t *module, mc
     uint64_t atomic_flags32 = MCA_BTL_UCT_TL_ATTR(tl, 0).cap.atomic32.fop_flags;
     uint64_t atomic_flags64 = MCA_BTL_UCT_TL_ATTR(tl, 0).cap.atomic64.fop_flags;
 
-    /* NTH: don't really have a way to separate 32-bit and 64-bit right now */
-    uint64_t all_flags = atomic_flags32 & atomic_flags64;
+    uint64_t all_flags = atomic_flags64 | atomic_flags32;
 
-    module->super.btl_atomic_flags = 0;
-
+    module->super.btl_atomic_flags = (0 != atomic_flags32) ? MCA_BTL_ATOMIC_SUPPORTS_32BIT : 0;
+    
     if (cap_flags & UCT_IFACE_FLAG_ATOMIC_CPU) {
         module->super.btl_atomic_flags |= MCA_BTL_ATOMIC_SUPPORTS_GLOB;
     }


### PR DESCRIPTION
The check that requires 32 and 64 bit atomic support is way outdated at this point. This commit takes the union of the two instead of the intersection because technically it is up to the btl user to determine which of each type are supported. This commit also ensures that MCA_BTL_ATOMIC_SUPPORTS_32BIT is set when 32-bit atomics are available and ensures that the required MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION flag is set on the btl.