### PR TITLE
Fixed typo in mpicc manpage v5.0.x

### DIFF
--- a/docs/man-openshmem/man1/oshmem-wrapper-compiler.1.rst
+++ b/docs/man-openshmem/man1/oshmem-wrapper-compiler.1.rst
@@ -113,7 +113,7 @@ Open MPI provides wrapper compilers for several languages:
 * ``oshfort``, ``shmemfort``: Fortran
 
 The wrapper compilers for each of the languages are identical; they
-can be use interchangeably.  The different names are provided solely
+can be used interchangeably.  The different names are provided solely
 for backwards compatibility.
 
 


### PR DESCRIPTION
(cherry picked from commit feba40bdf8413b344065ad0fce215e57c02a1db9)