### PR TITLE
op/example fix warnings and error at compilation

### DIFF
--- a/ompi/mca/op/example/README.md
+++ b/ompi/mca/op/example/README.md
@@ -56,7 +56,7 @@ do:
 - `op_example_component.c`: The main "component" source file.
 - `op_example_module.c`: The main "module" source file.
 - `op_example.h`: information that is shared between the `.c` files.
-- `.ompi_ignore`: the presence of this file causes OMPI's `autogen.pl`
+- `.opal_ignore`: the presence of this file causes OMPI's `autogen.pl`
   to skip this component in the configure/build/install process (see
   below).
 
@@ -69,18 +69,18 @@ shell$ cp -r example foo
 shell$ cd foo
 ```
 
-Remove the `.ompi_ignore` file (which makes the component "visible" to
-all developers) *OR* add an `.ompi_unignore` file with one username per
+Remove the `.opal_ignore` file (which makes the component "visible" to
+all developers) *OR* add an `.opal_unignore` file with one username per
 line (as reported by `whoami`).  OMPI's `autogen.pl` will skip any
-component with a `.ompi_ignore` file *unless* there is also an
-.ompi_unignore file containing your user ID in it.  This is a handy
+component with a `.opal_ignore` file *unless* there is also an
+`.opal_unignore` file containing your user ID in it.  This is a handy
 mechanism to have a component in the tree but have it not built / used
 by most other developers:
 
 ```
-shell$ rm .ompi_ignore
+shell$ rm .opal_ignore
 *OR*
-shell$ whoami > .ompi_unignore
+shell$ whoami > .opal_unignore
 ```
 
 Now rename any file that contains `example` in the filename to have

--- a/ompi/mca/op/example/op_example_component.c
+++ b/ompi/mca/op/example/op_example_component.c
@@ -123,7 +123,6 @@ static char *example_component_version;
  */
 static int example_component_register(void)
 {
-    int val;
     char *str;
 
     opal_output(ompi_op_base_framework.framework_output, "example component register");

--- a/ompi/mca/op/example/op_example_module_bxor.c
+++ b/ompi/mca/op/example/op_example_module_bxor.c
@@ -109,7 +109,7 @@ static OBJ_CLASS_INSTANCE(module_bxor_t,
 /**
  * Bxor function for C int
  */
-static void bxor_int(void *in, void *out, int *count,
+static void bxor_int(const void *in, void *out, int *count,
                     ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_bxor_t *m = (module_bxor_t*) module;
@@ -143,7 +143,7 @@ static void bxor_int(void *in, void *out, int *count,
 /**
  * Bxor function for C long
  */
-static void bxor_long(void *in, void *out, int *count,
+static void bxor_long(const void *in, void *out, int *count,
                      ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_bxor_t *m = (module_bxor_t*) module;
@@ -157,7 +157,7 @@ static void bxor_long(void *in, void *out, int *count,
 /**
  * Bxor function for Fortran INTEGER
  */
-static void bxor_integer(void *in, void *out, int *count,
+static void bxor_integer(const void *in, void *out, int *count,
                         ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_bxor_t *m = (module_bxor_t*) module;
@@ -191,10 +191,10 @@ ompi_op_base_module_t *ompi_op_example_setup_bxor(ompi_op_t *op)
        (i.e., they're already assigned on the op). */
 
     /* C int */
-    module->super.opm_fns[OMPI_OP_BASE_TYPE_INT] = bxor_int;
-    module->fallback_int = op->o_func.intrinsic.fns[OMPI_OP_BASE_TYPE_INT];
+    module->super.opm_fns[OMPI_OP_BASE_TYPE_INT32_T] = bxor_int;
+    module->fallback_int = op->o_func.intrinsic.fns[OMPI_OP_BASE_TYPE_INT32_T];
     module->fallback_int_module =
-        op->o_func.intrinsic.modules[OMPI_OP_BASE_TYPE_INT];
+        op->o_func.intrinsic.modules[OMPI_OP_BASE_TYPE_INT32_T];
     /* If you cache a fallback function, you *must* RETAIN (i.e.,
        increase the refcount) its module so that the module knows that
        it is being used and won't be freed/destructed. */

--- a/ompi/mca/op/example/op_example_module_max.c
+++ b/ompi/mca/op/example/op_example_module_max.c
@@ -118,7 +118,7 @@ static OBJ_CLASS_INSTANCE(module_max_t,
 /**
  * Max function for C float
  */
-static void max_float(void *in, void *out, int *count,
+static void max_float(const void *in, void *out, int *count,
                       ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_max_t *m = (module_max_t*) module;
@@ -152,7 +152,7 @@ static void max_float(void *in, void *out, int *count,
 /**
  * Max function for C double
  */
-static void max_double(void *in, void *out, int *count,
+static void max_double(const void *in, void *out, int *count,
                        ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_max_t *m = (module_max_t*) module;
@@ -166,7 +166,7 @@ static void max_double(void *in, void *out, int *count,
 /**
  * Max function for Fortran REAL
  */
-static void max_real(void *in, void *out, int *count,
+static void max_real(const void *in, void *out, int *count,
                      ompi_datatype_t **type, ompi_op_base_module_t *module)
 {
     module_max_t *m = (module_max_t*) module;
@@ -180,7 +180,7 @@ static void max_real(void *in, void *out, int *count,
 /**
  * Max function for Fortran DOUBLE PRECISION
  */
-static void max_double_precision(void *in, void *out, int *count,
+static void max_double_precision(const void *in, void *out, int *count,
                                  ompi_datatype_t **type,
                                  ompi_op_base_module_t *module)
 {


### PR DESCRIPTION
What
  Fix typos in README.md, modify .ompi_ignore to .opal_ignore.
  Fix MPI Datatype error, OMPI_OP_BASE_TYPE_INT is no longer used.
  Fix some warnings for type casting.