### PR TITLE
v5.0.x: fortran: fix ompi string c2f where len(fstr) < len(cstr)

### DIFF
--- a/ompi/mpi/fortran/base/strings.c
+++ b/ompi/mpi/fortran/base/strings.c
@@ -101,7 +101,7 @@ int ompi_fortran_string_c2f(const char *cstr, char *fstr, int len)
     // trailing \0 into the last position in fstr.  This is not what
     // Fortran wants; overwrite that \0 with the actual last character
     // that will fit into fstr.
-    if (len < strlen(cstr)) {
+    if (len <= strlen(cstr)) {
         fstr[len - 1] = cstr[len - 1];
     } else {
         // Otherwise, pad the end of the resulting Fortran string with


### PR DESCRIPTION
Thanks to Ben Menadue @benmenadue for pointing out that ompi_fortran_string_c2f() missed a case to properly terminate the resulting Fortran string when copying from a longer C source string.

(cherry picked from commit 694e78aa864e5dc219172a710bda8e129542094a)

This is the v5.0.x PR corresponding to main PR #13381 and #13387
Fixes #13375 