### PR TITLE
remove deprecated mca rmaps param

### DIFF
--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -76,7 +76,6 @@ jobs:
         mkdir -p "$(dirname "$mca_params")"
         echo mpi_param_check = true >> "$mca_params"
         echo mpi_show_handle_leaks = true >> "$mca_params"
-        echo rmaps_base_oversubscribe = true >> "$mca_params"
         mca_params="$HOME/.prte/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"


### PR DESCRIPTION
from being echoed into the .openmpi/mca-params.conf file.  its confusing people.

See https://docs.open-mpi.org/en/v5.0.x/mca.html#mca-parameter-changes-between-open-mpi-4-x-and-5-x