### PR TITLE
ubcl: remove unused cuda-related m4 macro

### DIFF
--- a/ompi/mca/pml/ubcl/configure.m4
+++ b/ompi/mca/pml/ubcl/configure.m4
@@ -21,8 +21,6 @@ AC_DEFUN([MCA_ompi_pml_ubcl_CONFIG], [
 
     AC_REQUIRE([MCA_ompi_common_ubcl_CONFIG])
     AC_REQUIRE([MCA_opal_common_ubcl_CONFIG])
-    AC_REQUIRE([OPAL_CHECK_CUDA])
-    AC_REQUIRE([OPAL_CHECK_CUDART])
 
     AS_IF([test "$pml_ubcl_happy" = "yes"],
           [$1],


### PR DESCRIPTION
These two macros were not used by the pml/ubcl. They are obsolete here since the removal of opal/mca/common/cuda and the introduction of the accelerator framework.