### PR TITLE
btl: fix ompi_info for btl_flags

### DIFF
--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -58,6 +58,7 @@ mca_base_var_enum_value_flag_t mca_btl_base_flag_enum_flags[]
        {MCA_BTL_FLAGS_PUT_AM, "put-am", MCA_BTL_FLAGS_PUT},
        {MCA_BTL_FLAGS_GET_AM, "get_am", MCA_BTL_FLAGS_GET},
        {MCA_BTL_FLAGS_ATOMIC_AM_FOP, "atomic-am", MCA_BTL_FLAGS_ATOMIC_FOPS},
+       {MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION, "rdma-remote-completion", 0},
        {0, NULL, 0}};
 
 mca_base_var_enum_value_flag_t mca_btl_base_atomic_enum_flags[]

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -273,6 +273,9 @@ typedef uint8_t mca_btl_base_tag_t;
  */
 #define MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION 0x800000
 
+/* End of btl flags. if additional flags are added please update
+ * mca_btl_base_flag_enum_flags in btl_base_frame.c */
+
 /* Default exclusivity levels */
 #define MCA_BTL_EXCLUSIVITY_HIGH    (64 * 1024) /* internal loopback */
 #define MCA_BTL_EXCLUSIVITY_DEFAULT 1024 /* GM/IB/etc. */


### PR DESCRIPTION
The flag enumerator used for btl_flags was missing an entry for the MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION flags. If this flag was set on a btl then it would cause ompi_info to fail when attempting to get the value for btl_flags leading to it just being omited from the output (another bug since it should fail and print an error).


(cherry picked from commit aac16475a0d8de1e7c24e229db955a867418afe1)