### PR TITLE
v6.0.x: fortran: create the Fortran module directory

### DIFF
--- a/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2012-2019 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2017-2020 Research Organization for Information Science
+# Copyright (c) 2017-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
@@ -72,6 +72,7 @@ CLEANFILES += *.i90
 # may generate different filenames, so we have to use a glob.  :-(
 #
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \

--- a/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2012-2019 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2020      Research Organization for Information Science
+# Copyright (c) 2020-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
@@ -70,6 +70,7 @@ CLEANFILES += *.i90
 # may generate different filenames, so we have to use a glob.  :-(
 #
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -7,7 +7,7 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2015-2021 Research Organization for Information Science
+# Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
@@ -460,6 +460,7 @@ MAINTAINERCLEANFILES = api_f08_generated.F90
 # may generate different filenames, so we have to use a glob.  :-(
 
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -7,7 +7,7 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2015-2020 Research Organization for Information Science
+# Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (C) 2024      Triad National Security, LLC. All rights
@@ -131,6 +131,7 @@ pmpi-f08-interfaces.lo: mpi-f08-interfaces-generated.h
 # may generate different filenames, so we have to use a glob.  :-(
 
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -1,7 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2006-2019 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015-2021 Research Organization for Information Science
+# Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
@@ -165,6 +165,7 @@ MAINTAINERCLEANFILES = mpi-ignore-tkr-interfaces-generated.h
 # may generate different filenames, so we have to use a glob.  :-(
 
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \

--- a/ompi/mpi/fortran/use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi/Makefile.am
@@ -7,7 +7,7 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2015-2020 Research Organization for Information Science
+# Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
@@ -54,6 +54,7 @@ mpi-types.lo: mpi-types.F90
 # may generate different filenames, so we have to use a glob.  :-(
 
 install-exec-hook:
+	@ $(INSTALL) -d $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR)
 	@ for file in `ls *.mod`; do \
 	  echo $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \
 	  $(INSTALL) $$file $(DESTDIR)$(OMPI_FORTRAN_MODULEDIR); \


### PR DESCRIPTION
Refs. open-mpi/ompi#12787


(cherry picked from commit 03fdd945cc568f99a069dc346848bee0e27d55fd)