### PR TITLE
pml/ob1: introduce a new protocol for intermediate-sized messages

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,7 @@
 
 #include "ompi_config.h"
 #include "opal/class/opal_free_list.h"
+#include "opal/class/opal_hash_table.h"
 #include "ompi/request/request.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/pml/base/pml_base_request.h"
@@ -74,6 +76,7 @@ struct mca_pml_ob1_t {
     opal_free_list_t pending_pckts;
     opal_free_list_t buffers;
     opal_free_list_t send_ranges;
+    opal_free_list_t multi_send_recv_frags;
 
     /* list of pending operations */
     opal_list_t pckt_pending;
@@ -82,6 +85,11 @@ struct mca_pml_ob1_t {
     opal_list_t rdma_pending;
     /* List of pending fragments without a matching communicator */
     opal_list_t non_existing_communicator_pending;
+
+    /* Multi-eager frags awaiting completion */
+    opal_mutex_t in_progress_multi_recv_frags_lock;
+    opal_hash_table_t in_progress_multi_recv_frags;
+
     bool enabled;
     char* allocator_name;
     mca_allocator_base_module_t* allocator;

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2020-2025 Google, LLC. All rights reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
  * $COPYRIGHT$
  *
@@ -55,6 +55,18 @@ typedef struct mca_pml_ob1_recv_frag_t mca_pml_ob1_recv_frag_t;
 
 OBJ_CLASS_DECLARATION(mca_pml_ob1_recv_frag_t);
 
+/* tracking structure for in-progress receives of multi-eager sends */
+struct mca_pml_ob1_recv_request_t;
+struct mca_pml_ob1_multi_eager_recv_frag_t {
+    opal_free_list_item_t super;                 /**< these are kept in a free list */
+    int32_t total_size;                          /**< total size expected */
+    opal_atomic_int32_t received_size;           /**< total bytes received */
+    struct mca_pml_ob1_recv_request_t *recvreq;  /**< matched receive (may be NULL) */
+    void *buffer;                                /**< temporary buffer if not matched */
+};
+typedef struct mca_pml_ob1_multi_eager_recv_frag_t mca_pml_ob1_multi_eager_recv_frag_t;
+
+OBJ_CLASS_DECLARATION(mca_pml_ob1_multi_eager_recv_frag_t);
 
 #define MCA_PML_OB1_RECV_FRAG_ALLOC(frag)                       \
 do {                                                            \
@@ -165,6 +177,12 @@ extern void mca_pml_ob1_recv_frag_callback_fin (mca_btl_base_module_t *btl,
  */
 extern void mca_pml_ob1_recv_frag_callback_cid( mca_btl_base_module_t *btl,
                                                 const mca_btl_base_receive_descriptor_t* descriptor);
+
+/**
+ * Callback from BTL on receipt of a multi_eager send fragment.
+ */
+void mca_pml_ob1_recv_frag_callback_multi_eager_send(mca_btl_base_module_t *btl,
+                                                     const mca_btl_base_receive_descriptor_t* descriptor);
 
 /**
  * Extract the next fragment from the cant_match ordered list. This fragment

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2020-2025 Google, LLC. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -465,6 +465,11 @@ int mca_pml_ob1_recv_request_get_frag(mca_pml_ob1_rdma_frag_t* frag);
  * unavailability. Recvreq is added to recv_pending list if scheduling of put
  * operation cannot be accomplished for some reason. */
 void mca_pml_ob1_recv_request_process_pending(void);
+
+size_t mca_pml_ob1_recv_request_unpack_frag(mca_pml_ob1_recv_request_t* recvreq,
+                                            const mca_btl_base_segment_t* segments,
+                                            size_t num_segments, size_t data_offset,
+                                            size_t hdr_size);
 
 END_C_DECLS
 

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2025      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +41,8 @@ BEGIN_C_DECLS
 typedef enum {
     MCA_PML_OB1_SEND_PENDING_NONE,
     MCA_PML_OB1_SEND_PENDING_SCHEDULE,
-    MCA_PML_OB1_SEND_PENDING_START
+    MCA_PML_OB1_SEND_PENDING_START,
+    MCA_PML_OB1_SEND_PENDING_MULTI_EAGER,
 } mca_pml_ob1_send_pending_t;
 
 struct mca_pml_ob1_send_request_t {
@@ -386,76 +388,116 @@ int mca_pml_ob1_send_request_start_rndv(
     size_t size,
     int flags);
 
+int mca_pml_ob1_send_request_start_multi_eager(
+    mca_pml_ob1_send_request_t *sendreq,
+    mca_bml_base_btl_t *bml_btl);
+
+static inline bool
+mca_pml_ob1_convertor_can_use_rget(const opal_convertor_t *convertor)
+{
+    return opal_convertor_need_buffers(convertor) == false &&
+        !(convertor->flags & CONVERTOR_ACCELERATOR) &&
+        !(convertor->flags & CONVERTOR_ACCELERATOR_UNIFIED);
+}
+
+static inline int
+mca_pml_ob1_send_request_start_eager_btl( mca_pml_ob1_send_request_t* sendreq,
+                                          mca_bml_base_btl_t* bml_btl )
+{
+    size_t size = sendreq->req_send.req_bytes_packed;
+
+    switch(sendreq->req_send.req_send_mode) {
+    case MCA_PML_BASE_SEND_SYNCHRONOUS:
+        return mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size, 0);
+    case MCA_PML_BASE_SEND_BUFFERED:
+        return mca_pml_ob1_send_request_start_copy(sendreq, bml_btl, size);
+    case MCA_PML_BASE_SEND_COMPLETE:
+        return mca_pml_ob1_send_request_start_prepare(sendreq, bml_btl, size);
+        break;
+    default:
+        if (size != 0 && bml_btl->btl_flags & MCA_BTL_FLAGS_SEND_INPLACE) {
+            return mca_pml_ob1_send_request_start_prepare(sendreq, bml_btl, size);
+        } else {
+            return mca_pml_ob1_send_request_start_copy(sendreq, bml_btl, size);
+        }
+    }
+}
+
 static inline int
 mca_pml_ob1_send_request_start_btl( mca_pml_ob1_send_request_t* sendreq,
                                     mca_bml_base_btl_t* bml_btl )
 {
     size_t size = sendreq->req_send.req_bytes_packed;
+    const bool need_ext_match = MCA_PML_OB1_SEND_REQUEST_REQUIRES_EXT_MATCH(sendreq);
     mca_btl_base_module_t* btl = bml_btl->btl;
-    size_t eager_limit = btl->btl_eager_limit - sizeof(mca_pml_ob1_hdr_t);
-    int rc;
+    size_t eager_header_size;
+
+    if (sendreq->req_send.req_send_mode == MCA_PML_BASE_SEND_SYNCHRONOUS) {
+        eager_header_size = need_ext_match ? sizeof(mca_pml_ob1_ext_rendezvous_hdr_t) : sizeof(mca_pml_ob1_rendezvous_hdr_t);
+    } else {
+        eager_header_size = need_ext_match ? sizeof(mca_pml_ob1_ext_match_hdr_t) : sizeof(mca_pml_ob1_match_hdr_t);
+    }
+    
+    size_t eager_limit = btl->btl_eager_limit - eager_header_size;
 
 #if OPAL_CUDA_GDR_SUPPORT
     if (btl->btl_accelerator_eager_limit && (sendreq->req_send.req_base.req_convertor.flags & CONVERTOR_ACCELERATOR)) {
-        eager_limit = btl->btl_accelerator_eager_limit - sizeof(mca_pml_ob1_hdr_t);
+        eager_limit = btl->btl_accelerator_eager_limit - eager_header_size;
     }
 #endif /* OPAL_CUDA_GDR_SUPPORT */
 
     if( OPAL_LIKELY(size <= eager_limit) ) {
-        switch(sendreq->req_send.req_send_mode) {
-        case MCA_PML_BASE_SEND_SYNCHRONOUS:
-            rc = mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size, 0);
-            break;
-        case MCA_PML_BASE_SEND_BUFFERED:
-            rc = mca_pml_ob1_send_request_start_copy(sendreq, bml_btl, size);
-            break;
-        case MCA_PML_BASE_SEND_COMPLETE:
-            rc = mca_pml_ob1_send_request_start_prepare(sendreq, bml_btl, size);
-            break;
-        default:
-            if (size != 0 && bml_btl->btl_flags & MCA_BTL_FLAGS_SEND_INPLACE) {
-                rc = mca_pml_ob1_send_request_start_prepare(sendreq, bml_btl, size);
-            } else {
-                rc = mca_pml_ob1_send_request_start_copy(sendreq, bml_btl, size);
-            }
-            break;
-        }
-    } else {
-        size = eager_limit;
-        if(OPAL_UNLIKELY(btl->btl_rndv_eager_limit < eager_limit))
-            size = btl->btl_rndv_eager_limit;
-        if(sendreq->req_send.req_send_mode == MCA_PML_BASE_SEND_BUFFERED) {
-            rc = mca_pml_ob1_send_request_start_buffered(sendreq, bml_btl, size);
-        } else if
-                (opal_convertor_need_buffers(&sendreq->req_send.req_base.req_convertor) == false &&
-                !(sendreq->req_send.req_base.req_convertor.flags & CONVERTOR_ACCELERATOR) &&
-                !(sendreq->req_send.req_base.req_convertor.flags & CONVERTOR_ACCELERATOR_UNIFIED)) {
-            unsigned char *base;
-            opal_convertor_get_current_pointer( &sendreq->req_send.req_base.req_convertor, (void**)&base );
-
-            if( 0 != (sendreq->req_rdma_cnt = (uint32_t)mca_pml_ob1_rdma_btls(
-                                                                              sendreq->req_endpoint,
-                                                                              base,
-                                                                              sendreq->req_send.req_bytes_packed,
-                                                                              sendreq->req_rdma))) {
-                rc = mca_pml_ob1_send_request_start_rdma(sendreq, bml_btl,
-                                                         sendreq->req_send.req_bytes_packed);
-                if( OPAL_UNLIKELY(OMPI_SUCCESS != rc) ) {
-                    mca_pml_ob1_free_rdma_resources(sendreq);
-                }
-            } else {
-                rc = mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size,
-                                                         MCA_PML_OB1_HDR_FLAGS_CONTIG);
-            }
-        } else {
-            if (sendreq->req_send.req_base.req_convertor.flags & CONVERTOR_ACCELERATOR) {
-                return mca_pml_ob1_send_request_start_accelerator(sendreq, bml_btl, size);
-            }
-            rc = mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size, 0);
-        }
+        return mca_pml_ob1_send_request_start_eager_btl(sendreq, bml_btl);
     }
 
-    return rc;
+    if (OPAL_LIKELY(size <= btl->btl_multi_eager_limit && !need_ext_match)) {
+        return mca_pml_ob1_send_request_start_multi_eager(sendreq, bml_btl);
+    }
+
+    /* In this path it will either be a rendezvous (put/send) or rget. The
+     * larger of these two headers is the rget header. Use that to
+     * determine the amount of data to eagerly send. */
+    eager_header_size = need_ext_match ?
+        sizeof(mca_pml_ob1_ext_rget_hdr_t) :
+        sizeof(mca_pml_ob1_rget_hdr_t);
+
+    size = btl->btl_eager_limit - eager_header_size;
+    if(OPAL_UNLIKELY(btl->btl_rndv_eager_limit < eager_limit)) {
+        size = btl->btl_rndv_eager_limit - eager_header_size;
+    }
+ 
+    if(sendreq->req_send.req_send_mode == MCA_PML_BASE_SEND_BUFFERED) {
+        return mca_pml_ob1_send_request_start_buffered(sendreq, bml_btl, size);
+    }
+
+    if (mca_pml_ob1_convertor_can_use_rget(&sendreq->req_send.req_base.req_convertor)) {
+        unsigned char *base;
+        opal_convertor_get_current_pointer( &sendreq->req_send.req_base.req_convertor, (void**)&base );
+
+        if( 0 != (sendreq->req_rdma_cnt = (uint32_t)mca_pml_ob1_rdma_btls(sendreq->req_endpoint,
+                                                                          base,
+                                                                          sendreq->req_send.req_bytes_packed,
+                                                                          sendreq->req_rdma))) {
+            /* Start the RDMA Get protocol. This may fall back to using put or send. */
+            int rc = mca_pml_ob1_send_request_start_rdma(sendreq, bml_btl,
+                                                         sendreq->req_send.req_bytes_packed);
+            if( OPAL_UNLIKELY(OMPI_SUCCESS != rc) ) {
+                mca_pml_ob1_free_rdma_resources(sendreq);
+            }
+
+            return rc;
+        }
+
+        return mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size,
+                                                   MCA_PML_OB1_HDR_FLAGS_CONTIG);
+    }
+
+
+    if (sendreq->req_send.req_base.req_convertor.flags & CONVERTOR_ACCELERATOR) {
+        return mca_pml_ob1_send_request_start_accelerator(sendreq, bml_btl, size);
+    }
+
+    return mca_pml_ob1_send_request_start_rndv(sendreq, bml_btl, size, 0);
 }
 
 static inline int
