### PR TITLE
part-persist: implement message aggregation

### DIFF
--- a/ompi/mca/part/base/Makefile.am
+++ b/ompi/mca/part/base/Makefile.am
@@ -11,9 +11,11 @@ headers += \
         base/base.h \
         base/part_base_prequest.h \
         base/part_base_precvreq.h \
-        base/part_base_psendreq.h 
+        base/part_base_psendreq.h \
+        base/aggregation_schemes/aggregation_scheme_regular.h
 
 libmca_part_la_SOURCES += \
+        base/aggregation_schemes/aggregation_scheme_regular.c \
         base/part_base_frame.c \
         base/part_base_precvreq.c \
         base/part_base_prequest.c \

--- a/ompi/mca/part/base/aggregation_schemes/aggregation_scheme_regular.c
+++ b/ompi/mca/part/base/aggregation_schemes/aggregation_scheme_regular.c
@@ -1,0 +1,83 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "aggregation_scheme_regular.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+// converts the index of a public partition to the index of its corresponding internal partition
+static inline int internal_partition(struct part_persist_aggregation_state *state, int public_part)
+{
+    return public_part / state->factor;
+}
+
+void aggregation_scheme_regular_psend_init(struct part_persist_aggregation_state *state,
+                                        int internal_partition_count, int factor, int last_internal_partition_size)
+{
+    state->public_partition_count = (internal_partition_count - 1) * factor + last_internal_partition_size;
+    state->internal_partition_count = internal_partition_count;
+
+    // number of user-partitions per internal partition (except for the last one)
+    state->factor = factor;
+    // number of user-partitions corresponding to the last internal partition
+    state->last_internal_partition_size = last_internal_partition_size;
+
+    // initialize counters
+    state->public_parts_ready = (opal_atomic_uint32_t *) calloc(state->internal_partition_count,
+                                                                 sizeof(opal_atomic_uint32_t));
+}
+
+void aggregation_scheme_regular_reset(struct part_persist_aggregation_state *state)
+{
+    // reset flags
+    if (NULL != state->public_parts_ready) {
+        memset((void*)state->public_parts_ready, 0, state->internal_partition_count * sizeof(opal_atomic_uint32_t));
+    }
+}
+
+static inline int is_last_partition(struct part_persist_aggregation_state *state, int partition) {
+    return (partition == state->internal_partition_count - 1);
+}
+
+static inline int num_public_parts(struct part_persist_aggregation_state *state, int partition) {
+    return is_last_partition(state, partition) ? state->last_internal_partition_size : state->factor;
+}
+
+void aggregation_scheme_regular_pready(struct part_persist_aggregation_state *state, int partition, int* available_partition)
+{
+    int internal_part = internal_partition(state, partition);
+    int corresponding_public_parts = num_public_parts(state, internal_part);
+
+    // this is the new value (after incrementing)
+    int count = opal_atomic_add_fetch_32(&state->public_parts_ready[internal_part], 1);
+
+    // output internal partition if ready
+    if (count == corresponding_public_parts) {
+        *available_partition = internal_part;
+    } else {
+        *available_partition = -1;
+    }
+}
+
+int aggregation_scheme_regular_internal_part(struct part_persist_aggregation_state *state,
+                                                      int partition)
+{
+    return internal_partition(state, partition);
+}
+
+void aggregation_scheme_regular_free(struct part_persist_aggregation_state *state)
+{
+    if (NULL != state->public_parts_ready)
+        free((void*)state->public_parts_ready);
+    state->public_parts_ready = NULL;
+}

