### PR TITLE
Replace deprecated inet_ntoa() with inet_ntop()

### DIFF
--- a/contrib/build-mca-comps-outside-of-tree/btl_tcp2_endpoint.c
+++ b/contrib/build-mca-comps-outside-of-tree/btl_tcp2_endpoint.c
@@ -122,7 +122,7 @@ static void mca_btl_tcp2_endpoint_send_handler(int sd, short flags, void* user);
 
 void mca_btl_tcp_endpoint_dump(mca_btl_base_endpoint_t* btl_endpoint, const char* msg)
 {
-    char src[64], dst[64], *status;
+    char src[INET_ADDRSTRLEN], dst[INET_ADDRSTRLEN], *status;
     int sndbuf, rcvbuf, nodelay, flags = -1;
 #if OPAL_ENABLE_IPV6
     struct sockaddr_storage inaddr;
@@ -144,7 +144,7 @@ void mca_btl_tcp_endpoint_dump(mca_btl_base_endpoint_t* btl_endpoint, const char
             }
         }
 #else
-        sprintf(src, "%s", inet_ntoa(inaddr.sin_addr));
+        inet_ntop(AF_INET, &inaddr.sin_addr, src, sizeof(src));
 #endif
         getpeername(btl_endpoint->endpoint_sd, (struct sockaddr*)&inaddr, &addrlen);
 #if OPAL_ENABLE_IPV6
@@ -156,7 +156,7 @@ void mca_btl_tcp_endpoint_dump(mca_btl_base_endpoint_t* btl_endpoint, const char
             }
         }
 #else
-        sprintf(dst, "%s", inet_ntoa(inaddr.sin_addr));
+        inet_ntop(AF_INET, &inaddr.sin_addr, dst, sizeof(dst));
 #endif
 
         if((flags = fcntl(btl_endpoint->endpoint_sd, F_GETFL, 0)) < 0) {

--- a/contrib/openmpi-valgrind.supp
+++ b/contrib/openmpi-valgrind.supp
@@ -67,22 +67,6 @@
 #
 ###############################################################
 
-# inet_ntoa on linux mallocs a static buffer.  We can't free
-# it, so we have to live with it
-{
-  linux_inet_ntoa
-  Memcheck:Leak
-  fun:malloc
-  fun:inet_ntoa
-}
-{
-  linux_inet_ntoa_thread
-  Memcheck:Leak
-  fun:calloc
-  fun:pthread_setspecific
-  fun:inet_ntoa
-}
-
 
 ###############################################################
 #

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -168,7 +168,11 @@ void mca_btl_tcp_endpoint_dump(int level, const char *fname, int lineno, const c
         }
     }
 #    else
-    used += snprintf(&outmsg[used], DEBUG_LENGTH - used, "%s -", inet_ntoa(inaddr.sin_addr));
+    {
+        char ep_addr[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &inaddr.sin_addr, ep_addr, sizeof(ep_addr));
+        used += snprintf(&outmsg[used], DEBUG_LENGTH - used, "%s -", ep_addr);
+    }
     if (used >= DEBUG_LENGTH)
         goto out;
 #    endif
@@ -184,7 +188,11 @@ void mca_btl_tcp_endpoint_dump(int level, const char *fname, int lineno, const c
         }
     }
 #    else
-    used += snprintf(&outmsg[used], DEBUG_LENGTH - used, " %s", inet_ntoa(inaddr.sin_addr));
+    {
+        char ep_addr[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &inaddr.sin_addr, ep_addr, sizeof(ep_addr));
+        used += snprintf(&outmsg[used], DEBUG_LENGTH - used, " %s", ep_addr);
+    }
     if (used >= DEBUG_LENGTH)
         goto out;
 #    endif

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1564,10 +1564,14 @@ static int create_ep(opal_btl_usnic_module_t *module, struct opal_btl_usnic_chan
     } else {
         str = "UNKNOWN";
     }
-    opal_output_verbose(15, USNIC_OUT,
-                        "btl:usnic:create_ep:%s: new usnic local endpoint channel %s: %s:%d",
-                        module->linux_device_name, str, inet_ntoa(sin->sin_addr),
-                        ntohs(sin->sin_port));
+    {
+        char ep_addr[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &sin->sin_addr, ep_addr, sizeof(ep_addr));
+        opal_output_verbose(15, USNIC_OUT,
+                            "btl:usnic:create_ep:%s: new usnic local endpoint channel %s: %s:%d",
+                            module->linux_device_name, str, ep_addr,
+                            ntohs(sin->sin_port));
+    }
 
     return OPAL_SUCCESS;
 }

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -406,7 +406,11 @@ char *opal_net_get_hostname(const struct sockaddr *addr)
     }
     return name;
 #    else
-    return inet_ntoa(((struct sockaddr_in *) addr)->sin_addr);
+    {
+        static char ntop_buf[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &((struct sockaddr_in *) addr)->sin_addr, ntop_buf, sizeof(ntop_buf));
+        return ntop_buf;
+    }
 #    endif
 }
 


### PR DESCRIPTION
`inet_ntoa()` is deprecated according to Linux man pages and is on Fedora's rpminspect forbidden functions list (badfuncs). All occurrences are replaced with `inet_ntop()`, which writes to a caller-provided buffer instead of returning a pointer to an internal static buffer.

Also removed two inet_ntoa valgrind leak suppressions in `contrib/openmpi-valgrind.supp` that are no longer needed.

Files changed:
- opal/util/net.c
- opal/mca/btl/tcp/btl_tcp_endpoint.c
- opal/mca/btl/usnic/btl_usnic_module.c
- contrib/build-mca-comps-outside-of-tree/btl_tcp2_endpoint.c
- contrib/openmpi-valgrind.supp

Fixes #13759