### PR TITLE
Complete rework of the UCT BTL

### DIFF
--- a/opal/mca/btl/uct/Makefile.am
+++ b/opal/mca/btl/uct/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2025      Google, LLC. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,22 +25,31 @@ AM_CPPFLAGS = $(btl_uct_CPPFLAGS)
 
 amca_paramdir = $(AMCA_PARAM_SETS_DIR)
 
-sources = \
+headers = \
     btl_uct.h \
+    btl_uct_rdma.h \
+    btl_uct_endpoint.h \
+    btl_uct_am.h \
+    btl_uct_frag.h \
+    btl_uct_types.h \
+    btl_uct_device_context.h \
+    btl_uct_discover.h \
+    btl_uct_modex.h \
+    btl_uct_include_list.h
+
+sources = \
     btl_uct_module.c \
     btl_uct_component.c \
-    btl_uct_rdma.h \
     btl_uct_rdma.c \
-    btl_uct_endpoint.h \
     btl_uct_endpoint.c \
     btl_uct_amo.c \
-    btl_uct_am.h \
     btl_uct_am.c \
-    btl_uct_frag.h \
     btl_uct_frag.c \
     btl_uct_tl.c \
-    btl_uct_types.h \
-    btl_uct_device_context.h
+    btl_uct_discover.c \
+    btl_uct_modex.c \
+    btl_uct_include_list.c \
+    btl_uct_device_context.c
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
@@ -50,20 +60,22 @@ lib =
 lib_sources =
 component = mca_btl_uct.la
 component_sources = $(sources)
+component_headers = $(headers)
 else
 lib = libmca_btl_uct.la
 lib_sources = $(sources)
