### PR TITLE
v6.0.x: GitHubAction: add timeout for compile-ze and more

### DIFF
--- a/.github/workflows/compile-ze.yaml
+++ b/.github/workflows/compile-ze.yaml
@@ -14,13 +14,15 @@ jobs:
         sudo apt update
         sudo apt install -y --no-install-recommends wget lsb-core software-properties-common gpg curl cmake git
     - name: Build OneAPI ZE  
+      # for some reason the build of the level-zero stuff can take a long time
+      timeout-minutes: 20
       run: |
         git clone https://github.com/oneapi-src/level-zero.git
         cd level-zero
         mkdir build
         cd build
         cmake ../ -DCMAKE_INSTALL_PREFIX=/opt/ze
-        sudo make -j install
+        sudo make -j1 install
     - uses: actions/checkout@v4
       with:
             submodules: recursive


### PR DESCRIPTION
something's changed and now it takes a long time to compile some of the ZE components, so give it up to 20 minutes.

also reduce parallelism of level zero libraries builds as this seems to stress the runner as well.


(cherry picked from commit 1947d759a223d124608d39ed6ff703012372c175)