### PR TITLE
comm: beef up use of PMIx_Group_construct

### DIFF
--- a/ompi/mpi/c/comm_create_from_group.c
+++ b/ompi/mpi/c/comm_create_from_group.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Triad National Security, LLC. All rights
+ * Copyright (c) 2021-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -46,6 +46,7 @@ static const char FUNC_NAME[] = "MPI_Comm_create_from_group";
 int MPI_Comm_create_from_group (MPI_Group group, const char *tag, MPI_Info info, MPI_Errhandler errhandler,
                                 MPI_Comm *newcomm) {
     int rc;
+    char *pmix_group_tag = NULL;
 
     MEMCHECKER(
         memchecker_comm(comm);
@@ -81,8 +82,22 @@ int MPI_Comm_create_from_group (MPI_Group group, const char *tag, MPI_Info info,
     }
 
 
-    rc = ompi_comm_create_from_group ((ompi_group_t *) group, tag, &info->super, errhandler,
+    /*
+     * we use PMIx group operations to implement comm/intercomm create from group/groups.
+     * PMIx group constructors require a unique tag across the processes using the same
+     * PMIx server.  This is not equivalent to the uniqueness requirements of the tag argument
+     * to MPI_Comm_create_from_group and MPI_Intercomm_create_from_groups, hence an
+     * additional discriminator needs to be added to the user supplied tag argument.
+     */
+    opal_asprintf (&pmix_group_tag, "%s-%s.%d", tag, OPAL_NAME_PRINT(ompi_group_get_proc_name (group, 0)),
+                   ompi_group_size(group));
+    if (OPAL_UNLIKELY(NULL == pmix_group_tag)) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    rc = ompi_comm_create_from_group ((ompi_group_t *) group, pmix_group_tag, &info->super, errhandler,
                                       (ompi_communicator_t **) newcomm);
+    free(pmix_group_tag);
     if (MPI_SUCCESS != rc) {
         return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
                                        rc, FUNC_NAME);


### PR DESCRIPTION
to avoid potential race conditions between successive calls to MPI_Comm_create_from_group and MPI_Intercomm_create_from_groups when using the same tag argument value.

The PMIx group constructor grp string argument has different semantics from the tag requirements for these MPI constructors, so use discriminators to avoid potential race conditions when using PMIx group ops.

Related to #10895