### PR TITLE
docs/rocm: fix syntax of osu_latency benchmark

### DIFF
--- a/docs/tuning-apps/networking/rocm.rst
+++ b/docs/tuning-apps/networking/rocm.rst
@@ -79,7 +79,7 @@ using Open MPI and UCX ROCm support is something like this:
 .. code-block::
 
    shell$ mpirun -n 2 --mca pml ucx \
-           ./osu_latency -d rocm D D
+           ./osu_latency D D
 
 Note: some additional configure flags are required to compile the OSU
 benchmark to support ROCm buffers. Please refer to the `UCX ROCm


### PR DESCRIPTION
fix the syntax for running the osu_latency benchmark for device memory. `-d rocm` is only required for the collective osu benchmark tests, not for the p2p ones.