### PR TITLE
Decrease minimum Python version to 3.6

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -33,7 +33,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
-python_min_version=3.7
+python_min_version=3.6
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,11 @@ sphinx>=4.2.0
 recommonmark
 docutils
 sphinx-rtd-theme
+
+# These modules are needed for the pympistandard module when you are
+# running Python 3.6 (they became part of core Python in 3.7).  We
+# specifically use "==" (vs. "<=") because the top-level Open MPI
+# VERSION file lists Python 3.6 as the minimum required version of
+# Python -- we will never be using < 3.6 to build the Open MPI docs.
+importlib_resources; python_version == "3.6"
+dataclasses; python_version == "3.6"


### PR DESCRIPTION
It was pointed out on the Open MPI packagers mailing list that RHEL 8 (and clones) has Python 3.6 inbox.  If we only allow Open MPI to build with Python >= 3.7, we'll break all builds on RHEL 8 (etc.).  That seems like a bad idea.

* Update the git submodule for the pympistandard module to a version that is friendly to running with Python 3.6.
* List the additional pip modules in docs/requirements.txt that are needed by pympistandard to be able to run with Python 3.6.
Fixes #13267