### PR TITLE
opal/mca: remove smcuda from dso list - v6.0.x

### DIFF
--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -186,7 +186,7 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
     else
        msg=
        if test -z "$enable_mca_dso"; then
-           enable_mca_dso="accelerator-cuda,accelerator-rocm,accelerator-ze,btl-smcuda,rcache-gpusm,rcache-rgpusm"
+           enable_mca_dso="accelerator-cuda,accelerator-rocm,accelerator-ze"
            msg="(default)"
        fi
        DSO_all=0


### PR DESCRIPTION
remove btl-smcuda,rcache-gpusm,rcache-rgpusm from the list of components that have to be compiled as dsos at all times. The components do not contain any references/function calls to a GPU software stack anymore, everything is based off the accelerator framework APIs.


(cherry picked from commit 66dfeec688ef873c7df2fb03766f251be260e2e8)