### PR TITLE
MPI_T_Events: but wait there is more!

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -432,8 +432,10 @@ OMPI_MAN3 = \
         MPI_T_category_changed.3 \
         MPI_T_category_get_categories.3 \
         MPI_T_category_get_cvars.3 \
+        MPI_T_category_get_events.3 \
         MPI_T_category_get_info.3 \
         MPI_T_category_get_num.3 \
+        MPI_T_category_get_num_events.3 \
         MPI_T_category_get_pvars.3 \
         MPI_T_cvar_get_info.3 \
         MPI_T_cvar_get_num.3 \

--- a/docs/man-openmpi/man3/MPI_T_category_get_events.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_category_get_events.3.rst
@@ -1,0 +1,50 @@
+.. _mpi_t_category_get_events:
+
+
+MPI_T_category_get_events
+=========================
+
+.. include_body
+
+:ref:`MPI_T_category_get_events` |mdash| Query which events are in a
+category
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_T_category_get_events(int cat_index, int len, int indices[])
+
+
+INPUT PARAMETERS
+----------------
+* ``cat_index``: Index of the category to be queried.
+* ``len``: The length of the indices array.
+
+OUTPUT PARAMETERS
+-----------------
+* ``indices``: An integer array of size len, indicating event indices.
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_T_category_get_events` can be used to query which events
+are contained in a particular category.
+
+
+ERRORS
+------
+
+:ref:`MPI_T_category_get_events` will fail if:
+
+* ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized
+
+* ``MPI_T_ERR_INVALID_INDEX``: The category index is invalid

--- a/docs/man-openmpi/man3/MPI_T_category_get_num_events.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_category_get_num_events.3.rst
@@ -1,0 +1,47 @@
+.. _mpi_t_category_get_num_events:
+
+
+MPI_T_category_get_num_events
+=============================
+
+.. include_body
+
+:ref:`MPI_T_category_get_num_events` |mdash| Query returns the number of event types contained
+in the queried category.
+
+
+SYNTAX
+------
+
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <mpi.h>
+
+   int MPI_T_category_get_num_events(int cat_index, int *num_events)
+
+
+INPUT PARAMETERS
+----------------
+* ``cat_index``: Index of the category to be queried
+
+OUTPUT PARAMETERS
+-----------------
+* ``num_events``: Number of event types in the category
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_T_category_get_num_events` can be used to query the number of events
+contained in the category.
+
+
+ERRORS
+------
+
+:ref:`MPI_T_category_get_num_events` will fail if:
+
+* ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -357,8 +357,10 @@ MPI API manual pages (section 3)
    MPI_T_category_changed.3.rst
    MPI_T_category_get_categories.3.rst
    MPI_T_category_get_cvars.3.rst
+   MPI_T_category_get_events.3.rst
    MPI_T_category_get_info.3.rst
    MPI_T_category_get_num.3.rst
+   MPI_T_category_get_num_events.3.rst
    MPI_T_category_get_pvars.3.rst
    MPI_T_cvar_get_info.3.rst
    MPI_T_cvar_get_num.3.rst

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -3759,11 +3759,13 @@ OMPI_DECLSPEC  int PMPI_T_cvar_handle_free (MPI_T_cvar_handle *handle);
 OMPI_DECLSPEC  int PMPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf);
 OMPI_DECLSPEC  int PMPI_T_cvar_write (MPI_T_cvar_handle handle, const void *buf);
 OMPI_DECLSPEC  int PMPI_T_category_get_num(int *num_cat);
+OMPI_DECLSPEC  int PMPI_T_category_get_num_events (int cat_index, int *num_events);
 OMPI_DECLSPEC  int PMPI_T_category_get_info(int cat_index, char *name, int *name_len,
                                             char *desc, int *desc_len, int *num_cvars,
                                             int *num_pvars, int *num_categories);
 OMPI_DECLSPEC  int PMPI_T_category_get_index (const char *name, int *category_index);
 OMPI_DECLSPEC  int PMPI_T_category_get_cvars(int cat_index, int len, int indices[]);
+OMPI_DECLSPEC  int PMPI_T_category_get_events(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int PMPI_T_category_get_pvars(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int PMPI_T_category_get_categories(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int PMPI_T_category_changed(int *stamp);
@@ -3844,11 +3846,13 @@ OMPI_DECLSPEC  int MPI_T_cvar_handle_free (MPI_T_cvar_handle *handle);
 OMPI_DECLSPEC  int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf);
 OMPI_DECLSPEC  int MPI_T_cvar_write (MPI_T_cvar_handle handle, const void *buf);
 OMPI_DECLSPEC  int MPI_T_category_get_num(int *num_cat);
+OMPI_DECLSPEC  int MPI_T_category_get_num_events (int cat_index, int *num_events);
 OMPI_DECLSPEC  int MPI_T_category_get_info(int cat_index, char *name, int *name_len,
                                            char *desc, int *desc_len, int *num_cvars,
                                            int *num_pvars, int *num_categories);
 OMPI_DECLSPEC  int MPI_T_category_get_index (const char *name, int *category_index);
 OMPI_DECLSPEC  int MPI_T_category_get_cvars(int cat_index, int len, int indices[]);
+OMPI_DECLSPEC  int MPI_T_category_get_events(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int MPI_T_category_get_pvars(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int MPI_T_category_get_categories(int cat_index, int len, int indices[]);
 OMPI_DECLSPEC  int MPI_T_category_changed(int *stamp);

--- a/ompi/mpi/tool/Makefile.am
+++ b/ompi/mpi/tool/Makefile.am
@@ -6,7 +6,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2018-2025 Triad National Security, LLC. All rightsa
+# Copyright (c) 2018-2025 Triad National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
@@ -54,9 +54,11 @@ interface_profile_sources = \
 	category_changed.c \
 	category_get_categories.c \
 	category_get_cvars.c \
+	category_get_events.c \
 	category_get_info.c \
 	category_get_index.c \
 	category_get_num.c \
+	category_get_num_events.c \
 	category_get_pvars.c \
 	cvar_get_info.c \
 	cvar_get_index.c \

--- a/ompi/mpi/tool/category_get_events.c
+++ b/ompi/mpi/tool/category_get_events.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_T_category_get_events = PMPI_T_category_get_events
+#endif
+#define MPI_T_category_get_events PMPI_T_category_get_events
+#endif
+
+int MPI_T_category_get_events(int cat_index, int len, int indices[])
+{
+    int rc = MPI_SUCCESS;
+
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+    return rc;
+}

--- a/ompi/mpi/tool/category_get_num_events.c
+++ b/ompi/mpi/tool/category_get_num_events.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2025      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/tool/mpit-internal.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_T_category_get_num_events = PMPI_T_category_get_num_events
+#endif
+#define MPI_T_category_get_num_events PMPI_T_category_get_num_events
+#endif
+
+int MPI_T_category_get_num_events (int cat_index, int *num_events)
+{
+    if (!mpit_is_initialized ()) {
+        return MPI_T_ERR_NOT_INITIALIZED;
+    }
+
+    if (MPI_PARAM_CHECK && NULL == num_events) {
+        return MPI_T_ERR_INVALID;
+    }
+
+    *num_events = 0;
+
+    return MPI_SUCCESS;
+}


### PR DESCRIPTION
Turns out I forgot to run the pcvs checker when adding MPI_T event stubs in PR #13086 and missed a couple of events related functions.  Also it looks like these were not included in PR #8057.

With this patch, the PCVS MPI API checker passes for MPI 4.0 standard.

The PCVS MPI API checker is described here https://dl.acm.org/doi/abs/10.1145/3615318.3615329