### PR TITLE
docs: Add a "Last updated on:" HTML footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,6 +233,8 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
 
+# Put a "Last updated on:" timestamp at the bottom of each page.
+html_last_updated_fmt = '%Y-%m-%d %H:%M:%S %Z'
 
 # Short hand external links
 # Allows smoother transitioning for commonly used articles and sites


### PR DESCRIPTION
This shows the build time of the document.  Will be useful for docs.open-mpi.org and for the pre-built HTML pages that we ship in distribution tarballs.

It looks like this:

![Screenshot 2025-05-05 at 4 19 43 PM](https://github.com/user-attachments/assets/119591c8-0789-4eae-9026-213afc2f9c53)
