### PR TITLE
dist: Prep for 5.0.9 release

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=5
 minor=0
-release=8
+release=9
 
 # MPI Standard Compliance Level
 mpi_standard_version=3
@@ -41,7 +41,7 @@ flex_min_version=2.5.4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc3
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
5.0.8 has shipped; on to the next one.

bot:notacherrypick