### PR TITLE
btl/ofi: fault tolerance fixes

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -389,7 +389,15 @@ int mca_btl_ofi_context_progress(mca_btl_ofi_context_t *context)
             MCA_BTL_OFI_ABORT();
         } else if(NULL != cqerr.op_context){
             switch(cqerr.err) {
-            case -FI_EIO: {
+            case FI_EREMOTEIO:
+            case FI_EHOSTUNREACH:
+            case FI_ECONNABORTED:
+            case FI_ECONNRESET:
+#ifdef FI_EHOSTDOWN
+            // FI_EHOSTDOWN added in libfabric 1.6.0
+            case FI_EHOSTDOWN:
+#endif
+            case FI_EIO: {
                 mca_btl_ofi_completion_context_t *c_ctx =
                     (mca_btl_ofi_completion_context_t*) cqerr.op_context;
                 mca_btl_ofi_base_completion_t *comp =

--- a/opal/mca/btl/ofi/btl_ofi_frag.c
+++ b/opal/mca/btl/ofi/btl_ofi_frag.c
@@ -44,6 +44,7 @@ mca_btl_ofi_frag_completion_t *mca_btl_ofi_frag_completion_alloc(mca_btl_base_mo
 
     comp = (mca_btl_ofi_frag_completion_t *) opal_free_list_get(&context->frag_comp_list);
     comp->base.btl = btl;
+    comp->base.endpoint = frag->endpoint;
     comp->base.my_context = context;
     comp->base.my_list = &context->frag_comp_list;
     comp->base.type = type;
@@ -158,8 +159,10 @@ int mca_btl_ofi_recv_frag(mca_btl_ofi_module_t *ofi_btl, mca_btl_base_endpoint_t
                                                    .tag = frag->hdr.tag,
                                                    .cbdata = reg->cbdata};
 
-    /* call the callback */
-    reg->cbfunc(&ofi_btl->super, &recv_desc);
+    if (OPAL_LIKELY(OPAL_SUCCESS == rc)) {
+        /* call the callback */
+        reg->cbfunc(&ofi_btl->super, &recv_desc);
+    }
     mca_btl_ofi_frag_complete(frag, rc);
 
     /* repost the recv */


### PR DESCRIPTION
Turns out my initial tests were lucky and faults were always detected elsewhere, because `cqerr.err` is the positive error value, not the negative. I also dug through the libfabric repo to find any more error codes that would indicate a failed rank.

Frag completions weren't setting the base completion's endpoint pointer. Always reporting failure on a null process was causing ob1 to abort every time.

Finally, don't call the fragment's callback if a 'received' message actually failed to be received. I weirdly wasn't getting errors from this, but digging through the TCP btl confirms that it's incorrect behavior.