### PR TITLE
sessions: fix some problems with multiple init/fini

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -222,6 +222,8 @@ void ompi_mpi_instance_release (void)
     opal_argv_free (ompi_mpi_instance_pmix_psets);
     ompi_mpi_instance_pmix_psets = NULL;
 
+    OBJ_DESTRUCT(&ompi_mpi_instance_null);
+
     opal_finalize_cleanup_domain (&ompi_instance_basic_domain);
     OBJ_DESTRUCT(&ompi_instance_basic_domain);
 
@@ -949,8 +951,6 @@ static int ompi_mpi_instance_finalize_common (void)
     }
 
     ompi_proc_finalize();
-
-    OBJ_DESTRUCT(&ompi_mpi_instance_null);
 
     ompi_mpi_instance_release ();
 

--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -374,6 +376,8 @@ int mca_base_var_group_deregister(int group_index)
     for (int i = 0; i < size; ++i) {
         OBJ_RELEASE(enums[i]);
     }
+    opal_value_array_set_size(&group->group_enums, 0);
+
 
     size = opal_value_array_get_size(&group->group_subgroups);
     subgroups = OPAL_VALUE_ARRAY_GET_BASE(&group->group_subgroups, int);


### PR DESCRIPTION
Fix a couple of problems uncovered in issue #12854.

Turns out the MCA param management system was "remembering" things even if a variable was deregistered when a framework was closed.

Also the test case showed that destructing ompi_mpi_session_null needs to be moved to ompi_mpi_instance_release.

Related to #12854

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 155ee5619bf0f485f9c7132b77c004c31014ef4e)