### PR TITLE
ci: Remove Ubuntu 18.04 (and gcc 5 / 6)

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -53,8 +53,8 @@ println('Tests Completed')
 // build stage is a map of different configurations to test.
 def prepare_check_stages() {
     def configure_options = ["--disable-dlopen", "--disable-oshmem", "--enable-builtin-atomic", "--enable-ipv6"]
-    def compilers = ["clang10", "gcc5", "gcc6", "gcc7", "gcc8", "gcc9", "gcc10"]
-    def platforms = ["amazon_linux_2", "amazon_linux_2-arm64", "rhel8", "ubuntu_18.04"]
+    def compilers = ["clang10", "gcc7", "gcc8", "gcc9", "gcc10"]
+    def platforms = ["amazon_linux_2", "amazon_linux_2-arm64", "rhel8"]
     def check_stages_list = []
 
     // Build everything stage

--- a/docs/release-notes/platform.rst
+++ b/docs/release-notes/platform.rst
@@ -27,11 +27,10 @@ that a release of Open MPI supports.
 * Systems that have been tested are:
 
   * Linux (various flavors/distros), 64 bit (x86, ppc, aarch64),
-    with gcc (>=4.8.x+), clang (>=3.6.0), Absoft (fortran), Intel,
+    with gcc/gfortran (>=7.x+), clang (>=10.x), Intel,
     and Portland (be sure to also see :ref:`the Compiler Notes
     section <compiler-notes-section-label>`)
-  * macOS (10.14-10.15, 11.x, 12.x), 64 bit (x86_64) with XCode
-    compilers
+  * macOS (14.x, 15.x), 64 bit (x86_64) with XCode compilers
 
 * Other systems have been lightly (but not fully) tested:
 


### PR DESCRIPTION
Ubuntu 18.04 is EOL, so will not be supported in the next version of Open MPI.  Remove from main's list of CI builders.  Ubuntu 18 was the last distro still including GCC 5 and GCC 6, so remove them as well.