### PR TITLE
Disable silent-rules on CI

### DIFF
--- a/.ci/community-jenkins/pr-builder.sh
+++ b/.ci/community-jenkins/pr-builder.sh
@@ -192,6 +192,7 @@ case ${PLATFORM_ID} in
         CONFIGURE_ARGS="$CONFIGURE_ARGS LDFLAGS=-Wl,-rpath,/usr/local/lib/gcc5 --with-wrapper-ldflags=-Wl,-rpath,/usr/local/lib/gcc5"
         ;;
 esac
+CONFIGURE_ARGS="$CONFIGURE_ARGS --disable-silent-rules"
 
 echo "--> Compiler setup: $CONFIGURE_ARGS"
 

--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -24,5 +24,5 @@ jobs:
     - name: Build Open MPI
       run: |
         ./autogen.pl
-        ./configure --prefix=${PWD}/install --with-cuda=${CUDA_PATH} --with-cuda-libdir=${CUDA_PATH}/lib64/stubs
+        ./configure --prefix=${PWD}/install --with-cuda=${CUDA_PATH} --with-cuda-libdir=${CUDA_PATH}/lib64/stubs --disable-silent-rules
         make -j

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -27,5 +27,5 @@ jobs:
     - name: Build Open MPI
       run: |
         ./autogen.pl
-        ./configure --prefix=${PWD}/install --with-rocm=/opt/rocm --disable-mpi-fortran
+        ./configure --prefix=${PWD}/install --with-rocm=/opt/rocm --disable-mpi-fortran --disable-silent-rules
         LD_LIBRARY_PATH=/opt/rocm/lib make -j

--- a/.github/workflows/compile-ze.yaml
+++ b/.github/workflows/compile-ze.yaml
@@ -27,5 +27,5 @@ jobs:
         #
         # we have to disable romio as its old ze stuff doesn't compile with supported ZE API
         #
-        ./configure --prefix=${PWD}/install --disable-mpi-fortran --disable-io-romio --disable-oshmem --with-ze
+        ./configure --prefix=${PWD}/install --disable-mpi-fortran --disable-io-romio --disable-oshmem --with-ze --disable-silent-rules
         make -j

--- a/.github/workflows/macos-checks.yaml
+++ b/.github/workflows/macos-checks.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Build Open MPI
       run: |
         ./autogen.pl
-        ./configure --prefix=/opt/openmpi
+        ./configure --prefix=/opt/openmpi --disable-silent-rules
         make -j $(sysctl -n hw.logicalcpu)
     - name: Run unit tests
       run: |

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -54,6 +54,7 @@ jobs:
               --disable-sphinx
               --disable-mpi-fortran
               --disable-oshmem
+              --disable-silent-rules
               --prefix=/opt/openmpi
               LDFLAGS=-Wl,-rpath,/opt/openmpi/lib
       working-directory: mpi-build


### PR DESCRIPTION
When CI fails with weird compiler / linker issues, it is frequently easier to debug when we have the exact compiler / linker flags that were used.  Disable silent rules (ie, run like make V=1) when building under CI.