### PR TITLE
sharedfp/lockedfile: do not limit filename length (v6.0.x)

### DIFF
--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.c
@@ -79,8 +79,7 @@ int mca_sharedfp_lockedfile_component_init_query(bool enable_progress_threads,
 struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_lockedfile_component_file_query(ompio_file_t *fh, int *priority) {
     struct flock lock;
     int fd, err;
-    /*char *filename;*/
-    char filename[256];
+    char *filename;
     int rank;
     bool has_file_lock_support=false;
 
@@ -117,7 +116,7 @@ struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_lockedfile_component_file
 
     /* Set the filename. */
     /*data filename created by appending .locktest.$rank to the original filename*/
-    snprintf(filename, sizeof(filename), "%s%s%d",fh->f_filename,".locktest.",rank);
+    opal_asprintf(&filename, "%s.locktest.%d",fh->f_filename, rank);
 
     lock.l_type   = F_WRLCK;
     lock.l_start  = 0;
@@ -160,6 +159,7 @@ struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_lockedfile_component_file
         close(fd);
         unlink( filename );
     }
+    free(filename);
     /**priority=100;*/
     if(has_file_lock_support){
         return &lockedfile;


### PR DESCRIPTION
The sharedfp/lockedfile component had a temp. buffer of size 256 characters for generating a temp. file for testing the file locking feature during file open. For very long filenames, that was not sufficient.

Switch to an asprintf based method instead of a fixed namelen to resolve the issue.

Fixes issue #13565


(cherry picked from commit a0593adfd520eb69347ac015e56f3f865ef643e7)