### PR TITLE
coll/accelerator add support for more functions

### DIFF
--- a/ompi/mca/coll/accelerator/Makefile.am
+++ b/ompi/mca/coll/accelerator/Makefile.am
@@ -12,7 +12,8 @@
 #
 
 sources = coll_accelerator_module.c coll_accelerator_reduce.c coll_accelerator_allreduce.c \
-          coll_accelerator_reduce_scatter_block.c coll_accelerator_component.c \
+          coll_accelerator_reduce_scatter_block.c coll_accelerator_reduce_scatter.c       \
+          coll_accelerator_component.c \
           coll_accelerator_scan.c coll_accelerator_exscan.c coll_accelerator.h
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/coll/accelerator/Makefile.am
+++ b/ompi/mca/coll/accelerator/Makefile.am
@@ -11,9 +11,10 @@
 # $HEADER$
 #
 
-sources = coll_accelerator_module.c coll_accelerator_reduce.c coll_accelerator_allreduce.c \
+sources = coll_accelerator_reduce.c coll_accelerator_allreduce.c \
           coll_accelerator_reduce_scatter_block.c coll_accelerator_reduce_scatter.c       \
-          coll_accelerator_component.c \
+	  coll_accelerator_allgather.c coll_accelerator_alltoall.c coll_accelerator_bcast.c \
+	  coll_accelerator_component.c coll_accelerator_module.c \
           coll_accelerator_scan.c coll_accelerator_exscan.c coll_accelerator.h
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/coll/accelerator/coll_accelerator.h
+++ b/ompi/mca/coll/accelerator/coll_accelerator.h
@@ -34,6 +34,11 @@ BEGIN_C_DECLS
 
 /* API functions */
 
+
+extern int mca_coll_accelerator_bcast_thresh;
+extern int mca_coll_accelerator_allgather_thresh;
+extern int mca_coll_accelerator_alltoall_thresh;
+
 int mca_coll_accelerator_init_query(bool enable_progress_threads,
                              bool enable_mpi_threads);
 mca_coll_base_module_t
