### PR TITLE
BSD: better makefile changes

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -21,7 +21,7 @@ dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
-dnl Copyright (c) 2019-2021 Triad National Security, LLC. All rights
+dnl Copyright (c) 2019-2026 Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl
 dnl $COPYRIGHT$
@@ -39,13 +39,18 @@ opal_show_subtitle "General configuration options"
 # Is this a developer copy?
 #
 
+AC_MSG_CHECKING([Checking if this is a developer copy])
 if test -d ${OPAL_TOP_SRCDIR}/.git; then
     OPAL_DEVEL=1
+    AC_MSG_RESULT([yes])
 else
     OPAL_DEVEL=0
+    AC_MSG_RESULT([no])
 fi
-
-
+AM_CONDITIONAL([OPAL_DEVEL_BUILD], [test "$OPAL_DEVEL" = "1"])
+AS_IF([test "$OPAL_DEVEL" = "1"],
+          [OPAL_SUMMARY_ADD([Miscellaneous], [Developer build], [], ["yes"])],
+          [OPAL_SUMMARY_ADD([Miscellaneous], [Developer build], [], ["no"])])
 #
 # Code coverage options
 #

--- a/ompi/mpi/bindings/ompi_bindings/c.py
+++ b/ompi/mpi/bindings/ompi_bindings/c.py
@@ -379,7 +379,7 @@ def generate_header(args, out):
 def generate_source(args, out):
     """Generate source file."""
     out.dump(f'/* {consts.GENERATED_MESSAGE} */')
-    template = SourceTemplate.load(args.source_file, args.srcdir, type_constructor=Type.construct)
+    template = SourceTemplate.load(args.source_file, type_constructor=Type.construct)
     base_name = util.mpi_fn_name_from_base_fn_name(template.prototype.name)
     if args.type == 'ompi':
         ompi_abi(base_name, template, out)

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -40,6 +40,8 @@
 
 include $(top_srcdir)/Makefile.ompi-rules
 
+SUFFIXES= _generated.c .c.in
+
 noinst_LTLIBRARIES = libmpi_c.la libmpi_c_profile.la
 if BUILD_MPI_BINDINGS_LAYER
 noinst_LTLIBRARIES += libmpi_c_noprofile.la
@@ -499,7 +501,7 @@ prototype_sources = \
         wtime.c.in
 
 # Include template files in case someone wants to update them
-EXTRA_DIST = $(prototype_sources) mpi_bindings_generated.stamp
+EXTRA_DIST = $(prototype_sources)
 
 # attr_fn.c contains attribute manipulation functions which do not
 # profiling implications, and so are always built.
@@ -1003,23 +1005,18 @@ libmpi_c_noprofile_la_SOURCES = $(interface_profile_sources)
 libmpi_c_noprofile_la_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=0
 
 # ABI generation rules
-mpi_bindings_generated.stamp: $(prototype_sources)
-	@set -e; \
-	for src in $(prototype_sources); do \
-	    base=`echo "$$src" | sed 's/\\.c\\.in$$//'`; \
-	    out="$$base"_generated.c; \
-	    $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
-	        --builddir $(abs_builddir) \
-	        --srcdir $(abs_srcdir) \
-	        --output "$$out" \
-	        c \
-	        source \
-	        ompi \
-	        "$$src"; \
-	done; \
-	touch $@
-
-$(interface_profile_sources): mpi_bindings_generated.stamp
+.c.in_generated.c:
+	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
+	    --builddir $(abs_top_builddir) \
+	    --srcdir $(abs_top_srcdir) \
+	    --output $@ \
+	    c \
+	    source \
+	    ompi \
+	    $<
 
 # Delete generated files on maintainer-clean
-MAINTAINERCLEANFILES = *_generated.c mpi_bindings_generated.stamp
+MAINTAINERCLEANFILES = *_generated.c
+if OPAL_DEVEL_BUILD
+CLEANFILES += *_generated.c
+endif

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -11,7 +11,7 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
-# Copyright (c) 2019-2022 Triad National Security, LLC. All rights
+# Copyright (c) 2019-2026 Triad National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2022      IBM Corporation.  All rights reserved.
@@ -453,6 +453,9 @@ EXTRA_DIST = $(prototype_files)
 
 # Delete generated file on maintainer-clean
 MAINTAINERCLEANFILES = api_f08_generated.F90
+if OPAL_DEVEL_BUILD
+CLEANFILES += api_f08_generated.F90
+endif
 
 ###########################################################################
 

--- a/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
@@ -3,6 +3,8 @@
 # Copyright (c) 2019      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2020      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (C) 2026      Triad National Security, LLC. All rights
+#                         reserved.
 #
 # $COPYRIGHT$
 #
@@ -62,5 +64,8 @@ api_f08_generated.c: $(template_files)
 
 # Delete generated files on maintainer-clean
 MAINTAINERCLEANFILES = api_f08_generated.c
+if OPAL_DEVEL_BUILD
+CLEANFILES += api_f08_generated.c
+endif
 
 endif

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2015-2024 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
-# Copyright (C) 2024      Triad National Security, LLC. All rights
+# Copyright (C) 2024-2026 Triad National Security, LLC. All rights
 #                         reserved.
 #
 # $COPYRIGHT$
@@ -99,6 +99,9 @@ mpi-f08-interfaces-generated.h: $(template_files)
 
 # Delete generated file on maintainer-clean
 MAINTAINERCLEANFILES = mpi-f08-interfaces-generated.h
+if OPAL_DEVEL_BUILD
+CLEANFILES += mpi-f08-interfaces-generated.h
+endif
 
 #
 # Automake doesn't do Fortran dependency analysis, so must list them

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -8,7 +8,7 @@
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 # Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
-# Copyright (c) 2025      Triad National Security, LLC. All rights
+# Copyright (c) 2025-2026 Triad National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -160,6 +160,9 @@ CLEANFILES += mpi-ignore-tkr-sizeof.h mpi-ignore-tkr-sizeof.f90
 MOSTLYCLEANFILES = *.mod
 CLEANFILES += *.i90
 MAINTAINERCLEANFILES = mpi-ignore-tkr-interfaces-generated.h
+if OPAL_DEVEL_BUILD
+CLEANFILES += mpi-ignore-tkr-interfaces-generated.h
+endif
 
 # Install the generated .mod files.  Unfortunately, each F90 compiler
 # may generate different filenames, so we have to use a glob.  :-(


### PR DESCRIPTION
use the SUFFIXES mechanism to replace not-so-good
time stamp based mechanism for making *_generated.c files from *.c.in files.

Improve the behavior of make clean to remove generated files when building from a git checkout of the project.