### PR TITLE
configury: allow knem to be disabled

### DIFF
--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -31,11 +31,15 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
 
     opal_check_knem_CPPFLAGS_save="${CPPFLAGS}"
 
-    AS_IF([test -n "${with_knem}" -a "${with_knem}" != "yes" -a "${with_knem}" != "no"],
-          [$1_CPPFLAGS="-I${with_knem}/include"
-           CPPFLAGS="$CPPFLAGS ${$1_CPPFLAGS}"])
+    AS_IF([test -n "${with_knem}" -a "${with_knem}" = "no"],
+          [opal_check_knem_happy="no"],
+          [opal_check_knem_happy="yes"])
 
-    AC_CHECK_HEADER([knem_io.h], [opal_check_knem_happy="yes"], [opal_check_knem_happy="no"])
+    AS_IF([test "${opal_check_knem_happy}" = "yes"],
+          [AS_IF([test -a "${with_knem}" != "yes"],
+                 [$1_CPPFLAGS="-I${with_knem}/include"
+                  CPPFLAGS="$CPPFLAGS ${$1_CPPFLAGS}"])
+           AC_CHECK_HEADER([knem_io.h], [opal_check_knem_happy="yes"], [opal_check_knem_happy="no"])])
 
     # need at least version 0x0000000b
     AS_IF([test "$opal_check_knem_happy" = "yes"],


### PR DESCRIPTION
without this patch --with-knem=no doesn't work

this is useful when knem software is installed but the knem device is not enabled. So this message:

_WARNING: Open MPI failed to open the /dev/knem device due to a permissions problem.  Please check with your system administrator to get the permissions fixed, or set the smsc MCA variable to "^knem" to silence this warning and run without knem support._

is avoided without needing the user to set an MCA parameter, etc.