### PR TITLE
Topic/fix ob1 segmentation with UCT BTL

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -143,7 +143,7 @@ static inline int mca_pml_ob1_send_inline (const void *buf, size_t count,
     }
 
     if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
-	return rc;
+        return rc;
     }
 
     return (int) size;

--- a/opal/datatype/opal_datatype_internal.h
+++ b/opal/datatype/opal_datatype_internal.h
@@ -539,7 +539,7 @@ struct opal_datatype_t;
 #    define OPAL_DATATYPE_SAFEGUARD_POINTER(ACTPTR, LENGTH, INITPTR, PDATA, COUNT)                \
         {                                                                                         \
             unsigned char *__lower_bound = (INITPTR), *__upper_bound;                             \
-            assert(((LENGTH) != 0) && ((COUNT) != 0));                                            \
+            assert( (COUNT) != 0 );                                                               \
             __lower_bound += (PDATA)->true_lb;                                                    \
             __upper_bound = (INITPTR) + (PDATA)->true_ub +                                        \
                             ((PDATA)->ub - (PDATA)->lb) * ((COUNT) -1);                           \

--- a/opal/datatype/opal_datatype_position.c
+++ b/opal/datatype/opal_datatype_position.c
@@ -66,8 +66,8 @@ static inline void position_single_block(opal_convertor_t *CONVERTOR, unsigned c
 }
 
 /**
- * Advance the convertors' position according. Update the pointer and the remaining space
- * accordingly.
+ * Advance the convertors' position according to account for *COUNT elements. Update
+ * the pointer and the remaining space accordingly.
  */
 static inline void position_predefined_data(opal_convertor_t *CONVERTOR, dt_elem_desc_t *ELEM,
                                             size_t *COUNT, unsigned char **POINTER, size_t *SPACE)
@@ -82,7 +82,8 @@ static inline void position_predefined_data(opal_convertor_t *CONVERTOR, dt_elem
 
     if (cando_count > *(COUNT)) {
         cando_count = *(COUNT);
-    }
+    } else if( 0 == cando_count )
+        return;
 
     if (1 == _elem->blocklen) {
         DO_DEBUG(opal_output(0,

--- a/opal/mca/btl/sm/btl_sm_send.c
+++ b/opal/mca/btl/sm/btl_sm_send.c
@@ -73,18 +73,4 @@ int mca_btl_sm_send(struct mca_btl_base_module_t *btl, struct mca_btl_base_endpo
     }
 
     return OPAL_SUCCESS;
-
-#if 0
-    if (((frag->hdr->flags & MCA_BTL_SM_FLAG_SINGLE_COPY) ||
-        !(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) &&
-        frag->base.des_cbfunc) {
-        frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
-
-        return OPAL_SUCCESS;
-    }
-
-    /* data is gone (from the pml's perspective). frag callback/release will
-       happen later */
-    return 1;
-#endif
 }


### PR DESCRIPTION
This PR addresses the two issues resulting from the discussions on #12698. First, it allows the UCT BTL to pack less data than expected, and to return the packed amount to correctly update the request. Second, it should fix the case where data was shifted in the buffer during the pack.

Many thanks to @ggouaillardet and @AnnaLena77 for the discussion and help.

Fixes #12698