+lib_headers = ${headers}
 component =
 component_sources =
 endif
 
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_btl_uct_la_SOURCES = $(component_sources)
+mca_btl_uct_la_SOURCES = $(component_sources) $(component_headers)
 mca_btl_uct_la_LDFLAGS = -module -avoid-version $(btl_uct_LDFLAGS)
 mca_btl_uct_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la $(btl_uct_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
-libmca_btl_uct_la_SOURCES = $(lib_sources)
+libmca_btl_uct_la_SOURCES = $(lib_sources) $(lib_headers)
 libmca_btl_uct_la_LDFLAGS = -module -avoid-version $(btl_uct_LDFLAGS)
 libmca_btl_uct_la_LIBADD = $(btl_uct_LIBS)

--- a/opal/mca/btl/uct/btl_uct_device_context.c
+++ b/opal/mca/btl/uct/btl_uct_device_context.c
@@ -1,0 +1,154 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019-2025 Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <uct/api/uct.h>
+#include <uct/api/uct_def.h>
+
+#include "btl_uct.h"
+#include "btl_uct_device_context.h"
+#include "btl_uct_types.h"
+
+#include "opal/class/opal_free_list.h"
+#include "opal/class/opal_object.h"
+
+#if HAVE_DECL_UCT_CB_FLAG_SYNC
+#    define MCA_BTL_UCT_CB_FLAG_SYNC UCT_CB_FLAG_SYNC
+#else
+#    define MCA_BTL_UCT_CB_FLAG_SYNC 0
+#endif
+
+static void mca_btl_uct_context_enable_progress(mca_btl_uct_device_context_t *context)
+{
+    if (!context->progress_enabled) {
+#if HAVE_DECL_UCT_PROGRESS_THREAD_SAFE
+        uct_iface_progress_enable(context->uct_iface,
+                                  UCT_PROGRESS_THREAD_SAFE | UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
+#else
+        uct_iface_progress_enable(context->uct_iface, UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
+#endif
+        context->progress_enabled = true;
+    }
+}
+
+void mca_btl_uct_context_enable_am_handler(mca_btl_uct_tl_t *tl,
+                                           mca_btl_uct_device_context_t *context)
+{
+    if (context->am_handler_installed) {
+        return;
+    }
+
+    BTL_VERBOSE(("installing AM handler for tl %s::%s context id %d",
+                 tl->uct_md->md_name, tl->uct_tl_name, context->context_id));
+    uct_iface_set_am_handler(context->uct_iface, MCA_BTL_UCT_FRAG, mca_btl_uct_am_handler,
+                             context, MCA_BTL_UCT_CB_FLAG_SYNC);
+    context->am_handler_installed = true;
+}
+
+mca_btl_uct_device_context_t *mca_btl_uct_context_create(mca_btl_uct_module_t *module,
+                                                         mca_btl_uct_tl_t *tl, int context_id,
+                                                         bool enable_progress)
+{
+#if UCT_API >= UCT_VERSION(1, 6)
+    uct_iface_params_t iface_params = {.field_mask = UCT_IFACE_PARAM_FIELD_OPEN_MODE
+                                                     | UCT_IFACE_PARAM_FIELD_DEVICE,
+                                       .open_mode = UCT_IFACE_OPEN_MODE_DEVICE,
+                                       .mode = {.device = {.tl_name = tl->uct_tl_name,
+                                                           .dev_name = tl->uct_dev_name}}};
+#else
+    uct_iface_params_t iface_params = {.rndv_cb = NULL,
+                                       .eager_cb = NULL,
+                                       .stats_root = NULL,
+                                       .rx_headroom = 0,
+                                       .open_mode = UCT_IFACE_OPEN_MODE_DEVICE,
+                                       .mode = {.device = {.tl_name = tl->uct_tl_name,
+                                                           .dev_name = tl->uct_dev_name}}};
+#endif
+    mca_btl_uct_device_context_t *context;
+    ucs_status_t ucs_status;
+    int rc;
+
+    context = calloc(1, sizeof(*context));
+    if (OPAL_UNLIKELY(NULL == context)) {
+        return NULL;
+    }
+
+    context->context_id = context_id;
+    context->uct_btl = module;
+    OBJ_CONSTRUCT(&context->completion_fifo, opal_fifo_t);
+    OBJ_CONSTRUCT(&context->mutex, opal_recursive_mutex_t);
+    OBJ_CONSTRUCT(&context->rdma_completions, opal_free_list_t);
+
+    rc = opal_free_list_init(&context->rdma_completions, sizeof(mca_btl_uct_uct_completion_t),
+                             opal_cache_line_size, OBJ_CLASS(mca_btl_uct_uct_completion_t), 0,
+                             opal_cache_line_size, 0, 4096, 128, NULL, 0, NULL, NULL, NULL);
+    if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+        mca_btl_uct_context_destroy(context);
+        return NULL;
+    }
+
+    /* apparently (in contradiction to the spec) UCT is *not* thread safe. because we have to
+     * use our own locks just go ahead and use UCS_THREAD_MODE_SINGLE. if they ever fix their
+     * api then change this back to UCS_THREAD_MODE_MULTI and remove the locks around the
+     * various UCT calls. */
+    ucs_status = uct_worker_create(tl->ucs_async, UCS_THREAD_MODE_SINGLE, &context->uct_worker);
+    if (OPAL_UNLIKELY(UCS_OK != ucs_status)) {
+        BTL_VERBOSE(("could not create a UCT worker"));
+        mca_btl_uct_context_destroy(context);
+        return NULL;
+    }
+
+    ucs_status = uct_iface_open(tl->uct_md->uct_md, context->uct_worker, &iface_params,
+                                tl->uct_tl_config, &context->uct_iface);
+    if (OPAL_UNLIKELY(UCS_OK != ucs_status)) {
+        BTL_VERBOSE(("could not open UCT interface. error code: %d", ucs_status));
+        mca_btl_uct_context_destroy(context);
+        return NULL;
+    }
+
+    if (module != NULL && tl == module->am_tl) {
+        mca_btl_uct_context_enable_am_handler(tl, context);
+    }
+
+    if (enable_progress) {
+        BTL_VERBOSE(("enabling progress for tl %s::%s context id %d",
+                     tl->uct_md->md_name, tl->uct_tl_name, context_id));
+        mca_btl_uct_context_enable_progress(context);
+    }
+
+    return context;
+}
+
+void mca_btl_uct_context_destroy(mca_btl_uct_device_context_t *context)
+{
+    if (context->uct_iface) {
+        uct_iface_close(context->uct_iface);
+        context->uct_iface = NULL;
+    }
+
+    if (context->uct_worker) {
+        uct_worker_destroy(context->uct_worker);
+        context->uct_worker = NULL;
+    }
+
+    OBJ_DESTRUCT(&context->completion_fifo);
+    OBJ_DESTRUCT(&context->rdma_completions);
+    free(context);
+}
+

--- a/opal/mca/btl/uct/btl_uct_device_context.h
+++ b/opal/mca/btl/uct/btl_uct_device_context.h
@@ -37,6 +37,15 @@ mca_btl_uct_device_context_t *mca_btl_uct_context_create(mca_btl_uct_module_t *m
  */
 void mca_btl_uct_context_destroy(mca_btl_uct_device_context_t *context);
 
+/**
+ * @brief Enable active messages on context if not already enabled
+ *
+ * @param[in] tl      TL this context belongs to
+ * @param[in] context Context to enable active messages on.
+ */
+void mca_btl_uct_context_enable_am_handler(mca_btl_uct_tl_t *tl,
+                                           mca_btl_uct_device_context_t *context);
+
 static inline bool mca_btl_uct_context_trylock(mca_btl_uct_device_context_t *context)
 {
     return OPAL_THREAD_TRYLOCK(&context->mutex);
@@ -94,14 +103,14 @@ mca_btl_uct_module_get_tl_context_specific(mca_btl_uct_module_t *module, mca_btl
     mca_btl_uct_device_context_t *context = tl->uct_dev_contexts[context_id];
 
     if (OPAL_UNLIKELY(NULL == context)) {
-        OPAL_THREAD_LOCK(&module->lock);
+        OPAL_THREAD_LOCK(&tl->tl_lock);
         context = tl->uct_dev_contexts[context_id];
         if (OPAL_UNLIKELY(NULL == context)) {
             context = tl->uct_dev_contexts[context_id] = mca_btl_uct_context_create(module, tl,
                                                                                     context_id,
                                                                                     true);
         }
-        OPAL_THREAD_UNLOCK(&module->lock);
+        OPAL_THREAD_UNLOCK(&tl->tl_lock);
     }
 
     return context;

--- a/opal/mca/btl/uct/btl_uct_discover.c
+++ b/opal/mca/btl/uct/btl_uct_discover.c
@@ -1,0 +1,522 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019-2025 Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "btl_uct_device_context.h"
+#include "btl_uct_discover.h"
+#include "btl_uct_include_list.h"
+
+#include "btl_uct.h"
+#include "opal/class/opal_list.h"
+#include "opal/util/printf.h"
+
+#if UCT_API >= UCT_VERSION(1, 7)
+static int mca_btl_uct_component_process_uct_md(uct_component_h component,
+                                                uct_md_resource_desc_t *md_desc)
+#else
+static int mca_btl_uct_component_process_uct_md(uct_md_resource_desc_t *md_desc)
+#endif
+{
+    uct_tl_resource_desc_t *tl_desc;
+    uct_md_config_t *uct_config;
+    mca_btl_uct_md_t *md;
+    int list_rank;
+    unsigned num_tls;
+    ucs_status_t ucs_status;
+    int connection_list_rank = -1;
+    bool consider_for_connection_module = false;
+
+    BTL_VERBOSE(("processing memory domain %s", md_desc->md_name));
+
+    BTL_VERBOSE(("checking if %s should be used for communication", md_desc->md_name));
+    list_rank = mca_btl_uct_include_list_rank (md_desc->md_name, &mca_btl_uct_component.memory_domain_list);
+
+    if (list_rank < 0) {
+        BTL_VERBOSE(("checking if %s should be used for connections", md_desc->md_name));
+        connection_list_rank = mca_btl_uct_include_list_rank (md_desc->md_name, &mca_btl_uct_component.connection_domain_list);
+
+        if (connection_list_rank < 0) {
+            /* nothing to do */
+            BTL_VERBOSE(("not continuing with memory domain %s", md_desc->md_name));
+            return OPAL_SUCCESS;
+        }
+
+        BTL_VERBOSE(("will be considering domain %s for connections only", md_desc->md_name));
+        consider_for_connection_module = true;
+    }
+
+    md = OBJ_NEW(mca_btl_uct_md_t);
+    md->md_name = strdup(md_desc->md_name);
+#if UCT_API >= UCT_VERSION(1, 7)
+    md->uct_component = component;
+#endif
+    md->connection_only_domain = consider_for_connection_module;
+
+#if UCT_API >= UCT_VERSION(1, 7)
+    ucs_status = uct_md_config_read(component, NULL, NULL, &uct_config);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_md_config_read failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    ucs_status = uct_md_open(component, md->md_name, uct_config, &md->uct_md);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_md_open failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+#else
+    ucs_status = uct_md_config_read(md->md_name, NULL, NULL, &uct_config);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_md_config_read failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    ucs_status = uct_md_open(md->md_name, uct_config, &md->uct_md);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_md_open failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+#endif
+    uct_config_release(uct_config);
+
+    ucs_status = uct_md_query(md->uct_md, &md->md_attr);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_config_release failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    ucs_status = uct_md_query_tl_resources(md->uct_md, &tl_desc, &num_tls);
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(("uct_config_release failed %d (%s)", ucs_status, ucs_status_string(ucs_status)));
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    (void) mca_btl_uct_populate_tls(md, tl_desc, num_tls);
+
+    uct_release_tl_resource_list(tl_desc);
+    opal_list_append(&mca_btl_uct_component.md_list, &md->super);
+
+    return OPAL_SUCCESS;
+}
+
+#if UCT_API >= UCT_VERSION(1, 7)
+static int mca_btl_uct_component_process_uct_component(uct_component_h component)
+{
+    uct_component_attr_t attr = {
+        .field_mask = UCT_COMPONENT_ATTR_FIELD_NAME
+            | UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT,
+    };
+    ucs_status_t ucs_status;
+    int rc;
+
+    ucs_status = uct_component_query(component, &attr);
+    if (UCS_OK != ucs_status) {
+        return OPAL_ERROR;
+    }
+
+    BTL_VERBOSE(("processing uct component %s", attr.name));
+
+    attr.md_resources = calloc(attr.md_resource_count, sizeof(*attr.md_resources));
+    attr.field_mask |= UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
+    ucs_status = uct_component_query(component, &attr);
+    if (UCS_OK != ucs_status) {
+        return OPAL_ERROR;
+    }
+
+    for (unsigned i = 0; i < attr.md_resource_count; ++i) {
+        rc = mca_btl_uct_component_process_uct_md(component, attr.md_resources + i);
+        if (OPAL_SUCCESS != rc) {
+            break;
+        }
+    }
+
+    free(attr.md_resources);
+
+    return OPAL_SUCCESS;
+}
+#endif /* UCT_API >= UCT_VERSION(1, 7) */
+
+int mca_btl_uct_component_discover_mds(void)
+{
+    mca_btl_uct_include_list_parse(mca_btl_uct_component.memory_domains,
+                                   &mca_btl_uct_component.memory_domain_list);
+    mca_btl_uct_include_list_parse(mca_btl_uct_component.connection_domains,
+                                   &mca_btl_uct_component.connection_domain_list);
+
+#if UCT_API >= UCT_VERSION(1, 7)
+    ucs_status_t ucs_status = uct_query_components(&mca_btl_uct_component.uct_components,
+                                                   &mca_btl_uct_component.num_uct_components);
+    if (UCS_OK != ucs_status) {
+        BTL_ERROR(("could not query UCT components"));
+        return OPAL_ERROR;
+    }
+
+    /* generate list of memory domains */
+    for (unsigned i = 0; i < mca_btl_uct_component.num_uct_components; ++i) {
+        int rc = mca_btl_uct_component_process_uct_component(mca_btl_uct_component.uct_components[i]);
+        if (OPAL_SUCCESS != rc) {
+            break;
+        }
+    }
+#else /* UCT 1.6 and older */
+    uct_md_resource_desc_t *resources;
+    unsigned resource_count;
+
+    uct_query_md_resources(&resources, &resource_count);
+
+    /* generate all suitable btl modules */
+    for (unsigned i = 0; i < resource_count; ++i) {
+        int rc = mca_btl_uct_component_process_uct_md(resources + i);
+        if (OPAL_SUCCESS != rc) {
+            break;
+        }
+    }
+
+    uct_release_md_resource_list(resources);
+
+#endif /* UCT_API >= UCT_VERSION(1, 7) */
+
+    return OPAL_SUCCESS;
+}
+
+static int mca_btl_uct_module_register_mca_var(mca_btl_uct_module_t *module)
+{
+    mca_base_component_t dummy_component;
+    /* mca_btl_uct_component starts with an mca_base_component_t structure */
+    memcpy(&dummy_component, &mca_btl_uct_component, sizeof(dummy_component));
+    snprintf(dummy_component.mca_component_name, sizeof(dummy_component.mca_component_name),
+            "uct_%s", module->md->md_name);
+
+    BTL_VERBOSE(("registering MCA parameters for module uct_%s", module->md->md_name));
+
+    module->allowed_transports = mca_btl_uct_component.allowed_transports;
+    (void) mca_base_component_var_register(
+        &dummy_component, "transports",
+        "Comma-delimited list of transports to use sorted by increasing "
+        "priority. The list of transports available can be queried using ucx_info. Special"
+        "values: any (any available) (default: dc_mlx5,rc_mlx5,ud,any)",
+        MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_3,
+        MCA_BASE_VAR_SCOPE_LOCAL, &module->allowed_transports);
+
+    return mca_btl_base_param_register(&dummy_component, &module->super);
+}
+
+static int tl_compare(opal_list_item_t **a, opal_list_item_t **b)
+{
+    mca_btl_uct_tl_t *tl_a = (mca_btl_uct_tl_t *) *a;
+    mca_btl_uct_tl_t *tl_b = (mca_btl_uct_tl_t *) *b;
+
+    return tl_a->priority - tl_b->priority;
+}
+
+static int mca_btl_uct_generate_module(mca_btl_uct_md_t *md)
+{
+    mca_btl_uct_tl_t *tl;
+    mca_btl_uct_module_t *module = mca_btl_uct_alloc_module(md, md->md_attr.rkey_packed_size);
+
+    BTL_VERBOSE(("attempting to create a BTL module for memory domain: %s", md->md_name));
+
+    int rc = mca_btl_uct_module_register_mca_var(module);
+    if (OPAL_SUCCESS != rc) {
+        mca_btl_uct_finalize(&module->super);
+        return rc;
+    }
+
+    mca_btl_uct_include_list_parse(module->allowed_transports,
+                                   &module->allowed_transport_list);
+    mca_btl_uct_tl_t *next;
+    OPAL_LIST_FOREACH_SAFE (tl, next, &md->tls, mca_btl_uct_tl_t) {
+        int rank = mca_btl_uct_include_list_rank(tl->uct_tl_name, &module->allowed_transport_list);
+        if (rank < 0) {
+            opal_list_remove_item(&md->tls, &tl->super);
+            OBJ_RELEASE(tl);
+            continue;
+        }
+        tl->priority = rank;
+    }
+
+    opal_list_sort(&md->tls, tl_compare);
+
+    /* Treat the flags specified by the user as a mask. */
+    uint32_t btl_flags = module->super.btl_flags;
+    uint32_t btl_atomic_flags = module->super.btl_atomic_flags;
+
+    module->super.btl_flags = 0;
+    module->super.btl_atomic_flags = 0;
+
+    OPAL_LIST_FOREACH (tl, &md->tls, mca_btl_uct_tl_t) {
+        mca_btl_uct_evaluate_tl(module, tl);
+        if (NULL != module->am_tl && NULL != module->rdma_tl) {
+            /* all done */
+            break;
+        }
+    }
+
+    module->super.btl_flags &= btl_flags;
+    module->super.btl_atomic_flags &= btl_atomic_flags;
+
+    if (NULL == module->rdma_tl) {
+        /* no rdma tls */
+        BTL_VERBOSE(("no rdma tl matched supplied filter. disabling RDMA support"));
+
+        module->super.btl_flags &= ~MCA_BTL_FLAGS_RDMA;
+        module->super.btl_put = NULL;
+        module->super.btl_get = NULL;
+        module->super.btl_atomic_fop = NULL;
+        module->super.btl_atomic_op = NULL;
+    }
+
+    if (NULL == module->am_tl) {
+        /* no active message tls == no send/recv */
+        BTL_VERBOSE(("no active message tl matched supplied filter. disabling send/recv support"));
+
+        module->super.btl_send = NULL;
+        module->super.btl_sendi = NULL;
+        module->super.btl_alloc = NULL;
+        module->super.btl_free = NULL;
+    }
+
+    if (NULL == module->am_tl && NULL == module->rdma_tl) {
+        mca_btl_uct_finalize(&module->super);
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    module->module_index = mca_btl_uct_component.module_count;
+    mca_btl_uct_component.modules[mca_btl_uct_component.module_count++] = module;
+
+    return OPAL_SUCCESS;
+}
+
+static void mca_btl_uct_enable_tl(mca_btl_uct_module_t *module, mca_btl_uct_tl_t *tl) {
+    if (NULL == tl) {
+        return;
+    } 
+
+    if (tl == module->am_tl) {
+        mca_btl_uct_device_context_t *context =
+            mca_btl_uct_module_get_tl_context_specific(module, tl, /*context_id=*/0);
+        /* If this context was created before a module was created it may not
+         * have an active message handler installed. Attempt to install one now. */
+        mca_btl_uct_context_enable_am_handler(tl, context);
+    }
+
+    if (tl->max_device_contexts < 1) {
+        tl->max_device_contexts = mca_btl_uct_component.num_contexts_per_module;
+    }
+}
+
+static int mca_btl_uct_enable_module(mca_btl_uct_module_t *module)
+{
+    /* NTH: a registration cache shouldn't be necessary when using UCT but there are measurable
+     * performance benefits to using rcache/grdma instead of assuming UCT will do the right
+     * thing. */
+    char *tmp = NULL;
+    (void) opal_asprintf(&tmp, "uct.%s", module->md->md_name);
+
+    mca_rcache_base_resources_t rcache_resources = {
+        .cache_name = tmp,
+        .reg_data = (void *) module,
+        .sizeof_reg = sizeof(mca_btl_uct_reg_t) + module->super.btl_registration_handle_size,
+        .register_mem = mca_btl_uct_reg_mem,
+        .deregister_mem = mca_btl_uct_dereg_mem,
+    };
+
+    module->rcache = mca_rcache_base_module_create("grdma", module, &rcache_resources);
+    free(tmp);
+    if (NULL == module->rcache) {
+        /* something went horribly wrong */
+        BTL_VERBOSE(("could not allocate a registration cache for this btl module"));
+        return OPAL_ERROR;
+    }
+
+    mca_btl_uct_enable_tl(module, module->rdma_tl);
+    mca_btl_uct_enable_tl(module, module->am_tl);
+
+    return OPAL_SUCCESS;
+}
+
+int mca_btl_uct_enable_modules(mca_btl_uct_module_t **modules, int module_count)
+{
+    for (int i = 0 ; i < module_count ; ++i) {
+        int rc = mca_btl_uct_enable_module(modules[i]);
+        if (OPAL_SUCCESS != rc) {
+            BTL_VERBOSE(("could not enable module for memory domain %s", modules[i]->md->md_name));
+            mca_btl_uct_finalize(&modules[i]->super);
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_btl_uct_component_generate_modules(opal_list_t *md_list)
+{
+    mca_btl_uct_component.module_count = 0;
+
+    mca_btl_uct_md_t *md;
+    OPAL_LIST_FOREACH(md, md_list, mca_btl_uct_md_t) {
+        if (MCA_BTL_UCT_MAX_MODULES == mca_btl_uct_component.module_count) {
+            BTL_VERBOSE(("created the maximum number of allowable modules"));
+            break;
+        }
+
+        if (md->connection_only_domain) {
+            /* will not build a module for this domain */
+            continue;
+        }
+
+        int rc = mca_btl_uct_generate_module(md);
+        if (OPAL_SUCCESS != rc) {
+            BTL_VERBOSE(("could not create a module for memory domain %s", md->md_name));
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_btl_uct_component_maybe_setup_conn_tl(void)
+{
+    bool connection_tl_required = false;
+    for (int i = 0 ; i < mca_btl_uct_component.module_count ; ++i) {
+        connection_tl_required |=
+            mca_btl_uct_tl_requires_connection_tl(mca_btl_uct_component.modules[i]->am_tl);
+        connection_tl_required |=
+            mca_btl_uct_tl_requires_connection_tl(mca_btl_uct_component.modules[i]->rdma_tl);
+        if (connection_tl_required) {
+            break;
+        }
+    }
+
+    if (!connection_tl_required) {
+        return OPAL_SUCCESS;
+    }
+
+    mca_btl_uct_md_t *md;
+    OPAL_LIST_FOREACH(md, &mca_btl_uct_component.md_list, mca_btl_uct_md_t) {
+        mca_btl_uct_tl_t *tl, *next;
+        OPAL_LIST_FOREACH_SAFE(tl, next, &md->tls, mca_btl_uct_tl_t) {
+            if (mca_btl_uct_tl_supports_conn(tl)) {
+                break;
+            }
+            tl = NULL;
+        }
+
+        if ((opal_list_item_t *) tl == &md->tls.opal_list_sentinel) {
+            BTL_VERBOSE(("No suitable connection tls in md %s", md->md_name));
+            continue;
+        }
+
+        if (NULL == mca_btl_uct_component.conn_tl) {
+            mca_btl_uct_component.conn_tl = tl;
+        }
+
+        if (tl != NULL && (md->connection_only_domain || NULL == mca_btl_uct_component.conn_tl)) {
+            mca_btl_uct_component.conn_tl = tl;
+            if (md->connection_only_domain) {
+                /* not going do to better */
+                break;
+            }
+        }
+    }
+
+    if (NULL == mca_btl_uct_component.conn_tl) {
+        /* no connection tl found, will need to disable all connect-to-endpoint modules */
+        BTL_VERBOSE(("could not find a suitable transport to support forming connections"));
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    BTL_VERBOSE(("using transport %s::%s for connection management",
+                 mca_btl_uct_component.conn_tl->uct_md->md_name,
+                 mca_btl_uct_component.conn_tl->uct_tl_name));
+
+    return mca_btl_uct_enable_tl_conn(mca_btl_uct_component.conn_tl);
+}
+
+int mca_btl_uct_component_filter_mds(void)
+{
+    int usable_module_count = mca_btl_uct_component.module_count;
+    /* clean out all unused mds, tls, and unusable modules */
+    if (NULL == mca_btl_uct_component.conn_tl) {
+        for (int i = 0 ; i < mca_btl_uct_component.module_count ; ++i) {
+            mca_btl_uct_module_t *module = mca_btl_uct_component.modules[i];
+            if (!(mca_btl_uct_tl_requires_connection_tl(module->am_tl) ||
+                  mca_btl_uct_tl_requires_connection_tl(module->rdma_tl))) {
+                continue;
+            }
+
+            /* module is unusable */
+            mca_btl_uct_finalize(&module->super);
+            mca_btl_uct_component.modules[i] = NULL;
+            --usable_module_count;
+        }
+    }
+
+    mca_btl_uct_md_t *md, *md_next;
+    OPAL_LIST_FOREACH_SAFE(md, md_next, &mca_btl_uct_component.md_list, mca_btl_uct_md_t) {
+        mca_btl_uct_module_t *module = NULL;
+        for (int i = 0 ; i < mca_btl_uct_component.module_count ; ++i) {
+            module = mca_btl_uct_component.modules[i];
+            if (NULL != module && module->md == md) {
+                break;
+            }
+            module = NULL;
+        }
+
+        mca_btl_uct_tl_t *tl, *next;
+        OPAL_LIST_FOREACH_SAFE(tl, next, &md->tls, mca_btl_uct_tl_t) {
+            if (tl == mca_btl_uct_component.conn_tl || (NULL != module &&
+                                                        (tl == module->rdma_tl ||
+                                                         tl == module->am_tl))) {
+                /* tl is in use */
+                continue;
+            }
+            opal_list_remove_item(&md->tls, &tl->super);
+            OBJ_RELEASE(tl);
+        }
+
+        if (opal_list_get_size(&md->tls) == 0) {
+            opal_list_remove_item(&mca_btl_uct_component.md_list, &md->super);
+            OBJ_RELEASE(md);
+        }
+    }
+
+    /* remove holes in the module array */
+    if (usable_module_count < mca_btl_uct_component.module_count) {
+        for (int i = 0 ; i < mca_btl_uct_component.module_count ; ++i) {
+            if (mca_btl_uct_component.modules[i] == NULL) {
+                for (int j = i ; j < mca_btl_uct_component.module_count ; ++j) {
+                    mca_btl_uct_component.modules[i++] = mca_btl_uct_component.modules[j];
+                }
+            }
+        }
+        mca_btl_uct_component.module_count = usable_module_count;
+    }
+
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/btl/uct/btl_uct_discover.h
+++ b/opal/mca/btl/uct/btl_uct_discover.h
@@ -1,0 +1,43 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2025      Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(MCA_BTL_UCT_DISCOVER_H)
+#define MCA_BTL_UCT_DISCOVER_H
+
+#include "btl_uct.h"
+#include "opal/class/opal_list.h"
+
+/**
+ * @brief Query UCT for the available memory domains. This list will be limited by 
+ */
+int mca_btl_uct_component_discover_mds(void);
+
+/**
+ * @brief Create BTL modules from the memory domain list.
+ *
+ * The modules are registered with MCA and must be shut down using
+ * mca_btl_module_finalize.
+ */
+int mca_btl_uct_component_generate_modules(opal_list_t *md_list);
+
+int mca_btl_uct_enable_modules(mca_btl_uct_module_t **modules, int module_count);
+
+/**
+ * @brief Scan detected transports and find a connection transport (if needed).
+ */
+int mca_btl_uct_component_maybe_setup_conn_tl(void);
+
+/**
+ * @brief Clean out unused memory domains and transport layers.
+ */
+int mca_btl_uct_component_filter_mds(void);
+
+
+#endif  /* !defined(MCA_BTL_UCT_DISCOVER_H) */

--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -16,6 +16,7 @@
 #include "btl_uct.h"
 #include "btl_uct_am.h"
 #include "btl_uct_device_context.h"
+#include "btl_uct_modex.h"
 #include "opal/mca/timer/base/base.h"
 #include "opal/util/proc.h"
 
@@ -24,7 +25,7 @@ static void mca_btl_uct_endpoint_construct(mca_btl_uct_endpoint_t *endpoint)
     memset(endpoint->uct_eps, 0,
            sizeof(endpoint->uct_eps[0]) * mca_btl_uct_component.num_contexts_per_module);
     endpoint->conn_ep = NULL;
-    OBJ_CONSTRUCT(&endpoint->ep_lock, opal_recursive_mutex_t);
+    OBJ_CONSTRUCT(&endpoint->ep_lock, opal_mutex_t);
 }
 
 static void mca_btl_uct_endpoint_destruct(mca_btl_uct_endpoint_t *endpoint)
@@ -61,53 +62,6 @@ mca_btl_base_endpoint_t *mca_btl_uct_endpoint_create(opal_proc_t *proc)
     endpoint->ep_proc = proc;
 
     return (mca_btl_base_endpoint_t *) endpoint;
-}
-
-static unsigned char *mca_btl_uct_process_modex_tl(unsigned char *modex_data)
-{
-    BTL_VERBOSE(
-        ("processing modex for tl %s. size: %u", modex_data + 4, *((uint32_t *) modex_data)));
-
-    /* skip size and name */
-    return modex_data + 4 + strlen((char *) modex_data + 4) + 1;
-}
-
-static void mca_btl_uct_process_modex(mca_btl_uct_module_t *uct_btl, unsigned char *modex_data,
-                                      unsigned char **rdma_tl_data, unsigned char **am_tl_data,
-                                      unsigned char **conn_tl_data)
-{
-    BTL_VERBOSE(("processing remote modex data"));
-
-    if (uct_btl->rdma_tl) {
-        BTL_VERBOSE(("modex contains RDMA data"));
-        if (rdma_tl_data) {
-            *rdma_tl_data = mca_btl_uct_process_modex_tl(modex_data);
-        }
-        modex_data += *((uint32_t *) modex_data);
-    } else if (rdma_tl_data) {
-        *rdma_tl_data = NULL;
-    }
-
-    if (uct_btl->am_tl && uct_btl->am_tl != uct_btl->rdma_tl) {
-        BTL_VERBOSE(("modex contains active message data"));
-        if (am_tl_data) {
-            *am_tl_data = mca_btl_uct_process_modex_tl(modex_data);
-        }
-        modex_data += *((uint32_t *) modex_data);
-    } else if (am_tl_data) {
-        *am_tl_data = NULL;
-    }
-
-    if (uct_btl->conn_tl && uct_btl->conn_tl != uct_btl->rdma_tl
-        && uct_btl->conn_tl != uct_btl->am_tl) {
-        BTL_VERBOSE(("modex contains connection data"));
-        if (conn_tl_data) {
-            *conn_tl_data = mca_btl_uct_process_modex_tl(modex_data);
-        }
-        modex_data += *((uint32_t *) modex_data);
-    } else if (conn_tl_data) {
-        *conn_tl_data = NULL;
-    }
 }
 
 static inline ucs_status_t mca_btl_uct_ep_create_connected_compat(uct_iface_h iface,
@@ -150,7 +104,7 @@ static int mca_btl_uct_endpoint_connect_iface(mca_btl_uct_module_t *uct_btl, mca
     /* easy case. just connect to the interface */
     iface_addr = (uct_iface_addr_t *) tl_data;
     device_addr = (uct_device_addr_t *) ((uintptr_t) iface_addr
-                                         + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id)
+                                         + tl->uct_iface_attr
                                                .iface_addr_len);
 
     BTL_VERBOSE(("connecting endpoint to interface"));
@@ -163,22 +117,6 @@ static int mca_btl_uct_endpoint_connect_iface(mca_btl_uct_module_t *uct_btl, mca
 
     return (UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERROR;
 }
-
-static void mca_btl_uct_connection_ep_construct(mca_btl_uct_connection_ep_t *ep)
-{
-    ep->uct_ep = NULL;
-}
-
-static void mca_btl_uct_connection_ep_destruct(mca_btl_uct_connection_ep_t *ep)
-{
-    if (ep->uct_ep) {
-        uct_ep_destroy(ep->uct_ep);
-        ep->uct_ep = NULL;
-    }
-}
-
-OBJ_CLASS_INSTANCE(mca_btl_uct_connection_ep_t, opal_object_t, mca_btl_uct_connection_ep_construct,
-                   mca_btl_uct_connection_ep_destruct);
 
 struct mca_btl_uct_conn_completion_t {
     uct_completion_t super;
@@ -203,24 +141,61 @@ static void mca_btl_uct_endpoint_flush_complete(uct_completion_t *self, ucs_stat
 }
 #endif
 
-static int mca_btl_uct_endpoint_send_conn_req(mca_btl_uct_module_t *uct_btl,
-                                              mca_btl_base_endpoint_t *endpoint,
-                                              mca_btl_uct_device_context_t *conn_tl_context,
-                                              mca_btl_uct_conn_req_t *request,
-                                              size_t request_length)
+static void mca_btl_uct_flush_conn_endpoint(mca_btl_uct_connection_ep_t *conn_ep)
 {
+    mca_btl_uct_device_context_t *conn_tl_context = conn_ep->tl->uct_dev_contexts[0];
     mca_btl_uct_conn_completion_t completion
         = {.super = {.count = 1, .func = mca_btl_uct_endpoint_flush_complete}, .complete = false};
     ucs_status_t ucs_status;
+    MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
+            ucs_status = uct_ep_flush(conn_ep->uct_ep, 0, &completion.super);
+    });
+    if (UCS_OK != ucs_status && UCS_INPROGRESS != ucs_status) {
+        /* NTH: I don't know if this path is needed. For some networks we must use a completion. */
+        do {
+            MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
+                    ucs_status = uct_ep_flush(conn_ep->uct_ep, 0, NULL);
+            });
+            mca_btl_uct_context_progress(conn_tl_context);
+        } while (UCS_INPROGRESS == ucs_status);
+    } else if (UCS_OK != ucs_status) {
+        do {
+            mca_btl_uct_context_progress(conn_tl_context);
+        } while (!completion.complete);
+    }
+}
+
+static void mca_btl_uct_connection_ep_construct(mca_btl_uct_connection_ep_t *ep)
+{
+    ep->uct_ep = NULL;
+    ep->tl = NULL;
+}
+
+static void mca_btl_uct_connection_ep_destruct(mca_btl_uct_connection_ep_t *ep)
+{
+    if (ep->uct_ep) {
+        mca_btl_uct_flush_conn_endpoint(ep);
+        uct_ep_destroy(ep->uct_ep);
+        ep->uct_ep = NULL;
+    }
+}
+
+OBJ_CLASS_INSTANCE(mca_btl_uct_connection_ep_t, opal_object_t, mca_btl_uct_connection_ep_construct,
+                   mca_btl_uct_connection_ep_destruct);
+
+static int mca_btl_uct_endpoint_send_conn_req(mca_btl_uct_module_t *uct_btl,
+                                              mca_btl_base_endpoint_t *endpoint,
+                                              mca_btl_uct_conn_req_t *request,
+                                              size_t request_length)
+{
+    mca_btl_uct_device_context_t *conn_tl_context = mca_btl_uct_component.conn_tl->uct_dev_contexts[0];
 
     BTL_VERBOSE(
         ("sending connection request to peer. context id: %d, type: %d, length: %" PRIsize_t,
          request->context_id, request->type, request_length));
 
-    /* need to drop the lock to avoid hold-and-wait */
-    opal_mutex_unlock(&endpoint->ep_lock);
-
     do {
+        ucs_status_t ucs_status;
         MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
             ucs_status = uct_ep_am_short(endpoint->conn_ep->uct_ep, MCA_BTL_UCT_CONNECT_RDMA,
                                          request->type, request, request_length);
@@ -233,75 +208,70 @@ static int mca_btl_uct_endpoint_send_conn_req(mca_btl_uct_module_t *uct_btl,
             return OPAL_ERROR;
         }
 
+        /* need to drop the lock to avoid hold-and-wait */
+        opal_mutex_unlock(&endpoint->ep_lock);
         /* some TLs (UD for example) need to be progressed to get resources */
         mca_btl_uct_context_progress(conn_tl_context);
+        opal_mutex_lock(&endpoint->ep_lock);
     } while (1);
 
-    /* for now we just wait for the connection request to complete before continuing */
-    ucs_status = uct_ep_flush(endpoint->conn_ep->uct_ep, 0, &completion.super);
-    if (UCS_OK != ucs_status && UCS_INPROGRESS != ucs_status) {
-        /* NTH: I don't know if this path is needed. For some networks we must use a completion. */
-        do {
-            ucs_status = uct_ep_flush(endpoint->conn_ep->uct_ep, 0, NULL);
-            mca_btl_uct_context_progress(conn_tl_context);
-        } while (UCS_INPROGRESS == ucs_status);
-    } else {
-        do {
-            mca_btl_uct_context_progress(conn_tl_context);
-        } while (!completion.complete);
+    return OPAL_SUCCESS;
+}
+
+static int mca_btl_uct_endpoint_get_helper_endpoint(mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint,
+                                                    uint8_t *conn_tl_data)
+{
+    if (NULL != endpoint->conn_ep) {
+        BTL_VERBOSE(("re-using existing connection endpoint"));
+        OBJ_RETAIN(endpoint->conn_ep);
+        return OPAL_SUCCESS;
     }
 
-    opal_mutex_lock(&endpoint->ep_lock);
+    mca_btl_uct_tl_t *conn_tl = mca_btl_uct_component.conn_tl;
+
+    BTL_VERBOSE(("creating a temporary endpoint for handling connections to %p",
+                 opal_process_name_print(endpoint->ep_proc->proc_name)));
+
+    uct_iface_addr_t *iface_addr = (uct_iface_addr_t *) conn_tl_data;
+    uct_device_addr_t *device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data
+                                                            + conn_tl->uct_iface_attr.iface_addr_len);
+
+    endpoint->conn_ep = OBJ_NEW(mca_btl_uct_connection_ep_t);
+    if (OPAL_UNLIKELY(NULL == endpoint->conn_ep)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    endpoint->conn_ep->tl = conn_tl;
+
+    ucs_status_t ucs_status;
+    mca_btl_uct_device_context_t *conn_tl_context = conn_tl->uct_dev_contexts[0];
+    /* create a temporary endpoint for setting up the rdma endpoint */
+    MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
+            ucs_status = mca_btl_uct_ep_create_connected_compat(conn_tl_context->uct_iface,
+                                                                device_addr, iface_addr,
+                                                                &endpoint->conn_ep->uct_ep);
+        });
+    if (UCS_OK != ucs_status) {
+        BTL_VERBOSE(
+                    ("could not create an endpoint for forming connection to remote peer. code = %d",
+                     ucs_status));
+        return OPAL_ERROR;
+    }
 
     return OPAL_SUCCESS;
 }
 
 static int mca_btl_uct_endpoint_send_connection_data(
-    mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint, mca_btl_uct_tl_t *tl,
-    mca_btl_uct_device_context_t *tl_context, mca_btl_uct_tl_endpoint_t *tl_endpoint,
-    uint8_t *conn_tl_data, int request_type)
+    mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint,
+    mca_btl_uct_tl_t *tl, mca_btl_uct_device_context_t *tl_context,
+    mca_btl_uct_tl_endpoint_t *tl_endpoint, int request_type, int remote_module_index)
 {
-    mca_btl_uct_tl_t *conn_tl = uct_btl->conn_tl;
-    mca_btl_uct_device_context_t *conn_tl_context = conn_tl->uct_dev_contexts[0];
-    uct_device_addr_t *device_addr = NULL;
-    uct_iface_addr_t *iface_addr;
     ucs_status_t ucs_status;
-
-    assert(NULL != conn_tl);
 
     BTL_VERBOSE(("connecting endpoint to remote endpoint"));
 
-    if (NULL == endpoint->conn_ep) {
-        BTL_VERBOSE(("creating a temporary endpoint for handling connections to %p",
-                     opal_process_name_print(endpoint->ep_proc->proc_name)));
-
-        iface_addr = (uct_iface_addr_t *) conn_tl_data;
-        device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data
-                                             + MCA_BTL_UCT_TL_ATTR(conn_tl, 0).iface_addr_len);
-
-        endpoint->conn_ep = OBJ_NEW(mca_btl_uct_connection_ep_t);
-        if (OPAL_UNLIKELY(NULL == endpoint->conn_ep)) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
-        }
-
-        /* create a temporary endpoint for setting up the rdma endpoint */
-        MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
-            ucs_status = mca_btl_uct_ep_create_connected_compat(conn_tl_context->uct_iface,
-                                                                device_addr, iface_addr,
-                                                                &endpoint->conn_ep->uct_ep);
-        });
-        if (UCS_OK != ucs_status) {
-            BTL_VERBOSE(
-                ("could not create an endpoint for forming connection to remote peer. code = %d",
-                 ucs_status));
-            return OPAL_ERROR;
-        }
-    } else {
-        OBJ_RETAIN(endpoint->conn_ep);
-    }
-
     size_t request_length = sizeof(mca_btl_uct_conn_req_t)
-                            + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id).ep_addr_len;
+                            + tl->uct_iface_attr.ep_addr_len;
     mca_btl_uct_conn_req_t *request = alloca(request_length);
 
     /* fill in common request parameters */
@@ -309,6 +279,7 @@ static int mca_btl_uct_endpoint_send_connection_data(
     request->context_id = tl_context->context_id;
     request->tl_index = tl->tl_index;
     request->type = request_type;
+    request->module_index = remote_module_index;
 
     /* fill in connection request */
     ucs_status = uct_ep_get_address(tl_endpoint->uct_ep, (uct_ep_addr_t *) request->ep_addr);
@@ -322,7 +293,7 @@ static int mca_btl_uct_endpoint_send_connection_data(
 
     /* let the remote side know that the connection has been established and
      * wait for the message to be sent */
-    int rc = mca_btl_uct_endpoint_send_conn_req(uct_btl, endpoint, conn_tl_context, request,
+    int rc = mca_btl_uct_endpoint_send_conn_req(uct_btl, endpoint, request,
                                                 request_length);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         OBJ_RELEASE(endpoint->conn_ep);
@@ -337,9 +308,9 @@ static int mca_btl_uct_endpoint_send_connection_data(
 }
 
 static int mca_btl_uct_endpoint_connect_endpoint(
-    mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint, mca_btl_uct_tl_t *tl,
-    mca_btl_uct_device_context_t *tl_context, mca_btl_uct_tl_endpoint_t *tl_endpoint,
-    uint8_t *tl_data, uint8_t *conn_tl_data, void *ep_addr)
+    mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint,
+    mca_btl_uct_tl_t *tl, mca_btl_uct_device_context_t *tl_context,
+    mca_btl_uct_tl_endpoint_t *tl_endpoint, uint8_t *tl_data, void *ep_addr, int remote_module_index)
 {
     ucs_status_t ucs_status;
 
@@ -367,20 +338,23 @@ static int mca_btl_uct_endpoint_connect_endpoint(
         if (UCS_OK != ucs_status) {
             return OPAL_ERROR;
         }
+    }
 
+    opal_timer_t now = opal_timer_base_get_usec();
+    if ((now - tl_endpoint->last_connection_req) > mca_btl_uct_component.connection_retry_timeout || ep_addr) {
+        int rc = mca_btl_uct_endpoint_send_connection_data(uct_btl, endpoint, tl, tl_context, tl_endpoint,
+                                                           /*request_type=*/!!ep_addr, remote_module_index);
+        if (OPAL_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    if (ep_addr) {
         mca_btl_uct_endpoint_set_flag(uct_btl, endpoint, tl_context->context_id, tl_endpoint,
                                       MCA_BTL_UCT_ENDPOINT_FLAG_EP_CONNECTED);
     }
 
-    opal_timer_t now = opal_timer_base_get_usec();
-    if ((now - tl_endpoint->last_connection_req) < mca_btl_uct_component.connection_retry_timeout && !ep_addr) {
-        return (tl_endpoint->flags & MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY) ? OPAL_SUCCESS
-            : OPAL_ERR_OUT_OF_RESOURCE;
-    }
-
-    int rc = mca_btl_uct_endpoint_send_connection_data(uct_btl, endpoint, tl, tl_context, tl_endpoint,
-                                                       conn_tl_data, /*request_type=*/!!ep_addr);
-    return (OPAL_SUCCESS == rc) ? OPAL_ERR_OUT_OF_RESOURCE : rc;
+    return OPAL_ERR_OUT_OF_RESOURCE;
 }
 
 int mca_btl_uct_endpoint_connect(mca_btl_uct_module_t *uct_btl, mca_btl_uct_endpoint_t *endpoint,
@@ -392,9 +366,8 @@ int mca_btl_uct_endpoint_connect(mca_btl_uct_module_t *uct_btl, mca_btl_uct_endp
                                : uct_btl->am_tl;
     mca_btl_uct_device_context_t *tl_context
         = mca_btl_uct_module_get_tl_context_specific(uct_btl, tl, context_id);
-    uint8_t *rdma_tl_data = NULL, *conn_tl_data = NULL, *am_tl_data = NULL, *tl_data;
+    uint8_t *conn_tl_data, *tl_data = NULL;
     mca_btl_uct_modex_t *modex;
-    uint8_t *modex_data;
     size_t msg_size;
     int rc;
 
@@ -410,19 +383,20 @@ int mca_btl_uct_endpoint_connect(mca_btl_uct_module_t *uct_btl, mca_btl_uct_endp
                  !!(MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY & tl_endpoint->flags)));
 
     opal_mutex_lock(&endpoint->ep_lock);
-    if (MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY & tl_endpoint->flags) {
-        opal_mutex_unlock(&endpoint->ep_lock);
-        /* nothing more to do. someone else completed the connection */
-        return OPAL_SUCCESS;
-    }
-
-    /* dumpicate connection request. nothing to do until the endpoint data is received */
-    if (NULL != tl_endpoint->uct_ep && NULL == ep_addr) {
-        opal_mutex_unlock(&endpoint->ep_lock);
-        return OPAL_ERR_OUT_OF_RESOURCE;
-    }
 
     do {
+        if (MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY & tl_endpoint->flags) {
+            /* nothing more to do. someone else completed the connection */
+            rc = OPAL_SUCCESS;
+            break;
+        }
+
+        /* dumpicate connection request. nothing to do until the endpoint data is received */
+        if (NULL != tl_endpoint->uct_ep && NULL == ep_addr) {
+            rc = OPAL_ERR_OUT_OF_RESOURCE;
+            break;
+        }
+
         /* read the modex. this is done both to start the connection and to process endpoint data */
         OPAL_MODEX_RECV(rc, &mca_btl_uct_component.super.btl_version, &endpoint->ep_proc->proc_name,
                         (void **) &modex, &msg_size);
@@ -434,45 +408,39 @@ int mca_btl_uct_endpoint_connect(mca_btl_uct_module_t *uct_btl, mca_btl_uct_endp
         BTL_VERBOSE(("received modex of size %lu for proc %s. module count %d",
                      (unsigned long) msg_size, OPAL_NAME_PRINT(endpoint->ep_proc->proc_name),
                      modex->module_count));
-        modex_data = modex->data;
 
-        /* look for matching transport in the modex */
-        for (int i = 0; i < modex->module_count; ++i) {
-            uint32_t modex_size = *((uint32_t *) modex_data);
-
-            BTL_VERBOSE(
-                ("found modex for md %s, searching for %s", modex_data + 4, uct_btl->md_name));
-
-            modex_data += 4;
-
-            if (0 != strcmp((char *) modex_data, uct_btl->md_name)) {
-                /* modex belongs to a different module, skip it and continue */
-                modex_data += modex_size - 4;
-                continue;
-            }
-
-            modex_data += strlen((char *) modex_data) + 1;
-
-            mca_btl_uct_process_modex(uct_btl, modex_data, &rdma_tl_data, &am_tl_data,
-                                      &conn_tl_data);
+        int remote_module_index;
+        tl_data = mca_btl_uct_find_modex(modex, tl, &remote_module_index);
+        if (OPAL_UNLIKELY(NULL == tl_data)) {
+            BTL_ERROR(("could not find modex data for this transport"));
+            rc = OPAL_ERR_UNREACH;
             break;
         }
 
-        tl_data = (tl == uct_btl->rdma_tl) ? rdma_tl_data : am_tl_data;
-
-        if (NULL == tl_data) {
-            opal_mutex_unlock(&endpoint->ep_lock);
-            return OPAL_ERR_UNREACH;
-        }
-
         /* connect the endpoint */
-        if (!mca_btl_uct_tl_requires_connection_tl(tl)) {
-            rc = mca_btl_uct_endpoint_connect_iface(uct_btl, tl, tl_context, tl_endpoint, tl_data);
-        } else {
-            rc = mca_btl_uct_endpoint_connect_endpoint(uct_btl, endpoint, tl, tl_context,
-                                                       tl_endpoint, tl_data, conn_tl_data, ep_addr);
-        }
+        if (mca_btl_uct_tl_requires_connection_tl(tl)) {
+            conn_tl_data = mca_btl_uct_find_modex(modex, mca_btl_uct_component.conn_tl,
+                                                  /*remote_module_index=*/NULL);
+            if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+                BTL_ERROR(("could not find modex for connection module"));
+                break;
+            }
 
+
+            if (NULL == tl_endpoint->uct_ep) {
+                /* allocate or retain a connection endpoint */
+                rc = mca_btl_uct_endpoint_get_helper_endpoint(uct_btl, endpoint,
+                                                              conn_tl_data);
+                if (OPAL_SUCCESS != rc) {
+                    break;
+                }
+            }
+
+            rc = mca_btl_uct_endpoint_connect_endpoint(uct_btl, endpoint, tl, tl_context, tl_endpoint,
+                                                       tl_data, ep_addr, remote_module_index);
+        } else {
+            rc = mca_btl_uct_endpoint_connect_iface(uct_btl, tl, tl_context, tl_endpoint, tl_data);
+        }
     } while (0);
 
     opal_mutex_unlock(&endpoint->ep_lock);

--- a/opal/mca/btl/uct/btl_uct_frag.c
+++ b/opal/mca/btl/uct/btl_uct_frag.c
@@ -26,11 +26,25 @@ static void mca_btl_uct_base_frag_constructor(mca_btl_uct_base_frag_t *frag)
     frag->base.des_segment_count = 1;
 
     frag->segments[0].seg_addr.pval = frag->base.super.ptr;
-    frag->uct_iov.buffer = frag->base.super.ptr;
-    frag->uct_iov.stride = 0;
-    frag->uct_iov.count = 1;
+    /* header */
+    frag->uct_iov[0].buffer = &frag->header;
+    frag->uct_iov[0].length = sizeof(frag->header);
+    frag->uct_iov[0].stride = 0;
+    frag->uct_iov[0].count = 1;
+
+    /* fragment buffer (reserve with or without data) */
+    frag->uct_iov[1].buffer = frag->base.super.ptr;
+    frag->uct_iov[1].stride = 0;
+    frag->uct_iov[1].count = 1;
+
+    /* reserved for user data */
+    frag->uct_iov[2].buffer = NULL;
+    frag->uct_iov[2].stride = 0;
+    frag->uct_iov[2].length = 0;
+    frag->uct_iov[2].count = 1;
+    frag->uct_iov_count = 1;
     if (reg) {
-        frag->uct_iov.memh = reg->uct_memh;
+        frag->uct_iov[1].memh = reg->uct_memh;
     }
 }
 

--- a/opal/mca/btl/uct/btl_uct_include_list.c
+++ b/opal/mca/btl/uct/btl_uct_include_list.c
@@ -1,0 +1,78 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2024-2025 Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <regex.h>
+
+#include "opal_config.h"
+
+#include "btl_uct_include_list.h"
+#include "btl_uct_types.h"
+#include "opal/class/opal_object.h"
+#include "opal/mca/btl/base/btl_base_error.h"
+#include "opal/util/argv.h"
+
+void mca_btl_uct_include_list_parse (const char *value, mca_btl_uct_include_list_t *list) {
+    list->list = NULL;
+    list->include = true;
+
+    if (value == NULL) {
+        return;
+    }
+
+    if (value[0] == '^') {
+        list->include = false;
+        value++;
+    }
+
+    list->list = opal_argv_split(value, ',');
+}
+
+int mca_btl_uct_include_list_rank (const char *name, const mca_btl_uct_include_list_t *list) {
+    if (list->list == NULL) {
+        return -1;
+    }
+
+    for (int i = 0; list->list[i]; ++i) {
+        regex_t preg;
+ 
+        BTL_VERBOSE(("evaluating %s vs %s-list item %s", name, list->include ? "include" : "exclude", list->list[i]));
+        int rc = regcomp(&preg, list->list[i], REG_ICASE);
+        if (0 != rc) {
+            char errbuf[256];
+            regerror(rc, &preg, errbuf, sizeof(errbuf));
+            BTL_ERROR(("when matching name, could not parse regular expression: %s, error: %s", list->list[i], errbuf));
+            continue;
+        }
+
+        int result = regexec(&preg, name, /*nmatch=*/0, /*pmatch=*/NULL, /*eflags=*/0);
+        regfree(&preg);
+        if (0 == result) {
+            return list->include ? i + 1 : -(i + 1);
+        }
+    }
+
+    return list->include ? -1 : 1;
+}
+
+static void mca_btl_uct_include_list_construct (mca_btl_uct_include_list_t *list)
+{
+    list->list = NULL;
+}
+
+static void mca_btl_uct_include_list_destruct (mca_btl_uct_include_list_t *list)
+{
+    opal_argv_free (list->list);
+    list->list = NULL;
+}
+
+OBJ_CLASS_INSTANCE(mca_btl_uct_include_list_t, opal_object_t, mca_btl_uct_include_list_construct,
+                   mca_btl_uct_include_list_destruct);
+
+

--- a/opal/mca/btl/uct/btl_uct_include_list.h
+++ b/opal/mca/btl/uct/btl_uct_include_list.h
@@ -1,0 +1,34 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2024-2025 Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "btl_uct_types.h"
+
+#if !defined(BTL_UCT_INCLUDE_LIST_H)
+#define BTL_UCT_INCLUDE_LIST_H
+
+/**
+ * @brief Parse `value` to create an include list.
+ *
+ * @param[in]     value  Comma-delimeted string to parse.
+ * @param[in,out] list   Include list object, must already be constructed.
+ */
+void mca_btl_uct_include_list_parse (const char *value, mca_btl_uct_include_list_t *list);
+
+/**
+ * @brief Find the rank of `name` in the include list `list`.
+ *
+ * @param[in] name   name to find
+ * @param[in] list   list to search
+ *
+ * A negative result means the name is not present or the list is negated.
+ */
+int mca_btl_uct_include_list_rank (const char *name, const mca_btl_uct_include_list_t *list);
+
+#endif /* !defined(BTL_UCT_INCLUDE_LIST_H) */

--- a/opal/mca/btl/uct/btl_uct_modex.c
+++ b/opal/mca/btl/uct/btl_uct_modex.c
@@ -1,0 +1,198 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019-2025 Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "btl_uct_modex.h"
+#include "btl_uct_types.h"
+#include "btl_uct_device_context.h"
+#include "opal/class/opal_list.h"
+#include "opal/mca/pmix/pmix-internal.h"
+
+static uint16_t mca_btl_uct_tl_modex_size(mca_btl_uct_tl_t *tl)
+{
+    uint16_t size = sizeof(mca_btl_uct_tl_modex_t);
+
+    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+        size += (uint16_t)tl->uct_iface_attr.iface_addr_len;
+    }
+
+    /* pad out to a multiple of 4 bytes */
+    return (3 + size + (uint16_t)tl->uct_iface_attr.device_addr_len) & ~3;
+}
+
+static uint16_t mca_btl_uct_md_modex_size(mca_btl_uct_md_t *md)
+{
+    uint16_t modex_size = sizeof(mca_btl_uct_md_modex_t);
+
+    mca_btl_uct_tl_t *tl;
+    OPAL_LIST_FOREACH(tl, &md->tls, mca_btl_uct_tl_t) {
+      modex_size += mca_btl_uct_tl_modex_size(tl);
+    }
+
+    return modex_size;
+}
+
+static uint8_t *mca_btl_uct_tl_modex_pack(mca_btl_uct_module_t *module, mca_btl_uct_tl_t *tl,
+                                        uint8_t *modex_data)
+{
+    mca_btl_uct_device_context_t *dev_context =
+        mca_btl_uct_module_get_tl_context_specific(module, tl, /*context_id=*/0);
+
+    mca_btl_uct_tl_modex_t *tl_modex = (mca_btl_uct_tl_modex_t *)modex_data;
+    tl_modex->size = mca_btl_uct_tl_modex_size(tl);
+
+    memset(tl_modex->tl_name, 0, sizeof(tl_modex->tl_name));
+    strncpy(tl_modex->tl_name, tl->uct_tl_name, sizeof(tl_modex->tl_name));
+
+    uint8_t *tl_modex_data = (uint8_t *) tl_modex->data;
+
+    /* NTH: only the first context is available. i assume the device addresses of the
+     * contexts will be the same but they will have different iface addresses. i also
+     * am assuming that it doesn't really matter if all remote contexts connect to
+     * the same endpoint since we are only doing RDMA. if any of these assumptions are
+     * wrong then we can't delay creating the other contexts and must include their
+     * information in the modex. */
+    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+        uct_iface_get_address(dev_context->uct_iface, (uct_iface_addr_t *) tl_modex_data);
+        tl_modex_data += tl->uct_iface_attr.iface_addr_len;
+    }
+
+    uct_iface_get_device_address(dev_context->uct_iface, (uct_device_addr_t *) tl_modex_data);
+    tl_modex_data += tl->uct_iface_attr.device_addr_len;
+
+    return modex_data + tl_modex->size;
+}
+
+static uint8_t *mca_btl_uct_modex_pack(mca_btl_uct_md_t *md, uint8_t *modex_data)
+{
+    mca_btl_uct_module_t *module = NULL;
+    for (int i = 0 ; i < mca_btl_uct_component.module_count ; ++i) {
+      if (mca_btl_uct_component.modules[i]->md == md) {
+        module = mca_btl_uct_component.modules[i];
+        break;
+      }
+    }
+
+    mca_btl_uct_md_modex_t *md_modex = (mca_btl_uct_md_modex_t *)modex_data;
+    modex_data = md_modex->data;
+
+    md_modex->size = mca_btl_uct_md_modex_size(md);
+    md_modex->module_index = module ? module->module_index : (uint16_t) -1;
+
+    memset(md_modex->md_name, 0, sizeof(md_modex->md_name));
+    strncpy(md_modex->md_name, md->md_name, sizeof(md_modex->md_name));
+
+    mca_btl_uct_tl_t *tl;
+    OPAL_LIST_FOREACH(tl, &md->tls, mca_btl_uct_tl_t) {
+        modex_data = mca_btl_uct_tl_modex_pack(module, tl, modex_data);
+    }
+    
+    return modex_data;
+}
+
+int mca_btl_uct_component_modex_send(void)
+{
+    size_t modex_size = sizeof(mca_btl_uct_modex_t);
+    mca_btl_uct_modex_t *modex;
+    uint8_t *modex_data;
+    int rc;
+
+    mca_btl_uct_md_t *md;
+    OPAL_LIST_FOREACH(md, &mca_btl_uct_component.md_list, mca_btl_uct_md_t) {
+      modex_size += mca_btl_uct_md_modex_size(md);
+    }
+
+    modex = alloca(modex_size);
+    modex_data = modex->data;
+
+    modex->module_count = opal_list_get_size(&mca_btl_uct_component.md_list);
+    OPAL_LIST_FOREACH(md, &mca_btl_uct_component.md_list, mca_btl_uct_md_t) {
+      modex_data = mca_btl_uct_modex_pack(md, modex_data);
+    }
+
+    OPAL_MODEX_SEND(rc, PMIX_GLOBAL, &mca_btl_uct_component.super.btl_version, modex, modex_size);
+    return rc;
+}
+
+static uint8_t *mca_btl_uct_find_tl_modex(mca_btl_uct_md_modex_t *md_modex, mca_btl_uct_tl_t *tl)
+{
+    uint8_t *modex_data = md_modex->data;
+
+    for (uint16_t modex_offset = 0 ; modex_offset < md_modex->size ; ){
+        mca_btl_uct_tl_modex_t *tl_modex = (mca_btl_uct_tl_modex_t *)(modex_data + modex_offset);
+
+        BTL_VERBOSE(("found modex for tl %s searching for %s", tl_modex->tl_name, tl->uct_tl_name));
+
+        if (0 == strcmp(tl->uct_tl_name, tl_modex->tl_name)) {
+            return tl_modex->data;
+        }
+
+        BTL_VERBOSE(("no match, continuing"));
+
+        modex_offset += tl_modex->size;
+    }
+
+    return NULL;
+}
+
+uint8_t *mca_btl_uct_find_modex(mca_btl_uct_modex_t *modex, mca_btl_uct_tl_t *tl, int *remote_module_index) {
+    uint8_t *modex_data = modex->data;
+
+    /* look for matching transport in the modex */
+    for (int i = 0; i < modex->module_count; ++i) {
+        mca_btl_uct_md_modex_t *md_modex = (mca_btl_uct_md_modex_t *)modex_data;
+
+        BTL_VERBOSE(("found modex for md %s (remote module index %hu), searching for %s",
+                     md_modex->md_name, md_modex->module_index, tl->uct_md->md_name));
+
+        if (0 != strcmp(tl->uct_md->md_name, md_modex->md_name)) {
+            /* modex belongs to a different module, skip it and continue */
+            modex_data += md_modex->size;
+            continue;
+        }
+
+        uint8_t *tl_modex = mca_btl_uct_find_tl_modex(md_modex, tl);
+        if (NULL == tl_modex) {
+            break;
+        }
+
+        if (NULL != remote_module_index) {
+            *remote_module_index = md_modex->module_index;
+        }
+
+        BTL_VERBOSE(("finished processing modex for %s", tl->uct_md->md_name));
+
+        return tl_modex;
+    }
+
+    BTL_ERROR(("could not find modex for %s::%s", tl->uct_md->md_name, tl->uct_tl_name));
+
+    return NULL;
+}

--- a/opal/mca/btl/uct/btl_uct_modex.h
+++ b/opal/mca/btl/uct/btl_uct_modex.h
@@ -1,0 +1,20 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2025      Google, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(MCA_BTL_UCT_MODEX_H)
+#define MCA_BTL_UCT_MODEX_H
+
+#include "btl_uct.h"
+
+int mca_btl_uct_component_modex_send(void);
+
+uint8_t *mca_btl_uct_find_modex(mca_btl_uct_modex_t *modex, mca_btl_uct_tl_t *tl, int *remote_module_index);
+
+#endif /* !defined(MCA_BTL_UCT_MODEX_H) */

--- a/opal/mca/btl/uct/btl_uct_rdma.c
+++ b/opal/mca/btl/uct/btl_uct_rdma.c
@@ -126,7 +126,7 @@ int mca_btl_uct_get(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
 
     mca_btl_uct_context_lock(context);
 
-    if (size <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.get.max_bcopy) {
+    if (size <= uct_btl->rdma_tl->uct_iface_attr.cap.get.max_bcopy) {
         ucs_status = uct_ep_get_bcopy(ep_handle, mca_btl_uct_get_unpack, local_address, size,
                                       remote_address, rkey.rkey, &comp->uct_comp);
     } else {
@@ -223,7 +223,7 @@ int mca_btl_uct_put(mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoin
     /* determine what UCT prototol should be used */
     if (size <= uct_btl->super.btl_put_local_registration_threshold) {
         use_short = size
-                    <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.put.max_short;
+                    <= uct_btl->rdma_tl->uct_iface_attr.cap.put.max_short;
         use_bcopy = !use_short;
     }
 

--- a/opal/mca/btl/uct/btl_uct_rdma.h
+++ b/opal/mca/btl/uct/btl_uct_rdma.h
@@ -53,7 +53,7 @@ static inline int mca_btl_uct_get_rkey(mca_btl_uct_module_t *module,
     }
 
 #    if UCT_API >= UCT_VERSION(1, 7)
-    ucs_status = uct_rkey_unpack(module->uct_component, (void *) remote_handle, rkey);
+    ucs_status = uct_rkey_unpack(module->md->uct_component, (void *) remote_handle, rkey);
 #    else
     ucs_status = uct_rkey_unpack((void *) remote_handle, rkey);
 #    endif
@@ -63,7 +63,7 @@ static inline int mca_btl_uct_get_rkey(mca_btl_uct_module_t *module,
 static inline void mca_btl_uct_rkey_release(mca_btl_uct_module_t *uct_btl, uct_rkey_bundle_t *rkey)
 {
 #    if UCT_API >= UCT_VERSION(1, 7)
-    uct_rkey_release(uct_btl->uct_component, rkey);
+    uct_rkey_release(uct_btl->md->uct_component, rkey);
 #    else
     (void) uct_btl;
     uct_rkey_release(rkey);


### PR DESCRIPTION
This PR contains a number of changes related to the UCT btl, these include:

 - Allow alternate connection methods for wiring up connect-to-endpoint transports. This includes using tcp to wire up ib. This may be needed depending on the level of UD support provided by a transport.
 - Clean up of modex code to improve readability.
 - Fix for a connection management issue that could cause accessing already-freed resources. This is separate from the other CLs but was discovered in the middle of the rework. I can take the time to extract if if needed.
 - Split the initialization code into a discovery and initialization phase. This is used to 1) check what memory domains are available, and 2) figure out network defaults. This code enables support for new MCA variables that allow controlling memory-domain specific behavior (since each memory domain may be a different btl).
