### PR TITLE
handle errors gracefuly to prevent SEGV

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -150,7 +150,7 @@ static ucc_status_t oob_allgather_test(void *req)
     size_t               msglen  = oob_req->msglen;
     int                  probe_count = 5;
     int rank, size, sendto, recvfrom, recvdatafrom,
-        senddatafrom, completed, probe;
+        senddatafrom, completed, probe, rc;
 
     size = ompi_comm_size(comm);
     rank = ompi_comm_rank(comm);
@@ -175,10 +175,16 @@ static ucc_status_t oob_allgather_test(void *req)
         senddatafrom = (rank - oob_req->iter + size) % size;
         tmprecv = (char*)oob_req->rbuf + (ptrdiff_t)recvdatafrom * (ptrdiff_t)msglen;
         tmpsend = (char*)oob_req->rbuf + (ptrdiff_t)senddatafrom * (ptrdiff_t)msglen;
-        MCA_PML_CALL(isend(tmpsend, msglen, MPI_BYTE, sendto, MCA_COLL_BASE_TAG_UCC,
+        rc = MCA_PML_CALL(isend(tmpsend, msglen, MPI_BYTE, sendto, MCA_COLL_BASE_TAG_UCC,
                            MCA_PML_BASE_SEND_STANDARD, comm, &oob_req->reqs[0]));
-        MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
+	if (OMPI_SUCCESS != rc) {
+            return rc;
+	}
+        rc = MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
                            MCA_COLL_BASE_TAG_UCC, comm, &oob_req->reqs[1]));
+	if (OMPI_SUCCESS != rc) {
+            return rc;
+	}
     }
     probe = 0;
     do {
@@ -206,6 +212,8 @@ static ucc_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
     oob_req->msglen              = msglen;
     oob_req->oob_coll_ctx        = oob_coll_ctx;
     oob_req->iter                = 0;
+    oob_req->reqs[0]             = NULL;
+    oob_req->reqs[1]             = NULL;
     *req                         = oob_req;
     return UCC_OK;
 }


### PR DESCRIPTION
oob_allgather_test() do not check isend() call
success, leading to the possibility to use
oob_req->reqs[] un-initialized upon error and
thus to SEGV.