### PR TITLE
v5.0.x: Use compiler basename in ltmain_flang_darwin patch

### DIFF
--- a/config/ltmain_flang_darwin.diff
+++ b/config/ltmain_flang_darwin.diff
@@ -1,13 +1,14 @@
 --- config/ltmain.sh	2025-03-25 11:32:01
 +++ config/ltmain.sh	2025-03-25 11:36:23
-@@ -9023,7 +9023,14 @@
+@@ -9023,7 +9023,15 @@
  	  compile_deplibs="$new_inherited_linker_flags $compile_deplibs"
  	  finalize_deplibs="$new_inherited_linker_flags $finalize_deplibs"
  	else
 -	  compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
 +	  case $host in
 +	    *-*-darwin*)
-+	      case $CC in
++	      func_cc_basename "$CC"
++	      case $func_cc_basename_result in
 +		flang*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
 +		*) compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
 +	      esac;;
@@ -16,21 +17,25 @@
  	fi
        fi
        dependency_libs=$newdependency_libs
-@@ -9367,7 +9374,7 @@
+@@ -9366,8 +9374,9 @@
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
  	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
            # On Darwin other compilers
-           case $CC in
+-          case $CC in
 -              nagfor*)
++          func_cc_basename "$CC"
++          case $func_cc_basename_result in
 +              flang*|nagfor*)
                    verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
                    ;;
                *)
-@@ -9867,7 +9874,10 @@
+@@ -9867,7 +9876,11 @@
        # Time to change all our "foo.ltframework" stuff back to "-framework foo"
        case $host in
  	*-*-darwin*)
 -	  newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
-+	  case $CC in
++	  func_cc_basename "$CC"
++	  case $func_cc_basename_result in
 +	    flang*) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -Wl,-framework,\1%g'`;;
 +	    *) newdeplibs=`$ECHO " $newdeplibs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`;;
 +	  esac


### PR DESCRIPTION
Checking $CC directly fails if the compiler is given with a full path (e.g., in a Spack-based build). This change fixes the check of the compiler to use the basename, as is done in a few other places.

Resolves #13770 for the v5.0.x branch. (See also #13771 for the corresponding PR to main: this is a back-port of that PR.)

Note that this patch differs from the one on main; there were differences in the patch even before this PR. A particularly meaningful difference is in hunk 2: the patch on this branch assumes that the original has `case $CC in`, whereas the patch on main assumes that the original already uses `func_cc_basename $CC` in that hunk. The latest version of libtool that I see matches the patch on this branch rather than the one on main. I am a bit concerned about the robustness of this patch, though: Does the change in the patch on `main` suggest anticipation that this hunk will change in libtool? If so, the patch here won't apply cleanly, since it assumes that libtool currently uses `case $CC in` and here changes that to use `func_cc_basename $CC`.

I have tested this with a spack install on a darwin system with llvm-flang, with the following differences in the package.py for openmpi:

```diff
--- package.py	2026-03-17 07:08:54
+++ /Users/sacks/my_spack_projects/spack_repo/myrepo/packages/openmpi/package.py	2026-03-17 07:03:39
@@ -75,6 +75,13 @@

     version("main", branch="main", submodules=True)

+    version(
+        "5.0.10-flang-fix",
+        git="https://github.com/billsacks/ompi.git",
+        commit="7afcd4a752d4c00901d577264e39b793f9a7ed96",
+        submodules=True
+    )
+
     # Current
     version(
         "5.0.10", sha256="0acecc4fc218e5debdbcb8a41d182c6b0f1d29393015ed763b2a91d5d7374cc6"
@@ -1137,6 +1144,13 @@
         if spec.satisfies("+two_level_namespace platform=darwin"):
             filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")

+    @when("@5.0.10-flang-fix")
+    def autoreconf(self, spec, prefix):
+        perl = which("perl", required=True)
+        perl("autogen.pl")
+        if spec.satisfies("+two_level_namespace platform=darwin"):
+            filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
+
     @when("@5.0.0:5.0.1")
     def autoreconf(self, spec, prefix):
         perl = which("perl", required=True)
```

The openmpi build was successful with that change.
