### PR TITLE
OSHMEM: squash compiler warning

### DIFF
--- a/oshmem/shmem/c/shmem_put_nb.c
+++ b/oshmem/shmem/c/shmem_put_nb.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 


### PR DESCRIPTION
without this patch I keep seeing this compiler warning when building with newer gcc's.

shmem_put_nb.c:230:6: warning: no previous prototype for ‘shmemx_alltoall_global_nb’ [-Wmissing-prototypes]
 void shmemx_alltoall_global_nb(void *dest,
      ^~~~~~~~~~~~~~~~~~~~~~~~~