### PR TITLE
Bring better Fortran TKR support in 4.1

### DIFF
--- a/config/ompi_fortran_check_asynchronous.m4
+++ b/config/ompi_fortran_check_asynchronous.m4
@@ -11,6 +11,8 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2024      Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -35,6 +37,10 @@ SUBROUTINE binky(buf)
  REAL, DIMENSION(*), ASYNCHRONOUS :: buf
 END SUBROUTINE
 END INTERFACE
+CONTAINS
+SUBROUTINE wookie(buf)
+ REAL, DIMENSION(*), ASYNCHRONOUS :: buf
+END SUBROUTINE
 END MODULE asynch_mod]])],
              [AS_VAR_SET(asynchronous_var, yes)],
              [AS_VAR_SET(asynchronous_var, no)])

--- a/config/ompi_fortran_check_bind_c.m4
+++ b/config/ompi_fortran_check_bind_c.m4
@@ -11,6 +11,8 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2020      Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -83,6 +85,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_BIND_C_TYPE],[
 end module]])],
              [AS_VAR_SET(bind_c_type_var, yes)],
              [AS_VAR_SET(bind_c_type_var, no)])
+        rm -rf *.mod 2>/dev/null
         AC_LANG_POP([Fortran])
        ])
 

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -224,7 +224,8 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
                     [msg=no
                      $5])
   AC_MSG_RESULT($msg)
+  # Make sure to clean up any generated *.mod files
+  rm -rf *.mod 2>/dev/null
   AC_LANG_POP([Fortran])
   OPAL_VAR_SCOPE_POP
 ])
-

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -200,12 +200,12 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   end subroutine force_assumed_shape
 
   module check_ignore_tkr
-  interface
-     subroutine foobar(buffer, count)
+  interface foobar
+     subroutine foobar_x(buffer, count)
        $1 buffer
        $2, intent(in) :: buffer
        integer, intent(in) :: count
-     end subroutine foobar
+     end subroutine foobar_x
   end interface
   end module
 

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -25,7 +25,7 @@ dnl $HEADER$
 # Does this compiler support (void*)-like functionality for MPI choice
 # buffers?  If so, which flavor?
 AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
-    OPAL_VAR_SCOPE_PUSH([result happy type predecl])
+    OPAL_VAR_SCOPE_PUSH([result ignore_tkr_happy type predecl])
 
     OMPI_FORTRAN_IGNORE_TKR_PREDECL=
     OMPI_FORTRAN_IGNORE_TKR_TYPE=
@@ -43,11 +43,11 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
     AS_VAR_COPY([result], [fortran_ignore_tkr_data])
 
     # Parse the result
-    happy=`echo $result | cut -d: -f1`
+    ignore_tkr_happy=`echo $result | cut -d: -f1`
     type=`echo $result | cut -d: -f2`
     predecl=`echo $result | cut -d: -f3-`
 
-    AS_IF([test $happy -eq 1],
+    AS_IF([test $ignore_tkr_happy -eq 1],
           [OMPI_FORTRAN_IGNORE_TKR_PREDECL=$predecl
            OMPI_FORTRAN_IGNORE_TKR_TYPE=$type
            $1],
@@ -60,7 +60,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR], [
 ################
 
 AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
-    OPAL_VAR_SCOPE_PUSH([happy ompi_fortran_ignore_tkr_predecl ompi_fortran_ignore_tkr_type])
+    OPAL_VAR_SCOPE_PUSH([internal_ignore_tkr_happy ompi_fortran_ignore_tkr_predecl ompi_fortran_ignore_tkr_type])
 
     # If we were called here, it means that the value was not cached,
     # so we need to check several different things.  Since CACHE_CHECK
@@ -76,10 +76,10 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
     OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
          [!], [type(*)],
          [TYPE(*), DIMENSION(*)],
-         [happy=1], [happy=0])
+         [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])
 
     # GCC compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK ::], [type(*), dimension(*)],
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK],
@@ -91,34 +91,34 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
               [!DIR\$ IGNORE_TKR],
               [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Intel compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!DEC\$ ATTRIBUTES NO_ARG_CHECK ::], [real, dimension(*)],
               [!DEC\$ ATTRIBUTES NO_ARG_CHECK],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Solaris Studio compilers
     # Note that due to a compiler bug, we have been advised by Oracle to
     # use the "character(*)" type
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!\$PRAGMA IGNORE_TKR], [character(*)],
               [!\$PRAGMA IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Cray compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!DIR\$ IGNORE_TKR], [real, dimension(*)],
               [!DIR\$ IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # IBM compilers
-    AS_IF([test $happy -eq 0],
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!IBM* IGNORE_TKR], [real, dimension(*)],
               [!IBM* IGNORE_TKR],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
 
     AS_VAR_SET(fortran_ignore_tkr_data,
-               [${happy}:${ompi_fortran_ignore_tkr_type}:${ompi_fortran_ignore_tkr_predecl}])
+               [${internal_ignore_tkr_happy}:${ompi_fortran_ignore_tkr_type}:${ompi_fortran_ignore_tkr_predecl}])
 
     # Now put the original CACHE_CHECK MSG_CHECKING back so that it can
     # output the MSG_RESULT.
@@ -150,7 +150,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
      end subroutine force_assumed_shape
   end interface
 
-  interface foo
+  interface
      subroutine foo(buffer, count)
        $1 buffer
        $2, intent(in) :: buffer

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -83,7 +83,13 @@ AC_DEFUN([_OMPI_FORTRAN_CHECK_IGNORE_TKR], [
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK ::], [type(*), dimension(*)],
               [!GCC\$ ATTRIBUTES NO_ARG_CHECK],
-              [happy=1], [happy=0])])
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
+    # LLVM compilers
+    AS_IF([test $internal_ignore_tkr_happy -eq 0],
+          [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(
+              [!DIR\$ IGNORE_TKR], [type(*)],
+              [!DIR\$ IGNORE_TKR],
+              [internal_ignore_tkr_happy=1], [internal_ignore_tkr_happy=0])])
     # Intel compilers
     AS_IF([test $happy -eq 0],
           [OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB(

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -14,6 +14,8 @@ dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2024      Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -133,6 +135,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
     AC_MSG_CHECKING([for Fortran compiler support of $3])
     AC_COMPILE_IFELSE(AC_LANG_PROGRAM([],[[!
 ! Autoconf puts "program main" at the top
+ implicit none
 
   interface
      subroutine force_assumed_shape(a, count)
@@ -157,6 +160,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   complex, pointer, dimension(:,:) :: ptr
   target :: buffer3
   integer :: buffer4
+  integer :: a
   ptr => buffer3
 
 ! Set some known values (somewhat irrelevant for this test, but just be
@@ -189,8 +193,23 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
     call foo(a, count)
   end subroutine force_assumed_shape
 
+  module check_ignore_tkr
+  interface
+     subroutine foobar(buffer, count)
+       $1 buffer
+       $2, intent(in) :: buffer
+       integer, intent(in) :: count
+     end subroutine foobar
+  end interface
+  end module
+
+  subroutine bar(var)
+    use check_ignore_tkr
+    implicit none
+    real, intent(inout) :: var(:, :, :)
+
+    call foobar(var(1,1,1), 1)
 ! Autoconf puts "end" after the last line
-  subroutine bogus
 ]]),
                     [msg=yes
                      ompi_fortran_ignore_tkr_predecl="$1"


### PR DESCRIPTION
This PR updates the 4.1 with #12512 and some parts of 30eb36fd7e9 and b6017d22ab.

bot:notacherrypick