### PR TITLE
v5.0.x: update platform file, and fix a UCC fallback issue

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -1,6 +1,6 @@
 enable_mca_no_build=coll-ml,btl-uct
 enable_debug_symbols=yes
-enable_orterun_prefix_by_default=yes
+enable_mpirun_prefix_by_default=yes
 with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes

--- a/ompi/mca/coll/ucc/coll_ucc.h
+++ b/ompi/mca/coll/ucc/coll_ucc.h
@@ -40,6 +40,11 @@ BEGIN_C_DECLS
                          "iallgatherv,ireduce,igather,igatherv,ireduce_scatter_block,"\
                          "ireduce_scatter,iscatterv,iscatter"
 
+#define mca_coll_ucc_call_previous(__api, ucc_module, ...) \
+    (ucc_module->previous_ ## __api == NULL ? \
+        UCC_ERR_NOT_SUPPORTED : \
+        ucc_module->previous_ ## __api (__VA_ARGS__, ucc_module->previous_ ## __api ## _module))
+
 typedef struct mca_coll_ucc_req {
     ompi_request_t super;
     ucc_coll_req_h ucc_req;

--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -77,8 +77,9 @@ int mca_coll_ucc_allgather(const void *sbuf, int scount, struct ompi_datatype_t 
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allgather");
-    return ucc_module->previous_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
-                                          comm, ucc_module->previous_allgather_module);
+
+    return mca_coll_ucc_call_previous(allgather, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, comm);
 }
 
 int mca_coll_ucc_iallgather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
@@ -104,6 +105,7 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_iallgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
-                                           comm, request, ucc_module->previous_iallgather_module);
+
+    return mca_coll_ucc_call_previous(iallgather, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
@@ -78,9 +78,8 @@ int mca_coll_ucc_allgatherv(const void *sbuf, int scount,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allgatherv");
-    return ucc_module->previous_allgatherv(sbuf, scount, sdtype,
-                                           rbuf, rcounts, rdisps, rdtype,
-                                           comm, ucc_module->previous_allgatherv_module);
+    return mca_coll_ucc_call_previous(allgatherv, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcounts, rdisps, rdtype, comm);
 }
 
 int mca_coll_ucc_iallgatherv(const void *sbuf, int scount,
@@ -108,7 +107,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_iallgatherv(sbuf, scount, sdtype,
-                                            rbuf, rcounts, rdisps, rdtype,
-                                            comm, request, ucc_module->previous_iallgatherv_module);
+    return mca_coll_ucc_call_previous(iallgatherv, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcounts, rdisps, rdtype, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -74,8 +74,8 @@ int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, int count,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allreduce");
-    return ucc_module->previous_allreduce(sbuf, rbuf, count, dtype, op,
-                                          comm, ucc_module->previous_allreduce_module);
+    return mca_coll_ucc_call_previous(allreduce, ucc_module,
+        sbuf, rbuf, count, dtype, op, comm);
 }
 
 int mca_coll_ucc_iallreduce(const void *sbuf, void *rbuf, int count,
@@ -100,6 +100,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_iallreduce(sbuf, rbuf, count, dtype, op,
-                                           comm, request, ucc_module->previous_iallreduce_module);
+    return mca_coll_ucc_call_previous(iallreduce, ucc_module,
+        sbuf, rbuf, count, dtype, op, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -77,8 +77,8 @@ int mca_coll_ucc_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback alltoall");
-    return ucc_module->previous_alltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype,
-                                          comm, ucc_module->previous_alltoall_module);
+    return mca_coll_ucc_call_previous(alltoall, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, comm);
 }
 
 int mca_coll_ucc_ialltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
@@ -104,6 +104,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ialltoall(sbuf, scount, sdtype, rbuf, rcount, rdtype,
-                                          comm, request, ucc_module->previous_ialltoall_module);
+    return mca_coll_ucc_call_previous(ialltoall, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
@@ -79,9 +79,8 @@ int mca_coll_ucc_alltoallv(const void *sbuf, const int *scounts,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback alltoallv");
-    return ucc_module->previous_alltoallv(sbuf, scounts, sdisps, sdtype,
-                                          rbuf, rcounts, rdisps, rdtype,
-                                          comm, ucc_module->previous_alltoallv_module);
+    return mca_coll_ucc_call_previous(alltoallv, ucc_module,
+        sbuf, scounts, sdisps, sdtype, rbuf, rcounts, rdisps, rdtype, comm);
 }
 
 int mca_coll_ucc_ialltoallv(const void *sbuf, const int *scounts,
@@ -109,7 +108,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ialltoallv(sbuf, scounts, sdisps, sdtype,
-                                          rbuf, rcounts, rdisps, rdtype,
-                                           comm, request, ucc_module->previous_ialltoallv_module);
+    return mca_coll_ucc_call_previous(ialltoallv, ucc_module,
+        sbuf, scounts, sdisps, sdtype, rbuf, rcounts, rdisps, rdtype, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_barrier.c
+++ b/ompi/mca/coll/ucc/coll_ucc_barrier.c
@@ -36,7 +36,7 @@ int mca_coll_ucc_barrier(struct ompi_communicator_t *comm,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback barrier");
-    return ucc_module->previous_barrier(comm, ucc_module->previous_barrier_module);
+    return mca_coll_ucc_call_previous(barrier, ucc_module, comm);
 }
 
 int mca_coll_ucc_ibarrier(struct ompi_communicator_t *comm,
@@ -58,6 +58,5 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ibarrier(comm, request,
-                                         ucc_module->previous_ibarrier_module);
+    return mca_coll_ucc_call_previous(ibarrier, ucc_module, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -51,8 +51,9 @@ int mca_coll_ucc_bcast(void *buf, int count, struct ompi_datatype_t *dtype,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback bcast");
-    return ucc_module->previous_bcast(buf, count, dtype, root,
-                                       comm, ucc_module->previous_bcast_module);
+    return mca_coll_ucc_call_previous(bcast, ucc_module,
+        buf, count, dtype, root, comm);
+
 }
 
 int mca_coll_ucc_ibcast(void *buf, int count, struct ompi_datatype_t *dtype,
@@ -76,6 +77,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ibcast(buf, count, dtype, root,
-                                       comm, request, ucc_module->previous_ibcast_module);
+    return mca_coll_ucc_call_previous(ibcast, ucc_module,
+        buf, count, dtype, root, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -91,9 +91,8 @@ int mca_coll_ucc_gather(const void *sbuf, int scount, struct ompi_datatype_t *sd
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback gather");
-    return ucc_module->previous_gather(sbuf, scount, sdtype, rbuf, rcount,
-                                       rdtype, root, comm,
-                                       ucc_module->previous_gather_module);
+    return mca_coll_ucc_call_previous(gather, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm);
 }
 
 int mca_coll_ucc_igather(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
@@ -119,7 +118,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_igather(sbuf, scount, sdtype, rbuf, rcount,
-                                        rdtype, root, comm, request,
-                                        ucc_module->previous_igather_module);
+    return mca_coll_ucc_call_previous(igather, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -86,9 +86,8 @@ int mca_coll_ucc_gatherv(const void *sbuf, int scount, struct ompi_datatype_t *s
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback gatherv");
-    return ucc_module->previous_gatherv(sbuf, scount, sdtype, rbuf, rcounts,
-                                        disps, rdtype, root, comm,
-                                        ucc_module->previous_gatherv_module);
+    return mca_coll_ucc_call_previous(gatherv, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcounts, disps, rdtype, root, comm);
 }
 
 int mca_coll_ucc_igatherv(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,
@@ -115,7 +114,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_igatherv(sbuf, scount, sdtype, rbuf, rcounts,
-                                         disps, rdtype, root, comm, request,
-                                         ucc_module->previous_igatherv_module);
+    return mca_coll_ucc_call_previous(igatherv, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcounts, disps, rdtype, root, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -76,8 +76,8 @@ int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, int count,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce");
-    return ucc_module->previous_reduce(sbuf, rbuf, count, dtype, op, root,
-                                       comm, ucc_module->previous_reduce_module);
+    return mca_coll_ucc_call_previous(reduce, ucc_module,
+        sbuf, rbuf, count, dtype, op, root, comm);
 }
 
 int mca_coll_ucc_ireduce(const void *sbuf, void* rbuf, int count,
@@ -103,6 +103,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ireduce(sbuf, rbuf, count, dtype, op, root,
-                                        comm, request, ucc_module->previous_ireduce_module);
+    return mca_coll_ucc_call_previous(ireduce, ucc_module,
+        sbuf, rbuf, count, dtype, op, root, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
@@ -87,9 +87,8 @@ int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, const int *rcounts
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce_scatter");
-    return ucc_module->previous_reduce_scatter(sbuf, rbuf, rcounts, dtype, op,
-                                               comm,
-                                               ucc_module->previous_reduce_scatter_module);
+    return mca_coll_ucc_call_previous(reduce_scatter, ucc_module,
+        sbuf, rbuf, rcounts, dtype, op, comm);
 }
 
 int mca_coll_ucc_ireduce_scatter(const void *sbuf, void *rbuf, const int *rcounts,
@@ -115,7 +114,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ireduce_scatter(sbuf, rbuf, rcounts, dtype, op,
-                                                comm, request,
-                                                ucc_module->previous_ireduce_scatter_module);
+    return mca_coll_ucc_call_previous(ireduce_scatter, ucc_module,
+        sbuf, rbuf, rcounts, dtype, op, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -82,9 +82,8 @@ int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce_scatter_block");
-    return ucc_module->previous_reduce_scatter_block(sbuf, rbuf, rcount, dtype,
-                                                     op, comm,
-                                                     ucc_module->previous_reduce_scatter_block_module);
+    return mca_coll_ucc_call_previous(reduce_scatter_block, ucc_module,
+        sbuf, rbuf, rcount, dtype, op, comm);
 }
 
 int mca_coll_ucc_ireduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
@@ -111,7 +110,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_ireduce_scatter_block(sbuf, rbuf, rcount, dtype,
-                                                      op, comm, request,
-                                                      ucc_module->previous_ireduce_scatter_block_module);
+    return mca_coll_ucc_call_previous(ireduce_scatter_block, ucc_module,
+        sbuf, rbuf, rcount, dtype, op, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -87,10 +87,8 @@ int mca_coll_ucc_scatter(const void *sbuf, int scount,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback scatter");
-    return ucc_module->previous_scatter(sbuf, scount, sdtype, rbuf, rcount,
-                                        rdtype, root, comm,
-                                        ucc_module->previous_scatter_module);
-
+    return mca_coll_ucc_call_previous(scatter, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm);
 }
 
 int mca_coll_ucc_iscatter(const void *sbuf, int scount,
@@ -117,7 +115,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_iscatter(sbuf, scount, sdtype, rbuf, rcount,
-                                         rdtype, root, comm, request,
-                                         ucc_module->previous_iscatter_module);
+    return mca_coll_ucc_call_previous(iscatter, ucc_module,
+        sbuf, scount, sdtype, rbuf, rcount, rdtype, root, comm, request);
 }

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -90,9 +90,8 @@ int mca_coll_ucc_scatterv(const void *sbuf, const int *scounts,
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback scatterv");
-    return ucc_module->previous_scatterv(sbuf, scounts, disps, sdtype, rbuf,
-                                         rcount, rdtype, root, comm,
-                                         ucc_module->previous_scatterv_module);
+    return mca_coll_ucc_call_previous(scatterv, ucc_module,
+        sbuf, scounts, disps, sdtype, rbuf, rcount, rdtype, root, comm);
 }
 
 int mca_coll_ucc_iscatterv(const void *sbuf, const int *scounts,
@@ -120,7 +119,6 @@ fallback:
     if (coll_req) {
         mca_coll_ucc_req_free((ompi_request_t **)&coll_req);
     }
-    return ucc_module->previous_iscatterv(sbuf, scounts, disps, sdtype, rbuf,
-                                          rcount, rdtype, root, comm, request,
-                                          ucc_module->previous_iscatterv_module);
+    return mca_coll_ucc_call_previous(iscatterv, ucc_module,
+        sbuf, scounts, disps, sdtype, rbuf, rcount, rdtype, root, comm, request);
 }


### PR DESCRIPTION
There are 2 commits in this PR independent of each other.

The first one just updates a platform file.
The second commit fixes a coll/ucc component issue.

Users can trigger the issue by changing the priority of collectives so that the UCC component doesn't have a fallback option.
This PR will simply set the fallback to NULL and let upper layer run the fallback collective according to priority order.

Main branch doesn't have this issue because UCC doesn't require backend collective modules.

bot:notacherrypick