### PR TITLE
Fix `see-also` errors in the document (v5.0.x)

### DIFF
--- a/docs/man-openmpi/man3/MPI_Recv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Recv_init.3.rst
@@ -92,7 +92,7 @@ ERRORS
    * :ref:`MPI_Bsend_init`
    * :ref:`MPI_Rsend_init`
    * :ref:`MPI_Send_init`
-   * MPI_Sssend_init
+   * :ref:`MPI_Ssend_init`
    * :ref:`MPI_Start`
    * :ref:`MPI_Startall`
    * :ref:`MPI_Request_free`

--- a/docs/man-openmpi/man3/MPI_Rsend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Rsend_init.3.rst
@@ -84,7 +84,7 @@ ERRORS
 .. seealso::
    * :ref:`MPI_Bsend_init`
    * :ref:`MPI_Send_init`
-   * MPI_Sssend_init
+   * :ref:`MPI_Ssend_init`
    * :ref:`MPI_Recv_init`
    * :ref:`MPI_Start`
    * :ref:`MPI_Startall`

--- a/docs/man-openmpi/man3/MPI_Start.3.rst
+++ b/docs/man-openmpi/man3/MPI_Start.3.rst
@@ -90,6 +90,6 @@ ERRORS
    * :ref:`MPI_Bsend_init`
    * :ref:`MPI_Rsend_init`
    * :ref:`MPI_Send_init`
-   * MPI_Sssend_init
+   * :ref:`MPI_Ssend_init`
    * :ref:`MPI_Recv_init`
    * :ref:`MPI_Startall`


### PR DESCRIPTION
(cherry picked from commit 0999325ad5f92a675c80acca3dfd603928bfebdb)

This is a v5.0.x PR corresponding to main PR https://github.com/open-mpi/ompi/pull/13439.  Thanks to @xbw22109 for submitting the fix.