@@ -552,6 +594,27 @@ void mca_pml_ob1_send_request_process_pending(mca_bml_base_btl_t *bml_btl);
 
 void mca_pml_ob1_send_request_copy_in_out(mca_pml_ob1_send_request_t *sendreq,
                 uint64_t send_offset, uint64_t send_length);
+
+/**
+ * Progress multi-eager sends for a send request with the request btl.
+ *
+ * @param(in) sendreq   Send request to progress.
+ * @param(in) bml_btl   BTL to use for fragments.
+ *
+ * The multi-eager protocol splits the user data into multiple eager-sized
+ * messages that are sent in parallel to the receiver. The receiver will
+ * first attempt to match it to a posted receive if one exists. If there is
+ * a posted received the fragments are copied directly into the receive buffer
+ * otherwise the entire send is buffered until all fragments have arrived. At
+ * that point it is treated as a single large eager send and matched. Usage of
+ * this protocol is controlled by the btl selected when the send was first
+ * started.
+ *
+ * This protocol may provide lower latency than a rendezvous but it will likely
+ * come at a cost of higher memory usage.
+ */
+int mca_pml_ob1_send_request_progess_multi_eager (mca_pml_ob1_send_request_t *sendreq,
+                                                  mca_bml_base_btl_t *bml_btl);
 
 END_C_DECLS
 

