### PR TITLE
v5.0.x: configury: remove whitespace from "conftestval"-style tests

### DIFF
--- a/config/ompi_fortran_check_logical_array.m4
+++ b/config/ompi_fortran_check_logical_array.m4
@@ -101,7 +101,7 @@ EOF
                  [ # assume we're ok
                   value=yes],
                  [OPAL_LOG_COMMAND([./conftest],
-                      [if test "`cat conftestval`" = "1" ; then
+                      [if test "`cat conftestval | xargs`" = "1" ; then
                            value=yes
                        else
                            value=no

--- a/config/ompi_fortran_check_real16_c_equiv.m4
+++ b/config/ompi_fortran_check_real16_c_equiv.m4
@@ -141,7 +141,7 @@ EOF
              [AC_MSG_RESULT([Error!])
               AC_MSG_ERROR([Can not determine if REAL*16 bit-matches C if cross compiling])],
              [OPAL_LOG_COMMAND([./conftest],
-                 [fortran_real16_happy=`cat conftestval`],
+                 [fortran_real16_happy=`cat conftestval | xargs`],
                  [AC_MSG_RESULT([Error!])
                   AC_MSG_ERROR([Could not determine if REAL*16 bit-matches C type])
                  ])

--- a/config/ompi_fortran_get_alignment.m4
+++ b/config/ompi_fortran_get_alignment.m4
@@ -203,7 +203,7 @@ end program]])],
                           [AS_IF([test "$cross_compiling" = "yes"],
                                  [AC_MSG_ERROR([Can not determine common alignment when cross-compiling])],
                                  [OPAL_LOG_COMMAND([./conftest],
-                                                   [AS_VAR_SET(ompi_cv_fortran_common_alignment, [`cat conftestval`])],
+                                                   [AS_VAR_SET(ompi_cv_fortran_common_alignment, [`cat conftestval | xargs`])],
                                                    [AC_MSG_ERROR([Could not determine common alignment])])])],
 
                           [AC_MSG_WARN([Could not determine common alignment])

--- a/config/ompi_fortran_get_alignment.m4
+++ b/config/ompi_fortran_get_alignment.m4
@@ -216,5 +216,4 @@ end program]])],
           [AC_MSG_CHECKING([Fortran common alignment])
            $1=0
            AC_MSG_RESULT([skipped])])
-
 ])dnl

--- a/config/ompi_fortran_get_sizeof.m4
+++ b/config/ompi_fortran_get_sizeof.m4
@@ -79,7 +79,7 @@ EOF
          AS_IF([test "$cross_compiling" = "yes"],
              [AC_MSG_ERROR([Can not determine size of $2 when cross-compiling])],
              [OPAL_LOG_COMMAND([./conftest],
-                 [AS_VAR_SET(type_var, [`cat conftestval`])],
+                 [AS_VAR_SET(type_var, [`cat conftestval | xargs`])],
                  [AC_MSG_ERROR([Could not determine size of $2])])])
 
         unset happy ompi_conftest_h


### PR DESCRIPTION
Several configure tests write integer result values to files and then do something like foo=$(cat conftestval). However, if the conftestval file contains whitespace around the integer value (e.g., if conftestval was written by a Fortran test code), then $foo will still contain that whitespace, too -- which then propagates throughout the configury and elsewhere.

This commit uses xargs to strip off the whitespace. There's really only one place where this is happening that is a problem, but let's do it in all places where we foo=$(cat conftestval) with integer results, just as a matter of consistency and defensive programming.

Thanks to Lisandro Dalcin (@dalcinl) for raising the issue.

Fixes https://github.com/open-mpi/ompi/issues/13285.

This is the v5.0.x PR corresponding to main PR #13286 