### PR TITLE
sessions: make sure to only finalize class

### DIFF
--- a/examples/hello_sessions_c.c
+++ b/examples/hello_sessions_c.c
@@ -11,14 +11,10 @@ int main(int argc, char** argv) {
   MPI_Info info;
   MPI_Session s1, s2;
 
-#if 0
-/* need PR https://github.com/open-mpi/ompi/pull/12868 to be merged in
- * before this can be uncommented.
- */
   MPI_Info_create(&info);
-#endif
   MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s1);
   MPI_Session_finalize(&s1);
   MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s2);
   MPI_Session_finalize(&s2);
+  MPI_Info_free(&info);
 }

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -954,13 +954,6 @@ static int ompi_mpi_instance_finalize_common (void)
 
     ompi_mpi_instance_release ();
 
-    if (0 == opal_initialized) {
-        /* if there is no MPI_T_init_thread that has been MPI_T_finalize'd,
-         * then be gentle to the app and release all the memory now (instead
-         * of the opal library destructor */
-        opal_class_finalize ();
-    }
-
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
when there are no more refs to opal util layer.

Update sessions smoke test to illustrate the issue in case this change gets reverted or undone by some future commit.