### PR TITLE
configury: always require Python for building Open MPI

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -138,7 +138,9 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     AC_DEFINE([ompi_fortran_bogus_type_t], [int],
               [A bogus type that allows us to have sentinel type values that are still valid])
 
-    OMPI_FORTRAN_GET_COMMON_ALIGNMENT([OMPI_FORTRAN_COMMON_ALIGNMENT])
+    AS_IF([test $ompi_fortran_happy -eq 1],
+          [OMPI_FORTRAN_GET_COMMON_ALIGNMENT([OMPI_FORTRAN_COMMON_ALIGNMENT])],
+          [OMPI_FORTRAN_COMMON_ALIGNMENT=0])
     AC_SUBST([OMPI_FORTRAN_COMMON_ALIGNMENT])
 
     # We want to set the #define's for all of these, so invoke the macros

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,11 @@ OAC_PUSH_PREFIX([OPAL])
 
 OPAL_CAPTURE_CONFIGURE_CLI([OPAL_CONFIGURE_CLI])
 
+#
+# Init automake
+#
+AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-pax])
+
 # Get our platform support file.  This has to be done very, very early
 # because it twiddles random bits of autoconf
 OPAL_LOAD_PLATFORM
@@ -93,24 +98,12 @@ AC_PROG_SED
 
 AC_CHECK_PROG([PERL],[perl],[perl],[no])
 AS_IF([test "X$PERL" = "Xno"],
-      [AC_MSG_ERROR([Open MPI requires perl to build. Aborting.])])
+      [AC_MSG_ERROR([Open MPI requires Perl 5 to build. Aborting.])])
 
-# We need Python if any of these are true:
-# - you're building the MPI Fortran bindings
-# - you're in a git clone (i.e., not a distribution tarball that has
-#   already been bootstrapped)
-AC_MSG_CHECKING([if we need Python])
-AS_IF([test "$enable_mpi_fortran" = "yes"], [need_python=yes],
-      [test -d "${OMPI_TOP_SRCDIR}/.git"], [need_python=yes],
-      [need_python=no])
-AC_MSG_RESULT([$need_python])
-
-AS_IF([test "$need_python" = "yes"],
-      [AM_PATH_PYTHON([$python_min_version],
-                      [have_good_python=1],
-                      [AC_MSG_ERROR([Open MPI requires Python >=$python_min_version to build. Aborting.])])],
-      [have_good_python=0])
-AM_CONDITIONAL(OMPI_GENERATE_BINDINGS, [test $have_good_python -eq 1])
+# Check to see that we have a "good" version of Python (i.e., >= the
+# version specified in the top-level VERSION file)
+AM_PATH_PYTHON([$python_min_version], [],
+               [AC_MSG_ERROR([Open MPI requires Python >= v$python_min_version to build. Aborting.])])
 
 #
 # Setup some things that must be done before AM-INIT-AUTOMAKE
@@ -125,11 +118,6 @@ AS_IF([test "$host" != "$target"],
        AC_MSG_WARN([Cross-compiling is only partially supported])
        AC_MSG_WARN([Proceed at your own risk!])])
 
