### PR TITLE
v5.0.x: Fix for issue #13432

### DIFF
--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -180,6 +181,7 @@ int ompi_errhandler_request_invoke(int count,
        that had an error. */
     for (; i < count; ++i) {
         if (MPI_REQUEST_NULL != requests[i] &&
+            !requests[i]->req_persistent &&
             MPI_SUCCESS != requests[i]->req_status.MPI_ERROR) {
 #if OPAL_ENABLE_FT_MPI
             /* Special case for MPI_ANY_SOURCE when marked as


### PR DESCRIPTION
@mentOS31 correctly identified few issues with the handling of persistent requests with regard to their error codes (more info in the issue). This PR fixes all wait and test function to have a consistent outcome for all types of requests. It also prevents the error handler invocation from releasing persistent requests.


(cherry picked from commit 38a7fbb837a9ffe48544dc6223201ac52b393b10)