### PR TITLE
show_help: only parse specific trees for help files

### DIFF
--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -128,8 +128,12 @@ libopalutil_core_la_SOURCES = \
         uri.c
 
 show_help_content.c: convert-help-files-to-c-code.py
-	$(OMPI_V_GEN) $(PYTHON) $(abs_srcdir)/convert-help-files-to-c-code.py \
-	    --root $(abs_top_srcdir) \
+	$(OMPI_V_GEN) subdirs=""; \
+	for dir in $(MCA_PROJECT_SUBDIRS); do \
+	    subdirs="$(abs_top_srcdir)/$$dir $$subdirs"; \
+	done; \
+	$(PYTHON) $(abs_srcdir)/convert-help-files-to-c-code.py \
+	    --roots $$subdirs \
 	    --out show_help_content.c
 
 if OPAL_COMPILE_TIMING


### PR DESCRIPTION
Change --root CLI param to --roots in order to accept a specific list of root directories to traverse to look for help files (rather than a single top-level root that contains all the directories that we want to traverse -- but which also contains directories that we *don't* want to traverse).  Also, just for the heckuvit, parameterize the list of subdirectories to skip (via --skip-dirs).
    
Using --roots prevents us from accidentally traversing into VPATH build directories, for example, and finding PMIx and/or PRTE help files.