### PR TITLE
v5.0.x: README.md and HACKING.md: update docs links

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -12,5 +12,5 @@ Please see the content of this file in its new location:
 https://docs.open-mpi.org/en/v5.0.x/developers/
 
 Additionally, see
-https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#sphinx
+https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#sphinx-and-therefore-python
 if you want to edit and build the documentation locally.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Developers who clone the Open MPI Git repository will not have the
 HTML documentation and man pages by default; it must be built.
 Instructions for how to build the Open MPI documentation can be found
 here:
-https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#sphinx.
+https://docs.open-mpi.org/en/v5.0.x/developers/prerequisites.html#sphinx-and-therefore-python.


### PR DESCRIPTION
README.md and HACKING.md: update docs links

analogous commit to 48883b7 on main, changed the hyperlink in README.md and HACKING.md to correctly reflect the prerequisite sphinx webpage

bot:notacherrypick