### PR TITLE
`--enable-mca-dso` breaks the datatype tests

### DIFF
--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -146,23 +146,6 @@ static int mca_btl_uct_component_register(void)
         MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_4,
         MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_uct_component.connection_retry_timeout);
 
-    OBJ_CONSTRUCT(&mca_btl_uct_component.md_list, opal_list_t);
-    OBJ_CONSTRUCT(&mca_btl_uct_component.memory_domain_list, mca_btl_uct_include_list_t);
-    OBJ_CONSTRUCT(&mca_btl_uct_component.connection_domain_list, mca_btl_uct_include_list_t);
-
-    int rc = mca_btl_uct_component_discover_mds();
-    if (OPAL_SUCCESS != rc) {
-        return rc;
-    }
-
-    rc = mca_btl_uct_component_generate_modules(&mca_btl_uct_component.md_list);
-    if (OPAL_SUCCESS != rc) {
-        return rc;
-    }
-
-    mca_btl_uct_component.initialized = true;
-    opal_finalize_register_cleanup(mca_btl_uct_cleanup);
-
     return OPAL_SUCCESS;
 }
 
@@ -205,6 +188,22 @@ static int mca_btl_uct_component_open(void)
         ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
         opal_mem_hooks_register_release(mca_btl_uct_mem_release_cb, NULL);
     }
+
+    OBJ_CONSTRUCT(&mca_btl_uct_component.md_list, opal_list_t);
+    OBJ_CONSTRUCT(&mca_btl_uct_component.memory_domain_list, mca_btl_uct_include_list_t);
+    OBJ_CONSTRUCT(&mca_btl_uct_component.connection_domain_list, mca_btl_uct_include_list_t);
+
+    int rc = mca_btl_uct_component_discover_mds();
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    rc = mca_btl_uct_component_generate_modules(&mca_btl_uct_component.md_list);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    mca_btl_uct_component.initialized = true;
 
     return OPAL_SUCCESS;
 }

--- a/test/datatype/checksum.c
+++ b/test/datatype/checksum.c
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
     free(packed);
 
     /* clean-ups all data allocations */
-    opal_finalize_util();
+    opal_finalize();
 
     return 0;
 }

--- a/test/datatype/ddt_pack.c
+++ b/test/datatype/ddt_pack.c
@@ -500,7 +500,7 @@ int main(int argc, char *argv[])
     ompi_datatype_destroy(&dup_type);
 
 cleanup:
-    opal_finalize_util();
+    opal_finalize();
 
     return ret;
 }

--- a/test/datatype/ddt_raw.c
+++ b/test/datatype/ddt_raw.c
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
     assert(pdt1 == NULL);
 
     /* clean-ups all data allocations */
-    opal_finalize_util();
+    opal_finalize();
 
     return OMPI_SUCCESS;
 }

--- a/test/datatype/ddt_test.c
+++ b/test/datatype/ddt_test.c
@@ -579,7 +579,7 @@ int main(int argc, char *argv[])
     assert(pdt2 == NULL);
 
     /* clean-ups all data allocations */
-    opal_finalize_util();
+    opal_finalize();
 
     return OMPI_SUCCESS;
 }

--- a/test/datatype/external32.c
+++ b/test/datatype/external32.c
@@ -260,7 +260,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    opal_finalize_util();
+    opal_finalize();
 
     return 0;
 }

--- a/test/datatype/opal_datatype_test.c
+++ b/test/datatype/opal_datatype_test.c
@@ -805,7 +805,7 @@ int main(int argc, char *argv[])
     assert(pdt2 == NULL);
 
     /* clean-ups all data allocations */
-    opal_finalize_util();
+    opal_finalize();
 
     return OPAL_SUCCESS;
 }

--- a/test/datatype/partial.c
+++ b/test/datatype/partial.c
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
     free(packed);
 
     /* clean-ups all data allocations */
-    opal_finalize_util();
+    opal_finalize();
 
     return 0;
 }

--- a/test/datatype/position.c
+++ b/test/datatype/position.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
     }
     free(segments);
 
-    opal_finalize_util();
+    opal_finalize();
 
     return (0 == errors ? 0 : -1);
 }

--- a/test/datatype/position_noncontig.c
+++ b/test/datatype/position_noncontig.c
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
     }
     free(segments);
 
-    opal_finalize_util();
+    opal_finalize();
 
     return (0 == errors ? 0 : -1);
 }


### PR DESCRIPTION
In 98f3af0bf4c2f3987034e4fcdd6a9527dc6984ee the datatype tests have been changed to call opal_init instead of opal_util_init in order to enable the newly added accelerator framework. Which mean we now have a full initialization of OPAL, and that must be matched by a full finalize of OPAL and not by a `opal_util_finalize` (as it is the case in the current tests). Replacing `opal_finalize_util` with `opal_finalize` fixes the problem.

Fixes #13717 