### PR TITLE
group_from_session_pset - remove confusing error message

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -1313,7 +1313,6 @@ fn_try_again:
             ret = opal_pmix_convert_status(rc);
             break;
         }
-        ompi_instance_print_error ("PMIx_Query_info() failed", ret);
         goto fn_w_query;
     }
 
@@ -1334,7 +1333,6 @@ fn_try_again:
 		if (OPAL_SUCCESS == rc) {
                     group->grp_proc_pointers[i] = ompi_proc_find_and_add(&pname,&isnew);
                 } else {
-                    ompi_instance_print_error ("OPAL_PMIX_CONVERT_PROCT failed %d", ret);
                     ompi_group_free(&group);
                     goto fn_w_info;
                 }


### PR DESCRIPTION
The implementation of MPI_Group_from_session_pset was emitting a confusing error message when querying the PMIx server for members of a process group.  The routine was using a method for creating an error message that was intended to be using during mpi initialization.

Remove that statement and let an error code be returned.

Related to #13497