### PR TITLE
coverity: fix cids 1659066 and 1659065

### DIFF
--- a/ompi/mpi/bindings/ompi_bindings/fortran_type.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran_type.py
@@ -225,7 +225,7 @@ class CountTypeInOut(FortranType):
         if self.bigcount:
             return f'INTEGER(KIND=MPI_COUNT_KIND), INTENT(OUT) :: {self.name}'
         else:
-            return f'INTEGER, INTENT(IN) :: {self.name}'
+            return f'INTEGER, INTENT(OUT) :: {self.name}'
 
     def use(self):
         return [('mpi_f08_types', 'MPI_COUNT_KIND')]

--- a/ompi/mpi/fortran/use-mpi-f08/alltoallw_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/alltoallw_ts.c.in
@@ -30,7 +30,7 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
     int size, c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
-    MPI_Datatype *c_sendtypes = NULL, *c_recvtypes;
+    MPI_Datatype *c_sendtypes = NULL, *c_recvtypes = NULL;
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @DISP_TYPE@ *tmp_sdispls = NULL;
     @COUNT_TYPE@ *tmp_recvcounts = NULL;
@@ -59,7 +59,7 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
     if (MPI_SUCCESS != c_ierr) {
         if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
-        return;
+        goto fn_exit;
     }
 
     c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
@@ -84,6 +84,7 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
                           c_recvtypes, c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
+fn_exit:
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sendcounts, tmp_sendcounts);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(sdispls, tmp_sdispls);
     OMPI_FORTRAN_BIGCOUNT_ARRAY_CLEANUP(recvcounts, tmp_recvcounts);
@@ -92,5 +93,7 @@ PROTOTYPE VOID alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
     if (NULL != c_sendtypes) {
         free(c_sendtypes);
     }
-    free(c_recvtypes);
+    if (NULL != c_recvtypes) {
+        free(c_recvtypes);
+    }
 }

--- a/ompi/mpi/fortran/use-mpi-f08/get_count.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/get_count.c.in
@@ -21,15 +21,14 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID get_count(STATUS status, DATATYPE datatype, COUNT count)
+PROTOTYPE VOID get_count(STATUS status, DATATYPE datatype, COUNT_OUT count)
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
     MPI_Status   c_status;
-    @COUNT_TYPE@ c_count;
+    @COUNT_TYPE@ c_count = 0;
 
     if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
-        *count = OMPI_INT_2_FINT(0);
         c_ierr = MPI_SUCCESS;
     } else {
         c_ierr = PMPI_Status_f2c(status, &c_status);


### PR DESCRIPTION
also fix a bug in the fortran python generation code and use COUNT_OUT for count arg to MPI_Get_status (f08).