### PR TITLE
v5.0.x: coll/ucc: enable asymmetric datatype check in UCC without OMPI fallback

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -27,6 +27,7 @@ static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, size_t sc
         if (!is_inplace) {
             ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
         }
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if ((COLL_UCC_DT_UNSUPPORTED == ucc_sdt) ||
             (COLL_UCC_DT_UNSUPPORTED == ucc_rdt)) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
@@ -34,13 +35,16 @@ static inline ucc_status_t mca_coll_ucc_gatherv_init(const void *sbuf, size_t sc
                         sdtype->super.name : rdtype->super.name);
             goto fallback;
         }
+#endif
     } else {
         ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if (COLL_UCC_DT_UNSUPPORTED == ucc_sdt) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
                         sdtype->super.name);
             goto fallback;
         }
+#endif
     }
 
     ucc_coll_args_t coll = {

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -29,6 +29,7 @@ ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const int *scounts,
             ucc_rdt = ompi_dtype_to_ucc_dtype(rdtype);
         }
 
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if ((COLL_UCC_DT_UNSUPPORTED == ucc_sdt) ||
             (COLL_UCC_DT_UNSUPPORTED == ucc_rdt)) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
@@ -36,13 +37,16 @@ ucc_status_t mca_coll_ucc_scatterv_init(const void *sbuf, const int *scounts,
                         sdtype->super.name : rdtype->super.name);
             goto fallback;
         }
+#endif
     } else {
         ucc_rdt = ompi_dtype_to_ucc_dtype(rdtype);
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if (COLL_UCC_DT_UNSUPPORTED == ucc_rdt) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
                         rdtype->super.name);
             goto fallback;
         }
+#endif
     }
 
     ucc_coll_args_t coll = {


### PR DESCRIPTION
This change enables UCC to perform asymmetric datatype checks internally for gather, gatherv, scatter, and scatterv operations. This feature is only available in UCC 1.8 or greater.

The motivation for this change is to avoid scenarios where a subset of processes fallback to OMPI while other processes proceed to UCC when asymmetric datatypes are supplied. By letting UCC handle the datatype asymmetry check, UCC can signal all processes to fallback when necessary, ensuring consistent collective operation execution across all ranks.