--- a/ompi/mca/part/base/aggregation_schemes/aggregation_scheme_regular.h
+++ b/ompi/mca/part/base/aggregation_schemes/aggregation_scheme_regular.h
@@ -1,0 +1,96 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/**
+ * @file
+ * This file defines a simple message aggregation scheme:
+ * A user-provided partitioning of n partitions of size b can be mapped
+ * to an internal partitioning of n/k partitions of size k*b,
+ * where k can be selected to optimize internal partition size.
+ */
+
+#ifndef AGGREGATION_SCHEME_REGULAR_H
+#define AGGREGATION_SCHEME_REGULAR_H
+
+#include "ompi_config.h"
+
+#include "opal/include/opal/sys/atomic.h"
+
+
+/**
+ * @brief tracks the number of pready calls corresponding to internal partitions
+ *
+ */
+struct part_persist_aggregation_state {
+    // counters for each internal partition
+    opal_atomic_uint32_t *public_parts_ready;
+
+    int internal_partition_count;
+
+    // parameters for message aggregation
+    int factor; // how many public partitions may be aggregated into an internal one
+
+    int public_partition_count;
+    int last_internal_partition_size; // number of public partitions corresponding to last internal
+                                      // one
+};
+
+/**
+ * @brief initializes the aggregation state for the sending side
+ *
+ * @param[out] state                        pointer to aggregation state object
+ * @param[in] internal_partition_count      number of internal partitions (i.e. number of messages
+ * per partitioned transfer)
+ * @param[in] factor                        number of public partitions corresponding to each internal one other than the last
+ * @param[in] last_internal_partition_size  number of public partitions corresponding to last
+ * internal partition
+ */
+void aggregation_scheme_regular_psend_init(struct part_persist_aggregation_state *state,
+                                           int internal_partition_count,
+                                           int factor,
+                                           int last_internal_partition_size);
+
+/**
+ * @brief resets the aggregation state
+ *
+ * @param[out] state                pointer to aggregation state object
+ */
+void aggregation_scheme_regular_reset(struct part_persist_aggregation_state *state);
+
+/**
+ * @brief marks a public partition as ready
+ *
+ * @param[in,out] state             pointer to aggregation state object
+ * @param[in] partition             index of the public partition to mark ready
+ * @param[out] available_partition  index of the internal partition if it is ready, otherwise -1
+ */
+void aggregation_scheme_regular_pready(struct part_persist_aggregation_state *state,
+                                       int partition, int* available_partition);
+
+/**
+ * @brief 
+ *
+ * @param[in,out] state             pointer to aggregation state object
+ * @param[in] partition             index of the public partition
+ * @return the internal partition number corresponding to the given 
+ */
+int aggregation_scheme_regular_internal_part(struct part_persist_aggregation_state *state,
+                                             int partition);
+
+/**
+ * @brief destroys the aggregation scheme
+ *
+ * @param[in,out] state             pointer to aggregation state object
+ */
+void aggregation_scheme_regular_free(struct part_persist_aggregation_state *state);
+
+#endif

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2021      Tennessee Technological University. All rights reserved.
  * Copyright (c) 2021      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021      Bull S.A.S. All rights reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,11 +80,70 @@ struct ompi_part_persist_t {
     int32_t                init_world;
     int32_t                my_world_rank; /* Because the back end communicators use a world rank, we need to communicate ours 
                                              to set up the requests. */
+
+    uint32_t min_message_size;          /* parameters to control internal partitioning */
+    uint32_t max_message_count;
+
     opal_atomic_int32_t    block_entry;
     opal_mutex_t lock; 
 };
 typedef struct ompi_part_persist_t ompi_part_persist_t;
 extern ompi_part_persist_t ompi_part_persist;
