### PR TITLE
coll tuned make mca parameters settable via MPI_T

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_component.c
+++ b/ompi/mca/coll/tuned/coll_tuned_component.c
@@ -132,9 +132,9 @@ static int tuned_register(void)
     ompi_coll_tuned_priority = 30;
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "priority", "Priority of the tuned coll component",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &ompi_coll_tuned_priority);
 
     /* some initial guesses at topology parameters */
@@ -142,18 +142,18 @@ static int tuned_register(void)
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "init_tree_fanout",
                                            "Initial fanout used in the tree topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &ompi_coll_tuned_init_tree_fanout);
 
     ompi_coll_tuned_init_chain_fanout = 4;
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "init_chain_fanout",
                                            "Initial fanout used in the chain (fanout followed by pipeline) topologies for each communicator. This is only an initial guess, if a tuned collective needs a different fanout for an operation, it build it dynamically. This parameter is only for the first guess and might save a little time",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &ompi_coll_tuned_init_chain_fanout);
 
     ompi_coll_tuned_alltoall_small_msg = 200;
@@ -177,18 +177,18 @@ static int tuned_register(void)
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "use_dynamic_rules",
                                            "Switch used to decide if we use static (compiled/if statements) or dynamic (built at runtime) decision function rules",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &ompi_coll_tuned_use_dynamic_rules);
 
     ompi_coll_tuned_dynamic_rules_filename = NULL;
     (void) mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                            "dynamic_rules_filename",
                                            "Filename of configuration file that contains the dynamic (@runtime) decision function rules",
-                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &ompi_coll_tuned_dynamic_rules_filename);
 
     /* register forced params */


### PR DESCRIPTION
This changes the scope so that these are settable via MPI_T interface. In particular making the `use_dynamic_rules` variable settable enables the variables needed for run time tuning of the individual collectives. resolves #12593

Signed-off-by: Burlen Loring <bloring@nvidia.com>
(cherry picked from commit a5fe137fe36e409bbc391da054d2f4277f2ed4d6)