### PR TITLE
coll/han: Fix use-after-free in sub-communicator finalization

### DIFF
--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -49,10 +49,15 @@
 #define HAN_SUBCOM_EXTRA_RETAIN(COMM, PARENT_COMM)                           \
     do                                                                       \
     {                                                                        \
-        if (OMPI_COMM_CID_IS_LOWER(COMM, PARENT_COMM)) {                     \
-            OMPI_COMM_SET_EXTRA_RETAIN(COMM);                                \
-            OBJ_RETAIN(COMM);                                                \
-        }                                                                    \
+        /* Always extra-retain HAN sub-communicators so that              \
+         * ompi_comm_finalize() does not free them before the parent      \
+         * communicator's destructor can clean them up properly.           \
+         * The conditional on CID ordering is insufficient because         \
+         * ompi_comm_finalize() iterates over all communicators and        \
+         * releases them regardless of parent-child relationships.         \
+         */                                                                  \
+        OMPI_COMM_SET_EXTRA_RETAIN(COMM);                                    \
+        OBJ_RETAIN(COMM);                                                                    \
     } while (0)
 
 /*


### PR DESCRIPTION
The HAN_SUBCOM_EXTRA_RETAIN macro only applied EXTRA_RETAIN when the sub-communicator's CID was lower than the parent's CID. This left higher-CID sub-communicators unprotected: ompi_comm_finalize() would free them during its iteration over all communicators, and then the parent's destructor (mca_coll_han_module_destruct) would attempt to call ompi_comm_free() on the already-freed sub-communicator, causing a use-after-free that corrupts the heap.

This manifests as "corrupted double-linked list" SIGABRT or SIGSEGV crashes during MPI_Finalize on any multi-node job where HAN is selected (which is the default for inter-node communicators).

The fix removes the CID ordering conditional so that all HAN sub-communicators are unconditionally extra-retained. This is safe because ompi_comm_free() already handles the EXTRA_RETAIN flag correctly for both CID orderings: it performs a lookup-and-free that is a no-op if the communicator was already destroyed.

Verified on x86_64 and aarch64 across Amazon Linux 2, Ubuntu 24.04, hpc6a.48xlarge, c5n.18xlarge, p4d.24xlarge, and c7g.16xlarge with OSU Micro-Benchmarks and valgrind memcheck (0 use-after-free errors post-fix).

Fixes the regression introduced by commit 5fadf8797 ("Prevent subcomms from being freed before user's comm").

The fix should be cherry-picked to v5.0.x.