### PR TITLE
Require UCX > 1.9

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -61,28 +61,18 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 
     AS_IF([test "$ompi_check_ucx_happy" = yes],
           [# Turn off UCX version v1.8 due to issue #8321
-           AC_CACHE_CHECK([UCX version 1.8.x],
-               [ompi_check_ucx_cv_have_version_1_8],
+           AC_CACHE_CHECK([UCX version > 1.9.x],
+               [ompi_check_ucx_cv_have_version_gt_1_9],
                [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
 #include <ucp/api/ucp_version.h>
                                  ]], [[
-#if (UCP_API_MAJOR == 1) && (UCP_API_MINOR == 8)
-#error "Invalid version"
-#endif
-                                 ]])],
-                             [ompi_check_ucx_cv_have_version_1_8=no],
-                             [ompi_check_ucx_cv_have_version_1_8=yes])])
-           AS_IF([test "${ompi_check_ucx_cv_have_version_1_8}" = "yes"],
-                 [AC_MSG_WARN([UCX support skipped because version 1.8.x was found, which has a known catastrophic issue.])
-                  ompi_check_ucx_happy=no])])
-           AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
-#include <ucp/api/ucp_version.h>
-                             ]], [[
 #if (UCP_API_MAJOR < 1) || ((UCP_API_MAJOR == 1) && (UCP_API_MINOR < 9))
 #error "Version too low"
 #endif
-                             ]])],
-                             [], [AC_MSG_WARN([UCX version is too old, please upgrade to 1.9 or higher.])])
+                                 ]])],
+                             [ompi_check_ucx_cv_have_version_gt_1_9=yes],
+                             [ompi_check_ucx_cv_have_version_gt_1_9=no
+                              ompi_check_ucx_happy=no])])])
 
     AS_IF([test "$ompi_check_ucx_happy" = yes],
           [AC_CHECK_DECLS([ucp_tag_send_nbr],


### PR DESCRIPTION
Don't just print a warning if the UCX version is too old, bail out and demand a newer version (at least 1.9, now more than 4 years old).

Fixes #13017.

Signed-off-by: George Bosilca <gbosilca@nvidia.com>
(cherry picked from commit 92881582024f071aa95f275a421e33a2ada2d55f)