### PR TITLE
Use compiler basename in ltmain_flang_darwin patch

### DIFF
--- a/config/ltmain_flang_darwin.diff
+++ b/config/ltmain_flang_darwin.diff
@@ -1,13 +1,14 @@
 --- config/ltmain.sh
 +++ config/ltmain.sh
-@@ -9024,7 +9024,14 @@
+@@ -9024,7 +9024,15 @@
 	  compile_deplibs="$new_inherited_linker_flags $compile_deplibs"
 	  finalize_deplibs="$new_inherited_linker_flags $finalize_deplibs"
 	else
 -	  compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
 +	  case $host in
 +	    *-*-darwin*)
-+	      case $CC in
++	      func_cc_basename "$CC"
++	      case $func_cc_basename_result in
 +		flang*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
 +		*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
 +	      esac;;
@@ -16,7 +17,7 @@
 	fi
        fi
        dependency_libs=$newdependency_libs
-@@ -9369,7 +9376,7 @@
+@@ -9369,7 +9377,7 @@
            # On Darwin other compilers
            func_cc_basename $CC
            case $func_cc_basename_result in
@@ -25,12 +26,13 @@
                    verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
                    ;;
                *)
-@@ -9869,7 +9876,10 @@
+@@ -9869,7 +9877,11 @@
        # Time to change all our "foo.ltframework" stuff back to "-framework foo"
        case $host in
 	  *-*-darwin*)
 -	  newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
-+	  case $CC in
++	  func_cc_basename "$CC"
++	  case $func_cc_basename_result in
 +	    flang*) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
 +	    *) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
 +	  esac


### PR DESCRIPTION
Checking $CC directly fails if the compiler is given with a full path (e.g., in a Spack-based build). This change fixes the check of the compiler to use the basename, as is done in a few other places.

Resolves #13770 for the main branch.

I haven't tested this with the main branch; I *have* tested it in the context of 5.0.10 (I'll open a separate PR for that shortly). At least in the version of libtool that I have, the ltmain_flang_darwin patch on main does *not* apply cleanly (before or after the changes in this PR): the versions of libtool that I see use a direct `case $CC` in hunk 2 rather than using `func_cc_basename` there, and hunk 3 also doesn't apply cleanly. (The patch on the v5.0.x branch *does* apply cleanly.)