### PR TITLE
docs: minor additions to the new MPI_Status_* man pages

### DIFF
--- a/docs/man-openmpi/man3/MPI_Status_get_error.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_error.3.rst
@@ -6,7 +6,7 @@ MPI_Status_get_error
 
 .. include_body
 
-:ref:`MPI_Status_get_error` |mdash| Retrieves the MPI_ERROR field from *status*.
+:ref:`MPI_Status_get_error` |mdash| Retrieves the ``MPI_ERROR`` field from ``status``.
 
 
 SYNTAX
@@ -52,16 +52,38 @@ INPUT PARAMETER
 
 OUTPUT PARAMETER
 ----------------
-* ``error``: error set in the MPI_ERROR field (integer).
+* ``error``: error set in the ``MPI_ERROR`` field (integer).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION
 -----------
 
-Returns in error the MPI_ERROR field from the status object.
+Returns in error the ``MPI_ERROR`` field from the ``status`` object.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_source`
+   * :ref:`MPI_Status_get_tag`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_error`
+   * :ref:`MPI_Status_set_source`
+   * :ref:`MPI_Status_set_tag`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/man-openmpi/man3/MPI_Status_get_source.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_source.3.rst
@@ -6,7 +6,7 @@ MPI_Status_get_source
 
 .. include_body
 
-:ref:`MPI_Status_get_source` |mdash| Retrieves the MPI_SOURCE field from *status*.
+:ref:`MPI_Status_get_source` |mdash| Retrieves the ``MPI_SOURCE`` field from ``status``.
 
 
 SYNTAX
@@ -53,16 +53,38 @@ INPUT PARAMETER
 
 OUTPUT PARAMETER
 ----------------
-* ``source``: rank set in the MPI_SOURCE field (integer).
+* ``source``: rank set in the ``MPI_SOURCE`` field (integer).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION
 -----------
 
-Returns in source the MPI_SOURCE field from the status object.
+Returns in source the ``MPI_SOURCE`` field from the ``status`` object.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_error`
+   * :ref:`MPI_Status_get_tag`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_error`
+   * :ref:`MPI_Status_set_source`
+   * :ref:`MPI_Status_set_tag`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/man-openmpi/man3/MPI_Status_get_tag.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_get_tag.3.rst
@@ -6,7 +6,7 @@ MPI_Status_get_tag
 
 .. include_body
 
-:ref:`MPI_Status_get_tag` |mdash| Retrieves the MPI_TAG field from *status*.
+:ref:`MPI_Status_get_tag` |mdash| Retrieves the ``MPI_TAG`` field from ``status``.
 
 
 SYNTAX
@@ -53,16 +53,38 @@ INPUT PARAMETER
 
 OUTPUT PARAMETER
 ----------------
-* ``tag``: tag set in the MPI_TAG field (integer).
+* ``tag``: tag set in the ``MPI_TAG`` field (integer).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION
 -----------
 
-Returns in tag the MPI_TAG field from the status object.
+Returns in tag the ``MPI_TAG`` field from the ``status`` object.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_error`
+   * :ref:`MPI_Status_get_source`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_error`
+   * :ref:`MPI_Status_set_source`
+   * :ref:`MPI_Status_set_tag`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/man-openmpi/man3/MPI_Status_set_error.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_error.3.rst
@@ -6,7 +6,7 @@ MPI_Status_set_error
 
 .. include_body
 
-:ref:`MPI_Status_set_error` |mdash| Sets the MPI_ERROR field on *status*.
+:ref:`MPI_Status_set_error` |mdash| Sets the ``MPI_ERROR`` field on ``status``.
 
 
 SYNTAX
@@ -53,7 +53,7 @@ INPUT/OUTPUT PARAMETER
 
 INPUT PARAMETER
 ---------------
-* ``error``: error to set in the MPI_ERROR field (integer).
+* ``error``: error to set in the ``MPI_ERROR`` field (integer).
 
 OUTPUT PARAMETER
 ----------------
@@ -62,10 +62,33 @@ OUTPUT PARAMETER
 DESCRIPTION
 -----------
 
