### PR TITLE
Mark mpif.h as deprecated

### DIFF
--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -252,4 +252,9 @@ else
    ompi_want_ompio=1
 fi
 AM_CONDITIONAL(OMPI_OMPIO_SUPPORT, test "$ompi_want_ompio" = "1")
+
+AC_ARG_ENABLE([deprecate-mpif-h],
+              [AS_HELP_STRING([--enable-deprecate-mpif-h],
+                              [Mark the mpif.h bindings as deprecated (default: enabled)])])
+
 ])dnl

--- a/config/ompi_fortran_check_warning.m4
+++ b/config/ompi_fortran_check_warning.m4
@@ -1,0 +1,49 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2025      Stony Brook University. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# Check whether the fortran compiler produces a warning when
+# it encounters a #warning directive
+
+# OMPI_FORTRAN_CHECK_WARNING([action if found],
+#                            [action if not found])
+# ----------------------------------------------------
+AC_DEFUN([OMPI_FORTRAN_CHECK_WARNING],[
+    AS_VAR_PUSHDEF([warning_var], [ompi_cv_fortran_warning])
+
+    AC_CACHE_CHECK([if Fortran compiler supports preprocessor warnings], warning_var,
+        [
+        # check if the compiler provides a proper #warning
+        # some compilers (gfortran) do not show the warning if the file is found
+        # through an include path, so create a temporary directory and include file
+        OAC_VAR_SCOPE_PUSH(msg, dir)
+        dir="tmp_includedir_$$"
+        msg="This is a deprecated file"
+        AS_MKDIR_P($dir)
+        echo "#warning $msg" > $dir/deprecated.h
+
+        echo "! -*- fortran -*-
+            program main
+                implicit none
+                include 'deprecated.h'
+            end program main
+        " > conftest.f
+        AS_IF([${FC} ${FCFLAGS} -c -I$dir conftest.f 2>conftest.err >conftest.out],
+              [ # compilation succeeded, check the produced output for the warning
+                AS_IF([grep "$msg" conftest.err conftest.out >/dev/null 2>/dev/null],
+                      [AS_VAR_SET(warning_var, "yes")],
+                      [AS_VAR_SET(warning_var, "no (missing warning)")],)],
+              [AS_VAR_SET(warning_var, "no (compilation failed)")])
+        OPAL_VAR_SCOPE_POP
+        rm -rf conftest.f conftest.err conftest.out $dir 2>/dev/null >/dev/null
+    ])
+    AS_VAR_IF(warning_var, [yes], [$1], [$2])
+    AS_VAR_POPDEF([warning_var])dnl
+])
+

--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -16,6 +16,7 @@ dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2020 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
+dnl Copyright (c) 2025      Stony Brook University. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -43,7 +44,7 @@ AC_DEFUN_ONCE([_OMPI_SETUP_FC_COMPILER],[
     # Fortran compilers (excluding the f77 compiler names) from AC's
     # default list of compilers and use it here.  This is the main
     # reason we have an OMPI-ized version of the PROG_FC macro.
-    AC_PROG_FC([gfortran f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor nvfortran])
+    AC_PROG_FC([gfortran flang-new flang f95 fort xlf95 ifort ifc efc pgfortran pgf95 lf95 f90 xlf90 pgf90 epcf90 nagfor nvfortran])
     FCFLAGS="$ompi_fcflags_save"
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -21,6 +21,7 @@ dnl Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 dnl Copyright (c) 2022      Triad National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2025      Stony Brook University.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -380,6 +381,20 @@ end program]])],
           [OMPI_FORTRAN_BUILD_SIZEOF=1],
           [OMPI_FORTRAN_BUILD_SIZEOF=0])
     AC_SUBST(OMPI_FORTRAN_BUILD_SIZEOF)
