### PR TITLE
docs: update TCP docs + support deep linking into PMIx and PRTE docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -517,6 +517,7 @@ docs/_static
 docs/_static/css/custom.css
 docs/_templates
 docs/man-openmpi/man3/bindings
+docs/*.inv
 
 # Common Python virtual environment and cache directory names
 venv

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1095,8 +1095,22 @@ $(ALL_MAN_BUILT):
 	cp -rpf "$(OMPI_PRRTE_RST_CONTENT_DIR)" "$(builddir)"; \
 	copied_dir=`basename $(OMPI_PRRTE_RST_CONTENT_DIR)`; \
 	chmod -R u+w "$(builddir)/$$copied_dir"
-	$(OMPI_V_SPHINX_HTML) OMPI_TOP_SRCDIR=$(top_srcdir) $(SPHINX_BUILD) -M html "$(builddir)" "$(OUTDIR)" $(SPHINX_OPTS)
-	$(OMPI_V_SPHINX_MAN) OMPI_TOP_SRCDIR=$(top_srcdir) $(SPHINX_BUILD) -M man "$(builddir)" "$(OUTDIR)" $(SPHINX_OPTS)
+	$(OMPI_V_SPHINX_HTML) \
+	    OMPI_TOP_SRCDIR="$(top_srcdir)" \
+	    OMPI_DOCDIR="$(docdir)" \
+	    OPAL_PMIX_DOCS_URL_BASE="$(OPAL_PMIX_DOCS_URL_BASE)" \
+	    OPAL_USING_INTERNAL_PMIX="$(OPAL_USING_INTERNAL_PMIX)" \
+	    OMPI_PRRTE_DOCS_URL_BASE="$(OMPI_PRRTE_DOCS_URL_BASE)" \
+	    OMPI_USING_INTERNAL_PRRTE="$(OMPI_USING_INTERNAL_PRRTE)" \
+	    $(SPHINX_BUILD) -M html "$(builddir)" "$(OUTDIR)" $(SPHINX_OPTS)
+	$(OMPI_V_SPHINX_HTML) \
+	    OMPI_TOP_SRCDIR="$(top_srcdir)" \
+	    OMPI_DOCDIR="$(docdir)" \
+	    OPAL_PMIX_DOCS_URL_BASE="$(OPAL_PMIX_DOCS_URL_BASE)" \
+	    OPAL_USING_INTERNAL_PMIX="$(OPAL_USING_INTERNAL_PMIX)" \
+	    OMPI_PRRTE_DOCS_URL_BASE="$(OMPI_PRRTE_DOCS_URL_BASE)" \
+	    OMPI_USING_INTERNAL_PRRTE="$(OMPI_USING_INTERNAL_PRRTE)" \
+	    $(SPHINX_BUILD) -M man "$(builddir)" "$(OUTDIR)" $(SPHINX_OPTS)
 
 # A useful rule to invoke manually to ensure that all of the external
 # HTML links we have are valid.  Running this rule requires
@@ -1117,6 +1131,7 @@ linkcheck:
 clean-local:
 	rm -rf $(OUTDIR)
 	rm -rf prrte-rst-content schizo-ompi-rst-content
+	rm -rf ompi-prrte-objects.inv opal-pmix-objects.inv
 	if test "$(srcdir)" != "$(builddir)"; then \
 	    len=`echo "$(srcdir)/" | wc -c`; \
 	    for file in $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES) $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG); do \

--- a/docs/launching-apps/gridengine.rst
+++ b/docs/launching-apps/gridengine.rst
@@ -17,7 +17,7 @@ Verify Grid Engine support
    command line switch to Open MPI's ``configure`` script.
 
 To verify if support for Grid Engine is configured into your Open MPI
-installation, run ``prte_info`` as shown below and look for
+installation, run :ref:`prte_info(1) <prrte:man1-prte_info>` as shown below and look for
 ``gridengine``.
 
 .. code-block::
@@ -30,8 +30,8 @@ installation, run ``prte_info`` as shown below and look for
    PMIx and PRRTE details from the end user, but this is one place
    that Open MPI is unable to hide the fact that PRRTE provides this
    functionality, not Open MPI.  Hence, users need to use the
-   ``prte_info`` command to check for Grid Engine support (not
-   ``ompi_info``).
+   :ref:`prte_info(1) <prrte:man1-prte_info>` command to check for Grid Engine support (not
+   :ref:`ompi_info(1) <man1-ompi_info>`).
 
 Launching
 ---------
@@ -40,7 +40,7 @@ When Grid Engine support is included, Open MPI will automatically
 detect when it is running inside SGE and will just "do the Right
 Thing."
 
-Specifically, if you execute an ``mpirun`` command in a Grid Engine
+Specifically, if you execute an :ref:`mpirun(1) <man1-mpirun>` command in a Grid Engine
 job, it will automatically use the Grid Engine mechanisms to launch
 and kill processes.  There is no need to specify what nodes to run on
 |mdash| Open MPI will obtain this information directly from Grid
@@ -231,13 +231,13 @@ Grid Engine job suspend / resume support
 ----------------------------------------
 
 To suspend the job, you send a SIGTSTP (not SIGSTOP) signal to
-``mpirun``.  ``mpirun`` will catch this signal and forward it to the
+:ref:`mpirun(1) <man1-mpirun>`.  :ref:`mpirun(1) <man1-mpirun>` will catch this signal and forward it to the
 ``mpi-hello-world`` as a SIGSTOP signal.  To resume the job, you send
-a SIGCONT signal to ``mpirun`` which will be caught and forwarded to
+a SIGCONT signal to :ref:`mpirun(1) <man1-mpirun>` which will be caught and forwarded to
 the ``mpi-hello-world``.
 
 By default, this feature is not enabled.  This means that both the
-SIGTSTP and SIGCONT signals will simply be consumed by the ``mpirun``
+SIGTSTP and SIGCONT signals will simply be consumed by the :ref:`mpirun(1) <man1-mpirun>`
 process.  To have them forwarded, you have to run the job with ``--mca
 orte_forward_job_control 1``.  Here is an example on Solaris:
 

--- a/docs/launching-apps/lsf.rst
+++ b/docs/launching-apps/lsf.rst
@@ -6,7 +6,8 @@ Open MPI supports the LSF resource manager.
 Verify LSF support
 ------------------
 
-The ``prte_info`` command can be used to determine whether or not an
+The :ref:`prte_info(1) <prrte:man1-prte_info>`
+command can be used to determine whether or not an
 installed Open MPI includes LSF support:
 
 .. code-block::
@@ -27,8 +28,9 @@ installed.
    PMIx and PRRTE details from the end user, but this is one place
    that Open MPI is unable to hide the fact that PRRTE provides this
    functionality, not Open MPI.  Hence, users need to use the
-   ``prte_info`` command to check for LSF support (not
-   ``ompi_info``).
+   :ref:`prte_info(1) <prrte:man1-prte_info>`
+   command to check for LSF support (not
+   :ref:`ompi_info(1) <man1-ompi_info>`).
 
 Launching
 ---------

--- a/docs/launching-apps/pals.rst
+++ b/docs/launching-apps/pals.rst
@@ -27,7 +27,8 @@ documentation :doc:`tm`.
 Verify PALS support
 -------------------
 
-The ``prte_info`` command can be used to determine whether or not an
+The :ref:`prte_info(1) <prrte:man1-prte_info>`
+command can be used to determine whether or not an
 installed Open MPI includes PALS support:
 
 .. code-block::
@@ -49,11 +50,12 @@ Using ``mpirun``
 
 This section assumes there is PALS support in the PRRTE being used for the Open MPI installation.
 
-When ``mpirun`` is launched in a PBS job, ``mpirun`` will
+When :ref:`mpirun(1) <man1-mpirun>` is launched in a PBS job,
+:ref:`mpirun(1) <man1-mpirun>` will
 automatically utilize the PALS infrastructure for launching and
 controlling the individual MPI processes.
 
-.. note:: Using ``mpirun`` is the recommended method for launching Open
+.. note:: Using :ref:`mpirun(1) <man1-mpirun>` is the recommended method for launching Open
    MPI jobs on HPE systems where PALS is available. This is primarily due to limitations in the
    PMIx server provided in PALS.
 
@@ -75,7 +77,7 @@ Using PALS "direct launch" functionality
 ----------------------------------------
 
 The HPE PALS 1.5.0 documentation states that it comes pre-built with PMIx support.
-By default the PALS ``aprun`` launcher does not use PMIx.  To use the launcher's
+By default the PALS ``aprun(1)`` launcher does not use PMIx.  To use the launcher's
 PMIx capabilities either the command line option ``--pmix=pmix`` needs to be set
 or the ``ALPS_PMI`` environment variable needs to be set to ``pmix``.
 
@@ -89,4 +91,4 @@ or the ``ALPS_PMI`` environment variable needs to be set to ``pmix``.
 
 In these examples, four instances of the application are started, two instances per node.
 
-See the PALS ``aprun`` man page for documentation on how to this command.
+See the PALS ``aprun(1)`` man page for documentation on how to this command.

--- a/docs/launching-apps/tm.rst
+++ b/docs/launching-apps/tm.rst
@@ -7,7 +7,7 @@ managers.
 Verify PBS/Torque support
 -------------------------
 
-The ``prte_info`` command can be used to determine whether or not an
+The :ref:`prte_info(1) <prrte:man1-prte_info>` command can be used to determine whether or not an
 installed Open MPI includes Torque/PBS Pro support:
 
 .. code-block::
@@ -28,8 +28,8 @@ installed.
    PMIx and PRRTE details from the end user, but this is one place
    that Open MPI is unable to hide the fact that PRRTE provides this
    functionality, not Open MPI.  Hence, users need to use the
-   ``prte_info`` command to check for PBS/Torque support (not
-   ``ompi_info``).
+   :ref:`prte_info(1) <prrte:man1-prte_info>` command to check for PBS/Torque support (not
+   :ref:`ompi_info(1) <man1-ompi_info>`).
 
 Launching
 ---------
@@ -37,7 +37,7 @@ Launching
 When properly configured, Open MPI obtains both the list of hosts and
 how many processes to start on each host from Torque / PBS Pro
 directly.  Hence, it is unnecessary to specify the ``--hostfile``,
-``--host``, or ``-n`` options to ``mpirun``.  Open MPI will use
+``--host``, or ``-n`` options to :ref:`mpirun(1) <man1-mpirun>`.  Open MPI will use
 PBS/Torque-native mechanisms to launch and kill processes (``ssh`` is
 not required).
 

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -530,8 +530,8 @@ Open MPI has a *large* number of MCA parameters available.  Users can
 use the :ref:`ompi_info(1) <man1-ompi_info>` command to see *all*
 available MCA parameters.
 
-.. note:: Similarly, you can use the ``pmix_info(1)`` and
-          ``prte_info(1)`` commands to see all the MCA parameters
+.. note:: Similarly, you can use the :ref:`pmix_info(1) <pmix:man1-pmix_info>` and
+          :ref:`prte_info(1) <prrte:man1-prte_info>` commands to see all the MCA parameters
           available for the PMIx and PRRTE projects, respectively.
 
           The documentation for these commands are not included in the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ sphinx>=4.2.0
 recommonmark
 docutils
 sphinx-rtd-theme
+sphobjinv
 
 # These modules are needed for the pympistandard module when you are
 # running Python 3.6 (they became part of core Python in 3.7).  We

--- a/docs/tuning-apps/networking/tcp.rst
+++ b/docs/tuning-apps/networking/tcp.rst
@@ -256,20 +256,16 @@ not use specific IP networks |mdash| or not use any IP networks at all
 .. warning:: If you use the ``btl_tcp_if_include`` and
              ``btl_tcp_if_exclude`` MCA parameters to shape the
              behavior of the TCP BTL for MPI communications, you may
-             also need/want to investigate the corresponding MCA
-             parameters ``oob_tcp_if_include`` and
-             ``oob_tcp_if_exclude``, which are used to shape non-MPI
-             TCP-based communication (e.g., communications setup and
-             coordination during ``MPI_INIT`` and ``MPI_FINALIZE``).
+             also need/want to investigate the corresponding PRRTE
+             parameters that control use of network interfaces by the
+             runtime (e.g., communications setup and coordination
+             during :ref:`MPI_Init` and :ref:`MPI_Finalize`) using the
+             ``prte_info(1)`` and ``pmix_info(1)`` commands.
 
-.. error:: TODO do corresponding OOB TCP params still exist in PMIx?
-
-Note that Open MPI will still use TCP for control messages, such as
-data between ``mpirun`` and the MPI processes, rendezvous information
-during ``MPI_INIT``, etc.  To disable TCP altogether, you also need to
-disable the ``tcp`` component from the OOB framework.
-
-.. error:: TODO Is this possible in PMIx?  I doubt it...?
+Note that the Open MPI runtime uses TCP for control messages, such as
+for data exchange between ``mpirun(1)`` and the MPI processes,
+rendezvous information during :ref:`MPI_Init`, etc. even if the
+``tcp`` BTL component is disabled.
 
 /////////////////////////////////////////////////////////////////////////
 

--- a/docs/tuning-apps/networking/tcp.rst
+++ b/docs/tuning-apps/networking/tcp.rst
@@ -260,7 +260,8 @@ not use specific IP networks |mdash| or not use any IP networks at all
              parameters that control use of network interfaces by the
              runtime (e.g., communications setup and coordination
              during :ref:`MPI_Init` and :ref:`MPI_Finalize`) using the
-             ``prte_info(1)`` and ``pmix_info(1)`` commands.
+             :ref:`prte_info(1) <prrte:man1-prte_info>`
+             and :ref:`pmix_info(1) <pmix:man1-pmix_info>` commands.
 
 Note that the Open MPI runtime uses TCP for control messages, such as
 for data exchange between ``mpirun(1)`` and the MPI processes,


### PR DESCRIPTION
This PR replaces PR #13584 (some minor TCP BTL docs updates), but also adds a lot more.  See individual commit messages for details, but here's the short version:

1. Opportunistic fixing of `update-my-copyright.pl` to properly support Git workspaces and also remove support for Mercurial and Subversion.
2. Update the TCP BTL docs, per #13584.
3. Add support for [Intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html), which allows deep linking into PMIx and PRTE docs.
4. Update all references to `pmix_info(1)` and `prte_info(1)` in OMPI's RST docs to deep link into their respective docs.
    * Made this a separate commit just to make reviewing the code changes for Intersphinx support easier.