### PR TITLE
docs: cleanup some hpe/crayisms

### DIFF
--- a/docs/features/ulfm.rst
+++ b/docs/features/ulfm.rst
@@ -87,7 +87,7 @@ non-blocking) use an optimized implementation on top of  ``ob1``.
 - Loopback (send-to-self)
 - TCP
 - UCT (InfiniBand)
-- uGNI (Cray Gemini, Aries)
+- OFI/libfabric
 - Shared Memory (FT supported with CMA and XPMEM; KNEM is untested)
 - Tuned and non-blocking collective communications
 
@@ -159,7 +159,7 @@ Running under a batch scheduler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ULFM can operate under a job/batch scheduler, and is tested routinely
-with ALPS, PBS, and Slurm. One difficulty comes from the fact that
+with PBS and Slurm. One difficulty comes from the fact that
 many job schedulers handle failures by triggering an immediate "cleanup"
 of the application as soon as any process fails. In addition, failure
 detection subsystems integrated into PRTE are not active in direct launch

--- a/docs/installing-open-mpi/configure-cli-options/runtime.rst
+++ b/docs/installing-open-mpi/configure-cli-options/runtime.rst
@@ -17,9 +17,9 @@ can be used with ``configure``:
   so that executables such as ``mpicc`` and ``mpirun`` can be found
   without needing to type long path names.
 
-* ``--with-alps``:
-  Force the building of for the Cray Alps run-time environment.  If
-  Alps support cannot be found, configure will abort.
+* ``--with-pals``:
+  Force the building of for the Cray PALS run-time environment.  If
+  PALS support cannot be found, configure will abort.
 
 * ``--with-lsf=DIR``:
   Specify the directory where the LSF libraries and header files are

--- a/docs/release-notes/platform.rst
+++ b/docs/release-notes/platform.rst
@@ -51,5 +51,5 @@ that a release of Open MPI supports.
   * PBS Pro, Torque
   * Platform LSF (tested with v9.1.1 and later)
   * Slurm
-  * Cray XE, XC, and XK
+  * HPE/Cray PALS
   * Oracle Grid Engine (OGE) 6.1, 6.2 and open source Grid Engine


### PR DESCRIPTION
that were scattered around in the docs.
Note that there are some places of historical
interest where the ALPS nomenclature was retained.