### PR TITLE
if/bsdx_ipv4: Fix name in COMPONENT_INIT()

### DIFF
--- a/opal/mca/if/bsdx_ipv4/if_bsdx.c
+++ b/opal/mca/if/bsdx_ipv4/if_bsdx.c
@@ -39,7 +39,7 @@ opal_if_base_component_t mca_if_bsdx_ipv4_component = {
     {/* This component is checkpointable */
      MCA_BASE_METADATA_PARAM_CHECKPOINT},
 };
-MCA_BASE_COMPONENT_INIT(opal, if, bsdx_ipv4_component)
+MCA_BASE_COMPONENT_INIT(opal, if, bsdx_ipv4)
 
 /* convert a netmask (in network byte order) to CIDR notation */
 static int prefix(uint32_t netmask)


### PR DESCRIPTION
When we added the MCA_BASE_COMPONENT_INIT() macro to clean up LTO build issues, we accidently added a _component to the end of the component name, breaking the build for any platform that uses the bsdx_ipv4 component.