### PR TITLE
use-mpi-f08: Always call generation script for sizeof_f08

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -365,13 +365,11 @@ lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES = \
         $(mpi_api_files) \
         mpi-f08.F90
 
-if BUILD_FORTRAN_SIZEOF
 SIZEOF_H = sizeof_f08.h
 nodist_lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES = \
         sizeof_f08.h \
         sizeof_f08.f90 \
         psizeof_f08.f90
-endif
 
 lib@OMPI_LIBMPI_NAME@_usempif08_la_FCFLAGS = \
         $(AM_FCFLAGS) \


### PR DESCRIPTION
mpi-f08.F90 always includes sizeof_f08.h, so compilation fails if the header isnt there. Script will print (pseudo-)empty file if the flag isnt set anyway.