### PR TITLE
v5.0.x: Add secret exception for trufflehog scan

### DIFF
--- a/.nspect-allowlist.toml
+++ b/.nspect-allowlist.toml
@@ -1,0 +1,9 @@
+version = "1.0.0"
+
+# Allowlist for test private key in libevent library
+[[pulse-trufflehog.files]]
+file = "3rd-party/libevent-2.1.12-stable.tar.gz"
+
+[[pulse-trufflehog.files.secrets]]
+type = "PrivateKey"
+values = [ "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAtK07Ili0dkJb79m/" ]


### PR DESCRIPTION
This PR adds an allowlist configuration to exclude a false positive detection of a test private key in the libevent library.

The file is part of the libevent test suite and is not a real secret.