### PR TITLE
btl/ofi: fixes for multi mpi init/fini scenarios

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -2,6 +2,8 @@
 /*
  * $COPYRIGHT$
  * Copyright (c) 2018      Intel Inc. All rights reserved
+ * Copyright (c) 2025      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,10 +16,10 @@
 #include "btl_ofi_rdma.h"
 
 #if OPAL_HAVE_THREAD_LOCAL
-opal_thread_local mca_btl_ofi_context_t *my_context = NULL;
+static opal_thread_local mca_btl_ofi_context_t *my_context = NULL;
 #endif /* OPAL_HAVE_THREAD_LOCAL */
 
-int init_context_freelists(mca_btl_ofi_context_t *context)
+static int init_context_freelists(mca_btl_ofi_context_t *context)
 {
     int rc;
     OBJ_CONSTRUCT(&context->rdma_comp_list, opal_free_list_t);
@@ -113,6 +115,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_normal(struct fi_info *info,
     context->tx_ctx = ep;
     context->rx_ctx = ep;
     context->context_id = 0;
+    my_context = NULL;
 
     return context;
 

--- a/opal/mca/btl/ofi/btl_ofi_endpoint.h
+++ b/opal/mca/btl/ofi/btl_ofi_endpoint.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2018      Intel, Inc, All rights reserved
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,10 +34,6 @@
 
 BEGIN_C_DECLS
 
-#if OPAL_HAVE_THREAD_LOCAL
-extern opal_thread_local mca_btl_ofi_context_t *my_context;
-#endif /* OPAL_HAVE_THREAD_LOCAL */
-
 struct mca_btl_base_endpoint_t {
     opal_list_item_t super;
 
@@ -52,8 +50,6 @@ struct mca_btl_base_endpoint_t {
 typedef struct mca_btl_base_endpoint_t mca_btl_base_endpoint_t;
 typedef mca_btl_base_endpoint_t mca_btl_ofi_endpoint_t;
 OBJ_CLASS_DECLARATION(mca_btl_ofi_endpoint_t);
-
-int init_context_freelists(mca_btl_ofi_context_t *context);
 
 mca_btl_base_endpoint_t *mca_btl_ofi_endpoint_create(opal_proc_t *proc, struct fid_ep *ep);
 

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -73,6 +74,7 @@ static int patcher_register(void);
 static int patcher_query(int *);
 
 static int mca_memory_patcher_priority;
+static int was_executed_already = 0;
 
 opal_memory_patcher_component_t mca_memory_patcher_component = {
     .super =
@@ -585,7 +587,6 @@ static int patcher_query(int *priority)
 
 static int patcher_open(void)
 {
-    static int was_executed_already = 0;
     int rc;
 
     if (was_executed_already) {
@@ -677,6 +678,8 @@ err_patching:
 static int patcher_close(void)
 {
     mca_base_framework_close(&opal_patcher_base_framework);
+
+    was_executed_already = 0;
 
     /* Note that we don't need to unpatch any symbols here; the
        patcher framework will take care of all of that for us. */


### PR DESCRIPTION
The OFI BTL was caching a context -in the case of normal OFI EPs - across multiple sessions init/finalize,  resulting in segfaults.

Also, there were some symbols being exported which should not have been.

Related to #13019