### PR TITLE
part_persist: fix component declaration

### DIFF
--- a/ompi/mca/part/persist/part_persist_component.h
+++ b/ompi/mca/part/persist/part_persist_component.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2004-2006 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ * Copyright (c) 2004-2025 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2020-2021 Sandia National Laboratories. All rights reserved.
  * $COPYRIGHT$
@@ -26,7 +26,7 @@ BEGIN_C_DECLS
 /*
  * PART module functions.
  */
-OMPI_DECLSPEC extern mca_part_base_component_4_0_0_t mca_part_rma_component;
+OMPI_DECLSPEC extern mca_part_base_component_4_0_0_t mca_part_persist_component;
 
 END_C_DECLS
 


### PR DESCRIPTION
This PR makes the declaration of the part_persist component struct consistent with the definition.
Apparently, the component has been renamed in part_persist_component.c, but not in the declaration in the corresponding header.