### PR TITLE
accelerator/cuda: defer VMM/mpool checks in check_addr fast path

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -321,9 +321,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
 
     *flags = 0;
 
-    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
-    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
-
 #if OPAL_CUDA_GET_ATTRIBUTES
     uint32_t is_managed = 0;
     /* With CUDA 7.0, we can get multiple attributes with a single call */
@@ -352,7 +349,20 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         } else {
             return OPAL_ERROR;
         }
-    } else if (CU_MEMORYTYPE_HOST == mem_type) {
+    }
+
+    if (CU_MEMORYTYPE_DEVICE == mem_type && NULL != mem_ctx) {
+        result = cuCtxGetCurrent(&ctx);
+        if (OPAL_UNLIKELY(NULL == ctx)) {
+            cuCtxSetCurrent(mem_ctx);
+        }
+        return 1;
+    }
+
+    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
+    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+
+    if (CU_MEMORYTYPE_HOST == mem_type) {
         if (is_vmm && (vmm_mem_type == CU_MEMORYTYPE_DEVICE)) {
             mem_type = CU_MEMORYTYPE_DEVICE;
             *dev_id = vmm_dev_id;
@@ -377,6 +387,9 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         }
     }
 #else /* OPAL_CUDA_GET_ATTRIBUTES */
+    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
+    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+
     result = cuPointerGetAttribute(&mem_type, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, dbuf);
     if (CUDA_SUCCESS != result) {
         /* If cuda is not initialized, assume it is a host buffer. */


### PR DESCRIPTION
For standard cudaMalloc pointers (DEVICE type with valid context), return early after cuPointerGetAttributes without calling accelerator_cuda_check_vmm or accelerator_cuda_check_mpool.

These checks invoke cuMemRetainAllocationHandle and cuPointerGetAttribute(MEMPOOL_HANDLE) respectively, adding unnecessary CUDA driver call overhead for standard cudaMalloc pointers.

The VMM and mpool checks are preserved for pointers that require them: host-type memory that may be device-backed via VMM or memory pools, and device memory with a NULL context.