### PR TITLE
Add explicit test for Python >= v3.7 in configure

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -33,6 +33,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
+python_min_version=3.7
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not

--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -252,13 +252,4 @@ else
    ompi_want_ompio=1
 fi
 AM_CONDITIONAL(OMPI_OMPIO_SUPPORT, test "$ompi_want_ompio" = "1")
-
-# If the binding source files don't exist, then we need Python to generate them
-AM_PATH_PYTHON([3.6],,[:])
-binding_file="${srcdir}/ompi/mpi/c/ompi_send.c"
-AS_IF([! test -e "$binding_file" && test "$PYTHON" = ":"],
-      [AC_MSG_ERROR([Open MPI requires Python >=3.6 for generating the bindings. Aborting])])
-AM_CONDITIONAL(OMPI_GENERATE_BINDINGS,[test "$PYTHON" != ":"])
-
 ])dnl
-

--- a/configure.ac
+++ b/configure.ac
@@ -77,15 +77,40 @@ OPAL_MAKEDIST_DISABLE=""
 # Start it up
 #
 
+. $srcdir/VERSION
 OPAL_CONFIGURE_SETUP
 opal_show_title "Configuring project_name_long"
 opal_show_subtitle "Prerequisites"
+
+OMPI_TOP_BUILDDIR="`pwd`"
+AC_SUBST(OMPI_TOP_BUILDDIR)
+cd "$srcdir"
+OMPI_TOP_SRCDIR="`pwd`"
+AC_SUBST(OMPI_TOP_SRCDIR)
+cd "$OMPI_TOP_BUILDDIR"
 
 AC_PROG_SED
 
 AC_CHECK_PROG([PERL],[perl],[perl],[no])
 AS_IF([test "X$PERL" = "Xno"],
-      [AC_MSG_ERROR(["Open MPI requires perl. Aborting"])])
+      [AC_MSG_ERROR([Open MPI requires perl to build. Aborting.])])
+
+# We need Python if any of these are true:
+# - you're building the MPI Fortran bindings
+# - you're in a git clone (i.e., not a distribution tarball that has
+#   already been bootstrapped)
+AC_MSG_CHECKING([if we need Python])
+AS_IF([test "$enable_mpi_fortran" = "yes"], [need_python=yes],
+      [test -d "${OMPI_TOP_SRCDIR}/.git"], [need_python=yes],
+      [need_python=no])
+AC_MSG_RESULT([$need_python])
+
+AS_IF([test "$need_python" = "yes"],
+      [AM_PATH_PYTHON([$python_min_version],
+                      [have_good_python=1],
+                      [AC_MSG_ERROR([Open MPI requires Python >=$python_min_version to build. Aborting.])])],
+      [have_good_python=0])
+AM_CONDITIONAL(OMPI_GENERATE_BINDINGS, [test $have_good_python -eq 1])
 
 #
 # Setup some things that must be done before AM-INIT-AUTOMAKE
