### PR TITLE
comm: add pmix timeout knob to group ops

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
@@ -391,7 +391,7 @@ int ompi_mpi_register_params(void)
 
     ompi_pmix_connect_timeout = 0; /* infinite timeout - see PMIx standard */
     (void) mca_base_var_register ("ompi", "mpi", NULL, "pmix_connect_timeout",
-                                  "Timeout(secs) for calls to PMIx_Connect. Default is no timeout.",
+                                  "Timeout(secs) for calls to PMIx_Connect and PMIx_Group_construct/destruct. Default is no timeout.",
                                   MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
                                   0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
                                   &ompi_pmix_connect_timeout);


### PR DESCRIPTION
Add pmix timeout option for the pmix group operations used by Open MPI to construct certain types of communicators.  Leverage the existing pmix connect mca parameter rather than adding yet another knob.