### PR TITLE
Updates to the acoll component

### DIFF
--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -20,15 +20,12 @@
 #include "ompi/mca/mca.h"
 #include "ompi/request/request.h"
 
-#ifdef HAVE_XPMEM_H
-#include "opal/mca/rcache/base/base.h"
-#include "opal/class/opal_hash_table.h"
-#include <xpmem.h>
-#endif
-
 #include "opal/mca/accelerator/accelerator.h"
 #include "opal/mca/shmem/base/base.h"
 #include "opal/mca/shmem/shmem.h"
+
+// For smsc
+#include "opal/mca/smsc/smsc.h"
 
 BEGIN_C_DECLS
 
@@ -88,6 +85,7 @@ int mca_coll_acoll_barrier_intra(struct ompi_communicator_t *comm, mca_coll_base
 
 END_C_DECLS
 
+#define MCA_COLL_ACOLL_MIN_COMM_SIZE 16
 #define MCA_COLL_ACOLL_ROOT_CHANGE_THRESH 10
 #define MCA_COLL_ACOLL_SPLIT_FACTOR_LIST_LEN 6
 #define MCA_COLL_ACOLL_SPLIT_FACTOR_LIST {2, 4, 8, 16, 32, 64}
@@ -127,20 +125,22 @@ typedef enum MCA_COLL_ACOLL_BASE_LYRS {
     MCA_COLL_ACOLL_NUM_BASE_LYRS
 } MCA_COLL_ACOLL_BASE_LYRS;
 
+typedef struct coll_acoll_smsc_info {
+    mca_smsc_endpoint_t **ep;
+    void **rreg;
+    void **sreg;
+} coll_acoll_smsc_info_t;
+
 typedef struct coll_acoll_data {
-#ifdef HAVE_XPMEM_H
-    xpmem_segid_t *allseg_id;
-    xpmem_apid_t *all_apid;
     void **allshm_sbuf;
     void **allshm_rbuf;
-    void **xpmem_saddr;
-    void **xpmem_raddr;
-    mca_rcache_base_module_t **rcache;
     void *scratch;
-    opal_hash_table_t **xpmem_reg_tracker_ht;
-#endif
+    void **smsc_saddr;
+    void **smsc_raddr;
+
     opal_shmem_ds_t *allshmseg_id;
     void **allshmmmap_sbuf;
+    coll_acoll_smsc_info_t smsc_info;
 
     int comm_size;
     int l1_local_rank;
@@ -204,11 +204,9 @@ typedef struct coll_acoll_subcomms {
     bool initialized_data;
     bool initialized_shm_data;
     int barrier_algo;
-#ifdef HAVE_XPMEM_H
-    uint64_t xpmem_buf_size;
-    int without_xpmem;
-    int xpmem_use_sr_buf;
-#endif
+    uint64_t smsc_buf_size;
+    int without_smsc;
+    int smsc_use_sr_buf;
 
 } coll_acoll_subcomms_t;
 
@@ -222,7 +220,6 @@ typedef struct coll_acoll_reserve_mem {
 typedef struct {
     int split_factor;
     size_t psplit_msg_thresh;
-    size_t xpmem_msg_thresh;
 } coll_acoll_alltoall_attr_t;
 
 struct mca_coll_acoll_module_t {
@@ -252,14 +249,9 @@ struct mca_coll_acoll_module_t {
     coll_acoll_reserve_mem_t reserve_mem_s;
     int num_subc;
     coll_acoll_alltoall_attr_t alltoall_attr;
+    // 1 if SMSC, in particular xpmem is available, 0 otherwise
+    int has_smsc;
 };
-
-#ifdef HAVE_XPMEM_H
-struct acoll_xpmem_rcache_reg_t {
-    mca_rcache_base_registration_t base;
-    void *xpmem_vaddr;
-};
-#endif
 
 typedef struct mca_coll_acoll_module_t mca_coll_acoll_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_acoll_module_t);

--- a/ompi/mca/coll/acoll/coll_acoll_allgather.c
+++ b/ompi/mca/coll/acoll/coll_acoll_allgather.c
@@ -537,6 +537,9 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
 
     /* Return if intra-node communicator */
     if ((1 == num_nodes) || (size <= 2)) {
+        /* Call barrier to ensure that the data is copied properly before returning */
+        ompi_coll_base_barrier_intra_basic_linear(comm, module);
+
         /* All done */
         return err;
     }
@@ -619,6 +622,9 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
             return err;
         }
     }
+
+    /* Call barrier to ensure that the data is copied properly before returning */
+    ompi_coll_base_barrier_intra_basic_linear(comm, module);
 
     /* All done */
     return err;

--- a/ompi/mca/coll/acoll/coll_acoll_component.c
+++ b/ompi/mca/coll/acoll/coll_acoll_component.c
@@ -42,14 +42,13 @@ int mca_coll_acoll_allgather_lin = 0;
 int mca_coll_acoll_allgather_ring_1 = 0;
 int mca_coll_acoll_reserve_memory_for_algo = 0;
 uint64_t mca_coll_acoll_reserve_memory_size_for_algo = 128 * 32768; // 4 MB
-uint64_t mca_coll_acoll_xpmem_buffer_size = 128 * 32768;
+uint64_t mca_coll_acoll_smsc_buffer_size = 128 * 32768;
 int mca_coll_acoll_alltoall_split_factor = 0;
 size_t mca_coll_acoll_alltoall_psplit_msg_thres = 0;
-size_t mca_coll_acoll_alltoall_xpmem_msg_thres = 0;
 
-/* By default utilize xpmem based algorithms applicable when built with xpmem. */
-int mca_coll_acoll_without_xpmem = 0;
-int mca_coll_acoll_xpmem_use_sr_buf = 1;
+/* By default utilize smsc based algorithms applicable when built with smsc. */
+int mca_coll_acoll_without_smsc = 0;
+int mca_coll_acoll_smsc_use_sr_buf = 1;
 /* Default barrier algorithm - hierarchical algorithm using shared memory */
 /* ToDo: check how this works with inter-node*/
 int mca_coll_acoll_barrier_algo = 0;
@@ -95,7 +94,7 @@ MCA_BASE_COMPONENT_INIT(ompi, coll, acoll)
 static int acoll_register(void)
 {
     /* Use a low priority, but allow other components to be lower */
-    mca_coll_acoll_priority = 0;
+    mca_coll_acoll_priority = 40;
     (void) mca_base_component_var_register(&mca_coll_acoll_component.collm_version, "priority",
                                            "Priority of the acoll coll component",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
@@ -192,25 +191,25 @@ static int acoll_register(void)
         MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
         &mca_coll_acoll_barrier_algo);
     (void) mca_base_component_var_register(
-        &mca_coll_acoll_component.collm_version, "without_xpmem",
-        "By default, xpmem-based algorithms are used when applicable. "
-        "When this flag is set to 1, xpmem-based algorithms are disabled.",
+        &mca_coll_acoll_component.collm_version, "without_smsc",
+        "By default, smsc (xpmem)-based algorithms are used when applicable. "
+        "When this flag is set to 1, smsc-based algorithms are disabled.",
         MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_coll_acoll_without_xpmem);
+        &mca_coll_acoll_without_smsc);
     (void) mca_base_component_var_register(
-        &mca_coll_acoll_component.collm_version, "xpmem_buffer_size",
+        &mca_coll_acoll_component.collm_version, "smsc_buffer_size",
         "Maximum size of memory that can be used for temporary buffers for "
-        "xpmem-based algorithms. By default these buffers are not created or "
-        "used unless xpmem_use_sr_buf is set to 0.",
+        "smsc-based algorithms. By default these buffers are not created or "
+        "used unless smsc_use_sr_buf is set to 0.",
         MCA_BASE_VAR_TYPE_UINT64_T, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_coll_acoll_xpmem_buffer_size);
+        &mca_coll_acoll_smsc_buffer_size);
     (void) mca_base_component_var_register(
-        &mca_coll_acoll_component.collm_version, "xpmem_use_sr_buf",
-        "Uses application provided send/recv buffers during xpmem registration "
+        &mca_coll_acoll_component.collm_version, "smsc_use_sr_buf",
+        "Uses application provided send/recv buffers during smsc registration "
         "when set to 1 instead of temporary buffers. The send/recv buffers are "
         "assumed to persist for the duration of the application.",
         MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_coll_acoll_xpmem_use_sr_buf);
