### PR TITLE
opal/common/ucx: fix opal_common_ucx_mca_pmix_fence and fence_nb to adhere to the pmix standard

### DIFF
--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -26,6 +26,7 @@
 #include "opal/memoryhooks/memory.h"
 #include "opal/util/argv.h"
 #include "opal/util/printf.h"
+#include "opal/util/proc.h"
 
 #include "mpi.h"
 
@@ -433,6 +434,12 @@ OPAL_DECLSPEC int opal_common_ucx_mca_pmix_fence_nb(int *fenced)
 {
     int ret;
     
+    /* Singleton processes don't need PMIx fence */
+    if (opal_process_info.is_singleton) {
+        *fenced = 1;
+        return OPAL_SUCCESS;
+    }
+    
     ret = PMIx_Fence_nb(NULL, 0, NULL, 0, opal_common_ucx_mca_fence_complete_cb, (void *) fenced);
     
     if (PMIX_OPERATION_SUCCEEDED == ret) {
@@ -449,6 +456,11 @@ OPAL_DECLSPEC int opal_common_ucx_mca_pmix_fence(ucp_worker_h worker)
 {
     volatile int fenced = 0;
     int ret;
+
+    /* Singleton processes don't need PMIx fence */
+    if (opal_process_info.is_singleton) {
+        return OPAL_SUCCESS;
+    }
 
     ret = PMIx_Fence_nb(NULL, 0, NULL, 0, opal_common_ucx_mca_fence_complete_cb,
                         (void *) &fenced);


### PR DESCRIPTION
The PMIx_Fence_nb() function can return PMIX_OPERATION_SUCCEEDED when the fence operation completes immediately/atomically. In this case, the callback will NOT be invoked by PMIx.

The original code would wait indefinitely for the callback to set the fenced flag, resulting in an infinite loop or deadlock.

This fix explicitly invokes the callback when PMIX_OPERATION_SUCCEEDED is returned, ensuring the fenced flag is properly set.

Fixed in both:
- opal_common_ucx_mca_pmix_fence_nb()
- opal_common_ucx_mca_pmix_fence()