### PR TITLE
MPI_Wtime relative to MPI_Init

### DIFF
--- a/ompi/mpi/c/wtime.c
+++ b/ompi/mpi/c/wtime.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,15 +43,13 @@
 #pragma weak MPI_Wtime = PMPI_Wtime
 #endif
 #define MPI_Wtime PMPI_Wtime
+#endif
 /**
- * Have a base time set on the first call to wtime, to improve the range
+ * Use this as a base time set early during MPI initialization to improve the range
  * and accuracy of the user visible timer.
  * More info: https://github.com/mpi-forum/mpi-issues/issues/77#issuecomment-369663119
  */
-struct timespec ompi_wtime_time_origin = {.tv_sec = 0};
-#else  /* OMPI_BUILD_MPI_PROFILING */
 extern struct timespec ompi_wtime_time_origin;
-#endif
 
 double MPI_Wtime(void)
 {
@@ -62,9 +61,6 @@ double MPI_Wtime(void)
     // https://github.com/open-mpi/ompi/issues/3003 for more details.
     struct timespec tp;
     (void) opal_clock_gettime(&tp);
-    if (OPAL_UNLIKELY(0 == ompi_wtime_time_origin.tv_sec)) {
-        ompi_wtime_time_origin = tp;
-    }
     wtime  = (double)(tp.tv_nsec - ompi_wtime_time_origin.tv_nsec)/1.0e+9;
     wtime += (tp.tv_sec - ompi_wtime_time_origin.tv_sec);
 


### PR DESCRIPTION
Issue #12953 identified an issue with MPI_Wtime taking the first call as the source of relative timing. This patch moves the timing root early in the MPI initialization (sessions or world model).

Fixes #12953.