### PR TITLE
v5.0.x: Fix OFI build warnings

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -983,17 +983,6 @@ select_prov:
     }
 
     /**
-     * Unfortunately the attempt to implement FI_MR_SCALABLE in the GNI provider
-     * doesn't work, at least not well.  Since we're asking for the 1.5 libfabric
-     * API now, we have to tell GNI we want to use Mr. Basic.  Using FI_MR_BASIC
-     * rather than FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY to stay
-     * compatible with older libfabrics.
-     */
-    if (!strncmp(prov->fabric_attr->prov_name,"gni",3)) {
-         prov->domain_attr->mr_mode = FI_MR_BASIC;
-    }
-
-    /**
      * Create the access domain, which is the physical or virtual network or
      * hardware port/collection of ports.  Returns a domain object that can be
      * used to create endpoints.  See man fi_domain for details.

--- a/opal/mca/btl/ofi/README.md
+++ b/opal/mca/btl/ofi/README.md
@@ -48,8 +48,8 @@ be explicit.
 Supported MR mode bits (will work with or without):
 
 * enum:
-  * `FI_MR_BASIC`
-  * `FI_MR_SCALABLE`
+  * `FI_MR_BASIC` (deprecated since libfabric 1.5)
+  * `FI_MR_SCALABLE` (deprecated since libfabric 1.5)
 * mode bits:
   * `FI_MR_VIRT_ADDR`
   * `FI_MR_ALLOCATED`

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -46,6 +46,16 @@
 
 #define MCA_BTL_OFI_REQUESTED_MR_MODE (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR | FI_MR_ENDPOINT)
 
+/**
+ * FI_MR_BASIC (1<<0) and FI_MR_SCALABLE (1<<1) are deprecated
+ * since Libfabric 1.5 and the symbols will get removed in
+ * future Libfabric 2.x versions. Use the internal mode bits
+ * for backward compatibilities without breaking compilation
+ * with newer libfabric.
+ */
+#define MCA_BTL_OFI_MR_BASIC    (1 << 0)
+#define MCA_BTL_OFI_MR_SCALABLE (1 << 1)
+
 static char *ofi_progress_mode;
 static bool disable_sep;
 static int mca_btl_ofi_init_device(struct fi_info *info);
@@ -105,7 +115,7 @@ static int validate_info(struct fi_info *info, uint64_t required_caps, char **in
 
     mr_mode = info->domain_attr->mr_mode;
 
-    if (!(mr_mode == FI_MR_BASIC || mr_mode == FI_MR_SCALABLE
+    if (!(mr_mode == MCA_BTL_OFI_MR_BASIC || mr_mode == MCA_BTL_OFI_MR_SCALABLE
 #if defined(FI_MR_HMEM)
           || (mr_mode & ~(FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_ENDPOINT | FI_MR_HMEM)) == 0)) {
 #else
@@ -655,7 +665,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     }
 #endif
 
-    if (ofi_info->domain_attr->mr_mode == FI_MR_BASIC
+    if (ofi_info->domain_attr->mr_mode == MCA_BTL_OFI_MR_BASIC
         || ofi_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
         module->use_virt_addr = true;
     }


### PR DESCRIPTION
Backport https://github.com/open-mpi/ompi/pull/13266 to v5.0.x