### PR TITLE
F08: refactor templates

### DIFF
--- a/ompi/mpi/bindings/ompi_bindings/fortran.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran.py
@@ -179,10 +179,11 @@ class FortranBinding:
         c_func = self.c_func_name
         self.dump(f'void {c_func}({parameters});')
         self.dump(f'void {c_func}({parameters})')
-        count_type, disp_type = ('MPI_Count', 'MPI_Aint') if self.bigcount else ('int', 'int')
+        count_type, disp_type, count_fint_type = ('MPI_Count', 'MPI_Aint', 'MPI_Count') if self.bigcount else ('int', 'int', 'MPI_Fint')
         self.template.print_body(c_func, out=self.out,
                                  replacements={'INNER_CALL': self.inner_call,
                                                'COUNT_TYPE': count_type,
+                                               'COUNT_FINT_TYPE': count_fint_type,
                                                'DISP_TYPE': disp_type})
 
     def print_interface(self):

--- a/ompi/mpi/fortran/use-mpi-f08/allgather_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/allgather_init_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -33,6 +33,7 @@ PROTOTYPE VOID allgather_init(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtyp
     MPI_Info c_info;
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@) *sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@) *recvcount;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x2, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -66,7 +67,7 @@ PROTOTYPE VOID allgather_init(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtyp
                           c_sendcount,
                           c_senddatatype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, c_comm, c_info, &c_req);
 
     if (c_senddatatype != c_sendtype) {

--- a/ompi/mpi/fortran/use-mpi-f08/allgather_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/allgather_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,7 +28,8 @@ PROTOTYPE VOID allgather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
 {
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    int c_sendcount = 0;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
     MPI_Datatype c_sendtype = NULL, c_senddatatype = NULL;
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
@@ -60,7 +61,7 @@ PROTOTYPE VOID allgather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
                           c_sendcount,
                           c_senddatatype,
                           recvbuf,
-                          OMPI_FINT_2_INT(*recvcount),
+                          c_recvcount,
                           c_recvtype, c_comm);
 
     if (c_senddatatype != c_sendtype) {

--- a/ompi/mpi/fortran/use-mpi-f08/alltoall_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoall_init_ts.c.in
@@ -32,6 +32,8 @@ PROTOTYPE VOID alltoall_init(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Info c_info;
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
 
     c_comm = PMPI_Comm_f2c(*comm);
     c_sendtype = PMPI_Type_f2c(*sendtype);
@@ -61,10 +63,10 @@ PROTOTYPE VOID alltoall_init(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf,
-                          (@COUNT_TYPE@) *sendcount,
+                          c_sendcount,
                           c_sendtype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, c_comm, c_info, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/use-mpi-f08/alltoall_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoall_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,11 +30,11 @@ PROTOTYPE VOID alltoall(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_sendtype = NULL, c_recvtype = PMPI_Type_f2c(*recvtype);
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
-    int c_sendcount = 0, c_recvcount =  OMPI_FINT_2_INT(*recvcount);
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)(*sendcount);
+    @COUNT_TYPE@ c_recvcount =  (@COUNT_TYPE@)(*recvcount);
 
     if (OMPI_COMM_IS_INTER(c_comm) || !OMPI_IS_FORTRAN_IN_PLACE(sendbuf)) {
         c_sendtype = PMPI_Type_f2c(*sendtype);
-        c_sendcount = OMPI_FINT_2_INT(*sendcount);
         OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
         if (MPI_SUCCESS != c_ierr) {
             if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/alltoallv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoallv_init_ts.c.in
@@ -62,8 +62,6 @@ PROTOTYPE VOID alltoallv_init(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts, DISP_ARRA
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(sdispls, size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
 

--- a/ompi/mpi/fortran/use-mpi-f08/alltoallv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoallv_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -72,10 +72,9 @@ PROTOTYPE VOID alltoallv(BUFFER x1, COUNT_ARRAY sendcounts, DISP_ARRAY sdispls,
                           c_recvtype, c_comm);
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_IN_PLACE == sendbuf) {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
-    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(rdispls, tmp_rdispls);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/alltoallw_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoallw_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -27,42 +27,42 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
                          DISP_ARRAY rdispls, DATATYPE_ARRAY recvtypes,
                          COMM comm)
 {
-    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    MPI_Datatype *c_sendtypes = NULL, *c_recvtypes;
     int size, c_ierr;
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    MPI_Datatype *c_sendtypes = NULL, *c_recvtypes;
+    @COUNT_TYPE@ *tmp_sendcounts = NULL;
+    @DISP_TYPE@ *tmp_sdispls = NULL;
+    @COUNT_TYPE@ *tmp_recvcounts = NULL;
+    @DISP_TYPE@ *tmp_rdispls = NULL;
 
-    OMPI_ARRAY_NAME_DECL(sendcounts);
-    OMPI_ARRAY_NAME_DECL(sdispls);
-    OMPI_ARRAY_NAME_DECL(recvcounts);
-    OMPI_ARRAY_NAME_DECL(rdispls);
+    size = OMPI_COMM_IS_INTER(c_comm)?ompi_comm_remote_size(c_comm):ompi_comm_size(c_comm);
 
-    OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
-    if (MPI_SUCCESS != c_ierr) {
-        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
-        return;
+    if (OMPI_COMM_IS_INTER(c_comm) || !OMPI_IS_FORTRAN_IN_PLACE(sendbuf)) {
+        OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
+        if (MPI_SUCCESS != c_ierr) {
+            if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+            OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
+            return;
+        }
+        c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+        for (int i=0; i<size; i++) {
+            c_sendtypes[i] = PMPI_Type_f2c(sendtypes[i]);
+        }
+        OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
+        OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, size);
+    } else {
+        sendbuf = MPI_IN_PLACE;
     }
+
     OMPI_CFI_CHECK_CONTIGUOUS(x2, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
         if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    size = OMPI_COMM_IS_INTER(c_comm)?ompi_comm_remote_size(c_comm):ompi_comm_size(c_comm);
-
-    if (!OMPI_IS_FORTRAN_IN_PLACE(sendbuf)) {
-        c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-        OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-        OMPI_ARRAY_FINT_2_INT(sdispls, size);
-        for (int i=0; i<size; i++) {
-            c_sendtypes[i] = PMPI_Type_f2c(sendtypes[i]);
-        }
-    }
 
     c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
-    OMPI_ARRAY_FINT_2_INT(rdispls, size);
     for (int i=0; i<size; i++) {
         c_recvtypes[i] = PMPI_Type_f2c(recvtypes[i]);
     }
@@ -71,20 +71,24 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
+
     c_ierr = @INNER_CALL@(sendbuf,
-                          OMPI_ARRAY_NAME_CONVERT(sendcounts),
-                          OMPI_ARRAY_NAME_CONVERT(sdispls),
+                          tmp_sendcounts,
+                          tmp_sdispls,
                           c_sendtypes,
                           recvbuf,
-                          OMPI_ARRAY_NAME_CONVERT(recvcounts),
-                          OMPI_ARRAY_NAME_CONVERT(rdispls),
+                          tmp_recvcounts,
+                          tmp_rdispls,
                           c_recvtypes, c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sendcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(sdispls);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(rdispls);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(rdispls, tmp_rdispls);
+
     if (NULL != c_sendtypes) {
         free(c_sendtypes);
     }

--- a/ompi/mpi/fortran/use-mpi-f08/base/bigcount.h
+++ b/ompi/mpi/fortran/use-mpi-f08/base/bigcount.h
@@ -15,7 +15,7 @@
 #define OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array, tmp_array, n) \
     do { \
         if (sizeof(*(array)) == sizeof(*(tmp_array))) { \
-            (tmp_array) = (array); \
+            (tmp_array) = (void *)(array); \
         } else { \
             (tmp_array) = malloc(sizeof(*tmp_array) * n); \
             for (int bigcount_array_i = 0; bigcount_array_i < n; ++bigcount_array_i) { \
@@ -24,9 +24,19 @@
         } \
     } while (0)
 
-#define OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array, tmp_array) \
+#define OMPI_FORTRAN_BIGCOUNT_ARRAY_COPYOUT(array, tmp_array, n) \
     do { \
         if ((array) != (tmp_array) && NULL != (tmp_array)) { \
+            for (int bigcount_array_i = 0; bigcount_array_i < n; ++bigcount_array_i) { \
+                (array)[bigcount_array_i] = (tmp_array)[bigcount_array_i]; \
+            } \
+        } \
+    } while (0)
+
+
+#define OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array, tmp_array) \
+    do { \
+        if ((void *)(array) != (void *)(tmp_array) && NULL != (tmp_array)) { \
             free(tmp_array); \
             tmp_array = NULL; \
         } \
@@ -36,7 +46,7 @@
     do { \
         if (MPI_SUCCESS == (c_ierr)) { \
             ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request; \
-            if ((array) != (tmp_array) && (tmp_array) != NULL) { \
+            if ((void *)(array) != (void *)(tmp_array) && (tmp_array) != NULL) { \
                 nb_request->data.release_arrays[(idx)++] = tmp_array; \
             } \
             nb_request->data.release_arrays[idx] = NULL; \

--- a/ompi/mpi/fortran/use-mpi-f08/base/ompi_type_get_contents_f_c.c
+++ b/ompi/mpi/fortran/use-mpi-f08/base/ompi_type_get_contents_f_c.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,6 +26,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mpi/fortran/base/fint_2_int.h"
+#include "ompi/mpi/fortran/use-mpi-f08/base/bigcount.h"
 
 /*
  * big count entry point, only needed by F08 bindings.
@@ -48,12 +49,10 @@ void ompi_type_get_contents_f_c(MPI_Fint *mtype, MPI_Count *max_integers,
                              MPI_Count *array_of_large_counts,
                              MPI_Fint *array_of_datatypes, MPI_Fint *ierr)
 {
-    MPI_Aint *c_address_array = NULL;
-    MPI_Count *c_large_counts_array = NULL;
     MPI_Datatype *c_datatype_array = NULL;
+    int *tmp_array_of_integers = NULL;
     MPI_Datatype c_mtype = PMPI_Type_f2c(*mtype);
     int i, c_ierr;
-    OMPI_ARRAY_NAME_DECL(array_of_integers);
 
     if (*max_datatypes) {
         c_datatype_array = (MPI_Datatype *) malloc(*max_datatypes * sizeof(MPI_Datatype));
@@ -65,62 +64,31 @@ void ompi_type_get_contents_f_c(MPI_Fint *mtype, MPI_Count *max_integers,
         }
     }
 
-    if (*max_addresses) {
-        c_address_array = (MPI_Aint *) malloc(*max_addresses * sizeof(MPI_Aint));
-        if (NULL == c_address_array) {
-            if (NULL != c_datatype_array) {
-              free(c_datatype_array);
-            }
-
-            c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM,
-                                            FUNC_NAME);
-            if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-            return;
-        }
+    if (*max_integers) {
+        OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_integers, tmp_array_of_integers, *max_integers);
     }
-
-    if (*max_large_counts) {
-        c_large_counts_array = (MPI_Count *) malloc(*max_large_counts * sizeof(MPI_Count));
-        if (NULL == c_large_counts_array) {
-            if (NULL != c_datatype_array) {
-              free(c_datatype_array);
-            }
-            if (NULL != c_address_array) {
-              free(c_address_array);
-            }
-
-            c_ierr = OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM,
-                                            FUNC_NAME);
-            if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-            return;
-        }
-    }
-
-    OMPI_ARRAY_FINT_2_INT(array_of_integers, *max_integers);
 
     c_ierr = PMPI_Type_get_contents_c(c_mtype,
-                                   OMPI_FINT_2_INT(*max_integers),
-                                   OMPI_FINT_2_INT(*max_addresses),
-                                   OMPI_FINT_2_INT(*max_datatypes),
-                                   OMPI_FINT_2_INT(*max_large_counts),
-                                   OMPI_ARRAY_NAME_CONVERT(array_of_integers),
-                                   c_address_array, c_large_counts_array, 
-			           c_datatype_array);
+                                      *max_integers,
+                                      *max_addresses,
+                                      *max_large_counts,
+                                      *max_datatypes,
+                                      tmp_array_of_integers,
+                                      array_of_addresses,
+                                      array_of_large_counts,
+			              c_datatype_array);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-        for (i = 0; i < *max_addresses; i++) {
-            array_of_addresses[i] = c_address_array[i];
-        }
-        for (i = 0; i < *max_large_counts; i++) {
-            array_of_large_counts[i] = c_large_counts_array[i];
-        }
+        OMPI_FORTRAN_BIGCOUNT_ARRAY_COPYOUT(array_of_integers, tmp_array_of_integers, *max_integers);
         for (i = 0; i < *max_datatypes; i++) {
           array_of_datatypes[i] = PMPI_Type_c2f(c_datatype_array[i]);
         }
     }
-    free(c_address_array);
-    free(c_datatype_array);
-    free(c_large_counts_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_integers);
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_integers, tmp_array_of_integers);
+
+    if (NULL != c_datatype_array) {
+        free(c_datatype_array);
+    }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/base/ompi_type_get_envelope_f_c.c
+++ b/ompi/mpi/fortran/use-mpi-f08/base/ompi_type_get_envelope_f_c.c
@@ -40,23 +40,17 @@ void ompi_type_get_envelope_f_c(MPI_Fint *type, MPI_Count *num_integers,
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
-    OMPI_SINGLE_NAME_DECL(num_integers);
-    OMPI_SINGLE_NAME_DECL(num_addresses);
-    OMPI_SINGLE_NAME_DECL(num_datatypes);
-    OMPI_SINGLE_NAME_DECL(combiner);
+    int c_combiner;
 
     c_ierr = PMPI_Type_get_envelope_c(c_type,
-                                   OMPI_SINGLE_NAME_CONVERT(num_integers),
-                                   OMPI_SINGLE_NAME_CONVERT(num_addresses),
-                                   OMPI_SINGLE_NAME_CONVERT(num_large_counts),
-                                   OMPI_SINGLE_NAME_CONVERT(num_datatypes),
-                                   OMPI_SINGLE_NAME_CONVERT(combiner));
+                                     num_integers,
+                                     num_addresses,
+                                     num_large_counts,
+                                     num_datatypes,
+                                     &c_combiner);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-        OMPI_SINGLE_INT_2_FINT(num_integers);
-        OMPI_SINGLE_INT_2_FINT(num_addresses);
-        OMPI_SINGLE_INT_2_FINT(num_datatypes);
-        OMPI_SINGLE_INT_2_FINT(combiner);
+        *combiner = (MPI_Fint)(c_combiner);
     }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_attach_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_attach_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -24,8 +24,10 @@
 PROTOTYPE VOID buffer_attach(BUFFER_ASYNC x, COUNT size)
 {
     int c_ierr;
+    @COUNT_TYPE@ c_size = (@COUNT_TYPE@)*size;
+
     if (OMPI_CFI_IS_CONTIGUOUS(x)) {
-        c_ierr = PMPI_Buffer_attach(OMPI_CFI_BASE_ADDR(x), OMPI_FINT_2_INT(*size));
+        c_ierr = PMPI_Buffer_attach(OMPI_CFI_BASE_ADDR(x), c_size);
     } else {
         c_ierr = MPI_ERR_BUFFER;
         OMPI_ERRHANDLER_INVOKE(MPI_COMM_SELF, c_ierr, FUNC_NAME);

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c.in
@@ -26,12 +26,13 @@ PROTOTYPE VOID buffer_detach(C_PTR_OUT buffer, COUNT size)
 {
     int c_ierr;
     void *dummy;
-    OMPI_SINGLE_NAME_DECL(size);
+    @COUNT_TYPE@ c_size;
 
-    c_ierr = @INNER_CALL@(&dummy, OMPI_SINGLE_NAME_CONVERT(size));
+    c_ierr = @INNER_CALL@(&dummy, &c_size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-        OMPI_SINGLE_INT_2_FINT(size);
+        *size = (@COUNT_FINT_TYPE@)(c_size);
     }
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/file_read_ordered_end_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/file_read_ordered_end_ts.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,7 +31,7 @@ PROTOTYPE VOID file_read_ordered_end(FILE fh, BUFFER_ASYNC x, STATUS_OUT status)
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_read_ordered_end(c_fh, buf, c_status);
+    c_ierr = @INNER_CALL@(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/use-mpi-f08/file_write_all_end_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/file_write_all_end_ts.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,7 +31,7 @@ PROTOTYPE VOID file_write_all_end(FILE fh, BUFFER_ASYNC x, STATUS_OUT status)
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_write_all_end(c_fh, buf, c_status);
+    c_ierr = @INNER_CALL@(c_fh, buf, c_status);
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/use-mpi-f08/gather_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/gather_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,7 +29,8 @@ PROTOTYPE VOID gather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
     MPI_Comm c_comm;
     MPI_Datatype c_senddatatype = NULL, c_sendtype = NULL;
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1);
-    int c_sendcount =  0, c_recvcount = 0;
+    @COUNT_TYPE@ c_sendcount =  (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount =  (@COUNT_TYPE@)*recvcount;
     MPI_Datatype c_recvtype = NULL;
     void *recvbuf = OMPI_CFI_BASE_ADDR(x2);
 
@@ -39,7 +40,6 @@ PROTOTYPE VOID gather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
     if (OMPI_COMM_IS_INTER(c_comm)) {
         if (MPI_ROOT == c_root) {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = OMPI_FINT_2_INT(*recvcount);
             OMPI_CFI_CHECK_CONTIGUOUS(x2, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -48,7 +48,6 @@ PROTOTYPE VOID gather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
             }
         } else if (MPI_PROC_NULL != c_root) {
             c_sendtype = PMPI_Type_f2c(*sendtype);
-            c_sendcount = OMPI_FINT_2_INT(*sendcount);
             OMPI_CFI_2_C(x1, c_sendcount, c_sendtype, c_senddatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -59,7 +58,6 @@ PROTOTYPE VOID gather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
     } else {
         if (ompi_comm_rank(c_comm) == c_root) {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = OMPI_FINT_2_INT(*recvcount);
             OMPI_CFI_CHECK_CONTIGUOUS(x2, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -71,7 +69,6 @@ PROTOTYPE VOID gather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
             sendbuf = MPI_IN_PLACE;
         } else {
             c_sendtype = PMPI_Type_f2c(*sendtype);
-            c_sendcount = OMPI_FINT_2_INT(*sendcount);
             OMPI_CFI_2_C(x1, c_sendcount, c_sendtype, c_senddatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/gatherv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/gatherv_init_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -107,12 +107,9 @@ PROTOTYPE VOID gatherv_init(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
         ompi_datatype_destroy(&c_senddatatype);
     }
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-    if (MPI_SUCCESS == c_ierr) {
-        *request = PMPI_Request_c2f(c_request);
-    } else {
-        OMPI_ARRAY_FINT_2_INT_CLEANUP(recvcounts);
-        OMPI_ARRAY_FINT_2_INT_CLEANUP(displs);
-    }
+    if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
+
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
 }
+

--- a/ompi/mpi/fortran/use-mpi-f08/get_count.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/get_count.c.in
@@ -26,7 +26,7 @@ PROTOTYPE VOID get_count(STATUS status, DATATYPE datatype, COUNT count)
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
     MPI_Status   c_status;
-    OMPI_SINGLE_NAME_DECL(count);
+    @COUNT_TYPE@ c_count;
 
     if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
         *count = OMPI_INT_2_FINT(0);
@@ -36,9 +36,13 @@ PROTOTYPE VOID get_count(STATUS status, DATATYPE datatype, COUNT count)
 
         if (MPI_SUCCESS == c_ierr) {
             c_ierr = @INNER_CALL@(&c_status, c_type,
-                                   OMPI_SINGLE_NAME_CONVERT(count));
-            OMPI_SINGLE_INT_2_FINT(count);
+                                   &c_count);
         }
     }
+
+    if (MPI_SUCCESS == c_ierr) {
+        *count = (@COUNT_FINT_TYPE@)(c_count);
+    }
+
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/get_elements.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/get_elements.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -23,22 +23,21 @@
 
 PROTOTYPE VOID get_elements(STATUS status, DATATYPE datatype, COUNT_OUT count)
 {
-    int c_ierr;
+    int c_ierr = MPI_SUCCESS;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
     MPI_Status   c_status;
-    OMPI_SINGLE_NAME_DECL(count);
+    @COUNT_TYPE@ c_count = 0;
 
-    if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
-        *count = OMPI_INT_2_FINT(0);
-        c_ierr = MPI_SUCCESS;
-    } else {
+    if (!OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
         c_ierr = PMPI_Status_f2c(status, &c_status);
-
         if (MPI_SUCCESS == c_ierr) {
             c_ierr = @INNER_CALL@(&c_status, c_type,
-                                      OMPI_SINGLE_NAME_CONVERT(count));
-            OMPI_SINGLE_INT_2_FINT(count);
+                                      &c_count);
         }
+    }
+
+    if (MPI_SUCCESS == c_ierr) {
+        *count = (@COUNT_FINT_TYPE@)(c_count);
     }
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/iallgather_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iallgather_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,7 +30,7 @@ PROTOTYPE VOID iallgather(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
     MPI_Request c_req;
     MPI_Datatype c_sendtype = NULL, c_senddatatype = NULL;
     void *sendbuf = OMPI_CFI_BASE_ADDR(x1);
-    @COUNT_TYPE@ c_sendcount = 0;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@) *sendcount;
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     void *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@) *recvcount;
@@ -43,7 +43,6 @@ PROTOTYPE VOID iallgather(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
     }
     if (OMPI_COMM_IS_INTER(c_comm) || !OMPI_IS_FORTRAN_IN_PLACE(sendbuf)) {
         c_sendtype = PMPI_Type_f2c(*sendtype);
-        c_sendcount = OMPI_FINT_2_INT(*sendcount);
         OMPI_CFI_2_C(x1, c_sendcount, c_sendtype, c_senddatatype, c_ierr);
         if (MPI_SUCCESS != c_ierr) {
             if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/iallgatherv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iallgatherv_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -27,7 +27,7 @@ PROTOTYPE VOID iallgatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
 {
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    @COUNT_TYPE@ c_sendcount = 0;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
     MPI_Datatype c_sendtype = NULL, c_senddatatype = NULL;
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
@@ -45,7 +45,6 @@ PROTOTYPE VOID iallgatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
     if (OMPI_COMM_IS_INTER(c_comm)) {
         size = ompi_comm_remote_size(c_comm);
         c_sendtype = PMPI_Type_f2c(*sendtype);
-        c_sendcount = (@COUNT_TYPE@) *sendcount;
         OMPI_CFI_2_C(x1, c_sendcount, c_sendtype, c_senddatatype, c_ierr);
         if (MPI_SUCCESS != c_ierr) {
             if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -58,7 +57,6 @@ PROTOTYPE VOID iallgatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
             sendbuf = MPI_IN_PLACE;
         } else {
             c_sendtype = PMPI_Type_f2c(*sendtype);
-            c_sendcount = (@COUNT_TYPE@) *sendcount;
             OMPI_CFI_2_C(x1, c_sendcount, c_sendtype, c_senddatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -74,13 +72,10 @@ PROTOTYPE VOID iallgatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(displs, tmp_displs, size);
-
     c_ierr = @INNER_CALL@(sendbuf, c_sendcount, c_sendtype,
                           recvbuf,
-                          OMPI_ARRAY_NAME_CONVERT(recvcounts),
-                          OMPI_ARRAY_NAME_CONVERT(displs),
+                          tmp_recvcounts,
+                          tmp_displs,
                           c_recvtype,
                           c_comm, &c_request);
 

--- a/ompi/mpi/fortran/use-mpi-f08/ialltoallv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ialltoallv_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -75,10 +75,9 @@ PROTOTYPE VOID ialltoallv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts, DISP_ARRAY sd
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
-    if (MPI_IN_PLACE == sendbuf) {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
-    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(rdispls, tmp_rdispls);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/iexscan_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iexscan_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,6 +31,7 @@ PROTOTYPE VOID iexscan(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     MPI_Request c_request;
     MPI_Op c_op;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -52,7 +53,7 @@ PROTOTYPE VOID iexscan(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     recvbuf = (char *) OMPI_F2C_BOTTOM (recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          OMPI_FINT_2_INT(*count),
+                          c_count,
                           c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);

--- a/ompi/mpi/fortran/use-mpi-f08/igatherv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/igatherv_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -27,7 +27,7 @@ PROTOTYPE VOID igatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
                         REQUEST_OUT request)
 {
 
-    int c_ierr;
+    int c_ierr, idx=0;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     int c_root = OMPI_FINT_2_INT(*root);
     MPI_Datatype c_senddatatype = NULL, c_sendtype = NULL, c_recvtype = NULL;
@@ -98,4 +98,8 @@ PROTOTYPE VOID igatherv(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sendtype,
                           c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
+
 }

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgather_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgather_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -33,7 +33,8 @@ PROTOTYPE VOID ineighbor_allgather(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE se
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     MPI_Datatype __opal_attribute_unused__  c_senddatatype;
     MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
-    @COUNT_TYPE@ __opal_attribute_unused__  c_sendcount = (@COUNT_TYPE@) *sendcount;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@) *sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@) *recvcount;
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     MPI_Request c_req;
 
@@ -58,10 +59,10 @@ PROTOTYPE VOID ineighbor_allgather(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE se
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf,
-                          (@COUNT_TYPE@) *sendcount,
+                          c_sendcount,
                           c_sendtype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, c_comm, &c_req);
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoall_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoall_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,6 +32,8 @@ PROTOTYPE VOID ineighbor_alltoall(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sen
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Request c_req;
     MPI_Datatype c_sendtype, c_recvtype;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
@@ -55,10 +57,10 @@ PROTOTYPE VOID ineighbor_alltoall(BUFFER_ASYNC x1, COUNT sendcount, DATATYPE sen
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf,
-                          (@COUNT_TYPE@) *sendcount,
+                          c_sendcount,
                           c_sendtype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, c_comm, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/use-mpi-f08/ireduce_scatter_block_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ireduce_scatter_block_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -33,6 +33,7 @@ PROTOTYPE VOID ireduce_scatter_block(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2,
     MPI_Op c_op;
     int size;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@) *recvcount;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -56,7 +57,7 @@ PROTOTYPE VOID ireduce_scatter_block(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = @INNER_CALL@(sendbuf, recvbuf, (@COUNT_TYPE@) *recvcount,
+    c_ierr = @INNER_CALL@(sendbuf, recvbuf, c_recvcount,
                           c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);

--- a/ompi/mpi/fortran/use-mpi-f08/ireduce_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ireduce_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,6 +31,7 @@ PROTOTYPE VOID ireduce(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     MPI_Op c_op;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@) *count;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -53,7 +54,7 @@ PROTOTYPE VOID ireduce(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_type, c_op,
                           OMPI_FINT_2_INT(*root),
                           c_comm, &c_request);

--- a/ompi/mpi/fortran/use-mpi-f08/iscan_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iscan_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,6 +31,7 @@ PROTOTYPE VOID iscan(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     MPI_Request c_request;
     MPI_Op c_op;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@) *count;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -53,7 +54,7 @@ PROTOTYPE VOID iscan(BUFFER_ASYNC x1, BUFFER_ASYNC_OUT x2, COUNT count,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_type, c_op,
                           c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/iscatter_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iscatter_ts.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,14 +31,14 @@ PROTOTYPE VOID iscatter(BUFFER_ASYNC x1, COUNT sendcount,
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     int c_root = OMPI_FINT_2_INT(*root);
     MPI_Datatype c_sendtype = NULL, c_recvtype = NULL, c_recvdatatype = NULL;
-    @COUNT_TYPE@ c_sendcount = 0, c_recvcount = 0;
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@) *sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@) *recvcount;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     MPI_Request c_request;
 
     if (OMPI_COMM_IS_INTER(c_comm)) {
         if (MPI_ROOT == c_root) {
             c_sendtype = PMPI_Type_f2c(*sendtype);
-            c_sendcount = OMPI_FINT_2_INT(*sendcount);
             OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -47,7 +47,6 @@ PROTOTYPE VOID iscatter(BUFFER_ASYNC x1, COUNT sendcount,
             }
         } else if (MPI_PROC_NULL != c_root) {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = OMPI_FINT_2_INT(*recvcount);
             OMPI_CFI_2_C(x2, c_recvcount, c_recvtype, c_recvdatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -58,7 +57,6 @@ PROTOTYPE VOID iscatter(BUFFER_ASYNC x1, COUNT sendcount,
     } else {
         if (ompi_comm_rank(c_comm) == c_root) {
             c_sendtype = PMPI_Type_f2c(*sendtype);
-            c_sendcount = (@COUNT_TYPE@) *sendcount;
             OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -70,7 +68,6 @@ PROTOTYPE VOID iscatter(BUFFER_ASYNC x1, COUNT sendcount,
             recvbuf = MPI_IN_PLACE;
         } else {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = (@COUNT_TYPE@) *recvcount;
             OMPI_CFI_2_C(x2, c_recvcount, c_recvtype, c_recvdatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/iscatterv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/iscatterv_ts.c.in
@@ -28,12 +28,12 @@ PROTOTYPE VOID iscatterv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
                          DATATYPE recvtype, RANK root,
                          COMM comm, REQUEST_OUT request)
 {
-    int c_ierr;
+    int c_ierr, idx = 0;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     int c_root = OMPI_FINT_2_INT(*root);
     MPI_Datatype  __opal_attribute_unused__ c_recvdatatype = MPI_DATATYPE_NULL;
     MPI_Datatype c_sendtype = MPI_DATATYPE_NULL, c_recvtype = MPI_DATATYPE_NULL;
-    @COUNT_TYPE@ c_recvcount = 0;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     MPI_Request c_request;
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
@@ -53,7 +53,6 @@ PROTOTYPE VOID iscatterv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
             OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(displs, tmp_displs, size);
         } else if (MPI_PROC_NULL != c_root) {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = OMPI_FINT_2_INT(*recvcount);
             OMPI_CFI_2_C(x2, c_recvcount, c_recvtype, c_recvdatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -78,7 +77,6 @@ PROTOTYPE VOID iscatterv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
             recvbuf = MPI_IN_PLACE;
         } else {
             c_recvtype = PMPI_Type_f2c(*recvtype);
-            c_recvcount = OMPI_FINT_2_INT(*recvcount);
             OMPI_CFI_2_C(x2, c_recvcount, c_recvtype, c_recvdatatype, c_ierr);
             if (MPI_SUCCESS != c_ierr) {
                 if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -106,6 +104,6 @@ PROTOTYPE VOID iscatterv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) *request = PMPI_Request_c2f(c_request);
 
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(displs, tmp_displs);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/isendrecv_replace_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/isendrecv_replace_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,7 @@ PROTOTYPE VOID isendrecv_replace(BUFFER_ASYNC_OUT x, COUNT count, DATATYPE datat
     MPI_Comm c_comm = PMPI_Comm_f2c (*comm);
 
     void *buf = OMPI_CFI_BASE_ADDR(x);
-    @COUNT_TYPE@  __opal_attribute_unused__ c_count = (@COUNT_TYPE@) *count;
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@) *count;
 
     OMPI_CFI_2_C(x, c_count, c_type, c_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -42,7 +42,7 @@ PROTOTYPE VOID isendrecv_replace(BUFFER_ASYNC_OUT x, COUNT count, DATATYPE datat
     }
 
     c_ierr = @INNER_CALL@(OMPI_F2C_BOTTOM(buf),
-                          OMPI_FINT_2_INT(*count),
+                          c_count,
                           c_datatype,
                           OMPI_FINT_2_INT(*dest),
                           OMPI_FINT_2_INT(*sendtag),

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_allgather_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_allgather_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -50,9 +50,6 @@ PROTOTYPE VOID neighbor_allgather(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -55,9 +55,6 @@ PROTOTYPE VOID neighbor_allgatherv_init(BUFFER x1, COUNT sendcount, DATATYPE sen
         return;
     }
 
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
-
     PMPI_Comm_size(c_comm, &size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(displs, tmp_displs, size);
@@ -83,10 +80,8 @@ PROTOTYPE VOID neighbor_allgatherv_init(BUFFER x1, COUNT sendcount, DATATYPE sen
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_request);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
-    } else {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(displs, tmp_displs);
     }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -50,9 +50,6 @@ PROTOTYPE VOID neighbor_allgatherv(BUFFER x1, COUNT sendcount, DATATYPE sendtype
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
 
     PMPI_Comm_size(c_comm, &size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,10 +30,13 @@ PROTOTYPE VOID neighbor_alltoall_init(BUFFER x1, COUNT sendcount, DATATYPE sendt
 {
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    MPI_Datatype c_sendtype, c_recvtype;
+    MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
+    MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     MPI_Request c_request;
     MPI_Info c_info;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
 
     c_info = PMPI_Info_f2c(*info);
 
@@ -50,18 +53,15 @@ PROTOTYPE VOID neighbor_alltoall_init(BUFFER x1, COUNT sendcount, DATATYPE sendt
         return;
     }
 
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
-
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf,
-                          (@COUNT_TYPE@) *sendcount,
+                          c_sendcount,
                           c_sendtype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, 
 			  c_comm,
 			  c_info,

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,8 +30,11 @@ PROTOTYPE VOID neighbor_alltoall(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
 {
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    MPI_Datatype c_sendtype, c_recvtype;
+    MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
+    MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_sendcount = (@COUNT_TYPE@)*sendcount;
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -46,18 +49,15 @@ PROTOTYPE VOID neighbor_alltoall(BUFFER x1, COUNT sendcount, DATATYPE sendtype,
         return;
     }
 
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
-
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf,
-                          (@COUNT_TYPE@) *sendcount,
+                          c_sendcount,
                           c_sendtype,
                           recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_recvtype, c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,8 @@ PROTOTYPE VOID neighbor_alltoallv_init(BUFFER x1, COUNT_ARRAY sendcounts, DISP_A
 				       REQUEST_OUT request)
 {
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    MPI_Datatype c_sendtype, c_recvtype;
+    MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
+    MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);;
     MPI_Info c_info;
     MPI_Request c_request;
     int size, c_ierr, idx = 0;
@@ -56,8 +57,6 @@ PROTOTYPE VOID neighbor_alltoallv_init(BUFFER x1, COUNT_ARRAY sendcounts, DISP_A
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
 
     PMPI_Comm_size(c_comm, &size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
@@ -84,14 +83,10 @@ PROTOTYPE VOID neighbor_alltoallv_init(BUFFER x1, COUNT_ARRAY sendcounts, DISP_A
 
     if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_request);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(rdispls, tmp_rdispls, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sdispls, tmp_sdispls, c_request, c_ierr, idx);
-    } else {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(rdispls, tmp_rdispls);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
     }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(rdispls, tmp_rdispls, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sdispls, tmp_sdispls, c_request, c_ierr, idx);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,7 +30,8 @@ PROTOTYPE VOID neighbor_alltoallv(BUFFER x1, COUNT_ARRAY sendcounts, DISP_ARRAY 
                                   COMM comm)
 {
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
-    MPI_Datatype c_sendtype, c_recvtype;
+    MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
+    MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
     int size, c_ierr;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
@@ -50,8 +51,6 @@ PROTOTYPE VOID neighbor_alltoallv(BUFFER x1, COUNT_ARRAY sendcounts, DISP_ARRAY 
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    c_sendtype = PMPI_Type_f2c(*sendtype);
-    c_recvtype = PMPI_Type_f2c(*recvtype);
 
     PMPI_Comm_size(c_comm, &size);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -90,17 +90,12 @@ PROTOTYPE VOID neighbor_alltoallw_init(BUFFER x1, COUNT_ARRAY sendcounts,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_request);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(rdispls, tmp_rdispls, c_request, c_ierr, idx);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sdispls, tmp_sdispls, c_request, c_ierr, idx);
-    } else {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(rdispls, tmp_rdispls);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
     }
 
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(rdispls, tmp_rdispls, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sdispls, tmp_sdispls, c_request, c_ierr, idx);
 
     free(c_sendtypes);
     free(c_recvtypes);

--- a/ompi/mpi/fortran/use-mpi-f08/pack_external_size.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_external_size.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,9 +26,10 @@ PROTOTYPE VOID pack_external_size(CHAR_ARRAY datarep, COUNT incount,
 {
     int c_ierr;
     MPI_Datatype type = PMPI_Type_f2c(*datatype);
+    @COUNT_TYPE@ c_incount = (@COUNT_TYPE@)*incount;
 
     c_ierr = @INNER_CALL@(datarep,
-                          OMPI_FINT_2_INT(*incount),
+                          c_incount,
                           type, size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/pack_external_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_external_ts.c.in
@@ -29,7 +29,7 @@ PROTOTYPE VOID pack_external(CHAR_ARRAY datarep, BUFFER x1, COUNT incount,
     MPI_Datatype c_datatype, c_type = PMPI_Type_f2c(*datatype);
     void *inbuf = OMPI_CFI_BASE_ADDR(x1);
     char *outbuf = OMPI_CFI_BASE_ADDR(x2);
-    int c_incount = OMPI_FINT_2_INT(*incount);
+    @COUNT_TYPE@ c_incount = (@COUNT_TYPE@)(*incount);
 
     OMPI_CFI_2_C(x1, c_incount, c_type, c_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {

--- a/ompi/mpi/fortran/use-mpi-f08/pack_size.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_size.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -27,17 +27,18 @@ PROTOTYPE VOID pack_size(COUNT incount, DATATYPE datatype,
     int c_ierr;
     MPI_Comm c_comm;
     MPI_Datatype c_type;
-    OMPI_SINGLE_NAME_DECL(size);
+    @COUNT_TYPE@ c_size;
+    @COUNT_TYPE@ c_incount = (@COUNT_TYPE@)*incount;
 
     c_comm = PMPI_Comm_f2c(*comm);
     c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*incount),
+    c_ierr = @INNER_CALL@(c_incount,
                           c_type, c_comm,
-                          OMPI_SINGLE_NAME_CONVERT(size));
+                          &c_size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-        OMPI_SINGLE_INT_2_FINT(size);
+        *size = (@COUNT_FINT_TYPE@)(c_size);
     }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/pack_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_ts.c.in
@@ -28,13 +28,11 @@ PROTOTYPE VOID pack(BUFFER x1, COUNT incount, DATATYPE datatype,
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_datatype, c_type = PMPI_Type_f2c(*datatype);
-    OMPI_SINGLE_NAME_DECL(position);
     void *inbuf = OMPI_CFI_BASE_ADDR(x1);
     char *outbuf = OMPI_CFI_BASE_ADDR(x2);
-    int c_incount = OMPI_FINT_2_INT(*incount);
-    int c_outsize = OMPI_FINT_2_INT(*outsize);
-
-    OMPI_SINGLE_FINT_2_INT(position);
+    @COUNT_TYPE@ c_position = (@COUNT_TYPE@)(*position);
+    @COUNT_TYPE@ c_incount = (@COUNT_TYPE@)(*incount);
+    @COUNT_TYPE@ c_outsize = (@COUNT_TYPE@)(*outsize);
 
     OMPI_CFI_2_C(x1, c_incount, c_type, c_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -53,10 +51,12 @@ PROTOTYPE VOID pack(BUFFER x1, COUNT incount, DATATYPE datatype,
         return;
     }
 
-    c_ierr = @INNER_CALL@(OMPI_F2C_BOTTOM(inbuf), c_incount,
-                       c_datatype, outbuf,
+    c_ierr = @INNER_CALL@(OMPI_F2C_BOTTOM(inbuf),
+                       c_incount,
+                       c_datatype,
+                       outbuf,
                        c_outsize,
-                       OMPI_SINGLE_NAME_CONVERT(position),
+                       &c_position,
                        c_comm);
     if (c_datatype != c_type) {
         ompi_datatype_destroy(&c_datatype);
@@ -64,6 +64,6 @@ PROTOTYPE VOID pack(BUFFER x1, COUNT incount, DATATYPE datatype,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-        OMPI_SINGLE_INT_2_FINT(position);
+        *position = (@COUNT_FINT_TYPE@)(c_position);
     }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/put_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/put_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,6 +32,7 @@ PROTOTYPE VOID put(BUFFER x, COUNT origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     char *origin_addr = OMPI_CFI_BASE_ADDR(x);
     @COUNT_TYPE@ c_origin_count = (@COUNT_TYPE@)*origin_count;
+    @COUNT_TYPE@ c_target_count = (@COUNT_TYPE@)*target_count;
 
     OMPI_CFI_2_C(x, c_origin_count, c_origin_type, c_origin_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -44,7 +45,7 @@ PROTOTYPE VOID put(BUFFER x, COUNT origin_count,
                           c_origin_datatype,
                           OMPI_FINT_2_INT(*target_rank),
                           *target_disp,
-                          (@COUNT_TYPE@) *target_count,
+                          c_target_count,
                           c_target_datatype, c_win);
     if (c_origin_datatype != c_origin_type) {
         ompi_datatype_destroy(&c_origin_datatype);

--- a/ompi/mpi/fortran/use-mpi-f08/raccumulate_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/raccumulate_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -39,6 +39,7 @@ PROTOTYPE VOID raccumulate(BUFFER x, COUNT origin_count,
     MPI_Request c_req;
     char *origin_addr = OMPI_CFI_BASE_ADDR(x);
     @COUNT_TYPE@ c_origin_count = (@COUNT_TYPE@) *origin_count;
+    @COUNT_TYPE@ c_target_count = (@COUNT_TYPE@) *target_count;
 
     OMPI_CFI_2_C(x, c_origin_count, c_origin_type, c_origin_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -51,7 +52,7 @@ PROTOTYPE VOID raccumulate(BUFFER x, COUNT origin_count,
                           c_origin_datatype,
                           OMPI_FINT_2_INT(*target_rank),
                           *target_disp,
-                          (@COUNT_TYPE@) *target_count,
+                          c_target_count,
                           c_target_datatype, c_op, c_win,
                           &c_req);
     if (c_origin_datatype != c_origin_type) {

--- a/ompi/mpi/fortran/use-mpi-f08/reduce_local_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/reduce_local_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,6 +28,7 @@ PROTOTYPE VOID reduce_local(BUFFER x1, BUFFER_OUT x2, COUNT count,
     MPI_Datatype c_type;
     MPI_Op c_op;
     char *inbuf = OMPI_CFI_BASE_ADDR(x1), *inoutbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -49,7 +50,7 @@ PROTOTYPE VOID reduce_local(BUFFER x1, BUFFER_OUT x2, COUNT count,
     inoutbuf = (char *) OMPI_F2C_BOTTOM(inoutbuf);
 
     c_ierr = @INNER_CALL@(inbuf, inoutbuf,
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_type, c_op);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_block_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_block_init_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -34,6 +34,7 @@ PROTOTYPE VOID reduce_scatter_block_init(BUFFER x1, BUFFER_OUT x2,
     MPI_Request c_request;
     int size;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
 
     c_info = PMPI_Info_f2c(*info);
 
@@ -59,7 +60,7 @@ PROTOTYPE VOID reduce_scatter_block_init(BUFFER x1, BUFFER_OUT x2,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_type, c_op, c_comm,
 			  c_info, &c_request);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_block_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_block_ts.c.in
@@ -31,6 +31,7 @@ PROTOTYPE VOID reduce_scatter_block(BUFFER x1, BUFFER_OUT x2,
     MPI_Op c_op;
     int size;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_recvcount = (@COUNT_TYPE@)*recvcount;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -54,7 +55,7 @@ PROTOTYPE VOID reduce_scatter_block(BUFFER x1, BUFFER_OUT x2,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *recvcount,
+                          c_recvcount,
                           c_type, c_op, c_comm);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/reduce_scatter_init_ts.c.in
@@ -26,7 +26,7 @@ PROTOTYPE VOID reduce_scatter_init(BUFFER x1, BUFFER_OUT x2,
                                    OP op, COMM comm, INFO info, 
 				   REQUEST_OUT request)
 {
-    int c_ierr;
+    int c_ierr, idx = 0;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_type;
     MPI_Op c_op;
@@ -71,14 +71,10 @@ PROTOTYPE VOID reduce_scatter_init(BUFFER x1, BUFFER_OUT x2,
 			  &c_request);
     if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_request);
-	if ((recvcounts != NULL) && (recvcounts != tmp_recvcounts)) {
-            ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
-            nb_request->data.release_arrays[0] = tmp_recvcounts;
-            nb_request->data.release_arrays[1] = NULL;
-	}
-    } else {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
     }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(recvcounts, tmp_recvcounts, c_request, c_ierr, idx);
+
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
 }

--- a/ompi/mpi/fortran/use-mpi-f08/rget_accumulate_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/rget_accumulate_ts.c.in
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -40,6 +40,7 @@ PROTOTYPE VOID rget_accumulate(BUFFER_ASYNC x1, COUNT origin_count,
     MPI_Op c_op = PMPI_Op_f2c(*op);
     char *origin_addr = OMPI_CFI_BASE_ADDR(x1);
     @COUNT_TYPE@ c_origin_count = (@COUNT_TYPE@) *origin_count;
+    @COUNT_TYPE@ c_target_count = (@COUNT_TYPE@) *target_count;
     char *result_addr = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ c_result_count = (@COUNT_TYPE@) *result_count;
     MPI_Request c_req;
@@ -67,7 +68,7 @@ PROTOTYPE VOID rget_accumulate(BUFFER_ASYNC x1, COUNT origin_count,
                           c_result_datatype,
                           OMPI_FINT_2_INT(*target_rank),
                           *target_disp,
-                          (@COUNT_TYPE@) *target_count,
+                          c_target_count,
                           c_target_datatype, c_op, c_win, &c_req);
     if (c_origin_datatype != c_origin_type) {
         ompi_datatype_destroy(&c_origin_datatype);

--- a/ompi/mpi/fortran/use-mpi-f08/rget_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/rget_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -35,6 +35,7 @@ PROTOTYPE VOID rget(BUFFER_ASYNC_OUT x, COUNT origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     char *origin_addr = OMPI_CFI_BASE_ADDR(x);
     @COUNT_TYPE@ c_origin_count = (@COUNT_TYPE@) *origin_count;
+    @COUNT_TYPE@ c_target_count = (@COUNT_TYPE@) *target_count;
     MPI_Request c_req;
 
     OMPI_CFI_2_C(x, c_origin_count, c_origin_type, c_origin_datatype, c_ierr);
@@ -48,7 +49,7 @@ PROTOTYPE VOID rget(BUFFER_ASYNC_OUT x, COUNT origin_count,
                           c_origin_datatype,
                           OMPI_FINT_2_INT(*target_rank),
                           *target_disp,
-                          (@COUNT_TYPE@) *target_count,
+                          c_target_count,
                           c_target_datatype, c_win, &c_req);
     if (c_origin_datatype != c_origin_type) {
         ompi_datatype_destroy(&c_origin_datatype);

--- a/ompi/mpi/fortran/use-mpi-f08/rput_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/rput_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -35,6 +35,7 @@ PROTOTYPE VOID rput(BUFFER_ASYNC x, COUNT origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     char *origin_addr = OMPI_CFI_BASE_ADDR(x);
     @COUNT_TYPE@ c_origin_count = (@COUNT_TYPE@) *origin_count;
+    @COUNT_TYPE@ c_target_count = (@COUNT_TYPE@) *target_count;
     MPI_Request c_req;
 
     OMPI_CFI_2_C(x, c_origin_count, c_origin_type, c_origin_datatype, c_ierr);
@@ -48,7 +49,7 @@ PROTOTYPE VOID rput(BUFFER_ASYNC x, COUNT origin_count,
                           c_origin_datatype,
                           OMPI_FINT_2_INT(*target_rank),
                           *target_disp,
-                          (@COUNT_TYPE@) *target_count,
+                          c_target_count,
                           c_target_datatype, c_win, &c_req);
     if (c_origin_datatype != c_origin_type) {
         ompi_datatype_destroy(&c_origin_datatype);

--- a/ompi/mpi/fortran/use-mpi-f08/scan_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/scan_init_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,6 +32,7 @@ PROTOTYPE VOID scan_init(BUFFER x1, BUFFER_OUT x2, COUNT count,
     MPI_Info c_info;
     MPI_Request c_request;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
     c_info = PMPI_Info_f2c(*info);
 
@@ -56,7 +57,7 @@ PROTOTYPE VOID scan_init(BUFFER x1, BUFFER_OUT x2, COUNT count,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_type, c_op,
                           c_comm,
 			  c_info,

--- a/ompi/mpi/fortran/use-mpi-f08/scan_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/scan_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,6 +29,7 @@ PROTOTYPE VOID scan(BUFFER x1, BUFFER_OUT x2, COUNT count,
     MPI_Datatype c_type;
     MPI_Op c_op;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -51,7 +52,7 @@ PROTOTYPE VOID scan(BUFFER x1, BUFFER_OUT x2, COUNT count,
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = @INNER_CALL@(sendbuf, recvbuf,
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_type, c_op,
                           c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/scatterv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/scatterv_init_ts.c.in
@@ -106,18 +106,10 @@ PROTOTYPE VOID scatterv_init(BUFFER x1, COUNT_ARRAY sendcounts,
     }
     if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_request);
-        ompi_coll_base_nbc_request_t* nb_request = (ompi_coll_base_nbc_request_t*)c_request;
-        if (tmp_sendcounts != sendcounts) {
-            nb_request->data.release_arrays[idx++] = tmp_sendcounts;
-	}
-        if (tmp_displs !=  displs) {
-            nb_request->data.release_arrays[idx++] = tmp_displs;
-        }
-        nb_request->data.release_arrays[idx]   = NULL;
-     } else {
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
-        OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(displs, tmp_displs);
-     }
+    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(sendcounts, tmp_sendcounts, c_request, c_ierr, idx);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP_NONBLOCKING(displs, tmp_displs, c_request, c_ierr, idx);
 
      if ((c_recvdatatype != NULL ) && (c_recvdatatype != c_recvtype)){
         ompi_datatype_destroy(&c_recvdatatype);

--- a/ompi/mpi/fortran/use-mpi-f08/sendrecv_replace_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/sendrecv_replace_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,7 @@ PROTOTYPE VOID sendrecv_replace(BUFFER_OUT x, COUNT count, DATATYPE datatype,
 
     MPI_Status c_status;
     void *buf = OMPI_CFI_BASE_ADDR(x);
-    @COUNT_TYPE@  __opal_attribute_unused__ c_count = (@COUNT_TYPE@) *count;
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@) *count;
 
     OMPI_CFI_2_C(x, c_count, c_type, c_datatype, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -42,7 +42,7 @@ PROTOTYPE VOID sendrecv_replace(BUFFER_OUT x, COUNT count, DATATYPE datatype,
     }
 
     c_ierr = @INNER_CALL@(OMPI_F2C_BOTTOM(buf),
-                          (@COUNT_TYPE@) *count,
+                          c_count,
                           c_datatype,
                           OMPI_FINT_2_INT(*dest),
                           OMPI_FINT_2_INT(*sendtag),

--- a/ompi/mpi/fortran/use-mpi-f08/status_set_elements_c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/status_set_elements_c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -22,11 +22,12 @@
  */
 
 PROTOTYPE VOID status_set_elements(STATUS status, DATATYPE datatype,
-			           COUNT_OUT count)
+			           COUNT count)
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
     MPI_Status c_status;
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
     /* This seems silly, but someone will do it */
 
@@ -35,8 +36,7 @@ PROTOTYPE VOID status_set_elements(STATUS status, DATATYPE datatype,
     } else {
         PMPI_Status_f2c( status, &c_status );
 
-        c_ierr = @INNER_CALL@(&c_status, c_type,
-                                         OMPI_FINT_2_INT(*count));
+        c_ierr = @INNER_CALL@(&c_status, c_type, c_count);
 
         /* If datatype is really being set, then that needs to be
            converted.... */

--- a/ompi/mpi/fortran/use-mpi-f08/testany.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/testany.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,9 +26,8 @@ PROTOTYPE VOID testany(INT count, REQUEST_ARRAY array_of_requests:count, INT ind
 {
     MPI_Request *c_req;
     MPI_Status c_status;
-    int i, c_ierr;
-    OMPI_LOGICAL_NAME_DECL(flag);
-    OMPI_SINGLE_NAME_DECL(indx);
+    int i, c_ierr, c_flag;
+    int tmp_indx;
 
     /* Shortcut to avoid malloc(0) if *count==0.  We're intentionally
        skipping other parameter error checks. */
@@ -54,24 +53,23 @@ PROTOTYPE VOID testany(INT count, REQUEST_ARRAY array_of_requests:count, INT ind
     }
 
     c_ierr = PMPI_Testany(OMPI_FINT_2_INT(*count), c_req,
-                         OMPI_SINGLE_NAME_CONVERT(indx),
-                         OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
+                          &tmp_indx,
+                          &c_flag,
                          &c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    OMPI_SINGLE_INT_2_LOGICAL(flag);
     if (MPI_SUCCESS == c_ierr) {
 
         /* Increment index by one for fortran conventions.  Note that
            all Fortran compilers have FALSE==0; we just need to check
            for any nonzero value (because TRUE is not always 1) */
 
-        OMPI_SINGLE_INT_2_FINT(indx);
-        if (*flag &&
-            MPI_UNDEFINED != *(OMPI_SINGLE_NAME_CONVERT(indx))) {
-            array_of_requests[OMPI_INT_2_FINT(*indx)] =
-                c_req[OMPI_INT_2_FINT(*indx)]->req_f_to_c_index;
-            ++(*indx);
+        if (c_flag &&
+            MPI_UNDEFINED != tmp_indx) {
+            array_of_requests[tmp_indx] =
+                c_req[tmp_indx]->req_f_to_c_index;
+            *indx = OMPI_INT_2_FINT(tmp_indx+1);
+            *flag = OMPI_INT_2_FINT(c_flag);
         }
         if (!OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
             PMPI_Status_c2f(&c_status, status);

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_darray.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_darray.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,30 +30,30 @@ PROTOTYPE VOID  type_create_darray(INT size, RANK rank,
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
-    OMPI_ARRAY_NAME_DECL(gsize_array);
-    OMPI_ARRAY_NAME_DECL(distrib_array);
-    OMPI_ARRAY_NAME_DECL(darg_array);
-    OMPI_ARRAY_NAME_DECL(psize_array);
+    @COUNT_TYPE@ *tmp_gsize_array = NULL;
+    int *tmp_distrib_array = NULL;
+    int *tmp_darg_array = NULL;
+    int *tmp_psize_array = NULL;
 
-    OMPI_ARRAY_FINT_2_INT(gsize_array, *ndims);
-    OMPI_ARRAY_FINT_2_INT(distrib_array, *ndims);
-    OMPI_ARRAY_FINT_2_INT(darg_array, *ndims);
-    OMPI_ARRAY_FINT_2_INT(psize_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(gsize_array, tmp_gsize_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(distrib_array, tmp_distrib_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(darg_array, tmp_darg_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(psize_array, tmp_psize_array, *ndims);
 
     c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*size),
                                     OMPI_FINT_2_INT(*rank),
                                     OMPI_FINT_2_INT(*ndims),
-                                    OMPI_ARRAY_NAME_CONVERT(gsize_array),
-                                    OMPI_ARRAY_NAME_CONVERT(distrib_array),
-                                    OMPI_ARRAY_NAME_CONVERT(darg_array),
-                                    OMPI_ARRAY_NAME_CONVERT(psize_array),
+                                    tmp_gsize_array,
+                                    tmp_distrib_array,
+                                    tmp_darg_array,
+                                    tmp_psize_array,
                                     OMPI_FINT_2_INT(*order), c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(gsize_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(distrib_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(darg_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(psize_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(gsize_array, tmp_gsize_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(distrib_array, tmp_distrib_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(darg_array, tmp_darg_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(psize_array, tmp_psize_array);
 
     if (MPI_SUCCESS == c_ierr) {
       *newtype = PMPI_Type_c2f(c_new);

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_hindexed.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_hindexed.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -30,12 +30,12 @@ PROTOTYPE VOID type_create_hindexed(COUNT count,
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
-    OMPI_ARRAY_NAME_DECL(array_of_blocklengths);
+    @COUNT_TYPE@ *tmp_array_of_blocklengths = NULL;
 
-    OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_blocklengths, tmp_array_of_blocklengths, *count);
 
     c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-                                OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
+                                tmp_array_of_blocklengths,
                                 array_of_displacements, c_old,
                                 &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
@@ -44,5 +44,5 @@ PROTOTYPE VOID type_create_hindexed(COUNT count,
         *newtype = PMPI_Type_c2f(c_new);
     }
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_blocklengths);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_blocklengths, tmp_array_of_blocklengths);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_hvector.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_hvector.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,9 +28,11 @@ PROTOTYPE VOID type_create_hvector(COUNT count, COUNT blocklength,
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
+    @COUNT_TYPE@ c_blocklength = (@COUNT_TYPE@)*blocklength;
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-                              OMPI_FINT_2_INT(*blocklength),
+    c_ierr = @INNER_CALL@(c_count,
+                              c_blocklength,
                               *stride,
                               c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_indexed_block.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_indexed_block.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,13 +28,15 @@ PROTOTYPE VOID type_create_indexed_block(COUNT count, COUNT blocklength,
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
-    OMPI_ARRAY_NAME_DECL(array_of_displacements);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
+    @COUNT_TYPE@ c_blocklength = (@COUNT_TYPE@)*blocklength;
+    @COUNT_TYPE@ *tmp_array_of_displacements = NULL;
 
-    OMPI_ARRAY_FINT_2_INT(array_of_displacements, *count);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_displacements, tmp_array_of_displacements, *count);
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-			OMPI_FINT_2_INT(*blocklength),
-			OMPI_ARRAY_NAME_CONVERT(array_of_displacements),
+    c_ierr = @INNER_CALL@(c_count,
+			c_blocklength,
+			tmp_array_of_displacements,
                         c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
@@ -42,6 +44,5 @@ PROTOTYPE VOID type_create_indexed_block(COUNT count, COUNT blocklength,
         *newtype = PMPI_Type_c2f(c_new);
     }
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_displacements);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_displacements, tmp_array_of_displacements);
 }
-

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_struct.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_struct.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,9 +28,10 @@ PROTOTYPE VOID  type_create_struct(COUNT count,
 			           DATATYPE_OUT newtype)
 {
     MPI_Datatype c_new;
-    MPI_Datatype *c_type_old_array;
+    MPI_Datatype *c_type_old_array = NULL;
     int i, c_ierr;
-    OMPI_ARRAY_NAME_DECL(array_of_block_lengths);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
+    @COUNT_TYPE@ *tmp_array_of_block_lengths = NULL;
 
     c_type_old_array = (MPI_Datatype *) malloc(*count * sizeof(MPI_Datatype));
     if (NULL == c_type_old_array) {
@@ -44,14 +45,15 @@ PROTOTYPE VOID  type_create_struct(COUNT count,
         c_type_old_array[i] = PMPI_Type_f2c(array_of_types[i]);
     }
 
-    OMPI_ARRAY_FINT_2_INT(array_of_block_lengths, *count);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_block_lengths, tmp_array_of_block_lengths, *count);
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-			   OMPI_ARRAY_NAME_CONVERT(array_of_block_lengths),
-                           array_of_displacements, c_type_old_array, &c_new);
+    c_ierr = @INNER_CALL@(c_count,
+			   tmp_array_of_block_lengths,
+                           array_of_displacements,
+                           c_type_old_array, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_block_lengths);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_block_lengths, tmp_array_of_block_lengths);
 
     if (MPI_SUCCESS == c_ierr) {
         *newtype = PMPI_Type_c2f(c_new);

--- a/ompi/mpi/fortran/use-mpi-f08/type_create_subarray.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_create_subarray.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,20 +29,20 @@ PROTOTYPE VOID type_create_subarray(INT ndims,  COUNT_ARRAY size_array,
     int c_ierr;
     MPI_Datatype c_old;
     MPI_Datatype c_new;
-    OMPI_ARRAY_NAME_DECL(size_array);
-    OMPI_ARRAY_NAME_DECL(subsize_array);
-    OMPI_ARRAY_NAME_DECL(start_array);
+    @COUNT_TYPE@ *tmp_size_array = NULL;
+    @COUNT_TYPE@ *tmp_subsize_array = NULL;
+    @COUNT_TYPE@ *tmp_start_array = NULL;
 
     c_old = PMPI_Type_f2c(*oldtype);
 
-    OMPI_ARRAY_FINT_2_INT(size_array, *ndims);
-    OMPI_ARRAY_FINT_2_INT(subsize_array, *ndims);
-    OMPI_ARRAY_FINT_2_INT(start_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(size_array, tmp_size_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(subsize_array, tmp_subsize_array, *ndims);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(start_array, tmp_start_array, *ndims);
 
     c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*ndims),
-                          OMPI_ARRAY_NAME_CONVERT(size_array),
-                          OMPI_ARRAY_NAME_CONVERT(subsize_array),
-                          OMPI_ARRAY_NAME_CONVERT(start_array),
+                          tmp_size_array,
+                          tmp_subsize_array,
+                          tmp_start_array,
                           *order, c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
@@ -50,7 +50,7 @@ PROTOTYPE VOID type_create_subarray(INT ndims,  COUNT_ARRAY size_array,
         *newtype = PMPI_Type_c2f(c_new);
     }
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(size_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(subsize_array);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(start_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(size_array, tmp_size_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(subsize_array, tmp_subsize_array);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(start_array, tmp_start_array);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/type_indexed.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_indexed.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,20 +28,21 @@ PROTOTYPE VOID type_indexed(COUNT count, COUNT_ARRAY array_of_blocklengths,
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
-    OMPI_ARRAY_NAME_DECL(array_of_blocklengths);
-    OMPI_ARRAY_NAME_DECL(array_of_displacements);
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
+    @COUNT_TYPE@ *tmp_array_of_blocklengths = NULL;
+    @COUNT_TYPE@ *tmp_array_of_displacements = NULL;
 
-    OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
-    OMPI_ARRAY_FINT_2_INT(array_of_displacements, *count);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_blocklengths, tmp_array_of_blocklengths, *count);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(array_of_displacements, tmp_array_of_displacements, *count);
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-                              OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
-                              OMPI_ARRAY_NAME_CONVERT(array_of_displacements),
-                              c_old, &c_new);
+    c_ierr = @INNER_CALL@(c_count,
+                          tmp_array_of_blocklengths,
+                          tmp_array_of_displacements,
+                          c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_blocklengths);
-    OMPI_ARRAY_FINT_2_INT_CLEANUP(array_of_displacements);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_blocklengths, tmp_array_of_blocklengths);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(array_of_displacements, tmp_array_of_displacements);
 
     if (MPI_SUCCESS == c_ierr) {
         *newtype = PMPI_Type_c2f(c_new);

--- a/ompi/mpi/fortran/use-mpi-f08/type_size.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_size.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -25,12 +25,11 @@ PROTOTYPE VOID type_size(DATATYPE type, COUNT size)
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
-    OMPI_SINGLE_NAME_DECL(size);
+    @COUNT_TYPE@ c_size;
 
-    c_ierr = @INNER_CALL@(c_type, OMPI_SINGLE_NAME_CONVERT(size));
-    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
-
-    if (MPI_SUCCESS == c_ierr) {
-        OMPI_SINGLE_INT_2_FINT(size);
+    c_ierr = @INNER_CALL@(c_type, &c_size);
+    if (MPI_SUCCESS == c_ierr)  {
+        *size = (@COUNT_FINT_TYPE@)(c_size);
     }
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/type_vector.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_vector.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,13 +28,16 @@ PROTOTYPE VOID  type_vector(COUNT count, COUNT blocklength,
     int c_ierr;
     MPI_Datatype c_old;
     MPI_Datatype c_new;
+    @COUNT_TYPE@ c_count = (@COUNT_TYPE@)*count;
+    @COUNT_TYPE@ c_blocklength = (@COUNT_TYPE@)*blocklength;
+    @COUNT_TYPE@ c_stride = (@COUNT_TYPE@)*stride;
 
     c_old = PMPI_Type_f2c(*oldtype);
 
-    c_ierr = @INNER_CALL@(OMPI_FINT_2_INT(*count),
-                             OMPI_FINT_2_INT(*blocklength),
-                             OMPI_FINT_2_INT(*stride),
-                             c_old, &c_new);
+    c_ierr = @INNER_CALL@(c_count,
+                          c_blocklength,
+                          c_stride,
+                          c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/use-mpi-f08/unpack_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/unpack_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -22,16 +22,17 @@
  */
 
 PROTOTYPE VOID unpack(BUFFER x1, COUNT insize, COUNT_INOUT position,
-                      BUFFER_OUT x2, COUNT_OUT outcount, DATATYPE datatype,
+                      BUFFER_OUT x2, COUNT outcount, DATATYPE datatype,
                       COMM comm)
 {
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_datatype, c_type = PMPI_Type_f2c(*datatype);
-    OMPI_SINGLE_NAME_DECL(position);
     char *inbuf = OMPI_CFI_BASE_ADDR(x1);
     void *outbuf = OMPI_CFI_BASE_ADDR(x2);
-    int c_outcount = OMPI_FINT_2_INT(*outcount);
+    @COUNT_TYPE@ c_outcount = (@COUNT_TYPE@)(*outcount);
+    @COUNT_TYPE@ c_position = (@COUNT_TYPE@)(*position);
+    @COUNT_TYPE@ c_insize = (@COUNT_TYPE@)(*insize);
 
     OMPI_CFI_CHECK_CONTIGUOUS(x1, c_ierr);
     if (MPI_SUCCESS != c_ierr) {
@@ -47,10 +48,9 @@ PROTOTYPE VOID unpack(BUFFER x1, COUNT insize, COUNT_INOUT position,
         return;
     }
 
-    OMPI_SINGLE_FINT_2_INT(position);
-
-    c_ierr = @INNER_CALL@(inbuf, OMPI_FINT_2_INT(*insize),
-                         OMPI_SINGLE_NAME_CONVERT(position),
+    c_ierr = @INNER_CALL@(inbuf, 
+                         c_insize,
+                         &c_position,
                          OMPI_F2C_BOTTOM(outbuf), c_outcount,
                          c_datatype, c_comm);
     if (c_datatype != c_type) {
@@ -59,6 +59,6 @@ PROTOTYPE VOID unpack(BUFFER x1, COUNT insize, COUNT_INOUT position,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {
-         OMPI_SINGLE_INT_2_FINT(position);
+         *position = (@COUNT_FINT_TYPE@)(c_position);
      }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/win_allocate.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/win_allocate.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,11 +29,12 @@ PROTOTYPE VOID win_allocate(AINT size, DISP disp_unit,
     MPI_Info c_info;
     MPI_Comm c_comm;
     MPI_Win c_win;
+    @DISP_TYPE@ c_disp_unit = (@DISP_TYPE@)*disp_unit;
 
     c_info = PMPI_Info_f2c(*info);
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = @INNER_CALL@(*size, OMPI_FINT_2_INT(*disp_unit),
+    c_ierr = @INNER_CALL@(*size, c_disp_unit,
                                      c_info, c_comm,
                                      baseptr, &c_win);
     *win = PMPI_Win_c2f(c_win);

--- a/ompi/mpi/fortran/use-mpi-f08/win_allocate_shared.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/win_allocate_shared.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,11 +29,12 @@ PROTOTYPE VOID win_allocate_shared(AINT size, DISP disp_unit,
     MPI_Info c_info;
     MPI_Comm c_comm;
     MPI_Win c_win;
+    @DISP_TYPE@ c_disp_unit = (@DISP_TYPE@)*disp_unit;
 
     c_info = PMPI_Info_f2c(*info);
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = @INNER_CALL@(*size, OMPI_FINT_2_INT(*disp_unit),
+    c_ierr = @INNER_CALL@(*size, c_disp_unit,
                                      c_info, c_comm,
                                      baseptr, &c_win);
     *win = PMPI_Win_c2f(c_win);

--- a/ompi/mpi/fortran/use-mpi-f08/win_create_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/win_create_ts.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -28,13 +28,14 @@ PROTOTYPE VOID win_create(BUFFER x, AINT size, DISP disp_unit,
     MPI_Win c_win;
     MPI_Info c_info;
     MPI_Comm c_comm;
+    @DISP_TYPE@ c_disp_unit = (@DISP_TYPE@)*disp_unit;
 
     c_comm = PMPI_Comm_f2c(*comm);
     c_info = PMPI_Info_f2c(*info);
 
     if (OMPI_CFI_IS_CONTIGUOUS(x)) {
         c_ierr = @INNER_CALL@(OMPI_CFI_BASE_ADDR(x), *size,
-                                 OMPI_FINT_2_INT(*disp_unit),
+                                 c_disp_unit,
                                  c_info, c_comm, &c_win);
     } else {
         c_ierr = MPI_ERR_BUFFER;

--- a/ompi/mpi/fortran/use-mpi-f08/win_shared_query.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/win_shared_query.c.in
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,12 +26,15 @@ PROTOTYPE VOID win_shared_query(WIN win, INT rank, AINT_OUT size,
 {
     int c_ierr;
     MPI_Win c_win;
-    OMPI_SINGLE_NAME_DECL(disp_unit);
+    @DISP_TYPE@ c_disp_unit;
 
     c_win = PMPI_Win_f2c(*win);
 
     c_ierr = @INNER_CALL@(c_win, OMPI_FINT_2_INT(*rank), size,
-                          OMPI_SINGLE_NAME_CONVERT(disp_unit), baseptr);
+                          &c_disp_unit, baseptr);
+    if (MPI_SUCCESS == c_ierr) {
+        *disp_unit =  (@COUNT_FINT_TYPE@)(c_disp_unit);
+    }
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
 }


### PR DESCRIPTION
This PR refactors some of the f08 template files introduced in PR #12621. Many of them had been using, incorrectly, macros from fint_2_int.h. The code in the use-mpi-f08 folder now makes use of generated code in the wrapper around the internal c code to avoid many of the problems that these older macros were trying to solve by providing 'c' interfaces directly to the fortran compiler.  Also, generalized macros for handling translation of arrays of MPI_Fint's to c int's (and other types) are used in these templates.

Related to #13168 and associated issue raised by a user on the mail list.