### PR TITLE
MPI_HOST: deprecate for MPI 4.1

### DIFF
--- a/docs/man-openmpi/man3/MPI_Comm_set_attr.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_set_attr.3.rst
@@ -55,6 +55,8 @@ in an integer.
 If an attribute is already present, the delete function (specified when
 the corresponding keyval was created) will be called.
 
+Note that the ``MPI_HOST`` attribute is  *deprecated* as of MPI-4.1.
+
 
 ERRORS
 ------

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -652,7 +652,7 @@ typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
 enum {
     /* MPI-1 */
     MPI_TAG_UB,
-    MPI_HOST,
+    MPI_HOST __mpi_interface_deprecated_in_mpi41__("MPI_HOST is deprecated since MPI 4.1"), 
     MPI_IO,
     MPI_WTIME_IS_GLOBAL,
 


### PR DESCRIPTION
related to #12193