### PR TITLE
accelerator/rocm and smsc/accelerator: add owner.txt

### DIFF
--- a/opal/mca/accelerator/rocm/owner.txt
+++ b/opal/mca/accelerator/rocm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: AMD
+status: active

--- a/opal/mca/smsc/accelerator/owner.txt
+++ b/opal/mca/smsc/accelerator/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: AMD
+status: active


### PR DESCRIPTION
the owner files of accelerator/rocm and smsc/accelerator component were accidentally ommitted.