### PR TITLE
mca/op: always define aarch64 macros

### DIFF
--- a/ompi/mca/op/aarch64/Makefile.am
+++ b/ompi/mca/op/aarch64/Makefile.am
@@ -43,12 +43,12 @@ specialized_op_libs =
 if MCA_BUILD_ompi_op_has_neon_support
 specialized_op_libs += liblocal_ops_neon.la
 liblocal_ops_neon_la_SOURCES = op_aarch64_functions.c
-liblocal_ops_neon_la_CPPFLAGS = -DGENERATE_NEON_CODE
+liblocal_ops_neon_la_CPPFLAGS = -DGENERATE_NEON_CODE=1 -DGENERATE_SVE_CODE=0
 endif
 if MCA_BUILD_ompi_op_has_sve_support
 specialized_op_libs += liblocal_ops_sve.la
 liblocal_ops_sve_la_SOURCES = op_aarch64_functions.c
-liblocal_ops_sve_la_CPPFLAGS = -DGENERATE_SVE_CODE
+liblocal_ops_sve_la_CPPFLAGS = -DGENERATE_NEON_CODE=0 -DGENERATE_SVE_CODE=1
 endif
 
 component_noinst  = $(specialized_op_libs)

--- a/ompi/mca/op/aarch64/configure.m4
+++ b/ompi/mca/op/aarch64/configure.m4
@@ -49,29 +49,6 @@ AC_DEFUN([MCA_ompi_op_aarch64_CONFIG],[
                       [op_cv_neon_support=no])])
 
            #
-           # Check for NEON FP support
-           #
-           AC_CACHE_CHECK([for NEON FP support], op_cv_neon_fp_support,
-                [AS_IF([test "$op_cv_neon_support" = "yes"],
-                        [
-                          AC_LINK_IFELSE(
-                              [AC_LANG_PROGRAM([[
-#if defined(__aarch64__) && defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP))
-#include <arm_neon.h>
-#else
-#error "No support for __aarch64__ or NEON FP"
-#endif
-                                             ]],
-                                             [[
-#if defined(__aarch64__) && defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP))
-    float32x4_t vA;
-    vA = vmovq_n_f32(0)
-#endif
-                                             ]])],
-                            [op_cv_neon_fp_support=yes],
-                            [op_cv_neon_fp_support=no])])])
-
-           #
            # Check for SVE support
            #
           AC_CACHE_CHECK([for SVE support], [op_cv_sve_support], [
@@ -133,21 +110,18 @@ int main(void) {
 ])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_neon_support],
                    [test "$op_cv_neon_support" = "yes"])
-    AM_CONDITIONAL([MCA_BUILD_ompi_op_has_neon_fp_support],
-                   [test "$op_cv_neon_fp_support" = "yes"])
     AM_CONDITIONAL([MCA_BUILD_ompi_op_has_sve_support],
                    [test "$op_cv_sve_support" = "yes"])
 
     AC_SUBST(MCA_BUILD_ompi_op_has_neon_support)
-    AC_SUBST(MCA_BUILD_ompi_op_has_neon_fp_support)
     AC_SUBST(MCA_BUILD_ompi_op_has_sve_support)
 
     AS_IF([test "$op_cv_neon_support" = "yes"],
-          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON], [1],[NEON supported in the current build])])
-    AS_IF([test "$op_cv_neon_fp_support" = "yes"],
-          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON_FP], [1],[NEON FP supported in the current build])])
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON], [1],[NEON supported in the current build])],
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_NEON], [0],[NEON not supported in the current build])])
     AS_IF([test "$op_cv_sve_support" = "yes"],
-          [AC_DEFINE([OMPI_MCA_OP_HAVE_SVE], [1],[SVE supported in the current build])])
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_SVE], [1],[SVE supported in the current build])],
+          [AC_DEFINE([OMPI_MCA_OP_HAVE_SVE], [0],[SVE not supported in the current build])])
     AS_IF([test "$op_cv_sve_add_flags" = "yes"],
           [AC_DEFINE([OMPI_MCA_OP_SVE_EXTRA_FLAGS], [1],[SVE supported with additional compile attributes])],
           [AC_DEFINE([OMPI_MCA_OP_SVE_EXTRA_FLAGS], [0],[SVE not supported])])

