### PR TITLE
part: multithreading deadlocks fixes and safety checks

### DIFF
--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -304,8 +304,7 @@ mca_part_persist_progress(void)
                         req->flags[i] = 0;
                     }
 
-                    if(0 == req->flags[i])
-                    {
+                    if(0 == req->flags[i] && OMPI_REQUEST_ACTIVE == req->persist_reqs[i]->req_state) {
                         ompi_request_test(&(req->persist_reqs[i]), &(req->flags[i]), MPI_STATUS_IGNORE);
                         if(0 != req->flags[i]) req->done_count++;
                     }
@@ -323,16 +322,14 @@ mca_part_persist_progress(void)
                 to_delete = req;
             }
         }
-
     }
+
+    if(NULL != to_delete && OPAL_SUCCESS == err) {
+        err = mca_part_persist_free_req(to_delete);
+    }
+
     OPAL_THREAD_UNLOCK(&ompi_part_persist.lock);
     block_entry = opal_atomic_add_fetch_32(&(ompi_part_persist.block_entry), -1);
-    if(to_delete) {
-        err =  mca_part_persist_free_req(to_delete);
-        if (OMPI_SUCCESS != err) {
-            return OMPI_ERROR;
-        }
-    }
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/part/persist/part_persist_component.c
+++ b/ompi/mca/part/persist/part_persist_component.c
@@ -98,11 +98,8 @@ mca_part_persist_component_open(void)
 
     mca_part_persist_init_lists(); 
 
-    ompi_part_persist.init_comms = 0;
     ompi_part_persist.init_world = -1;
-
-    ompi_part_persist.part_comm_ready = 0;
-    ompi_part_persist.part_comm_ready = 0;
+    ompi_part_persist.init_world_step = 0;
 
     ompi_part_persist.block_entry = 0;
     return OMPI_SUCCESS;

--- a/ompi/mca/part/persist/part_persist_request.h
+++ b/ompi/mca/part/persist/part_persist_request.h
@@ -44,6 +44,11 @@ struct ompi_mca_persist_setup_t {
    size_t count;
 };
 
+typedef enum {
+    MCA_PART_PERSIST_PARTITION_STARTED = 0,   /* partition request started. The default after initialization, or after MPI_Start for receive requests */
+    MCA_PART_PERSIST_PARTITION_COMPLETE = 1,  /* partition request complete */
+    MCA_PART_PERSIST_PARTITION_QUEUED = 2     /* next progress loop will start the partition request (send only) */
+} mca_part_persist_partition_state_t;
 
 /**
  *  Base type for PART PERSIST requests
@@ -89,10 +94,10 @@ struct mca_part_persist_request_t {
 
     int32_t initialized;                  /**< flag for initialized state */
     int32_t first_send;                   /**< flag for whether the first send has happened */
-    int32_t flag_post_setup_recv;  
-    size_t done_count;             /**< counter for the number of partitions marked ready */
+    int32_t flag_post_setup_recv;
 
-    int32_t *flags;               /**< array of flags to determine whether a partition has arrived */
+    mca_part_persist_partition_state_t* flags;  /**< the state of each partition */
+    int32_t *part_ready;                        /**< readiness flag of each partition, NULL for receive requests */
 
     struct ompi_mca_persist_setup_t setup_info[2]; /**< Setup info to send during initialization. */
   


### PR DESCRIPTION
This PR fixes multiple deadlocks and issues encountered with partitioned communications.

The first deadlocks occur when one thread is in `opal_progress` and others are working on the partitioned request:

- `MPI_Pready` could change the `req->flags` of a partition while the progress thread is testing it, leading to an edge case where `req->done_count` would be greater than the number of partitions
- The changes done by `MPI_Pready` could be overwritten by the progress thread

Both were fixed by adding the array `req->part_ready` where `MPI_Pready` would mark the partitions ready to be sent.
This prevents the progress engine from touching the state of a partition as long as it isn't ready.
Since no atomic operations were added, this should have little to no impact on the performance.

I fixed another deadlock that I rarely encountered at the initialization of the part module: two `ompi_comm_idup` need to be done, both are started in the progress engine, and will prevent progressing partitioned requests until they are done.
Sometimes the second `ompi_comm_idup` would be marked as completed in one rank, but not in the other, leading to a deadlock.
This was fixed by doing one `ompi_comm_idup` at a time, with the side-effect of slowing down the initialization (the first request must be done before starting the next `ompi_comm_idup`).

A very rare segfault caused by calling `mca_part_persist_free_req` while `ompi_part_persist.lock` was unlocked was also fixed.

I added many error checks to `mca_part_persist_progress`, ensuring no new deadlock can occur when an internal function fails.

For testing, I used a two-way ring exchange with a fixed number of partitions distributed among multiple OpenMP threads. This was my original use-case for which I encountered all those issues since all threads need to call `MPI_Pready` and `MPI_Parrived`.
Using up to 128 cores with varying amounts of processes and threads showed no new deadlocks or communication issues.