### PR TITLE
accelerator/cuda: fix get_memkind func name

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -1222,7 +1222,7 @@ static int accelerator_cuda_get_mem_bw(int device, float *bw)
     return OPAL_SUCCESS;
 }
 
-static void mca_accelerator_cuda_get_memkind (ompi_memkind_t *memkind)
+static void accelerator_cuda_get_memkind (ompi_memkind_t *memkind)
 {
   memkind->im_name = strdup("cuda");
   memkind->im_no_restrictors = false;


### PR DESCRIPTION
fix the name of the get_memkind interface in the cuda component to match the name that was registered.
This should hopefully fix the issue reported in https://github.com/open-mpi/ompi/issues/13096