### PR TITLE
v6.0.x: PML/UCX: fix problem with (i)mrecv

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -9,7 +9,7 @@
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2025 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1175,6 +1175,7 @@ int mca_pml_ucx_imrecv(void *buf, size_t count, ompi_datatype_t *datatype,
     }
 
     PML_UCX_VERBOSE(8, "got request %p", (void*)req);
+    req->req_mpi_object.comm = (*message)->comm;
     PML_UCX_MESSAGE_RELEASE(message);
     *request = req;
     return OMPI_SUCCESS;
@@ -1197,6 +1198,7 @@ int mca_pml_ucx_mrecv(void *buf, size_t count, ompi_datatype_t *datatype,
         return OMPI_ERROR;
     }
 
+    req->req_mpi_object.comm = (*message)->comm;
     PML_UCX_MESSAGE_RELEASE(message);
 
     return ompi_request_wait(&req, status);


### PR DESCRIPTION
the communicator in the message struct was not being added to the returned request.

Related to issue #13484


(cherry picked from commit 304ac63865d00b505577076f17414fddc5cb2fbc)