### PR TITLE
Fix inverted collective_buffering hint logic

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -328,7 +328,7 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     bool info_is_set=false;
     opal_info_get (info, "collective_buffering", &stripe_str, &flag);
     if ( flag ) {
-        if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
+        if ( 0 == strncasecmp(stripe_str->string, "false", 5) ){
             info_is_set = true;
             OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "enforcing using individual fcoll component");
         } else {
@@ -340,7 +340,7 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     } else {
         opal_info_get (fh->f_info, "collective_buffering", &stripe_str, &flag);
         if ( flag ) {
-            if ( strncmp ( stripe_str->string, "false", sizeof("true") )){
+            if ( 0 == strncasecmp(stripe_str->string, "false", 5) ){
                 info_is_set = true;
                 OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "enforcing using individual fcoll component");
             } else {


### PR DESCRIPTION
The collective_buffering hint had inverted logic due to incorrect use of strncmp. When set to 'true', it would disable collective buffering, and when set to 'false' it would enable it.


(cherry picked from commit 1ebc899f26723460d25eac009388dc37686652df)