### PR TITLE
btl/uct: add Intel iRDMA to the default list of UCT memory domains

### DIFF
--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2019-2024 Google, LLC. All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -48,13 +48,13 @@ static int mca_btl_uct_component_register(void)
 {
     mca_btl_uct_module_t *module = &mca_btl_uct_module_template;
 
-    mca_btl_uct_component.memory_domains = "mlx5_0,mlx4_0";
+    mca_btl_uct_component.memory_domains = "mlx5_0,mlx4_0,rocep0s4";
     (void) mca_base_component_var_register(
         &mca_btl_uct_component.super.btl_version, "memory_domains",
         "Comma-delimited list of memory domains of the form "
         "to use for communication. Memory domains MUST provide transports that "
         "support put, get, and amos. Special values: all (all available), none."
-        " (default: mlx5_0,mlx4_0)",
+        " (default: mlx5_0,mlx4_0,rocep0s4)",
         MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_3,
         MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_uct_component.memory_domains);
 


### PR DESCRIPTION
This commit adds rocep0s4 (iRDMA device) to the default list of memory domains to ensure it is available by default. This device should work once iRDMA support has been fixed in UCX (UD is currently broken).