### PR TITLE
btl/uct: fix coverity findings

### DIFF
--- a/opal/mca/btl/uct/btl_uct_discover.c
+++ b/opal/mca/btl/uct/btl_uct_discover.c
@@ -419,12 +419,11 @@ int mca_btl_uct_component_maybe_setup_conn_tl(void)
 
     mca_btl_uct_md_t *md;
     OPAL_LIST_FOREACH(md, &mca_btl_uct_component.md_list, mca_btl_uct_md_t) {
-        mca_btl_uct_tl_t *tl, *next;
-        OPAL_LIST_FOREACH_SAFE(tl, next, &md->tls, mca_btl_uct_tl_t) {
+        mca_btl_uct_tl_t *tl;
+        OPAL_LIST_FOREACH(tl, &md->tls, mca_btl_uct_tl_t) {
             if (mca_btl_uct_tl_supports_conn(tl)) {
                 break;
             }
-            tl = NULL;
         }
 
         if ((opal_list_item_t *) tl == &md->tls.opal_list_sentinel) {
@@ -432,11 +431,7 @@ int mca_btl_uct_component_maybe_setup_conn_tl(void)
             continue;
         }
 
-        if (NULL == mca_btl_uct_component.conn_tl) {
-            mca_btl_uct_component.conn_tl = tl;
-        }
-
-        if (tl != NULL && (md->connection_only_domain || NULL == mca_btl_uct_component.conn_tl)) {
+        if (md->connection_only_domain || NULL == mca_btl_uct_component.conn_tl) {
             mca_btl_uct_component.conn_tl = tl;
             if (md->connection_only_domain) {
                 /* not going do to better */

--- a/opal/mca/btl/uct/btl_uct_modex.c
+++ b/opal/mca/btl/uct/btl_uct_modex.c
@@ -69,7 +69,7 @@ static uint8_t *mca_btl_uct_tl_modex_pack(mca_btl_uct_module_t *module, mca_btl_
     tl_modex->size = mca_btl_uct_tl_modex_size(tl);
 
     memset(tl_modex->tl_name, 0, sizeof(tl_modex->tl_name));
-    strncpy(tl_modex->tl_name, tl->uct_tl_name, sizeof(tl_modex->tl_name));
+    strncpy(tl_modex->tl_name, tl->uct_tl_name, sizeof(tl_modex->tl_name) - 1);
 
     uint8_t *tl_modex_data = (uint8_t *) tl_modex->data;
 
@@ -107,7 +107,7 @@ static uint8_t *mca_btl_uct_modex_pack(mca_btl_uct_md_t *md, uint8_t *modex_data
     md_modex->module_index = module ? module->module_index : (uint16_t) -1;
 
     memset(md_modex->md_name, 0, sizeof(md_modex->md_name));
-    strncpy(md_modex->md_name, md->md_name, sizeof(md_modex->md_name));
+    strncpy(md_modex->md_name, md->md_name, sizeof(md_modex->md_name) - 1);
 
     mca_btl_uct_tl_t *tl;
     OPAL_LIST_FOREACH(tl, &md->tls, mca_btl_uct_tl_t) {

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -322,11 +322,15 @@ int mca_btl_uct_finalize(mca_btl_base_module_t *btl)
     OBJ_DESTRUCT(&uct_module->endpoint_lock);
 
     char *tmp;
-    asprintf(&tmp, "uct_%s", uct_module->md->md_name);
-    int rc = mca_base_var_group_find("opal", "btl", tmp);
-    free(tmp);
-    if (rc >= 0) {
-        mca_base_var_group_deregister(rc);
+    int rc = asprintf(&tmp, "uct_%s", uct_module->md->md_name);
+    if (rc > 0) {
+        rc = mca_base_var_group_find("opal", "btl", tmp);
+        free(tmp);
+        if (rc >= 0) {
+            mca_base_var_group_deregister(rc);
+        }
+    } else {
+        BTL_ERROR(("could not deregister var group for UCT module %s", uct_module->md->md_name));
     }
 
     OBJ_RELEASE(uct_module->md);


### PR DESCRIPTION
Fixes the following:

** CID 1675024:       Memory - illegal accesses  (BUFFER_SIZE)
** CID 1675023:       Null pointer dereferences  (REVERSE_INULL)
** CID 1675022:       Error handling issues  (CHECKED_RETURN)
** CID 1675021:       Memory - illegal accesses  (BUFFER_SIZE)