### PR TITLE
UCX: squash compiler warning

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -944,7 +944,7 @@ static inline int ompi_osc_ucx_check_ops_and_flush (ompi_osc_ucx_module_t *modul
     uint64_t base_tmp, tail_tmp;
     int ret = OMPI_SUCCESS;
 
-    if (module->ctx->num_incomplete_req_ops > ompi_osc_ucx_outstanding_ops_flush_threshold) {
+    if ((size_t)module->ctx->num_incomplete_req_ops > ompi_osc_ucx_outstanding_ops_flush_threshold) {
         ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
         if (ret != OPAL_SUCCESS) {
             ret = OMPI_ERROR;


### PR DESCRIPTION
my gcc 15.1.0 is chattier than older gcc's and reported this warning when compiling opal_ucx_common.c

osc_ucx_comm.c: In function 'ompi_osc_ucx_check_ops_and_flush': osc_ucx_comm.c:947:45: warning: comparison of integer expressions of different signedness: 'opal_atomic_int64_t' {aka 'long int'} and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
  947 |     if (module->ctx->num_incomplete_req_ops > ompi_osc_ucx_outstanding_ops_flush_threshold) {
      |                                             ^

this patch squashses that warning.