### PR TITLE
Backport handle errors gracefully to prevent SEGV to v4.1.x

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -199,9 +199,9 @@ static ucc_status_t oob_allgather_test(void *req)
         }
         rc = MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
                            MCA_COLL_BASE_TAG_UCC, comm, &oob_req->reqs[1]));
-	if (OMPI_SUCCESS != rc) {
+        if (OMPI_SUCCESS != rc) {
             return UCC_ERR_NO_MESSAGE;
-	}
+        }
     }
     probe = 0;
     do {


### PR DESCRIPTION
oob_allgather_test() do not check isend() call
success, leading to the possibility to use
oob_req->reqs[] un-initialized upon error and
thus to SEGV.

(cherry picked from commit https://github.com/open-mpi/ompi/commit/109f4bcb21570f4bfe111af5dd4f0a349da2597a)

Backport this fix in main branch to v4.1.x, so 4.1 version can run with UCC without segmentation fault.