### PR TITLE
configure: be more verbose about fort TS 29113

### DIFF
--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -49,7 +49,11 @@ EOF
         elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPI_BINDINGS ; then
             echo "Build MPI Fortran bindings: mpif.h, use mpi" >&AS_MESSAGE_FD
         elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPIF08_BINDINGS ; then
-            echo "Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08" >&AS_MESSAGE_FD
+            if test $OMPI_FORTRAN_HAVE_TS -eq 1; then
+                echo "Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08(including TS 29113 support)" >&AS_MESSAGE_FD
+            else
+                echo "Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08(NOT including TS 29113 support)" >&AS_MESSAGE_FD
+            fi
         else
             echo "Build MPI Fortran bindings: no" >&AS_MESSAGE_FD
         fi


### PR DESCRIPTION
It turns out that those working with the fortran bindings are becoming increasingly aware of the need to know whether or not Open MPI fortran bindings are being built by a fortran compiler that is 2018 compliant or at least supports 2008 plus TS 29113.

with this patch, when using a fortran compiler that supports TS 29113 features the configury summary will be:

Open MPI configuration:
-----------------------
Version: 5.1.0a1
MPI Standard Version: 3.1
Build MPI C bindings: yes
Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08(TS 29113) 
Build MPI Java bindings (experimental): no
Build Open SHMEM support: false (no spml)
Debug build: no
Platform file: (none)

If the compiler doesn't support TS 29113 features then the (TS 29113) will not be present.