### PR TITLE
[v5.0.x] pml/ob1: Return MPI_ERR_PROC_FAILED on unmatched I(m)probes when appropriate

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_iprobe.c
+++ b/ompi/mca/pml/ob1/pml_ob1_iprobe.c
@@ -47,6 +47,11 @@ int mca_pml_ob1_iprobe(int src,
         *matched = 1;
     } else {
         *matched = 0;
+#if OPAL_ENABLE_FT_MPI
+        if( ompi_request_is_failed((ompi_request_t*)&recvreq) ) {
+            rc = recvreq.req_recv.req_base.req_ompi.req_status.MPI_ERROR;
+        }
+#endif
         opal_progress();
     }
     MCA_PML_BASE_RECV_REQUEST_FINI( &recvreq.req_recv );
@@ -119,6 +124,11 @@ mca_pml_ob1_improbe(int src,
         (*message)->count = recvreq->req_recv.req_base.req_ompi.req_status._ucount;
     } else {
         *matched = 0;
+#if OPAL_ENABLE_FT_MPI
+        if( ompi_request_is_failed((ompi_request_t*)recvreq) ) {
+            rc = recvreq->req_recv.req_base.req_ompi.req_status.MPI_ERROR;
+        }
+#endif
 
         /* we only free if we didn't match, because we're going to
            translate the request into a receive request later on if it

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -108,16 +108,19 @@ static int mca_pml_ob1_recv_request_cancel(struct ompi_request_t* ompi_request, 
     }
     if( !request->req_match_received ) { /* the match has not been already done */
         assert( OMPI_ANY_TAG == ompi_request->req_status.MPI_TAG ); /* not matched isn't it */
+        if(OPAL_LIKELY(request->req_recv.req_base.req_type != MCA_PML_REQUEST_IPROBE &&
+                       request->req_recv.req_base.req_type != MCA_PML_REQUEST_IMPROBE)) {
 #if MCA_PML_OB1_CUSTOM_MATCH
-        custom_match_prq_cancel(ob1_comm->prq, request);
+            custom_match_prq_cancel(ob1_comm->prq, request);
 #else
-        if( request->req_recv.req_base.req_peer == OMPI_ANY_SOURCE ) {
-            opal_list_remove_item( &ob1_comm->wild_receives, (opal_list_item_t*)request );
-        } else {
-            mca_pml_ob1_comm_proc_t* proc = mca_pml_ob1_peer_lookup (comm, request->req_recv.req_base.req_peer);
-            opal_list_remove_item(&proc->specific_receives, (opal_list_item_t*)request);
-        }
+            if( request->req_recv.req_base.req_peer == OMPI_ANY_SOURCE ) {
+                opal_list_remove_item( &ob1_comm->wild_receives, (opal_list_item_t*)request );
+            } else {
+                mca_pml_ob1_comm_proc_t* proc = mca_pml_ob1_peer_lookup (comm, request->req_recv.req_base.req_peer);
+                opal_list_remove_item(&proc->specific_receives, (opal_list_item_t*)request);
+            }
 #endif
+        }
         PERUSE_TRACE_COMM_EVENT( PERUSE_COMM_REQ_REMOVE_FROM_POSTED_Q,
                                 &(request->req_recv.req_base), PERUSE_RECV );
         OB1_MATCHING_UNLOCK(&ob1_comm->matching_lock);

--- a/ompi/request/req_ft.c
+++ b/ompi/request/req_ft.c
@@ -128,7 +128,9 @@ bool ompi_request_is_failed_fn(ompi_request_t *req)
             req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED_PENDING;
             /* If it is a probe/mprobe, escalate the error */
             if( (MCA_PML_REQUEST_MPROBE == pml_req->req_type) ||
-                (MCA_PML_REQUEST_PROBE == pml_req->req_type) ) {
+                (MCA_PML_REQUEST_IMPROBE == pml_req->req_type) ||
+                (MCA_PML_REQUEST_PROBE == pml_req->req_type) ||
+                (MCA_PML_REQUEST_IPROBE == pml_req->req_type) ) {
                 req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED;
             }
             opal_output_verbose(10, ompi_ftmpi_output_handle,


### PR DESCRIPTION
(cherry picked from commit 7d026989e4c440d32675fa2ddc891b73c16ea410)