### PR TITLE
opal/mca/common/ucx : assert fix -  change thread mode sent to UCX api

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -835,6 +835,9 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
         opal_set_using_threads(true);
     }
 
+    /* Set single-threaded flag for optimization purposes */
+    opal_single_threaded = (ts_level == MPI_THREAD_SINGLE);
+
     opal_mutex_lock (&instance_lock);
     if (0 == opal_atomic_fetch_add_32 (&ompi_instance_count, 1)) {
         ret = ompi_mpi_instance_init_common (argc, argv);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -190,6 +190,7 @@ static int component_register(void) {
     free(description_str);
 
     opal_common_ucx_thread_enabled = opal_using_threads();
+    opal_common_ucx_single_threaded = opal_single_threaded;
     mca_osc_ucx_component.acc_single_intrinsic = false;
 
     opal_asprintf(&description_str, "Enable optimizations for MPI_Fetch_and_op, MPI_Accumulate, etc for codes "

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -3,8 +3,6 @@
 #include "common_ucx.h"
 #include "common_ucx_wpool.h"
 #include "common_ucx_wpool_int.h"
-#include "mpi.h"
-#include "ompi/runtime/mpiruntime.h"
 #include "opal/mca/base/mca_base_framework.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/pmix/pmix-internal.h"
@@ -34,6 +32,7 @@ __thread int initialized = 0;
 #endif
 
 bool opal_common_ucx_thread_enabled = false;
+bool opal_common_ucx_single_threaded = true;
 opal_atomic_int64_t opal_common_ucx_ep_counts = 0;
 opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts = 0;
 
@@ -57,7 +56,7 @@ static opal_common_ucx_winfo_t *_winfo_create(opal_common_ucx_wpool_t *wpool)
     if (opal_common_ucx_thread_enabled || wpool->dflt_winfo == NULL) {
         memset(&worker_params, 0, sizeof(worker_params));
         worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-        worker_params.thread_mode = ompi_mpi_thread_provided == MPI_THREAD_SINGLE ? UCS_THREAD_MODE_SINGLE : UCS_THREAD_MODE_SERIALIZED;
+        worker_params.thread_mode = opal_common_ucx_single_threaded ? UCS_THREAD_MODE_SINGLE : UCS_THREAD_MODE_SERIALIZED;
         status = ucp_worker_create(wpool->ucp_ctx, &worker_params, &worker);
         if (UCS_OK != status) {
             MCA_COMMON_UCX_ERROR("ucp_worker_create failed: %d", status);

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -3,6 +3,8 @@
 #include "common_ucx.h"
 #include "common_ucx_wpool.h"
 #include "common_ucx_wpool_int.h"
+#include "mpi.h"
+#include "ompi/runtime/mpiruntime.h"
 #include "opal/mca/base/mca_base_framework.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/pmix/pmix-internal.h"
@@ -55,7 +57,7 @@ static opal_common_ucx_winfo_t *_winfo_create(opal_common_ucx_wpool_t *wpool)
     if (opal_common_ucx_thread_enabled || wpool->dflt_winfo == NULL) {
         memset(&worker_params, 0, sizeof(worker_params));
         worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-        worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        worker_params.thread_mode = ompi_mpi_thread_provided == MPI_THREAD_SINGLE ? UCS_THREAD_MODE_SINGLE : UCS_THREAD_MODE_SERIALIZED;
         status = ucp_worker_create(wpool->ucp_ctx, &worker_params, &worker);
         if (UCS_OK != status) {
             MCA_COMMON_UCX_ERROR("ucp_worker_create failed: %d", status);

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -59,6 +59,7 @@ typedef struct {
 } opal_common_ucx_wpool_t;
 
 extern bool opal_common_ucx_thread_enabled;
+extern bool opal_common_ucx_single_threaded;
 extern opal_atomic_int64_t opal_common_ucx_ep_counts;
 extern opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts;
 

--- a/opal/mca/threads/base/mutex.c
+++ b/opal/mca/threads/base/mutex.c
@@ -35,6 +35,12 @@
  */
 bool opal_uses_threads = false;
 
+/*
+ * Track if MPI is running in single-threaded mode (MPI_THREAD_SINGLE).
+ * Default is true until MPI_Init/MPI_Init_thread determines otherwise.
+ */
+bool opal_single_threaded = true;
+
 static void mca_threads_mutex_constructor(opal_mutex_t *p_mutex)
 {
 #if OPAL_ENABLE_DEBUG

--- a/opal/mca/threads/thread_usage.h
+++ b/opal/mca/threads/thread_usage.h
@@ -33,6 +33,7 @@
 #include "opal/sys/atomic.h"
 
 OPAL_DECLSPEC extern bool opal_uses_threads;
+OPAL_DECLSPEC extern bool opal_single_threaded;
 
 /**
  * Check and see if the process is using multiple threads.


### PR DESCRIPTION
UCP Worker Thread Modes in OpenUCX define how multiple threads interact with a UCP worker. `UCS_THREAD_MODE_SINGLE` indicates that only one unique thread can use this worker throughout the whole application. 
In a multithreaded application, OMPI may reuse `winfo` objects among different threads, conflicting with hard-coded `UCS_THREAD_MODE_SINGLE`, and resulting in an assert failure

If an application use multiple threads, we want to use parameter `UCS_THREAD_MODE_SERIALIZED` that allows different threads to use the same worker successively