### PR TITLE
ci: Fix build of branch commits

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -34,7 +34,11 @@ milestone(buildNumber)
 // back to the PR. The "Details" link at the bottom of the GitHub PR page brings
 // you to the Jenkins Build page, so we're adding the link back to the GitHub PR
 // page.
-currentBuild.description = "This is a build of <a href=\"${CHANGE_URL}\"}\">Open MPI PR #${CHANGE_ID}</a>"
+if (env.CHANGE_URL) {
+    currentBuild.description = "This is a build of <a href=\"${CHANGE_URL}\"}\">Open MPI PR #${CHANGE_ID}</a>"
+} else {
+    currentBuild.description = "Build of ${BRANCH_NAME}"
+}
 
 check_stages = prepare_check_stages()
 println("Initialized Pipeline")


### PR DESCRIPTION
The community Jenkins jenkinsfile is evaluated both on each PR and for each commit to one of the branches in the openmpi/ompi repository. The builds for the commit checks were broken because of a bug in the description setting code, that assumed every invocation was for a PR. This commit fixes that by differentiating the type of build before setting the description.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 58cde2fd1d7f378417d813abb63c2134175335ca)