### PR TITLE
Force alignment of opal_atomic_int128_t to be 16B

### DIFF
--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -72,7 +72,7 @@ typedef _Atomic opal_int128_t opal_atomic_int128_t;
 
 #        else
 
-typedef volatile opal_int128_t opal_atomic_int128_t;
+typedef volatile opal_int128_t opal_atomic_int128_t __opal_attribute_aligned__(16);
 
 #        endif
 


### PR DESCRIPTION
Some architectures will align 128bit integer on 8B but require 16B alignment for 128bit CAS instructions and otherwise fall back to a lock-based atomicity model. By forcing 16bit alignment we can ensure that the variables are properly aligned and the fall-back is not triggered.

Thanks to Ulrich Weigand for the analysis and proposed fix in https://github.com/open-mpi/ompi/issues/10988#issuecomment-2913388506.

Fixes https://github.com/open-mpi/ompi/issues/10988.