### PR TITLE
mtl: ofi change to allow cxi anywhere in provname -v5.0.x

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -832,7 +832,8 @@ select_prov:
          * have a problem here since it uses fi_mr_regattr only within the context of an rcache, and manages the
          * requested_key field in this way.
          */
-         if (!strncasecmp(prov->fabric_attr->prov_name, "cxi", 3)) {
+         if ((NULL != strstr(prov->fabric_attr->prov_name, "cxi")) ||
+             (NULL != strstr(prov->fabric_attr->prov_name, "CXI")) ) {
              ompi_mtl_ofi.hmem_needs_reg = false;
          }
 


### PR DESCRIPTION
Note: This is needed to allow for cases when CXI
      appears elsewhere in the libfabirc provider name
      (e.g., "shm+cxi:linkx").

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>
Signed-off-by: Amir Shehata <shehataa@ornl.gov>
(cherry picked from commit 63222d3b2da0081038bd04daa77071b4a80916c7)