### PR TITLE
configury: fix support for flang on OSX

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -867,6 +867,10 @@ sub patch_autotools_output {
         verbose "$indent_str"."Patching \"-pthread\" option for NAG compiler in ltmain.sh\n";
         system("$patch_prog -N -p0 < $topdir/config/ltmain_nag_pthread.diff >/dev/null 2>&1");
         unlink("config/ltmain.sh.rej");
+
+        verbose "$indent_str"."Patching \"-framework\" option for flang compiler in ltmain.sh\n";
+        system("$patch_prog -N -p0 < $topdir/config/ltmain_flang_darwin.diff >/dev/null 2>&1");
+        unlink("config/ltmain.sh.rej");
     }
 
     # If there's no configure script, there's nothing else to do.
@@ -1071,8 +1075,14 @@ sub patch_autotools_output {
         lt_prog_compiler_static_FC=\'-Bstatic\'
         ;;';
     $replace_string = "case \$cc_basename in
+      flang*)
+        # flang compiler
+        lt_prog_compiler_wl_FC='-Wl,'
+        lt_prog_compiler_pic_FC='-fPIC'
+        lt_prog_compiler_static_FC='-static'
+        ;;
       icc* | ifort*)
-        #Intel Fortran compiler
+        # Intel Fortran compiler
         lt_prog_compiler_wl_FC='-Wl,'
         lt_prog_compiler_pic_FC='-fno-common -PIC'
         lt_prog_compiler_static_FC=''
@@ -1108,6 +1118,23 @@ sub patch_autotools_output {
         push(@verbose_out, $indent_str . "Patching configure for NVIDIA Fortran compiler (${tag})\n");
         $c =~ s/$search_string/$replace_string/g;
     }
+
+    $search_string = 'case \$cc_basename in
+     ifort\*\|nagfor\*\) _lt_dar_can_shared=yes ;;
+     \*\) _lt_dar_can_shared=\$GCC ;;
+  esac';
+    $replace_string = "case \$cc_basename in
+     flang*|ifort*|nagfor*) _lt_dar_can_shared=yes ;;
+     *) _lt_dar_can_shared=\$GCC ;;
+  esac";
+    push(@verbose_out, $indent_str . "Patching configure for flang compiler on Darwin (FC)\n");
+    $c =~ s/$search_string/$replace_string/g;
+
+    $search_string = 'archive_cmds_FC="\\\\\\$CC -dynamiclib';
+    $replace_string = 'archive_cmds_FC="\$CC --shared';
+    push(@verbose_out, $indent_str . "Patching configure for flang compiler on Darwin (FC)\n");
+    $c =~ s/$search_string/$replace_string/g;
+    $c =~ s/(archive_cmds_FC.*)-install_name \\\$rpath/$1-Wl,-install_name,\\\`echo \\\$rpath | sed \'s%^[ ]*%%\'\\\`/g;
 
     # Only write out verbose statements and a new configure if the
     # configure content actually changed

--- a/config/ltmain_flang_darwin.diff
+++ b/config/ltmain_flang_darwin.diff
@@ -1,0 +1,39 @@
+--- config/ltmain.sh
++++ config/ltmain.sh
+@@ -9024,7 +9024,14 @@
+	  compile_deplibs="$new_inherited_linker_flags $compile_deplibs"
+	  finalize_deplibs="$new_inherited_linker_flags $finalize_deplibs"
+	else
+-	  compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
++	  case $host in
++	    *-*-darwin*)
++	      case $CC in
++		flang*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
++		*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
++	      esac;;
++	  *) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
++	  esac
+	fi
+       fi
+       dependency_libs=$newdependency_libs
+@@ -9369,7 +9376,7 @@
+           # On Darwin other compilers
+           func_cc_basename $CC
+           case $func_cc_basename_result in
+-              nagfor*)
++              flang*|nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+               *)
+@@ -9869,7 +9876,10 @@
+       # Time to change all our "foo.ltframework" stuff back to "-framework foo"
+       case $host in
+	  *-*-darwin*)
+-	  newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
++	  case $CC in
++	    flang*) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
++	    *) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
++	  esac
+	  new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
+	  deplibs=`$ECHO " $deplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
+	  ;;


### PR DESCRIPTION
Refs. open-mpi/ompi#13137

- replace -framework foo with -Wl,-framework,foo
- replace -dynamiclib with --shared when flang is used
- use -Wl when needed