### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -38,6 +38,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       # https://github.com/marketplace/actions/close-stale-issues
       - uses: actions/stale@v9

--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -2,6 +2,9 @@ name: CUDA
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   CUDA_PATH: /usr/local/cuda
 jobs:

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -2,6 +2,9 @@ name: Compile ignored components
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   compile-ignored:
     runs-on: ubuntu-24.04

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -2,6 +2,9 @@ name: ROCM
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   ROCM_VER: 6.2.2
 jobs:

--- a/.github/workflows/compile-ze.yaml
+++ b/.github/workflows/compile-ze.yaml
@@ -2,6 +2,9 @@ name: OneAPI ZE
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   compile-ze:
     runs-on: ubuntu-22.04

--- a/.github/workflows/hdf5-tests.yaml
+++ b/.github/workflows/hdf5-tests.yaml
@@ -2,6 +2,9 @@ name: HDF5
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   hdf5-testsuite:
     runs-on: ubuntu-22.04

--- a/.github/workflows/macos-checks.yaml
+++ b/.github/workflows/macos-checks.yaml
@@ -2,6 +2,9 @@ name: macOS
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macos-latest

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,5 +1,7 @@
 name: ompi_NVIDIA CI
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
 
   nvidia_deployment:

--- a/.github/workflows/remove-awaiting-user-info-label.yaml
+++ b/.github/workflows/remove-awaiting-user-info-label.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     # From
     # https://github.com/marketplace/actions/close-issues-after-no-reply:
     # only remove the label if someone replies to an issue who is not

--- a/.github/workflows/riscv64-qemu-test.yaml
+++ b/.github/workflows/riscv64-qemu-test.yaml
@@ -1,6 +1,8 @@
 name: riscv64-qemu-test
 
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/open-mpi/ompi/security/code-scanning/22](https://github.com/open-mpi/ompi/security/code-scanning/22)

In general, the fix is to add an explicit `permissions` block to the workflow so that the `GITHUB_TOKEN` used in this job is limited to the least privileges necessary. For a workflow that only checks out code and compiles it, `contents: read` is typically sufficient, and no write or additional scopes are needed.

The best way to fix this concrete workflow without changing existing functionality is to add a `permissions` section at the root level of `.github/workflows/compile-examples.yaml`, just after the `on:` definition and before `jobs:`. This will apply to all jobs in this workflow (currently only `compile-ignored`) and constrain the token to repository contents read-only. No additional imports, methods, or definitions are needed since this is a YAML configuration change only.

Concretely: edit `.github/workflows/compile-examples.yaml` to insert:

```yaml
permissions:
  contents: read
```

between lines 3 and 5 in the provided snippet (after `on: [pull_request]` and before `jobs:`). This does not alter any steps or runtime behavior, only the permission scope of `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

**EDIT:** @jsquyres also added in several other similar suggested fixes from Copilot Autofixes, including a few that required write permissions.  Squashed them all into a single commit.
