### PR TITLE
external data pack: switch to using size_t

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -11,6 +11,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation. All rights reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -377,15 +378,15 @@ OMPI_DECLSPEC int ompi_datatype_safeguard_pointer_debug_breakpoint( const void* 
                                                                     int count );
 #endif  /* OPAL_ENABLE_DEBUG */
 
-OMPI_DECLSPEC int ompi_datatype_pack_external( const char datarep[], const void *inbuf, int incount,
+OMPI_DECLSPEC int ompi_datatype_pack_external( const char datarep[], const void *inbuf, size_t incount,
                                                ompi_datatype_t *datatype, void *outbuf,
                                                MPI_Aint outsize, MPI_Aint *position);
 
 OMPI_DECLSPEC int ompi_datatype_unpack_external( const char datarep[], const void *inbuf, MPI_Aint insize,
-                                                 MPI_Aint *position, void *outbuf, int outcount,
+                                                 MPI_Aint *position, void *outbuf, size_t outcount,
                                                  ompi_datatype_t *datatype);
 
-OMPI_DECLSPEC int ompi_datatype_pack_external_size( const char datarep[], int incount,
+OMPI_DECLSPEC int ompi_datatype_pack_external_size( const char datarep[], size_t incount,
                                                     ompi_datatype_t *datatype, MPI_Aint *size);
 
 #define OMPI_DATATYPE_RETAIN(ddt)                                       \

--- a/ompi/datatype/ompi_datatype_external.c
+++ b/ompi/datatype/ompi_datatype_external.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "opal/datatype/opal_convertor.h"
 
-int ompi_datatype_pack_external(const char datarep[], const void *inbuf, int incount,
+int ompi_datatype_pack_external(const char datarep[], const void *inbuf, size_t incount,
                                 ompi_datatype_t *datatype, void *outbuf,
                                 MPI_Aint outsize, MPI_Aint *position)
 {
@@ -73,7 +74,7 @@ int ompi_datatype_pack_external(const char datarep[], const void *inbuf, int inc
 }
 
 int ompi_datatype_unpack_external (const char datarep[], const void *inbuf, MPI_Aint insize,
-                                   MPI_Aint *position, void *outbuf, int outcount,
+                                   MPI_Aint *position, void *outbuf, size_t outcount,
                                    ompi_datatype_t *datatype)
 {
     int rc = MPI_SUCCESS;
@@ -92,7 +93,7 @@ int ompi_datatype_unpack_external (const char datarep[], const void *inbuf, MPI_
 
     /* Check for truncation */
     opal_convertor_get_packed_size( &local_convertor, &size );
-    if( (*position + size) > (unsigned int)insize ) {
+    if( (*position + (MPI_Aint)size) > insize ) {
         OBJ_DESTRUCT( &local_convertor );
         return MPI_ERR_TRUNCATE;
     }
@@ -112,7 +113,7 @@ int ompi_datatype_unpack_external (const char datarep[], const void *inbuf, MPI_
     return (rc == 1) ? OMPI_SUCCESS : MPI_ERR_UNKNOWN;
 }
 
-int ompi_datatype_pack_external_size(const char datarep[], int incount,
+int ompi_datatype_pack_external_size(const char datarep[], size_t incount,
                                      ompi_datatype_t *datatype, MPI_Aint *size)
 {
     opal_convertor_t local_convertor;


### PR DESCRIPTION
for count args.

This helps with the big count effort.

Related to https://github.com/open-mpi/ompi/pull/12226 
Related to https://github.com/open-mpi/ompi/issues/13152