### PR TITLE
v5.0.x: mpi_f08: remove invalid fast check for request_get_status

### DIFF
--- a/ompi/mpi/fortran/mpif-h/request_get_status_f.c
+++ b/ompi/mpi/fortran/mpif-h/request_get_status_f.c
@@ -12,6 +12,9 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,17 +78,18 @@ void ompi_request_get_status_f(MPI_Fint *request, ompi_fortran_logical_t *flag,
     MPI_Request c_req = PMPI_Request_f2c( *request );
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    /* This seems silly, but someone will do it */
+    /* BUGFIX: removed invalid fast check for MPI_STATUS_IGNORE.
+     * Must always call PMPI_Request_get_status to get the correct flag value.
+     * See issue #13671 */
 
-    if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
-        *flag = OMPI_INT_2_LOGICAL(0);
-        c_ierr = MPI_SUCCESS;
-    } else {
-        c_ierr = PMPI_Request_get_status(c_req,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
-                                        &c_status);
-        OMPI_SINGLE_INT_2_LOGICAL(flag);
+    c_ierr = PMPI_Request_get_status(c_req,
+                                    OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
+                                    &c_status);
+    OMPI_SINGLE_INT_2_LOGICAL(flag);
+    
+    if (!OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
         PMPI_Status_c2f( &c_status, status );
     }
+    
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }


### PR DESCRIPTION
Backport of commit 95e4599ed2 from main branch.

In v5.0.x, the F08 bindings use the mpif-h layer, so the fix is applied to ompi/mpi/fortran/mpif-h/request_get_status_f.c instead of the use-mpi-f08 template file.

The invalid fast-path optimization would return early with flag=false when MPI_STATUS_IGNORE was passed, even for completed operations. The fix ensures PMPI_Request_get_status is always called to get the correct flag value.

Related to issue #13671

bot:notacherrypick

## Key Difference: Architecture Changed Between Versions

The Fortran F08 bindings were **completely refactored** between v5.0.x and main, requiring a different backport approach.

---

## Original PR (main branch)

**File Modified:** `ompi/mpi/fortran/use-mpi-f08/request_get_status.c.in`

### Architecture (main)
- Uses **template files** (`.c.in`) that are processed at build time
- Direct C implementation of F08 binding
- Uses `@INNER_CALL@` macro that gets expanded during build

### Original Change (main)
```c
// BEFORE (buggy code):
if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
    c_ierr = MPI_SUCCESS;              // ❌ BUG: doesn't set flag!
} else {
    c_ierr = @INNER_CALL@(c_req,
                          &c_flag,
                          &c_status);
}

// AFTER (fixed):
c_ierr = @INNER_CALL@(c_req,          // ✓ Always call to get flag
                      &c_flag,
                      &c_status);
```

**Lines changed:** 14 lines (5 insertions, 9 deletions)

---

## Backport (v5.0.x branch)

**File Modified:** `ompi/mpi/fortran/mpif-h/request_get_status_f.c`

### Architecture (v5.0.x)
- Uses **F90 wrapper** files (`.F90`) that call into mpif-h layer
- F08 binding calls → F90 wrapper → mpif-h C implementation
- The actual bug is in the **mpif-h** layer, not use-mpi-f08

### Backport Change (v5.0.x)
```c
// BEFORE (buggy code):
if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
    *flag = OMPI_INT_2_LOGICAL(0);     // ❌ BUG: sets flag to false!
    c_ierr = MPI_SUCCESS;
} else {
    c_ierr = PMPI_Request_get_status(c_req,
                                    OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                                    &c_status);
    OMPI_SINGLE_INT_2_LOGICAL(flag);
    PMPI_Status_c2f( &c_status, status );
}

// AFTER (fixed):
c_ierr = PMPI_Request_get_status(c_req,     // ✓ Always call to get flag
                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                                &c_status);
OMPI_SINGLE_INT_2_LOGICAL(flag);

if (!OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {  // ✓ Only convert if needed
    PMPI_Status_c2f( &c_status, status );
}
```

**Lines changed:** 18 lines (9 insertions, 9 deletions)

---

## Comparison Summary

| Aspect | Original PR (main) | Backport (v5.0.x) |
|--------|-------------------|-------------------|
| **File** | `use-mpi-f08/request_get_status.c.in` | `mpif-h/request_get_status_f.c` |
| **Type** | Template file (`.c.in`) | C source file (`.c`) |
| **Layer** | F08 direct binding | mpif-h layer (called by F08 wrapper) |
| **Macro** | Uses `@INNER_CALL@` | Direct `PMPI_Request_get_status()` call |
| **Logic** | Simpler - unconditional call | More complex - separate status conversion |
| **Lines** | 14 changed | 18 changed |

---

## Why They're Different

### 1. **Architectural Change**
Between v5.0.x and main, the F08 bindings were refactored:
- **v5.0.x**: F08 → F90 wrapper → mpif-h C layer
- **main**: F08 → Direct C template implementation

### 2. **Bug Location**
- **main**: Bug was in the F08 template file
- **v5.0.x**: Bug is in the shared mpif-h layer that F08 wraps

### 3. **Status Handling**
- **main**: `@INNER_CALL@` handles status internally
- **v5.0.x**: Must explicitly convert status with `PMPI_Status_c2f()` only when not ignored

### 4. **Flag Handling**
- **main**: Uses `int c_flag`
- **v5.0.x**: Uses `ompi_fortran_logical_t *flag` with conversion macros

---