@@ -85,6 +90,28 @@ mca_coll_accelerator_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_arr
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
+int
+mca_coll_accelerator_allgather(const void *sbuf, size_t scount,
+			       struct ompi_datatype_t *sdtype,
+			       void *rbuf, size_t rcount,
+			       struct ompi_datatype_t *rdtype,
+			       struct ompi_communicator_t *comm,
+			       mca_coll_base_module_t *module);
+
+int
+mca_coll_accelerator_alltoall(const void *sbuf, size_t scount,
+			      struct ompi_datatype_t *sdtype,
+			      void *rbuf, size_t rcount,
+			      struct ompi_datatype_t *rdtype,
+			      struct ompi_communicator_t *comm,
+			      mca_coll_base_module_t *module);
+
+int
+mca_coll_accelerator_bcast(void *buff, size_t count,
+			   struct ompi_datatype_t *datatype,
+			   int root,
+			   struct ompi_communicator_t *comm,
+			   mca_coll_base_module_t *module);
 
 /* Checks the type of pointer
  *

--- a/ompi/mca/coll/accelerator/coll_accelerator.h
+++ b/ompi/mca/coll/accelerator/coll_accelerator.h
@@ -78,6 +78,13 @@ mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t r
                                    struct ompi_communicator_t *comm,
                                    mca_coll_base_module_t *module);
 
+int
+mca_coll_accelerator_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_array_t rcounts,
+                                   struct ompi_datatype_t *dtype,
+                                   struct ompi_op_t *op,
+                                   struct ompi_communicator_t *comm,
+                                   mca_coll_base_module_t *module);
+
 
 /* Checks the type of pointer
  *

--- a/ompi/mca/coll/accelerator/coll_accelerator_allgather.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_allgather.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_accelerator.h"
+
+#include <stdio.h>
+
+#include "ompi/op/op.h"
+#include "opal/datatype/opal_convertor.h"
+
+/*
+ *	Function:	- allgather for device buffers through temp CPU buffer
+ *	Accepts:	- same as MPI_Allgather()
+ *	Returns:	- MPI_SUCCESS or error code
+ */
+int
+mca_coll_accelerator_allgather(const void *sbuf, size_t scount,
+                       struct ompi_datatype_t *sdtype,
+                       void *rbuf, size_t rcount,
+                       struct ompi_datatype_t *rdtype,
+                       struct ompi_communicator_t *comm,
+                       mca_coll_base_module_t *module)
+{
+    mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
+    ptrdiff_t sgap, rgap;
+    char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
+    size_t sbufsize, rbufsize;
+    int rc;
+    int comm_size = ompi_comm_size(comm);
+    
+    sbufsize = opal_datatype_span(&sdtype->super, scount, &sgap);
+    rc = mca_coll_accelerator_check_buf((void *)sbuf, &sbuf_dev);
+    if (rc < 0) {
+        return rc;
+    }
+    if ((MPI_IN_PLACE != sbuf) && (rc > 0) &&
+        (sbufsize <= (size_t)mca_coll_accelerator_allgather_thresh)) {
+        sbuf1 = (char*)malloc(sbufsize);
+        if (NULL == sbuf1) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        mca_coll_accelerator_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev,
+                                    sbufsize, MCA_ACCELERATOR_TRANSFER_DTOH);
+        sbuf = sbuf1 - sgap;
+    }
+
+    rbufsize = opal_datatype_span(&rdtype->super, rcount, &rgap);
+    rc = mca_coll_accelerator_check_buf(rbuf, &rbuf_dev);
+    if (rc < 0) {
+        goto exit;
+    }
+    /* Using sbufsize here on purpose to ensure symmetric decision for handling of GPU vs
+       CPU buffers. The two buffer sizes are expected to be the same for pre-defined datatypes,
+       but could vary due to layout issues/gaps for derived datatypes */
+    if ((rc > 0) && (sbufsize <= (size_t)mca_coll_accelerator_allgather_thresh)) {
+        rbuf1 = (char*)malloc(rbufsize * comm_size);
+        if (NULL == rbuf1) {
+            rc = OMPI_ERR_OUT_OF_RESOURCE;
+            goto exit;
+        }
+        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev,
+                                    rbufsize * comm_size, MCA_ACCELERATOR_TRANSFER_DTOH);
+        rbuf2 = rbuf; /* save original buffer */
+        rbuf = rbuf1 - rgap;
+    }
+    rc = s->c_coll.coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                  comm, s->c_coll.coll_allgather_module);
+    if (rc < 0) {
+        goto exit;
+    }
+
+    if (NULL != rbuf1) {
+        mca_coll_accelerator_memcpy(rbuf2, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbufsize * comm_size,
+                                    MCA_ACCELERATOR_TRANSFER_HTOD);
+    }
+
+ exit:
+    if (NULL != sbuf1) {
+        free(sbuf1);
+    }
+    if (NULL != rbuf1) {
+        free(rbuf1);
+    }
+
+    return rc;
+}

--- a/ompi/mca/coll/accelerator/coll_accelerator_alltoall.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_alltoall.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_accelerator.h"
+
+#include <stdio.h>
+
+#include "ompi/op/op.h"
+#include "opal/datatype/opal_convertor.h"
+
+/*
+ *	Function:	- alltoall for device buffers using temp. CPU buffer
+ *	Accepts:	- same as MPI_Alltoall()
+ *	Returns:	- MPI_SUCCESS or error code
+ */
+int
+mca_coll_accelerator_alltoall(const void *sbuf, size_t scount,
+                      struct ompi_datatype_t *sdtype,
+                      void *rbuf, size_t rcount,
+                      struct ompi_datatype_t *rdtype,
+                      struct ompi_communicator_t *comm,
+                      mca_coll_base_module_t *module)
+{
+    mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
+    ptrdiff_t sgap, rgap;
+    char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
+    size_t sbufsize, rbufsize;
+    int rc;
+    int comm_size = ompi_comm_size(comm);
+
+    sbufsize = opal_datatype_span(&sdtype->super, scount, &sgap);
+    rc = mca_coll_accelerator_check_buf((void *)sbuf, &sbuf_dev);
+    if (rc < 0) {
+        return rc;
+    }
+    if ((MPI_IN_PLACE != sbuf) && (rc > 0) &&
+        (sbufsize <= (size_t)mca_coll_accelerator_alltoall_thresh)) {
+        sbuf1 = (char*)malloc(sbufsize * comm_size);
+        if (NULL == sbuf1) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        mca_coll_accelerator_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev,
+                                    sbufsize * comm_size, MCA_ACCELERATOR_TRANSFER_DTOH);
+        sbuf = sbuf1 - sgap;
+    }
+
+    rbufsize = opal_datatype_span(&rdtype->super, rcount, &rgap);
+    rc = mca_coll_accelerator_check_buf(rbuf, &rbuf_dev);
+    if (rc < 0) {
+        goto exit;
+    }
+    /* Using sbufsize here on purpose to ensure symmetric decision for handling of GPU vs
+       CPU buffers. The two buffer sizes are expected to be the same for pre-defined datatypes,
+       but could vary due to layout issues/gaps for derived datatypes */
+    if ((rc > 0) && (sbufsize <= (size_t)mca_coll_accelerator_alltoall_thresh)) {
+        rbuf1 = (char*)malloc(rbufsize * comm_size);
+        if (NULL == rbuf1) {
+            rc = OMPI_ERR_OUT_OF_RESOURCE;
+            goto exit;
+        }
+        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev,
+                                    rbufsize * comm_size, MCA_ACCELERATOR_TRANSFER_DTOH);
+        rbuf2 = rbuf; /* save away original buffer */
+        rbuf = rbuf1 - rgap;
+    }
+    rc = s->c_coll.coll_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                  comm, s->c_coll.coll_alltoall_module);
+    if (rc < 0) {
+        goto exit;;
+    }
+    if (NULL != rbuf1) {
+         mca_coll_accelerator_memcpy(rbuf2, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID,
+				     rbufsize * comm_size, MCA_ACCELERATOR_TRANSFER_HTOD);
+    }
+
+ exit:
+    if (NULL != sbuf1) {
+        free(sbuf1);
+    }
+    if (NULL != rbuf1) {
+        free(rbuf1);
+    }
+
+    return rc;
+}