+
+
+
+/**
+ * @brief selects an internal partitioning based on the user-provided partitioning
+ * and the mca parameters for minimal partition size and maximal partition count.
+ * 
+ * More precisely, given a partitioning into p partitions of size s, computes
+ * an internal partitioning into p'-1 partitions of size s' and an additional 
+ * partition (remainder) of size r * s. s' is selected to be a multiple of s
+ * and r such that remainder r * s is smaller than s.
+ *
+ * @param (IN)  partitions           number of user-provided partitions
+ * @param (IN)  count                size of user-provided partitions in elements
+ * @param (OUT) internal_partitions  number of internal partitions
+ * @param (OUT) factor               number of public partitions corresponding to each internal partitions other than the last one
+ * @param (OUT) last_size            number of public partitions corresponding to the last internal partition
+ */
+static inline void part_persist_select_internal_partitioning(size_t partitions, size_t part_size, size_t* internal_partitions, size_t* factor, size_t* remainder) {
+    size_t buffer_size = partitions * part_size;
+    size_t min_part_size  = ompi_part_persist.min_message_size;
+    size_t max_part_count = ompi_part_persist.max_message_count;
+
+    // check if max_part_count imposes higher limit on partition size
+    if (max_part_count > 0 && (buffer_size / max_part_count) > min_part_size) {
+        min_part_size = buffer_size / max_part_count;
+    }
+
+    // cannot have partitions larger than buffer size
+    if (min_part_size > buffer_size) {
+        min_part_size = buffer_size;
+    }
+
+    size_t _internal_partitions, _factor, _remainder;
+
+    if (part_size < min_part_size) {
+        // solve partitions = (internal_partitions - 1) * factor + remainder for factor and remainder
+        _factor = min_part_size / part_size;
+        _internal_partitions = (partitions + _factor - 1) / _factor;
+        _remainder = partitions % (_factor);
+
+        if (0 == _remainder) { 
+            // we still need the size of the last partition
+            _remainder = _factor;
+        }
+    } else {    // can keep original partitioning
+        _internal_partitions = partitions;
+        _factor = 1;
+        _remainder = 1;
+    }
+
+    *internal_partitions = _internal_partitions;
+    *factor = _factor;
+    *remainder = _remainder;
+}
 
 
 /**
@@ -95,6 +156,10 @@ mca_part_persist_free_req(struct mca_part_persist_request_t* req)
     size_t i;
     opal_list_remove_item(ompi_part_persist.progress_list, (opal_list_item_t*)req->progress_elem);
     OBJ_RELEASE(req->progress_elem);
+
+    if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
+        aggregation_scheme_regular_free(&req->aggregation_state);
+    }
 
     /* The per-partition requests are only created once the setup handshake
      * has completed, so an uninitialized request has none. */
@@ -261,21 +326,23 @@ mca_part_persist_progress(void)
                     dt_size = (dt_size_ > (size_t) UINT_MAX) ? (uint32_t)MPI_UNDEFINED : (uint32_t) dt_size_;
                     uint32_t bytes = req->real_count * dt_size;
 
