### PR TITLE
C interface templates - return MPI_Fint for c2f

### DIFF
--- a/ompi/mpi/c/comm_c2f.c.in
+++ b/ompi/mpi/c/comm_c2f.c.in
@@ -30,7 +30,7 @@
 #include "ompi/mpi/fortran/base/fint_2_int.h"
 #include "ompi/memchecker.h"
 
-PROTOTYPE ERROR_CLASS comm_c2f(COMM comm)
+PROTOTYPE FINT comm_c2f(COMM comm)
 {
     MEMCHECKER(
         memchecker_comm(comm);

--- a/ompi/mpi/c/win_c2f.c.in
+++ b/ompi/mpi/c/win_c2f.c.in
@@ -31,7 +31,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mpi/fortran/base/fint_2_int.h"
 
-PROTOTYPE ERROR_CLASS win_c2f(WIN win)
+PROTOTYPE FINT win_c2f(WIN win)
 {
     if ( MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);


### PR DESCRIPTION
A bug was found with the c templates for the handle conversion routines comm_c2f and win_c2f while working on

https://github.com/open-mpi/ompi/pull/13168