### PR TITLE
MPI 4.0: Allow MPI_WIN_SHARED_QUERY on regular windows

### DIFF
--- a/docs/man-openmpi/man3/MPI_Win_shared_query.3.rst
+++ b/docs/man-openmpi/man3/MPI_Win_shared_query.3.rst
@@ -28,19 +28,24 @@ DESCRIPTION
 
 :ref:`MPI_Win_shared_query` queries the process-local address for
 remote memory segments created with
-:ref:`MPI_Win_allocate_shared`. This function can return different
+:ref:`MPI_Win_create`, :ref:`MPI_Win_allocate`, or
+:ref:`MPI_Win_allocate_shared`. Shared memory is only guaranteed to be
+available for windows created with :ref:`MPI_Win_allocate_shared`.
+This function can return different
 process-local addresses for the same physical memory on different
 processes. The returned memory can be used for load/store accesses
-subject to the constraints defined in MPI-3.1 section 11.7. This
-function can only be called with windows of flavor
-MPI_WIN_FLAVOR_SHARED. If the passed window is not of flavor
-MPI_WIN_FLAVOR_SHARED, the error MPI_ERR_RMA_FLAVOR is raised. When
+subject to the constraints defined in MPI-3.1 section 11.7.
+If the passed a dynamic window, the error MPI_ERR_RMA_FLAVOR is raised. When
 rank is ``MPI_PROC_NULL``, the *pointer*, *disp_unit*, and *size* returned
 are the pointer, disp_unit, and size of the memory segment belonging
-the lowest rank that specified *size* > 0. If all processes in the
+to the lowest rank that specified *size* > 0. If all processes in the
 group attached to the window specified *size* = 0, then the call
 returns *size* = 0 and a *baseptr* as if :ref:`MPI_Alloc_mem` was
 called with *size* = 0.
+If the window was created with :ref:`MPI_Win_create` or
+:ref:`MPI_Win_allocate` and shared memory is not supported for these windows,
+the call returns *size* = 0 and a *baseptr* as if
+:ref:`MPI_Alloc_mem` was called with *size* = 0.
 
 
 C NOTES
@@ -59,3 +64,5 @@ ERRORS
 .. seealso::
    * :ref:`MPI_Alloc_mem`
    * :ref:`MPI_Win_allocate_shared`
