### PR TITLE
OMPI/MCA/PML/UCX: Set node local id - v4.1.x

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -141,7 +141,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                          UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK,
                                          UCP_OP_ATTR_FLAG_MULTI_SEND,
                                          UCS_MEMORY_TYPE_RDMA,
-                                         UCP_MEM_MAP_SYMMETRIC_RKEY],
+                                         UCP_MEM_MAP_SYMMETRIC_RKEY,
+                                         UCP_PARAM_FIELD_NODE_LOCAL_ID],
                                         [], [],
                                         [#include <ucp/api/ucp.h>])
                          AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -178,6 +178,16 @@ static int ucp_context_init(void) {
     context_params.request_init = internal_req_init;
     context_params.request_size = sizeof(ompi_osc_ucx_internal_request_t);
 
+#if HAVE_DECL_UCP_PARAM_FIELD_ESTIMATED_NUM_PPN
+    context_params.estimated_num_ppn = opal_process_info.num_local_peers + 1;
+    context_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
+#endif
+
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    context_params.node_local_id = opal_process_info.my_local_rank;
+    context_params.field_mask |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     status = ucp_init(&context_params, config, &mca_osc_ucx_component.ucp_context);
     ucp_config_release(config);
     if (UCS_OK != status) {

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -232,6 +232,11 @@ int mca_pml_ucx_open(void)
     params.field_mask       |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
 #endif
 
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    params.node_local_id = opal_process_info.my_local_rank;
+    params.field_mask   |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     status = ucp_init(&params, config, &ompi_pml_ucx.ucp_context);
     ucp_config_release(config);
 

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -292,6 +292,11 @@ static int spml_ucx_init(void)
     params.field_mask       |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
 #endif
 
+#if HAVE_DECL_UCP_PARAM_FIELD_NODE_LOCAL_ID
+    params.node_local_id = opal_process_info.my_local_rank;
+    params.field_mask   |= UCP_PARAM_FIELD_NODE_LOCAL_ID;
+#endif
+
     err = ucp_init(&params, ucp_config, &mca_spml_ucx.ucp_context);
     ucp_config_release(ucp_config);
     if (UCS_OK != err) {


### PR DESCRIPTION
- backport of #13406
- Adding missing estimated number of ppn to common ucx infra

bot:notacherrypick
