### PR TITLE
Revert "tuned: use tree instead of bruck at scale"

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -490,8 +490,14 @@ int ompi_coll_tuned_barrier_intra_dec_fixed(struct ompi_communicator_t *comm,
         alg = 3;
     } else if (communicator_size < 256) {
         alg = 4;
-    } else {
+    } else if (communicator_size < 512) {
         alg = 6;
+    } else if (communicator_size < 1024) {
+        alg = 4;
+    } else if (communicator_size < 4096) {
+        alg = 6;
+    } else {
+        alg = 4;
     }
 
     return ompi_coll_tuned_barrier_intra_do_this (comm, module,


### PR DESCRIPTION
Concerns have been raised about this change in the backport to v6.0.x in #13481 and I have zero intention to argue about barriers in coll/tuned. Reverting this to avoid inconsistencies between main and release branches. Whoever feels compelled to argue about it can bring it back.


Reverts #11023.
Closes #13481.

This reverts commit 9bd775769b2d64286a50c768d3a543312de4aaa5.