### PR TITLE
fs/ufs and fs/lustre: change mca var type

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre_component.c
+++ b/ompi/mca/fs/lustre/fs_lustre_component.c
@@ -47,6 +47,15 @@ int mca_fs_lustre_priority = 20;
 int mca_fs_lustre_stripe_size = 0;
 int mca_fs_lustre_stripe_width = 0;
 int mca_fs_lustre_lock_algorithm = 0; /* auto */
+
+static const mca_base_var_enum_value_t ompi_fs_lustre_lock_algorithm_modes[] = {
+    {.value = 0, .string = "auto"},
+    {.value = 1, .string = "skip locking"},
+    {.value = 2, .string = "always lock entire file"},
+    {.value = 3, .string = "lock specific ranges"},
+    {.string = NULL},
+};
+
 /*
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
@@ -77,6 +86,8 @@ mca_fs_base_component_2_0_0_t mca_fs_lustre_component = {
 static int
 lustre_register(void)
 {
+    mca_base_var_enum_t *new_enum;
+
     mca_fs_lustre_priority = 20;
     (void) mca_base_component_var_register(&mca_fs_lustre_component.fsm_version,
                                            "priority", "Priority of the lustre fs component",
@@ -95,15 +106,18 @@ lustre_register(void)
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_fs_lustre_stripe_width);
+
+    (void) mca_base_var_enum_create("mca_fs_lustre_lock_algorithm", ompi_fs_lustre_lock_algorithm_modes, &new_enum);
+
     mca_fs_lustre_lock_algorithm = 0;
     (void) mca_base_component_var_register(&mca_fs_lustre_component.fsm_version,
-                                           "lock_algorithm", "Locking algorithm used by the fs ufs component. "
-                                           " 0: auto (default), 1: skip locking, 2: always lock entire file, "
-                                           "3: lock only specific ranges",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           "lock_algorithm", "Locking algorithm used by the fs lustre component. "
+                                           "(default: auto)",
+                                           MCA_BASE_VAR_TYPE_INT, new_enum, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY,
-                                           &mca_fs_lustre_lock_algorithm );
+                                           &mca_fs_lustre_lock_algorithm);
+    OBJ_RELEASE(new_enum);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/fs/ufs/fs_ufs_component.c
+++ b/ompi/mca/fs/ufs/fs_ufs_component.c
@@ -32,6 +32,15 @@
 
 int mca_fs_ufs_priority = 10;
 int mca_fs_ufs_lock_algorithm=0; /* auto */
+
+static const mca_base_var_enum_value_t ompi_fs_ufs_lock_algorithm_modes[] = {
+    {.value = 0, .string = "auto"},
+    {.value = 1, .string = "skip locking"},
+    {.value = 2, .string = "always lock entire file"},
+    {.value = 3, .string = "lock specific ranges"},
+    {.string = NULL},
+};
+
 /*
  * Private functions
  */
@@ -73,6 +82,8 @@ mca_fs_base_component_2_0_0_t mca_fs_ufs_component = {
 
 static int register_component(void)
 {
+    mca_base_var_enum_t *new_enum;
+
     mca_fs_ufs_priority = 10;
     (void) mca_base_component_var_register(&mca_fs_ufs_component.fsm_version,
                                            "priority", "Priority of the fs ufs component",
@@ -81,15 +92,17 @@ static int register_component(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_fs_ufs_priority);
 
+    (void) mca_base_var_enum_create("mca_fs_ufs_lock_algorithm", ompi_fs_ufs_lock_algorithm_modes, &new_enum);
+
     mca_fs_ufs_lock_algorithm = 0;
     (void) mca_base_component_var_register(&mca_fs_ufs_component.fsm_version,
                                            "lock_algorithm", "Locking algorithm used by the fs ufs component. "
-                                           " 0: auto (default), 1: skip locking, 2: always lock entire file, "
-                                           "3: lock only specific ranges",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           "(default: auto)",
+                                           MCA_BASE_VAR_TYPE_INT, new_enum, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY,
-                                           &mca_fs_ufs_lock_algorithm );
+                                           &mca_fs_ufs_lock_algorithm);
+    OBJ_RELEASE(new_enum);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
use an enum to specify the valid values for the lock_algorithm used by the fs/ufs and fs/lustre components.