### PR TITLE
coll MCA variables READONLY scope prevents their use via MPI_T tools interface

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_component.c
+++ b/ompi/mca/coll/adapt/coll_adapt_component.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -114,39 +115,39 @@ static int adapt_register(void)
        we should have a high priority */
     cs->adapt_priority = 0;
     (void) mca_base_component_var_register(c, "priority", "Priority of the adapt coll component",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->adapt_priority);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->adapt_priority);
 
     cs->adapt_verbose = ompi_coll_base_framework.framework_verbose;
     (void) mca_base_component_var_register(c, "verbose",
                                            "Verbose level (default set to the collective framework verbosity)",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->adapt_verbose);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->adapt_verbose);
 
     cs->adapt_context_free_list_min = 64;
     (void) mca_base_component_var_register(c, "context_free_list_min",
                                            "Minimum number of segments in context free list",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &cs->adapt_context_free_list_min);
 
     cs->adapt_context_free_list_max = 1024;
     (void) mca_base_component_var_register(c, "context_free_list_max",
                                            "Maximum number of segments in context free list",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &cs->adapt_context_free_list_max);
 
     cs->adapt_context_free_list_inc = 32;
     (void) mca_base_component_var_register(c, "context_free_list_inc",
                                            "Increasement number of segments in context free list",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &cs->adapt_context_free_list_inc);
     ompi_coll_adapt_ibcast_register();
     ompi_coll_adapt_ireduce_register();

