### PR TITLE
Prep for 4.1.8 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,8 +59,31 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+4.1.8 -- January, 2024
+----------------------
+
+** NOTE: Open MPI 4.1.7 incorrectly changed the shared library
+   versioning information for the OpenSHMEM interface, potentially
+   causing link errors when updating from prior releases of Open MPI
+   to 4.1.7.  This release resets the shared library version number
+   history to allow updates from Open MPI 4.1.6 and prior.  Customers
+   who updated to 4.1.7 and relinked their OpenSHMEM applications will
+   have to relink their application again.
+
+- Allocate and exchange OpenSHMEM base segment addresses earlier in
+  startup.
+- Fixed file_seek calculation when using SEEK_END and io/ompio.
+- Protect against using CUDA without VMM support.
+- Change several variables in coll/adapt, coll/basic, coll/han,
+  coll/hcoll, and coll/ucc from READONLY to ALL scope so that they can
+  be set via the MPI_T interface.
+- Add version identifier to rules file in coll/tuned and extend the
+  dynamic rules file to support the alltoall_algorithm_max_requests
+  tuning parameter.
+
+
 4.1.7 -- October, 2024
----------------------
+----------------------
 
 - Improve CUDA memory pool and context handling.
 - Fix detection of host vs. CUDA memory when cumemcreate is used with

--- a/VERSION
+++ b/VERSION
@@ -61,7 +61,7 @@
 
 major=4
 minor=1
-release=7
+release=8
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -128,7 +128,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=70:7:30
+libmpi_so_version=70:8:30
 libmpi_cxx_so_version=70:1:30
 libmpi_mpifh_so_version=70:1:30
 libmpi_usempi_tkr_so_version=70:1:30
@@ -137,7 +137,7 @@ libmpi_usempif08_so_version=70:1:30
 libopen_rte_so_version=70:4:30
 libopen_pal_so_version=70:4:30
 libmpi_java_so_version=70:0:30
-liboshmem_so_version=70:4:31
+liboshmem_so_version=70:5:30
 libompitrace_so_version=70:1:30
 
 # "Common" components install standalone libraries that are run-time


### PR DESCRIPTION
v4.1.7 included a mistake in setting the shared library version number which caused link incompatibility between previous v4.1.x releases and 4.1.7.  There isn't a great way to fix that, so this release undoes the age increment, which will mean that a 4.1.8 release is link compatible with 4.1.0 - 4.1.16, but not link compatible with 4.1.7. This seems better than any other path forward, given the low number of complaints about this issue since 4.1.7 was released 3 months ago.

bot:notacherrypick

Fixes #13052 