### PR TITLE
request: add acquire/release barriers for sync struct handoff

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -103,6 +103,7 @@ int ompi_request_default_wait_any(size_t count,
 
 recheck:
     WAIT_SYNC_INIT(&sync, 1);
+    opal_atomic_wmb();  /* release: sync struct init must be visible before CAS publishes &sync */
 
     num_requests_null_inactive = 0;
     for (i = 0; i < count; i++) {
@@ -238,6 +239,7 @@ int ompi_request_default_wait_all( size_t count,
 
 recheck:
     WAIT_SYNC_INIT(&sync, count);
+    opal_atomic_wmb();  /* release: sync struct init must be visible before CAS publishes &sync */
     rptr = requests;
     for (i = 0; i < count; i++) {
         void *_tmp_ptr = REQUEST_PENDING;
@@ -466,6 +468,7 @@ int ompi_request_default_wait_some(size_t count,
 
   recheck:
     WAIT_SYNC_INIT(&sync, 1);
+    opal_atomic_wmb();  /* release: sync struct init must be visible before CAS publishes &sync */
 
     *outcount = 0;
 

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -465,6 +465,7 @@ static inline void ompi_request_wait_completion(ompi_request_t *req)
             _tmp_ptr = REQUEST_PENDING;
 
             WAIT_SYNC_INIT(&sync, 1);
+            opal_atomic_wmb();  /* release: sync struct init must be visible before CAS publishes &sync */
 
             if (OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&req->req_complete, &_tmp_ptr, &sync)) {
                 SYNC_WAIT(&sync);
@@ -533,6 +534,7 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
             ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                     REQUEST_COMPLETED);
+            opal_atomic_rmb();  /* acquire: pair with wmb before CAS to see sync struct contents */
             if( REQUEST_PENDING != tmp_sync ) {
                 wait_sync_update(tmp_sync, 1, request->req_status.MPI_ERROR);
             }


### PR DESCRIPTION
On weakly-ordered architectures (ARM64), the request completion handoff between `ompi_request_wait_completion` and `ompi_request_complete` lacks ordering guarantees for the sync struct publication pattern.

The waiter initializes a sync struct on the stack (`WAIT_SYNC_INIT`) and publishes its address into `req->req_complete` via a relaxed CAS. The completer retrieves this address via a relaxed swap. Without barriers, the completer can dereference the sync pointer before the struct initialization stores are visible, causing `wait_sync_update` to operate on stale data and the wakeup signal to be lost.

Add `opal_atomic_wmb()` before the CAS in `ompi_request_wait_completion` to ensure the sync struct initialization is visible before the pointer is published. Add `opal_atomic_rmb()` after the swap in `ompi_request_complete` to ensure the completer sees the initialized struct contents before dereferencing.

Apply the same wmb fence in `ompi_request_default_wait_any`, `ompi_request_default_wait_all`, and `ompi_request_default_wait_some`, which use the same `WAIT_SYNC_INIT` + CAS publication pattern.

This follows the established OMPI pattern of caller-imposed barriers around relaxed atomic primitives, consistent with the fix in a55e9b2 (btl/smcuda: Add atomic_wmb() before sm_fifo_write).

Observed as a deadlock under `MPI_THREAD_MULTIPLE` on 64-core ARM64 (Graviton) instances: GDB shows `req_complete=REQUEST_COMPLETED` but `sync->count=1`, indicating the completer retrieved the sync pointer but the wakeup never reached the waiter.

Fixes: #13761
Related to #12011, #11999