### PR TITLE
mpit: define correct names for source ordering

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -954,8 +954,8 @@ typedef enum {
  * MPIT source ordering
  */
 enum ompi_mpi_t_source_order_t {
-  MPI_T_ORDERED,
-  MPI_T_UNORDERED,
+  MPI_T_SOURCE_ORDERED,
+  MPI_T_SOURCE_UNORDERED,
 };
 
 typedef enum ompi_mpi_t_source_order_t MPI_T_source_order;


### PR DESCRIPTION
The enum for MPI_T_source_order was not correct.
Found while working on the ABI effort #13280