### PR TITLE
btl/self: add accelerator-aware memory copy for put/get

### DIFF
--- a/opal/mca/btl/self/btl_self.c
+++ b/opal/mca/btl/self/btl_self.c
@@ -32,7 +32,56 @@
 #include "btl_self_frag.h"
 #include "opal/class/opal_bitmap.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/mca/accelerator/accelerator.h"
+#include "opal/mca/accelerator/base/base.h"
+#include "opal/mca/btl/base/btl_base_error.h"
 #include "opal/util/proc.h"
+
+/**
+ * Accelerator-aware memory copy. Checks whether src and/or dst reside
+ * in accelerator memory and dispatches to opal_accelerator.mem_copy()
+ * accordingly. Falls back to a regular memcpy() when both buffers are in
+ * host memory.
+ *
+ * @param dst (IN) Destination buffer (host or device memory)
+ * @param src (IN) Source buffer (host or device memory)
+ * @param size (IN) Number of bytes to copy
+ * @return     OPAL_SUCCESS or error status on failure.
+ */
+static int mca_btl_self_memcpy(void *dst, const void *src, size_t size)
+{
+    int dst_dev = MCA_ACCELERATOR_NO_DEVICE_ID;
+    int src_dev = MCA_ACCELERATOR_NO_DEVICE_ID;
+    int dst_type, src_type;
+    int copy_type = MCA_ACCELERATOR_TRANSFER_DTOD;
+    uint64_t flags;
+    int rc;
+
+    dst_type = opal_accelerator.check_addr(dst, &dst_dev, &flags);
+    src_type = opal_accelerator.check_addr(src, &src_dev, &flags);
+
+    if (dst_type < 0 || src_type < 0) {
+        BTL_ERROR(("check_addr failed (dst_type=%d, src_type=%d)", dst_type, src_type));
+        return OPAL_ERROR;
+    }
+
+    if (0 == dst_type && 0 == src_type) {
+        memcpy(dst, src, size);
+        return OPAL_SUCCESS;
+    } else if (dst_type == 0 && src_type > 0) {
+        copy_type = MCA_ACCELERATOR_TRANSFER_DTOH;
+        dst_dev = MCA_ACCELERATOR_NO_DEVICE_ID;
+    } else if (dst_type > 0 && src_type == 0) {
+        copy_type = MCA_ACCELERATOR_TRANSFER_HTOD;
+        src_dev = MCA_ACCELERATOR_NO_DEVICE_ID;
+    }
+
+    rc = opal_accelerator.mem_copy(dst_dev, src_dev, dst, src, size, copy_type);
+    if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+        BTL_ERROR(("accelerator mem_copy failed (rc=%d)", rc));
+    }
+    return rc;
+}
 
 /**
  * PML->BTL notification of change in the process list.
@@ -268,9 +317,9 @@ static int mca_btl_self_put(mca_btl_base_module_t *btl, struct mca_btl_base_endp
                             int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
                             void *cbcontext, void *cbdata)
 {
-    memcpy((void *) (intptr_t) remote_address, local_address, size);
+    int rc = mca_btl_self_memcpy((void *) (intptr_t) remote_address, local_address, size);
 
-    cbfunc(btl, endpoint, local_address, NULL, cbcontext, cbdata, OPAL_SUCCESS);
+    cbfunc(btl, endpoint, local_address, NULL, cbcontext, cbdata, rc);
 
     return OPAL_SUCCESS;
 }
@@ -282,9 +331,9 @@ static int mca_btl_self_get(mca_btl_base_module_t *btl, struct mca_btl_base_endp
                             int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
                             void *cbcontext, void *cbdata)
 {
-    memcpy(local_address, (void *) (intptr_t) remote_address, size);
+    int rc = mca_btl_self_memcpy(local_address, (void *) (intptr_t) remote_address, size);
 
-    cbfunc(btl, endpoint, local_address, NULL, cbcontext, cbdata, OPAL_SUCCESS);
+    cbfunc(btl, endpoint, local_address, NULL, cbcontext, cbdata, rc);
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/self/btl_self_component.c
+++ b/opal/mca/btl/self/btl_self_component.c
@@ -110,6 +110,8 @@ static int mca_btl_self_component_register(void)
     mca_btl_self.btl_flags = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND;
     /* for self, remote completion is local completion */
     mca_btl_self.btl_flags |= MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION;
+    /* put/get go directly to/from accelerator memory, no host staging */
+    mca_btl_self.btl_flags |= MCA_BTL_FLAGS_ACCELERATOR_RDMA;
     mca_btl_self.btl_bandwidth = 100;
     mca_btl_self.btl_latency = 0;
     mca_btl_base_param_register(&mca_btl_self_component.super.btl_version, &mca_btl_self);


### PR DESCRIPTION
The btl/self component was not accelerator aware. Send-to-self operations involving GPU memory would copy data through the host instead of performing a direct device memory copy.

Add mca_btl_self_memcpy() which checks whether src/dst buffers reside in accelerator memory via opal_accelerator.check_addr() and dispatches to opal_accelerator.mem_copy() accordingly, falling back to memcpy() when both buffers are in host memory.

Fixes #12230