### PR TITLE
fortran i8: sqaush some more compiler warnings

### DIFF
--- a/ompi/mpi/fortran/mpif-h/get_elements_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_elements_x_f.c
@@ -74,7 +74,6 @@ void ompi_get_elements_x_f(MPI_Fint *status, MPI_Fint *datatype, MPI_Count *coun
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
     MPI_Status   c_status;
-    OMPI_SINGLE_NAME_DECL(count);
 
     if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
         *count = OMPI_INT_2_FINT(0);

--- a/ompi/mpi/fortran/mpif-h/remove_error_class_f.c
+++ b/ompi/mpi/fortran/mpif-h/remove_error_class_f.c
@@ -70,12 +70,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_REMOVE_ERROR_CLASS,
 void ompi_remove_error_class_f(MPI_Fint *errorclass, MPI_Fint *ierr)
 {
     int ierr_c;
-    OMPI_SINGLE_NAME_DECL(errorclass);
 
     ierr_c = PMPI_Remove_error_class(OMPI_FINT_2_INT(*errorclass));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
-
-    if (MPI_SUCCESS == ierr_c) {
-        OMPI_SINGLE_INT_2_FINT(errorclass);
-    }
 }

--- a/ompi/mpi/fortran/mpif-h/remove_error_code_f.c
+++ b/ompi/mpi/fortran/mpif-h/remove_error_code_f.c
@@ -70,12 +70,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_REMOVE_ERROR_CODE,
 void ompi_remove_error_code_f(MPI_Fint *errorcode, MPI_Fint *ierr)
 {
     int ierr_c;
-    OMPI_SINGLE_NAME_DECL(errorcode);
 
     ierr_c = PMPI_Remove_error_code(OMPI_FINT_2_INT(*errorcode));
-
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
-    if (MPI_SUCCESS == ierr_c) {
-        OMPI_SINGLE_INT_2_FINT(errorcode);
-    }
 }

--- a/ompi/mpi/fortran/mpif-h/type_size_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_size_x_f.c
@@ -72,7 +72,6 @@ void ompi_type_size_x_f(MPI_Fint *type, MPI_Count *size, MPI_Fint *ierr)
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
-    OMPI_SINGLE_NAME_DECL(size);
 
     c_ierr = PMPI_Type_size_x(c_type, size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);


### PR DESCRIPTION
that show up when trying to build fortran bindings with integer(kind=8) default.


(cherry picked from commit 8e3823a3134e9daaf91116217a789d7d8f2a6c1d)