### PR TITLE
Latest Fedora has dropped the arch suffix from the openjdk directory

### DIFF
--- a/config/ompi_setup_java.m4
+++ b/config/ompi_setup_java.m4
@@ -101,7 +101,7 @@ AC_DEFUN([_OMPI_SETUP_JAVA],[
            if test "$ompi_java_found" = "0"; then
                # Various Linux
                if test -z "$JAVA_HOME"; then
-                   ompi_java_dir='/usr/lib/jvm/java-*-openjdk-*/include/'
+                   ompi_java_dir='/usr/lib/jvm/java-*-openjdk*/include/'
                else
                    ompi_java_dir=$JAVA_HOME/include
                fi


### PR DESCRIPTION
It is now `/usr/lib/jvm/java-21-openjdk`