### PR TITLE
v5.0.x: Latest Fedora has dropped the arch suffix from the openjdk directory

### DIFF
--- a/config/ompi_setup_java.m4
+++ b/config/ompi_setup_java.m4
@@ -101,7 +101,7 @@ AC_DEFUN([_OMPI_SETUP_JAVA],[
            if test "$ompi_java_found" = "0"; then
                # Various Linux
                if test -z "$JAVA_HOME"; then
-                   ompi_java_dir='/usr/lib/jvm/java-*-openjdk-*/include/'
+                   ompi_java_dir='/usr/lib/jvm/java-*-openjdk*/include/'
                else
                    ompi_java_dir=$JAVA_HOME/include
                fi


### PR DESCRIPTION
Signed-off-by: Orion Poplawski <orion@nwra.com>
(cherry picked from commit 28e08dbf0bd1e8bca0eb5e5c150aa73f262aa3de)

This is the v5.0.x PR corresponding to main PR #13117 

Thanks to @opoplawski