### PR TITLE
OSHMEM/SHMEM/C: v1.5 - shmem_signal_fetch implementation

### DIFF
--- a/oshmem/shmem/c/shmem_put_signal.c
+++ b/oshmem/shmem/c/shmem_put_signal.c
@@ -225,6 +225,6 @@ SHMEM_TYPE_PUTMEM_SIGNAL(_put128_signal, 16, shmem)
 
 uint64_t shmem_signal_fetch(const uint64_t *sig_addr)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    return shmem_uint64_atomic_fetch(sig_addr, pshmem_my_pe());
 }
 


### PR DESCRIPTION
# What?
This PR implements the shmem_signal_fetch function for OpenSHMEM

It leverages the existing shmem_uint64_atomic_fetch operation to retrieve the signal value at the specified address on the local PE.

# Why?
The shmem_signal_fetch function is part of the OpenSHMEM signaling API (introduced in 1.5 specification).
