### PR TITLE
pml/ob1: Move sendreq 'error after freed' check to correct location

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -278,15 +278,14 @@ send_request_pml_complete(mca_pml_ob1_send_request_t *sendreq)
             if( !REQUEST_COMPLETE( &((sendreq->req_send).req_base.req_ompi)) ) {
                 /* Should only be called for long messages (maybe synchronous) */
                 MCA_PML_OB1_SEND_REQUEST_MPI_COMPLETE(sendreq, true);
-            } else {
-                if( MPI_SUCCESS != sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR ) {
-                    /* An error after freeing the request MUST be fatal
-                     * MPI3 ch3.7: MPI_REQUEST_FREE */
-                    int err = MPI_ERR_REQUEST;
-                    ompi_mpi_errors_are_fatal_comm_handler(NULL, &err, "Send error after request freed");
-                }
             }
         } else {
+            if( MPI_SUCCESS != sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR ) {
+                /* An error after freeing the request MUST be fatal
+                 * MPI3 ch3.7: MPI_REQUEST_FREE */
+                int err = MPI_ERR_REQUEST;
+                ompi_mpi_errors_are_fatal_comm_handler(NULL, &err, "Send error after request freed");
+            }
             MCA_PML_OB1_SEND_REQUEST_RETURN(sendreq);
         }
     }


### PR DESCRIPTION
It is currently in the path for send requests which have NOT been freed. This moves it to the correct conditional branch. For reference, this change reflects how it is done for recv requests [here](https://github.com/open-mpi/ompi/blob/3a2e90895e15822912002be1e9aea8032c4c0bae/ompi/mca/pml/ob1/pml_ob1_recvreq.h#L180:L187).

Full disclaimer: I'm only really seeing this give spurious errors when using the resilient OFI btl from PR **https://github.com/open-mpi/ompi/pull/13429**, but the issue seems to be generic.