### PR TITLE
mpool/hugepage: fix sizing of hugepages

### DIFF
--- a/opal/mca/mpool/hugepage/mpool_hugepage_component.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_component.c
@@ -218,7 +218,6 @@ static void mca_mpool_hugepage_find_hugepages(void)
     mca_mpool_hugepage_hugepage_t *hp;
     FILE *fh;
     struct mntent *mntent;
-    char *opts, *tok, *ctx;
 
     fh = setmntent("/proc/mounts", "r");
     if (NULL == fh) {
@@ -232,6 +231,18 @@ static void mca_mpool_hugepage_find_hugepages(void)
             continue;
         }
 
+#if defined(USE_STATFS)
+        struct statfs info;
+        statfs(mntent->mnt_dir, &info);
+        page_size = info.f_bsize;
+#elif defined(HAVE_STATVFS)
+        struct statvfs info;
+        statvfs(mntent->mnt_dir, &info);
+        page_size = info.f_bsize;
+#else
+        // Fallback for extremely old systems that do not have
+        // statfs().
+        char *opts, *tok, *ctx;
         opts = strdup(mntent->mnt_opts);
         if (NULL == opts) {
             break;
@@ -240,25 +251,19 @@ static void mca_mpool_hugepage_find_hugepages(void)
         tok = strtok_r(opts, ",", &ctx);
         do {
             if (NULL != tok && 0 == strncmp(tok, "pagesize", 8)) {
-                break;
+                // It is expected that pagesize=X will be an integer
+                // number with no units qualifier following it.
+                // Specifically: Linux circa 2025 has /proc/mounts
+                // output like "... rw,relatime,pagesize=2M".  But if
+                // your system is signifncantly older than that
+                // (statfs() was introduced around 1994), we're
+                // assuming that there is no units qualifier.
+                (void) sscanf(tok, "pagesize=%lu", &page_size);
             }
             tok = strtok_r(NULL, ",", &ctx);
         } while (tok);
-
-        if (!tok) {
-#    if defined(USE_STATFS)
-            struct statfs info;
-
-            statfs(mntent->mnt_dir, &info);
-#    elif defined(HAVE_STATVFS)
-            struct statvfs info;
-            statvfs(mntent->mnt_dir, &info);
-#    endif
-            page_size = info.f_bsize;
-        } else {
-            (void) sscanf(tok, "pagesize=%lu", &page_size);
-        }
         free(opts);
+#endif
 
         if (0 == page_size) {
             /* could not get page size */


### PR DESCRIPTION
Really old code was still preferring to parse Linux's /proc/mounts to find the size of hugepages instead of just using statfs() or statvfs() to get the size directly.

Thanks to @wangshaochuang for noticing that the parsing of /proc/mounts wasn't even quite right in modern Linux systems, we have changed the preference in the code to use statfs() / statvfs() if available (which it almost certainly will be), and only fall back to parsing /proc/mounts on really, really, really old systems (where the /proc/mounts parsing will likely be correct).

Refs #13214 