### PR TITLE
make instance name dynamic array

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -9,6 +9,7 @@
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      BULL S.A.S.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -108,8 +109,9 @@ static opal_finalize_domain_t ompi_instance_common_domain;
 static void ompi_instance_construct (ompi_instance_t *instance)
 {
     instance->i_f_to_c_index = opal_pointer_array_add (&ompi_instance_f_to_c_table, instance);
+    instance->i_name = (char*) malloc (MPI_MAX_OBJECT_NAME);
     instance->i_name[0] = '\0';
-    instance->i_flags = 0;
+    instance->i_flags   = 0;
     instance->i_keyhash = NULL;
     OBJ_CONSTRUCT(&instance->s_lock, opal_mutex_t);
     instance->errhandler_type = OMPI_ERRHANDLER_TYPE_INSTANCE;
@@ -118,6 +120,8 @@ static void ompi_instance_construct (ompi_instance_t *instance)
 
 static void ompi_instance_destruct(ompi_instance_t *instance)
 {
+    free(instance->i_name);
+    instance->i_name = NULL;
     OBJ_DESTRUCT(&instance->s_lock);
 }
 

--- a/ompi/instance/instance.h
+++ b/ompi/instance/instance.h
@@ -29,7 +29,7 @@ struct ompi_instance_t {
     opal_infosubscriber_t  super;
     opal_mutex_t           s_lock;
     int                    i_thread_level;
-    char                   i_name[MPI_MAX_OBJECT_NAME];
+    char                  *i_name;
     uint32_t               i_flags;
 
     /* Attributes */


### PR DESCRIPTION
make the i_name element of the instance structure a dynamic
element. This change was suggested by hppritcha [here](https://github.com/open-mpi/ompi/pull/13667#discussion_r2717253038)
This allows us to keep the size of PREDEFINED_INSTANCE_PAD  to 512 despite adding to the instance structure. Keeping it to 512 make it so we don't introduce breaking change.