--- a/ompi/mca/coll/accelerator/coll_accelerator_bcast.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_bcast.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_accelerator.h"
+
+#include <stdio.h>
+
+#include "ompi/op/op.h"
+#include "opal/datatype/opal_convertor.h"
+
+/*
+ *
+ *	Function:	- Bcast for device buffers through temp CPU buffer. 
+ *	Accepts:	- same as MPI_Bcast()
+ *	Returns:	- MPI_SUCCESS or error code
+ */
+int
+mca_coll_accelerator_bcast(void *orig_buf, size_t count,
+			   struct ompi_datatype_t *datatype,
+			   int root,
+			   struct ompi_communicator_t *comm,
+			   mca_coll_base_module_t *module)
+{
+    mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
+    ptrdiff_t gap;
+    char *buf1 = NULL;
+    char *sbuf = (char*) orig_buf;
+    int buf_dev;
+    size_t bufsize;
+    int rc;
+
+    bufsize = opal_datatype_span(&datatype->super, count, &gap);
+
+    rc = mca_coll_accelerator_check_buf((void *)orig_buf, &buf_dev);
+    if (rc < 0) {
+        return rc;
+    }
+    if ((rc > 0) && (bufsize <= (size_t)mca_coll_accelerator_bcast_thresh)) {
+        buf1 = (char*)malloc(bufsize);
+        if (NULL == buf1) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        mca_coll_accelerator_memcpy(buf1, MCA_ACCELERATOR_NO_DEVICE_ID, orig_buf, buf_dev, bufsize,
+                                    MCA_ACCELERATOR_TRANSFER_DTOH);
+        sbuf = buf1 - gap;
+    }
+
+    rc = s->c_coll.coll_bcast((void *) sbuf, count, datatype, root, comm,
+                               s->c_coll.coll_bcast_module);
+    if (rc < 0) {
+        goto exit;
+    }
+    if (NULL != buf1) {
+        mca_coll_accelerator_memcpy((void*)orig_buf, buf_dev, buf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                                    MCA_ACCELERATOR_TRANSFER_HTOD);
+    }
+
+ exit:
+    if (NULL != buf1) {
+        free(buf1);
+    }
+
+    return rc;
+}

--- a/ompi/mca/coll/accelerator/coll_accelerator_component.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_component.c
@@ -22,6 +22,11 @@
 #include "ompi/constants.h"
 #include "coll_accelerator.h"
 
+
+int mca_coll_accelerator_bcast_thresh = 256;
+int mca_coll_accelerator_allgather_thresh = 65536;
+int mca_coll_accelerator_alltoall_thresh = 65536;
+
 /*
  * Public string showing the coll ompi_accelerator component version number
  */
@@ -87,6 +92,33 @@ static int accelerator_register(void)
                                            OPAL_INFO_LVL_2,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_coll_accelerator_component.disable_accelerator_coll);
