### PR TITLE
v5.0.x: hurd: Fix build

### DIFF
--- a/ompi/mca/fs/base/base.h
+++ b/ompi/mca/fs/base/base.h
@@ -94,9 +94,9 @@ static inline bool mca_fs_base_is_link (const char *filename)
 static inline void mca_fs_base_get_real_filename (const char *filename, char **rfilename)
 {
     int namelen;
-    char linkbuf[PATH_MAX+1];
+    char linkbuf[OPAL_PATH_MAX+1];
 
-    namelen = readlink(filename, linkbuf, PATH_MAX);
+    namelen = readlink(filename, linkbuf, OPAL_PATH_MAX);
     if (namelen == -1) {
         /* something strange has happened between the time that
          * we determined that this was a link and the time that

--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -43,7 +43,7 @@ int mca_memheap_base_static_init(mca_memheap_map_t *map)
     uint64_t offset;
     char dev[8];
     uint64_t inode;
-    char pathname[MAXPATHLEN];
+    char pathname[OPAL_PATH_MAX];
     FILE *fp;
     char line[1024];
     map_segment_t *s;

--- a/test/util/opal_os_path.c
+++ b/test/util/opal_os_path.c
@@ -182,7 +182,7 @@ static bool test3(void)
 
 static bool test4(void)
 {
-    char a[MAXPATHLEN + 10];
+    char a[OPAL_PATH_MAX + 10];
     int i;
 
     if (NULL == path_sep) {
@@ -190,7 +190,7 @@ static bool test4(void)
         return(false);
     }
 
-    for (i=0; i< MAXPATHLEN+5; i++) {
+    for (i = 0; i < OPAL_PATH_MAX + 5; i++) {
         a[i] = 'a';
     }
     a[i] = '\0';


### PR DESCRIPTION
Use the shared OPAL_PATH_MAX definition rather than PATH_MAX or MAXPATHLEN.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>
(cherry picked from commit 13efcd0d461f6e63f38f67aeb7541f2712b6dfa3)

This is the v5.0.x PR corresponding to main PR #13063

FYI / thanks @sthibaul 