### PR TITLE
comm_create_from_groups: cherrypick two commits from main to fix mpi4py comm create from group etc tests

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -24,7 +24,7 @@
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
- * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
@@ -1741,7 +1741,7 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
                                        ompi_communicator_t **newintercomm)
 {
     ompi_communicator_t *newcomp = NULL, *local_comm, *leader_comm = MPI_COMM_NULL;
-    ompi_comm_extended_cid_block_t new_block;
+    ompi_comm_extended_cid_block_t new_block = {0};
     bool i_am_leader = local_leader == local_group->grp_my_rank;
     ompi_proc_t **rprocs;
     uint64_t data[4];
@@ -1867,14 +1867,7 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
         return rc;
     }
 
-    /* will be using a communicator ID derived from the bridge communicator to save some time */
-    new_block.block_cid.cid_base = data[1];
-    new_block.block_cid.cid_sub.u64 = data[2];
-    new_block.block_nextsub = 0;
-    new_block.block_nexttag = 0;
-    new_block.block_level = (int8_t) data[3];
-
-    rc = ompi_comm_nextcid (newcomp, NULL, NULL, (void *) tag, &new_block, false, OMPI_COMM_CID_GROUP_NEW);
+    rc = ompi_comm_nextcid (newcomp, NULL, NULL, (void *) tag, NULL, false, OMPI_COMM_CID_GROUP_NEW);
     if ( OMPI_SUCCESS != rc ) {
         OBJ_RELEASE(newcomp);
         return rc;

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1787,22 +1787,22 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
                 leader_procs[1] = tmp;
             }
 
-            /* create a unique tag for allocating the leader communicator. we can eliminate this step
-             * if we take a CID from the newly allocated block belonging to local_comm. this is
-             * a note to make this change at a later time. */
-            opal_asprintf (&sub_tag, "%s-OMPIi-LC", tag);
-            if (OPAL_UNLIKELY(NULL == sub_tag)) {
-                ompi_comm_free (&local_comm);
-                free(leader_procs);
-                return OMPI_ERR_OUT_OF_RESOURCE;
-            }
-
             leader_group = ompi_group_allocate_plist_w_procs (NULL, leader_procs, 2);
             ompi_set_group_rank (leader_group, my_proc);
             if (OPAL_UNLIKELY(NULL == leader_group)) {
-                free (sub_tag);
                 free(leader_procs);
                 ompi_comm_free (&local_comm);
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
+
+            /* create a unique tag for allocating the leader communicator. we can eliminate this step
+             * if we take a CID from the newly allocated block belonging to local_comm. this is
+             * a note to make this change at a later time. */
+            opal_asprintf (&sub_tag, "%s-OMPIi-LC-%s", tag, OPAL_NAME_PRINT(ompi_group_get_proc_name (leader_group, 0)));
+            if (OPAL_UNLIKELY(NULL == sub_tag)) {
+                free(leader_procs);
+                ompi_comm_free (&local_comm);
+                OBJ_RELEASE(leader_group);
                 return OMPI_ERR_OUT_OF_RESOURCE;
             }
 
@@ -1812,6 +1812,7 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
             rc = ompi_comm_create_from_group (leader_group, sub_tag, info, errhandler, &leader_comm);
             OBJ_RELEASE(leader_group);
             free (sub_tag);
+            sub_tag = NULL;
             if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
                 free(leader_procs);
                 ompi_comm_free (&local_comm);
@@ -1867,7 +1868,16 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
         return rc;
     }
 