+
+    mca_coll_accelerator_bcast_thresh = 256;
+    (void) mca_base_component_var_register(&mca_coll_accelerator_component.super.collm_version,
+                                           "bcast_thresh",
+                                           "max. msg length for which to copy accelerator buffer to CPU for bcast operation",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_accelerator_bcast_thresh);
+
+    mca_coll_accelerator_allgather_thresh = 65536;
+    (void) mca_base_component_var_register(&mca_coll_accelerator_component.super.collm_version,
+                                           "allgather_thresh",
+                                           "max. msg length for which to copy accelerator buffer to CPU for allgather operation",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_accelerator_allgather_thresh);
+
+    mca_coll_accelerator_alltoall_thresh = 65536;
+    (void) mca_base_component_var_register(&mca_coll_accelerator_component.super.collm_version,
+                                           "alltoall_thresh",
+                                           "max. msg length for which to copy accelerator buffer to CPU for alltoall operation",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_accelerator_alltoall_thresh);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/coll/accelerator/coll_accelerator_module.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_module.c
@@ -93,8 +93,11 @@ mca_coll_accelerator_comm_query(struct ompi_communicator_t *comm,
     accelerator_module->super.coll_module_enable = mca_coll_accelerator_module_enable;
     accelerator_module->super.coll_module_disable = mca_coll_accelerator_module_disable;
 
+    accelerator_module->super.coll_allgather  = mca_coll_accelerator_allgather;
     accelerator_module->super.coll_allreduce  = mca_coll_accelerator_allreduce;
+    accelerator_module->super.coll_alltoall   = mca_coll_accelerator_alltoall;
     accelerator_module->super.coll_reduce     = mca_coll_accelerator_reduce;
+    accelerator_module->super.coll_bcast      = mca_coll_accelerator_bcast;
     accelerator_module->super.coll_reduce_local         = mca_coll_accelerator_reduce_local;
     accelerator_module->super.coll_reduce_scatter       = mca_coll_accelerator_reduce_scatter;
     accelerator_module->super.coll_reduce_scatter_block = mca_coll_accelerator_reduce_scatter_block;
@@ -142,7 +145,10 @@ mca_coll_accelerator_module_enable(mca_coll_base_module_t *module,
 {
     mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
 
+    ACCELERATOR_INSTALL_COLL_API(comm, s, allgather);
     ACCELERATOR_INSTALL_COLL_API(comm, s, allreduce);
+    ACCELERATOR_INSTALL_COLL_API(comm, s, alltoall);
+    ACCELERATOR_INSTALL_COLL_API(comm, s, bcast);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce_local);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce_scatter);
@@ -162,8 +168,11 @@ mca_coll_accelerator_module_disable(mca_coll_base_module_t *module,
 {
     mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
 
+    ACCELERATOR_UNINSTALL_COLL_API(comm, s, allgather);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, allreduce);
+    ACCELERATOR_UNINSTALL_COLL_API(comm, s, alltoall);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce);
+    ACCELERATOR_UNINSTALL_COLL_API(comm, s, bcast);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_local);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_scatter);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_scatter_block);