-                    /* Set up persistent sends */
+                    /* Set up persistent sends. Last partition is handled separately as size may differ */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
-                    for(i = 0; i < req->real_parts; i++) {
+                    for(i = 0; i < req->real_parts - 1; i++) {
                          void *buf = ((void*) (((char*)req->req_addr) + (bytes * i)));
                          err = MCA_PML_CALL(isend_init(buf, req->real_count, req->req_datatype, req->world_peer, req->my_send_tag+i, MCA_PML_BASE_SEND_STANDARD, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
                     }    
+                    void *buf = ((void*) (((char*)req->req_addr) + (bytes * i)));
+                    err = MCA_PML_CALL(isend_init(buf, req->real_count_last, req->req_datatype, req->world_peer, req->my_send_tag+i, MCA_PML_BASE_SEND_STANDARD, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
                 } else {
                     /* parse message */
-                    req->world_peer   = req->setup_info[1].world_rank; 
-                    req->my_send_tag  = req->setup_info[1].start_tag;
-                    req->my_recv_tag  = req->setup_info[1].setup_tag;
-                    req->real_parts   = req->setup_info[1].num_parts;
-                    req->real_count   = req->setup_info[1].count;
-                    req->real_dt_size = req->setup_info[1].dt_size;
-
+                    req->world_peer      = req->setup_info[1].world_rank; 
+                    req->my_send_tag     = req->setup_info[1].start_tag;
+                    req->my_recv_tag     = req->setup_info[1].setup_tag;
+                    req->real_parts      = req->setup_info[1].num_parts;
+                    req->real_count      = req->setup_info[1].count;
+                    req->real_count_last = req->setup_info[1].count_last;
+                    req->real_dt_size    = req->setup_info[1].dt_size;
 
                     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
                     if(OMPI_SUCCESS != err) return OMPI_ERROR;
@@ -284,22 +351,27 @@ mca_part_persist_progress(void)
 
 
 
-		    /* Set up persistent sends */
+                    /* Set up persistent sends */
                     req->persist_reqs = (ompi_request_t**) malloc(sizeof(ompi_request_t*)*(req->real_parts));
                     req->flags = (int*) calloc(req->real_parts,sizeof(int));
 
                     if(req->real_dt_size == dt_size) {
 
-     	                for(i = 0; i < req->real_parts; i++) {
+                        /* Last partition is handled separately as the size may differ */
+                         for(i = 0; i < req->real_parts - 1; i++) {
                             void *buf = ((void*) (((char*)req->req_addr) + (bytes * i)));
                             err = MCA_PML_CALL(irecv_init(buf, req->real_count, req->req_datatype, req->world_peer, req->my_send_tag+i, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
                         }
+                        void *buf = ((void*) (((char*)req->req_addr) + (bytes * i)));
+                        err = MCA_PML_CALL(irecv_init(buf, req->real_count_last, req->req_datatype, req->world_peer, req->my_send_tag+i, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
                     } else {
-                        for(i = 0; i < req->real_parts; i++) {
+                        for(i = 0; i < req->real_parts - 1; i++) {
                             void *buf = ((void*) (((char*)req->req_addr) + (req->real_count * req->real_dt_size * i)));
                             err = MCA_PML_CALL(irecv_init(buf, req->real_count * req->real_dt_size, MPI_BYTE, req->world_peer, req->my_send_tag+i, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
                         }
-		    }
+                        void *buf = ((void*) (((char*)req->req_addr) + (req->real_count * req->real_dt_size * i)));
+                        err = MCA_PML_CALL(irecv_init(buf, req->real_count_last * req->real_dt_size, MPI_BYTE, req->world_peer, req->my_send_tag+i, ompi_part_persist.part_comm, &(req->persist_reqs[i])));
+                    }
                     err = req->persist_reqs[0]->req_start(req->real_parts, (&(req->persist_reqs[0])));                     
 
                     /* Send back a message */
@@ -467,15 +539,27 @@ mca_part_persist_psend_init(const void* buf,
 
     /* non-blocking send set-up data */
     req->setup_info[0].world_rank = ompi_comm_rank(&ompi_mpi_comm_world.comm);
-    req->setup_info[0].start_tag = ompi_part_persist.next_send_tag; ompi_part_persist.next_send_tag += parts; 
+    req->setup_info[0].start_tag = ompi_part_persist.next_send_tag;
     req->my_send_tag = req->setup_info[0].start_tag;
-    req->setup_info[0].setup_tag = ompi_part_persist.next_recv_tag; ompi_part_persist.next_recv_tag++;
+    req->setup_info[0].setup_tag = ompi_part_persist.next_recv_tag;
     req->my_recv_tag = req->setup_info[0].setup_tag;
-    req->setup_info[0].num_parts = parts;
-    req->real_parts = parts;
-    req->setup_info[0].count = count;
-    req->real_count = count;
+
+    /* select internal partitioning (i.e. real_parts) here */
+    size_t factor, remaining_partitions;
+    part_persist_select_internal_partitioning(parts, count, &req->real_parts, &factor, &remaining_partitions);
+
+    aggregation_scheme_regular_psend_init(&req->aggregation_state, req->real_parts, factor, remaining_partitions);
+
+    req->real_count_last = remaining_partitions * count;     // convert to number of elements
+    req->real_count = factor * count;
+    req->setup_info[0].num_parts = req->real_parts;         // setup info has to contain internal partitioning
+    req->setup_info[0].count     = req->real_count;
+    req->setup_info[0].count_last = req->real_count_last;
     req->setup_info[0].dt_size = dt_size;
+    opal_output_verbose(5, ompi_part_base_framework.framework_output, "mapped given %lu*%lu partitioning to internal partitioning of %lu*%lu + %lu elements\n", parts, count, req->real_parts - 1, req->real_count, req->real_count_last);
+
+    ompi_part_persist.next_send_tag += req->real_parts; 
+    ompi_part_persist.next_recv_tag++;
 
     req->flags = (int*) calloc(req->real_parts, sizeof(int));
 
@@ -519,6 +603,11 @@ mca_part_persist_start(size_t count, ompi_request_t** requests)
 
     for(i = 0; i < _count && OMPI_SUCCESS == err; i++) {
         mca_part_persist_request_t *req = (mca_part_persist_request_t *)(requests[i]);
+
+        if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
+            aggregation_scheme_regular_reset(&req->aggregation_state);
+        }
+
         /* First use is a special case, to support lazy initialization */
         if(false == req->first_send)
         {
@@ -560,19 +649,24 @@ mca_part_persist_pready(size_t min_part,
     size_t i;
 
     mca_part_persist_request_t *req = (mca_part_persist_request_t *)(request);
-    if(true == req->initialized)
-    {
-        err = req->persist_reqs[min_part]->req_start(max_part-min_part+1, (&(req->persist_reqs[min_part])));
-        for(i = min_part; i <= max_part && OMPI_SUCCESS == err; i++) {
-            req->flags[i] = 0; /* Mark partition as ready for testing */
+
+
+    // queue or start available internal partitions
+    int internal_part_ready;
+    for(i = min_part; i <= max_part && OMPI_SUCCESS == err; i++) {
+        aggregation_scheme_regular_pready(&req->aggregation_state, i, &internal_part_ready);
+
+        if (-1 != internal_part_ready) {
+            if(true == req->initialized) {
+                err = req->persist_reqs[internal_part_ready]->req_start(1, (&(req->persist_reqs[internal_part_ready])));
+                req->flags[internal_part_ready] = 0;     /* Mark partition as ready for testing */
+
+            } else {
+                req->flags[internal_part_ready] = -2;    /* Mark partition as queued */
+            }
         }
     }
-    else
-    {
-        for(i = min_part; i <= max_part && OMPI_SUCCESS == err; i++) {
-            req->flags[i] = -2; /* Mark partition as queued */
-        }
-    }
+    
     return err;
 }
 
@@ -594,19 +688,23 @@ mca_part_persist_parrived(size_t min_part,
         return err;
     }
 
-    if(0 != req->flags) {
+    if (true == req->initialized) { 
+        // handle case where Precv_init was called with different partitioning
+        if(req->req_parts != req->real_parts) {
+            // convert to element indices
+            min_part *= req->req_count;
+            max_part *= req->req_count;
+            // point to last entry of max_part
+            max_part += req->req_count - 1;
+
+            // convert to internal partitions
+            min_part /= req->real_count;
+            max_part /= req->real_count;
+        }
+
         _flag = 1;
-        if(req->req_parts == req->real_parts) {
-            for(i = min_part; i <= max_part; i++) {
-                _flag = _flag && req->flags[i];            
-            }
-        } else {
-            float convert = ((float)req->real_parts) / ((float)req->req_parts);
-            size_t _min = floor(convert * min_part);
-            size_t _max = ceil(convert * max_part);
-            for(i = _min; i <= _max; i++) {
-                _flag = _flag && req->flags[i];
-            }
+        for(i = min_part; _flag && i <= max_part; i++) {
+            _flag = _flag && req->flags[i];
         }
     }
 

--- a/ompi/mca/part/persist/part_persist_component.c
+++ b/ompi/mca/part/persist/part_persist_component.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2013-2021 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,6 +87,23 @@ mca_part_persist_component_register(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &ompi_part_persist.free_list_inc);
 
+    // variable for minimal internal partition size
+    ompi_part_persist.min_message_size = 512;
+    (void) mca_base_component_var_register(&mca_part_persist_component.partm_version, "min_message_size",
+                                           "Minimum size of transferred messages (internal partitions)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_part_persist.min_message_size);
+
+    // variable for maximal internal partition count
+    ompi_part_persist.max_message_count = 4096;
+    (void) mca_base_component_var_register(&mca_part_persist_component.partm_version, "max_message_count",
+                                           "Maximum number of transferred messages (internal partitions)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_part_persist.max_message_count);
 
     return OPAL_SUCCESS;
 }

--- a/ompi/mca/part/persist/part_persist_request.h
+++ b/ompi/mca/part/persist/part_persist_request.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
  * Copyright (c) 2020-2021 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2024      High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +22,8 @@
 
 #ifndef PART_PERSIST_REQUEST_H
 #define PART_PERSIST_REQUEST_H
+
+#include "ompi/mca/part/base/aggregation_schemes/aggregation_scheme_regular.h"
 
 #include "ompi/mca/part/base/part_base_psendreq.h"
 #include "ompi/mca/part/part.h"
@@ -42,6 +46,7 @@ struct ompi_mca_persist_setup_t {
    size_t num_parts;
    size_t dt_size;
    size_t count;
+   size_t count_last;
 };
 
 
@@ -72,6 +77,7 @@ struct mca_part_persist_request_t {
 
     size_t real_parts;                   /**< internal number of partitions */
     size_t real_count;
+    size_t real_count_last;               /**< size of last internal partition (in elements) */
     size_t real_dt_size;                 /**< receiver needs to know how large the sender's datatype is. */
     size_t part_size; 
 
@@ -98,6 +104,7 @@ struct mca_part_persist_request_t {
   
     struct mca_part_persist_list_t* progress_elem; /**< pointer to progress list element for removal during free. */ 
 
+    struct part_persist_aggregation_state aggregation_state;
 };
 typedef struct mca_part_persist_request_t mca_part_persist_request_t;
 OBJ_CLASS_DECLARATION(mca_part_persist_request_t);

--- a/ompi/test/part/parrived_null_inactive.c
+++ b/ompi/test/part/parrived_null_inactive.c
@@ -190,11 +190,14 @@ int main(int argc, char *argv[])
         /* Case 3b: mark the send partitions ready one at a time; each
            must eventually arrive on the receive side (MPI-5.0 section
            4.2.2: "Repeated calls to MPI_PARRIVED ... will eventually
-           return flag = true"). */
+           return flag = true if ... and all send partitions have been 
+           marked as ready."). */
         for (i = 0; i < PARTITIONS; ++i) {
             rc = MPI_Pready(i, sreq);
             check(MPI_SUCCESS == rc, "MPI_Pready failed");
+        }
 
+        for (i = 0; i < PARTITIONS; ++i) {
             flag = 0;
             for (j = 0; j < MAX_POLL && !flag; ++j) {
                 rc = MPI_Parrived(rreq, i, &flag);


### PR DESCRIPTION
Created a component for partitioned communication that supports message aggregation, based on the existing part-persist component. The goal is to prevent drops in effective bandwidth when using too fine-grained partitionings.

This component allows enforcing hard limits on size and count of transferred partitions, regardless of the partitioning required by the application. These limits can be specified using mca-parameters (min_message_size, max_message_count). Their default values might require revision.

If a user-provided partitioning violates the constraints, a more coarse-grained partitioning is selected, where multiple user-partitions are mapped to an internal (transfer) partition. Transfer of an internal partition is started as soon as Pready has been called on all corresponding user-partitions. Each transfer partition is associated with an atomic counter, tracking the number of corresponding user-partitions that have been marked ready.

The implementation could also be extended to use more advanced aggregation algorithms.

This implementation is a result of "Benchmarking the State of MPI Partitioned Communication in Open MPI" presented at EuroMPI 2024 (https://events.vsc.ac.at/event/123/page/341-program).