--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c) 2024      NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,8 +35,9 @@ int ompi_coll_adapt_ibcast_register(void)
 
     mca_coll_adapt_component.adapt_ibcast_algorithm = 1;
     mca_base_component_var_register(c, "bcast_algorithm",
-                                    "Algorithm of broadcast, 0: tuned, 1: binomial, 2: in_order_binomial, 3: binary, 4: pipeline, 5: chain, 6: linear", MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                    OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                    "Algorithm of broadcast, 0: tuned, 1: binomial, 2: in_order_binomial, 3: binary, 4: pipeline, 5: chain, 6: linear",
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                    OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ibcast_algorithm);
     if( (mca_coll_adapt_component.adapt_ibcast_algorithm < 0) ||
         (mca_coll_adapt_component.adapt_ibcast_algorithm >= OMPI_COLL_ADAPT_ALGORITHM_COUNT) ) {
@@ -45,33 +47,33 @@ int ompi_coll_adapt_ibcast_register(void)
     mca_coll_adapt_component.adapt_ibcast_segment_size = 0;
     mca_base_component_var_register(c, "bcast_segment_size",
                                     "Segment size in bytes used by default for bcast algorithms. Only has meaning if algorithm is forced and supports segmenting. 0 bytes means no segmentation.",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ibcast_segment_size);
 
     mca_coll_adapt_component.adapt_ibcast_max_send_requests = 2;
     mca_base_component_var_register(c, "bcast_max_send_requests",
                                     "Maximum number of send requests",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ibcast_max_send_requests);
 
     mca_coll_adapt_component.adapt_ibcast_max_recv_requests = 3;
     mca_base_component_var_register(c, "bcast_max_recv_requests",
                                     "Maximum number of receive requests",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ibcast_max_recv_requests);
 
     mca_coll_adapt_component.adapt_ibcast_synchronous_send = true;
     (void) mca_base_component_var_register(c, "bcast_synchronous_send",
                                            "Whether to use synchronous send operations during setup of bcast operations",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &mca_coll_adapt_component.adapt_ibcast_synchronous_send);
 
     mca_coll_adapt_component.adapt_ibcast_context_free_list = NULL;

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2024      NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +39,9 @@ int ompi_coll_adapt_ireduce_register(void)
 
     mca_coll_adapt_component.adapt_ireduce_algorithm = 1;
     mca_base_component_var_register(c, "reduce_algorithm",
-                                    "Algorithm of reduce, 1: binomial, 2: in_order_binomial, 3: binary, 4: pipeline, 5: chain, 6: linear", MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                    OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                    "Algorithm of reduce, 1: binomial, 2: in_order_binomial, 3: binary, 4: pipeline, 5: chain, 6: linear",
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                    OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ireduce_algorithm);
     if( (mca_coll_adapt_component.adapt_ireduce_algorithm < 0) ||
         (mca_coll_adapt_component.adapt_ireduce_algorithm > OMPI_COLL_ADAPT_ALGORITHM_COUNT) ) {
@@ -49,58 +51,58 @@ int ompi_coll_adapt_ireduce_register(void)
     mca_coll_adapt_component.adapt_ireduce_segment_size = 163740;
     mca_base_component_var_register(c, "reduce_segment_size",
                                     "Segment size in bytes used by default for reduce algorithms. Only has meaning if algorithm is forced and supports segmenting. 0 bytes means no segmentation.",
-                                    MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ireduce_segment_size);
 
     mca_coll_adapt_component.adapt_ireduce_max_send_requests = 2;
     mca_base_component_var_register(c, "reduce_max_send_requests",
                                     "Maximum number of send requests",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ireduce_max_send_requests);
 
     mca_coll_adapt_component.adapt_ireduce_max_recv_requests = 3;
     mca_base_component_var_register(c, "reduce_max_recv_requests",
                                     "Maximum number of receive requests per peer",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_ireduce_max_recv_requests);
 
     mca_coll_adapt_component.adapt_inbuf_free_list_min = 10;
     mca_base_component_var_register(c, "inbuf_free_list_min",
                                     "Minimum number of segment in inbuf free list",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_inbuf_free_list_min);
 
     mca_coll_adapt_component.adapt_inbuf_free_list_max = 10000;
     mca_base_component_var_register(c, "inbuf_free_list_max",
                                     "Maximum number of segment in inbuf free list",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_inbuf_free_list_max);
 
 
     mca_coll_adapt_component.adapt_inbuf_free_list_inc = 10;
     mca_base_component_var_register(c, "inbuf_free_list_inc",
                                     "Number of segments to allocate when growing the inbuf free list",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_READONLY,
+                                    MCA_BASE_VAR_SCOPE_ALL,
                                     &mca_coll_adapt_component.adapt_inbuf_free_list_inc);
 
     mca_coll_adapt_component.adapt_ireduce_synchronous_send = true;
     (void) mca_base_component_var_register(c, "reduce_synchronous_send",
                                            "Whether to use synchronous send operations during setup of reduce operations",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &mca_coll_adapt_component.adapt_ireduce_synchronous_send);
 
     mca_coll_adapt_component.adapt_ireduce_context_free_list = NULL;

--- a/ompi/mca/coll/basic/coll_basic_component.c
+++ b/ompi/mca/coll/basic/coll_basic_component.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,16 +92,16 @@ basic_register(void)
     mca_coll_basic_priority = 10;
     (void) mca_base_component_var_register(&mca_coll_basic_component.collm_version, "priority",
                                            "Priority of the basic coll component",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &mca_coll_basic_priority);
     mca_coll_basic_crossover = 4;
     (void) mca_base_component_var_register(&mca_coll_basic_component.collm_version, "crossover",
                                            "Minimum number of processes in a communicator before using the logarithmic algorithms",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &mca_coll_basic_crossover);
 
     return OMPI_SUCCESS;

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2023      Computer Architecture and VLSI Systems (CARV)
  *                         Laboratory, ICS Forth. All rights reserved.
  * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2024      NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -257,9 +258,9 @@ mca_coll_han_query_module_from_mca(mca_base_component_t* c,
     *storage = ompi_coll_han_available_components[mod_id].component_name;
 
     (void) mca_base_component_var_register(c, param_name, param_doc,
-                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            info_level,
-                                           MCA_BASE_VAR_SCOPE_READONLY, storage);
+                                           MCA_BASE_VAR_SCOPE_ALL, storage);
     module_name = *storage;
     mod_id = strtol(module_name, &endptr, 10);
     if( module_name == endptr ) {  /* no conversion, maybe we got a module name instead */
@@ -288,22 +289,22 @@ static int han_register(void)
     COMPONENT_T component;
 
     (void) mca_base_component_var_register(c, "priority", "Priority of the HAN coll component",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_priority);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_priority);
 
     cs->han_output_verbose = 0;
     (void) mca_base_component_var_register(c, "verbose", "Verbosity of the HAN coll component (use coll base verbosity if not set)",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_output_verbose);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_output_verbose);
 
     cs->han_bcast_segsize = 65536;
     (void) mca_base_component_var_register(c, "bcast_segsize",
                                            "segment size for bcast",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_bcast_segsize);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_bcast_segsize);
 
     cs->han_bcast_up_module = 0;
     (void) mca_coll_han_query_module_from_mca(c, "bcast_up_module",
@@ -321,9 +322,9 @@ static int han_register(void)
     cs->han_reduce_segsize = 65536;
     (void) mca_base_component_var_register(c, "reduce_segsize",
                                            "segment size for reduce",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_reduce_segsize);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_reduce_segsize);
 
     cs->han_reduce_up_module = 0;
     (void) mca_coll_han_query_module_from_mca(c, "reduce_up_module",
@@ -340,9 +341,9 @@ static int han_register(void)
     cs->han_allreduce_segsize = 65536;
     (void) mca_base_component_var_register(c, "allreduce_segsize",
                                            "segment size for allreduce",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_9,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_allreduce_segsize);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_allreduce_segsize);
 
     cs->han_allreduce_up_module = 0;
     (void) mca_coll_han_query_module_from_mca(c, "allreduce_up_module",
@@ -424,8 +425,8 @@ static int han_register(void)
     (void) mca_base_component_var_register(c, "alltoall_pstages",
                                               "Parallel Stages for alltoall.  Higher numbers require more memory, "
                                               "and performs more communication in parallel.  0 chooses pstages based on message size.",
-                                              MCA_BASE_VAR_TYPE_INT32_T, NULL, 0, 0,
-                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                              MCA_BASE_VAR_TYPE_INT32_T, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                               &cs->han_alltoall_pstages);
 
     cs->han_alltoallv_low_module = 0;
@@ -436,16 +437,16 @@ static int han_register(void)
     cs->han_alltoallv_smsc_avg_send_limit = 8192;
     (void) mca_base_component_var_register(c, "alltoallv_smsc_avg_send_limit",
                                               "The per-rank averaged send bytes limit above which smsc-based alltoallv will disqualify itself.",
-                                              MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, 0,
-                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                              MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                               &cs->han_alltoallv_smsc_avg_send_limit);
     cs->han_alltoallv_smsc_noncontig_activation_limit = 0.10;
     (void) mca_base_component_var_register(c, "alltoallv_smsc_noncontig_limit",
                                               "The fractional (0.00-1.00) limit of peers in the communicator which have "
                                               "strided or otherwise non-contiguous data buffers.  Above this limit "
                                               "smsc-based alltoallv will ignore the avg_send_limit, and always remain active.",
-                                              MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
-                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                              MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                              OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                               &cs->han_alltoallv_smsc_noncontig_activation_limit);
 
     cs->han_reproducible = 0;
@@ -453,21 +454,21 @@ static int han_register(void)
                                            "whether we need reproducible results "
                                            "(enabling this disables optimisations using topology)"
                                            "0 disable 1 enable, default 0",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3,
-                                           MCA_BASE_VAR_SCOPE_READONLY, &cs->han_reproducible);
+                                           MCA_BASE_VAR_SCOPE_ALL, &cs->han_reproducible);
 
     cs->han_packbuf_bytes = 128*1024;
     (void) mca_base_component_var_register(c, "packbuf_bytes",
                                            "The number of bytes in each HAN packbuf.",
-                                           MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, 0,
-                                           OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                            &cs->han_packbuf_bytes);
     cs->han_packbuf_max_count = 32;
     (void) mca_base_component_var_register(c, "packbuf_max_count",
                                            "The maximum number of packbufs that are allowed to be allocated.",
-                                           MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, 0,
-                                           OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_TYPE_INT64_T, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                            &cs->han_packbuf_max_count);
 
     /*
@@ -582,9 +583,9 @@ static int han_register(void)
             }
 
             mca_base_component_var_register(c, param_name, param_desc,
-                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                             OPAL_INFO_LVL_9,
-                                            MCA_BASE_VAR_SCOPE_READONLY,
+                                            MCA_BASE_VAR_SCOPE_ALL,
                                             &(cs->mca_sub_components[coll][topo_lvl]));
         }
     }
@@ -594,27 +595,27 @@ static int han_register(void)
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "use_dynamic_file_rules",
                                            "Enable the dynamic selection provided via the dynamic_rules_filename MCA",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->use_dynamic_file_rules));
 
     cs->dynamic_rules_filename = NULL;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "dynamic_rules_filename",
                                            "Configuration file containing the dynamic selection rules",
-                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->dynamic_rules_filename));
 
     cs->dump_dynamic_rules = false;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "dump_dynamic_rules",
                                            "Switch used to decide if we dump  dynamic rules provided by configuration file",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->dump_dynamic_rules));
 
     if((cs->dump_dynamic_rules || NULL != cs->dynamic_rules_filename)
@@ -631,9 +632,9 @@ static int han_register(void)
                                            "errors printed on rank 0 "
                                            "with a 0 verbosity."
                                            "Useless if coll_base_verbose is 30 or more.",
-                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->max_dynamic_errors));
 
 

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2011 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024 NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,8 +108,8 @@ static int reg_int(const char* param_name,
     index = mca_base_component_var_register(
             &mca_coll_hcoll_component.super.collm_version,
             param_name, param_desc, MCA_BASE_VAR_TYPE_INT,
-            NULL, 0, 0,OPAL_INFO_LVL_9,
-            MCA_BASE_VAR_SCOPE_READONLY, storage);
+            NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,OPAL_INFO_LVL_9,
+            MCA_BASE_VAR_SCOPE_ALL, storage);
     if (NULL != deprecated_param_name) {
         (void) mca_base_var_register_synonym(index,
                 "ompi", "coll", "hcoll", deprecated_param_name,

--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2024 NVIDIA CORPORATION. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,24 +61,24 @@ static int mca_coll_ucc_register(void)
     mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
     mca_base_component_t     *c  = &cm->super.collm_version;
     mca_base_component_var_register(c, "priority", "Priority of the UCC coll component",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_9,
-                                    MCA_BASE_VAR_SCOPE_READONLY, &cm->ucc_priority);
+                                    MCA_BASE_VAR_SCOPE_ALL, &cm->ucc_priority);
 
     mca_base_component_var_register(c, "verbose", "Verbose level of the UCC coll component",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_9,
-                                    MCA_BASE_VAR_SCOPE_READONLY, &cm->ucc_verbose);
+                                    MCA_BASE_VAR_SCOPE_ALL, &cm->ucc_verbose);
 
     mca_base_component_var_register(c, "enable", "[0|1] Enable/Disable the UCC coll component",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_9,
-                                    MCA_BASE_VAR_SCOPE_READONLY, &cm->ucc_enable);
+                                    MCA_BASE_VAR_SCOPE_ALL, &cm->ucc_enable);
 
     mca_base_component_var_register(c, "np", "Minimal communicator size for the UCC coll component",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                     OPAL_INFO_LVL_9,
-                                    MCA_BASE_VAR_SCOPE_READONLY, &cm->ucc_np);
+                                    MCA_BASE_VAR_SCOPE_ALL, &cm->ucc_np);
 
     mca_base_component_var_register(c, MCA_COMPILETIME_VER,
                                     "Version of the libucc library with which Open MPI was compiled",
@@ -94,14 +95,14 @@ static int mca_coll_ucc_register(void)
     cm->cls = "";
     mca_base_component_var_register(c, "cls",
                                     "Comma separated list of UCC CLS to be used for team creation",
-                                    MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                    OPAL_INFO_LVL_6, MCA_BASE_VAR_SCOPE_READONLY, &cm->cls);
+                                    MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                    OPAL_INFO_LVL_6, MCA_BASE_VAR_SCOPE_ALL, &cm->cls);
 
     cm->cts = COLL_UCC_CTS_STR;
     mca_base_component_var_register(c, "cts",
                                     "Comma separated list of UCC coll types to be enabled",
-                                    MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                    OPAL_INFO_LVL_6, MCA_BASE_VAR_SCOPE_READONLY, &cm->cts);
+                                    MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                    OPAL_INFO_LVL_6, MCA_BASE_VAR_SCOPE_ALL, &cm->cts);
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
Several of the coll component's MCA variables are restrictively scoped as `MCA_BASE_VAR_SCOPE_READONLY`. A variable scoped READONLY can be set on the command line but not with the MPI\_T tools interface. A change to `MCA_BASE_VAR_SCOPE_ALL` would enable these to be set by the MPI_T tools interface.

Resolves #12902