--- a/ompi/mca/op/aarch64/op_aarch64_component.c
+++ b/ompi/mca/op/aarch64/op_aarch64_component.c
@@ -105,12 +105,12 @@ OMPI_SVE_ATTR static int mca_op_aarch64_component_register(void)
 {
 
     mca_op_aarch64_component.hardware_available = 1;  /* Check for Neon */
-#if defined(OMPI_MCA_OP_HAVE_SVE)
+#if OMPI_MCA_OP_HAVE_SVE
     uint64_t id_aa64pfr0_el1 = (1UL << 32);
     __asm__("mrs %0, ID_AA64PFR0_EL1" : "=r"(id_aa64pfr0_el1) : :);
     /* Check for SVE support */
     mca_op_aarch64_component.hardware_available |= ((id_aa64pfr0_el1 & (1UL << 32)) ? 2 : 0);
-#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+#endif  /* OMPI_MCA_OP_HAVE_SVE */
     (void) mca_base_component_var_register(&mca_op_aarch64_component.super.opc_version,
                                            "hardware_available",
                                            "Whether the Neon (1) or SVE (2) hardware is available",
@@ -119,9 +119,9 @@ OMPI_SVE_ATTR static int mca_op_aarch64_component_register(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_op_aarch64_component.hardware_available);
     uint64_t id_aa64zfr0_el1 = 0;
-#if defined(OMPI_MCA_OP_HAVE_SVE)
+#if OMPI_MCA_OP_HAVE_SVE
     __asm__("mrs %0, ID_AA64ZFR0_EL1" : "=r"(id_aa64zfr0_el1) : :);
-#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+#endif  /* OMPI_MCA_OP_HAVE_SVE */
     mca_op_aarch64_component.double_supported = id_aa64zfr0_el1 & (1UL << 56);
     /* Bit 1: mandatory SVE2 instructions */
     /* Bit 2: mandatory SVE2.1 instructions */
@@ -148,18 +148,18 @@ static int mca_op_aarch64_component_init_query(bool enable_progress_threads,
     return OMPI_ERR_NOT_SUPPORTED;
 }
 
-#if defined(OMPI_MCA_OP_HAVE_NEON)
+#if OMPI_MCA_OP_HAVE_NEON
 extern ompi_op_base_handler_fn_t
 ompi_op_aarch64_functions_neon[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
 extern ompi_op_base_3buff_handler_fn_t
 ompi_op_aarch64_3buff_functions_neon[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
-#endif  /* defined(OMPI_MCA_OP_HAVE_NEON) */
-#if defined(OMPI_MCA_OP_HAVE_SVE)
+#endif  /* OMPI_MCA_OP_HAVE_NEON */
+#if OMPI_MCA_OP_HAVE_SVE
 extern ompi_op_base_handler_fn_t
 ompi_op_aarch64_functions_sve[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
 extern ompi_op_base_3buff_handler_fn_t
 ompi_op_aarch64_3buff_functions_sve[OMPI_OP_BASE_FORTRAN_OP_MAX][OMPI_OP_BASE_TYPE_MAX];
-#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
+#endif  /* OMPI_MCA_OP_HAVE_SVE */
 
 /*
  * Query whether this component can be used for a specific op
@@ -189,13 +189,13 @@ static struct ompi_op_base_module_1_0_0_t *
         for (int i = 0; i < OMPI_OP_BASE_TYPE_MAX; ++i) {
             module->opm_fns[i] = NULL;
             module->opm_3buff_fns[i] = NULL;
-#if defined(OMPI_MCA_OP_HAVE_SVE)
+#if OMPI_MCA_OP_HAVE_SVE
             if( mca_op_aarch64_component.hardware_available & 2 ) {
                 module->opm_fns[i] = ompi_op_aarch64_functions_sve[op->o_f_to_c_index][i];
                 module->opm_3buff_fns[i] = ompi_op_aarch64_3buff_functions_sve[op->o_f_to_c_index][i];
             }
-#endif  /* defined(OMPI_MCA_OP_HAVE_SVE) */
-#if defined(OMPI_MCA_OP_HAVE_NEON)
+#endif  /* OMPI_MCA_OP_HAVE_SVE */
+#if OMPI_MCA_OP_HAVE_NEON
             if( mca_op_aarch64_component.hardware_available & 1 ) {
                 if( NULL == module->opm_fns[i] ) {
                     module->opm_fns[i] = ompi_op_aarch64_functions_neon[op->o_f_to_c_index][i];
@@ -204,7 +204,7 @@ static struct ompi_op_base_module_1_0_0_t *
                     module->opm_3buff_fns[i] = ompi_op_aarch64_3buff_functions_neon[op->o_f_to_c_index][i];
                 }
             }
-#endif  /* defined(OMPI_MCA_OP_HAVE_NEON) */
+#endif  /* OMPI_MCA_OP_HAVE_NEON */
         }
         break;
     case OMPI_OP_BASE_FORTRAN_LAND:


### PR DESCRIPTION
This pull request refactors the aarch64 op component’s build configuration to ensure macros are consistently defined in compliance with the [style guide](https://docs.open-mpi.org/en/v5.0.x/developers/source-code.html#c-c).

There are no code logic changes. All changes in the source code files are preprocessor only.

Build system changes:
    - configure.m4: remove check for Neon floating point support as it is never used
    - configure.m4: always define macros to either 0 or 1
    - Makefile.am: always declare GENERATE_NEON_CODE and GENERATE_SVE_CODE
    
Source code (only preprocessor):
    - updated macro check to #if instead of #ifdef
    - Add compile-time guard in op_aarch64_functions.c to ensure exactly one of GENERATE_SVE_CODE or GENERATE_NEON_CODE is enabled
    - added comment above compile-time guard

This is a follow-up PR of https://github.com/open-mpi/ompi/pull/13204