### PR TITLE
hdf5-tests: abbreviate the wget output

### DIFF
--- a/.github/workflows/hdf5-tests.yaml
+++ b/.github/workflows/hdf5-tests.yaml
@@ -20,7 +20,7 @@ jobs:
         make -j 8 && make install
     - name: Install HDF5
       run: |
-         wget https://github.com/HDFGroup/hdf5/releases/latest/download/hdf5.tar.gz
+         wget --progress=dot:giga https://github.com/HDFGroup/hdf5/releases/latest/download/hdf5.tar.gz
          tar -xzf hdf5.tar.gz
          mv hdf5-1* hdf5
          cd hdf5


### PR DESCRIPTION
The default "wget" output shows ~850 lines of output when downloading the HDF5 tarball.  Use an abbreviated wget progress output so that it only emits 2 lines of output (thereby making it slightly easier for humans to examine the lines).