### PR TITLE
fortran/use-mpi-f08: Add missing profile symbols

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/Makefile.am
@@ -21,6 +21,7 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2022      Triad National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -69,6 +70,7 @@ pmpi_api_files = \
         pallgatherv_init_f08.F90 \
         palloc_mem_f08.F90 \
         pallreduce_f08.F90 \
+        pallreduce_init_f08.F90 \
         palltoall_f08.F90 \
         palltoall_init_f08.F90 \
         palltoallv_f08.F90 \
@@ -230,6 +232,7 @@ pmpi_api_files = \
         pgroup_difference_f08.F90 \
         pgroup_excl_f08.F90 \
         pgroup_free_f08.F90 \
+        pgroup_from_session_pset_f08.F90 \
         pgroup_incl_f08.F90 \
         pgroup_intersection_f08.F90 \
         pgroup_range_excl_f08.F90 \
@@ -347,6 +350,7 @@ pmpi_api_files = \
         psend_init_f08.F90 \
         psendrecv_f08.F90 \
         psendrecv_replace_f08.F90 \
+        psession_call_errhandler_f08.F90 \
         psession_create_errhandler_f08.F90\
         psession_get_errhandler_f08.F90\
         psession_get_info_f08.F90 \


### PR DESCRIPTION
The profiling symbols for PMPI_Allreduce_init,
PMPI_Group_from_session_pset, and PMPI_Session_call_errhandler were missing from the mpi_f08 Fortran library.  This commit adds them to the relevant Makefile.am.

Thanks to @gcorbin for identifying and reporting the problem.

Refs #12954

This will need to be cherry picked to v5.0.x as well.