### PR TITLE
v4.1.x: configury: patch configure to support nvfortran

### DIFF
--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -43,7 +43,7 @@ AC_DEFUN_ONCE([_OMPI_SETUP_FC_COMPILER],[
     # Fortran compilers (excluding the f77 compiler names) from AC's
     # default list of compilers and use it here.  This is the main
     # reason we have an OMPI-ized version of the PROG_FC macro.
-    AC_PROG_FC([gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor])
+    AC_PROG_FC([gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor nvfortran])
     FCFLAGS="$ompi_fcflags_save"
     OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
nvfortran needs to be passed -fPIC when building shared libraries, so patch the generated configure script in order to properly handle nvfortran:
- add nvfortran to the list of known fortran compilers
- pass -fPIC to the compiler

Refs. #8919
Backport of #12722

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
Signed-off-by: George Bosilca <gbosilca@nvidia.com>
(cherry picked from commit ccd641593cb8a08794c723eb36eb1ddb12d50390)