### PR TITLE
dist: Move VERSION to 4.1.9a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -61,7 +61,7 @@
 
 major=4
 minor=1
-release=8
+release=9
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -70,7 +70,7 @@ release=8
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
4.1.8 is shipped, on to the next one.

bot:notacherrypick