### PR TITLE
GitHub Actions: add backport workflows

### DIFF
--- a/.github/workflows/backport-command.yaml
+++ b/.github/workflows/backport-command.yaml
@@ -1,0 +1,190 @@
+# Slash-command handler for /backport.
+#
+# Posting a comment on a merged PR with:
+#
+#   /backport v5.0.x v4.1.x
+#
+# is equivalent to manually triggering the "Backport" workflow from the
+# GitHub Actions UI with those branch names.  Multiple branches may be
+# supplied as space- or comma-separated values on the same line.
+#
+# Only users with write, maintain, or admin access to the repository may
+# trigger the command.  If an unauthorized user attempts /backport, the bot
+# replies with an explanatory comment.  For valid commands it acknowledges
+# with a 👀 reaction; invalid or unrecognised commands get a usage hint.
+
+name: Backport slash command
+
+on:
+    issue_comment:
+        types: [created]
+
+permissions: {}
+
+jobs:
+    dispatch:
+        name: Handle /backport comment
+        runs-on: ubuntu-latest
+        # Only act on PR comments (issue_comment fires for both issues and PRs).
+        if: github.event.issue.pull_request != null
+        permissions:
+            actions: write       # trigger workflow_dispatch
+            issues: write        # post reactions and comments
+            pull-requests: read  # read PR merge status
+        steps:
+            - name: Parse command and validate PR
+              id: parse
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const body        = context.payload.comment.body;
+                      const commentId   = context.payload.comment.id;
+                      const issueNumber = context.payload.issue.number;
+                      const login       = context.payload.comment.user.login;
+
+                      // Detect a bare /backport with no arguments and reply helpfully.
+                      const bareMatch = /^\/backport\s*$/m.test(body);
+                      // Look for /backport with arguments at the start of any line.
+                      const match = body.match(/^\/backport\s+([^\r\n]+)/m);
+
+                      // If the comment doesn't contain any /backport command at all,
+                      // do nothing — no need to check permissions.
+                      if (!bareMatch && !match) {
+                          core.setOutput('triggered', 'false');
+                          return;
+                      }
+
+                      // Check actual repository permission level rather than
+                      // author_association: MEMBER alone does not imply write
+                      // access on org-owned public repos.
+                      let permission = 'none';
+                      try {
+                          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                              owner:    context.repo.owner,
+                              repo:     context.repo.repo,
+                              username: login,
+                          });
+                          // Use role_name rather than permission: the legacy
+                          // permission field collapses 'maintain' into 'write',
+                          // losing the distinction between the two tiers.
+                          permission = data.role_name; // 'admin' | 'maintain' | 'write' | 'triage' | 'read'
+                      } catch (err) {
+                          if (err.status !== 404) throw err;
+                          // 404 = not a collaborator; permission stays 'none'
+                      }
+                      if (!['admin', 'maintain', 'write'].includes(permission)) {
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: issueNumber,
+                              body:         `⚠️ @${login} Backports can only be triggered by users with write, maintain, or admin access.`,
+                          });
+                          core.setOutput('triggered', 'false');
+                          return;
+                      }
+
+                      if (bareMatch && !match) {
+                          core.setOutput('triggered', 'false');
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: issueNumber,
+                              body:         '⚠️ `/backport` requires at least one target branch, e.g. `/backport v5.0.x`.',
+                          });
+                          return;
+                      }
+                      if (!match) {
+                          core.setOutput('triggered', 'false');
+                          return;
+                      }
+
+                      // Parse branch list (space- or comma-separated).
+                      const branches = match[1].trim().split(/[\s,]+/).filter(Boolean);
+                      if (branches.length === 0) {
+                          // e.g. "/backport ,,," — separators only, no real branch names
+                          core.setOutput('triggered', 'false');
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: issueNumber,
+                              body:         '⚠️ `/backport` requires at least one target branch, e.g. `/backport v5.0.x`.',
+                          });
+                          return;
+                      }
+
+                      // Validate branch names with the same allow-list used in
+                      // backport.yaml so the user gets immediate feedback rather
+                      // than a silent dispatch failure.
+                      const validBranchRe = /^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$/;
+                      const invalidBranches = branches.filter(b => !validBranchRe.test(b));
+                      if (invalidBranches.length > 0) {
+                          core.setOutput('triggered', 'false');
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: issueNumber,
+                              body:         `⚠️ Invalid branch name(s): ${invalidBranches.map(b => `\`${b}\``).join(', ')}. Branch names may only contain alphanumeric characters, dots, hyphens, underscores, and slashes.`,
+                          });
+                          return;
+                      }
+
+                      // Confirm the PR is actually merged.
+                      const { data: pr } = await github.rest.pulls.get({
+                          owner:       context.repo.owner,
+                          repo:        context.repo.repo,
+                          pull_number: issueNumber,
+                      });
+
+                      if (!pr.merged) {
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: issueNumber,
+                              body:         '⚠️ Cannot backport: this PR has not been merged yet.',
+                          });
+                          core.setOutput('triggered', 'false');
+                          return;
+                      }
+
+                      // Acknowledge the command with a 👀 reaction.
+                      // Ignore 422 (reaction already exists) so re-runs don't fail.
+                      try {
+                          await github.rest.reactions.createForIssueComment({
+                              owner:      context.repo.owner,
+                              repo:       context.repo.repo,
+                              comment_id: commentId,
+                              content:    'eyes',
+                          });
+                      } catch (err) {
+                          if (err.status !== 422) throw err;
+                      }
+
+                      core.setOutput('triggered', 'true');
+                      core.setOutput('pr_number', String(issueNumber));
+                      core.setOutput('branches',  branches.join(','));
+                      core.notice(`Dispatching backport of PR #${issueNumber} to: ${branches.join(', ')}`);
+
+            - name: Trigger backport workflow
+              if: steps.parse.outputs.triggered == 'true'
+              uses: actions/github-script@v7
+              env:
+                  PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+                  BRANCHES:  ${{ steps.parse.outputs.branches }}
+              with:
+                  script: |
+                      // workflow_dispatch requires a ref; use the default branch.
+                      const { data: repo } = await github.rest.repos.get({
+                          owner: context.repo.owner,
+                          repo:  context.repo.repo,
+                      });
+
+                      await github.rest.actions.createWorkflowDispatch({
+                          owner:       context.repo.owner,
+                          repo:        context.repo.repo,
+                          workflow_id: 'backport.yaml',
+                          ref:         repo.default_branch,
+                          inputs: {
+                              pr_number: process.env.PR_NUMBER,
+                              branches:  process.env.BRANCHES,
+                          },
+                      });

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,379 @@
+# Backport merged PRs to release branches.
+#
+# This workflow supports two modes:
+#
+# 1. Automatic (label-based): Apply one or more "backport:vX.Y.z" labels to a
+#    PR before merging.  Once the PR is merged, this workflow fires and creates
+#    a cherry-pick PR for each labelled target branch.
+#
+# 2. Manual (workflow_dispatch): After a PR has already been merged, trigger
+#    this workflow manually via the GitHub Actions UI, providing the PR number
+#    and a comma-separated list of target branches.
+#
+# For every successful cherry-pick, a new PR is opened against the target
+# branch and tagged with a "target:vX.Y.z" label.  If the cherry-pick
+# produces conflicts, a comment is posted on the original PR instead so a
+# developer can handle it manually.
+
+name: Backport
+
+on:
+    pull_request_target:
+        types: [closed]
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: 'Number of the merged PR to backport'
+                required: true
+                type: number
+            branches:
+                description: 'Target release branches (comma-separated, e.g. v5.0.x,v4.1.x)'
+                required: true
+                type: string
+
+permissions: {}
+
+jobs:
+    # -------------------------------------------------------------------------
+    # Determine which branches need a backport and expose them as a matrix.
+    # -------------------------------------------------------------------------
+    prepare:
+        name: Prepare backport targets
+        runs-on: ubuntu-latest
+        # For pull_request_target: only act when the PR was actually merged AND
+        # carries at least one "backport:" label (avoids a spurious job run on
+        # every other merge).  For workflow_dispatch: always proceed.
+        if: >
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.pull_request.merged == true &&
+             contains(toJson(github.event.pull_request.labels.*.name), '"backport:'))
+        outputs:
+            matrix: ${{ steps.targets.outputs.matrix }}
+            has_targets: ${{ steps.targets.outputs.has_targets }}
+            pr_number: ${{ steps.targets.outputs.pr_number }}
+        steps:
+            - name: Determine backport targets
+              id: targets
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      let branches = [];
+                      let prNumber;
+
+                      if (context.eventName === 'workflow_dispatch') {
+                          prNumber = Number(context.payload.inputs.pr_number);
+                          if (!Number.isFinite(prNumber) || prNumber <= 0 || !Number.isInteger(prNumber)) {
+                              core.setFailed(`Invalid pr_number: "${context.payload.inputs.pr_number}"`);
+                              return;
+                          }
+                          branches = context.payload.inputs.branches
+                              .split(',')
+                              .map(b => b.trim())
+                              .filter(Boolean);
+                      } else {
+                          prNumber = context.payload.pull_request.number;
+                          const labels = context.payload.pull_request.labels.map(l => l.name);
+                          for (const label of labels) {
+                              const match = label.match(/^backport:(.+)$/);
+                              if (match) {
+                                  branches.push(match[1].trim());
+                              }
+                          }
+                      }
+
+                      // Validate branch names with a strict allow-list: must start
+                      // with alphanumeric and contain only alphanumeric, dot,
+                      // hyphen, underscore, or slash.  De-duplicate preserving order.
+                      const validBranchRe = /^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$/;
+                      const invalid = branches.filter(b => !validBranchRe.test(b));
+                      if (invalid.length > 0) {
+                          core.setFailed(`Invalid branch name(s): ${invalid.join(', ')}`);
+                          return;
+                      }
+                      branches = [...new Set(branches)];
+
+                      core.setOutput('pr_number', String(prNumber));
+                      core.setOutput('has_targets', branches.length > 0 ? 'true' : 'false');
+                      core.setOutput('matrix', JSON.stringify({ branch: branches }));
+
+                      if (branches.length === 0) {
+                          core.notice('No backport targets found — nothing to do.');
+                      } else {
+                          core.notice(`Will backport PR #${prNumber} to: ${branches.join(', ')}`);
+                      }
+
+    # -------------------------------------------------------------------------
+    # One job per target branch.  All branches run in parallel; a failure on
+    # one branch does not cancel the others.
+    # -------------------------------------------------------------------------
+    backport:
+        name: Backport to ${{ matrix.branch }}
+        needs: prepare
+        if: needs.prepare.outputs.has_targets == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+        strategy:
+            matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+            fail-fast: false
+        env:
+            PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+            TARGET_BRANCH: ${{ matrix.branch }}
+        steps:
+            - name: Checkout repository (full history)
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Configure git identity
+              run: |
+                  git config user.name  "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Retrieve PR metadata (title, body, commit list) via the API.
+            # Use paginate() so PRs with more than 100 commits are handled correctly.
+            - name: Fetch PR metadata
+              id: pr_meta
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const pr = await github.rest.pulls.get({
+                          owner: context.repo.owner,
+                          repo:  context.repo.repo,
+                          pull_number: Number(process.env.PR_NUMBER),
+                      });
+                      core.setOutput('title', pr.data.title);
+                      // Body may be empty/null — default to empty string.
+                      core.setOutput('body',  pr.data.body ?? '');
+
+                      // Collect all commit SHAs in merge order, paginating as needed.
+                      const commits = await github.paginate(github.rest.pulls.listCommits, {
+                          owner:       context.repo.owner,
+                          repo:        context.repo.repo,
+                          pull_number: Number(process.env.PR_NUMBER),
+                          per_page:    100,
+                      });
+                      const shas = commits.map(c => c.sha);
+                      core.setOutput('commits', shas.join(' '));
+
+            # Verify the target release branch actually exists before doing any
+            # work.  Post a comment and skip if it does not.
+            - name: Validate target branch exists
+              id: validate
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      try {
+                          await github.rest.repos.getBranch({
+                              owner:  context.repo.owner,
+                              repo:   context.repo.repo,
+                              branch: process.env.TARGET_BRANCH,
+                          });
+                          core.setOutput('branch_exists', 'true');
+                      } catch (err) {
+                          if (err.status !== 404) throw err;
+                          await github.rest.issues.createComment({
+                              owner:        context.repo.owner,
+                              repo:         context.repo.repo,
+                              issue_number: Number(process.env.PR_NUMBER),
+                              body: `⚠️ Cannot backport to \`${process.env.TARGET_BRANCH}\`: branch does not exist in this repository.`,
+                          });
+                          core.setOutput('branch_exists', 'false');
+                      }
+
+            # Cherry-pick every commit from the PR onto a new branch based on
+            # the target release branch.  Push the branch on success; set a
+            # flag on conflict so the next step can report the failure.
+            - name: Cherry-pick commits onto backport branch
+              id: cherry_pick
+              if: steps.validate.outputs.branch_exists == 'true'
+              env:
+                  COMMITS: ${{ steps.pr_meta.outputs.commits }}
+              run: |
+                  set -euo pipefail
+
+                  # Resolve a unique branch name.  The counter handles the common
+                  # case of re-running a backport; the push-retry below handles the
+                  # rare race where two concurrent runs pick the same name.
+                  git fetch --prune origin
+                  # Fetch the PR's original commits so they are available locally
+                  # regardless of how the PR was merged (squash, rebase, merge commit).
+                  git fetch origin "refs/pull/${PR_NUMBER}/head"
+                  BASE_BRANCH="backport/pr-${PR_NUMBER}-to-${TARGET_BRANCH}"
+                  BACKPORT_BRANCH="${BASE_BRANCH}"
+                  counter=1
+                  while git ls-remote --exit-code --heads origin "${BACKPORT_BRANCH}" > /dev/null 2>&1; do
+                      counter=$((counter + 1))
+                      BACKPORT_BRANCH="${BASE_BRANCH}-${counter}"
+                  done
+                  echo "backport_branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+
+                  git fetch origin "${TARGET_BRANCH}"
+                  git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
+
+                  cherry_pick_failed=false
+                  failed_sha=""
+                  for sha in $COMMITS; do
+                      echo "Cherry-picking ${sha} ..."
+
+                      # Detect merge commits (more than one parent) and cherry-pick
+                      # relative to the first parent with -m 1.
+                      parent_count=$(git cat-file -p "${sha}" | grep -c '^parent ' || true)
+                      if [ "${parent_count}" -gt 1 ]; then
+                          echo "  Merge commit detected, using -m 1"
+                          cherry_flags="-m 1"
+                      else
+                          cherry_flags=""
+                      fi
+
+                      # --empty=drop silently skips commits already applied to the
+                      # target branch rather than recording a no-op empty commit.
+                      if ! git cherry-pick --empty=drop -x ${cherry_flags} "${sha}"; then
+                          cherry_pick_failed=true
+                          failed_sha="${sha}"
+                          git cherry-pick --abort 2>/dev/null || true
+                          break
+                      fi
+                  done
+
+                  echo "cherry_pick_failed=${cherry_pick_failed}" >> "$GITHUB_OUTPUT"
+                  echo "failed_sha=${failed_sha}"               >> "$GITHUB_OUTPUT"
+
+                  if [ "${cherry_pick_failed}" = "false" ]; then
+                      # If every commit was already present in the target branch,
+                      # cherry-pick dropped them all and HEAD hasn't moved.
+                      new_commits=$(git rev-list --count "origin/${TARGET_BRANCH}..HEAD")
+                      if [ "${new_commits}" -eq 0 ]; then
+                          echo "nothing_to_backport=true" >> "$GITHUB_OUTPUT"
+                      else
+                          echo "nothing_to_backport=false" >> "$GITHUB_OUTPUT"
+                          # Push; on a naming collision from a concurrent run, fall back
+                          # to a name that includes the unique run ID.
+                          if ! git push origin "${BACKPORT_BRANCH}" 2>/dev/null; then
+                              BACKPORT_BRANCH="${BASE_BRANCH}-${GITHUB_RUN_ID}"
+                              git branch -m "${BACKPORT_BRANCH}"
+                              git push origin "${BACKPORT_BRANCH}"
+                              echo "backport_branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+                          fi
+                      fi
+                  fi
+
+            # All commits were already present in the target branch — no PR needed.
+            - name: Comment when nothing to backport
+              if: steps.cherry_pick.outputs.nothing_to_backport == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.createComment({
+                          owner:        context.repo.owner,
+                          repo:         context.repo.repo,
+                          issue_number: Number(process.env.PR_NUMBER),
+                          body: `ℹ️ All commits from this PR are already present in \`${process.env.TARGET_BRANCH}\` — no backport needed.`,
+                      });
+                      core.notice(`Nothing to backport to ${process.env.TARGET_BRANCH} — all commits already present.`);
+
+            # Open a PR against the target branch and attach the target:* label.
+            - name: Create backport PR
+              if: >-
+                  steps.cherry_pick.outputs.cherry_pick_failed == 'false' &&
+                  steps.cherry_pick.outputs.nothing_to_backport == 'false'
+              uses: actions/github-script@v7
+              env:
+                  ORIGINAL_TITLE: ${{ steps.pr_meta.outputs.title }}
+                  ORIGINAL_BODY:  ${{ steps.pr_meta.outputs.body }}
+                  BACKPORT_BRANCH: ${{ steps.cherry_pick.outputs.backport_branch }}
+              with:
+                  script: |
+                      const prNumber     = Number(process.env.PR_NUMBER);
+                      const targetBranch = process.env.TARGET_BRANCH;
+                      const labelName    = `target:${targetBranch}`;
+
+                      // Ensure the target:* label exists in this repo.
+                      try {
+                          await github.rest.issues.getLabel({
+                              owner: context.repo.owner,
+                              repo:  context.repo.repo,
+                              name:  labelName,
+                          });
+                      } catch (err) {
+                          if (err.status === 404) {
+                              try {
+                                  await github.rest.issues.createLabel({
+                                      owner: context.repo.owner,
+                                      repo:  context.repo.repo,
+                                      name:  labelName,
+                                      color: '0075ca',
+                                      description: `Backport targeting the ${targetBranch} branch`,
+                                  });
+                              } catch (createErr) {
+                                  // 422 = another concurrent job created the label first; safe to ignore.
+                                  if (createErr.status !== 422) throw createErr;
+                              }
+                          } else {
+                              throw err;
+                          }
+                      }
+
+                      const title = `[${targetBranch}] ${process.env.ORIGINAL_TITLE}`;
+                      const body  = [
+                          `Backport of #${prNumber} to \`${targetBranch}\`.`,
+                          '',
+                          '---',
+                          '',
+                          process.env.ORIGINAL_BODY,
+                      ].join('\n');
+
+                      const { data: newPR } = await github.rest.pulls.create({
+                          owner: context.repo.owner,
+                          repo:  context.repo.repo,
+                          title,
+                          body,
+                          head:  process.env.BACKPORT_BRANCH,
+                          base:  targetBranch,
+                      });
+
+                      await github.rest.issues.addLabels({
+                          owner:        context.repo.owner,
+                          repo:         context.repo.repo,
+                          issue_number: newPR.number,
+                          labels:       [labelName],
+                      });
+
+                      core.notice(`Opened backport PR #${newPR.number}: ${newPR.html_url}`);
+
+            # If cherry-pick failed, leave a comment on the original PR so a
+            # developer knows to create the backport manually.
+            - name: Comment on cherry-pick failure
+              if: steps.cherry_pick.outputs.cherry_pick_failed == 'true'
+              uses: actions/github-script@v7
+              env:
+                  FAILED_SHA: ${{ steps.cherry_pick.outputs.failed_sha }}
+              with:
+                  script: |
+                      const prNumber     = Number(process.env.PR_NUMBER);
+                      const targetBranch = process.env.TARGET_BRANCH;
+                      const failedSha    = process.env.FAILED_SHA;
+
+                      await github.rest.issues.createComment({
+                          owner:        context.repo.owner,
+                          repo:         context.repo.repo,
+                          issue_number: prNumber,
+                          body: [
+                              `⚠️ **Automatic backport to \`${targetBranch}\` failed.**`,
+                              '',
+                              `Cherry-pick of commit ${failedSha} produced conflicts.`,
+                              'Please create the backport manually:',
+                              '',
+                              '```bash',
+                              `git fetch origin ${targetBranch}`,
+                              `git checkout -b backport/pr-${prNumber}-to-${targetBranch} origin/${targetBranch}`,
+                              `git cherry-pick -x <commits>`,
+                              `git push origin backport/pr-${prNumber}-to-${targetBranch}`,
+                              '```',
+                          ].join('\n'),
+                      });
+
+                      core.warning(`Cherry-pick to ${targetBranch} failed at ${failedSha} — manual backport required.`);


### PR DESCRIPTION
Add two workflows to automate backporting merged PRs to release branches:

- `backport.yaml`: cherry-picks PR commits to target branches and opens backport PRs with `target:*` labels. Triggered automatically via `backport:*` labels on merge, or manually via workflow_dispatch.
- `backport-command.yaml`: parses /backport <branch>... comments on merged PRs and dispatches backport.yaml, with 👀 acknowledgement reactions.

I tested this locally, not sure if the settings are the same on the main repository. The `backport:*` labels will have to be created.