### PR TITLE
docs: update documentation of collective operations -v6.0.x

### DIFF
--- a/docs/tuning-apps/collectives/acoll.rst
+++ b/docs/tuning-apps/collectives/acoll.rst
@@ -1,0 +1,175 @@
+Working with the ``acoll`` Collective Component
+===============================================
+
+Introduction
+------------
+
+The ``acoll`` (AMD Collective) component is a high-performance MPI collective implementation optimized for AMD Zen-based processors. At present, ``acoll`` is optimized for the following commonly used collective algorithms:
+
+- MPI_Allgather
+- MPI_Allreduce
+- MPI_Alltoall
+- MPI_Barrier
+- MPI_Bcast
+- MPI_Gather
+- MPI_Reduce
+
+The component uses topology-aware algorithms that leverage subgroups, NUMA domains, and socket hierarchies to achieve optimal performance on AMD Zen architectures.
+
+Enabling the acoll Component
+-----------------------------
+
+To enable the ``acoll`` component, set its priority higher than other collective components:
+
+.. code-block:: sh
+
+   shell$ mpirun <common mpi runtime parameters> --bind-to core \
+                 --mca coll acoll,tuned,libnbc,basic --mca coll_acoll_priority 40 <executable>
+
+The component will only activate for communicators meeting the minimum size threshold (default: 16 ranks). Use ``--bind-to core`` for optimal performance.
+
+MCA Parameters
+--------------
+
+Core Configuration
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``coll_acoll_priority``
+     - 0
+     - Component selection priority
+   * - ``coll_acoll_comm_size_thresh``
+     - 16
+     - Minimum communicator size for which ``acoll`` component is enabled
+
+Topology Parameters
+~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``coll_acoll_max_comms``
+     - 10
+     - Maximum number of nested layers of subcommunicators to be derived by ``acoll`` from a given communicator. For example, for a given parent communicator, child1 is derived out of parent, child2 is derived out of child1, so on till child10 is derived out of child9. No split of child10 is allowed.
+   * - ``coll_acoll_force_numa``
+     - -1
+     - Force NUMA based subgroups to be used in hierarchical version of the broadcast collective. Default is auto-tuned, where NUMA based subgroup is enabled based on communicator size and message size. Force enable (1) or disable (0) NUMA-based communicator split; -1 for auto.
+   * - ``coll_acoll_bcast_socket``
+     - -1
+     - Enable (1) or disable (0) socket based hierarchy rather than node based hierarchy in broadcast and allreduce collectives. The default value is -1, where the hierarchy is pre-configured based on message size and communicator size.
+
+Runtime Optimization Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``coll_acoll_use_dynamic_rules``
+     - 0
+     - Dynamically select algorithms for the broadcast collective. If set to (1), uses the hierarchical algorithm specified by the command line arguments ``coll_acoll_bcast_lin0``, ``coll_acoll_bcast_lin1``, ``coll_acoll_bcast_lin2``.
+   * - ``coll_acoll_disable_shmbcast``
+     - 0
+     - If set to (1), disables shared-memory data copy based broadcast collective.
+   * - ``coll_acoll_bcast_lin0``
+     - 0
+     - Choose binomial (0) or flat tree (1) based topology for the first stage of hierarchical broadcast collective.
+   * - ``coll_acoll_bcast_lin1``
+     - 0
+     - Choose binomial (0) or flat tree (1) based topology for the second stage of hierarchical broadcast collective.
+   * - ``coll_acoll_bcast_lin2``
+     - 0
+     - Choose binomial (0) or flat tree (1) based topology for the third stage of hierarchical broadcast collective.
+   * - ``coll_acoll_bcast_nonsg``
+     - 0
+     - If set (1), uses 2 stages instead of 3 stages in hierarchical broadcast collective.
+   * - ``coll_acoll_barrier_algo``
+     - 0
+     - Barrier algorithm selection for the intra-node case: shared-memory hierarchical algorithm (0), shared-memory flat algorithm (1), non-shared memory algorithm (any other value). This parameter is ignored for multinode cases.
+   * - ``coll_acoll_alltoall_split_factor``
+     - 0
+     - Factor that specifies the amount of parallelism to go for in parallel-split alltoall algorithm. Set it to 0 (default) to use pre-configured value that is set based on communicator size, message size and mapping pattern; 2, 4, 8, 16, 32, 64 are supported values.
+   * - ``coll_acoll_alltoall_psplit_msg_thres``
+     - 0
+     - Message size (bytes) threshold below which parallel-split alltoall is enabled. Default is 0 that uses a pre-configured value.
+   * - ``coll_acoll_without_smsc``
+     - 0
+     - Disable Shared Memory Single Copy (SMSC) based algorithms when set to 1. This is applicable to allreduce and reduce collectives.
+   * - ``coll_acoll_smsc_use_sr_buf``
+     - 1
+     - Use application send/recv buffers for SMSC registration instead of temporary buffers. This parameter is applicable when SMSC is enabled using ``coll_acoll_without_smsc``.
+   * - ``coll_acoll_smsc_buffer_size``
+     - 4MB for each rank
+     - Maximum size (bytes) for temporary SMSC buffers (default: 4 MB). This parameter is applicable when SMSC is enabled and ``coll_acoll_smsc_use_sr_buf`` is set to 0.
+   * - ``coll_acoll_reserve_memory_for_algo``
+     - 1
+     - If set to 0, disable allocation of reserved memory for use in ``acoll``.
+   * - ``coll_acoll_reserve_memory_size_for_algo``
+     - 4MB for each rank
+     - Use to specify the amount of reserved memory to be allocated in ``acoll``.
+
+
+Usage Examples
+--------------
+
+Basic Usage
+~~~~~~~~~~~
+
+Enable acoll with default settings:
+
+.. code-block:: sh
+
+   shell$ mpirun --mca coll acoll,tuned,libnbc,basic \
+                 --mca coll_acoll_priority 40 ./my_app
+
+
+Multi-Node Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For multi-node runs, enable dynamic rules:
+
+.. code-block:: sh
+
+   shell$ mpirun --mca coll acoll,tuned,libnbc,basic \
+                 --mca coll_acoll_priority 40 \
+                 --mca coll_acoll_bcast_lin0 0 \
+                 --mca coll_acoll_bcast_lin1 1 \
+                 --mca coll_acoll_bcast_lin2 1 \
+                 --mca coll_acoll_use_dynamic_rules 1 ./my_app
+
+If ``coll_acoll_bcast_lin0``, ``coll_acoll_bcast_lin1``, and ``coll_acoll_bcast_lin2`` are not specified when ``coll_acoll_use_dynamic_rules`` is passed as 1, default value (0) will be used for each of these parameters.
+
+Disabling Shared Memory Single Copy (SMSC)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If SMSC causes issues, disable it:
+
+.. code-block:: sh
+
+   shell$ mpirun --mca coll acoll,tuned,libnbc,basic \
+                 --mca coll_acoll_priority 40 \
+                 --mca coll_acoll_without_smsc 1 ./my_app
+
+Alltoall Tuning
+~~~~~~~~~~~~~~~
+
+Enable parallel split algorithm for alltoall with split factor 4:
+
+.. code-block:: sh
+
+   shell$ mpirun --mca coll acoll,tuned,libnbc,basic \
+                 --mca coll_acoll_priority 40 \
+                 --mca coll_acoll_alltoall_split_factor 4 ./my_app

