### PR TITLE
osc: Fix rdma component when not using ob1

### DIFF
--- a/ompi/mca/osc/base/osc_base_init.c
+++ b/ompi/mca/osc/base/osc_base_init.c
@@ -30,6 +30,8 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/win/win.h"
 
+bool ompi_osc_base_requires_world = false;
+
 int
 ompi_osc_base_select(ompi_win_t *win,
                      void **base,

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -53,6 +53,9 @@ struct ompi_datatype_t;
 struct ompi_op_t;
 struct ompi_request_t;
 
+
+extern bool ompi_osc_base_requires_world;
+
 /* ******************************************************************** */
 
 
@@ -418,6 +421,11 @@ typedef ompi_osc_base_module_4_0_0_t ompi_osc_base_module_t;
 
 
 /* ******************************************************************** */
+
+static inline bool mca_osc_base_requires_world (void)
+{
+    return ompi_osc_base_requires_world;
+}
 
 
 END_C_DECLS

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -349,6 +349,8 @@ component_init(bool enable_progress_threads, bool enable_mpi_threads)
         return ret;
     }
 
+    ompi_osc_base_requires_world = true;
+
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -345,6 +345,27 @@ static int ompi_osc_rdma_component_init (bool enable_progress_threads,
                             __FILE__, __LINE__, ret);
     }
 
+    ret = mca_bml_base_init(enable_progress_threads, enable_mpi_threads);
+    if (OPAL_SUCCESS != ret) {
+        opal_output_verbose(1, ompi_osc_base_framework.framework_output,
+                            "%s:%d: bml_base_init() failed: %d",
+                            __FILE__, __LINE__, ret);
+        return ret;
+    }
+
+    /* check if any btls do not support dynamic add_procs */
+    mca_btl_base_selected_module_t* selected_btl;
+    OPAL_LIST_FOREACH(selected_btl, &mca_btl_base_modules_initialized,
+                      mca_btl_base_selected_module_t) {
+        mca_btl_base_module_t *btl = selected_btl->btl_module;
+
+        if (btl->btl_flags & MCA_BTL_FLAGS_SINGLE_ADD_PROCS) {
+            ompi_osc_base_requires_world = true;
+            break;
+        }
+
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
When the ob1 PML was not eligible for selection (such as when the user sets --mca pml cm), the BML and BTL frameworks are not initialized and the rdma osc component will later fail as there are no BTLs available. This patch resolves the issue by having the rdma osc component initialize the BML interface.

Making this change required two additional, related changes.  First, since the BTLs use the modex, the rdma initialization must be moved before the modex point, so that putting data in the modex works as expected.  Second, BTLs can require loading the entire world during init (such as TCP when there are multiple threads and multiple NICs or usnic), so we extend the world loading checks to include OSC.

Since the other Portals4 components say that they do require world loading, we also assume the Portals4 osc component also requires world loading.