### PR TITLE
fix: Eliminate potential ODR risks

### DIFF
--- a/opal/mca/common/ucx/Makefile.am
+++ b/opal/mca/common/ucx/Makefile.am
@@ -61,8 +61,7 @@ lib@OPAL_LIB_NAME@mca_common_ucx_la_LDFLAGS = \
 		$(common_ucx_LDFLAGS)
 lib@OPAL_LIB_NAME@mca_common_ucx_la_LIBADD = \
 		$(common_ucx_LIBS) \
-		$(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_NAME@.la \
-		$(OMPI_TOP_BUILDDIR)/opal/mca/memory/libmca_memory.la
+		$(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_NAME@.la
 lib@OPAL_LIB_NAME@mca_common_ucx_noinst_la_SOURCES = \
         $(headers) $(sources)
 lib@OPAL_LIB_NAME@mca_common_ucx_noinst_la_CPPFLAGS = \


### PR DESCRIPTION
In the compilation of` libopen-pal.so `and` libopen-palmca_common_ucx.so`, the static library `libmca_memory.a` is linked. Although` libopen-palmca_common_ucx.so` is dlopen, the flag is set to `RTLD_GLOBAL`.

`libopen-palmca_common_ucx.so` only uses symbol `opal_memory_base_framework`, and the code has defined extern, so you can directly use the definition in `libopen-pal.so`.