### PR TITLE
docs: add image of all Open MPI github contributors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,3 +82,11 @@ Table of contents
    history
    man-openmpi/index
    man-openshmem/index
+
+Contributors
+============
+
+A gigantic "thank you!" to all of our contributors:
+
+.. image:: https://contrib.rocks/image?repo=open-mpi/ompi&max=999
+   :target: https://github.com/open-mpi/ompi/graphs/contributors


### PR DESCRIPTION
Many thanks to https://contrib.rocks/ for this cool picture!

I added a (live) picture of all of our Github contributors to the bottom of docs top-level index page.  See https://ompi--13004.org.readthedocs.build/en/13004/#contributors