-Set the MPI_ERROR field in the status object to the provided error argument.
+Set the ``MPI_ERROR`` field in the ``status`` object to the provided
+error argument.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_error`
+   * :ref:`MPI_Status_get_source`
+   * :ref:`MPI_Status_get_tag`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_source`
+   * :ref:`MPI_Status_set_tag`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/man-openmpi/man3/MPI_Status_set_source.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_source.3.rst
@@ -6,7 +6,7 @@ MPI_Status_set_source
 
 .. include_body
 
-:ref:`MPI_Status_set_source` |mdash| Sets the MPI_SOURCE field on *status*.
+:ref:`MPI_Status_set_source` |mdash| Sets the ``MPI_SOURCE`` field on ``status``.
 
 
 SYNTAX
@@ -53,7 +53,7 @@ INPUT/OUTPUT PARAMETER
 
 INPUT PARAMETER
 ---------------
-* ``source``: rank to set in the MPI_SOURCE field (integer).
+* ``source``: rank to set in the ``MPI_SOURCE`` field (integer).
 
 OUTPUT PARAMETER
 ----------------
@@ -62,10 +62,33 @@ OUTPUT PARAMETER
 DESCRIPTION
 -----------
 
-Set the MPI_SOURCE field in the status object to the provided source argument.
+Set the ``MPI_SOURCE`` field in the ``status`` object to the provided
+source argument.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_error`
+   * :ref:`MPI_Status_get_source`
+   * :ref:`MPI_Status_get_tag`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_error`
+   * :ref:`MPI_Status_set_tag`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/man-openmpi/man3/MPI_Status_set_tag.3.rst
+++ b/docs/man-openmpi/man3/MPI_Status_set_tag.3.rst
@@ -6,7 +6,7 @@ MPI_Status_set_tag
 
 .. include_body
 
-:ref:`MPI_Status_set_tag` |mdash| Sets the MPI_TAG field on *status*.
+:ref:`MPI_Status_set_tag` |mdash| Sets the ``MPI_TAG`` field on ``status``.
 
 
 SYNTAX
@@ -53,7 +53,7 @@ INPUT/OUTPUT PARAMETER
 
 INPUT PARAMETER
 ---------------
-* ``tag``: tag to set in the MPI_TAG field (integer).
+* ``tag``: tag to set in the ``MPI_TAG`` field (integer).
 
 OUTPUT PARAMETER
 ----------------
@@ -62,10 +62,33 @@ OUTPUT PARAMETER
 DESCRIPTION
 -----------
 
-Set the MPI_TAG field in the status object to the provided tag argument.
+Set the ``MPI_TAG`` field in the ``status`` object to the provided tag
+argument.
+
+While the ``status`` object members ``MPI_SOURCE``, ``MPI_TAG``, and
+``MPI_ERROR`` are directly accessible in C and Fortran, for
+convenience in other contexts (e.g., when using alternate MPI bindings
+in languages that do not directly translate the ``status`` object),
+users can also access these values via procedure calls such as this
+one.
 
 
 ERRORS
 ------
 
 .. include:: ./ERRORS.rst
+
+
+.. seealso::
+   * :ref:`MPI_Get_count`
+   * :ref:`MPI_Get_elements`
+   * :ref:`MPI_Get_elements_x`
+   * :ref:`MPI_Status_get_error`
+   * :ref:`MPI_Status_get_source`
+   * :ref:`MPI_Status_get_tag`
+   * :ref:`MPI_Status_set_cancelled`
+   * :ref:`MPI_Status_set_elements`
+   * :ref:`MPI_Status_set_elements_x`
+   * :ref:`MPI_Status_set_error`
+   * :ref:`MPI_Status_set_source`
+   * :ref:`MPI_Test_cancelled`

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -10,4 +10,4 @@ Open MPI version v6.0.0
 
 - Open MPI now requires a C11-compliant compiler to build.
 - Removed ROMIO package.
-
+- Added MPI-4.1 ``MPI_Status_*`` functions.


### PR DESCRIPTION
Also added the new MPI-4.1 MPI_Status_* to the 6.0 changelog.

This is a minor follow-on to #13125 based on @devreal's clarification from https://github.com/open-mpi/ompi/pull/13125#issuecomment-2708822413