### PR TITLE
Set the refcnt to zero for new memory zones.

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -844,6 +844,7 @@ int ompi_osc_ucx_win_attach(struct ompi_win_t *win, void *base, size_t len) {
         memmove((void *)&module->state.dynamic_wins[insert_index+1],
                 (void *)&module->state.dynamic_wins[insert_index],
                 (OMPI_OSC_UCX_ATTACH_MAX - (insert_index + 1)) * sizeof(ompi_osc_dynamic_win_info_t));
+        module->local_dynamic_win_info[insert_index].refcnt = 0;
     } else {
         insert_index = 0;
     }


### PR DESCRIPTION
Thanks @ymeur for the report and the proposed fix.

Covers #12892 for the 4.x version

Signed-off-by: George Bosilca <gbosilca@nvidia.com>
(cherry picked from commit c95e4538bf09fc8750daf87b0a2436128dd285e2)