### PR TITLE
[5.0.x] Add missing memcpy header

### DIFF
--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -13,6 +13,7 @@
 #include "opal/mca/accelerator/base/base.h"
 #include "opal/constants.h"
 #include "opal/util/output.h"
+#include <string.h>
 
 /* Accelerator API's */
 static int mca_accelerator_rocm_check_addr(const void *addr, int *dev_id, uint64_t *flags);


### PR DESCRIPTION
Cherry picked from #13295 

(commit aa5577441ff1ab7f97f8b63e442b37457c7bd997)