### PR TITLE
Backport MTL/BTL Fabric and Domain sharing patches

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -379,9 +379,18 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init(int *num_btl_modules,
 no_hmem:
 #endif
 
+    hints.fabric_attr->fabric = opal_common_ofi.fabric;
+    hints.domain_attr->domain = opal_common_ofi.domain;
+
     /* Do the query. The earliest version that supports FI_HMEM hints is 1.9.
      * The earliest version the explictly allow provider to call CUDA API is 1.18  */
     rc = fi_getinfo(FI_VERSION(1, 18), NULL, NULL, 0, &hints, &info_list);
+    if (FI_ENODATA == -rc && (hints.fabric_attr->fabric || hints.domain_attr->domain)) {
+        /* Retry without fabric and domain */
+        hints.fabric_attr->fabric = NULL;
+        hints.domain_attr->domain = NULL;
+        rc = fi_getinfo(FI_VERSION(1, 18), NULL, NULL, 0, &hints, &info_list);
+    }
     if (FI_ENOSYS == -rc) {
         rc = fi_getinfo(FI_VERSION(1, 9), NULL, NULL, 0, &hints, &info_list);
     }
@@ -560,14 +569,14 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         ("initializing dev:%s provider:%s", linux_device_name, info->fabric_attr->prov_name));
 
     /* fabric */
-    rc = fi_fabric(ofi_info->fabric_attr, &fabric, NULL);
+    rc = opal_common_ofi_fi_fabric(ofi_info->fabric_attr, &fabric);
     if (0 != rc) {
         BTL_VERBOSE(("%s failed fi_fabric with err=%s", linux_device_name, fi_strerror(-rc)));
         goto fail;
     }
 
     /* domain */
-    rc = fi_domain(fabric, ofi_info, &domain, NULL);
+    rc = opal_common_ofi_fi_domain(fabric, ofi_info, &domain);
     if (0 != rc) {
         BTL_VERBOSE(("%s failed fi_domain with err=%s", linux_device_name, fi_strerror(-rc)));
         goto fail;
@@ -750,11 +759,11 @@ fail:
     }
 
     if (NULL != domain) {
-        fi_close(&domain->fid);
+        opal_common_ofi_domain_release(domain);
     }
 
     if (NULL != fabric) {
-        fi_close(&fabric->fid);
+        opal_common_ofi_fabric_release(fabric);
     }
     free(module);
 

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -380,11 +380,11 @@ int mca_btl_ofi_finalize(mca_btl_base_module_t *btl)
     }
 
     if (NULL != ofi_btl->domain) {
-        fi_close(&ofi_btl->domain->fid);
+        opal_common_ofi_domain_release(ofi_btl->domain);
     }
 
     if (NULL != ofi_btl->fabric) {
-        fi_close(&ofi_btl->fabric->fid);
+        opal_common_ofi_fabric_release(ofi_btl->fabric);
     }
 
     if (NULL != ofi_btl->fabric_info) {

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2020-2024 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021      Amazon.com, Inc. or its affiliates. All rights
+ * Copyright (c) 2021-2025 Amazon.com, Inc. or its affiliates. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -30,6 +30,10 @@ typedef struct opal_common_ofi_module {
     char **prov_include;
     char **prov_exclude;
     int output;
+    struct fid_fabric *fabric;
+    struct fid_domain *domain;
+    int fabric_ref_count;
+    int domain_ref_count;
 } opal_common_ofi_module_t;
 
 /**
@@ -222,6 +226,57 @@ OPAL_DECLSPEC struct fi_info *opal_common_ofi_select_provider(struct fi_info *pr
  *
  */
 OPAL_DECLSPEC int opal_common_ofi_fi_getname(fid_t fid, void **addr, size_t *addrlen);
+
+/**
+ * Get or create fabric object
+ *
+ * Reuses existing fabric from fabric_attr->fabric if available,
+ * otherwise creates new fabric using fi_fabric().
+ *
+ * @param fabric_attr (IN) Fabric attributes
+ * @param fabric (OUT)     Fabric object (new or existing)
+ *
+ * @return                 OPAL_SUCCESS or error code
+ */
+OPAL_DECLSPEC int opal_common_ofi_fi_fabric(struct fi_fabric_attr *fabric_attr,
+                                            struct fid_fabric **fabric);
+
+/**
+ * Get or create domain object
+ *
+ * Reuses existing domain from info->domain_attr->domain if available,
+ * otherwise creates new domain using fi_domain().
+ *
+ * @param fabric (IN)      Fabric object
+ * @param info (IN)        Provider info
+ * @param domain (OUT)     Domain object (new or existing)
+ *
+ * @return                 OPAL_SUCCESS or error code
+ */
+OPAL_DECLSPEC int opal_common_ofi_fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+                                            struct fid_domain **domain);
+
+/**
+ * Release fabric reference
+ *
+ * Decrements fabric reference count and closes fabric if count reaches zero.
+ *
+ * @param fabric (IN)      Fabric object to release
+ *
+ * @return                 OPAL_SUCCESS or error code
+ */
+OPAL_DECLSPEC int opal_common_ofi_fabric_release(struct fid_fabric *fabric);
+
+/**
+ * Release domain reference
+ *
+ * Decrements domain reference count and closes domain if count reaches zero.
+ *
+ * @param domain (IN)      Domain object to release
+ *
+ * @return                 OPAL_SUCCESS or error code
+ */
+OPAL_DECLSPEC int opal_common_ofi_domain_release(struct fid_domain *domain);
 
 END_C_DECLS
 


### PR DESCRIPTION
Backport of https://github.com/open-mpi/ompi/pull/13415 to the v5.0.x branch.  This patch series fixes a couple of places where we weren't conforming to the Libfabric spec, but also adds a bugfix for EFA systems, allowing the BTL and MTL to share the same Fabric and Domain (but still use different endpoints).