### PR TITLE
spml/ucx: shuffle EPs creation

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -710,7 +710,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
             swap_index = rand() % (proc_index + 1);
             temp_index = indices[proc_index];
             indices[proc_index] = indices[swap_index];
-            indices[proc_index] = temp_index;
+            indices[swap_index] = temp_index;
         }
 
         ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -693,7 +693,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
     }
 
     indices = malloc(nprocs * sizeof(*indices));
-    if (!indices) {
+    if (NULL == indices) {
         goto error;
     }
 
@@ -701,7 +701,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
         indices[i] = i;
     }
 
-    srand((unsigned int)time(NULL));
+    srand(time(NULL));
 
     /* Get the EP connection requests for all the processes from modex */
     for (proc_index = nprocs - 1; proc_index >= 0; --proc_index) {
@@ -719,7 +719,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
         err = ucp_ep_create(mca_spml_ucx_ctx_default.ucp_worker[0], &ep_params,
                             &mca_spml_ucx_ctx_default.ucp_peers[indices[proc_index]].ucp_conn);
         if (UCS_OK != err) {
-            SPML_UCX_ERROR("ucp_ep_create(proc=%d/%zu) failed: %s", proc_index, nprocs,
+            SPML_UCX_ERROR("ucp_ep_create(proc=%d/%zu, index=%u) failed: %s", proc_index, nprocs, indices[proc_index],
                     ucs_status_string(err));
             goto error2;
         }

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -692,7 +692,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
         }
     }
 
-    indices = malloc(nprocs * sizeof(int));
+    indices = malloc(nprocs * sizeof(*indices));
     if (!indices) {
         goto error;
     }
@@ -719,7 +719,7 @@ int mca_spml_ucx_add_procs(oshmem_group_t* group, size_t nprocs)
         err = ucp_ep_create(mca_spml_ucx_ctx_default.ucp_worker[0], &ep_params,
                             &mca_spml_ucx_ctx_default.ucp_peers[indices[proc_index]].ucp_conn);
         if (UCS_OK != err) {
-            SPML_UCX_ERROR("ucp_ep_create(proc=%zu/%zu) failed: %s", n, nprocs,
+            SPML_UCX_ERROR("ucp_ep_create(proc=%d/%zu) failed: %s", proc_index, nprocs,
                     ucs_status_string(err));
             goto error2;
         }


### PR DESCRIPTION
## What?
This PR randomize the order in which endpoints (EPs) are created in the `mca_spml_ucx_add_procs` function. Each new EP is placed at a random position instead of cyclic order.

## Why?
Recently, a customer raised concerns about incast behavior during SHMEM quiet operations, where many EPs communicating in a fixed order could lead to network congestion and performance degradation. They believe that randomizing the order of EPs could reduce the likelihood of incast collisions.
The customer is interested in testing a patch to address this.

## How?
Used the Fisher-Yates shuffle algorithm to randomize indices and modified the loop to handle all indices, including 0, within a single pass.
