### PR TITLE
OSHMEM/MCA/SPML/UCX: added pSync and pWrk arrays to team struct

### DIFF
--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -29,6 +29,15 @@
 
 BEGIN_C_DECLS
 
+/**
+ * Base team structure - common fields for all SPML team implementations
+ */
+struct mca_spml_base_team_t {
+    long *pSync;  /* Synchronization work array */
+    long *pWrk;   /* Reduction work array */
+};
+typedef struct mca_spml_base_team_t mca_spml_base_team_t;
+
 /*
  * This is the base priority for a SPML wrapper component
  * If there exists more than one then it is undefined
@@ -96,6 +105,20 @@ OSHMEM_DECLSPEC void mca_spml_base_memuse_hook(void *addr, size_t length);
 
 OSHMEM_DECLSPEC int mca_spml_base_put_all_nb(void *target, const void *source,
                                              size_t size, long *counter);
+
+/**
+ * Helper function to allocate and initialize a sync array using private_alloc
+ * @param count Number of long elements to allocate
+ * @param array Pointer to store the allocated array address
+ * @return OSHMEM_SUCCESS or OSHMEM_ERROR
+ */
+OSHMEM_DECLSPEC int mca_spml_base_alloc_sync_array(size_t count, long **array);
+
+/**
+ * Helper function to free a sync array using private_free
+ * @param array Pointer to the array pointer (will be set to NULL)
+ */
+OSHMEM_DECLSPEC void mca_spml_base_free_sync_array(long **array);
 
 /*
  * MCA framework

--- a/oshmem/mca/spml/base/spml_base.c
+++ b/oshmem/mca/spml/base/spml_base.c
@@ -16,6 +16,9 @@
 #include "opal/datatype/opal_convertor.h"
 #include "oshmem/proc/proc.h"
 #include "oshmem/mca/spml/base/base.h"
+#include "oshmem/mca/memheap/memheap.h"
+#include "oshmem/mca/memheap/base/base.h"
+#include "oshmem/include/shmem.h"
 #include "opal/mca/btl/btl.h"
 
 #define SPML_BASE_DO_CMP(_res, _addr, _op, _val) \
@@ -175,4 +178,25 @@ int mca_spml_base_put_all_nb(void *target, const void *source,
                              size_t size, long *counter)
 {
     return OSHMEM_ERR_NOT_IMPLEMENTED;
+}
+
+/* Helper function to allocate and initialize a single sync array */
+int mca_spml_base_alloc_sync_array(size_t count, long **array)
+{
+    MCA_MEMHEAP_CALL(private_alloc(count * sizeof(long), (void **)array));
+    if (*array == NULL) {
+        SPML_ERROR("Failed to allocate sync array");
+        return OSHMEM_ERROR;
+    }
+    memset(*array, 0, count * sizeof(long));
+    return OSHMEM_SUCCESS;
+}
+
+/* Helper function to free a single sync array */
+void mca_spml_base_free_sync_array(long **array)
+{
+    if (*array != NULL) {
+        MCA_MEMHEAP_CALL(private_free(*array));
+        *array = NULL;
+    }
 }

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -130,14 +130,13 @@ typedef struct mca_spml_ucx_team_config {
 } mca_spml_ucx_team_config_t;
 
 typedef struct mca_spml_ucx_team {
+    mca_spml_base_team_t        super;
     int                         n_pes;
     int                         my_pe;
     int                         stride;
     int                         start;
     mca_spml_ucx_team_config_t  *config;
     struct mca_spml_ucx_team    *parent_team;
-    long                        *pSync;
-    long                        *pWrk;
 } mca_spml_ucx_team_t;
 
 struct mca_spml_ucx {

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -90,8 +90,18 @@ int oshmem_shmem_finalize(void)
 static int _shmem_finalize(void)
 {
     int ret = OSHMEM_SUCCESS;
+    mca_spml_base_team_t *world_team, *shared_team;
 
     shmem_barrier_all();
+
+    /* Free pSync and pWrk for predefined teams */
+    world_team = (mca_spml_base_team_t *)oshmem_team_world;
+    shared_team = (mca_spml_base_team_t *)oshmem_team_shared;
+
+    mca_spml_base_free_sync_array(&world_team->pSync);
+    mca_spml_base_free_sync_array(&world_team->pWrk);
+    mca_spml_base_free_sync_array(&shared_team->pSync);
+    mca_spml_base_free_sync_array(&shared_team->pWrk);
 
     shmem_lock_finalize();
 


### PR DESCRIPTION
## 1. SPML Base Infrastructure
- Added `mca_spml_base_team_t` structure with `pSync` and `pWrk` work arrays
- Added `mca_spml_base_alloc_sync_array()` and `mca_spml_base_free_sync_array()` helper functions
- Provides consistent symmetric heap allocation/deallocation across all SPML components

## 2. UCX SPML Implementation  
- Modified `mca_spml_ucx_team_t` to inherit from `mca_spml_base_team_t`
- Updated `team_split_strided()` to allocate work arrays with proper error handling
- Updated `team_destroy()` to free work arrays

## 3. Predefined Teams Initialization
- Changed `SHMEM_TEAM_WORLD` and `SHMEM_TEAM_SHARED` to statically-allocated instances
- Added work array allocation during `shmem_init()`
- Added work array cleanup during `shmem_finalize()`