### PR TITLE
btl/smcuda and others: disable compiling components without GPU support

### DIFF
--- a/config/opal_check_all_gpus.m4
+++ b/config/opal_check_all_gpus.m4
@@ -1,0 +1,45 @@
+dnl
+dnl Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+
+# OMPI_CHECK_ALL_GPUS(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if any of the supported GPU types are supported.
+# This macro does set any env, just returns a succes/failure
+# result.
+
+
+#
+# Check for any GPU type support. Will have to be adjusted if any new GPU
+# type is added to Open MPI
+#
+AC_DEFUN([OPAL_CHECK_ALL_GPUS],[
+     OPAL_VAR_SCOPE_PUSH([opal_check_allgpus_happy])
+
+     OPAL_CHECK_CUDA([allgpus_cuda],
+	             [opal_allgpus_cuda_support="yes"],
+	             [opal_allgpus_cuda_support="no"])
+
+     OPAL_CHECK_ROCM([allgpus_rocm],
+	             [opal_allgpus_rocm_support="yes"],
+	             [opal_allgpus_rocm_support="no"])
+
+     OPAL_CHECK_ZE([allgpus_ze],
+	             [opal_allgpus_ze_support="yes"],
+	             [opal_allgpus_ze_support="no"])
+
+     AS_IF([test "$opal_allgpus_rocm_support" = "yes" ||
+            test "$opal_allgpus_cuda_support" = "yes" ||
+	    test "$opal_allgpus_ze_support" = "yes"],
+           [$2],
+	   [AC_MSG_WARN([No GPU support detected])
+	   $3])
+
+     OPAL_VAR_SCOPE_POP
+])

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -186,7 +186,7 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
     else
        msg=
        if test -z "$enable_mca_dso"; then
-           enable_mca_dso="accelerator-cuda,accelerator-rocm,accelerator-ze,btl-smcuda,rcache-gpusm,rcache-rgpusm"
+           enable_mca_dso="accelerator-cuda,accelerator-rocm,accelerator-ze"
            msg="(default)"
        fi
        DSO_all=0

--- a/ompi/mca/coll/accelerator/configure.m4
+++ b/ompi/mca/coll/accelerator/configure.m4
@@ -1,0 +1,24 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Advanced Micro Devices, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ompi_coll_accelerator_CONFIG([action-if-can-compile],
+#                                  [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_coll_accelerator_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/coll/accelerator/Makefile])
+
+    OPAL_CHECK_ALL_GPUS([coll_accelerator],
+	        [coll_accelerator_happy="yes"],
+	        [coll_accelerator_happy="no"])
+
+    AS_IF([test "$coll_accelerator_happy" = "yes"],
+	  [$1],
+	  [$2])
+])dnl

--- a/opal/mca/btl/smcuda/configure.m4
+++ b/opal/mca/btl/smcuda/configure.m4
@@ -1,0 +1,24 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Advanced Micro Devices, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_opal_btl_smcuda_CONFIG([action-if-can-compile],
+#                            [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_opal_btl_smcuda_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/btl/smcuda/Makefile])
+
+    OPAL_CHECK_ALL_GPUS([btl_smcuda],
+	        [btl_smcuda_happy="yes"],
+	        [btl_smcuda_happy="no"])
+
+    AS_IF([test "$btl_smcuda_happy" = "yes"],
+	  [$1],
+	  [$2])
+])dnl

--- a/opal/mca/rcache/gpusm/configure.m4
+++ b/opal/mca/rcache/gpusm/configure.m4
@@ -1,0 +1,24 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Advanced Micro Devices, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_opal_rcache_gpusm_CONFIG([action-if-can-compile],
+#                              [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_opal_rcache_gpusm_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/rcache/gpusm/Makefile])
+
+    OPAL_CHECK_ALL_GPUS([rcache_gpusm],
+	        [rcache_gpusm_happy="yes"],
+	        [rcache_gpusm_happy="no"])
+
+    AS_IF([test "$rcache_gpusm_happy" = "yes"],
+	  [$1],
+	  [$2])
+])dnl

--- a/opal/mca/rcache/rgpusm/configure.m4
+++ b/opal/mca/rcache/rgpusm/configure.m4
@@ -1,0 +1,24 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Advanced Micro Devices, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_opal_rcache_gpusm_CONFIG([action-if-can-compile],
+#                              [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_opal_rcache_rgpusm_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/rcache/rgpusm/Makefile])
+
+    OPAL_CHECK_ALL_GPUS([rcache_rgpusm],
+	        [rcache_rgpusm_happy="yes"],
+	        [rcache_rgpusm_happy="no"])
+
+    AS_IF([test "$rcache_rgpusm_happy" = "yes"],
+	  [$1],
+	  [$2])
+])dnl

--- a/opal/mca/smsc/accelerator/configure.m4
+++ b/opal/mca/smsc/accelerator/configure.m4
@@ -1,0 +1,24 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Advanced Micro Devices, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_opal_smsc_accelerator_CONFIG([action-if-can-compile],
+#                                  [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_opal_smsc_accelerator_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/smsc/accelerator/Makefile])
+
+    OPAL_CHECK_ALL_GPUS([smsc_accelerator],
+	        [smsc_accelerator_happy="yes"],
+	        [smsc_accelerator_happy="no"])
+
+    AS_IF([test "$smsc_accelerator_happy" = "yes"],
+	  [$1],
+	  [$2])
+])dnl


### PR DESCRIPTION
certain components only make sense to be compiled if there is any GPU support compiled into the library. The current list contains:

- btl/smcuda
- rcache/gpusm
- rcache/rgpusm
- smsc/accelerator
- coll/accelerator

add a check whether we find any GPU support when configuring the library. If not, do not compile these components.

In addition, the rcache/gpusm, rcache/rgpusm, and btl/smcuda were forced to compile as a dso in 5.0.x, that is not required for 6.0.x anymore: the components do not have a dependency on a particular GPU software stack anymore, they are making fully use of the accelerator framework APIs.