### PR TITLE
fix some memleak

### DIFF
--- a/ompi/mca/op/avx/op_avx_component.c
+++ b/ompi/mca/op/avx/op_avx_component.c
@@ -298,12 +298,6 @@ avx_component_op_query(struct ompi_op_t *op, int *priority)
                 }
             }
 #endif
-            if( NULL != module->opm_fns[i] ) {
-                OBJ_RETAIN(module);
-            }
-            if( NULL != module->opm_3buff_fns[i] ) {
-                OBJ_RETAIN(module);
-            }
         }
         break;
     case OMPI_OP_BASE_FORTRAN_LAND:

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -211,6 +211,9 @@ OPAL_DECLSPEC void opal_common_ucx_mca_deregister(void)
     }
     opal_mem_hooks_unregister_release(opal_common_ucx_mem_release_cb);
     opal_output_close(opal_common_ucx.output);
+    if (opal_common_ucx.opal_mem_hooks) {
+        mca_base_framework_close(&opal_memory_base_framework);
+    }
 }
 
 #if HAVE_DECL_OPEN_MEMSTREAM

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -73,6 +73,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
 {
     char *default_tls = "rc_verbs,ud_verbs,rc_mlx5,dc_mlx5,ud_mlx5,cuda_ipc,rocm_ipc";
     char *default_devices = "mlx*";
+    char *old_str = NULL;
     int hook_index;
     int verbose_index;
     int progress_index;
@@ -113,6 +114,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
     if (NULL == *opal_common_ucx.tls) {
         *opal_common_ucx.tls = strdup(default_tls);
     }
+    old_str = *opal_common_ucx.tls;
 
     tls_index = mca_base_var_register(
         "opal", "opal_common", "ucx", "tls",
@@ -123,6 +125,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
         "please set to '^posix,sysv,self,tcp,cma,knem,xpmem'.",
         MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE | MCA_BASE_VAR_FLAG_DWG,
         OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL, opal_common_ucx.tls);
+    free(old_str);
 
     if (NULL == opal_common_ucx.devices) {
         opal_common_ucx.devices = (char**) malloc(sizeof(char*));
@@ -132,6 +135,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
     if (NULL == *opal_common_ucx.devices) {
         *opal_common_ucx.devices = strdup(default_devices);
     }
+    old_str = *opal_common_ucx.devices;
 
     devices_index = mca_base_var_register(
         "opal", "opal_common", "ucx", "devices",
@@ -139,6 +143,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
         "bump its priority above ob1. Special values: any (any available)",
         MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE | MCA_BASE_VAR_FLAG_DWG,
         OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL, opal_common_ucx.devices);
+    free(old_str);
 
     if (component) {
         mca_base_var_register_synonym(verbose_index, component->mca_project_name,

--- a/opal/mca/patcher/base/patcher_base_frame.c
+++ b/opal/mca/patcher/base/patcher_base_frame.c
@@ -90,7 +90,7 @@ static int opal_patcher_base_close(void)
         return opal_patcher->patch_fini();
     }
 
-    return OPAL_SUCCESS;
+    return mca_base_framework_components_close(&opal_patcher_base_framework, NULL);
 }
 
 /* Use default register/open functions */

--- a/opal/mca/patcher/base/patcher_base_frame.c
+++ b/opal/mca/patcher/base/patcher_base_frame.c
@@ -90,7 +90,7 @@ static int opal_patcher_base_close(void)
         return opal_patcher->patch_fini();
     }
 
-    return mca_base_framework_components_close(&opal_patcher_base_framework, NULL);
+    return OPAL_SUCCESS;
 }
 
 /* Use default register/open functions */


### PR DESCRIPTION
avx_component module retain twice by avx_component_op_query and ompi_op_base_op_select function;
mca_base_var_register will strdup, and not free old string;
opal_patcher_base_framework not close;