### PR TITLE
ofi/btl: CHange default support to 1 & 2 sided ops

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -150,7 +150,7 @@ static int mca_btl_ofi_component_register(void)
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-    mca_btl_ofi_component.mode = MCA_BTL_OFI_MODE_ONE_SIDED;
+    mca_btl_ofi_component.mode = MCA_BTL_OFI_MODE_FULL_SUPPORT;
     (void) mca_base_component_var_register(&mca_btl_ofi_component.super.btl_version, "mode", msg,
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_READONLY,


### PR DESCRIPTION
Historically, the OFI BTL has defaulted to only supporting one-sided operations (ie, the RDMA OSC component).  Howard and I can't think of a current Libfabric provider that has a performance difference when in one-sided vs. both one and two-sided mode, so change the default to support both.  This allows users who want to use the OB1 PML to specify `-mca pml ob1` without also having to change the default mode in the BTL.