### PR TITLE
Github Action: enforce cherry picks on this release branch (v6.0.x)

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: open-mpi/pr-git-commit-checker@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
+          cherry-pick-required: true
   label:
     permissions:
       pull-requests: write


### PR DESCRIPTION
v6.0.x is a release branch; set the parameter on the Github action to enforce cherry picks.

bot:notacherrypick