### PR TITLE
add support for riscv64 timer

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -538,6 +538,9 @@ AC_DEFUN([OPAL_CHECK_INLINE_C_GCC],[
             powerpc-*|powerpc64-*|powerpcle-*|powerpc64le-*|rs6000-*|ppc-*)
                 opal_gcc_inline_assign='"1: li %0,0" : "=&r"(ret)'
                 ;;
+            riscv64*)
+                opal_gcc_inline_assign='"li %0, 0" : "=r"(ret)'
+                ;;
         esac
 
         AS_IF([test  "$opal_gcc_inline_assign" != ""],

--- a/opal/include/opal/sys/Makefile.am
+++ b/opal/include/opal/sys/Makefile.am
@@ -42,4 +42,5 @@ headers += \
 include opal/sys/x86_64/Makefile.am
 include opal/sys/arm64/Makefile.am
 include opal/sys/powerpc/Makefile.am
+include opal/sys/riscv64/Makefile.am
 include opal/sys/gcc_builtin/Makefile.am

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -59,6 +59,10 @@
 #        define __NR_process_vm_readv  270
 #        define __NR_process_vm_writev 271
 
+#    elif defined(PLATFORM_ARCH_RISCV)
+#        define __NR_process_vm_readv  270
+#        define __NR_process_vm_writev 271
+
 #    else
 #        error "Unsupported architecture for process_vm_readv and process_vm_writev syscalls"
 #    endif

--- a/opal/include/opal/sys/riscv64/Makefile.am
+++ b/opal/include/opal/sys/riscv64/Makefile.am
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from opal/include/Makefile.am
+
+headers += \
+	opal/sys/riscv64/timer.h
+

--- a/opal/include/opal/sys/riscv64/timer.h
+++ b/opal/include/opal/sys/riscv64/timer.h
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2008      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2016      Broadcom Limited. All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2021      Google, LLC. All rights reserved.
+ * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_SYS_ARCH_TIMER_H
+#define OPAL_SYS_ARCH_TIMER_H 1
+
+typedef uint64_t opal_timer_t;
+
+#if OPAL_C_GCC_INLINE_ASSEMBLY
+
+static inline opal_timer_t opal_sys_timer_get_cycles(void)
+{
+    opal_timer_t ret;
+    __asm__ __volatile__("fence iorw, iorw" ::: "memory");
+    __asm__ __volatile__("rdtime %0" : "=r"(ret));
+
+    return ret;
+}
+
+#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+
+#endif /* OPAL_C_GCC_INLINE_ASSEMBLY */
+
+#endif /* ! OPAL_SYS_ARCH_TIMER_H */
+

--- a/opal/include/opal/sys/timer.h
+++ b/opal/include/opal/sys/timer.h
@@ -63,6 +63,8 @@ BEGIN_C_DECLS
 #    include "opal/sys/arm64/timer.h"
 #elif defined(PLATFORM_ARCH_POWERPC)
 #    include "opal/sys/powerpc/timer.h"
+#elif defined(PLATFORM_ARCH_RISCV)
+#    include "opal/sys/riscv64/timer.h"
 #endif
 
 #ifndef DOXYGEN

--- a/opal/mca/timer/linux/configure.m4
+++ b/opal/mca/timer/linux/configure.m4
@@ -47,7 +47,7 @@ AC_DEFUN([MCA_opal_timer_linux_CONFIG],[
                  [timer_linux_happy="no"])])
 
    case "${host}" in
-   i?86-*linux*|x86_64*linux*|ia64-*linux*|powerpc-*linux*|powerpc64-*linux*|powerpc64le-*linux*|powerpcle-*linux*|sparc*-*linux*|aarch64-*linux*)
+   i?86-*linux*|x86_64*linux*|ia64-*linux*|powerpc-*linux*|powerpc64-*linux*|powerpc64le-*linux*|powerpcle-*linux*|sparc*-*linux*|aarch64-*linux*|riscv64-*linux*)
         AS_IF([test "$timer_linux_happy" = "yes"],
               [AS_IF([test -r "/proc/cpuinfo"],
                      [timer_linux_happy="yes"],

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -29,6 +29,7 @@
 
 #include <string.h>
 #include <time.h>
+#include <arpa/inet.h>
 
 #include "opal/constants.h"
 #include "opal/mca/timer/base/base.h"
@@ -176,6 +177,20 @@ static int opal_timer_linux_find_freq(void)
             }
         }
     }
+
+#if defined(PLATFORM_ARCH_RISCV)
+    if (0 == opal_timer_linux_freq) {
+        /* read timebase-frequency in device-tree */
+        FILE *fp_rv = fopen("/proc/device-tree/cpus/timebase-frequency", "rb");
+        if (NULL == fp_rv) {
+            return OPAL_ERR_IN_ERRNO;
+        }
+        if (1 == fread(&opal_timer_linux_freq, 4, 1, fp_rv)){
+            opal_timer_linux_freq = ntohl(opal_timer_linux_freq);
+        }
+        fclose(fp_rv);
+    }
+#endif
 
     fclose(fp);
 


### PR DESCRIPTION
Hi, this patch add support for riscv64 timer,

1. Implemet opal_sys_timer_get_cycles on RISC-V 64 platform using rdtime instruction.
2. Add a method to read tsc frequency on RISC-V 64 platform.
3. Correspondingly modified serveral configuration files.
4. Tested test/util/opal_timer.c on RISC-V hardware,
```
[root@host util]# ./opal_timer
--> frequency: 50000000 
--> cycle count  
    Slept approximately 50004395 cycles, or 1000087 us 
--> usecs 
    Slept approximately 1000077 us
```