### PR TITLE
docs/mca.rst: fix MCA environment variable prefix for PRRTE

### DIFF
--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -252,13 +252,13 @@ shells):
              When setting PMIx- and PRRTE-specific MCA parameters via
              environment variables, use a different prefix:
 
-             +----------+----------------+
-             | Open MPI | ``OMPI_MCA_``  |
-             +----------+----------------+
-             | PMIx     | ``PMIX_MCA_``  |
-             +----------+----------------+
-             | PRRTE    | ``PRRTE_MCA_`` |
-             +----------+----------------+
+             +----------+-----------------------------------+
+             | Open MPI | ``OMPI_MCA_``                     |
+             +----------+-----------------------------------+
+             | PMIx     | ``PMIX_MCA_``                     |
+             +----------+-----------------------------------+
+             | PRRTE    | ``PRTE_MCA_`` (with a single "R") |
+             +----------+-----------------------------------+
 
 Tuning MCA parameter files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The table added in 061f90860f (A variety of docs updates:, 2022-09-12) mentioning the different prefixes for Open MPI, PMIx and PRRTE MCA parameters set via environment variables has one too many "R"'s in 'PRRTE_MCA_': the correct prefix is 'PRTE_MCA_'. Fix that, and make it clear that it is not a typo.


(cherry picked from commit bd9adb41c1644775f4792221fbc01f552d1d637c)