### PR TITLE
Retain info references on public info dup

### DIFF
--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -82,6 +82,11 @@ static int opal_info_dup_impl(opal_info_t *info, opal_info_t **newinfo, bool pub
         newentry->ie_key = iterator->ie_key;
         OBJ_RETAIN(iterator->ie_key);
         newentry->ie_value = iterator->ie_value;
+        if (public_only) {
+            /* for public info-dup we also duplicate the references so that subsequent
+             * duplications see the same info keys */
+            newentry->ie_referenced = iterator->ie_referenced;
+        }
         OBJ_RETAIN(iterator->ie_value);
         opal_list_append (&((*newinfo)->super), (opal_list_item_t *) newentry);
     }


### PR DESCRIPTION
We need to keep the references when duplicating info through MPI_Info_dup so that subsequent calls to MPI_Info_dup see the same info entries.

Test case provided by Neil Fortner:

```C
#include <mpi.h>
#include <stdio.h>
#include <stdlib.h>

#define ERROR(msg) \
do { \
    printf(msg "\n"); \
    exit(1); \
} while(0)

int main(void) {
    MPI_Info info1 = MPI_INFO_NULL, info2 = MPI_INFO_NULL, info3 = MPI_INFO_NULL;
    int nkeys1, nkeys2, nkeys3;

    if (MPI_Info_create(&info1) != MPI_SUCCESS)
        ERROR("MPI_Info_create failed");

    if (MPI_Info_set(info1, "custom_key", "custom_value") != MPI_SUCCESS)
        ERROR("MPI_Info_set failed");

    if (MPI_Info_get_nkeys(info1, &nkeys1) != MPI_SUCCESS)
        ERROR("MPI_Info_get_nkeys(info1, &nkeys1) failed");

    if (MPI_Info_dup(info1, &info2) != MPI_SUCCESS)
        ERROR("MPI_Info_dup failed");

    if (MPI_Info_free(&info1) != MPI_SUCCESS)
        ERROR("MPI_Info_free(&info1) failed");

    if (MPI_Info_get_nkeys(info2, &nkeys2) != MPI_SUCCESS)
        ERROR("MPI_Info_get_nkeys(info2, &nkeys2) failed");

    if (nkeys1 != nkeys2)
        ERROR("Number of keys on duplicated MPI info object does not match that on original");

    if (MPI_Info_dup(info2, &info3) != MPI_SUCCESS)
        ERROR("MPI_Info_dup failed");

    if (MPI_Info_free(&info2) != MPI_SUCCESS)
        ERROR("MPI_Info_free(&info2) failed");

    if (MPI_Info_get_nkeys(info3, &nkeys3) != MPI_SUCCESS)
        ERROR("MPI_Info_get_nkeys(info3, &nkeys3) failed");

    if (nkeys1 != nkeys3)
        ERROR("Number of keys on double duplicated MPI info object does not match that on original");

    if (MPI_Info_free(&info3) != MPI_SUCCESS)
        ERROR("MPI_Info_free(&info3) failed");

    printf("test passed\n");

    return 0;
}
```

Signed-off-by: Joseph Schuchart <joseph.schuchart@stonybrook.edu>
(cherry picked from commit 89eb96de30f8a559e2aa0e96da48877207a04829)