### PR TITLE
Add secret exception for trufflehog scan

### DIFF
--- a/.nspect-allowlist.toml
+++ b/.nspect-allowlist.toml
@@ -1,0 +1,9 @@
+version = "1.0.0"
+
+# Allowlist for test private key in libevent library
+[[pulse-trufflehog.files]]
+file = "3rd-party/libevent-2.1.12-stable.tar.gz"
+
+[[pulse-trufflehog.files.secrets]]
+type = "PrivateKey"
+values = [ "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAtK07Ili0dkJb79m/" ]


### PR DESCRIPTION
# Add secret exception for security scan
This PR adds an allowlist configuration to exclude a false positive detection of a test private key in the libevent library.

## Background

Security scanning tools may flag a test private key in `3rd-party/libevent-2.1.12-stable.tar.gz`. This is a known false positive for the following reasons:

- The file is part of the libevent test suite (`test/regress_ssl.c`)
- The file is never compiled or executed in Open MPI's build
## Changes

- Added `.nspect-allowlist.toml` configuration file
- Configured exception for the test private key in the libevent tarball
