### PR TITLE
mpif-h: fix request_get_status when MPI_STATUS_IGNORE is passed

### DIFF
--- a/ompi/mpi/fortran/mpif-h/request_get_status_f.c
+++ b/ompi/mpi/fortran/mpif-h/request_get_status_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,16 +76,11 @@ void ompi_request_get_status_f(MPI_Fint *request, ompi_fortran_logical_t *flag,
     MPI_Request c_req = PMPI_Request_f2c( *request );
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    /* This seems silly, but someone will do it */
-
-    if (OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
-        *flag = OMPI_INT_2_LOGICAL(0);
-        c_ierr = MPI_SUCCESS;
-    } else {
-        c_ierr = PMPI_Request_get_status(c_req,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
-                                        &c_status);
-        OMPI_SINGLE_INT_2_LOGICAL(flag);
+    c_ierr = PMPI_Request_get_status(c_req,
+                                    OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
+                                    &c_status);
+    OMPI_SINGLE_INT_2_LOGICAL(flag);
+    if (!OMPI_IS_FORTRAN_STATUS_IGNORE(status)) {
         PMPI_Status_c2f( &c_status, status );
     }
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);


### PR DESCRIPTION
The Fortran mpif-h binding for MPI_Request_get_status incorrectly returned flag=false when MPI_STATUS_IGNORE was passed, without ever checking request completion. Always call PMPI_Request_get_status to get the correct flag value, and only conditionally copy the status back.

This is the mpif-h counterpart to 95e4599ed2 which fixed the same bug in the use-mpi-f08 .c.in template.

Related to issue #13671



(cherry picked from commit fb7766299dc3bb9a0b09d2ff512cf0d2a529ab31)