### PR TITLE
Add support for get_name with predefined NULL objects.

### DIFF
--- a/ompi/datatype/ompi_datatype_internal.h
+++ b/ompi/datatype/ompi_datatype_internal.h
@@ -35,7 +35,7 @@
  * This is the OMPI-layered numbering of ALL supported MPI types
  * (derived from the old DT_ names).
  */
-#define OMPI_DATATYPE_MPI_EMPTY                   0x00
+#define OMPI_DATATYPE_MPI_NULL                    0x00
 #define OMPI_DATATYPE_MPI_INT8_T                  0x01
 #define OMPI_DATATYPE_MPI_UINT8_T                 0x02
 #define OMPI_DATATYPE_MPI_INT16_T                 0x03

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -65,14 +65,21 @@ int32_t ompi_datatype_number_of_predefined_data = 0;
  *   Additionally to OMPI_DATATYPE_INIT_PREDEFINED_BASIC_TYPE, we have a OMPI_DATATYPE_INIT_PREDEFINED,
  *   for all available types (getting rid of duplication of the name.
  */
-ompi_predefined_datatype_t ompi_mpi_datatype_null =
+ompi_predefined_datatype_t ompi_mpi_datatype_null = {
     {
-        {
-            OPAL_DATATYPE_INITIALIZER_EMPTY(OMPI_DATATYPE_FLAG_PREDEFINED|OPAL_DATATYPE_FLAG_CONTIGUOUS),
-            OMPI_DATATYPE_EMPTY_DATA(EMPTY),
-        },
-        {0, } /* padding */
-    };
+        OPAL_DATATYPE_INITIALIZER_EMPTY(OMPI_DATATYPE_FLAG_PREDEFINED
+                                        | OPAL_DATATYPE_FLAG_CONTIGUOUS),
+        .id = OMPI_DATATYPE_MPI_NULL,
+        .d_f_to_c_index = -1,
+        .d_keyhash = NULL,
+        .args = NULL,
+        .packed_description = 0,
+        .name = "MPI_DATATYPE_NULL",
+    },
+    {
+        0,
+    } /* padding */
+};
 
 ompi_predefined_datatype_t ompi_mpi_unavailable =    OMPI_DATATYPE_INIT_PREDEFINED (UNAVAILABLE, 0);
 
@@ -317,7 +324,7 @@ ompi_predefined_datatype_t ompi_mpi_count = OMPI_DATATYPE_INIT_UNAVAILABLE_BASIC
  * Everything referring to types/ids should be ORDERED as in ompi_datatype_basicDatatypes array.
  */
 const ompi_datatype_t* ompi_datatype_basicDatatypes[OMPI_DATATYPE_MPI_MAX_PREDEFINED] = {
-    [OMPI_DATATYPE_MPI_EMPTY] = &ompi_mpi_datatype_null.dt,
+    [OMPI_DATATYPE_MPI_NULL] = &ompi_mpi_datatype_null.dt,
     [OMPI_DATATYPE_MPI_INT8_T] = &ompi_mpi_int8_t.dt,
     [OMPI_DATATYPE_MPI_UINT8_T] = &ompi_mpi_uint8_t.dt,
     [OMPI_DATATYPE_MPI_INT16_T] = &ompi_mpi_int16_t.dt,

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -58,7 +58,7 @@ ptl_op_t ompi_coll_portals4_atomic_op [OMPI_OP_NUM_OF_TYPES] =
 
 ptl_datatype_t ompi_coll_portals4_atomic_datatype [OMPI_DATATYPE_MPI_MAX_PREDEFINED] =
 {
-        [OMPI_DATATYPE_MPI_EMPTY] = COLL_PORTALS4_NO_DTYPE,
+        [OMPI_DATATYPE_MPI_NULL] = COLL_PORTALS4_NO_DTYPE,
         [OMPI_DATATYPE_MPI_UINT8_T] = PTL_UINT8_T,
         [OMPI_DATATYPE_MPI_INT16_T] = PTL_INT16_T,
         [OMPI_DATATYPE_MPI_UINT16_T] = PTL_UINT16_T,

--- a/ompi/mpi/c/type_get_name.c.in
+++ b/ompi/mpi/c/type_get_name.c.in
@@ -43,7 +43,7 @@ PROTOTYPE ERROR_CLASS type_get_name(DATATYPE type, STRING_OUT type_name, INT_OUT
 
    if ( MPI_PARAM_CHECK ) {
       OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-      if (NULL == type || MPI_DATATYPE_NULL == type) {
+      if (NULL == type) {
         return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_TYPE,
                                       FUNC_NAME );
       } else if (NULL == type_name || NULL == resultlen) {

--- a/ompi/mpi/c/win_get_name.c.in
+++ b/ompi/mpi/c/win_get_name.c.in
@@ -36,7 +36,7 @@ PROTOTYPE ERROR_CLASS win_get_name(WIN win, STRING_OUT win_name, INT_OUT resultl
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 
-        if (ompi_win_invalid(win)) {
+        if (ompi_win_invalid(win) && MPI_WIN_NULL != win) {
             return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_WIN, FUNC_NAME);
         } else if (NULL == win_name || NULL == resultlen) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_ARG, FUNC_NAME);


### PR DESCRIPTION
This PR complements #13276 to add support for MPI_*_get_name for predefined NULL objects (MPI_DATATYPE_NULL and MPI_WIN_NULL) as requested in MPI 4.1 chapter B 1.2 item 18.

Fixes #12079.