### PR TITLE
OMPI/RTE: Modify job name printing to use thread local storage

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -85,56 +85,20 @@ static int _setup_proc_session_dir(char **sdir);
 #define OPAL_PRINT_NAME_ARGS_MAX_SIZE   50
 #define OPAL_PRINT_NAME_ARG_NUM_BUFS    16
 
-static bool fns_init=false;
-static opal_tsd_tracked_key_t print_args_tsd_key;
 static char* opal_print_args_null = "NULL";
 typedef struct {
-    char *buffers[OPAL_PRINT_NAME_ARG_NUM_BUFS];
+    char buffers[OPAL_PRINT_NAME_ARG_NUM_BUFS][OPAL_PRINT_NAME_ARGS_MAX_SIZE + 1];
     int cntr;
 } opal_print_args_buffers_t;
-
-static void
-buffer_cleanup(void *value)
-{
-    int i;
-    opal_print_args_buffers_t *ptr;
-
-    if (NULL != value) {
-        ptr = (opal_print_args_buffers_t*)value;
-        for (i=0; i < OPAL_PRINT_NAME_ARG_NUM_BUFS; i++) {
-            free(ptr->buffers[i]);
-        }
-        free (ptr);
-    }
-    fns_init = false;
-}
 
 static opal_print_args_buffers_t*
 get_print_name_buffer(void)
 {
-    opal_print_args_buffers_t *ptr;
-    int ret, i;
+    static opal_thread_local opal_print_args_buffers_t name_buffer = {
+        .cntr = 0
+    };
 
-    if (!fns_init) {
-        /* setup the print_args function */
-        OBJ_CONSTRUCT(&print_args_tsd_key, opal_tsd_tracked_key_t);
-        opal_tsd_tracked_key_set_destructor(&print_args_tsd_key, buffer_cleanup);
-        fns_init = true;
-    }
-
-    ret = opal_tsd_tracked_key_get(&print_args_tsd_key, (void**)&ptr);
-    if (OPAL_SUCCESS != ret) return NULL;
-
-    if (NULL == ptr) {
-        ptr = (opal_print_args_buffers_t*)malloc(sizeof(opal_print_args_buffers_t));
-        for (i=0; i < OPAL_PRINT_NAME_ARG_NUM_BUFS; i++) {
-            ptr->buffers[i] = (char *) malloc((OPAL_PRINT_NAME_ARGS_MAX_SIZE+1) * sizeof(char));
-        }
-        ptr->cntr = 0;
-        ret = opal_tsd_tracked_key_set(&print_args_tsd_key, (void*)ptr);
-    }
-
-    return (opal_print_args_buffers_t*) ptr;
+    return &name_buffer;
 }
 
 static char* ompi_pmix_print_jobids(const opal_jobid_t job)
@@ -1041,10 +1005,6 @@ int ompi_rte_finalize(void)
     if (NULL != opal_process_info.initial_errhandler) {
         free(opal_process_info.initial_errhandler);
         opal_process_info.initial_errhandler = NULL;
-    }
-
-    if (fns_init) {
-        OBJ_DESTRUCT(&print_args_tsd_key);
     }
 
     /* cleanup our internal nspace hack */


### PR DESCRIPTION
## What
Modify job name printing to use thread local storage instead of heap storage

## Why
Prevent dynamic allocation using malloc during initialization (to avoid race with memory hooks)