### PR TITLE
Always populate failed procs in comms' groups

### DIFF
--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -792,13 +792,12 @@ bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remot
 
 int ompi_comm_set_rank_failed(ompi_communicator_t *comm, int peer_id, bool remote)
 {
-#if OPAL_ENABLE_DEBUG
     /* populate the proc in the comm's group array so that it is not a
        sentinel and can be read as failed */
-    ompi_proc_t *ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
-                                                     peer_id, true);
+    ompi_proc_t *ompi_proc __opal_attribute_unused__;
+    ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
+                                        peer_id, true);
     assert(NULL != ompi_proc);
-#endif
 
     /* Disable ANY_SOURCE */
     comm->any_source_enabled = false;


### PR DESCRIPTION
This behavior was changed to avoid an unused variable during release compilation, but calling the function itself is important.

Earlier in this file ([here](https://github.com/open-mpi/ompi/blob/dc5f7c50916518f808f5aacccaa8a55406ed6da4/ompi/communicator/ft/comm_ft.c#L787C1-L790C72)), `ompi_comm_is_proc_active` assumes that any processes not populated in the group have not failed. This can lead to deadlocks in agree operations, which will mistakenly expect that some ranks are alive.