-
-#
-# Init automake
-#
-AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-pax])
 
 # SILENT_RULES is new in AM 1.11, but we require 1.11 or higher via
 # autogen.  Limited testing shows that calling SILENT_RULES directly

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -82,6 +82,11 @@ Open MPI still uses Perl for a few of its build scripts (most notably,
 Generally speaking, any recent-ish release of Perl 5 should be
 sufficient to correctly execute Open MPI's Perl scripts.
 
+.. note:: The Open MPI community is slowly converting its Perl scripts
+          to Python; it is expected (hoped) that we'll someday have no
+          more Perl in the build process for official distribution
+          tarballs or Git clones.
+
 Flex
 ----
 

--- a/docs/installing-open-mpi/supported-systems.rst
+++ b/docs/installing-open-mpi/supported-systems.rst
@@ -31,9 +31,12 @@ systems to test these on, we probably will only claim to
 Perl and Python
 ^^^^^^^^^^^^^^^
 
-Open MPI requires Perl while building.  If you are building the
-Fortran MPI bindings, or if you are building from a Git clone, Open
-MPI also requires Python >= |python_min_version| while building.
+Open MPI requires Perl 5 and Python >= |python_min_version| while
+building.
+
+.. note:: Note that these requirements are only for *building* Open
+          MPI itself.  Open MPI does not require Perl or Python to
+          build or run MPI or OSHMEM applications.
 
 .. note:: The Open MPI community is slowly converting its Perl scripts
           to Python; it is expected (hoped) that we'll someday have no

--- a/ompi/include/Makefile.am
+++ b/ompi/include/Makefile.am
@@ -86,7 +86,7 @@ sizeof_py=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.py
 mpif-sizeof.h: $(top_builddir)/config.status
 mpif-sizeof.h: $(sizeof_py)
 mpif-sizeof.h:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --header=$@ --ierror=mandatory \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \
@@ -107,7 +107,7 @@ mpif_mangling_py=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-mangling.py
 mpif-c-constants-decl.h: $(top_builddir)/config.status
 mpif-c-constants-decl.h: $(mpif_mangling_py)
 mpif-c-constants-decl.h:
-	$(OMPI_V_GEN) $(python) $(mpif_mangling_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(mpif_mangling_py) \
 	    --caps $(OMPI_FORTRAN_CAPS) \
 	    --plain $(OMPI_FORTRAN_PLAIN) \
 	    --single $(OMPI_FORTRAN_SINGLE_UNDERSCORE) \

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -539,7 +539,6 @@ libmpi_c_noprofile_la_SOURCES = $(interface_profile_sources)
 libmpi_c_noprofile_la_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=0
 
 # ABI generation rules
-if OMPI_GENERATE_BINDINGS
 %_generated.c: %.c.in
 	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
 	    --builddir $(abs_top_builddir) \
@@ -550,6 +549,5 @@ if OMPI_GENERATE_BINDINGS
 	    ompi \
 	    $<
 
-endif
 # Delete generated files on maintainer-clean
 MAINTAINERCLEANFILES = *_generated.c

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -121,7 +121,7 @@ sizeof_py = $(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.py
 sizeof_f.f90: $(top_builddir)/config.status
 sizeof_f.f90: $(sizeof_py)
 sizeof_f.f90:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --impl=$@ --ierror=mandatory --mpi \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -492,7 +492,7 @@ sizeof_py=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.py
 psizeof_f.f90: $(top_builddir)/config.status
 psizeof_f.f90: $(sizeof_py)
 psizeof_f.f90:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --impl=$@ --ierror=mandatory --pmpi \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -46,7 +46,7 @@ AM_CPPFLAGS =
 # involves a user supplied buffer(s), and hence the need to generate
 # either assumed rank or assumed shape arrays with possible async
 # attributes, the *.c.in method needs to be used. Otherwise a *.F90
-# file can be used.   In addition, the mod/mpi-f08-rename.h file 
+# file can be used.   In addition, the mod/mpi-f08-rename.h file
 # will need to be updated to include a rename line for the new method.
 #
 if OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -85,7 +85,7 @@ sizeof_py=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.py
 sizeof_f08.h: $(top_builddir)/config.status
 sizeof_f08.h: $(sizeof_py)
 sizeof_f08.h:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --header=$@ --ierror=optional \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \
@@ -100,7 +100,7 @@ sizeof_f08.h:
 sizeof_f08.f90: $(top_builddir)/config.status
 sizeof_f08.f90: $(sizeof_py)
 sizeof_f08.f90:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --impl=$@ --ierror=optional --mpi \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \
@@ -113,7 +113,7 @@ sizeof_f08.f90:
 psizeof_f08.f90: $(top_builddir)/config.status
 psizeof_f08.f90: $(sizeof_py)
 psizeof_f08.f90:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --impl=$@ --ierror=optional --pmpi \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \
@@ -431,8 +431,6 @@ lib@OMPI_LIBMPI_NAME@_usempif08_profile_la_FCFLAGS = \
 # *.in template.
 #
 
-if OMPI_GENERATE_BINDINGS
-
 include Makefile.prototype_files
 template_files =${prototype_files:%=$(abs_top_srcdir)/ompi/mpi/fortran/use-mpi-f08/%}
 
@@ -452,8 +450,6 @@ api_f08_generated.F90: $(template_files)
 	    --prototype-files $(template_files)
 
 EXTRA_DIST = $(prototype_files)
-
-endif
 
 # Delete generated file on maintainer-clean
 MAINTAINERCLEANFILES = api_f08_generated.F90

--- a/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
@@ -46,7 +46,6 @@ endif
 # api_f08_generated.c should work with all compilers, supporting CFI or TS 29113 support
 # through macros in ts.h and ts.c.
 #
-if OMPI_GENERATE_BINDINGS
 
 include ../Makefile.prototype_files
 template_files =${prototype_files:%=$(abs_top_srcdir)/ompi/mpi/fortran/use-mpi-f08/%}
@@ -60,8 +59,6 @@ api_f08_generated.c: $(template_files)
 	    code \
 	    --lang c \
 	    --prototype-files $(template_files)
-
-endif
 
 # Delete generated files on maintainer-clean
 MAINTAINERCLEANFILES = api_f08_generated.c

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -77,7 +77,6 @@ config_h = \
     $(top_srcdir)/ompi/mpi/fortran/configure-fortran-output-bottom.h
 
 # Generate the Fortran interfaces
-if OMPI_GENERATE_BINDINGS
 
 include ../Makefile.prototype_files
 template_files =${prototype_files:%=$(abs_top_srcdir)/ompi/mpi/fortran/use-mpi-f08/%}
@@ -96,8 +95,6 @@ mpi-f08-interfaces-generated.h: $(template_files)
 	    $(gen_ts) \
 	    interface \
 	    --prototype-files $(template_files)
-
-endif
 
 # Delete generated file on maintainer-clean
 MAINTAINERCLEANFILES = mpi-f08-interfaces-generated.h

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -99,7 +99,7 @@ sizeof_py=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.py
 mpi-ignore-tkr-sizeof.h: $(top_builddir)/config.status
 mpi-ignore-tkr-sizeof.h: $(sizeof_py)
 mpi-ignore-tkr-sizeof.h:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --header=$@ --ierror=mandatory \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \
@@ -114,7 +114,7 @@ mpi-ignore-tkr-sizeof.h:
 mpi-ignore-tkr-sizeof.f90: $(top_builddir)/config.status
 mpi-ignore-tkr-sizeof.f90: $(sizeof_py)
 mpi-ignore-tkr-sizeof.f90:
-	$(OMPI_V_GEN) $(python) $(sizeof_py) \
+	$(OMPI_V_GEN) $(PYTHON) $(sizeof_py) \
 	    --impl=$@ --ierror=mandatory --mpi --pmpi \
 	    --maxrank=$(OMPI_FORTRAN_MAX_ARRAY_RANK) \
 	    --generate=$(OMPI_FORTRAN_BUILD_SIZEOF) \


### PR DESCRIPTION
See individual commit messages for details.  The main / important commit in this PR has the following commit message:

-----

Commit cb4fe484bc didn't quite get the Python configury tests correct. This commit fixes several issues:
    
* Move the AM_INIT_AUTOMAKE up before we call AM_PATH_PYTHON.
    
* Since we converted a few Perl scripts to Python in a60b03b, we now *always* need Python to build Open MPI.  Multiple Python scripts are invoked post-configure (i.e., reacting to configure results -- see a60b03b) to build the C and Fortran and MPI bindings.
    
* Since we now always have Python, remove the OMPI_GENERATE_BINDINGS AM_CONDITIONAL.
    
* Use the slightly-more-correct `$(PYTHON)` in Makefile.am (vs. `$(python)`).