### PR TITLE
pml/ob1 remove mpi_init race condition

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -471,7 +471,7 @@ void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
 
     /* communicator pointer */
     comm_ptr = ompi_comm_lookup(hdr->hdr_ctx);
-    if(OPAL_UNLIKELY(NULL == comm_ptr)) {
+    if(OPAL_UNLIKELY(NULL == comm_ptr || NULL == comm_ptr->c_pml_comm)) {
         /* This is a special case. A message for a not yet existing
          * communicator can happens. Instead of doing a matching we
          * will temporarily add it the a pending queue in the PML.


### PR DESCRIPTION
It is possible for the ob1 pml to receive a message on MPI_COMM_WORLD while waiting on a PMIx fence here:
https://github.com/open-mpi/ompi/blob/7c5a40521c7b9991fd0f28588430bb8e179a1959/ompi/runtime/ompi_mpi_init.c#L490

This leads to a segfault, since MPI_COMM_WORLD is not set up in the pml until after the fence:
https://github.com/open-mpi/ompi/blob/7c5a40521c7b9991fd0f28588430bb8e179a1959/ompi/runtime/ompi_mpi_init.c#L496

This change adds the early messages to the non_existing_communicator_pending list, which is then checked when MPI_COMM_WORLD is added to the pml.