### PR TITLE
v6.0.x: coll/ucc: enable asymmetric datatype check in UCC without OMPI fallback 

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -24,6 +24,27 @@ mca_coll_ucc_gather_init_common(const void *sbuf, size_t scount, struct ompi_dat
     int comm_size = ompi_comm_size(ucc_module->comm);
     uint64_t flags = 0;
 
+#if UCC_API_VERSION >= UCC_VERSION(1, 8)
+    if (comm_rank == root) {
+        if ((is_inplace || ompi_datatype_is_contiguous_memory_layout(sdtype, scount)) &&
+            ompi_datatype_is_contiguous_memory_layout(rdtype, rcount * comm_size)) {
+            ucc_rdt = ompi_dtype_to_ucc_dtype(rdtype);
+            if (!is_inplace) {
+                ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
+            }
+        } else {
+            ucc_sdt = COLL_UCC_DT_UNSUPPORTED;
+            ucc_rdt = COLL_UCC_DT_UNSUPPORTED;
+        }
+    } else {
+        if (ompi_datatype_is_contiguous_memory_layout(sdtype, scount)) {
+            ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
+        } else {
+            ucc_sdt = COLL_UCC_DT_UNSUPPORTED;
+            ucc_rdt = COLL_UCC_DT_UNSUPPORTED;
+        }
+    }
+#else
     if (comm_rank == root) {
         if (!(is_inplace || ompi_datatype_is_contiguous_memory_layout(sdtype, scount)) ||
             !ompi_datatype_is_contiguous_memory_layout(rdtype, rcount * comm_size)) {
@@ -54,6 +75,7 @@ mca_coll_ucc_gather_init_common(const void *sbuf, size_t scount, struct ompi_dat
             goto fallback;
         }
     }
+#endif
 
     flags = (is_inplace ? UCC_COLL_ARGS_FLAG_IN_PLACE : 0) |
             (persistent ? UCC_COLL_ARGS_FLAG_PERSISTENT : 0);

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -29,6 +29,7 @@ mca_coll_ucc_gatherv_init_common(const void *sbuf, size_t scount, struct ompi_da
         if (!is_inplace) {
             ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
         }
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if ((COLL_UCC_DT_UNSUPPORTED == ucc_sdt) ||
             (COLL_UCC_DT_UNSUPPORTED == ucc_rdt)) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
@@ -36,13 +37,16 @@ mca_coll_ucc_gatherv_init_common(const void *sbuf, size_t scount, struct ompi_da
                         sdtype->super.name : rdtype->super.name);
             goto fallback;
         }
+#endif
     } else {
         ucc_sdt = ompi_dtype_to_ucc_dtype(sdtype);
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if (COLL_UCC_DT_UNSUPPORTED == ucc_sdt) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
                         sdtype->super.name);
             goto fallback;
         }
+#endif
     }
 
     flags = (ompi_count_array_is_64bit(rcounts) ? UCC_COLL_ARGS_FLAG_COUNT_64BIT : 0) |

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -29,6 +29,7 @@ mca_coll_ucc_scatterv_init_common(const void *sbuf, ompi_count_array_t scounts,
             ucc_rdt = ompi_dtype_to_ucc_dtype(rdtype);
         }
 
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if ((COLL_UCC_DT_UNSUPPORTED == ucc_sdt) ||
             (COLL_UCC_DT_UNSUPPORTED == ucc_rdt)) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
@@ -36,13 +37,16 @@ mca_coll_ucc_scatterv_init_common(const void *sbuf, ompi_count_array_t scounts,
                         sdtype->super.name : rdtype->super.name);
             goto fallback;
         }
+#endif
     } else {
         ucc_rdt = ompi_dtype_to_ucc_dtype(rdtype);
+#if UCC_API_VERSION < UCC_VERSION(1, 8)
         if (COLL_UCC_DT_UNSUPPORTED == ucc_rdt) {
             UCC_VERBOSE(5, "ompi_datatype is not supported: dtype = %s",
                         rdtype->super.name);
             goto fallback;
         }
+#endif
     }
 
     flags = (ompi_count_array_is_64bit(scounts) ? UCC_COLL_ARGS_FLAG_COUNT_64BIT : 0) |


### PR DESCRIPTION
This change enables UCC to perform asymmetric datatype checks internally for gather, gatherv, scatter, and scatterv operations. This feature is only available in UCC 1.8 or greater.

The motivation for this change is to avoid scenarios where a subset of processes fallback to OMPI while other processes proceed to UCC when asymmetric datatypes are supplied. By letting UCC handle the datatype asymmetry check, UCC can signal all processes to fallback when necessary, ensuring consistent collective operation execution across all ranks.