### PR TITLE
[Fix] Provided MPI_type_get_content array sizes may exceed actual ones, do not use them

### DIFF
--- a/ompi/mpi/c/type_get_contents.c
+++ b/ompi/mpi/c/type_get_contents.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2025      BULL S.A.S. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
                           MPI_Aint array_of_addresses[],
                           MPI_Datatype array_of_datatypes[])
 {
-    int rc, i;
+    int rc, i, type_code;
     MPI_Datatype newtype;
 
     MEMCHECKER(
@@ -63,6 +64,13 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,
                                           FUNC_NAME );
         }
+    }
+
+    /* Counts may exceed actual ones, we have no choice but to recompute them */
+    rc = ompi_datatype_get_args(mtype, 0, &max_integers, NULL, &max_addresses, NULL, &max_datatypes,
+                                NULL, &type_code);
+    if (rc != MPI_SUCCESS) {
+        OMPI_ERRHANDLER_RETURN(MPI_ERR_INTERN, MPI_COMM_WORLD, MPI_ERR_INTERN, FUNC_NAME);
     }
 
     rc = ompi_datatype_get_args( mtype, 1, &max_integers, array_of_integers,


### PR DESCRIPTION
MPI 4.1 specifications, page 166, lines 24-27:
The values given for max_integers, max_addresses, max_large_counts, and max_datatypes must be at least as large as the value returned in num_integers, num_addresses, num_large_counts, and num_datatypes, respectively, in the call MPI_TYPE_GET_ENVELOPE for the same datatype argument.