### PR TITLE
io/ompio: file file_seek calculation - v5.0.x

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -414,19 +414,21 @@ static void mca_io_ompio_file_get_eof_offset (ompio_file_t *fh,
     in_offset -= fh->f_disp;
     if ( fh->f_view_size  > 0 ) {
         /* starting offset of the current copy of the filew view */
-        start_offset = in_offset / fh->f_view_extent;
+        start_offset = (in_offset / fh->f_view_extent) * fh->f_view_extent;
         
         index_in_file_view = 0;
         /* determine block id that the offset is located in and
            the starting offset of that block */
-        while ( offset <= in_offset && index_in_file_view < fh->f_iov_count) {
-            prev_offset = offset;
+        while (offset <= in_offset && index_in_file_view < fh->f_iov_count) {
             offset = start_offset + (OMPI_MPI_OFFSET_TYPE)(intptr_t) fh->f_decoded_iov[index_in_file_view++].iov_base;
+	    if (offset <= in_offset) {
+		prev_offset = offset;
+	    }
         }
         
         offset = prev_offset;
         blocklen = fh->f_decoded_iov[index_in_file_view-1].iov_len;
-        while (  offset <= in_offset && k <= blocklen )  {
+        while (offset <= in_offset && k <= blocklen)  {
             prev_offset = offset;
             offset += fh->f_etype_size;
             k += fh->f_etype_size;


### PR DESCRIPTION
fix the file_seek calculations when using SEEK_END. Thanks @tukss for reporting the issue.

Fixes #12952

(note: some minor changes were required compared to the main PR to handle differences in the code base)

Signed-off-by: Edgar Gabriel <edgar.gabriel@amd.com>
(cherry picked from commit d82d905d82c621fd710027214b9c508bf8a31845)