### PR TITLE
[v4.1.x]btl/tcp: Correctly report TCP connect errors

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -844,7 +844,7 @@ static int mca_btl_tcp_endpoint_complete_connect(mca_btl_base_endpoint_t* btl_en
         opal_show_help("help-mpi-btl-tcp.txt", "client connect fail",
                        true, opal_process_info.nodename,
                        getpid(), msg,
-                       strerror(opal_socket_errno), opal_socket_errno);
+                       strerror(so_error), so_error);
         free(msg);
         mca_btl_tcp_endpoint_close(btl_endpoint);
         return OPAL_ERROR;

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -796,7 +796,7 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
         mca_btl_base_endpoint_t *endpoint;
         opal_proc_t *opal_proc;
 
-        BTL_VERBOSE(("adding tcp proc for unknown peer {%s}",
+        BTL_VERBOSE(("adding tcp proc for peer {%s}",
                      OPAL_NAME_PRINT(*name)));
 
         opal_proc = opal_proc_for_name (*name);

--- a/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
+++ b/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
@@ -156,14 +156,3 @@ continue properly.
 
   Local host: %s
   PID:        %d
-#
-[client connect fail]
-WARNING: Open MPI failed to TCP connect to a peer MPI process via
-TCP.  This should not happen.
-
-Your Open MPI job may now fail.
-
-  Local host: %s
-  PID:        %d
-  Message:    %s
-  Error:      %s (%d)


### PR DESCRIPTION
Backport https://github.com/open-mpi/ompi/pull/7131
Correctly report TCP connect errors
Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit 476562752f46d7eb24bf8bec2221517a08ab4d26)