### PR TITLE
mpi: add new status_set/get functions

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -419,9 +419,15 @@ OMPI_MAN3 = \
         MPI_Status_f082f.3 \
         MPI_Status_f2c.3 \
         MPI_Status_f2f08.3 \
+        MPI_Status_get_error.3 \
+        MPI_Status_get_source.3 \
+        MPI_Status_get_tag.3 \
         MPI_Status_set_cancelled.3 \
         MPI_Status_set_elements.3 \
         MPI_Status_set_elements_x.3 \
+        MPI_Status_set_error.3 \
+        MPI_Status_set_source.3 \
+        MPI_Status_set_tag.3 \
         MPI_T.3 \
         MPI_T_category_changed.3 \
         MPI_T_category_get_categories.3 \

--- a/docs/man-openmpi/man3/MPI_Status_get_error.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_error.3.rst
@@ -1,0 +1,67 @@
+.. _mpi_status_get_error:
+
+
+MPI_Status_get_error
+========================
+
+.. include_body
+
+:ref:`MPI_Status_get_error` |mdash| Retrieves the MPI_ERROR field from *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_get_error(MPI_Status *status, int *error)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_GET_ERROR(STATUS, ERROR, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER ERROR
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_get_error(status, error, ierror)
+        TYPE(MPI_Status), INTENT(IN) :: status
+        INTEGER, INTENT(OUT) :: error
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+INPUT PARAMETER
+---------------
+* ``status``: Status from which to retrieve the error (status).
+
+OUTPUT PARAMETER
+----------------
+* ``error``: error set in the MPI_ERROR field (integer).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Returns in error the MPI_ERROR field from the status object.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_get_source.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_source.3.rst
@@ -1,0 +1,68 @@
+.. _mpi_status_get_source:
+
+
+MPI_Status_get_source
+========================
+
+.. include_body
+
+:ref:`MPI_Status_get_source` |mdash| Retrieves the MPI_SOURCE field from *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_get_source(MPI_Status *status, int *source)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_GET_SOURCE(STATUS, SOURCE, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER SOURCE
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_get_source(status, source, ierror)
+        TYPE(MPI_Status), INTENT(IN) :: status
+        INTEGER, INTENT(OUT) :: source
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+
+INPUT PARAMETER
+---------------
+* ``status``: Status from which to retrieve the source rank (status).
+
+OUTPUT PARAMETER
+----------------
+* ``source``: rank set in the MPI_SOURCE field (integer).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Returns in source the MPI_SOURCE field from the status object.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_get_tag.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_tag.3.rst
@@ -1,0 +1,68 @@
+.. _mpi_status_get_tag:
+
+
+MPI_Status_get_tag
+========================
+
+.. include_body
+
+:ref:`MPI_Status_get_tag` |mdash| Retrieves the MPI_TAG field from *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_get_tag(MPI_Status *status, int *tag)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_GET_TAG(STATUS, TAG, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER TAG
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_get_tag(status, tag, ierror)
+        TYPE(MPI_Status), INTENT(IN) :: status
+        INTEGER, INTENT(OUT) :: tag
+        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+
+INPUT PARAMETER
+---------------
+* ``status``: Status from which to retrieve the tag (status).
+
+OUTPUT PARAMETER
+----------------
+* ``tag``: tag set in the MPI_TAG field (integer).
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Returns in tag the MPI_TAG field from the status object.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_set_error.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_error.3.rst
@@ -1,0 +1,71 @@
+.. _mpi_status_set_error:
+
+
+MPI_Status_set_error
+========================
+
+.. include_body
+
+:ref:`MPI_Status_set_error` |mdash| Sets the MPI_ERROR field on *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_set_error(MPI_Status *status, int error)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_SET_ERROR(STATUS, ERROR, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER ERROR
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_set_error(status, error, ierror)
+   	TYPE(MPI_Status), INTENT(INOUT) :: status
+   	INTEGER, INTENT(IN) :: error
+   	INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+
+INPUT/OUTPUT PARAMETER
+----------------------
+* ``status``: Status with which to associate error (status).
+
+INPUT PARAMETER
+---------------
+* ``error``: error to set in the MPI_ERROR field (integer).
+
+OUTPUT PARAMETER
+----------------
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Set the MPI_ERROR field in the status object to the provided error argument.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_set_source.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_source.3.rst
@@ -1,0 +1,71 @@
+.. _mpi_status_set_source:
+
+
+MPI_Status_set_source
+========================
+
+.. include_body
+
+:ref:`MPI_Status_set_source` |mdash| Sets the MPI_SOURCE field on *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_set_source(MPI_Status *status, int source)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_SET_SOURCE(STATUS, SOURCE, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER SOURCE
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_set_source(status, source, ierror)
+   	TYPE(MPI_Status), INTENT(INOUT) :: status
+   	INTEGER, INTENT(IN) :: source
+   	INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+
+INPUT/OUTPUT PARAMETER
+----------------------
+* ``status``: Status with which to associate source rank (status).
+
+INPUT PARAMETER
+---------------
+* ``source``: rank to set in the MPI_SOURCE field (integer).
+
+OUTPUT PARAMETER
+----------------
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Set the MPI_SOURCE field in the status object to the provided source argument.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/MPI_Status_set_tag.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_tag.3.rst
@@ -1,0 +1,71 @@
+.. _mpi_status_set_tag:
+
+
+MPI_Status_set_tag
+========================
+
+.. include_body
+
+:ref:`MPI_Status_set_tag` |mdash| Sets the MPI_TAG field on *status*.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_Status_set_tag(MPI_Status *status, int tag)
+
+
+Fortran Syntax
+^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE MPI
+   ! or the older form: INCLUDE 'mpif.h'
+   MPI_STATUS_SET_TAG(STATUS, TAG, IERROR)
+   	INTEGER	STATUS(MPI_STATUS_SIZE), IERROR
+   	INTEGER TAG
+
+
+Fortran 2008 Syntax
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: fortran
+
+   USE mpi_f08
+   MPI_Status_set_tag(status, tag, ierror)
+   	TYPE(MPI_Status), INTENT(INOUT) :: status
+   	INTEGER, INTENT(IN) :: tag
+   	INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+
+INPUT/OUTPUT PARAMETER
+----------------------
+* ``status``: Status with which to associate tag (status).
+
+INPUT PARAMETER
+---------------
+* ``tag``: tag to set in the MPI_TAG field (integer).
+
+OUTPUT PARAMETER
+----------------
+* ``ierror``: Fortran only: Error status (integer).
+
+DESCRIPTION
+-----------
+
+Set the MPI_TAG field in the status object to the provided tag argument.
+
+
+ERRORS
+------
+
+.. include:: ./ERRORS.rst

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -344,9 +344,15 @@ MPI API manual pages (section 3)
    MPI_Status_f082f.3.rst
    MPI_Status_f2c.3.rst
    MPI_Status_f2f08.3.rst
+   MPI_Status_get_error.3.rst
+   MPI_Status_get_source.3.rst
+   MPI_Status_get_tag.3.rst
    MPI_Status_set_cancelled.3.rst
    MPI_Status_set_elements.3.rst
    MPI_Status_set_elements_x.3.rst
+   MPI_Status_set_error.3.rst
+   MPI_Status_set_source.3.rst
+   MPI_Status_set_tag.3.rst
    MPI_T.3.rst
    MPI_T_category_changed.3.rst
    MPI_T_category_get_categories.3.rst

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -28,6 +28,7 @@
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  * Copyright (c) 2018-2022 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1985,7 +1986,13 @@ OMPI_DECLSPEC  int MPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status
 OMPI_DECLSPEC  int MPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint *f_status);
 OMPI_DECLSPEC  int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
 OMPI_DECLSPEC  int MPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status);
+OMPI_DECLSPEC  int MPI_Status_get_error(const MPI_Status *status, int *error);
+OMPI_DECLSPEC  int MPI_Status_get_source(const MPI_Status *status, int *source);
+OMPI_DECLSPEC  int MPI_Status_get_tag(const MPI_Status *status, int *tag);
 OMPI_DECLSPEC  int MPI_Status_set_cancelled(MPI_Status *status, int flag);
+OMPI_DECLSPEC  int MPI_Status_set_error(MPI_Status *status, int error);
+OMPI_DECLSPEC  int MPI_Status_set_source(MPI_Status *status, int source);
+OMPI_DECLSPEC  int MPI_Status_set_tag(MPI_Status *status, int tag);
 OMPI_DECLSPEC  int MPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype,
                                            int count);
 OMPI_DECLSPEC  int MPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype,
@@ -2746,7 +2753,13 @@ OMPI_DECLSPEC  int PMPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint 
 OMPI_DECLSPEC  int PMPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status *c_status);
 OMPI_DECLSPEC  int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
 OMPI_DECLSPEC  int PMPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status);
