### PR TITLE
OMPI/MCA/PML/UCX: Set node local id.

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -99,7 +99,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                            UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK,
                            UCP_OP_ATTR_FLAG_MULTI_SEND,
                            UCS_MEMORY_TYPE_RDMA,
-                           UCP_MEM_MAP_SYMMETRIC_RKEY],
+                           UCP_MEM_MAP_SYMMETRIC_RKEY,
+                           UCP_PARAM_FIELD_NODE_LOCAL_ID],
                           [], [],
                           [#include <ucp/api/ucp.h>])
            AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -271,6 +271,11 @@ static int ucp_context_init(bool enable_mt, int proc_world_size) {
     context_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
 #endif
 
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    context_params.node_local_id = opal_process_info.my_local_rank;
+    context_params.field_mask |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     status = ucp_init(&context_params, config, &mca_osc_ucx_component.wpool->ucp_ctx);
     if (UCS_OK != status) {
         OSC_UCX_VERBOSE(1, "ucp_init failed: %d", status);

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -249,6 +249,11 @@ int mca_pml_ucx_open(void)
     params.field_mask       |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
 #endif
 
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    params.node_local_id = opal_process_info.my_local_rank;
+    params.field_mask   |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     status = ucp_init(&params, config, &ompi_pml_ucx.ucp_context);
     ucp_config_release(config);
 

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -293,6 +293,11 @@ static int spml_ucx_init(void)
     params.field_mask       |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
 #endif
 
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    params.node_local_id = opal_process_info.my_local_rank;
+    params.field_mask   |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     err = ucp_init(&params, ucp_config, &mca_spml_ucx.ucp_context);
     ucp_config_release(ucp_config);
     if (UCS_OK != err) {


### PR DESCRIPTION
Set mode local id hint for UCX context.
The parameter is introduced by https://github.com/openucx/ucx/pull/10870.
The parameter does not affect semantics, only transport selection criteria and the resulting performance.