--- a/opal/mca/btl/base/btl_base_mca.c
+++ b/opal/mca/btl/base/btl_base_mca.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      Google, LLC. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -68,6 +69,14 @@ int mca_btl_base_param_register(mca_base_component_t *version, mca_btl_base_modu
         "Maximum size (in bytes, including header) of \"short\" messages (must be >= 1).",
         MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
         &module->btl_eager_limit);
+
+    (void) mca_base_component_var_register(
+        version, "multi_eager_limit",
+        "Size (in bytes, including header) when to switch from a mult-send eager to rendezvous. "
+        "If set smaller than the eager limit the protocol is effectively disabled. This is a hint "
+        "to the ob1 pml only.",
+        MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
+        &module->btl_multi_eager_limit);
 
     if ((module->btl_flags & MCA_BTL_FLAGS_GET) && module->btl_get) {
         if (0 == module->btl_get_limit) {

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -1180,6 +1180,7 @@ struct mca_btl_base_module_t {
     size_t btl_rndv_eager_limit; /**< the size of a data sent in a first fragment of rendezvous
                                     protocol */
     size_t btl_max_send_size;    /**< maximum send fragment size supported by the BTL */
+    size_t btl_multi_eager_limit;  /**< limit for doing fragmented sends without rendevous */
     size_t btl_rdma_pipeline_send_length; /**< amount of bytes that should be send by pipeline
                                              protocol */
     size_t btl_rdma_pipeline_frag_size;   /**< maximum rdma fragment size supported by the BTL */


### PR DESCRIPTION
This commit introduces the multi-eager protocol to ob1. This protocol works by fragmenting into multiple eager-sized messages and sending them in parallel to the destination. On the receiver the first fragment is matched against a posted receive if one exists. If a receive is matched then each incoming multi- eager packet is copied directly into the user buffer without additional buffering in ob1. Once all fragments have arrived the receive request is marked complete. If the message is unexpected it is buffered until all fragments have arrived then processed as a large eager message.

Usage of this protocol is disabled by default and is enabled by setting a BTL's multi_eager_limit larger than its eager_limit. When enabled ob1 will use the new protocol for messages that are larger than the eager limit but smaller than the multi_eager_limit. At that point ob1 will switch to doing a full rendezvous.

This protocol is inspired by the multiple send eager protocol used by OpenUCX. It can provide lower latency communication at a cost of additional resources for in-flight messages vs the various rendezvous protocols because it doesn't wait for an ack from the receiver and does not make use of either RDMA read or RDMA write. The cost is highest for non-contiguous data on the sender and unexpected receives on the receiver.

This commit also re-organizes the match code so that multi-eager can make use of the same code.