### PR TITLE
comm: beef up args checking for some comm constructors

### DIFF
--- a/ompi/mpi/c/comm_create_from_group.c
+++ b/ompi/mpi/c/comm_create_from_group.c
@@ -55,23 +55,31 @@ int MPI_Comm_create_from_group (MPI_Group group, const char *tag, MPI_Info info,
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 
+        if (NULL == errhandler ||
+               MPI_ERRHANDLER_NULL == errhandler ||
+                    ( OMPI_ERRHANDLER_TYPE_COMM != errhandler->eh_mpi_object_type &&
+                     OMPI_ERRHANDLER_TYPE_PREDEFINED != errhandler->eh_mpi_object_type) ) {
+               return ompi_errhandler_invoke (NULL, MPI_COMM_NULL, OMPI_ERRHANDLER_TYPE_COMM,
+                                              MPI_ERR_ARG,FUNC_NAME);
+        }
+
         if (NULL == tag) {
-            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
+            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, OMPI_ERRHANDLER_TYPE_COMM,
                                            MPI_ERR_TAG, FUNC_NAME);
         }
 
         if (NULL == group) {
-            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
+            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, OMPI_ERRHANDLER_TYPE_COMM,
                                            MPI_ERR_GROUP, FUNC_NAME);
         }
 
         if (NULL == info || ompi_info_is_freed(info)) {
-            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
+            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, OMPI_ERRHANDLER_TYPE_COMM,
                                            MPI_ERR_INFO, FUNC_NAME);
         }
 
         if (NULL == newcomm) {
-            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
+            return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, OMPI_ERRHANDLER_TYPE_COMM,
                                            MPI_ERR_ARG, FUNC_NAME);
         }
     }


### PR DESCRIPTION
The MPI_Comm_create_from_group and especially the
MPI_Intercomm_create_from_groups functions are recent additions to the standard (MPI 4.0) and users may get confused easily trying to use them.

So better parameter checking is needed.

Related to #12906 where an incorrect code example showed up.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit a0486e0d45b9bcd1f8598b77c5ba6a765602924e)