### PR TITLE
adjust hdf5 workflow script -v6.0.x

### DIFF
--- a/.github/workflows/hdf5-tests.yaml
+++ b/.github/workflows/hdf5-tests.yaml
@@ -20,9 +20,9 @@ jobs:
         make -j 8 && make install
     - name: Install HDF5
       run: |
-         wget --progress=dot:giga https://github.com/HDFGroup/hdf5/releases/latest/download/hdf5.tar.gz
-         tar -xzf hdf5.tar.gz
-         mv hdf5-1* hdf5
+         wget --progress=dot:giga https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz
+         tar -xzf hdf5-1.14.6.tar.gz
+         mv hdf5-1.14.6 hdf5
          cd hdf5
          export PATH=/opt/openmpi/bin:${PATH}
          export LD_LIBRARY_PATH=/opt/openmpi/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
hdf5-2.0 was released, which was breaking our github workflow for hdf5. However, the new 2.0 release of hdf5 changed the build system to CMake instead of configure/make. Will investigate at a later stage how to adjust the CI workflow script for hdf5-2.0, for now just hard code the last release of hdf5-1.14.x


(cherry picked from commit 091d788ff675d980f69714428a06b3fe5a0dd49d)