### PR TITLE
ompi_nvidia CI: add concurrency queue to serialize PR runs

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -2,6 +2,11 @@ name: ompi_NVIDIA CI
 on: [pull_request]
 permissions:
   contents: read
+
+concurrency:
+  group: ompi-ci-nvidia
+  cancel-in-progress: false
+
 jobs:
 
   nvidia_deployment:


### PR DESCRIPTION
### Add concurrency control to serialize NVIDIA CI runs.

## Why

The NVIDIA CI crashes when multiple PRs run simultaneously due to pod collisions in the self-hosted runner infrastructure. All workflow instances share the same pod resources, causing conflicts when executed in parallel.

This change adds a concurrency queue to serialize CI executions, ensuring only one PR runs at a time and preventing resource conflicts.

## References

- GitHub Actions concurrency documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency