### PR TITLE
v5.0.x: configury: ensure to remove *.mod files

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -224,7 +224,8 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
                     [msg=no
                      $5])
   AC_MSG_RESULT($msg)
+  # Make sure to clean up any generated *.mod files
+  rm -rf *.mod 2>/dev/null
   AC_LANG_POP([Fortran])
   OPAL_VAR_SCOPE_POP
 ])
-


### PR DESCRIPTION
At the end of the OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB macro, ensure to remove any generated *.mod files (rather than relying on some other macro -- cough cough OMPI_FORTRAN_CHECK_BIND_C_TYPE cough cough -- to remove *.mod files for us).

(cherry picked from commit c08258cd2857caec190b41638e5267b5f5e5e2aa)

This is the v5.0.x PR corresponding to #13255 