### PR TITLE
configury: test Fortran complex(real16)

### DIFF
--- a/config/ompi_fortran_check_iso_fortran_env_real16.m4
+++ b/config/ompi_fortran_check_iso_fortran_env_real16.m4
@@ -28,6 +28,22 @@ end program]])],
              [AS_VAR_SET(iso_fortran_env_var_real16, no)])
         AC_LANG_POP([Fortran])
        ])
+    AS_VAR_IF(iso_fortran_env_var_real16, [yes],
+          [AC_MSG_CHECKING([if Fortran compiler supports complex(ISO_FORTRAN_ENV:REAL16)])
+           AC_LANG_PUSH([Fortran])
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([[program check_for_iso_fortran_env_real16
+   use, intrinsic :: iso_fortran_env
+   complex(REAL16) :: var
+   var = 12.34
+end program]])],
+             [AC_MSG_RESULT([yes])],
+             [AC_MSG_RESULT([no])
+              AC_MSG_WARN([*** Fortran compiler supports real(REAL16) but])
+              AC_MSG_WARN([*** does *not* support complex(REAL16)])
+              AC_MSG_WARN([*** Disabling support for ISO_FORTRAN_ENV:REAL16])
+              AS_VAR_SET(iso_fortran_env_var_real16, no)])
+           AC_LANG_POP([Fortran])],
+          [])
 
     AS_VAR_IF(iso_fortran_env_var_real16, [yes], [$1], [$2])
     AS_VAR_POPDEF([iso_fortran_env_var_real16])


### PR DESCRIPTION
Recent NVHPC compilers now support the REAL16 intrinsic from the ISO_FORTRAN_ENV module. Though they do support real(REAL16), they do not support complex(REAL16), causing a compilation error in the MPI_Sizeof() Fortran subroutine.

This patch does test complex(REAL16) on top of real(REAL16), and issue a warning and disable ISO_FORTRAN_ENV:REAL16 support if the former is not supported but the latter is.

Thanks Jorge Cabrera for reporting this.

Refs #13190


(cherry picked from commit 58960cca8de2f06c25aba1db935c3f4d403fae17)