### PR TITLE
[UBCL] Fixed warnings to build with -Werror

### DIFF
--- a/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
@@ -26,7 +26,7 @@
 #include "ompi/mca/osc/ubcl/osc_ubcl_request.h"
 #include "ompi/mca/common/ubcl/common_ubcl.h"
 
-int get_ubcl_int_type(size_t size, bool is_signed, ubcl_win_atomic_datatype_t *ubcl_type)
+static int get_ubcl_int_type(size_t size, bool is_signed, ubcl_win_atomic_datatype_t *ubcl_type)
 {
     int ret = OMPI_SUCCESS;
 
@@ -51,7 +51,7 @@ int get_ubcl_int_type(size_t size, bool is_signed, ubcl_win_atomic_datatype_t *u
     return ret;
 }
 
-int get_ubcl_fp_type(size_t size, ubcl_win_atomic_datatype_t *ubcl_type)
+static int get_ubcl_fp_type(size_t size, ubcl_win_atomic_datatype_t *ubcl_type)
 {
     int ret = OMPI_SUCCESS;
 

--- a/ompi/mca/osc/ubcl/osc_ubcl_get.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_get.c
@@ -139,7 +139,6 @@ int ompi_osc_ubcl_rget(void *origin_addr, size_t origin_count,
         target_iov[0].iov_base = (char *) target_addr + gap;
         target_iov[0].iov_len = span;
     } else {
-        int ret = OMPI_SUCCESS;
         ret = osc_ubcl_build_ddt_iov(target_addr, proc, target_count, target_dt, &target_iov,
                                      &target_iov_count);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {

--- a/ompi/mca/osc/ubcl/osc_ubcl_put.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_put.c
@@ -147,7 +147,6 @@ int ompi_osc_ubcl_rput(const void *origin_addr, size_t origin_count,
         target_iov[0].iov_base = (char *) target_addr + gap;
         target_iov[0].iov_len = span;
     } else {
-        int ret = OMPI_SUCCESS;
         ret = osc_ubcl_build_ddt_iov(target_addr, proc, target_count, target_dt, &target_iov,
                                      &target_iov_count);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {

--- a/ompi/mca/pml/ubcl/pml_ubcl_component.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_component.c
@@ -191,7 +191,7 @@ int mca_pml_ubcl_component_register(void)
     return OMPI_SUCCESS;
 }
 
-static void mca_pml_ubcl_check_cuda_accelerator()
+static void mca_pml_ubcl_check_cuda_accelerator(void)
 {
     const char* cuda_component_name = "cuda";
     const char* selected_component_name = opal_accelerator_base_selected_component.base_version.mca_component_name;

--- a/ompi/mca/pml/ubcl/pml_ubcl_endpoint.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_endpoint.c
@@ -309,7 +309,7 @@ void mca_pml_ubcl_endpoint_retain(ompi_proc_t *proc)
     OBJ_RETAIN(proc);
 }
 
-int mca_pml_ubcl_create_endpoints(ompi_proc_t *proc)
+static int mca_pml_ubcl_create_endpoints(ompi_proc_t *proc)
 {
     int err = OMPI_SUCCESS;
     mca_common_ubcl_endpoint_t *new_endpoint;

--- a/ompi/mca/pml/ubcl/pml_ubcl_isend.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_isend.c
@@ -100,7 +100,7 @@ static inline void mca_pml_ubcl_isend_prepare(const void *buf, size_t count,
 void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
 {
     OPAL_OUTPUT_VERBOSE(
-        (50, mca_pml_ubcl_component.output, "UBCL_MODULE_ISEND_START %p\n", *request));
+        (50, mca_pml_ubcl_component.output, "UBCL_MODULE_ISEND_START %p\n", *(void **)request));
 
     mca_pml_ubcl_request_t *req = container_of((*request), mca_pml_ubcl_request_t, ompi_req);
 
@@ -167,7 +167,7 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
     OPAL_OUTPUT_VERBOSE((50, mca_pml_ubcl_component.output,
                          "PML/UBCL ISEND: send mpi_tag=%x comm_id=%zu\n", tag, ubcl_cid.bits));
     OPAL_OUTPUT_VERBOSE(
-        (50, mca_pml_ubcl_component.output, "PML/UBCL ISEND: ompi_req=%p\n", *request));
+        (50, mca_pml_ubcl_component.output, "PML/UBCL ISEND: ompi_req=%p\n", *(void **)request));
     OPAL_OUTPUT_VERBOSE(
         (50, mca_pml_ubcl_component.output, "PML/UBCL ISEND: sending to rank=%zu\n", endpoint->rank));
 

--- a/ompi/mca/pml/ubcl/pml_ubcl_request.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_request.c
@@ -177,7 +177,7 @@ mca_pml_ubcl_request_cancel(struct ompi_request_t *request, int complete)
     return OMPI_SUCCESS;
 }
 
-int mca_pml_ubcl_request_complete(struct ompi_request_t *request)
+static int mca_pml_ubcl_request_complete(struct ompi_request_t *request)
 {
     /* Null check */
     if (MPI_REQUEST_NULL == request) {
@@ -248,7 +248,7 @@ void ubcl_request_send_complete_cb(ubcl_status_t status, void *cb_data)
     }
 
     OPAL_OUTPUT_VERBOSE((50, mca_pml_ubcl_component.output,
-                         "PML/UBCL SEND_COMPLETE pml_req=%p mpi_tag=%x\n", req, req->tag));
+                         "PML/UBCL SEND_COMPLETE pml_req=%p mpi_tag=%x\n", (void *)req, req->tag));
 
     /** mca_pml_ubcl_request_complete((ompi_request_t *) cb_data); */
 }
@@ -284,7 +284,7 @@ void ubcl_request_recv_complete_cb(ubcl_status_t status, void *cb_data)
     ompi_request_complete(&(req->ompi_req), true);
 
     OPAL_OUTPUT_VERBOSE((50, mca_pml_ubcl_component.output,
-                         "PML/UBCL RECV_COMPLETE pml_req=%p mpi_tag=%d\n", req, req->tag));
+                         "PML/UBCL RECV_COMPLETE pml_req=%p mpi_tag=%d\n", (void *)req, req->tag));
 
     /** mca_pml_ubcl_request_complete((ompi_request_t *) cb_data); */
 }