--- a/ompi/mca/coll/accelerator/coll_accelerator_module.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_module.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2014-2024 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -96,6 +96,7 @@ mca_coll_accelerator_comm_query(struct ompi_communicator_t *comm,
     accelerator_module->super.coll_allreduce  = mca_coll_accelerator_allreduce;
     accelerator_module->super.coll_reduce     = mca_coll_accelerator_reduce;
     accelerator_module->super.coll_reduce_local         = mca_coll_accelerator_reduce_local;
+    accelerator_module->super.coll_reduce_scatter       = mca_coll_accelerator_reduce_scatter;
     accelerator_module->super.coll_reduce_scatter_block = mca_coll_accelerator_reduce_scatter_block;
     if (!OMPI_COMM_IS_INTER(comm)) {
         accelerator_module->super.coll_scan       = mca_coll_accelerator_scan;
@@ -144,6 +145,7 @@ mca_coll_accelerator_module_enable(mca_coll_base_module_t *module,
     ACCELERATOR_INSTALL_COLL_API(comm, s, allreduce);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce_local);
+    ACCELERATOR_INSTALL_COLL_API(comm, s, reduce_scatter);
     ACCELERATOR_INSTALL_COLL_API(comm, s, reduce_scatter_block);
     if (!OMPI_COMM_IS_INTER(comm)) {
         /* MPI does not define scan/exscan on intercommunicators */
@@ -163,6 +165,7 @@ mca_coll_accelerator_module_disable(mca_coll_base_module_t *module,
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, allreduce);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_local);
+    ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_scatter);
     ACCELERATOR_UNINSTALL_COLL_API(comm, s, reduce_scatter_block);
     if (!OMPI_COMM_IS_INTER(comm))
     {

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_accelerator.h"
+
+#include <stdio.h>
+
+#include "ompi/op/op.h"
+#include "opal/datatype/opal_convertor.h"
+
+/*
+ *	reduce_scatter
+ *
+ *	Function:	- reduce_scatter for device buffers through temp. CPU buffer
+ *	Accepts:	- same as MPI_Reduce_scatter()
+ *	Returns:	- MPI_SUCCESS or error code
+ *
+ * Algorithm:
+ *     reduce and scatter (needs to be cleaned
+ *     up at some point)
+ */
+int
+mca_coll_accelerator_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_array_t rcounts,
+                                   struct ompi_datatype_t *dtype,
+                                   struct ompi_op_t *op,
+                                   struct ompi_communicator_t *comm,
+                                   mca_coll_base_module_t *module)
+{
+    mca_coll_accelerator_module_t *s = (mca_coll_accelerator_module_t*) module;
+    ptrdiff_t gap;
+    char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
+    size_t sbufsize, rbufsize, elemsize;
+    int rc, i;
+    int comm_size = ompi_comm_size(comm);
+    int total_count = 0;
+    
+    elemsize = opal_datatype_span(&dtype->super, 1, &gap);
+    for (i = 0; i < comm_size; i++) {
+	total_count += ompi_count_array_get(rcounts, i);
+    }
+    sbufsize = elemsize * total_count;
+
+    rc = mca_coll_accelerator_check_buf((void *)sbuf, &sbuf_dev);
+    if (0 > rc) {
+        return rc;
+    }
+    if ((MPI_IN_PLACE != sbuf) && (0 < rc)) {
+        sbuf1 = (char*)malloc(sbufsize);
+        if (NULL == sbuf1) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        mca_coll_accelerator_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, sbufsize,
+                                    MCA_ACCELERATOR_TRANSFER_DTOH);
+        sbuf = sbuf1 - gap;
+    }
+
+    rc = mca_coll_accelerator_check_buf(rbuf, &rbuf_dev);
+    if (0 > rc) {
+        goto exit;
+    }
+    rbufsize = elemsize * ompi_count_array_get(rcounts, ompi_comm_rank(comm));
+    if (0 < rc) {
+        rbuf1 = (char*)malloc(rbufsize);
+        if (NULL == rbuf1) {
+            rc = OMPI_ERR_OUT_OF_RESOURCE;
+	    goto exit;
+        }
+        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbufsize,
+                                    MCA_ACCELERATOR_TRANSFER_DTOH);
+        rbuf2 = rbuf; /* save away original buffer */
+        rbuf = rbuf1 - gap;
+    }
+    rc = s->c_coll.coll_reduce_scatter(sbuf, rbuf, rcounts, dtype, op, comm,
+                                       s->c_coll.coll_reduce_scatter_block_module);
+    if (0 > rc) {
+        goto exit;
+    }
+
+    if (NULL != rbuf1) {
+        mca_coll_accelerator_memcpy(rbuf2, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbufsize,
+                                    MCA_ACCELERATOR_TRANSFER_HTOD);
+    }
+
+ exit:
+    if (NULL != sbuf1) {
+        free(sbuf1);
+    }
+    if (NULL != rbuf1) {
+        free(rbuf1);
+    }
+
+    return rc;
+}
+

--- a/ompi/mca/coll/accelerator/owner.txt
+++ b/ompi/mca/coll/accelerator/owner.txt
@@ -3,5 +3,5 @@
 # owner: institution that is responsible for this package
 # status: e.g. active, maintenance, unmaintained
 #
-owner: NVIDIA
-status: maintenance
+owner: NVIDIA/AMD
+status: active


### PR DESCRIPTION
Add support for more functions to the coll/accelerator component. Specifically:
 - MPI_Reduce_scatter was missing as the only reduction operation
 - introduce support for Bcast, Allgather, and Alltoall operations. The max. msg size for which to use the copy-through-CPU mechanism can be controlled by MCA parameters for each function separatly.

