### PR TITLE
coll/acoll: A few miscellaneous bugfixes

### DIFF
--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -37,12 +37,14 @@ extern int mca_coll_acoll_max_comms;
 extern int mca_coll_acoll_sg_size;
 extern int mca_coll_acoll_sg_scale;
 extern int mca_coll_acoll_node_size;
+extern int mca_coll_acoll_force_numa;
 extern int mca_coll_acoll_use_dynamic_rules;
 extern int mca_coll_acoll_mnode_enable;
 extern int mca_coll_acoll_bcast_lin0;
 extern int mca_coll_acoll_bcast_lin1;
 extern int mca_coll_acoll_bcast_lin2;
 extern int mca_coll_acoll_bcast_nonsg;
+extern int mca_coll_acoll_bcast_socket;
 extern int mca_coll_acoll_allgather_lin;
 extern int mca_coll_acoll_allgather_ring_1;
 
@@ -160,7 +162,7 @@ typedef struct coll_acoll_subcomms {
     int numa_root;
     int socket_ldr_root;
     int base_root[MCA_COLL_ACOLL_NUM_BASE_LYRS][MCA_COLL_ACOLL_NUM_LAYERS];
-    int base_rank[MCA_COLL_ACOLL_NUM_BASE_LYRS];
+    int base_rank[MCA_COLL_ACOLL_NUM_BASE_LYRS][MCA_COLL_ACOLL_NUM_LAYERS];
     int socket_rank;
     int subgrp_size;
     int initialized;
@@ -198,12 +200,14 @@ struct mca_coll_acoll_module_t {
     int log2_sg_cnt;
     int node_cnt;
     int log2_node_cnt;
+    int force_numa;
     int use_dyn_rules;
     // Todo: Use substructure for every API related ones
     int use_mnode;
     int use_lin0;
     int use_lin1;
     int use_lin2;
+    int use_socket;
     int mnode_sg_size;
     int mnode_log2_sg_size;
     int allg_lin;

--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -22,6 +22,7 @@
 
 #ifdef HAVE_XPMEM_H
 #include "opal/mca/rcache/base/base.h"
+#include "opal/class/opal_hash_table.h"
 #include <xpmem.h>
 #endif
 
@@ -125,6 +126,7 @@ typedef struct coll_acoll_data {
     void **xpmem_raddr;
     mca_rcache_base_module_t **rcache;
     void *scratch;
+    opal_hash_table_t **xpmem_reg_tracker_ht;
 #endif
     opal_shmem_ds_t *allshmseg_id;
     void **allshmmmap_sbuf;

--- a/ompi/mca/coll/acoll/coll_acoll_allgather.c
+++ b/ompi/mca/coll/acoll/coll_acoll_allgather.c
@@ -344,7 +344,7 @@ static inline int mca_coll_acoll_allgather_intra(const void *sbuf, size_t scount
     }
 
     /* Return if all ranks belong to single subgroup */
-    if (num_sgs == 1) {
+    if (1 == num_sgs) {
         /* All done */
         return err;
     }
@@ -396,7 +396,7 @@ static inline int mca_coll_acoll_allgather_intra(const void *sbuf, size_t scount
     }
     /* Now all base ranks have the full data */
     /* Do broadcast within subgroups from the base ranks for the extra data */
-    if (sg_id == 0) {
+    if (0 == sg_id) {
         num_data_blks = 1;
         data_blk_size[0] = bcount * (num_sgs - 2) + last_subgrp_rcnt;
         blk_ofst[0] = bcount;
@@ -527,7 +527,7 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
         if (num_nodes > 1) {
             assert(subc->local_r_comm != NULL);
         }
-        intra_comm = num_nodes == 1 ? comm : subc->local_r_comm;
+        intra_comm = 1 == num_nodes ? comm : subc->local_r_comm;
     }
     err = mca_coll_acoll_allgather_intra(sbuf, scount, sdtype, local_rbuf, rcount, rdtype,
                                          intra_comm, module);
@@ -536,7 +536,7 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
     }
 
     /* Return if intra-node communicator */
-    if ((num_nodes == 1) || (size <= 2)) {
+    if ((1 == num_nodes) || (size <= 2)) {
         /* All done */
         return err;
     }
@@ -592,7 +592,7 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
     } /* End of if inter leader */
 
     /* Do intra node broadcast */
-    if (node_id == 0) {
+    if (0 == node_id) {
         num_data_blks = 1;
         data_blk_size[0] = bcount * (num_nodes - 2) + last_subgrp_rcnt;
         blk_ofst[0] = bcount;
@@ -613,7 +613,7 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
     /* Loop over data blocks */
     for (i = 0; i < num_data_blks; i++) {
         char *buff = (char *) rbuf + (ptrdiff_t) blk_ofst[i] * rext;
-        err = (comm)->c_coll->coll_bcast(buff, data_blk_size[i], rdtype, 0, subc->local_r_comm,
+        err = ompi_coll_base_bcast_intra_basic_linear(buff, data_blk_size[i], rdtype, 0, subc->local_r_comm,
                                          module);
         if (MPI_SUCCESS != err) {
             return err;

--- a/ompi/mca/coll/acoll/coll_acoll_barrier.c
+++ b/ompi/mca/coll/acoll/coll_acoll_barrier.c
@@ -141,7 +141,7 @@ int mca_coll_acoll_barrier_intra(struct ompi_communicator_t *comm, mca_coll_base
     }
 
     size = ompi_comm_size(comm);
-    if (size == 1) {
+    if (1 == size) {
         return err;
     }
     if (!subc->initialized && size > 1) {

--- a/ompi/mca/coll/acoll/coll_acoll_bcast.c
+++ b/ompi/mca/coll/acoll/coll_acoll_bcast.c
@@ -126,8 +126,9 @@ static int bcast_flat_tree(void *buff, size_t count, struct ompi_datatype_t *dat
     *lin_2 = l2;
 
 static inline void coll_bcast_decision_fixed(int size, size_t total_dsize, int node_size,
-                                             int *sg_cnt, int *use_0, int *use_numa, int *lin_0,
-                                             int *lin_1, int *lin_2,
+                                             int *sg_cnt, int *use_0, int *use_numa,
+                                             int *use_socket, int *lin_0,
+                                             int *lin_1, int *lin_2, int num_nodes,
                                              mca_coll_acoll_module_t *acoll_module,
                                              coll_acoll_subcomms_t *subc)
 {
@@ -135,8 +136,13 @@ static inline void coll_bcast_decision_fixed(int size, size_t total_dsize, int n
     *use_0 = 0;
     *lin_0 = 0;
     *use_numa = 0;
+    *use_socket = 0;
     if (size <= node_size) {
-        if (size <= sg_size) {
+        if (acoll_module->use_dyn_rules) {
+            *sg_cnt = (acoll_module->mnode_sg_size == acoll_module->sg_cnt) ? acoll_module->sg_cnt : node_size;
+            *use_0 = 0;
+            SET_BCAST_PARAMS(acoll_module->use_lin0, acoll_module->use_lin1, acoll_module->use_lin2)
+        } else if (size <= sg_size) {
             *sg_cnt = sg_size;
             if (total_dsize <= 8192) {
                 SET_BCAST_PARAMS(0, 0, 0)
@@ -223,67 +229,70 @@ static inline void coll_bcast_decision_fixed(int size, size_t total_dsize, int n
         }
     } else {
         if (acoll_module->use_dyn_rules) {
-            *sg_cnt = acoll_module->mnode_sg_size;
+            *sg_cnt = (acoll_module->mnode_sg_size == acoll_module->sg_cnt) ? acoll_module->sg_cnt : node_size;
             *use_0 = acoll_module->use_mnode;
             SET_BCAST_PARAMS(acoll_module->use_lin0, acoll_module->use_lin1, acoll_module->use_lin2)
         } else {
-            int derived_node_size = subc->derived_node_size;
             *use_0 = 1;
-            if (size <= (derived_node_size << 2)) {
-                size_t dsize_thresh[2][3] = {{512, 8192, 131072}, {128, 8192, 65536}};
-                int thr_ind = (size <= (derived_node_size << 1)) ? 0 : 1;
-                if (total_dsize <= dsize_thresh[thr_ind][0]) {
-                    *sg_cnt = node_size;
-                    SET_BCAST_PARAMS(0, 0, 0)
-                } else if (total_dsize <= dsize_thresh[thr_ind][1]) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 0, 0)
-                } else if (total_dsize <= dsize_thresh[thr_ind][2]) {
-                    *sg_cnt = sg_size;
+            *sg_cnt = sg_size;
+            if (2 == num_nodes) {
+                SET_BCAST_PARAMS(1, 1, 1)
+                *use_socket = 1;
+                *use_numa = (total_dsize <= 2097152) ? 0 : 1;
+            } else if (num_nodes <= 4) {
+                if (total_dsize <= 512) {
+                    *use_socket = 1;
+                    SET_BCAST_PARAMS(1, 1, 0)
+                } else if (total_dsize <= 2097152) {
+                    *use_socket = 1;
                     SET_BCAST_PARAMS(1, 1, 1)
                 } else {
-                    *sg_cnt = node_size;
+                    *use_numa = 1;
+                    *use_socket = (total_dsize <= 4194304) ? 0 : 1;
                     SET_BCAST_PARAMS(1, 1, 1)
                 }
-            } else if (size <= (derived_node_size << 3)) {
-                if (total_dsize <= 1024) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 0, 1)
-                } else if (total_dsize <= 8192) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(1, 0, 1)
-                } else if (total_dsize <= 65536) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(1, 1, 1)
-                } else if (total_dsize <= 2097152) {
-                    *sg_cnt = node_size;
-                    SET_BCAST_PARAMS(0, 1, 1)
+            } else if (num_nodes <= 6) {
+                SET_BCAST_PARAMS(1, 1, 1)
+                if (total_dsize <= 524288) {
+                    *use_socket = 1;
                 } else {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 0, 0)
+                    *use_numa = 1;
                 }
-            } else if (size <= (derived_node_size << 4)) {
-                if (total_dsize <= 64) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 1, 1)
-                } else if (total_dsize <= 8192) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 0, 1)
-                } else if (total_dsize <= 32768) {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(1, 1, 1)
-                } else if (total_dsize <= 2097152) {
-                    *sg_cnt = node_size;
-                    SET_BCAST_PARAMS(0, 1, 1)
+            } else if (num_nodes <= 8) {
+                SET_BCAST_PARAMS(1, 1, 1)
+                if (total_dsize <= 8192) {
+                    *use_numa = 0;
                 } else {
-                    *sg_cnt = sg_size;
-                    SET_BCAST_PARAMS(0, 0, 0)
+                    *use_numa = 1;
+                }
+            } else if (num_nodes <= 10) {
+                *use_numa = 1;
+                if (total_dsize <= 32768) {
+                    SET_BCAST_PARAMS(1, 1, 0)
+                } else {
+                    SET_BCAST_PARAMS(1, 1, 1)
                 }
             } else {
-                *sg_cnt = sg_size;
-                SET_BCAST_PARAMS(0, 0, 0)
+                *use_numa = 1;
+                if (total_dsize <= 64) {
+                    SET_BCAST_PARAMS(1, 0, 1)
+                } else if (total_dsize <= 2097152) {
+                    SET_BCAST_PARAMS(1, 1, 1)
+                } else {
+                    *use_socket = 1;
+                    SET_BCAST_PARAMS(0, 1, 1)
+                }
             }
         }
+    }
+    if (-1 != acoll_module->force_numa) {
+        *use_numa = acoll_module->force_numa;
+        if (acoll_module->force_numa) {
+            *sg_cnt = sg_size;
+        }
+    }
+    if (-1 != acoll_module->use_socket) {
+        *use_socket = acoll_module->use_socket;
     }
 }
 
@@ -291,32 +300,38 @@ static inline void coll_acoll_bcast_subcomms(struct ompi_communicator_t *comm,
                                              coll_acoll_subcomms_t *subc,
                                              struct ompi_communicator_t **subcomms, int *subc_roots,
                                              int root, int num_nodes, int use_0, int no_sg,
-                                             int use_numa)
+                                             int use_numa, int use_socket)
 {
+    int lyr_id = use_socket ? MCA_COLL_ACOLL_LYR_SOCKET : MCA_COLL_ACOLL_LYR_NODE;
     /* Node leaders */
     if (use_0) {
         subcomms[MCA_COLL_ACOLL_NODE_L] = subc->leader_comm;
         subc_roots[MCA_COLL_ACOLL_NODE_L] = subc->outer_grp_root;
     }
+    /* Socket leaders */
+    if (use_socket) {
+        subcomms[MCA_COLL_ACOLL_NODE_L] = subc->socket_ldr_comm;
+        subc_roots[MCA_COLL_ACOLL_NODE_L] = subc->socket_ldr_root;
+    }
     /* Intra comm */
-    if ((num_nodes > 1) && use_0) {
-        subc_roots[MCA_COLL_ACOLL_INTRA] = subc->is_root_node
-                                               ? subc->local_root[MCA_COLL_ACOLL_LYR_NODE]
-                                               : 0;
-        subcomms[MCA_COLL_ACOLL_INTRA] = subc->local_comm;
+    if (((num_nodes > 1) && use_0) || use_socket) {
+        int is_root = use_socket ? subc->is_root_socket : subc->is_root_node;
+        subc_roots[MCA_COLL_ACOLL_INTRA] = is_root ? subc->local_root[lyr_id] : 0;
+        subcomms[MCA_COLL_ACOLL_INTRA] = use_socket ? subc->socket_comm : subc->local_comm;
     } else {
         subc_roots[MCA_COLL_ACOLL_INTRA] = root;
         subcomms[MCA_COLL_ACOLL_INTRA] = comm;
     }
     /* Base ranks comm */
+    int parent = lyr_id;
     if (no_sg) {
         subcomms[MCA_COLL_ACOLL_L3_L] = subcomms[MCA_COLL_ACOLL_INTRA];
         subc_roots[MCA_COLL_ACOLL_L3_L] = subc_roots[MCA_COLL_ACOLL_INTRA];
     } else {
         subcomms[MCA_COLL_ACOLL_L3_L] = subc->base_comm[MCA_COLL_ACOLL_L3CACHE]
-                                                       [MCA_COLL_ACOLL_LYR_NODE];
+                                                       [parent];
         subc_roots[MCA_COLL_ACOLL_L3_L] = subc->base_root[MCA_COLL_ACOLL_L3CACHE]
-                                                         [MCA_COLL_ACOLL_LYR_NODE];
+                                                         [parent];
     }
     /* Subgroup comm */
     subcomms[MCA_COLL_ACOLL_LEAF] = subc->subgrp_comm;
@@ -325,9 +340,9 @@ static inline void coll_acoll_bcast_subcomms(struct ompi_communicator_t *comm,
     /* Override with numa when needed */
     if (use_numa) {
         subcomms[MCA_COLL_ACOLL_L3_L] = subc->base_comm[MCA_COLL_ACOLL_NUMA]
-                                                       [MCA_COLL_ACOLL_LYR_NODE];
+                                                       [parent];
         subc_roots[MCA_COLL_ACOLL_L3_L] = subc->base_root[MCA_COLL_ACOLL_NUMA]
-                                                         [MCA_COLL_ACOLL_LYR_NODE];
+                                                         [parent];
         subcomms[MCA_COLL_ACOLL_LEAF] = subc->numa_comm;
         subc_roots[MCA_COLL_ACOLL_LEAF] = subc->numa_root;
     }
@@ -338,7 +353,7 @@ static int mca_coll_acoll_bcast_intra_node(void *buff, size_t count, struct ompi
                                            coll_acoll_subcomms_t *subc,
                                            struct ompi_communicator_t **subcomms, int *subc_roots,
                                            int lin_1, int lin_2, int no_sg, int use_numa,
-                                           int world_rank)
+                                           int use_socket, int world_rank)
 {
     int size;
     int rank;
@@ -363,8 +378,9 @@ static int mca_coll_acoll_bcast_intra_node(void *buff, size_t count, struct ompi
     if (no_sg) {
         is_base = 1;
     } else {
-        int ind = use_numa ? MCA_COLL_ACOLL_NUMA : MCA_COLL_ACOLL_L3CACHE;
-        is_base = rank == subc->base_rank[ind] ? 1 : 0;
+        int ind1 = use_numa ? MCA_COLL_ACOLL_NUMA : MCA_COLL_ACOLL_L3CACHE;
+        int ind2 = use_socket ? MCA_COLL_ACOLL_LYR_SOCKET : MCA_COLL_ACOLL_LYR_NODE;
+        is_base = rank == subc->base_rank[ind1][ind2] ? 1 : 0;
     }
 
     /* All base ranks receive from root */
@@ -439,7 +455,7 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
     int num_nodes;
     int use_0 = 0;
     int lin_0 = 0, lin_1 = 0, lin_2 = 0;
-    int use_numa = 0;
+    int use_numa = 0, use_socket = 0;
     int no_sg;
     size_t total_dsize, dsize;
     mca_coll_acoll_module_t *acoll_module = (mca_coll_acoll_module_t *) module;
@@ -447,6 +463,12 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
     coll_acoll_subcomms_t *subc = NULL;
     struct ompi_communicator_t *subcomms[MCA_COLL_ACOLL_NUM_SC] = {NULL};
     int subc_roots[MCA_COLL_ACOLL_NUM_SC] = {-1};
+
+    /* For small communicators, use linear bcast */
+    size = ompi_comm_size(comm);
+    if (size < 8) {
+        return ompi_coll_base_bcast_intra_basic_linear(buff, count, datatype, root, comm, module);
+    }
 
     /* Obtain the subcomms structure */
     err = check_and_create_subc(comm, acoll_module, &subc);
@@ -460,7 +482,6 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
         && (root != subc->prev_init_root)) {
         return ompi_coll_base_bcast_intra_knomial(buff, count, datatype, root, comm, module, 0, 4);
     }
-    size = ompi_comm_size(comm);
     if ((!subc->initialized || (root != subc->prev_init_root)) && size > 2) {
         err = mca_coll_acoll_comm_split_init(comm, acoll_module, subc, root);
         if (MPI_SUCCESS != err) {
@@ -482,7 +503,7 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
 
     /* Use knomial for nodes 8 and above and non-large messages */
     if ((num_nodes >= 8 && total_dsize <= 65536)
-        || (num_nodes == 1 && size >= 256 && total_dsize < 16384)) {
+        || (1 == num_nodes && size >= 256 && total_dsize < 16384)) {
         return ompi_coll_base_bcast_intra_knomial(buff, count, datatype, root, comm, module, 0, 4);
     }
 
@@ -490,14 +511,14 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
     /* sg_cnt determines subgroup based communication */
     /* lin_1 and lin_2 indicate whether to use linear or log based
      sends/receives across and within subgroups respectively. */
-    coll_bcast_decision_fixed(size, total_dsize, node_size, &sg_cnt, &use_0, &use_numa, &lin_0,
-                              &lin_1, &lin_2, acoll_module, subc);
+    coll_bcast_decision_fixed(size, total_dsize, node_size, &sg_cnt, &use_0, &use_numa, &use_socket, &lin_0,
+                              &lin_1, &lin_2, num_nodes, acoll_module, subc);
     no_sg = (sg_cnt == node_size) ? 1 : 0;
     if (size <= 2)
         no_sg = 1;
 
     coll_acoll_bcast_subcomms(comm, subc, subcomms, subc_roots, root, num_nodes, use_0, no_sg,
-                              use_numa);
+                              use_numa, use_socket);
 
     reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
     if (NULL == reqs) {
@@ -507,7 +528,7 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
     preq = reqs;
     err = MPI_SUCCESS;
 
-    if (use_0) {
+    if (use_0 || use_socket) {
         if (subc_roots[MCA_COLL_ACOLL_NODE_L] != -1) {
             err = bcast_func[lin_0](buff, count, datatype, subc_roots[MCA_COLL_ACOLL_NODE_L],
                                     subcomms[MCA_COLL_ACOLL_NODE_L], preq, &nreqs, rank);
@@ -528,7 +549,7 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
     }
 
     err = mca_coll_acoll_bcast_intra_node(buff, count, datatype, module, subc, subcomms, subc_roots,
-                                          lin_1, lin_2, no_sg, use_numa, rank);
+                                          lin_1, lin_2, no_sg, use_numa, use_socket, rank);
 
     if (MPI_SUCCESS != err) {
         ompi_coll_base_free_reqs(reqs, nreqs);

--- a/ompi/mca/coll/acoll/coll_acoll_module.c
+++ b/ompi/mca/coll/acoll/coll_acoll_module.c
@@ -132,11 +132,15 @@ mca_coll_base_module_t *mca_coll_acoll_comm_query(struct ompi_communicator_t *co
         break;
     }
 
+    acoll_module->force_numa = mca_coll_acoll_force_numa;
     acoll_module->use_dyn_rules = mca_coll_acoll_use_dynamic_rules;
     acoll_module->use_mnode = mca_coll_acoll_mnode_enable;
+    /* Value of 0 is currently unsupported for mnode_enable */
+    acoll_module->use_mnode = 1;
     acoll_module->use_lin0 = mca_coll_acoll_bcast_lin0;
     acoll_module->use_lin1 = mca_coll_acoll_bcast_lin1;
     acoll_module->use_lin2 = mca_coll_acoll_bcast_lin2;
+    acoll_module->use_socket = mca_coll_acoll_bcast_socket;
     if (mca_coll_acoll_bcast_nonsg) {
         acoll_module->mnode_sg_size = acoll_module->node_cnt;
         acoll_module->mnode_log2_sg_size = acoll_module->log2_node_cnt;
@@ -181,6 +185,11 @@ static int acoll_module_enable(mca_coll_base_module_t *module, struct ompi_commu
    ACOLL_INSTALL_COLL_API(comm, acoll_module, bcast);
    ACOLL_INSTALL_COLL_API(comm, acoll_module, gather);
    ACOLL_INSTALL_COLL_API(comm, acoll_module, reduce);
+
+   /* Initialize k-nomial tree */
+    module->base_data->cached_kmtree = NULL;
+    module->base_data->cached_kmtree_root = -1;
+    module->base_data->cached_kmtree_radix = 4;
 
     /* All done */
     return OMPI_SUCCESS;


### PR DESCRIPTION
This PR has some bug fixes and addition of a few command line arguments for configurability.

### Bug fixes
- Selection logic and associated parameter assignments fixed for socket level and node level subcommunicators (bcast.c, reduce.c, utils.h)
- Calling appropriate bcast function from acoll's allgather/allreduce for subcommunicators (allreduce.c, allgather.c)
- Proper free and deregister for xpmem related memory (component.c, utils.h)

### Command-line arguments
- To enable/disable use of NUMA and socket based subcommunicators (component.c, bcast.c)

In addition, the algorithm selection logic for multinode bcast is modified for better performance after the bugfixes.