### PR TITLE
fortran: fix common symbol sizes and alignments

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -15,7 +15,7 @@ dnl Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2014-2021 Research Organization for Information Science
+dnl Copyright (c) 2014-2025 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
@@ -142,6 +142,8 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     OMPI_FORTRAN_IKINDS=
     OMPI_FORTRAN_RKINDS=
     OMPI_FORTRAN_CKINDS=
+    OMPI_FORTRAN_GET_COMMON_ALIGNMENT([OMPI_FORTRAN_COMMON_ALIGNMENT])
+    AC_SUBST([OMPI_FORTRAN_COMMON_ALIGNMENT])
 
     # We want to set the #define's for all of these, so invoke the macros
     # regardless of whether we have F77 support or not.

--- a/ompi/include/Makefile.am
+++ b/ompi/include/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
-# Copyright (c) 2014-2021 Research Organization for Information Science
+# Copyright (c) 2014-2025 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # Copyright (c) 2022      IBM Corporation.  All rights reserved.
@@ -110,7 +110,10 @@ mpif-c-constants-decl.h:
 	    --caps $(OMPI_FORTRAN_CAPS) \
 	    --plain $(OMPI_FORTRAN_PLAIN) \
 	    --single $(OMPI_FORTRAN_SINGLE_UNDERSCORE) \
-	    --double $(OMPI_FORTRAN_DOUBLE_UNDERSCORE)
+	    --double $(OMPI_FORTRAN_DOUBLE_UNDERSCORE) \
+	    --status-size $(OMPI_FORTRAN_STATUS_SIZE) \
+	    --align $(OMPI_FORTRAN_COMMON_ALIGNMENT)
+
 
 if WANT_INSTALL_HEADERS
 ompidir = $(ompiincludedir)


### PR DESCRIPTION
with mpif-h and usempi, MPI constants (e.g. MPI_COMM_WORLD) are all parts of a unique common block. Fortran compilers generally have alignment requirements for these (16 with gfortran, 32 with ifort or 64 with nvfortran to name a few), so pass these requirements to the actual symbols that are defined in the C code to make pick linkers (e.g. ubuntu) happy pandas. Such linkers also complain about the size of MPI_STATUS, so define these are arrays intead of pointer.

Refs #13043

Thanks MJ Rutter for the report

back-ported from ec2b164a513dc5550b58f2dffa8f91c002c539c3

:bot:notacherrypick