### PR TITLE
btl,mtl/ofi: set device only flag

### DIFF
--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -148,7 +148,7 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_MR_IFACE],
                               [${opal_check_fi_mr_attr_iface}],
-                              [check if iface avaiable in fi_mr_attr])
+                              [check if iface available in fi_mr_attr])
 
            AC_CHECK_DECL([FI_HMEM_ROCR],
                          [opal_check_fi_hmem_rocr=1],
@@ -157,7 +157,7 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ROCR],
                               [${opal_check_fi_hmem_rocr}],
-                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])
+                              [check if FI_HMEM_ROCR available in fi_hmem_iface])
 
            AC_CHECK_DECL([FI_HMEM_ZE],
                          [opal_check_fi_hmem_ze=1],
@@ -166,7 +166,16 @@ AC_DEFUN([OPAL_CHECK_OFI],[
 
            AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ZE],
                               [${opal_check_fi_hmem_ze}],
-                              [check if FI_HMEM_ZE avaiable in fi_hmem_iface])])
+                              [check if FI_HMEM_ZE available in fi_hmem_iface])
+
+           AC_CHECK_DECL([FI_HMEM_DEVICE_ONLY],
+                         [opal_check_fi_hmem_device_only=1],
+                         [opal_check_fi_hmem_device_only=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_DEVICE_ONLY],
+                              [${opal_check_fi_hmem_device_only}],
+                              [check if OPAL_OFI_HAVE_FI_HMEM_DEVICE_ONLY available])])
 
     CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
     LDFLAGS=${opal_check_ofi_save_LDFLAGS}

--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -91,6 +91,7 @@ BEGIN_C_DECLS
  */
 /* Unified memory buffers */
 #define MCA_ACCELERATOR_FLAGS_UNIFIED_MEMORY 0x00000001
+#define MCA_ACCELERATOR_FLAGS_DEVICE_ONLY_MEMORY 0x00000002
 
 /**
  * Transfer types.


### PR DESCRIPTION
In OFI, the FI_HMEM_DEVICE_ONLY registration flag signals to the provider that the memory is only on the device and is not unified memory (which can migrate between the GPU and host). IPC is only usable with device only memory and is not valid for unified memory. Without this flag, providers cannot provide optimizations like IPC. Set the flag if the address was found to be non-unified memory. This enables IPC copies in OFI.

This also includes an indentation fix within the same function