### PR TITLE
OSHMEM/MCA/ATOMIC/UCX: check UCX version for non-blocking atomics value packing

### DIFF
--- a/oshmem/mca/atomic/ucx/atomic_ucx_module.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_module.c
@@ -29,12 +29,19 @@ static ucp_request_param_t mca_spml_ucp_request_params[] = {
 };
 #endif
 
+static int mca_atomic_ucx_nb_support = 0;
+
 /*
  * Initial query function that is invoked during initialization, allowing
  * this module to indicate what level of thread support it provides.
  */
 int mca_atomic_ucx_startup(bool enable_progress_threads, bool enable_threads)
 {
+    unsigned major, minor, release_number;
+    ucp_get_version(&major, &minor, &release_number);
+
+    mca_atomic_ucx_nb_support = UCX_VERSION(major, minor, release_number) >= UCX_VERSION(1, 20, 0);
+
     return OSHMEM_SUCCESS;
 }
 
@@ -73,7 +80,15 @@ int mca_atomic_ucx_op(shmem_ctx_t ctx,
     status_ptr = ucp_atomic_op_nbx(ucx_ctx->ucp_peers[pe].ucp_conn,
                                    op, &value, 1, rva, ucx_mkey->rkey,
                                    &mca_spml_ucp_request_params[size >> 3]);
-    res = UCS_PTR_IS_ERR(status_ptr) ? OSHMEM_ERROR : OSHMEM_SUCCESS;
+    if (mca_atomic_ucx_nb_support) {
+        /* UCX is packing (copying) the value pointer, so there's no need to wait for completion
+           (no stack corruption concerns). Additionally, there's no need to free the status pointer 
+           as its already freed by ucp_atomic_op_nbx when a reply buffer is not provided. */
+        res = UCS_PTR_IS_ERR(status_ptr) ? OSHMEM_ERROR : OSHMEM_SUCCESS;
+    } else {
+        res = opal_common_ucx_wait_request(status_ptr, ucx_ctx->ucp_worker[0], 
+                                           "ucp_atomic_op_nbx");
+    }
 #else
     status = ucp_atomic_post(ucx_ctx->ucp_peers[pe].ucp_conn,
                              op, value, size, rva,


### PR DESCRIPTION
# What
Added a check for UCX version which packs the atomic operation "value" buffer

# Why
Otherwise, we might cause stack corruption when UCX tries to access the atomic value pointer after exiting `mca_atomic_ucx_op` scope

This is a fix for changes introduced in #13568, and relevant for those cherry-pick PRs: #13631 and #13608