### PR TITLE
v5.0.x: docs: Add a "Last updated on:" HTML footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,6 +233,8 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
 
+# Put a "Last updated on:" timestamp at the bottom of each page.
+html_last_updated_fmt = '%Y-%m-%d %H:%M:%S %Z'
 
 # Short hand external links
 # Allows smoother transitioning for commonly used articles and sites


### PR DESCRIPTION
This shows the build time of the document.  Will be useful for docs.open-mpi.org and for the pre-built HTML pages that we ship in distribution tarballs.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 1f5e1a140fea449ba2cc99bc053788784e9fa3fe)

This is the v5.0.x PR corresponding to main PR #13236