### PR TITLE
v4.1.x: Fix for code scanning alerts 1-7, 12, 17-19, 21-22

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -1,5 +1,7 @@
 name: ompi_NVIDIA CI
 on: [pull_request]
+permissions:
+  contents: read
 
 concurrency:
   group: ompi-ci-nvidia


### PR DESCRIPTION
Add explicit permissions into GitHub action workflows, as suggested by Copilot.

Ported to v4.1.x branch from main commit b15a17bec9c60594716ee1332b9133038a4b0f7c.

(cherry picked from commit b15a17bec9c60594716ee1332b9133038a4b0f7c)