@@ -296,7 +296,7 @@ void ubcl_request_recv_complete_cb(ubcl_status_t status, void *cb_data)
 void mca_pml_ubcl_request_finalize(mca_pml_ubcl_request_t *req)
 {
     OPAL_OUTPUT_VERBOSE((50, mca_pml_ubcl_component.output,
-                         "PML/UBCL REQUEST_FINALIZE BEGIN pml_req=%p mpi_tag=%x\n", req, req->tag));
+                         "PML/UBCL REQUEST_FINALIZE BEGIN pml_req=%p mpi_tag=%x\n", (void *)req, req->tag));
 
     opal_convertor_cleanup(&req->convertor);
     OBJ_DESTRUCT(&req->convertor);
@@ -308,7 +308,7 @@ void mca_pml_ubcl_request_finalize(mca_pml_ubcl_request_t *req)
     opal_free_list_return(&mca_pml_ubcl_component.pml_req_free_list, (opal_free_list_item_t *) req);
 
     OPAL_OUTPUT_VERBOSE(
-        (50, mca_pml_ubcl_component.output, "PML/UBCL REQUEST_FINALIZED %p\n", req));
+        (50, mca_pml_ubcl_component.output, "PML/UBCL REQUEST_FINALIZED %p\n", (void *)req));
 }
 
 


### PR DESCRIPTION
UBCL components  (pml/ubcl and osc/ubcl) do not compile with -Werror options.
This patch should fix it.