### PR TITLE
tests: Add stdint.h header

### DIFF
--- a/test/support/support.h
+++ b/test/support/support.h
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #define TEST_AND_REPORT(res, exp_res, str) \
     if (res == exp_res)                    \


### PR DESCRIPTION
The build was failing on FreeBSD because stdint.h is required for int64_t.