### PR TITLE
configure: update ubcl with newer help macro

### DIFF
--- a/config/ompi_check_ubcl.m4
+++ b/config/ompi_check_ubcl.m4
@@ -27,7 +27,7 @@ AC_DEFUN([OMPI_CHECK_UBCL],[
     m4_ifblank([$1], [m4_fatal([First argument to OMPI_CHECK_UBCL cannot be blank])])
 
     AC_ARG_WITH([ubcl],
-        [AC_HELP_STRING([--with-ubcl(=DIR)],
+        [AS_HELP_STRING([--with-ubcl(=DIR)],
             [Build with UBCL support])])
 
     # UBCL is dlopen'd to avoid direct link to libubcl.so.


### PR DESCRIPTION
with recent autoconf tool chain autogen.pl emits a warning mess when processing the ompi_check_ubcl.m4 file:

autoreconf: running: /opt/homebrew/Cellar/autoconf/2.71/bin/autoconf --include=config --include=config/oac --force
configure.ac:1209: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:1209: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1553: AC_ARG_WITH is expanded from...
config/ompi_check_ubcl.m4:24: OMPI_CHECK_UBCL is expanded from...
opal/mca/common/ubcl/configure.m4:11: MCA_opal_common_ubcl_CONFIG is expanded from...
config/opal_mca.m4:597: MCA_CONFIGURE_M4_CONFIG_COMPONENT is expanded from...
config/opal_mca.m4:376: MCA_CONFIGURE_FRAMEWORK is expanded from...
config/opal_mca.m4:268: MCA_CONFIGURE_PROJECT is expanded from...
config/opal_mca.m4:42: OPAL_MCA is expanded from...

This patch fixes that.


(cherry picked from commit 64e86bd30c341ee8c2aa9505bc9a7c22eeafdbff)