### PR TITLE
Fix patcher for ppc and aarch64

### DIFF
--- a/opal/mca/patcher/patcher.h
+++ b/opal/mca/patcher/patcher.h
@@ -30,9 +30,9 @@
  * Reference: "64-bit PowerPC ELF Application Binary Interface Supplement 1.9" */
 #    define OPAL_PATCHER_BEGIN                      \
         unsigned long toc_save;                     \
-        asm volatile("std 2, %0" : "=m"(toc_save)); \
-        asm volatile("nop; nop; nop; nop; nop");
-#    define OPAL_PATCHER_END asm volatile("ld  2, %0" : : "m"(toc_save));
+        asm volatile("std 2, %0" : "=m"(toc_save) :: "memory"); \
+        asm volatile("nop; nop; nop; nop; nop"::: "memory");
+#    define OPAL_PATCHER_END asm volatile("ld  2, %0" : : "m"(toc_save) : "memory");
 
 #else /* !__PPC64__ */
 


### PR DESCRIPTION
Prevent the compiler from reordering the instructions in the patcher by marking the assembly code as clobbering memory.

Thanks @pinskia for the patch and for bringing the discussion on the gcc bugzilla.

I was not able to test this. The code generated by [godbolt](https://godbolt.org/) seems legit, but I did not yet figured out how to look at the disassembled code in OMPI.

Fixes #13014.