+   * :ref:`MPI_Win_create`
+   * :ref:`MPI_Win_allocate`

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -990,7 +991,7 @@ int ompi_osc_rdma_compare_and_swap (const void *origin_addr, const void *compare
      * OR if we have an exclusive lock
      * OR if other processes won't try to use the network either */
     bool use_shared_mem = module->single_node ||
-                          (ompi_osc_rdma_peer_local_base (peer) &&
+                          (ompi_osc_rdma_peer_cpu_atomics (peer) &&
                               (ompi_osc_rdma_peer_is_exclusive (peer) ||
                                   !module->acc_single_intrinsic));
 
@@ -1013,7 +1014,7 @@ int ompi_osc_rdma_compare_and_swap (const void *origin_addr, const void *compare
         lock_acquired = true;
     }
 
-    if (ompi_osc_rdma_peer_local_base (peer)) {
+    if (ompi_osc_rdma_peer_cpu_atomics (peer)) {
         ret = ompi_osc_rdma_cas_local (origin_addr, compare_addr, result_addr, dt,
                                        peer, target_address, target_handle, module,
                                        lock_acquired);
@@ -1095,7 +1096,7 @@ int ompi_osc_rdma_rget_accumulate_internal (ompi_win_t *win, const void *origin_
         (void) ompi_osc_rdma_lock_acquire_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, accumulate_lock));
     }
 
-    if (ompi_osc_rdma_peer_local_base (peer)) {
+    if (ompi_osc_rdma_peer_cpu_atomics (peer)) {
         /* local/self optimization */
         ret = ompi_osc_rdma_gacc_local (origin_addr, origin_count, origin_datatype, result_addr, result_count,
                                         result_datatype, peer, target_address, target_handle, target_count,

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,6 +143,8 @@ enum {
     OMPI_OSC_RDMA_PEER_BASE_FREE            = 0x40,
     /** peer was demand locked as part of lock-all (when in demand locking mode) */
     OMPI_OSC_RDMA_PEER_DEMAND_LOCKED        = 0x80,
+    /** we can use CPU atomics on that peer */
+    OMPI_OSC_RDMA_PEER_CPU_ATOMICS          = 0x100,
 };
 
 /**
@@ -222,6 +225,11 @@ static inline void ompi_osc_rdma_peer_clear_flag (ompi_osc_rdma_peer_t *peer, in
 static inline bool ompi_osc_rdma_peer_local_base (ompi_osc_rdma_peer_t *peer)
 {
     return !!(peer->flags & OMPI_OSC_RDMA_PEER_LOCAL_BASE);
+}
+
+static inline bool ompi_osc_rdma_peer_cpu_atomics (ompi_osc_rdma_peer_t *peer)
+{
+    return ompi_osc_rdma_peer_local_base(peer) && !!(peer->flags & OMPI_OSC_RDMA_PEER_CPU_ATOMICS);
 }
 
 /**

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -5,6 +5,7 @@
  *                         reserved.
  *
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -290,7 +291,7 @@ static int component_init(bool enable_progress_threads, bool enable_mpi_threads)
     return OMPI_SUCCESS;
 }
 
-static int component_set_priority() {
+static int component_set_priority(void) {
     int param, ret;
     opal_common_ucx_support_level_t support_level = OPAL_COMMON_UCX_SUPPORT_NONE;
     mca_base_var_source_t param_source = MCA_BASE_VAR_SOURCE_DEFAULT;
@@ -468,39 +469,68 @@ static const char* ompi_osc_ucx_set_no_lock_info(opal_infosubscriber_t *obj, con
     return module->no_locks ? "true" : "false";
 }
 
+static int ompi_osc_ucx_shared_query_peer(ompi_osc_ucx_module_t *module, int peer, size_t *size,
+    ptrdiff_t *disp_unit, void *baseptr) {
+
+    int rc;
+    ucp_ep_h *dflt_ep;
+    ucp_ep_h ep; // ignored
+    ucp_rkey_h rkey;
+    OSC_UCX_GET_DEFAULT_EP(dflt_ep, module, peer);
+    opal_common_ucx_winfo_t *winfo; // ignored
+    rc = opal_common_ucx_tlocal_fetch(module->mem, peer, &ep, &rkey, &winfo, dflt_ep);
+    if (OMPI_SUCCESS != rc) {
+        return OMPI_ERR_NOT_SUPPORTED;
+    }
+    void *addr_p;
+    if (UCS_OK != ucp_rkey_ptr(rkey, module->addrs[peer], &addr_p)) {
+        return OMPI_ERR_NOT_SUPPORTED;
+    }
+    *size = ompi_osc_ucx_get_size(module, peer);
+    *((void**) baseptr) = addr_p;
+    *disp_unit = (module->disp_unit < 0) ? module->disp_units[peer] : module->disp_unit;
+
+    return OMPI_SUCCESS;
+}
+
 int ompi_osc_ucx_shared_query(struct ompi_win_t *win, int rank, size_t *size,
         ptrdiff_t *disp_unit, void *baseptr)
 {
     ompi_osc_ucx_module_t *module =
         (ompi_osc_ucx_module_t*) win->w_osc_module;
 
+    *size = 0;
+    *((void**) baseptr) = NULL;
+    *disp_unit = 0;
+
     if (module->flavor != MPI_WIN_FLAVOR_SHARED) {
-        return MPI_ERR_WIN;
-    }
 
-    if (MPI_PROC_NULL != rank) {
-        *size = module->sizes[rank];
-        *((void**) baseptr) = (void *)module->shmem_addrs[rank];
-        if (module->disp_unit == -1) {
-            *disp_unit = module->disp_units[rank];
-        } else {
-            *disp_unit = module->disp_unit;
-        }
-    } else {
-        int i = 0;
-
-        *size = 0;
-        *((void**) baseptr) = NULL;
-        *disp_unit = 0;
-        for (i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
-            if (0 != module->sizes[i]) {
-                *size = module->sizes[i];
-                *((void**) baseptr) = (void *)module->shmem_addrs[i];
-                if (module->disp_unit == -1) {
-                    *disp_unit = module->disp_units[rank];
-                } else {
-                    *disp_unit = module->disp_unit;
+        if (MPI_PROC_NULL == rank) {
+            for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
+                if (0 != ompi_osc_ucx_get_size(module, i)) {
+                    if (OMPI_SUCCESS == ompi_osc_ucx_shared_query_peer(module, i, size, disp_unit, baseptr)) {
+                        return OMPI_SUCCESS;
+                    }
                 }
+            }
+        } else {
+            if (0 != ompi_osc_ucx_get_size(module, rank)) {
+                return ompi_osc_ucx_shared_query_peer(module, rank, size, disp_unit, baseptr);
+            }
+        }
+        return OMPI_ERR_NOT_SUPPORTED;
+
+    } else if (MPI_PROC_NULL != rank) { // shared memory window with given rank
+        *size = ompi_osc_ucx_get_size(module, rank);
+        *((void**) baseptr) = (void *)module->shmem_addrs[rank];
+        *disp_unit = ompi_osc_ucx_get_disp_unit(module, rank);
+    } else { // shared memory window with MPI_PROC_NULL
+        for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
+            size_t peer_size = ompi_osc_ucx_get_size(module, i);
+            if (0 != peer_size) {
+                *size = peer_size;
+                *((void**) baseptr) = (void *)module->shmem_addrs[i];
+                *disp_unit = ompi_osc_ucx_get_disp_unit(module, i);
                 break;
             }
         }
@@ -514,8 +544,9 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, pt
                             int flavor, int *model) {
     ompi_osc_ucx_module_t *module = NULL;
     char *name = NULL;
-    long values[2];
+    long values[4];
     int ret = OMPI_SUCCESS;
+    int val_count = 0;
     int i, comm_size = ompi_comm_size(comm);
     bool env_initialized = false;
     void *state_base = NULL;
@@ -525,7 +556,7 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, pt
     uint64_t my_info[3] = {0};
     char *recv_buf = NULL;
     void *dynamic_base = NULL;
-    unsigned long total, *rbuf;
+    unsigned long adjusted_size = size;
     int flag;
     size_t pagesize;
     bool unlink_needed = false;
@@ -639,35 +670,102 @@ select_unlock:
     module->acc_single_intrinsic = check_config_value_bool ("acc_single_intrinsic", info);
     module->skip_sync_check = false;
 
+    if (flavor == MPI_WIN_FLAVOR_SHARED) {
+        opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
+                            "allocating shared memory region of size %ld\n", (long) size);
+        /* get the pagesize */
+        pagesize = opal_getpagesize();
+
+        /* Note that the alloc_shared_noncontig info key only has
+         * meaning during window creation.  Once the window is
+         * created, we can't move memory around without making
+         * everything miserable.  So we intentionally do not subscribe
+         * to updates on the info key, because there's no useful
+         * update to occur. */
+        module->noncontig_shared_win = false;
+        if (OMPI_SUCCESS != opal_info_get_bool(info, "alloc_shared_noncontig",
+                                               &module->noncontig_shared_win, &flag)) {
+            ret = OMPI_ERR_BAD_PARAM;
+            goto error;
+        }
+
+        if (module->noncontig_shared_win) {
+            opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
+                                "allocating window using non-contiguous strategy");
+            adjusted_size = ((size - 1) / pagesize + 1) * pagesize;
+        } else {
+            opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
+                                "allocating window using contiguous strategy");
+            adjusted_size = size;
+        }
+    }
+
     /* share everyone's displacement units. Only do an allgather if
        strictly necessary, since it requires O(p) state. */
     values[0] = disp_unit;
     values[1] = -disp_unit;
+    values[2] = adjusted_size;
+    values[3] = -(long)adjusted_size;
 
-    ret = module->comm->c_coll->coll_allreduce(MPI_IN_PLACE, values, 2, MPI_LONG,
+    ret = module->comm->c_coll->coll_allreduce(MPI_IN_PLACE, values, 4, MPI_LONG,
                                                MPI_MIN, module->comm,
                                                module->comm->c_coll->coll_allreduce_module);
     if (OMPI_SUCCESS != ret) {
         goto error;
     }
 
-    if (values[0] == -values[1]) { /* everyone has the same disp_unit, we do not need O(p) space */
-        module->disp_unit = disp_unit;
-    } else { /* different disp_unit sizes, allocate O(p) space to store them */
-        module->disp_unit = -1;
-        module->disp_units = calloc(comm_size, sizeof(ptrdiff_t));
-        if (module->disp_units == NULL) {
-            ret = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-            goto error;
-        }
+    bool same_disp_unit = (values[0] == -values[1]);
+    bool same_size = (values[2] == -values[3]);
 
-        ret = module->comm->c_coll->coll_allgather(&disp_unit, sizeof(ptrdiff_t), MPI_BYTE,
-                                                   module->disp_units, sizeof(ptrdiff_t), MPI_BYTE,
-                                                   module->comm,
-                                                   module->comm->c_coll->coll_allgather_module);
+    if (same_disp_unit) { /* everyone has the same disp_unit, we do not need O(p) space */
+        module->disp_unit = disp_unit;
+        module->disp_units = NULL;
+    } else {
+        values[val_count++] = disp_unit;
+    }
+
+    if (same_size) {
+        module->same_size = true;
+        module->sizes = NULL;
+    } else {
+        values[val_count++] = size;
+    }
+
+    if (!same_disp_unit || !same_size) {
+        long* peer_values = malloc(comm_size * val_count * sizeof(long));
+        ret = module->comm->c_coll->coll_allgather(values, val_count * sizeof(long), MPI_BYTE,
+                                                    peer_values, sizeof(long) * val_count, MPI_BYTE,
+                                                    module->comm,
+                                                    module->comm->c_coll->coll_allgather_module);
         if (OMPI_SUCCESS != ret) {
             goto error;
         }
+
+        if (!same_disp_unit) { /* everyone has a different disp_unit */
+            module->disp_unit = -1;
+            module->disp_units = calloc(comm_size, sizeof(ptrdiff_t));
+            if (module->disp_units == NULL) {
+                ret = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
+                goto error;
+            }
+            for (i = 0; i < comm_size; i++) {
+                module->disp_units[i] = (ptrdiff_t)peer_values[i*val_count];
+            }
+        }
+
+        if (!same_size) { /* everyone has the same disp_unit, we do not need O(p) space */
+            module->same_size = false;
+            module->sizes = calloc(comm_size, sizeof(size_t));
+            if (module->sizes == NULL) {
+                ret = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
+                goto error;
+            }
+
+            for (i = 0; i < comm_size; i++) {
+                module->sizes[i] = (size_t)peer_values[(i+1)*val_count - 1];
+            }
+        }
+        free(peer_values);
     }
 
     ret = opal_common_ucx_wpctx_create(mca_osc_ucx_component.wpool, comm_size,
@@ -679,50 +777,14 @@ select_unlock:
 
     if (flavor == MPI_WIN_FLAVOR_SHARED) {
         /* create the segment */
-        opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
-                            "allocating shared memory region of size %ld\n", (long) size);
-        /* get the pagesize */
-        pagesize = opal_getpagesize();
 
-        rbuf = malloc(sizeof(unsigned long) * comm_size);
-        if (NULL == rbuf) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-
-        /* Note that the alloc_shared_noncontig info key only has
-         * meaning during window creation.  Once the window is
-         * created, we can't move memory around without making
-         * everything miserable.  So we intentionally do not subscribe
-         * to updates on the info key, because there's no useful
-         * update to occur. */
-        module->noncontig_shared_win = false;
-        if (OMPI_SUCCESS != opal_info_get_bool(info, "alloc_shared_noncontig",
-                                               &module->noncontig_shared_win, &flag)) {
-            free(rbuf);
-            goto error;
-        }
-
-        if (module->noncontig_shared_win) {
-            opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
-                                "allocating window using non-contiguous strategy");
-            total = ((size - 1) / pagesize + 1) * pagesize;
-        } else {
-            opal_output_verbose(MCA_BASE_VERBOSE_DEBUG, ompi_osc_base_framework.framework_output,
-                                "allocating window using contiguous strategy");
-            total = size;
-        }
-        ret = module->comm->c_coll->coll_allgather(&total, 1, MPI_UNSIGNED_LONG,
-                                                  rbuf, 1, MPI_UNSIGNED_LONG,
-                                                  module->comm,
-                                                  module->comm->c_coll->coll_allgather_module);
-        if (OMPI_SUCCESS != ret) return ret;
-
-        total = 0;
+        size_t total = 0;
         for (i = 0 ; i < comm_size ; ++i) {
-            total += rbuf[i];
+            total += ompi_osc_ucx_get_size(module, i);
         }
 
         module->segment_base = NULL;
         module->shmem_addrs = NULL;
-        module->sizes = NULL;
 
         if (total != 0) {
             /* user opal/shmem directly to create a shared memory segment */
@@ -733,14 +795,12 @@ select_unlock:
                                      OMPI_PROC_MY_NAME->jobid, (int) OMPI_PROC_MY_NAME->vpid,
                                      ompi_comm_print_cid(module->comm));
                 if (ret < 0) {
-                    free(rbuf);
                     return OMPI_ERR_OUT_OF_RESOURCE;
                 }
 
                 ret = opal_shmem_segment_create (&module->seg_ds, data_file, total);
                 free(data_file);
                 if (OPAL_SUCCESS != ret) {
-                    free(rbuf);
                     goto error;
                 }
 
@@ -750,20 +810,18 @@ select_unlock:
             ret = module->comm->c_coll->coll_bcast (&module->seg_ds, sizeof (module->seg_ds), MPI_BYTE, 0,
                                                     module->comm, module->comm->c_coll->coll_bcast_module);
             if (OMPI_SUCCESS != ret) {
-                free(rbuf);
                 goto error;
             }
 
             module->segment_base = opal_shmem_segment_attach (&module->seg_ds);
             if (NULL == module->segment_base) {
-                free(rbuf);
+                ret = OMPI_ERR_OUT_OF_RESOURCE;
                 goto error;
             }
 
             /* wait for all processes to attach */
             ret = module->comm->c_coll->coll_barrier (module->comm, module->comm->c_coll->coll_barrier_module);
             if (OMPI_SUCCESS != ret) {
-                free(rbuf);
                 goto error;
             }
 
@@ -778,34 +836,25 @@ select_unlock:
          * different between different processes. To use direct load/store,
          * shmem_addrs can be used, however, for RDMA, virtual address of
          * remote process that will be stored in module->addrs should be used */
-        module->sizes = malloc(sizeof(size_t) * comm_size);
-        if (NULL == module->sizes) {
-            free(rbuf);
-            ret = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-            goto error;
-        }
         module->shmem_addrs = malloc(sizeof(uint64_t) * comm_size);
         if (NULL == module->shmem_addrs) {
             free(module->sizes);
-            free(rbuf);
             ret =  OMPI_ERR_TEMP_OUT_OF_RESOURCE;
             goto error;
         }
 
 
         for (i = 0, total = 0; i < comm_size ; ++i) {
-            module->sizes[i] = rbuf[i];
-            if (module->sizes[i] || !module->noncontig_shared_win) {
+            size_t peer_size = ompi_osc_ucx_get_size(module, i);
+            if (peer_size || !module->noncontig_shared_win) {
                 module->shmem_addrs[i] = ((uint64_t) module->segment_base) + total;
-                total += rbuf[i];
+                total += peer_size;
             } else {
                 module->shmem_addrs[i] = (uint64_t)NULL;
             }
         }
 
-        free(rbuf);
-
-        module->size = module->sizes[ompi_comm_rank(module->comm)];
+        module->size = ompi_osc_ucx_get_size(module, ompi_comm_rank(module->comm));
         *base = (void *)module->shmem_addrs[ompi_comm_rank(module->comm)];
     }
 
@@ -942,6 +991,7 @@ select_unlock:
 error:
     if (module->disp_units) free(module->disp_units);
     if (module->comm) ompi_comm_free(&module->comm);
+    if (module->sizes) free(module->sizes);
     free(module);
     module = NULL;
 
@@ -1168,8 +1218,6 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
             opal_shmem_segment_detach(&module->seg_ds);
         if (module->shmem_addrs != NULL)
             free(module->shmem_addrs);
-        if (module->sizes != NULL)
-            free(module->sizes);
     }
 
     if (module->flavor == MPI_WIN_FLAVOR_DYNAMIC) {
@@ -1201,6 +1249,9 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
 
     if (module->disp_units) {
         free(module->disp_units);
+    }
+    if (module->sizes) {
+        free(module->sizes);
     }
     ompi_comm_free(&module->comm);
 

--- a/ompi/mpi/c/win_shared_query.c.in
+++ b/ompi/mpi/c/win_shared_query.c.in
@@ -7,6 +7,7 @@
  *                         reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,9 +27,9 @@
 
 PROTOTYPE ERROR_CLASS win_shared_query(WIN win, INT rank, AINT_OUT size, INT_AINT_OUT disp_unit, BUFFER_OUT baseptr)
 {
-    int rc;
     size_t tsize;
     ptrdiff_t du;
+    int rc = OMPI_SUCCESS;
 
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
@@ -40,12 +41,27 @@ PROTOTYPE ERROR_CLASS win_shared_query(WIN win, INT rank, AINT_OUT size, INT_AIN
          }
     }
 
+    if (MPI_WIN_FLAVOR_DYNAMIC == win->w_flavor) {
+        rc = MPI_ERR_RMA_FLAVOR;
+    } else {
+        rc = OMPI_ERR_NOT_SUPPORTED;
+    }
+
     if (NULL != win->w_osc_module->osc_win_shared_query) {
         rc = win->w_osc_module->osc_win_shared_query(win, rank, &tsize, &du, baseptr);
-        *size = tsize;
-        *disp_unit = du;
-    } else {
-        rc = MPI_ERR_RMA_FLAVOR;
+        if (OMPI_SUCCESS == rc) {
+            *size = tsize;
+            *disp_unit = du;
+        }
     }
+
+    if (OMPI_ERR_NOT_SUPPORTED == rc) {
+        /* gracefully bail out */
+        *size = 0;
+        *disp_unit = 0;
+        *(void**) baseptr = NULL;
+        rc = MPI_SUCCESS; // don't raise an error if the function is not supported
+    }
+
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }


### PR DESCRIPTION
MPI 4.0 allows MPI_WIN_SHARED_QUERY to be called on any allocated and created windows. It may return the pointer, size, and displacement unit if the peer is located on the same node and the memory is shared.

This PR adds this functionality for osc/sm and osc/rdma. There is an attempt to implement it in osc/ucx but it's incomplete. We need to exchange and store the base pointer for the peer processes on the same node so we can pass them to `ucp_rkey_ptr()`. I'm not sure how to easily determine whether a process is on the same node. Some help would be appreciated.