-    rc = ompi_comm_nextcid (newcomp, NULL, NULL, (void *) tag, NULL, false, OMPI_COMM_CID_GROUP_NEW);
+    /*
+     * append the pmix CONTEXT_ID obtained when creating the leader comm as discriminator
+     */
+    opal_asprintf (&sub_tag, "%s-%ld", tag, data[1]);
+    if (OPAL_UNLIKELY(NULL == sub_tag)) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    rc = ompi_comm_nextcid (newcomp, NULL, NULL, (void *) sub_tag, NULL, false, OMPI_COMM_CID_GROUP_NEW);
+    free (sub_tag);
     if ( OMPI_SUCCESS != rc ) {
         OBJ_RELEASE(newcomp);
         return rc;

--- a/ompi/mpi/c/comm_create_from_group.c
+++ b/ompi/mpi/c/comm_create_from_group.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Triad National Security, LLC. All rights
+ * Copyright (c) 2021-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -46,6 +46,7 @@ static const char FUNC_NAME[] = "MPI_Comm_create_from_group";
 int MPI_Comm_create_from_group (MPI_Group group, const char *tag, MPI_Info info, MPI_Errhandler errhandler,
                                 MPI_Comm *newcomm) {
     int rc;
+    char *pmix_group_tag = NULL;
 
     MEMCHECKER(
         memchecker_comm(comm);
@@ -81,8 +82,22 @@ int MPI_Comm_create_from_group (MPI_Group group, const char *tag, MPI_Info info,
     }
 
 
-    rc = ompi_comm_create_from_group ((ompi_group_t *) group, tag, &info->super, errhandler,
+    /*
+     * we use PMIx group operations to implement comm/intercomm create from group/groups.
+     * PMIx group constructors require a unique tag across the processes using the same
+     * PMIx server.  This is not equivalent to the uniqueness requirements of the tag argument
+     * to MPI_Comm_create_from_group and MPI_Intercomm_create_from_groups, hence an
+     * additional discriminator needs to be added to the user supplied tag argument.
+     */
+    opal_asprintf (&pmix_group_tag, "%s-%s.%d", tag, OPAL_NAME_PRINT(ompi_group_get_proc_name (group, 0)),
+                   ompi_group_size(group));
+    if (OPAL_UNLIKELY(NULL == pmix_group_tag)) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    rc = ompi_comm_create_from_group ((ompi_group_t *) group, pmix_group_tag, &info->super, errhandler,
                                       (ompi_communicator_t **) newcomm);
+    free(pmix_group_tag);
     if (MPI_SUCCESS != rc) {
         return ompi_errhandler_invoke (errhandler, MPI_COMM_NULL, errhandler->eh_mpi_object_type,
                                        rc, FUNC_NAME);

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
@@ -104,6 +104,7 @@ bool ompi_ftmpi_enabled = false;
 #endif /* OPAL_ENABLE_FT_MPI */
 
 static int ompi_stream_buffering_mode = -1;
+int ompi_comm_verbose_level = 0;
 
 int ompi_mpi_register_params(void)
 {
@@ -445,6 +446,10 @@ int ompi_mpi_register_params(void)
     }
 #endif /* OPAL_ENABLE_FT_MPI */
 
+    (void) mca_base_var_register ("ompi", "mpi", "comm", "verbose",
+                                  "Verbosity level for communicator management subsystem",
+                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                  OPAL_INFO_LVL_8, MCA_BASE_VAR_SCOPE_LOCAL, &ompi_comm_verbose_level);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -16,7 +16,7 @@
  * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved
- * Copyright (c) 2018-2021 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
@@ -190,6 +190,12 @@ OMPI_DECLSPEC extern bool ompi_enable_timing;
 
 OMPI_DECLSPEC extern int ompi_mpi_event_tick_rate;
 OMPI_DECLSPEC extern bool ompi_mpi_yield_when_idle;
+
+ /**
+ * An integer value specifying verbosity level for communicator management
+ * subsystem.
+ */
+OMPI_DECLSPEC extern int ompi_comm_verbose_level;
 
 /**
  * Register MCA parameters used by the MPI layer.


### PR DESCRIPTION
Turns out we need parts of 95e3323e5ff2c0e67dcd982127f86de2587bce02 as well as 46ff69826e8f558e78d9b32f7f401ffc99e986fe to address some race conditions brought out by mpi4py comm create from group related tests.