### PR TITLE
romio314: do not link with cudart

### DIFF
--- a/ompi/mca/io/romio341/configure.m4
+++ b/ompi/mca/io/romio341/configure.m4
@@ -79,10 +79,10 @@ AC_DEFUN([MCA_ompi_io_romio341_CONFIG],[
                         AS_IF([test ! -z $target], [io_romio341_flags="$io_romio341_flags --target=$target"])])
                    AS_IF([test "$enable_grequest_extensions" = "yes"],
                          [io_romio341_flags="$io_romio341_flags --enable-grequest-extensions"])
-                   io_romio341_flags_define="$io_romio341_flags FROM_OMPI=yes CC='$CC' CFLAGS='$CFLAGS -D__EXTENSIONS__' CPPFLAGS='$CPPFLAGS' FFLAGS='$FFLAGS' LDFLAGS='$LDFLAGS' --$io_romio341_shared-shared --$io_romio341_static-static $io_romio341_flags $io_romio341_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90 ac_cv_lib_cuda_cuMemGetAddressRange=no"
+                   io_romio341_flags_define="$io_romio341_flags FROM_OMPI=yes CC='$CC' CFLAGS='$CFLAGS -D__EXTENSIONS__' CPPFLAGS='$CPPFLAGS' FFLAGS='$FFLAGS' LDFLAGS='$LDFLAGS' --$io_romio341_shared-shared --$io_romio341_static-static $io_romio341_flags $io_romio341_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90 ac_cv_lib_cuda_cuMemGetAddressRange=no ac_cv_lib_cudart_cudaStreamSynchronize=no"
                    AC_DEFINE_UNQUOTED([MCA_io_romio341_COMPLETE_CONFIGURE_FLAGS], ["$io_romio341_flags_define"], [Complete set of command line arguments given to ROMIOs configure script])
 
-                   io_romio341_flags="$io_romio341_flags FROM_OMPI=yes CC="'"'"$CC"'"'" CFLAGS="'"'"$CFLAGS -D__EXTENSIONS__"'"'" CPPFLAGS="'"'"$CPPFLAGS"'"'" FFLAGS="'"'"$FFLAGS"'"'" LDFLAGS="'"'"$LDFLAGS"'"'" --$io_romio341_shared-shared --$io_romio341_static-static $io_romio341_flags $io_romio341_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90 ac_cv_lib_cuda_cuMemGetAddressRange=no"
+                   io_romio341_flags="$io_romio341_flags FROM_OMPI=yes CC="'"'"$CC"'"'" CFLAGS="'"'"$CFLAGS -D__EXTENSIONS__"'"'" CPPFLAGS="'"'"$CPPFLAGS"'"'" FFLAGS="'"'"$FFLAGS"'"'" LDFLAGS="'"'"$LDFLAGS"'"'" --$io_romio341_shared-shared --$io_romio341_static-static $io_romio341_flags $io_romio341_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90 ac_cv_lib_cuda_cuMemGetAddressRange=no ac_cv_lib_cudart_cudaStreamSynchronize=no"
 
                    opal_show_subtitle "Configuring ROMIO distribution"
                    OPAL_CONFIG_SUBDIR([3rd-party/romio341],


### PR DESCRIPTION
identical to #9144 for libcuda, applied to libcudart as well

This commit forces ROMIO to not detect cudart at configure time by using setting the hidden/undocumented `ac_cv_lib_cudart_cudaStreamSynchronize=no` variable before invoking ROMIO's configure.

Refs:

- #9144 introduced the same patch for detection of `libcuda` using `ac_cv_lib_cuda_cuMemGetAddressRange=no`
- #8884 describing libcuda issue (same issue happens with libcudart)
- https://github.com/conda-forge/openmpi-feedstock/pull/186 shows building openmpi with `--with-io-romio-flags=ac_cv_lib_cudart_cudaStreamSynchronize=no` fixes the cudart link, suggesting this patch will work

Signed-off-by: Min RK [benjaminrk@gmail.com](mailto:benjaminrk@gmail.com)