### PR TITLE
comm: couple of enhancements wrt pmix groups

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -391,7 +391,7 @@ int ompi_mpi_register_params(void)
 
     ompi_pmix_connect_timeout = 0; /* infinite timeout - see PMIx standard */
     (void) mca_base_var_register ("ompi", "mpi", NULL, "pmix_connect_timeout",
-                                  "Timeout(secs) for calls to PMIx_Connect. Default is no timeout.",
+                                  "Timeout(secs) for calls to PMIx_Connect and PMIx_Group_construct/destruct. Default is no timeout.",
                                   MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
                                   0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
                                   &ompi_pmix_connect_timeout);


### PR DESCRIPTION
add a pmix timeout option for group operations.
This may be a no-op with certain pmix server variants but set it anyway.

For protection make sure when creating intercomm communicators using pmix group construct that all procs supply the same ordered list of pmix procs to pmix group construct.

update the description for ompi_mca_mpi_pmix_connect_timeout to not it can be used to control timeout for pmix group calls as well.