### PR TITLE
docs: generalize a couple of places for current

### DIFF
--- a/docs/building-apps/abi-compatibility.rst
+++ b/docs/building-apps/abi-compatibility.rst
@@ -11,7 +11,7 @@ application compiled with Open MPI v4.x can be executed with Open MPI
 .. important:: ABI is maintained for *most* of the Fortran MPI bindings, too |mdash| see below for additional information.
 
 There are however a few scenarios where an application compiled with
-Open MPI v4.x might not execute correctly with Open MPI 5.0.
+Open MPI v4.x might not execute correctly with Open MPI |ompi_series|.
 
 - Fortran compilers provide varying degrees of ABI guarantees between
   their releases.  As such, Open MPI can only provide ABI guarantees

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -661,8 +661,8 @@ presented here so that they can easily be found via internet searches:
 
 .. _label-mca-backward-compat:
 
-MCA Parameter Changes Between Open MPI 4.x and 5.x
---------------------------------------------------
+MCA Parameter Changes Between Open MPI 4.x and newer releases
+-------------------------------------------------------------
 
 When Open MPI :ref:`switched from using ORTE to PRRTE as its run-time
 environment, <label-running-role-of-pmix-and-prte>` some MCA


### PR DESCRIPTION
release rather than hardwired to 5.0.(0,x).