### PR TITLE
btl/uct: add support for using an another memory domain to form connections

### DIFF
--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -139,9 +139,15 @@ struct mca_btl_uct_component_t {
 
     /** allowed UCT memory domains */
     char *memory_domains;
+    mca_btl_uct_include_list_t memory_domain_list;
 
     /** allowed transports */
     char *allowed_transports;
+    mca_btl_uct_include_list_t allowed_transport_list;
+
+    /** transports to consider for forming connections */
+    char *connection_domains;
+    mca_btl_uct_include_list_t connection_domain_list;
 
     /** number of worker contexts to create */
     int num_contexts_per_module;
@@ -153,6 +159,10 @@ struct mca_btl_uct_component_t {
 
     /** disable UCX memory hooks */
     bool disable_ucx_memory_hooks;
+
+    /** alternate connection-only module that can be used if no suitable
+     * connection tl is found. this is usually a tcp tl. */
+    mca_btl_uct_module_t *conn_module;
 };
 typedef struct mca_btl_uct_component_t mca_btl_uct_component_t;
 
@@ -289,7 +299,8 @@ struct mca_btl_base_endpoint_t *mca_btl_uct_get_ep(struct mca_btl_base_module_t 
                                                    opal_proc_t *proc);
 
 int mca_btl_uct_query_tls(mca_btl_uct_module_t *module, mca_btl_uct_md_t *md,
-                          uct_tl_resource_desc_t *tl_descs, unsigned tl_count);
+                          uct_tl_resource_desc_t *tl_descs, unsigned tl_count,
+                          bool evaluate_for_conn_only);
 int mca_btl_uct_process_connection_request(mca_btl_uct_module_t *module,
                                            mca_btl_uct_conn_req_t *req);
 