+
+    OMPI_FORTRAN_SUPPORTS_WARNING="no"
+    AS_IF([! test x"$enable_deprecate_mpif_h" = "xno"],
+            [OMPI_FORTRAN_CHECK_WARNING([OMPI_FORTRAN_SUPPORTS_WARNING="yes"],
+                                        [OMPI_FORTRAN_SUPPORTS_WARNING="no"])])
+    AC_MSG_CHECKING([if we mark mpif.h bindings as deprecated])
+    AS_IF([test "x$enable_deprecate_mpif_h" = "xyes" && test "$OMPI_FORTRAN_SUPPORTS_WARNING" = "no"],
+          [AC_MSG_ERROR([Request to mark mpif.h as deprecated but Fortran compiler does not support warning preprocessor directive.])])
+    AS_IF([test "x$enable_deprecate_mpif_h" != "xno" && test "$OMPI_FORTRAN_SUPPORTS_WARNING" = "yes"],
+            [OMPI_FORTRAN_DEPRECATE_MPIF_H="#warning mpif.h has been deprecated since MPI 4.1. See MPI-4.1:19.1.4 for details."
+             AC_MSG_RESULT([yes])],
+            [OMPI_FORTRAN_DEPRECATE_MPIF_H=""
+             AC_MSG_RESULT([no])])
+    AC_SUBST(OMPI_FORTRAN_DEPRECATE_MPIF_H)
 
     #--------------------------------------------
     # Fortran use mpi or use mpi_f08 MPI bindings

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -30,3 +30,7 @@ Open MPI version v6.0.0
   (which has been the default for quite a while, anyway).
 
 - Added MPI-4.1 ``MPI_Status_*`` functions.
+
+- MPI-4.1 has deprecated the use of the Fortran ``mpif.h`` include
+  file.  Open MPI will now issue a warning when the file is included
+  and the Fortran compiler supports the ``#warning`` directive.

--- a/ompi/include/mpif.h.in
+++ b/ompi/include/mpif.h.in
@@ -53,6 +53,8 @@
 ! WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+@OMPI_FORTRAN_DEPRECATE_MPIF_H@
+
       include 'mpif-config.h'
       include 'mpif-constants.h'
       include 'mpif-handles.h'


### PR DESCRIPTION
MPI 4.1 deprecated `mpif.h` so we may want to start warning about it. Unfortunately, Fortran does not provide a standardized pre-processor so we're at the mercy of the compiler to print the warning. This patch enables the warning by default but allows it to be disabled through `--disable-deprecate-mpif-h` passed to `configure`.

flang-new prints the warning correctly:

```
flang-new -I$HOME/opt/openmpi-main/include deprecated.F -c
/Users/joseph/opt/openmpi-main/include/mpif.h:56:2: warning: #warning mpif.h is deprecated since MPI 4.1. Refer to MPI Sec. 19.1.4.
  #warning mpif.h is deprecated since MPI 4.1. Refer to MPI Sec. 19.1.4.
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
./deprecated.F:4:1: warning: included here
          include 'mpif.h'
  ^^^^^^^^^^^^^^^^^^^^^^^^
```

gfortran doesn't:

```
gfortran -I$HOME/opt/openmpi-main/include deprecated.F -c
mpif.h:56:2:

Warning: Illegal preprocessor directive
```

Unless the include file that contains the warning in the same directory as the file being compiled so that it is not found through the include path:

```
cp ~/opt/openmpi-main/include/mpif* .
gfortran deprecated.F -c
mpif.h:56:2:

   56 | #warning mpif.h is deprecated since MPI 4.1. Refer to MPI Sec. 19.1.4.
      |  1
Warning: Illegal preprocessor directive
```

The file I used for testing:

```
cat deprecated.F

      program main
        implicit none
        include 'mpif.h'
        integer :: ierror
        call MPI_INIT(ierror)
        call MPI_FINALIZE(ierror)
      end program main
```

So in the end gfortran spoils the fun here. Maybe the compiler wrapper could copy a file that contains the warning and is included by `mpif.h` but that is more time than I have right now. Putting this out here in case someone has a smarter idea for how to do it.

Fixes https://github.com/open-mpi/ompi/issues/12190.