### PR TITLE
Fix the generated files for VPATH builds

### DIFF
--- a/ompi/mpi/bindings/ompi_bindings/c.py
+++ b/ompi/mpi/bindings/ompi_bindings/c.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
 # Copyright (c) 2023      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -378,7 +379,7 @@ def generate_header(args, out):
 def generate_source(args, out):
     """Generate source file."""
     out.dump(f'/* {consts.GENERATED_MESSAGE} */')
-    template = SourceTemplate.load(args.source_file, type_constructor=Type.construct)
+    template = SourceTemplate.load(args.source_file, args.srcdir, type_constructor=Type.construct)
     base_name = util.mpi_fn_name_from_base_fn_name(template.prototype.name)
     if args.type == 'ompi':
         ompi_abi(base_name, template, out)

--- a/ompi/mpi/bindings/ompi_bindings/parser.py
+++ b/ompi/mpi/bindings/ompi_bindings/parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024      Triad National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -7,6 +8,8 @@
 #
 # $HEADER$
 """Source parsing code."""
+
+import os
 
 class Parameter:
 

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -22,6 +22,7 @@
 # Copyright (c) 2025      Advanced Micro Devices, Inc. All Rights reserved.
 # Copyright (c) 2025-2026 Triad National Security, LLC.  All rights reserved.
 # Copyright (c) 2025      UT-Battelle, LLC.  All rights reserved.
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -1008,8 +1009,8 @@ mpi_bindings_generated.stamp: $(prototype_sources)
 	    base=`echo "$$src" | sed 's/\\.c\\.in$$//'`; \
 	    out="$$base"_generated.c; \
 	    $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
-	        --builddir $(abs_top_builddir) \
-	        --srcdir $(abs_top_srcdir) \
+	        --builddir $(abs_builddir) \
+	        --srcdir $(abs_srcdir) \
 	        --output "$$out" \
 	        c \
 	        source \


### PR DESCRIPTION
In VPATH builds we need to point to the right location for the source and the output files.

Fixes the VPATH build issue introduced in #13670