### PR TITLE
v5.0.x: docs: fix typo about --with-ft configure CLI option

### DIFF
--- a/docs/installing-open-mpi/configure-cli-options/misc.rst
+++ b/docs/installing-open-mpi/configure-cli-options/misc.rst
@@ -20,8 +20,8 @@ above categories that can be used with ``configure``:
 
 * ``--with-ft=TYPE``:
   Specify the type of fault tolerance to enable.  The only allowed
-  values are ``ulfm`` and ``none``.  See :ref:`the ULFM section
-  <ulfm-label>` for more details.
+  values are ``ulfm`` and ``no`` (the default value is ``no``).  See
+  :ref:`the ULFM section <ulfm-label>` for more details.
 
 * ``--enable-peruse``:
   Enable the PERUSE MPI data analysis interface.


### PR DESCRIPTION
Thanks to Tibor Győri (@TiborGY) for reporting the issue.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit fb9ee3e1ffe317a9475d64c84a34b9c86cf4c3bd)

Fixes #13232