@@ -335,6 +346,16 @@ static inline bool mca_btl_uct_tl_requires_connection_tl(mca_btl_uct_tl_t *tl)
 {
     return !(MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
+
+/**
+ * @brief Find the rank of `name` in the include list `list`.
+ *
+ * @param[in] name   name to find
+ * @param[in] list   list to search
+ *
+ * A negative result means the name is not present or the list is negated.
+ */
+int mca_btl_uct_include_list_rank (const char *name, const mca_btl_uct_include_list_t *list);
 
 END_C_DECLS
 #endif

--- a/opal/mca/btl/uct/btl_uct_endpoint.h
+++ b/opal/mca/btl/uct/btl_uct_endpoint.h
@@ -34,6 +34,31 @@ mca_btl_base_endpoint_t *mca_btl_uct_endpoint_create(opal_proc_t *proc);
 int mca_btl_uct_endpoint_connect(mca_btl_uct_module_t *module, mca_btl_uct_endpoint_t *endpoint,
                                  int ep_index, void *ep_addr, int tl_index);
 
+static inline bool mca_btl_uct_tl_endpoint_ready(mca_btl_uct_tl_endpoint_t *tl_endpoint)
+{
+    return !!(tl_endpoint->flags & MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY);
+}
+
+/**
+ * @brief Mark all frags associated with the endpoint/context_id pair as ready.
+ *
+ * @param[in] module      UCT BTL module
+ * @param[in] endpoint    UCT BTL endpoint
+ * @param[in] context_id  context id
+ *
+ * Requires holding the endpoint mutex.
+ */
+static inline void btl_uct_release_pending_frags(mca_btl_uct_module_t *module, mca_btl_base_endpoint_t *endpoint,
+                                                 int context_id)
+{
+    mca_btl_uct_base_frag_t *frag;
+    OPAL_LIST_FOREACH (frag, &module->pending_frags, mca_btl_uct_base_frag_t) {
+        if (frag->context->context_id == context_id && endpoint == frag->endpoint) {
+            frag->ready = true;
+        }
+    }
+}
+
 static inline int mca_btl_uct_endpoint_test_am(mca_btl_uct_module_t *module,
                                                mca_btl_uct_endpoint_t *endpoint,
                                                mca_btl_uct_device_context_t *context,
@@ -42,13 +67,22 @@ static inline int mca_btl_uct_endpoint_test_am(mca_btl_uct_module_t *module,
     int tl_index = module->am_tl->tl_index;
     int ep_index = context->context_id;
 
-    if (OPAL_LIKELY(MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY
-                    & endpoint->uct_eps[ep_index][tl_index].flags)) {
+    if (OPAL_LIKELY(mca_btl_uct_tl_endpoint_ready(endpoint->uct_eps[ep_index] + tl_index))) {
         *ep_handle = endpoint->uct_eps[ep_index][tl_index].uct_ep;
         return OPAL_SUCCESS;
     }
 
     return OPAL_ERR_NOT_AVAILABLE;
+}
+
+static inline void mca_btl_uct_tl_endpoint_set_flag(mca_btl_uct_tl_endpoint_t *tl_endpoint, int32_t flag)
+{
+    int32_t flags = opal_atomic_or_fetch_32(&tl_endpoint->flags, flag);
+    int32_t conn_ready_flags = MCA_BTL_UCT_ENDPOINT_FLAG_CONN_REM_READY | MCA_BTL_UCT_ENDPOINT_FLAG_CONN_REC;
+    if ((flags & conn_ready_flags) == conn_ready_flags) {
+        /* remote side is ready and the local endpoint is connected */
+        (void) opal_atomic_or_fetch_32(&tl_endpoint->flags, MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY);
+    }
 }
 
 /**
@@ -72,8 +106,7 @@ static inline int mca_btl_uct_endpoint_check(mca_btl_uct_module_t *module,
     int ep_index = context->context_id;
     int rc;
 
-    if (OPAL_LIKELY(MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY
-                    & endpoint->uct_eps[ep_index][tl_index].flags)) {
+    if (OPAL_LIKELY(mca_btl_uct_tl_endpoint_ready(endpoint->uct_eps[ep_index] + tl_index))) {
         *ep_handle = endpoint->uct_eps[ep_index][tl_index].uct_ep;
         return OPAL_SUCCESS;
     }

--- a/opal/mca/btl/uct/btl_uct_tl.c
+++ b/opal/mca/btl/uct/btl_uct_tl.c
@@ -196,7 +196,6 @@ int mca_btl_uct_process_connection_request(mca_btl_uct_module_t *module,
     struct opal_proc_t *remote_proc = opal_proc_for_name(req->proc_name);
     mca_btl_base_endpoint_t *endpoint = mca_btl_uct_get_ep(&module->super, remote_proc);
     mca_btl_uct_tl_endpoint_t *tl_endpoint = endpoint->uct_eps[req->context_id] + req->tl_index;
-    int32_t ep_flags;
     int rc;
 
     BTL_VERBOSE(("got connection request for endpoint %p. type = %d. context id = %d",
@@ -209,16 +208,12 @@ int mca_btl_uct_process_connection_request(mca_btl_uct_module_t *module,
 
     assert(req->type < 2);
 
-    ep_flags = opal_atomic_fetch_or_32(&tl_endpoint->flags, MCA_BTL_UCT_ENDPOINT_FLAG_CONN_REC);
-
-    if (!(ep_flags & MCA_BTL_UCT_ENDPOINT_FLAG_CONN_REC)) {
-        /* create any necessary resources */
-        rc = mca_btl_uct_endpoint_connect(module, endpoint, req->context_id, req->ep_addr,
-                                          req->tl_index);
-        if (OPAL_SUCCESS != rc && OPAL_ERR_OUT_OF_RESOURCE != rc) {
-            BTL_ERROR(("could not setup rdma endpoint. rc = %d", rc));
-            return rc;
-        }
+    /* create any necessary resources */
+    rc = mca_btl_uct_endpoint_connect(module, endpoint, req->context_id, req->ep_addr,
+                                      req->tl_index);
+    if (OPAL_SUCCESS != rc && OPAL_ERR_OUT_OF_RESOURCE != rc) {
+        BTL_ERROR(("could not setup rdma endpoint. rc = %d", rc));
+        return rc;
     }
 
     /* the connection is ready once we have received the connection data and also a connection ready
@@ -226,20 +221,15 @@ int mca_btl_uct_process_connection_request(mca_btl_uct_module_t *module,
      * an endpoint can be used. */
     if (req->type == 1) {
         /* remote side is ready */
-        mca_btl_uct_base_frag_t *frag;
 
         /* to avoid a race with send adding pending frags grab the lock here */
         OPAL_THREAD_SCOPED_LOCK(&endpoint->ep_lock, {
             BTL_VERBOSE(("connection ready. sending %" PRIsize_t " frags",
                          opal_list_get_size(&module->pending_frags)));
-            (void) opal_atomic_or_fetch_32(&tl_endpoint->flags,
-                                           MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY);
+            mca_btl_uct_tl_endpoint_set_flag(tl_endpoint, MCA_BTL_UCT_ENDPOINT_FLAG_CONN_REM_READY);
             opal_atomic_wmb();
-
-            OPAL_LIST_FOREACH (frag, &module->pending_frags, mca_btl_uct_base_frag_t) {
-                if (frag->context->context_id == req->context_id && endpoint == frag->endpoint) {
-                    frag->ready = true;
-                }
+            if (mca_btl_uct_tl_endpoint_ready(tl_endpoint)) {
+                btl_uct_release_pending_frags(module, endpoint, req->context_id);
             }
         });
     }
@@ -562,57 +552,30 @@ static int mca_btl_uct_evaluate_tl(mca_btl_uct_module_t *module, mca_btl_uct_tl_
 }
 
 int mca_btl_uct_query_tls(mca_btl_uct_module_t *module, mca_btl_uct_md_t *md,
-                          uct_tl_resource_desc_t *tl_descs, unsigned tl_count)
+                          uct_tl_resource_desc_t *tl_descs, unsigned tl_count,
+                          bool evaluate_for_conn_only)
 {
-    bool include = true, any = false;
     mca_btl_uct_tl_t *tl;
     opal_list_t tl_list;
-    char **tl_filter;
-    int any_priority = 0;
 
     OBJ_CONSTRUCT(&tl_list, opal_list_t);
 
-    tl_filter = opal_argv_split(mca_btl_uct_component.allowed_transports, ',');
-
-    if ('^' == tl_filter[0][0]) {
-        /* user has negated the include list */
-        char *tmp = strdup(tl_filter[0] + 1);
-
-        free(tl_filter[0]);
-        tl_filter[0] = tmp;
-        include = false;
-    }
-
-    /* check for the any keyword */
-    for (unsigned j = 0; tl_filter[j]; ++j) {
-        if (0 == strcmp(tl_filter[j], "any")) {
-            any_priority = j;
-            any = true;
-            break;
-        }
-    }
-
-    if (any && !include) {
-        opal_argv_free(tl_filter);
-        return OPAL_ERR_NOT_AVAILABLE;
-    }
-
     for (unsigned i = 0; i < tl_count; ++i) {
-        bool try_tl = any;
-        int priority = any_priority;
+        int priority = 0;
 
-        for (unsigned j = 0; tl_filter[j]; ++j) {
-            if (0 == strcmp(tl_filter[j], tl_descs[i].tl_name)) {
-                try_tl = include;
-                priority = j;
-                break;
+        BTL_VERBOSE(("processing tl %s, evaluate_for_conn_only=%d", tl_descs[i].tl_name, evaluate_for_conn_only));
+        
+        if (!evaluate_for_conn_only) {
+            priority = mca_btl_uct_include_list_rank (tl_descs[i].tl_name, &mca_btl_uct_component.allowed_transport_list);
+
+            BTL_VERBOSE(("tl filter: tl_name = %s, priority = %d", tl_descs[i].tl_name,
+                         priority));
+
+            if (priority < 0) {
+                continue;
             }
-        }
-
-        BTL_VERBOSE(("tl filter: tl_name = %s, use = %d, priority = %d", tl_descs[i].tl_name,
-                     try_tl, priority));
-
-        if (!try_tl) {
+        } else if (tl_descs[i].dev_type != UCT_DEVICE_TYPE_NET) {
+            /* only network types are suitable for forming connections */
             continue;
         }
 
@@ -625,11 +588,22 @@ int mca_btl_uct_query_tls(mca_btl_uct_module_t *module, mca_btl_uct_md_t *md,
         tl = mca_btl_uct_create_tl(module, md, tl_descs + i, priority);
 
         if (tl) {
-            opal_list_append(&tl_list, &tl->super);
+            if (mca_btl_uct_tl_supports_conn(tl) && evaluate_for_conn_only) {
+                BTL_VERBOSE(("evaluating tl %s for forming connections", tl_descs[i].tl_name));
+                int rc = mca_btl_uct_set_tl_conn(module, tl);
+                OBJ_RELEASE(tl);
+
+                if (OPAL_SUCCESS == rc) {
+                    mca_btl_uct_context_enable_progress(tl->uct_dev_contexts[0]);
+                    return OPAL_SUCCESS;
+                }
+
+                BTL_VERBOSE(("tl %s cannot be used for forming connections", tl_descs[i].tl_name));
+            } else {
+                opal_list_append(&tl_list, &tl->super);
+            }
         }
     }
-
-    opal_argv_free(tl_filter);
 
     if (0 == opal_list_get_size(&tl_list)) {
         BTL_VERBOSE(("no suitable tls match filter: %s", mca_btl_uct_component.allowed_transports));
@@ -679,10 +653,6 @@ int mca_btl_uct_query_tls(mca_btl_uct_module_t *module, mca_btl_uct_md_t *md,
         /* no connection tl needed for selected transports */
         OBJ_RELEASE(module->conn_tl);
         module->conn_tl = NULL;
-    } else if (NULL == module->conn_tl) {
-        BTL_VERBOSE(("a connection tl is required but no tls match the filter %s",
-                     mca_btl_uct_component.allowed_transports));
-        return OPAL_ERROR;
     }
 
     return OPAL_SUCCESS;

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -85,6 +85,9 @@ struct mca_btl_uct_conn_req_t {
     /** transport index that should be connected */
     int tl_index;
 
+    /** name of the connecting module */
+    char module_name[64];
+
     /** endpoint address data */
     uint8_t ep_addr[];
 };
@@ -180,6 +183,18 @@ union mca_btl_uct_am_header_t {
 };
 
 typedef union mca_btl_uct_am_header_t mca_btl_uct_am_header_t;
+
+/**
+ * @brief parsed include/exclude list
+ *
+ */
+struct mca_btl_uct_include_list_t {
+    /** argv-style (NULL terminated) array of strings */
+    char **list;
+    /** is an inclusive list (vs exclusive) */
+    bool include;
+};
+typedef struct mca_btl_uct_include_list_t mca_btl_uct_include_list_t;
 
 /**
  * @brief structure to keep track of btl callback


### PR DESCRIPTION
The UCT BTL looks for a connect-to-iface interface in each memory domain to form connections for connect-to-endpoint transports. For example, with ib the btl will pick the UD transport as the means to setup RC. While there are connection transports available (RDMACM) I chose using UD (etc) to support networks that did not necessarily provide a connection transport.

I am currently working with improving support for Open MPI on a RoCEv2 system that does not provide support for UD (yet). This breaks the assumption that there will always be a connect-to-ifact transport available in all memory domains. To fix this issue this change updates the detection logic to locate a suitable transport for making connections (tcp by default). If a memory domain does not have a suitable connection transport the alternate will be used instead. This has been tested on our broken-UD system and works well.

It a connection-only transport is not needed the extra transport module is destroyed and the in-memory domain connection transport is used.