### PR TITLE
docs: update cuda related docs to reflect

### DIFF
--- a/docs/tuning-apps/networking/cuda.rst
+++ b/docs/tuning-apps/networking/cuda.rst
@@ -53,9 +53,12 @@ be found, please also pass ``--with-cuda-libdir``. For example:
 ``--with-cuda=<path-to-cuda> --with-cuda-libdir=/usr/local/cuda/lib64/stubs``.
 
 Open MPI supports building with CUDA libraries and running on systems
-without CUDA libraries or hardware. In order to take advantage of
-this functionality, when compiling, you have to specify the CUDA
-dependent components to be built as DSOs using the
+without CUDA libraries or hardware.
+
+For releases v5.0.2 and newer no special steps are required to get this behavior.
+
+In order to realize this behavior for the v5.0.0 and v5.0.1 releases,
+when configuring Open MPI, you have to specify the CUDA dependent components to be built as DSOs using the
 ``--enable-mca-dso=<comma-delimited-list-of-cuda-components.``
 configure option.
 


### PR DESCRIPTION
to reflect commit https://github.com/open-mpi/ompi/commit/9580fd513e79bdde00013874a44ee73da8f4ace8

the commit was backported to v5.0.2 and later.

related to #12911

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 75e7cc076e3b139c4cbf2cd9e463c30999c9dff5)