### PR TITLE
coll/acoll: Fix sbuf handling in reduce_topo

### DIFF
--- a/ompi/mca/coll/acoll/coll_acoll_reduce.c
+++ b/ompi/mca/coll/acoll/coll_acoll_reduce.c
@@ -66,7 +66,7 @@ static inline int coll_acoll_reduce_topo(const void *sbuf, void *rbuf, size_t co
     int use_socket = (0 == acoll_module->use_socket) ? 1 : acoll_module->use_socket;
     
     tmp_sbuf = (char *) sbuf;
-    if ((MPI_IN_PLACE == sbuf) && (rank == root)) {
+    if (MPI_IN_PLACE == sbuf) {
         tmp_sbuf = (char *) rbuf;
     }
 


### PR DESCRIPTION
Fixes the way MPI_IN_PLACE is handled in coll_acoll_reduce_topo().
This resolves https://github.com/open-mpi/ompi/issues/13736.