### PR TITLE
coll: make bcast ring unsigned-safe

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -277,6 +277,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Wstrict-prototypes, Wstrict_prototypes)
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Wcomment, Wcomment)
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Wshadow, Wshadow)
+        _OPAL_CHECK_SPECIFIC_CFLAGS(-Wtype-limits,Wtype_limits)
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Werror-implicit-function-declaration, Werror_implicit_function_declaration)
         _OPAL_CHECK_SPECIFIC_CFLAGS(-Wno-long-double, Wno_long_double, int main() { long double x; })
         _OPAL_CHECK_SPECIFIC_CFLAGS(-fno-strict-aliasing, fno_strict_aliasing, int main() { long double x; })


### PR DESCRIPTION
In the conversion to support big count, there are several places where signed int's were replaced by unsigned types (size_t). Unfortunately there were a few places where signedness was being used and these need to be refactored.

To find these places the -Wtype-limit gnu compile option was used. This compile option is added to the --enable-picky compile option list as part of this PR.