### PR TITLE
v5.0.x: coll/ucc: fix int overflow in coll init 

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                       void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_allgather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                       void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                        mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,
                                                        mca_coll_ucc_req_t *coll_req)

--- a/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
@@ -9,7 +9,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allgatherv_init(const void *sbuf, int scount,
+static inline ucc_status_t mca_coll_ucc_allgatherv_init(const void *sbuf, size_t scount,
                                                         struct ompi_datatype_t *sdtype,
                                                         void* rbuf, const int *rcounts, const int *rdisps,
                                                         struct ompi_datatype_t *rdtype,

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -9,7 +9,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_allreduce_init(const void *sbuf, void *rbuf, size_t count,
                                                        struct ompi_datatype_t *dtype,
                                                        struct ompi_op_t *op, mca_coll_ucc_module_t *ucc_module,
                                                        ucc_coll_req_h *req,

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -9,8 +9,8 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                                      void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
+static inline ucc_status_t mca_coll_ucc_alltoall_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                                      void* rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                                       mca_coll_ucc_module_t *ucc_module,
                                                       ucc_coll_req_h *req,
                                                       mca_coll_ucc_req_t *coll_req)

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, int count, struct ompi_datatype_t *dtype,
+static inline ucc_status_t mca_coll_ucc_bcast_init(void *buf, size_t count, struct ompi_datatype_t *dtype,
                                                    int root, mca_coll_ucc_module_t *ucc_module,
                                                    ucc_coll_req_h *req,
                                                    mca_coll_ucc_req_t *coll_req)

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -11,8 +11,8 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
-                                      void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
+ucc_status_t mca_coll_ucc_gather_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
+                                      void *rbuf, size_t rcount, struct ompi_datatype_t *rdtype,
                                       int root, mca_coll_ucc_module_t *ucc_module,
                                       ucc_coll_req_h *req,
                                       mca_coll_ucc_req_t *coll_req)

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -10,7 +10,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
+static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, size_t scount, struct ompi_datatype_t *sdtype,
                                                      void *rbuf, const int *rcounts, const int *disps,
                                                      struct ompi_datatype_t *rdtype, int root,
                                                      mca_coll_ucc_module_t *ucc_module,

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -8,7 +8,7 @@
 
 #include "coll_ucc_common.h"
 
-static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, int count,
+static inline ucc_status_t mca_coll_ucc_reduce_init(const void *sbuf, void *rbuf, size_t count,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op, int root,
                                                     mca_coll_ucc_module_t *ucc_module,

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -11,7 +11,7 @@
 
 static inline
 ucc_status_t mca_coll_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf,
-                                                    int rcount,
+                                                    size_t rcount,
                                                     struct ompi_datatype_t *dtype,
                                                     struct ompi_op_t *op,
                                                     mca_coll_ucc_module_t *ucc_module,

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -10,9 +10,9 @@
 #include "coll_ucc_common.h"
 
 static inline
-ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, int scount,
+ucc_status_t mca_coll_ucc_scatter_init(const void *sbuf, size_t scount,
                                        struct ompi_datatype_t *sdtype,
-                                       void *rbuf, int rcount,
+                                       void *rbuf, size_t rcount,
                                        struct ompi_datatype_t *rdtype, int root,
                                        mca_coll_ucc_module_t *ucc_module,
                                        ucc_coll_req_h *req,

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -12,7 +12,7 @@
 static inline
 ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const int *scounts,
                                         const int *disps, struct ompi_datatype_t *sdtype,
-                                        void *rbuf, int rcount,
+                                        void *rbuf, size_t rcount,
                                         struct ompi_datatype_t *rdtype, int root,
                                         mca_coll_ucc_module_t *ucc_module,
                                         ucc_coll_req_h *req,


### PR DESCRIPTION
Fixing src/dst buffer size overflow. If scount or rcount are big enough result of multiplication of srount * comm_size or rcount * comm_size won't fit in int.

bot:notacherrypick