### PR TITLE
btl/sm: rewrite of fast box (per-peer receive buffers)

### DIFF
--- a/opal/mca/btl/sm/btl_sm_module.c
+++ b/opal/mca/btl/sm/btl_sm_module.c
@@ -91,8 +91,10 @@ static int sm_btl_first_time_init(mca_btl_sm_t *sm_btl, int n)
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
+    /* Fast box buffers are prepended with a metadata section. */
     rc = opal_free_list_init(&component->sm_fboxes, sizeof(opal_free_list_item_t), 8,
-                             OBJ_CLASS(opal_free_list_item_t), mca_btl_sm_component.fbox_size,
+                             OBJ_CLASS(opal_free_list_item_t), mca_btl_sm_component.fbox_size +
+                             sizeof (mca_btl_sm_fbox_metadata_t),
                              opal_cache_line_size, 0, mca_btl_sm_component.fbox_max, 4,
                              component->mpool, 0, NULL, NULL, NULL);
     if (OPAL_SUCCESS != rc) {

--- a/opal/mca/btl/sm/btl_sm_types.h
+++ b/opal/mca/btl/sm/btl_sm_types.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2020-2025 Google, LLC. All rights reserved.
  *
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -49,24 +49,32 @@ struct mca_btl_sm_modex_t {
 
 typedef struct mca_btl_sm_modex_t mca_btl_sm_modex_t;
 
+typedef struct mca_btl_sm_fbox_metadata {
+    uint32_t start;
+    uint8_t  padding[26];
+} mca_btl_sm_fbox_metadata_t;
+
+typedef struct mca_btl_sm_fbox_out {
+    unsigned char *buffer; /**< starting address of peer's fast box in */
+    mca_btl_sm_fbox_metadata_t *metadata;
+    unsigned int start, end;
+    uint16_t seq;
+    opal_free_list_item_t *fbox; /**< fast-box free list item */
+} mca_btl_sm_fbox_out_t;
+
+typedef struct mca_btl_sm_fbox_in {
+    unsigned char *buffer; /**< starting address of peer's fast box out */
+    mca_btl_sm_fbox_metadata_t *metadata;
+    unsigned int start;
+    uint16_t seq;
+} mca_btl_sm_fbox_in_t;
+
 typedef struct mca_btl_base_endpoint_t {
     opal_list_item_t super;
 
     /* per peer buffers */
-    struct {
-        unsigned char *buffer; /**< starting address of peer's fast box out */
-        uint32_t *startp;
-        unsigned int start;
-        uint16_t seq;
-    } fbox_in;
-
-    struct {
-        unsigned char *buffer; /**< starting address of peer's fast box in */
-        uint32_t *startp;      /**< pointer to location storing start offset */
-        unsigned int start, end;
-        uint16_t seq;
-        opal_free_list_item_t *fbox; /**< fast-box free list item */
-    } fbox_out;
+    mca_btl_sm_fbox_in_t fbox_in;
+    mca_btl_sm_fbox_out_t fbox_out;
 
     uint16_t peer_smp_rank;        /**< my peer's SMP process rank.  Used for accessing
                                     *   SMP specific data structures. */


### PR DESCRIPTION
I was investigating possibly lost btl/sm messages and realized that the code is difficult to follow and it is not always clear what I was attempting to do. It is not clear if there is a problem but the rewrite is worth committing.

This change does the following:

 - Seperate the fast box metadata out from the fast box receive data. These parts are logically separate so there was no need to keep adjusting the offset based on the metadata (start of buffer was offset 64, now 0).

 - Use modulo-math instead of toggling an extra bit to determine full vs empty. To keep this fast the modulo is done with bitwise-and with a mask and the fast box size has been limited to a power of two. This change simplifies the math and only has one special case to cover ( end overflow-- end less than start).

 - General cleanup of the code overall to improve readability.