### PR TITLE
OSHMEM/MCA/SPML/UCX: v1.5 implement put_signal and put_signal_nbi

### DIFF
--- a/oshmem/mca/atomic/atomic.h
+++ b/oshmem/mca/atomic/atomic.h
@@ -296,6 +296,11 @@ struct mca_atomic_base_module_1_0_0_t {
                        uint64_t value,
                        size_t size,
                        int pe);
+    int (*atomic_set)(shmem_ctx_t ctx,
+                      void *target,
+                      uint64_t value,
+                      size_t size,
+                      int pe);
 };
 typedef struct mca_atomic_base_module_1_0_0_t mca_atomic_base_module_1_0_0_t;
 

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -1644,19 +1644,60 @@ int mca_spml_ucx_put_all_nb(void *dest, const void *source, size_t size, long *c
     return OSHMEM_SUCCESS;
 }
 
-/* This routine is not implemented */
-int mca_spml_ucx_put_signal(shmem_ctx_t ctx, void* dst_addr, size_t size, void*
-        src_addr, uint64_t *sig_addr, uint64_t signal, int sig_op, int dst)
+
+static inline int mca_spml_ucx_signal(shmem_ctx_t ctx,
+                                      uint64_t *sig_addr,
+                                      uint64_t signal,
+                                      int sig_op,
+                                      int dst)
 {
+    if (sig_op == SHMEM_SIGNAL_SET) {
+        return MCA_ATOMIC_CALL(set(ctx, (void*)sig_addr, signal,
+                                   sizeof(uint64_t), dst));
+    } else if (sig_op == SHMEM_SIGNAL_ADD) {
+        return MCA_ATOMIC_CALL(add(ctx, (void*)sig_addr, signal,
+                                   sizeof(uint64_t), dst));
+    }
+
+    SPML_UCX_ERROR("Invalid signal operation: %d", sig_op);
     return OSHMEM_ERR_NOT_IMPLEMENTED;
 }
 
-/* This routine is not implemented */
+int mca_spml_ucx_put_signal(shmem_ctx_t ctx, void* dst_addr, size_t size, void*
+        src_addr, uint64_t *sig_addr, uint64_t signal, int sig_op, int dst)
+{
+    int res;
+
+    res = mca_spml_ucx_put(ctx, dst_addr, size, src_addr, dst);
+    if (OPAL_UNLIKELY(OSHMEM_SUCCESS != res)) {
+        return res;
+    }
+
+    res = mca_spml_ucx_fence(ctx);
+    if (OPAL_UNLIKELY(OSHMEM_SUCCESS != res)) {
+        return res;
+    }
+
+    return mca_spml_ucx_signal(ctx, sig_addr, signal, sig_op, dst);
+}
+
 int mca_spml_ucx_put_signal_nb(shmem_ctx_t ctx, void* dst_addr, size_t size,
         void* src_addr, uint64_t *sig_addr, uint64_t signal, int sig_op, int
         dst)
 {
-    return OSHMEM_ERR_NOT_IMPLEMENTED;
+    int res;
+
+    res = mca_spml_ucx_put_nb(ctx, dst_addr, size, src_addr, dst, NULL);
+    if (OPAL_UNLIKELY(OSHMEM_SUCCESS != res)) {
+        return res;
+    }
+
+    res = mca_spml_ucx_fence(ctx);
+    if (OPAL_UNLIKELY(OSHMEM_SUCCESS != res)) {
+        return res;
+    }
+
+    return mca_spml_ucx_signal(ctx, sig_addr, signal, sig_op, dst);
 }
 
 /* This routine is not implemented */

--- a/oshmem/shmem/c/shmem_set.c
+++ b/oshmem/shmem/c/shmem_set.c
@@ -25,19 +25,16 @@
  */
 #define DO_SHMEM_TYPE_ATOMIC_SET(ctx, type, target, value, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \
-        size_t size = 0;                                            \
-        type out_value;                                             \
+        size_t size = sizeof(type);                                 \
         uint64_t value_tmp;                                         \
         RUNTIME_CHECK_INIT();                                       \
         RUNTIME_CHECK_PE(pe);                                       \
         RUNTIME_CHECK_ADDR(target);                                 \
                                                                     \
-        size = sizeof(out_value);                                   \
         memcpy(&value_tmp, &value, size);                           \
-        rc = MCA_ATOMIC_CALL(swap(                                  \
+        rc = MCA_ATOMIC_CALL(set(                                   \
             ctx,                                                    \
             (void*)target,                                          \
-            (void*)&out_value,                                      \
             value_tmp,                                              \
             size,                                                   \
             pe));                                                   \


### PR DESCRIPTION
# What?
Implements `mca_spml_ucx_put_signal` and `mca_spml_ucx_put_signal_nb` for OpenSHMEM signaling operations with UCX backend.

# Why 
The put_signal operations are part of the OpenSHMEM 1.5 specification and were previously unimplemented (returning OSHMEM_ERR_NOT_IMPLEMENTED).
