### PR TITLE
memchecker: fix some problems with arg checking

### DIFF
--- a/ompi/mpi/c/gather.c.in
+++ b/ompi/mpi/c/gather.c.in
@@ -50,12 +50,13 @@ PROTOTYPE ERROR_CLASS gather(BUFFER sendbuf, COUNT sendcount, DATATYPE sendtype,
         ptrdiff_t ext;
 
         rank = ompi_comm_rank(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
             if(ompi_comm_rank(comm) == root) {
                 /* check whether root's send buffer is defined. */
+                memchecker_datatype(recvtype);
+                ompi_datatype_type_extent(recvtype, &ext);
                 if (MPI_IN_PLACE == sendbuf) {
                   memchecker_call(&opal_memchecker_base_isdefined,
                                   (char *)(recvbuf)+rank*ext,

--- a/ompi/mpi/c/gather_init.c.in
+++ b/ompi/mpi/c/gather_init.c.in
@@ -50,13 +50,14 @@ PROTOTYPE ERROR_CLASS gather_init(BUFFER sendbuf, COUNT sendcount, DATATYPE send
         ptrdiff_t ext;
 
         rank = ompi_comm_rank(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
             if(ompi_comm_rank(comm) == root) {
                 /* check whether root's send buffer is defined. */
                 if (MPI_IN_PLACE == sendbuf) {
+                  memchecker_datatype(recvtype);
+                  ompi_datatype_type_extent(recvtype, &ext);
                   memchecker_call(&opal_memchecker_base_isdefined,
                                   (char *)(recvbuf)+rank*ext,
                                   recvcount, recvtype);

--- a/ompi/mpi/c/gatherv.c.in
+++ b/ompi/mpi/c/gatherv.c.in
@@ -49,11 +49,12 @@ PROTOTYPE ERROR_CLASS gatherv(BUFFER sendbuf, COUNT sendcount, DATATYPE sendtype
         ptrdiff_t ext;
 
         size = ompi_comm_remote_size(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
             if(ompi_comm_rank(comm) == root) {
+                memchecker_datatype(recvtype);
+                ompi_datatype_type_extent(recvtype, &ext);
                 /* check whether root's send buffer is defined. */
                 if (MPI_IN_PLACE == sendbuf) {
                     for (i = 0; i < size; i++) {
@@ -66,7 +67,6 @@ PROTOTYPE ERROR_CLASS gatherv(BUFFER sendbuf, COUNT sendcount, DATATYPE sendtype
                     memchecker_call(&opal_memchecker_base_isdefined, sendbuf, sendcount, sendtype);
                 }
 
-                memchecker_datatype(recvtype);
                 /* check whether root's receive buffer is addressable. */
                 for (i = 0; i < size; i++) {
                     memchecker_call(&opal_memchecker_base_isaddressable,
@@ -82,6 +82,7 @@ PROTOTYPE ERROR_CLASS gatherv(BUFFER sendbuf, COUNT sendcount, DATATYPE sendtype
             if (MPI_ROOT == root) {
                 memchecker_datatype(recvtype);
                 /* check whether root's receive buffer is addressable. */
+                ompi_datatype_type_extent(recvtype, &ext);
                 for (i = 0; i < size; i++) {
                     memchecker_call(&opal_memchecker_base_isaddressable,
                                     (char *)(recvbuf)+displs[i]*ext,

--- a/ompi/mpi/c/igather.c.in
+++ b/ompi/mpi/c/igather.c.in
@@ -51,13 +51,14 @@ PROTOTYPE ERROR_CLASS igather(BUFFER sendbuf, COUNT sendcount, DATATYPE sendtype
         ptrdiff_t ext;
 
         rank = ompi_comm_rank(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
             if(ompi_comm_rank(comm) == root) {
                 /* check whether root's send buffer is defined. */
                 if (MPI_IN_PLACE == sendbuf) {
+                  memchecker_datatype(recvtype);
+                  ompi_datatype_type_extent(recvtype, &ext);
                   memchecker_call(&opal_memchecker_base_isdefined,
                                   (char *)(recvbuf)+rank*ext,
                                   recvcount, recvtype);

--- a/ompi/mpi/c/iscatterv.c.in
+++ b/ompi/mpi/c/iscatterv.c.in
@@ -49,12 +49,12 @@ PROTOTYPE ERROR_CLASS iscatterv(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP_ARR
         ptrdiff_t ext;
 
         size = ompi_comm_remote_size(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
               if(ompi_comm_rank(comm) == root) {
                 memchecker_datatype(sendtype);
+                ompi_datatype_type_extent(sendtype, &ext);
                 /* check whether root's send buffer is defined. */
                 for (i = 0; i < size; i++) {
                     memchecker_call(&opal_memchecker_base_isdefined,
@@ -74,6 +74,7 @@ PROTOTYPE ERROR_CLASS iscatterv(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP_ARR
         } else {
             if(MPI_ROOT == root) {
                   memchecker_datatype(sendtype);
+                  ompi_datatype_type_extent(sendtype, &ext);
                   /* check whether root's send buffer is defined. */
                   for (i = 0; i < size; i++) {
                       memchecker_call(&opal_memchecker_base_isdefined,

--- a/ompi/mpi/c/scatterv.c.in
+++ b/ompi/mpi/c/scatterv.c.in
@@ -49,12 +49,12 @@ PROTOTYPE ERROR_CLASS scatterv(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP_ARRA
         ptrdiff_t ext;
 
         size = ompi_comm_remote_size(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
               if(ompi_comm_rank(comm) == root) {
                 memchecker_datatype(sendtype);
+                ompi_datatype_type_extent(sendtype, &ext);
                 /* check whether root's send buffer is defined. */
                 for (i = 0; i < size; i++) {
                     memchecker_call(&opal_memchecker_base_isdefined,
@@ -74,6 +74,7 @@ PROTOTYPE ERROR_CLASS scatterv(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP_ARRA
         } else {
             if(MPI_ROOT == root) {
                   memchecker_datatype(sendtype);
+                  ompi_datatype_type_extent(sendtype, &ext);
                   /* check whether root's send buffer is defined. */
                   for (i = 0; i < size; i++) {
                       memchecker_call(&opal_memchecker_base_isdefined,

--- a/ompi/mpi/c/scatterv_init.c.in
+++ b/ompi/mpi/c/scatterv_init.c.in
@@ -49,12 +49,12 @@ PROTOTYPE ERROR_CLASS scatterv_init(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP
         ptrdiff_t ext;
 
         size = ompi_comm_remote_size(comm);
-        ompi_datatype_type_extent(recvtype, &ext);
 
         memchecker_comm(comm);
         if(OMPI_COMM_IS_INTRA(comm)) {
               if(ompi_comm_rank(comm) == root) {
                 memchecker_datatype(sendtype);
+                ompi_datatype_type_extent(sendtype, &ext);
                 /* check whether root's send buffer is defined. */
                 for (i = 0; i < size; i++) {
                     memchecker_call(&opal_memchecker_base_isdefined,
@@ -74,6 +74,7 @@ PROTOTYPE ERROR_CLASS scatterv_init(BUFFER sendbuf, COUNT_ARRAY sendcounts, DISP
         } else {
             if(MPI_ROOT == root) {
                   memchecker_datatype(sendtype);
+                  ompi_datatype_type_extent(sendtype, &ext);
                   /* check whether root's send buffer is defined. */
                   for (i = 0; i < size; i++) {
                       memchecker_call(&opal_memchecker_base_isdefined,


### PR DESCRIPTION
The code which is conditionally compiled when Open MPI is configured with the --enable-memchecker had some bugs.  In particular the ompi_datatype_type_extent function was being invoked for some rooted collectives for ranks where the datatype being checked doesn't have to be defined.  Also in certain cases the wrong datatype (send,recv) was not being correctly checked.

These problems only show up when using the --enable-memchecker config option.