--- a/docs/tuning-apps/collectives/components.rst
+++ b/docs/tuning-apps/collectives/components.rst
@@ -1,0 +1,113 @@
+Available Collective Components
+===============================
+
+Open MPI's ``coll`` framework provides a number of components
+implementing collective communication, each of which target a
+different environment or scenario.  Some of these components may not
+be available depending on how Open MPI was compiled and what hardware
+is available on the system.  A run-time decision based on each
+component's self reported priority, selects which component will be
+used.  These priorities may be adjusted on the command line or with
+any of the other usual ways of setting MCA variables, giving us a way
+to influence or override component selection.  In the end, which of
+the available components is selected depends on a number of factors
+such as the underlying hardware and the whether or not a specific
+collective is provided by the component as not all components
+implement all collectives.  However, there is always a fallback
+``basic`` component that steps in and takes over when another component
+fails to provide an implementation. 
+
+The following provides a list of components and their primary target scenario:
+
+ - ``han`` : component providing hierarchical algorithms.
+ - ``libnbc``: component providing non-blocking collective operations
+   based on a modified version of the libNBC library.
+ - ``self``: component providing single-process collective algorithms.
+ - ``tuned``: component providing fine grained mechanisms to switch
+   between algorithms for each operation and message size. See :doc:`tuned` for
+   more details.
+ - ``ucc``: component using the `UCC library <https://github.com/openucx/ucc/>`_
+   for collective operations.
+ - ``xhc``: shared memory collective component using XPMEM for data transfers.
+ - ``acoll``: collective component tuned for AMD Zen architectures. See :doc:`acoll` for
+   more details.
+ - ``accelerator``: component providing host-proxy algorithms for some
+   collective operations using device buffers.
+ - ``ftagree``: component providing fault-tolerant collective operations.
+ - ``inter``: component providing collective operaitons for inter-communicators.
+ - ``basic``: component providing basic algorithms, used as a fall-back component.
+ - ``sync``: component used in scenarios where some nodes can be
+   overrun with messages. This component can be used to insert
+   synchronization points every *n-th* execution of a collective
+   operations.
+ - ``portals4``: component targetting portals4 networks.
+
+Different component can and will be used for different collective
+operations, since no component is providing implementations for all
+operations defined in the MPI specification.
+
+Displaying collective component selection
+-----------------------------------------
+
+Open MPI 6.0.x provides a mechanism to display which component has
+been selected for a particular communication and communicator by setting the verbosity level
+of the *coll_base_verbose* mca variable.
+
+Specifically, setting *coll_base_verbose* to certain values will
+influence which functions are precisely being displayed:
+
+ - values between *1 - 19*: will print the selected component for
+   blocking and non-blocking collectives assigned to MPI_COMM_WORLD,
+   but not for persistent collective operations
+ - value *20*: will print the selected component for all blocking and
+   non-blocking collectives for all communicators, but not the
+   persistent collectives
+ - values larger than *20*: will print the selected component for all
+   communicators and all collective operations
+
+Example:
+
+.. code-block:: sh
+
+    shell$ mpiexec --mca coll_base_verbose 10 -n 4 ./<executable>
+    ...
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 allgather -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 allgatherv -> tuned
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 allreduce -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 alltoall -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 alltoallv -> tuned
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 alltoallw -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 barrier -> tuned
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 bcast -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 exscan -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 gather -> tuned
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 gatherv -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 reduce -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 reduce_scatter_block -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 reduce_scatter -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 scan -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 scatter -> tuned
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 scatterv -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 neighbor_allgather -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 neighbor_allgatherv -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 neighbor_alltoall -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 neighbor_alltoallv -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 neighbor_alltoallw -> basic
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 reduce_local -> accelerator
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 iallgather -> libnbc
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 iallgatherv -> libnbc
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 iallreduce -> libnbc
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 ialltoall -> libnbc
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 ialltoallv -> libnbc
+    coll:base:comm_select: communicator MPI_COMM_WORLD rank 1 ialltoallw -> libnbc
+
+ 
+.. note:: While this output can provide valuable information, it might
+   not always accurately reflect which component executes the
+   operation, since some components have built-in logic to call the
+   next component in the priority list if certain conditions are not
+   met. For example, the `accelerator` collective component will use
+   this mechanism to hand-off the execution of the operation to the
+   next component in the priority list if the collective operation
+   invoked does not use device buffers.
+   