+        &mca_coll_acoll_smsc_use_sr_buf);
     (void) mca_base_component_var_register(
         &mca_coll_acoll_component.collm_version, "alltoall_split_factor",
         "Split factor value to be used in alltoall parallel split algorithm,"
@@ -223,12 +222,6 @@ static int acoll_register(void)
         "should not be used.",
         MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
         &mca_coll_acoll_alltoall_psplit_msg_thres);
-    (void) mca_base_component_var_register(
-        &mca_coll_acoll_component.collm_version, "alltoall_xpmem_msg_thresh",
-        "Message threshold above which xpmem based linear alltoall algorithm "
-        "should be used for intra node cases.",
-        MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_coll_acoll_alltoall_xpmem_msg_thres);
 
     return OMPI_SUCCESS;
 }
@@ -275,12 +268,6 @@ static void mca_coll_acoll_module_construct(mca_coll_acoll_module_t *module)
         (module->alltoall_attr).psplit_msg_thresh =
             mca_coll_acoll_alltoall_psplit_msg_thres;
     }
-
-    (module->alltoall_attr).xpmem_msg_thresh = 0;
-    if (0 < mca_coll_acoll_alltoall_xpmem_msg_thres) {
-        (module->alltoall_attr).xpmem_msg_thresh =
-            mca_coll_acoll_alltoall_xpmem_msg_thres;
-    }
 }
 
 /*
@@ -301,51 +288,20 @@ static void mca_coll_acoll_module_destruct(mca_coll_acoll_module_t *module)
             }
             coll_acoll_data_t *data = subc->data;
             if (NULL != data) {
-#ifdef HAVE_XPMEM_H
-                for (int j = 0; j < data->comm_size; j++) {
-                    if (ompi_comm_rank(subc->orig_comm) == j) {
-                        continue;
-                    }
-                    // Dereg all rcache regs.
-                    uint64_t key = 0;
-                    uint64_t value = 0;
-                    uint64_t zero_value = 0;
-                    OPAL_HASH_TABLE_FOREACH(key,uint64,value,(data->xpmem_reg_tracker_ht[j])) {
-                        mca_rcache_base_registration_t* reg =
-                            (mca_rcache_base_registration_t*) key;
-
-                        for (uint64_t d_i = 0; d_i < value; ++d_i) {
-                            (data->rcache[j])->rcache_deregister(data->rcache[j], reg);
-                        }
-                        opal_hash_table_set_value_uint64(data->xpmem_reg_tracker_ht[j],
-                                 key, (void*)(zero_value));
-                    }
-                    xpmem_release(data->all_apid[j]);
-                    mca_rcache_base_module_destroy(data->rcache[j]);
-                    opal_hash_table_remove_all(data->xpmem_reg_tracker_ht[j]);
-                    OBJ_RELEASE(data->xpmem_reg_tracker_ht[j]);
-                }
-                xpmem_remove(data->allseg_id[ompi_comm_rank(subc->orig_comm)]);
-
-                free(data->allseg_id);
-                data->allseg_id = NULL;
-                free(data->all_apid);
-                data->all_apid = NULL;
+                free(data->smsc_info.sreg);
+                data->smsc_info.sreg = NULL;
+                free(data->smsc_info.rreg);
+                data->smsc_info.rreg = NULL;
+                free(data->smsc_saddr);
+                data->smsc_saddr = NULL;
+                free(data->smsc_raddr);
+                data->smsc_raddr = NULL;
                 free(data->allshm_sbuf);
                 data->allshm_sbuf = NULL;
                 free(data->allshm_rbuf);
                 data->allshm_rbuf = NULL;
-                free(data->xpmem_saddr);
-                data->xpmem_saddr = NULL;
-                free(data->xpmem_raddr);
-                data->xpmem_raddr = NULL;
                 free(data->scratch);
                 data->scratch = NULL;
-                free(data->xpmem_reg_tracker_ht);
-                data->xpmem_reg_tracker_ht = NULL;
-                free(data->rcache);
-                data->rcache = NULL;
-#endif
                 free(data->allshmseg_id);
                 data->allshmseg_id = NULL;
                 free(data->allshmmmap_sbuf);
@@ -418,7 +374,6 @@ static void mca_coll_acoll_module_destruct(mca_coll_acoll_module_t *module)
 
     (module->alltoall_attr).split_factor = 0;
     (module->alltoall_attr).psplit_msg_thresh = 0;
-    (module->alltoall_attr).xpmem_msg_thresh = 0;
 }
 
 OBJ_CLASS_INSTANCE(mca_coll_acoll_module_t, mca_coll_base_module_t, mca_coll_acoll_module_construct,

--- a/ompi/mca/coll/acoll/coll_acoll_module.c
+++ b/ompi/mca/coll/acoll/coll_acoll_module.c
@@ -64,7 +64,7 @@ mca_coll_base_module_t *mca_coll_acoll_comm_query(struct ompi_communicator_t *co
         *priority = 0;
         return NULL;
     }
-    if (OMPI_COMM_IS_INTRA(comm) && ompi_comm_size(comm) < 2) {
+    if (OMPI_COMM_IS_INTRA(comm) && ompi_comm_size(comm) < MCA_COLL_ACOLL_MIN_COMM_SIZE) {
         *priority = 0;
         return NULL;
     }
@@ -130,6 +130,17 @@ mca_coll_base_module_t *mca_coll_acoll_comm_query(struct ompi_communicator_t *co
     default:
         assert(0);
         break;
+    }
+
+    // Check SMSC availability (currently only for XPMEM)
+    if (!mca_smsc_base_has_feature(MCA_SMSC_FEATURE_CAN_MAP)) {
+        opal_output_verbose(MCA_BASE_VERBOSE_ERROR, ompi_coll_base_framework.framework_output,
+                            "coll:acoll: Error: SMSC's xpmem component is not available. "
+                            "SMSC will be disabled for this communicator irrespective of "
+                            "the mca parameters.");
+        acoll_module->has_smsc = 0;
+    } else {
+        acoll_module->has_smsc = 1;
     }
 
     acoll_module->force_numa = mca_coll_acoll_force_numa;


### PR DESCRIPTION
This commit has the following updates:
- converts the xpmem-based collectives to SMSC-based for collective operations.
- fixes coverity issues
- misc bug-fixes

TO_BE_UPDATED: change the default acoll priority back to 0 before merging the PR. It is set to 40 for testing.