+OMPI_DECLSPEC  int PMPI_Status_get_error(const MPI_Status *status, int *error);
+OMPI_DECLSPEC  int PMPI_Status_get_source(const MPI_Status *status, int *source);
+OMPI_DECLSPEC  int PMPI_Status_get_tag(const MPI_Status *status, int *tag);
 OMPI_DECLSPEC  int PMPI_Status_set_cancelled(MPI_Status *status, int flag);
+OMPI_DECLSPEC  int PMPI_Status_set_error(MPI_Status *status, int error);
+OMPI_DECLSPEC  int PMPI_Status_set_source(MPI_Status *status, int source);
+OMPI_DECLSPEC  int PMPI_Status_set_tag(MPI_Status *status, int tag);
 OMPI_DECLSPEC  int PMPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype,
                                             int count);
 OMPI_DECLSPEC  int PMPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype,

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -19,6 +19,7 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
+# Copyright (c) 2025      Advanced Micro Devices, Inc. All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -392,9 +393,15 @@ interface_profile_sources = \
         status_f082f.c \
         status_f2c.c \
         status_f2f08.c \
+        status_get_error.c \
+        status_get_source.c \
+        status_get_tag.c \
         status_set_cancelled.c \
         status_set_elements.c \
         status_set_elements_x.c \