--- a/docs/tuning-apps/collectives/index.rst
+++ b/docs/tuning-apps/collectives/index.rst
@@ -1,0 +1,14 @@
+Collective operations
+=====================
+
+Open MPI provides a number of components implementing collective
+operations and significant flexbility to tune collective operations.
+This section documents the available components and gives for some
+components additional information on how to utilize them.
+
+.. toctree::
+   :maxdepth: 1
+
+   components
+   tuned
+   acoll

--- a/docs/tuning-apps/collectives/tuned.rst
+++ b/docs/tuning-apps/collectives/tuned.rst
@@ -1,22 +1,7 @@
-Tuning Collectives
-==================
+The ``tuned`` Component
+=======================
 
-Open MPI's ``coll`` framework provides a number of components implementing
-collective communication, including: ``han``, ``libnbc``, ``self``, ``ucc`` ``base``,
-``sync``, ``xhc``, ``accelerator``, ``basic``, ``ftagree``, ``inter``, ``portals4``, ``acoll``,
-and ``tuned``.  Some of these components may not be available depending on how
-Open MPI was compiled and what hardware is available on the system.  A run-time
-decision based on each component's self reported priority, selects which
-component will be used.  These priorities may be adjusted on the command line
-or with any of the other usual ways of setting MCA variables, giving us a way
-to influence or override component selection.  In the end, which of the
-available components is selected depends on a number of factors such as the
-underlying hardware and the whether or not a specific collective is provided by
-the component as not all components implement all collectives.  However, there
-is always a fallback ``base`` component that steps in and takes over when another
-component fails to provide an implementation.
-
-The remainder of this section describes the tuning options available in the
+This section describes the tuning options available in the
 ``tuned`` collective component.
 
 Fixed, Forced, and Dynamic Decisions

--- a/docs/tuning-apps/index.rst
+++ b/docs/tuning-apps/index.rst
@@ -10,6 +10,7 @@ components that can be tuned to affect behavior at run time.
    environment-var
    networking/index
    accelerators/index
+   collectives/index
    multithreaded
    dynamic-loading
    fork-system-popen
@@ -17,6 +18,5 @@ components that can be tuned to affect behavior at run time.
    large-clusters/index
    affinity
    mpi-io
-   coll-tuned
    benchmarking
    heterogeneity


### PR DESCRIPTION
- split out documentation about components in general
- move documentation for the tuned component into its own file
- add documentation for the acoll component.





(cherry picked from commit 667cae4d0497902d9628fe0a9a1778ed1be15470)