To motivate the work on non-reduction operations, the main benefit is for short messages, since communication from GPU buffers has typically a higher latency than communication from CPU buffers. 

Here is some data to support the PR, gathered on an MI250X node with 16 GPUs:

MPI_Bcast:
```
# OSU MPI-ROCM Broadcast Latency Test v7.5
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)
# procs                   16         16         32       32
# copy to CPU?            no        yes         no      yes  
1                      12.24       2.84      14.86     3.44
2                      17.19       4.18	     21.37     4.64
4                      17.22       4.13	     21.13     4.65
8                      17.19       4.09	     21.08     4.63
16                     17.23       4.11	     21.11     4.63
32                     17.47       4.18	     28.43     4.71
64                     20.02       4.15	     28.03     4.74
128                    27.54       8.37	     45.03     8.05
256                    28.30      12.67	     44.73    13.38
512                    27.65      32.51	     44.65    28.39
1024                   27.86      57.93	     44.92    64.72
2048                   28.06      27.66	    207.97    34.89
4096                   54.40      32.14	    429.97    36.70
8192                   54.64      45.65	    430.32    57.30
16384                  55.76      56.71	    433.16    67.10
32768                  56.96      84.60	    459.17    93.21
65536                  59.84     141.01	    440.84   162.06
131072                 65.34     256.07	    466.58   279.53
262144                 76.69     474.92	    553.10   524.82
524288                 97.60     803.38	    674.06   955.30
1048576               271.92    2030.49	   1069.67  1844.79
```
MPI_Allgather:
```
# OSU MPI-ROCM Allgather Latency Test v7.5
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)
# procs                   16        16        32         32
# Copy to CPU?            no       yes        no        yes
1                      44.70      5.86     54.62       6.85
2                      45.41      8.68	   54.67       9.67
4                      45.88      8.76	   54.09       9.71
8                      44.98      8.84	   66.06      10.12
16                     59.17      9.18	   83.69      10.70
32                     72.29      9.69	   99.86      11.57
64                     83.31     10.35	  120.70      12.65
128                    95.16     16.67	  148.10      19.50
256                    95.92     28.52	  148.03      33.09
512                    95.41     72.15	  147.25      86.03
1024                  111.54    144.25	  393.00     146.43
2048                  112.29     84.30	  761.04     105.84
4096                  159.91    111.35	  794.44     132.48
8192                  163.18    164.20	  801.66     188.61
16384                 169.69    277.55	  806.56     326.65
32768                 178.70    544.21	  810.47     622.84
65536                 195.38    891.83	 1661.78    1925.92
131072                226.69   1527.13	 1643.53    9896.87
262144                298.12   6354.89	 1667.39   19147.58
524288                450.23  12872.46	 1910.64   40723.25
1048576               764.79  26134.81	 3752.21   81590.10
```
MPI_Alltoall:
```
# OSU MPI-ROCM All-to-All Personalized Exchange Latency Test v7.5
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)
# procs                   16        16        32        32
# copy to CPU?            no       yes        no       yes
1                     102.40     62.82    109.26     39.49
2                     119.86     65.76	  131.27     41.89
4                      70.86     27.01	  135.16     41.77
8                      75.00     26.99	  147.80     41.83
16                     88.56     27.45	  175.73     42.33
32                    112.92     27.56	  243.95     42.88
64                    184.78     27.92	  409.48     44.33
128                   363.13     34.33	  611.12     53.13
256                   484.21     46.77	  948.13     70.85
512                   205.33    135.85	  489.44    235.73
1024                  184.16    196.80	  482.84    295.78
2048                  182.26    154.94	  487.60    296.06
4096                  187.28    163.12	  538.29    311.60
8192                  189.87    184.98	  539.06    346.44
16384                 190.54    232.64	  544.14    431.32
32768                 191.31    336.01	  549.42    533.02
65536                 197.93    492.32	  557.00   1050.14
131072                199.14    889.92	  583.84  11395.43
262144                244.68   7316.06	  843.04  21582.68
524288                389.49  13314.65	 1481.85  40945.10
1048576               697.91  24498.35	 2753.87  80627.56
```

This data demonstrates that there are benefits of using the copy-to-host approach especially for short messages. Results on different settings might vary, but the user has the option to control the desired behavior using the MCA parameter (and later using https://github.com/open-mpi/ompi/pull/12991 by explicitly specifying which collective operation this component should be registered for.