### PR TITLE
mpi-rma: embiggen second level mpi rma support infrastructure

### DIFF
--- a/ompi/mpi/c/win_allocate.c.in
+++ b/ompi/mpi/c/win_allocate.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -67,22 +67,8 @@ PROTOTYPE ERROR_CLASS win_allocate(AINT size, DISP disp_unit, INFO info,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-/*
- * TODO:BIGCOUNT remove this check once ompi-rma supports bigcount
- */
-#if OMPI_BIGCOUNT_SRC
-    OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(ret, disp_unit);
-    if (OMPI_SUCCESS != ret) {
-        *win = MPI_WIN_NULL;
-        return OMPI_ERRHANDLER_INVOKE(comm, ret, FUNC_NAME);
-    }
-#endif
-
     /* create window and return */
-/*
- * TODO:BIGCOUNT remove (int) before disp_unit  once ompi-rma supports bigcount
- */
-    ret = ompi_win_allocate((size_t)size, (int)disp_unit, &(info->super),
+    ret = ompi_win_allocate((size_t)size, (ptrdiff_t)disp_unit, &(info->super),
                             comm, baseptr, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;

--- a/ompi/mpi/c/win_allocate_shared.c.in
+++ b/ompi/mpi/c/win_allocate_shared.c.in
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -61,16 +61,6 @@ PROTOTYPE ERROR_CLASS win_allocate_shared(AINT size, DISP disp_unit, INFO info,
         } else if ( size < 0 ) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_SIZE, FUNC_NAME);
         }
-/*
- * TODO:BIGCOUNT remove this check once ompi-rma supports bigcount
- */
-#if OMPI_BIGCOUNT_SRC
-        OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(ret, disp_unit);
-        if (OMPI_SUCCESS != ret) {
-            *win = MPI_WIN_NULL;
-            return OMPI_ERRHANDLER_INVOKE(comm, ret, FUNC_NAME);
-        }
-#endif
     }
 
     /* communicator must be an intracommunicator */
@@ -79,10 +69,7 @@ PROTOTYPE ERROR_CLASS win_allocate_shared(AINT size, DISP disp_unit, INFO info,
     }
 
     /* create window and return */
-/*
- * TODO:BIGCOUNT remove (int) from disp_unit once ompi-rma supports bigcount
- */
-    ret = ompi_win_allocate_shared((size_t)size, (int)disp_unit, &(info->super),
+    ret = ompi_win_allocate_shared((size_t)size, (ptrdiff_t)disp_unit, &(info->super),
                                    comm, baseptr, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;

--- a/ompi/mpi/c/win_create.c.in
+++ b/ompi/mpi/c/win_create.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -60,16 +60,6 @@ PROTOTYPE ERROR_CLASS win_create(BUFFER_OUT base, AINT size, DISP disp_unit,
         } else if ( disp_unit <= 0 ) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_DISP, FUNC_NAME);
         }
-/*
- * TODO:BIGCOUNT remove this check once ompi-rma supports bigcount
- */
-#if OMPI_BIGCOUNT_SRC
-        OMPI_CHECK_MPI_COUNT_INT_CONVERSION_OVERFLOW(ret, disp_unit);
-        if (OMPI_SUCCESS != ret) {
-            *win = MPI_WIN_NULL;
-            return OMPI_ERRHANDLER_INVOKE(comm, ret, FUNC_NAME);
-        }
-#endif
     }
 
     /* communicator must be an intracommunicator */
@@ -77,11 +67,8 @@ PROTOTYPE ERROR_CLASS win_create(BUFFER_OUT base, AINT size, DISP disp_unit,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-/*
- * TODO:BIGCOUNT remove (int) before disp_unit once ompi-rma supports bigcount
- */
     /* create window and return */
-    ret = ompi_win_create(base, (size_t)size, (int)disp_unit, comm,
+    ret = ompi_win_create(base, (size_t)size, (ptrdiff_t)disp_unit, comm,
                           &(info->super), win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2024      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
@@ -206,7 +206,7 @@ static int alloc_window(struct ompi_communicator_t *comm, opal_info_t *info, int
 }
 
 static int
-config_window(void *base, size_t size, int disp_unit,
+config_window(void *base, size_t size, ptrdiff_t disp_unit,
               int flavor, int model, ompi_win_t *win)
 {
     int ret;
@@ -220,9 +220,15 @@ config_window(void *base, size_t size, int disp_unit,
                              MPI_WIN_SIZE, size, true);
     if (OMPI_SUCCESS != ret) return ret;
 
+    /* 
+     * No this isn't really right but the MPI Forum RMA WG was spleeping during
+     * Big count proposal reading and didn't put in something for Table 12.1 of the 
+     * MPI 5.0 standard for embiggened disp_unit, so here we go with int * in accordance
+     * with that table.
+     */
     ret = ompi_attr_set_int(WIN_ATTR, win,
                             &win->w_keyhash,
-                            MPI_WIN_DISP_UNIT, disp_unit,
+                            MPI_WIN_DISP_UNIT, (int)disp_unit,
                             true);
     if (OMPI_SUCCESS != ret) return ret;
 
@@ -244,7 +250,7 @@ config_window(void *base, size_t size, int disp_unit,
 
 int
 ompi_win_create(void *base, size_t size,
-                int disp_unit, ompi_communicator_t *comm,
+                ptrdiff_t disp_unit, ompi_communicator_t *comm,
                 opal_info_t *info,
                 ompi_win_t** newwin)
 {
@@ -275,7 +281,7 @@ ompi_win_create(void *base, size_t size,
 }
 
 int
-ompi_win_allocate(size_t size, int disp_unit, opal_info_t *info,
+ompi_win_allocate(size_t size, ptrdiff_t disp_unit, opal_info_t *info,
                   ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin)
 {
     ompi_win_t *win;
@@ -307,7 +313,7 @@ ompi_win_allocate(size_t size, int disp_unit, opal_info_t *info,
 }
 
 int
-ompi_win_allocate_shared(size_t size, int disp_unit, opal_info_t *info,
+ompi_win_allocate_shared(size_t size, ptrdiff_t disp_unit, opal_info_t *info,
                          ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin)
 {
     ompi_win_t *win;

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -134,12 +134,12 @@ OMPI_DECLSPEC extern ompi_predefined_win_t *ompi_mpi_win_null_addr;
 
 int ompi_win_init(void);
 
-int ompi_win_create(void *base, size_t size, int disp_unit,
+int ompi_win_create(void *base, size_t size, ptrdiff_t disp_unit,
                     ompi_communicator_t *comm, opal_info_t *info,
                     ompi_win_t **newwin);
-int ompi_win_allocate(size_t size, int disp_unit, opal_info_t *info,
+int ompi_win_allocate(size_t size, ptrdiff_t disp_unit, opal_info_t *info,
                       ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin);
-int ompi_win_allocate_shared(size_t size, int disp_unit, opal_info_t *info,
+int ompi_win_allocate_shared(size_t size, ptrdiff_t disp_unit, opal_info_t *info,
                       ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin);
 int ompi_win_create_dynamic(opal_info_t *info, ompi_communicator_t *comm, ompi_win_t **newwin);
 int ompi_win_free(ompi_win_t *win);


### PR DESCRIPTION
The top level API files generated by the bindings generation code and the lower level OSC frameworks have been embiggened previously, but the middle layer within OMPI has not been till this patch.

There's a present for the RMA WG in this commit in the form of a comment.  Something for them to work on.

Related to #13151