### PR TITLE
use-mpi-f08: fix prototypes and more

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/add_error_string_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/add_error_string_f08.F90
@@ -11,13 +11,14 @@
 
 subroutine MPI_Add_error_string_f08(errorcode,string,ierror)
    use :: ompi_mpifh_bindings, only : ompi_add_error_string_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    integer, intent(in) :: errorcode
    character(len=*), intent(in) :: string
    integer, optional, intent(out) :: ierror
    integer :: c_ierror
 
-   call ompi_add_error_string_f(errorcode, string, c_ierror, len(string))
+   call ompi_add_error_string_f(errorcode, string, c_ierror, len(string,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Add_error_string_f08

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -595,7 +595,7 @@ end subroutine ompi_pack_f
 subroutine ompi_pack_external_f(datarep,inbuf,incount,datatype, &
                                 outbuf,outsize,position,ierror,datarep_len) &
    BIND(C, name="ompi_pack_external_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: datarep
@@ -606,12 +606,12 @@ subroutine ompi_pack_external_f(datarep,inbuf,incount,datatype, &
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: outsize
    INTEGER(MPI_ADDRESS_KIND), INTENT(INOUT) :: position
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_pack_external_f
 
 subroutine ompi_pack_external_size_f(datarep,incount,datatype,size,ierror,datarep_len) &
    BIND(C, name="ompi_pack_external_size_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER, INTENT(IN) :: datatype
@@ -619,7 +619,7 @@ subroutine ompi_pack_external_size_f(datarep,incount,datatype,size,ierror,datare
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: datarep
    INTEGER(MPI_ADDRESS_KIND), INTENT(OUT) :: size
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_pack_external_size_f
 
 subroutine ompi_pack_size_f(incount,datatype,comm,size,ierror) &
@@ -895,7 +895,7 @@ end subroutine ompi_unpack_f
 subroutine ompi_unpack_external_f(datarep,inbuf,insize,position, &
                                   outbuf,outcount,datatype,ierror,datarep_len) &
    BIND(C, name="ompi_unpack_external_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: datarep
@@ -906,7 +906,7 @@ subroutine ompi_unpack_external_f(datarep,inbuf,insize,position, &
    INTEGER, INTENT(IN) :: outcount
    INTEGER, INTENT(IN) :: datatype
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_unpack_external_f
 
 subroutine ompi_allgather_f(sendbuf,sendcount,sendtype,recvbuf, &
@@ -1632,7 +1632,7 @@ end subroutine ompi_comm_create_f
 
 subroutine ompi_comm_create_from_group_f(group, stringtag, info, errhandler, newcomm, ierror, name_len) &
    BIND(C, name="ompi_comm_create_from_group_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    integer, intent(in) :: group
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: stringtag
@@ -1640,7 +1640,7 @@ subroutine ompi_comm_create_from_group_f(group, stringtag, info, errhandler, new
    integer, intent(in) :: errhandler
    integer, intent(out) :: newcomm
    integer, intent(out) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_comm_create_from_group_f
 
 subroutine ompi_comm_create_group_f(comm, group, tag, newcomm, ierror) &
@@ -1725,13 +1725,13 @@ end subroutine ompi_comm_get_info_f
 
 subroutine ompi_comm_get_name_f(comm,comm_name,resultlen,ierror,comm_name_len) &
    BIND(C, name="ompi_comm_get_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: comm
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: comm_name
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: comm_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: comm_name_len
 end subroutine ompi_comm_get_name_f
 
 subroutine ompi_comm_from_group_f(group, stringtag, info, errhandler, newcomm, ierror, name_len) &
@@ -1808,12 +1808,12 @@ end subroutine ompi_comm_set_info_f
 
 subroutine ompi_comm_set_name_f(comm,comm_name,ierror,comm_name_len) &
    BIND(C, name="ompi_comm_set_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: comm
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: comm_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: comm_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: comm_name_len
 end subroutine ompi_comm_set_name_f
 
 subroutine ompi_comm_size_f(comm,size,ierror) &
@@ -1870,13 +1870,13 @@ end subroutine ompi_group_free_f
 
 subroutine ompi_group_from_session_pset_f(session, pset_name, newgroup, ierror, name_len) &
    BIND(C, name="ompi_group_from_session_pset_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: session
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: pset_name
    INTEGER, INTENT(OUT) :: newgroup
    integer, intent(out) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_group_from_session_pset_f
 
 subroutine ompi_group_incl_f(group,n,ranks,newgroup,ierror) &
@@ -1966,7 +1966,7 @@ subroutine ompi_intercomm_create_from_groups_f(local_group, local_leader, remote
                                                remote_leader, stringtag, info, errhandler, &
                                                newintercomm, ierror, name_len) &
    BIND(C, name="ompi_intercomm_create_from_groups_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: local_group, remote_group
    INTEGER, INTENT(IN) :: local_leader, remote_leader
@@ -1974,7 +1974,7 @@ subroutine ompi_intercomm_create_from_groups_f(local_group, local_leader, remote
    INTEGER, INTENT(IN) :: info, errhandler
    INTEGER, INTENT(OUT) :: newintercomm
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_intercomm_create_from_groups_f
 
 subroutine ompi_type_create_keyval_f(type_copy_attr_fn,type_delete_attr_fn, &
@@ -2007,13 +2007,13 @@ end subroutine ompi_type_free_keyval_f
 
 subroutine ompi_type_get_name_f(datatype,type_name,resultlen,ierror,type_name_len) &
    BIND(C, name="ompi_type_get_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: datatype
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: type_name
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: type_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: type_name_len
 end subroutine ompi_type_get_name_f
 
 subroutine ompi_type_set_attr_f(datatype,type_keyval,attribute_val,ierror) &
@@ -2028,12 +2028,12 @@ end subroutine ompi_type_set_attr_f
 
 subroutine ompi_type_set_name_f(datatype,type_name,ierror,type_name_len) &
    BIND(C, name="ompi_type_set_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: datatype
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: type_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: type_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: type_name_len
 end subroutine ompi_type_set_name_f
 
 subroutine ompi_win_allocate_f(size, disp_unit, info, comm, &
@@ -2092,13 +2092,13 @@ end subroutine ompi_win_free_keyval_f
 
 subroutine ompi_win_get_name_f(win,win_name,resultlen,ierror,win_name_len) &
    BIND(C, name="ompi_win_get_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: win
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: win_name
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: win_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: win_name_len
 end subroutine ompi_win_get_name_f
 
 subroutine ompi_win_set_attr_f(win,win_keyval,attribute_val,ierror) &
@@ -2113,12 +2113,12 @@ end subroutine ompi_win_set_attr_f
 
 subroutine ompi_win_set_name_f(win,win_name,ierror,win_name_len) &
    BIND(C, name="ompi_win_set_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: win
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: win_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: win_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: win_name_len
 end subroutine ompi_win_set_name_f
 
 subroutine ompi_cartdim_get_f(comm,ndims,ierror) &
@@ -2284,12 +2284,12 @@ end subroutine ompi_add_error_code_f
 
 subroutine ompi_add_error_string_f(errorcode,string,ierror,str_len) &
    BIND(C, name="ompi_add_error_string_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: errorcode
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: string
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: str_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: str_len
 end subroutine ompi_add_error_string_f
 
 subroutine ompi_alloc_mem_f(size,info,baseptr,ierror) &
@@ -2353,13 +2353,13 @@ end subroutine ompi_error_class_f
 
 subroutine ompi_error_string_f(errorcode,string,resultlen,ierror,str_len) &
    BIND(C, name="ompi_error_string_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: errorcode
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: string
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: str_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: str_len
 end subroutine ompi_error_string_f
 
 subroutine ompi_file_call_errhandler_f(fh,errorcode,ierror) &
@@ -2410,12 +2410,12 @@ end subroutine ompi_free_mem_f
 
 subroutine ompi_get_processor_name_f(name,resultlen,ierror,name_len) &
    BIND(C, name="ompi_get_processor_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: name
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_get_processor_name_f
 
 subroutine ompi_get_version_f(version,subversion,ierror) &
@@ -2480,12 +2480,12 @@ end subroutine ompi_info_create_env_f
 
 subroutine ompi_info_delete_f(info,key,ierror,key_len) &
    BIND(C, name="ompi_info_delete_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: info
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: key
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: key_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: key_len
 end subroutine ompi_info_delete_f
 
 subroutine ompi_info_dup_f(info,newinfo,ierror) &
@@ -2513,37 +2513,37 @@ end subroutine ompi_info_get_nkeys_f
 
 subroutine ompi_info_get_nthkey_f(info,n,key,ierror,key_len) &
    BIND(C, name="ompi_info_get_nthkey_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(IN) :: n
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: key
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: key_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: key_len
 end subroutine ompi_info_get_nthkey_f
 
 subroutine ompi_info_set_f(info,key,value,ierror,key_len,value_len) &
    BIND(C, name="ompi_info_set_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: info
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: key, value
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: key_len, value_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: key_len, value_len
 end subroutine ompi_info_set_f
 
 subroutine ompi_close_port_f(port_name,ierror,port_name_len) &
    BIND(C, name="ompi_close_port_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: port_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: port_name_len
 end subroutine ompi_close_port_f
 
 subroutine ompi_comm_accept_f(port_name,info,root,comm,newcomm,ierror,port_name_len) &
    BIND(C, name="ompi_comm_accept_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: port_name
    INTEGER, INTENT(IN) :: info
@@ -2551,12 +2551,12 @@ subroutine ompi_comm_accept_f(port_name,info,root,comm,newcomm,ierror,port_name_
    INTEGER, INTENT(IN) :: comm
    INTEGER, INTENT(OUT) :: newcomm
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: port_name_len
 end subroutine ompi_comm_accept_f
 
 subroutine ompi_comm_connect_f(port_name,info,root,comm,newcomm,ierror,port_name_len) &
    BIND(C, name="ompi_comm_connect_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: port_name
    INTEGER, INTENT(IN) :: info
@@ -2564,7 +2564,7 @@ subroutine ompi_comm_connect_f(port_name,info,root,comm,newcomm,ierror,port_name
    INTEGER, INTENT(IN) :: comm
    INTEGER, INTENT(OUT) :: newcomm
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: port_name_len
 end subroutine ompi_comm_connect_f
 
 subroutine ompi_comm_disconnect_f(comm,ierror) &
@@ -2592,7 +2592,7 @@ end subroutine ompi_comm_join_f
 subroutine ompi_comm_spawn_f(command,argv,maxprocs,info,root,comm, &
                              intercomm, array_of_errcodes,ierror,cmd_len,argv_len) &
    BIND(C, name="ompi_comm_spawn_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: command, argv
    INTEGER, INTENT(IN) :: maxprocs, root
@@ -2601,7 +2601,7 @@ subroutine ompi_comm_spawn_f(command,argv,maxprocs,info,root,comm, &
    INTEGER, INTENT(OUT) :: intercomm
    INTEGER, INTENT(OUT) :: array_of_errcodes(*)
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: cmd_len, argv_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: cmd_len, argv_len
 end subroutine ompi_comm_spawn_f
 
 
@@ -2611,7 +2611,7 @@ subroutine ompi_comm_spawn_multiple_f(count,array_of_commands, &
                                       comm,intercomm,array_of_errcodes,ierror, &
                                       cmd_len, argv_len) &
    BIND(C, name="ompi_comm_spawn_multiple_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: count, root
    INTEGER, INTENT(IN) :: array_of_maxprocs(count)
@@ -2621,51 +2621,51 @@ subroutine ompi_comm_spawn_multiple_f(count,array_of_commands, &
    INTEGER, INTENT(OUT) :: intercomm
    INTEGER, INTENT(OUT) :: array_of_errcodes(*)
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: cmd_len, argv_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: cmd_len, argv_len
 end subroutine ompi_comm_spawn_multiple_f
 
 subroutine ompi_lookup_name_f(service_name,info,port_name,ierror, &
                               service_name_len,port_name_len) &
    BIND(C, name="ompi_lookup_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: service_name
    INTEGER, INTENT(IN) :: info
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: port_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: service_name_len, port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: service_name_len, port_name_len
 end subroutine ompi_lookup_name_f
 
 subroutine ompi_open_port_f(info,port_name,ierror,port_name_len) &
    BIND(C, name="ompi_open_port_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: info
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: port_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: port_name_len
 end subroutine ompi_open_port_f
 
 subroutine ompi_publish_name_f(service_name,info,port_name,ierror, &
                                service_name_len,port_name_len) &
    BIND(C, name="ompi_publish_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: info
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: service_name, port_name
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: service_name_len, port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: service_name_len, port_name_len
 end subroutine ompi_publish_name_f
 
 subroutine ompi_unpublish_name_f(service_name,info,port_name, &
                                  ierror,service_name_len,port_name_len) &
    BIND(C, name="ompi_unpublish_name_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: service_name, port_name
    INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: service_name_len, port_name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: service_name_len, port_name_len
 end subroutine ompi_unpublish_name_f
 
 subroutine ompi_accumulate_f(origin_addr,origin_count,origin_datatype, &
@@ -3108,12 +3108,12 @@ end subroutine ompi_file_close_f
 
 subroutine ompi_file_delete_f(filename,info,ierror,filename_len) &
    BIND(C, name="ompi_file_delete_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: filename
    INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: filename_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: filename_len
 end subroutine ompi_file_delete_f
 
 subroutine ompi_file_get_amode_f(fh,amode,ierror) &
@@ -3189,7 +3189,7 @@ end subroutine ompi_file_get_type_extent_f
 
 subroutine ompi_file_get_view_f(fh,disp,etype,filetype,datarep,ierror,datarep_len) &
    BIND(C, name="ompi_file_get_view_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_OFFSET_KIND
    implicit none
    INTEGER, INTENT(IN) :: fh
@@ -3198,7 +3198,7 @@ subroutine ompi_file_get_view_f(fh,disp,etype,filetype,datarep,ierror,datarep_le
    INTEGER, INTENT(OUT) :: filetype
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: datarep
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_file_get_view_f
 
 subroutine ompi_file_iread_f(fh,buf,count,datatype,request,ierror) &
@@ -3321,7 +3321,7 @@ end subroutine ompi_file_iwrite_shared_f
 
 subroutine ompi_file_open_f(comm,filename,amode,info,fh,ierror,filename_len) &
    BIND(C, name="ompi_file_open_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: comm
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: filename
@@ -3329,7 +3329,7 @@ subroutine ompi_file_open_f(comm,filename,amode,info,fh,ierror,filename_len) &
    INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: fh
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: filename_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: filename_len
 end subroutine ompi_file_open_f
 
 subroutine ompi_file_preallocate_f(fh,size,ierror) &
@@ -3516,7 +3516,7 @@ end subroutine ompi_file_set_size_f
 
 subroutine ompi_file_set_view_f(fh,disp,etype,filetype,datarep,info,ierror,datarep_len) &
    BIND(C, name="ompi_file_set_view_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_OFFSET_KIND
    implicit none
    INTEGER, INTENT(IN) :: fh
@@ -3526,7 +3526,7 @@ subroutine ompi_file_set_view_f(fh,disp,etype,filetype,datarep,info,ierror,datar
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: datarep
    INTEGER, INTENT(IN) :: info
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_file_set_view_f
 
 subroutine ompi_file_sync_f(fh,ierror) &
@@ -3676,7 +3676,7 @@ subroutine ompi_register_datarep_f(datarep,read_conversion_fn, &
                                    write_conversion_fn,dtype_file_extent_fn, &
                                    extra_state,ierror,datarep_len) &
    BIND(C, name="ompi_register_datarep_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    use, intrinsic :: iso_c_binding, only: c_funptr
    implicit none
@@ -3686,7 +3686,7 @@ subroutine ompi_register_datarep_f(datarep,read_conversion_fn, &
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: datarep
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: extra_state
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: datarep_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: datarep_len
 end subroutine ompi_register_datarep_f
 
 !
@@ -3763,12 +3763,12 @@ end subroutine ompi_f_sync_reg_f
 
 subroutine ompi_get_library_version_f(name,resultlen,ierror,name_len) &
    BIND(C, name="ompi_get_library_version_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: name
    INTEGER, INTENT(OUT) :: resultlen
    INTEGER, INTENT(OUT) :: ierror
-   INTEGER, VALUE, INTENT(IN) :: name_len
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_get_library_version_f
 
 subroutine ompi_mprobe_f(source,tag,comm,message,status,ierror) &
@@ -4053,13 +4053,13 @@ end subroutine ompi_session_get_num_psets_f
 
 subroutine ompi_session_get_pset_info_f(session, pset_name, info, ierror, name_len) &
    BIND(C, name="ompi_session_get_pset_info_f")
-   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR, C_INT
    implicit none
    INTEGER, INTENT(IN) :: session
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: pset_name
-   INTEGER, VALUE, INTENT(IN) :: name_len
    INTEGER, INTENT(out) :: info
    INTEGER, INTENT(out) :: ierror
+   INTEGER(KIND=C_INT), VALUE, INTENT(IN) :: name_len
 end subroutine ompi_session_get_pset_info_f
 
 subroutine ompi_session_init_f(info, errhandler, session, ierror) &

--- a/ompi/mpi/fortran/use-mpi-f08/close_port_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/close_port_f08.F90
@@ -11,12 +11,13 @@
 
 subroutine MPI_Close_port_f08(port_name,ierror)
    use :: ompi_mpifh_bindings, only : ompi_close_port_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: port_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_close_port_f(port_name,c_ierror,len(port_name))
+   call ompi_close_port_f(port_name,c_ierror,len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Close_port_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_accept_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_accept_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Comm_accept_f08(port_name,info,root,comm,newcomm,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: ompi_mpifh_bindings, only : ompi_comm_accept_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: port_name
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -22,7 +23,7 @@ subroutine MPI_Comm_accept_f08(port_name,info,root,comm,newcomm,ierror)
    integer :: c_ierror
 
    call ompi_comm_accept_f(port_name,info%MPI_VAL,root,comm%MPI_VAL,newcomm%MPI_VAL, &
-                           c_ierror,len(port_name))
+                           c_ierror,len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_accept_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_connect_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_connect_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Comm_connect_f08(port_name,info,root,comm,newcomm,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: ompi_mpifh_bindings, only : ompi_comm_connect_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: port_name
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -22,7 +23,7 @@ subroutine MPI_Comm_connect_f08(port_name,info,root,comm,newcomm,ierror)
    integer :: c_ierror
 
    call ompi_comm_connect_f(port_name,info%MPI_VAL,root,comm%MPI_VAL,newcomm%MPI_VAL, &
-                            c_ierror,len(port_name))
+                            c_ierror,len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_connect_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_create_from_group_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_create_from_group_f08.F90
@@ -14,6 +14,7 @@
 subroutine MPI_Comm_create_from_group_f08(group, stringtag, info, errhandler, newcomm, ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_comm_create_from_group_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Group), INTENT(IN) :: group
    CHARACTER(LEN=*), INTENT(IN) :: stringtag
@@ -24,7 +25,7 @@ subroutine MPI_Comm_create_from_group_f08(group, stringtag, info, errhandler, ne
    integer :: c_ierror
 
    call ompi_comm_create_from_group_f(group%MPI_VAL, stringtag, info%MPI_VAL, errhandler%MPI_VAL, &
-                                      newcomm%MPI_VAL, c_ierror, len(stringtag))
+                                      newcomm%MPI_VAL, c_ierror, len(stringtag,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_create_from_group_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_get_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_get_name_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Comm_get_name_f08(comm,comm_name,resultlen,ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_MAX_OBJECT_NAME
    use :: ompi_mpifh_bindings, only : ompi_comm_get_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Comm), INTENT(IN) :: comm
    CHARACTER(LEN=*), INTENT(OUT) :: comm_name
@@ -20,7 +21,7 @@ subroutine MPI_Comm_get_name_f08(comm,comm_name,resultlen,ierror)
    integer :: c_ierror
 
    call ompi_comm_get_name_f(comm%MPI_VAL,comm_name,resultlen,c_ierror, &
-                             len(comm_name))
+                             len(comm_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_get_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_set_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_set_name_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Comm_set_name_f08(comm,comm_name,ierror)
    use :: mpi_f08_types, only : MPI_Comm
    use :: ompi_mpifh_bindings, only : ompi_comm_set_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Comm), INTENT(IN) :: comm
    CHARACTER(LEN=*), INTENT(IN) :: comm_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_comm_set_name_f(comm%MPI_VAL,comm_name,c_ierror,len(comm_name))
+   call ompi_comm_set_name_f(comm%MPI_VAL,comm_name,c_ierror,len(comm_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_set_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_spawn_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_spawn_f08.F90
@@ -14,6 +14,7 @@ subroutine MPI_Comm_spawn_f08(command,argv,maxprocs,info,root,comm,intercomm, &
                               array_of_errcodes,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: ompi_mpifh_bindings, only : ompi_comm_spawn_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: command, argv(*)
    INTEGER, INTENT(IN) :: maxprocs, root
@@ -27,7 +28,7 @@ subroutine MPI_Comm_spawn_f08(command,argv,maxprocs,info,root,comm,intercomm, &
    call ompi_comm_spawn_f(command,argv,maxprocs,                            &
                           info%MPI_VAL,root,comm%MPI_VAL,intercomm%MPI_VAL, &
                           array_of_errcodes,c_ierror,                       &
-                          len(command), len(argv))
+                          len(command,KIND=C_INT), len(argv,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_spawn_f08

--- a/ompi/mpi/fortran/use-mpi-f08/comm_spawn_multiple_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_spawn_multiple_f08.F90
@@ -15,6 +15,7 @@ subroutine MPI_Comm_spawn_multiple_f08(count,array_of_commands,array_of_argv, &
                                        comm,intercomm,array_of_errcodes,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: ompi_mpifh_bindings, only : ompi_comm_spawn_multiple_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    INTEGER, INTENT(IN) :: count, root
    INTEGER, INTENT(IN) :: array_of_maxprocs(count)
@@ -33,7 +34,7 @@ subroutine MPI_Comm_spawn_multiple_f08(count,array_of_commands,array_of_argv, &
    call ompi_comm_spawn_multiple_f(count,array_of_commands,array_of_argv, &
                                    array_of_maxprocs,array_of_info(:)%MPI_VAL,root, &
                                    comm%MPI_VAL,intercomm%MPI_VAL,array_of_errcodes,c_ierror, &
-                                   len(array_of_commands), len(array_of_argv))
+                                   len(array_of_commands,KIND=C_INT), len(array_of_argv,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_spawn_multiple_f08

--- a/ompi/mpi/fortran/use-mpi-f08/error_string_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/error_string_f08.F90
@@ -11,6 +11,7 @@
 
 subroutine MPI_Error_string_f08(errorcode,string,resultlen,ierror)
    use :: ompi_mpifh_bindings, only : ompi_error_string_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    integer, intent(in) :: errorcode
    character(len=*), intent(out) :: string
@@ -18,7 +19,7 @@ subroutine MPI_Error_string_f08(errorcode,string,resultlen,ierror)
    integer, optional, intent(out) :: ierror
    integer :: c_ierror
 
-   call ompi_error_string_f(errorcode,string,resultlen,c_ierror,len(string))
+   call ompi_error_string_f(errorcode,string,resultlen,c_ierror,len(string,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Error_string_f08

--- a/ompi/mpi/fortran/use-mpi-f08/file_delete_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/file_delete_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_File_delete_f08(filename,info,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_file_delete_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: filename
    TYPE(MPI_Info), INTENT(IN) :: info
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_file_delete_f(filename,info%MPI_VAL,c_ierror,len(filename))
+   call ompi_file_delete_f(filename,info%MPI_VAL,c_ierror,len(filename,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_File_delete_f08

--- a/ompi/mpi/fortran/use-mpi-f08/file_get_view_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/file_get_view_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_File_get_view_f08(fh,disp,etype,filetype,datarep,ierror)
    use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_OFFSET_KIND
    use :: ompi_mpifh_bindings, only : ompi_file_get_view_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_File), INTENT(IN) :: fh
    INTEGER(MPI_OFFSET_KIND), INTENT(OUT) :: disp
@@ -22,7 +23,7 @@ subroutine MPI_File_get_view_f08(fh,disp,etype,filetype,datarep,ierror)
    integer :: c_ierror
 
    call ompi_file_get_view_f(fh%MPI_VAL,disp,etype%MPI_VAL,filetype%MPI_VAL, &
-                             datarep,c_ierror,len(datarep))
+                             datarep,c_ierror,len(datarep,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_File_get_view_f08

--- a/ompi/mpi/fortran/use-mpi-f08/file_open_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/file_open_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_File_open_f08(comm,filename,amode,info,fh,ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Info, MPI_File
    use :: ompi_mpifh_bindings, only : ompi_file_open_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Comm), INTENT(IN) :: comm
    CHARACTER(LEN=*), INTENT(IN) :: filename
@@ -22,7 +23,7 @@ subroutine MPI_File_open_f08(comm,filename,amode,info,fh,ierror)
    integer :: c_ierror
 
    call ompi_file_open_f(comm%MPI_VAL,filename,amode,info%MPI_VAL,fh%MPI_VAL, &
-                         c_ierror, len(filename))
+                         c_ierror, len(filename,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_File_open_f08

--- a/ompi/mpi/fortran/use-mpi-f08/file_set_view_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/file_set_view_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_File_set_view_f08(fh,disp,etype,filetype,datarep,info,ierror)
    use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_Info, MPI_OFFSET_KIND
    use :: ompi_mpifh_bindings, only : ompi_file_set_view_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_File), INTENT(IN) :: fh
    INTEGER(MPI_OFFSET_KIND), INTENT(IN) :: disp
@@ -23,7 +24,7 @@ subroutine MPI_File_set_view_f08(fh,disp,etype,filetype,datarep,info,ierror)
    integer :: c_ierror
 
    call ompi_file_set_view_f(fh%MPI_VAL,disp,etype%MPI_VAL,filetype%MPI_VAL, &
-                             datarep,info%MPI_VAL,c_ierror,len(datarep))
+                             datarep,info%MPI_VAL,c_ierror,len(datarep,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_File_set_view_f08

--- a/ompi/mpi/fortran/use-mpi-f08/get_library_version_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/get_library_version_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Get_library_version_f08(version,resultlen,ierror)
    use :: mpi_f08_types, only : MPI_MAX_LIBRARY_VERSION_STRING
    use :: ompi_mpifh_bindings, only : ompi_get_library_version_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    character(len=MPI_MAX_LIBRARY_VERSION_STRING), intent(out) :: version
    integer, intent(out) :: resultlen
    integer, optional, intent(out) :: ierror
    integer :: c_ierror
 
-   call ompi_get_library_version_f(version,resultlen,c_ierror,len(version))
+   call ompi_get_library_version_f(version,resultlen,c_ierror,len(version,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Get_library_version_f08

--- a/ompi/mpi/fortran/use-mpi-f08/get_processor_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/get_processor_name_f08.F90
@@ -11,13 +11,14 @@
 
 subroutine MPI_Get_processor_name_f08(name,resultlen,ierror)
    use :: ompi_mpifh_bindings, only : ompi_get_processor_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    character(len=*), intent(out) :: name
    integer, intent(out) :: resultlen
    integer, optional, intent(out) :: ierror
    integer :: c_ierror
 
-   call ompi_get_processor_name_f(name,resultlen,c_ierror,len(name))
+   call ompi_get_processor_name_f(name,resultlen,c_ierror,len(name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Get_processor_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/group_from_session_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/group_from_session_pset_f08.F90
@@ -15,6 +15,7 @@
 subroutine MPI_Group_from_session_pset_f08(session, pset_name, newgroup, ierror)
    use :: mpi_f08_types, only : MPI_Session, MPI_Group
    use :: ompi_mpifh_bindings, only : ompi_group_from_session_pset_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Session), INTENT(IN) :: session
    CHARACTER(LEN=*), INTENT(IN) :: pset_name
@@ -22,7 +23,7 @@ subroutine MPI_Group_from_session_pset_f08(session, pset_name, newgroup, ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_group_from_session_pset_f(session%MPI_VAL, pset_name, newgroup%MPI_VAL, c_ierror, len(pset_name))
+   call ompi_group_from_session_pset_f(session%MPI_VAL, pset_name, newgroup%MPI_VAL, c_ierror, len(pset_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Group_from_session_pset_f08

--- a/ompi/mpi/fortran/use-mpi-f08/info_delete_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/info_delete_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Info_delete_f08(info,key,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_info_delete_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
    CHARACTER(LEN=*), INTENT(IN) :: key
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_info_delete_f(info%MPI_VAL,key,c_ierror,len(key))
+   call ompi_info_delete_f(info%MPI_VAL,key,c_ierror,len(key,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Info_delete_f08

--- a/ompi/mpi/fortran/use-mpi-f08/info_get_nthkey_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/info_get_nthkey_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Info_get_nthkey_f08(info,n,key,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_info_get_nthkey_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
    INTEGER, INTENT(IN) :: n
@@ -19,7 +20,7 @@ subroutine MPI_Info_get_nthkey_f08(info,n,key,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_info_get_nthkey_f(info%MPI_VAL,n,key,c_ierror,len(key))
+   call ompi_info_get_nthkey_f(info%MPI_VAL,n,key,c_ierror,len(key,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Info_get_nthkey_f08

--- a/ompi/mpi/fortran/use-mpi-f08/info_set_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/info_set_f08.F90
@@ -12,13 +12,15 @@
 subroutine MPI_Info_set_f08(info,key,value,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_info_set_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
    CHARACTER(LEN=*), INTENT(IN) :: key, value
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_info_set_f(info%MPI_VAL,key,value,c_ierror,len(key),len(value))
+   call ompi_info_set_f(info%MPI_VAL,key,value,c_ierror, &
+                        len(key,KIND=C_INT),len(value,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Info_set_f08

--- a/ompi/mpi/fortran/use-mpi-f08/intercomm_create_from_groups_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/intercomm_create_from_groups_f08.F90
@@ -16,6 +16,7 @@ subroutine MPI_Intercomm_create_from_groups_f08(local_group, local_leader, remot
                                                 newintercomm, ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_intercomm_create_from_groups_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Group), INTENT(IN) :: local_group, remote_group
    INTEGER, INTENT(IN):: local_leader, remote_leader
@@ -30,7 +31,7 @@ subroutine MPI_Intercomm_create_from_groups_f08(local_group, local_leader, remot
                                             remote_group%MPI_VAL,  &
                                             remote_leader, stringtag, info%MPI_VAL, &
                                             errhandler%MPI_VAL, &
-                                            newintercomm%MPI_VAL, c_ierror, len(stringtag))
+                                            newintercomm%MPI_VAL, c_ierror, len(stringtag,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Intercomm_create_from_groups_f08

--- a/ompi/mpi/fortran/use-mpi-f08/lookup_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/lookup_name_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Lookup_name_f08(service_name,info,port_name,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_lookup_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: service_name
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -20,7 +21,7 @@ subroutine MPI_Lookup_name_f08(service_name,info,port_name,ierror)
    integer :: c_ierror
 
    call ompi_lookup_name_f(service_name,info%MPI_VAL,port_name,c_ierror, &
-                           len(service_name),len(port_name))
+                           len(service_name,KIND=C_INT),len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Lookup_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/open_port_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/open_port_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Open_port_f08(info,port_name,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_open_port_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
    CHARACTER(LEN=*), INTENT(OUT) :: port_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_open_port_f(info%MPI_VAL,port_name,c_ierror,len(port_name))
+   call ompi_open_port_f(info%MPI_VAL,port_name,c_ierror,len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Open_port_f08

--- a/ompi/mpi/fortran/use-mpi-f08/publish_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/publish_name_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Publish_name_f08(service_name,info,port_name,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_publish_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
    CHARACTER(LEN=*), INTENT(IN) :: service_name, port_name
@@ -19,7 +20,7 @@ subroutine MPI_Publish_name_f08(service_name,info,port_name,ierror)
    integer :: c_ierror
 
    call ompi_publish_name_f(service_name,info%MPI_VAL,port_name,c_ierror, &
-                            len(service_name), len(port_name))
+                            len(service_name,KIND=C_INT), len(port_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Publish_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/register_datarep_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/register_datarep_f08.F90
@@ -13,7 +13,7 @@
 
 subroutine MPI_Register_datarep_f08(datarep,read_conversion_fn,write_conversion_fn, &
                                     dtype_file_extent_fn,extra_state,ierror)
-   use, intrinsic :: iso_c_binding, only: c_funptr, c_funloc
+   use, intrinsic :: iso_c_binding, only: c_funptr, c_funloc, C_INT
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    use :: mpi_f08_interfaces_callbacks, only : MPI_Datarep_conversion_function
    use :: mpi_f08_interfaces_callbacks, only : MPI_Datarep_extent_function
@@ -32,7 +32,7 @@ subroutine MPI_Register_datarep_f08(datarep,read_conversion_fn,write_conversion_
    fwrite_fn = c_funloc(write_conversion_fn)
    fdtype_fn = c_funloc(dtype_file_extent_fn)
    call ompi_register_datarep_f(datarep,fread_fn,fwrite_fn, &
-                                fdtype_fn,extra_state,c_ierror,len(datarep))
+                                fdtype_fn,extra_state,c_ierror,len(datarep,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Register_datarep_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
@@ -14,6 +14,7 @@
 subroutine MPI_Session_get_nth_pset_f08(session, info, n, pset_len, pset_name, ierror)
    use :: mpi_f08_types, only : MPI_Session, MPI_Info, MPI_INFO_NULL
    use :: ompi_mpifh_bindings, only : ompi_session_get_nth_pset_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Session), INTENT(IN) :: session
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -22,9 +23,10 @@ subroutine MPI_Session_get_nth_pset_f08(session, info, n, pset_len, pset_name, i
    CHARACTER(LEN=*), INTENT(OUT) :: pset_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
-
+ 
    call ompi_session_get_nth_pset_f(session%MPI_VAL, MPI_INFO_NULL%MPI_VAL, n,     &
-                                    pset_len, pset_name, c_ierror, len(pset_name))
+                                    pset_len, pset_name, c_ierror,                 &
+                                    len(pset_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Session_get_nth_pset_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_pset_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_pset_info_f08.F90
@@ -14,6 +14,7 @@
 subroutine MPI_Session_get_pset_info_f08(session, pset_name, info, ierror)
    use :: mpi_f08_types, only : MPI_Session, MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_session_get_pset_info_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Session), INTENT(IN) :: session
    CHARACTER(LEN=*), INTENT(IN) :: pset_name
@@ -21,7 +22,8 @@ subroutine MPI_Session_get_pset_info_f08(session, pset_name, info, ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_session_get_pset_info_f(session%MPI_VAL, pset_name, info%MPI_VAL, c_ierror, len(pset_name))
+   call ompi_session_get_pset_info_f(session%MPI_VAL, pset_name, info%MPI_VAL, c_ierror, &
+                                     len(pset_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Session_get_pset_info_f08

--- a/ompi/mpi/fortran/use-mpi-f08/type_get_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/type_get_name_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Type_get_name_f08(datatype,type_name,resultlen,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_MAX_OBJECT_NAME
    use :: ompi_mpifh_bindings, only : ompi_type_get_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    CHARACTER(LEN=*), INTENT(OUT) :: type_name
@@ -19,7 +20,8 @@ subroutine MPI_Type_get_name_f08(datatype,type_name,resultlen,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_type_get_name_f(datatype%MPI_VAL,type_name,resultlen,c_ierror,len(type_name))
+   call ompi_type_get_name_f(datatype%MPI_VAL,type_name,resultlen,c_ierror, &
+                             len(type_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Type_get_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/type_set_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/type_set_name_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Type_set_name_f08(datatype,type_name,ierror)
    use :: mpi_f08_types, only : MPI_Datatype
    use :: ompi_mpifh_bindings, only : ompi_type_set_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    CHARACTER(LEN=*), INTENT(IN) :: type_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_type_set_name_f(datatype%MPI_VAL,type_name,c_ierror,len(type_name))
+   call ompi_type_set_name_f(datatype%MPI_VAL,type_name,c_ierror,len(type_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Type_set_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/unpublish_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/unpublish_name_f08.F90
@@ -12,6 +12,7 @@
 subroutine MPI_Unpublish_name_f08(service_name,info,port_name,ierror)
    use :: mpi_f08_types, only : MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_unpublish_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: service_name, port_name
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -19,7 +20,8 @@ subroutine MPI_Unpublish_name_f08(service_name,info,port_name,ierror)
    integer :: c_ierror
 
    call ompi_unpublish_name_f(service_name,info%MPI_VAL,port_name,c_ierror, &
-                              len(service_name), len(port_name))
+                              len(service_name,KIND=C_INT), &
+                              len(port_name, KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Unpublish_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/win_get_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_get_name_f08.F90
@@ -13,6 +13,7 @@ subroutine MPI_Win_get_name_f08(win,win_name,resultlen,ierror)
    use, intrinsic :: ISO_C_BINDING, only : C_CHAR
    use :: mpi_f08_types, only : MPI_Win, MPI_MAX_OBJECT_NAME
    use :: ompi_mpifh_bindings, only : ompi_win_get_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Win), INTENT(IN) :: win
    CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: win_name
@@ -20,7 +21,8 @@ subroutine MPI_Win_get_name_f08(win,win_name,resultlen,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_win_get_name_f(win%MPI_VAL,win_name,resultlen,c_ierror,len(win_name))
+   call ompi_win_get_name_f(win%MPI_VAL,win_name,resultlen,c_ierror, &
+                            len(win_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Win_get_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/win_set_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_set_name_f08.F90
@@ -12,13 +12,14 @@
 subroutine MPI_Win_set_name_f08(win,win_name,ierror)
    use :: mpi_f08_types, only : MPI_Win
    use :: ompi_mpifh_bindings, only : ompi_win_set_name_f
+   use, intrinsic :: ISO_C_BINDING, only : C_INT
    implicit none
    TYPE(MPI_Win), INTENT(IN) :: win
    CHARACTER(LEN=*), INTENT(IN) :: win_name
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_win_set_name_f(win%MPI_VAL,win_name,c_ierror,len(win_name))
+   call ompi_win_set_name_f(win%MPI_VAL,win_name,c_ierror,len(win_name,KIND=C_INT))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Win_set_name_f08


### PR DESCRIPTION
In the course of checking out a user reported problem:

https://www.mail-archive.com/users@lists.open-mpi.org//msg35382.html

it was discovered that many of the f08 entry points were improperly treating 'c' int args to the internal ompi*_f functions as fortran integers.

This commit fixes that and also addressed the problem reported by
the user.   It was a special case where they were building the fortran
bindings with non-default integer size which happened to no longer match
the 'c' int.

The fact that this problem wasn't seen before just shows that probably 99% of the time the default Fortran integer kind is compatible with 'c' int.