+        status_set_error.c \
+        status_set_source.c \
+        status_set_tag.c \
         testall.c \
         testany.c \
         test.c \

--- a/ompi/mpi/c/status_get_error.c
+++ b/ompi/mpi/c/status_get_error.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+#include <limits.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_get_error = PMPI_Status_get_error
+#endif
+#define MPI_Status_get_error PMPI_Status_get_error
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_get_error";
+
+
+int MPI_Status_get_error(const MPI_Status *status, int *error)
+{
+    int rc      = MPI_SUCCESS;
+
+    MEMCHECKER(
+               if (status != MPI_STATUSES_IGNORE) {
+                   /*
+                    * Before checking the complete status, we need to reset the definedness
+                    * of the MPI_ERROR-field (single-completion calls wait/test).
+                    */
+                   opal_memchecker_base_mem_defined((void*)&status->MPI_ERROR, sizeof(int));
+                   memchecker_status(status);
+               }
+               );
+
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        if (NULL == error) {
+            rc = MPI_ERR_ARG;
+        }
+
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    *error = status->MPI_ERROR;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/status_get_source.c
+++ b/ompi/mpi/c/status_get_source.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+#include <limits.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_get_source = PMPI_Status_get_source
+#endif
+#define MPI_Status_get_source PMPI_Status_get_source
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_get_source";
+
+
+int MPI_Status_get_source(const MPI_Status *status, int *source)
+{
+    int rc      = MPI_SUCCESS;
+
+    MEMCHECKER(
+               if (status != MPI_STATUSES_IGNORE) {
+                   /*
+                    * Before checking the complete status, we need to reset the definedness
+                    * of the MPI_ERROR-field (single-completion calls wait/test).
+                    */
+                   opal_memchecker_base_mem_defined((void*)&status->MPI_ERROR, sizeof(int));
+                   memchecker_status(status);
+               }
+               );
+
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        if (NULL == source) {
+            rc = MPI_ERR_ARG;
+        }
+
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    *source = status->MPI_SOURCE;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/status_get_tag.c
+++ b/ompi/mpi/c/status_get_tag.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+#include <limits.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_get_tag = PMPI_Status_get_tag
+#endif
+#define MPI_Status_get_tag PMPI_Status_get_tag
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_get_tag";
+
+
+int MPI_Status_get_tag(const MPI_Status *status, int *tag)
+{
+    int rc      = MPI_SUCCESS;
+
+    MEMCHECKER(
+               if (status != MPI_STATUSES_IGNORE) {
+                   /*
+                    * Before checking the complete status, we need to reset the definedness
+                    * of the MPI_ERROR-field (single-completion calls wait/test).
+                    */
+                   opal_memchecker_base_mem_defined((void*)&status->MPI_ERROR, sizeof(int));
+                   memchecker_status(status);
+               }
+               );
+
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        if (NULL == tag) {
+            rc = MPI_ERR_ARG;
+        }
+
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    *tag = status->MPI_TAG;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/status_set_error.c
+++ b/ompi/mpi/c/status_set_error.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_set_error = PMPI_Status_set_error
+#endif
+#define MPI_Status_set_error PMPI_Status_set_error
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_set_error";
+
+
+int MPI_Status_set_error(MPI_Status *status, int error)
+{
+    MEMCHECKER(
+        if(status != MPI_STATUSES_IGNORE) {
+            /*
+             * Before checking the complete status, we need to reset the definedness
+             * of the MPI_ERROR-field (single-completion calls wait/test).
+             */
+            opal_memchecker_base_mem_defined(&status->MPI_ERROR, sizeof(int));
+            memchecker_status(status);
+        }
+    );
+
+    if (MPI_PARAM_CHECK) {
+        int rc = MPI_SUCCESS;
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    status->MPI_ERROR = error;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/status_set_source.c
+++ b/ompi/mpi/c/status_set_source.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_set_source = PMPI_Status_set_source
+#endif
+#define MPI_Status_set_source PMPI_Status_set_source
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_set_source";
+
+
+int MPI_Status_set_source(MPI_Status *status, int source)
+{
+    MEMCHECKER(
+        if(status != MPI_STATUSES_IGNORE) {
+            /*
+             * Before checking the complete status, we need to reset the definedness
+             * of the MPI_ERROR-field (single-completion calls wait/test).
+             */
+            opal_memchecker_base_mem_defined(&status->MPI_ERROR, sizeof(int));
+            memchecker_status(status);
+        }
+    );
+
+    if (MPI_PARAM_CHECK) {
+        int rc = MPI_SUCCESS;
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    status->MPI_SOURCE = source;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/status_set_tag.c
+++ b/ompi/mpi/c/status_set_tag.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+#include <stdio.h>
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Status_set_tag = PMPI_Status_set_tag
+#endif
+#define MPI_Status_set_tag PMPI_Status_set_tag
+#endif
+
+static const char FUNC_NAME[] = "MPI_Status_set_tag";
+
+
+int MPI_Status_set_tag(MPI_Status *status, int tag)
+{
+    MEMCHECKER(
+        if(status != MPI_STATUSES_IGNORE) {
+            /*
+             * Before checking the complete status, we need to reset the definedness
+             * of the MPI_ERROR-field (single-completion calls wait/test).
+             */
+            opal_memchecker_base_mem_defined(&status->MPI_ERROR, sizeof(int));
+            memchecker_status(status);
+        }
+    );
+
+    if (MPI_PARAM_CHECK) {
+        int rc = MPI_SUCCESS;
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == status ||
+            MPI_STATUS_IGNORE == status ||
+            MPI_STATUSES_IGNORE == status) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
+    }
+
+    status->MPI_TAG = tag;
+    return MPI_SUCCESS;
+}


### PR DESCRIPTION
MPI4.1 introduced a few new MPI_Status_get/set functions. This PR is the C API implementations of the functions.

Fixes issue https://github.com/open-mpi/ompi/issues/12073

Note: this is just the C-API, I need potentially help for the Fortran API of these functions.