@@ -153,7 +178,6 @@ OPAL_SAVE_VERSION([OPAL], [Open Portable Access Layer], [$srcdir/VERSION],
 
 # Get shared library version numbers
 
-. $srcdir/VERSION
 m4_ifdef([project_ompi],
          [AC_SUBST(libmpi_so_version)
           AC_SUBST(libmpi_mpifh_so_version)
@@ -205,13 +229,6 @@ m4_ifdef([project_oshmem],
          [AC_CONFIG_HEADERS([oshmem/include/shmem.h])])
 
 opal_show_subtitle "Initialization, setup"
-
-OMPI_TOP_BUILDDIR="`pwd`"
-AC_SUBST(OMPI_TOP_BUILDDIR)
-cd "$srcdir"
-OMPI_TOP_SRCDIR="`pwd`"
-AC_SUBST(OMPI_TOP_SRCDIR)
-cd "$OMPI_TOP_BUILDDIR"
 
 AC_MSG_NOTICE([builddir: $OMPI_TOP_BUILDDIR])
 AC_MSG_NOTICE([srcdir: $OMPI_TOP_SRCDIR])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ automake_min_version = f"{ompi_data['automake_min_version']}"
 autoconf_min_version = f"{ompi_data['autoconf_min_version']}"
 libtool_min_version = f"{ompi_data['libtool_min_version']}"
 flex_min_version = f"{ompi_data['flex_min_version']}"
+python_min_version = f"{ompi_data['python_min_version']}"
 mpi_standard_major_version = f"{ompi_data['mpi_standard_version']}"
 mpi_standard_minor_version = f"{ompi_data['mpi_standard_subversion']}"
 
@@ -304,6 +305,7 @@ rst_prolog = f"""
 .. |autoconf_min_version| replace:: {autoconf_min_version}
 .. |libtool_min_version| replace:: {libtool_min_version}
 .. |flex_min_version| replace:: {flex_min_version}
+.. |python_min_version| replace:: {python_min_version}
 .. |mpi_standard_version| replace:: {mpi_standard_major_version}.{mpi_standard_minor_version}
 .. |mpi_standard_major_version| replace:: {mpi_standard_major_version}
 .. |mpi_standard_minor_version| replace:: {mpi_standard_minor_version}

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -50,11 +50,28 @@ more detail.
 Python
 ------
 
-Python >= v3.6 is required for generating the Fortran bindings, which
-is necessary if you build Open MPI from a Git clone.
+Python >= |python_min_version| is required for several tasks during
+the Open MPI build, such as (but not limited to):
 
-Python is also required for running Sphinx to generate the docs, too
-(:ref:`see below <developers-requirements-sphinx-label>`).
+* In all cases (including from distribution tarballs):
+
+  * Generating Fortran constants and compiler-specific symbols
+
+* When building from a Git clone:
+
+  * Generating the Fortran bindings
+
+  * Generating the "show help" messages
+
+  * Generating bindings in the MPI man pages (via the `pympistandard
+    module <https://github.com/mpi-forum/pympistandard/>`_) module)
+
+  * Building the Open MPI documentation and man pages
+
+All of these are necessary when building from a Git clone.  Most of
+these can be accomplished with core Python; only building the full
+Open MPI documentation and man pages requires additional Python
+packages (:ref:`see below <developers-requirements-sphinx-label>`).
 
 Perl
 ----

--- a/docs/developers/sphinx.rst
+++ b/docs/developers/sphinx.rst
@@ -13,8 +13,8 @@ Installing Python
 -----------------
 
 The `Sphinx tool <https://www.sphinx-doc.org/>`_ is written in Python,
-and therefore needs to have Python available.  As of late 2022, Sphinx
-requires Python >= v3.7.
+and therefore needs to have Python available.  As of May 2025, Sphinx
+|mdash| and Open MPI |mdash| requires Python >= v3.7.
 
 This documentation does not contain detailed instructions for
 installing a Python version sufficient for using Sphinx.  Consult your

--- a/docs/installing-open-mpi/quickstart.rst
+++ b/docs/installing-open-mpi/quickstart.rst
@@ -62,7 +62,9 @@ Download the Open MPI source code from `the main Open MPI web site
              They are **not** official Open MPI releases.
 
 Open MPI uses a traditional ``configure`` script paired with ``make``
-to build.  Typical installs can be of the pattern:
+to build.  Open MPI requires Perl, and may require Python >=
+|python_min_version|, as part of its build process.  Typical installs
+can be of the pattern:
 
 .. code-block:: sh
 

--- a/docs/installing-open-mpi/supported-systems.rst
+++ b/docs/installing-open-mpi/supported-systems.rst
@@ -28,6 +28,18 @@ operating systems that we do not currently support.  If we do not have
 systems to test these on, we probably will only claim to
 "unofficially" support those systems.
 
+Perl and Python
+^^^^^^^^^^^^^^^
+
+Open MPI requires Perl while building.  If you are building the
+Fortran MPI bindings, or if you are building from a Git clone, Open
+MPI also requires Python >= |python_min_version| while building.
+
+.. note:: The Open MPI community is slowly converting its Perl scripts
+          to Python; it is expected (hoped) that we'll someday have no
+          more Perl in the build process for official distribution
+          tarballs or Git clones.
+
 Supported Hardware Platforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -9,5 +9,13 @@ Open MPI version v6.0.0
 :Date: ...fill me in...
 
 - Open MPI now requires a C11-compliant compiler to build.
+
+- Open MPI now requires Python >= |python_min_version| to build the
+  Fortran MPI bindings (or when building from a Git clone).
+
+  - Open MPI has always required Perl to build; our Perl scripts are
+    slowly being converted to Python.
+
 - Removed ROMIO package.
+
 - Added MPI-4.1 ``MPI_Status_*`` functions.


### PR DESCRIPTION
Open MPI's Python scripts have been tested with v3.6 and work, but the pympistandard module requires Python >= v3.7.  Hence, the minimum Python version required is v3.7.
    
* Add an explicit test to early in configure.ac for Python >= v3.7 if:
  * We're building the Fortran MPI bindings
  * We're in a Git clone
* Remove a test later in configure for Python >= v3.6 for generating the Fortran bindings
* Update several places in the docs to note that Open MPI now requires Python >= v3.7 to build in certain conditions
* Maintain the minimum required Python version in VERSION (along with other external dependency minimum versions)

Fixes #13242