### PR TITLE
v5.0.x: docs: add image of all Open MPI github contributors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,3 +82,11 @@ Table of contents
    history
    man-openmpi/index
    man-openshmem/index
+
+Contributors
+============
+
+A gigantic "thank you!" to all of our contributors:
+
+.. image:: https://contrib.rocks/image?repo=open-mpi/ompi&max=999
+   :target: https://github.com/open-mpi/ompi/graphs/contributors


### PR DESCRIPTION
Many thanks to https://contrib.rocks/ for this cool picture!

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 963213d18e1ca7398eaf778cccabcf865ae15125)

This is a v5.0.x PR corresponding to main PR #13004 