### PR TITLE
v5.0.x: Fix for code scanning alerts 1-7, 12, 17-19, 21-22

### DIFF
--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -2,6 +2,9 @@ name: CUDA
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   CUDA_PATH: /usr/local/cuda
 jobs:

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -2,6 +2,9 @@ name: ROCM
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   ROCM_VER: 5-4
 jobs:

--- a/.github/workflows/macos-checks.yaml
+++ b/.github/workflows/macos-checks.yaml
@@ -2,6 +2,9 @@ name: macOS
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macos-latest

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -2,6 +2,9 @@ name: mpi4py
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ompi_mpi4py_tests.yaml
+++ b/.github/workflows/ompi_mpi4py_tests.yaml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   mpi4py-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,5 +1,7 @@
 name: ompi_NVIDIA CI
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
 
   nvidia_deployment:


### PR DESCRIPTION
Add explicit permissions into GitHub action workflows, as suggested by Copilot.

Ported to v5.0.x branch from main commit b15a17bec9c60594716ee1332b9133038a4b0f7c.

Co-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>
Signed-off-by: Jeff Squyres <jeff@squyres.com>

(cherry picked from commit b15a17bec9c60594716ee1332b9133038a4b0f7c)