### PR TITLE
Topic/fix comm free dependencies

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -28,6 +28,7 @@
  *                         reserved.
  * Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2025      BULL S.A.S. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -278,10 +279,14 @@ int ompi_comm_set_nb (ompi_communicator_t **ncomm, ompi_communicator_t *oldcomm,
             /* NTH: use internal idup function that takes a local group argument */
             ompi_comm_idup_internal (old_localcomm, newcomm->c_local_group, NULL, NULL,
                                      &newcomm->c_local_comm, req);
+            if (NULL != newcomm->c_local_comm
+                && !OMPI_COMM_IS_INTRINSIC(newcomm->c_local_comm)) {
+                OBJ_RETAIN(newcomm->c_local_comm);
+            }
         } else {
-            /* take ownership of the old communicator (it must be an intracommunicator) */
             assert (OMPI_COMM_IS_INTRA(oldcomm));
             newcomm->c_local_comm = oldcomm;
+            OBJ_RETAIN(newcomm->c_local_comm);
         }
     } else {
         newcomm->c_remote_group = newcomm->c_local_group;
@@ -2169,8 +2174,6 @@ static int ompi_comm_allgather_emulate_intra( void *inbuf, int incount,
 int ompi_comm_free( ompi_communicator_t **comm )
 {
     int ret;
-    int cid = (*comm)->c_index;
-    int is_extra_retain = OMPI_COMM_IS_EXTRA_RETAIN(*comm);
 
     /* Release attributes.  We do this now instead of during the
        communicator destructor for 2 reasons:
@@ -2199,7 +2202,9 @@ int ompi_comm_free( ompi_communicator_t **comm )
     }
 
     if ( OMPI_COMM_IS_INTER(*comm) ) {
-        if ( ! OMPI_COMM_IS_INTRINSIC((*comm)->c_local_comm)) {
+        if (NULL != (*comm)->c_local_comm
+            && ! OMPI_COMM_IS_INTRINSIC((*comm)->c_local_comm)) {
+            OBJ_RELEASE((*comm)->c_local_comm);
             ompi_comm_free (&(*comm)->c_local_comm);
         }
     }
@@ -2221,29 +2226,6 @@ int ompi_comm_free( ompi_communicator_t **comm )
         ompi_comm_num_dyncomm --;
     }
     OBJ_RELEASE( (*comm) );
-
-    if ( is_extra_retain) {
-        /* This communicator has been marked as an "extra retain"
-         * communicator. This can happen if a communicator creates
-         * 'dependent' subcommunicators (e.g. for inter
-         * communicators or when using hierarch collective
-         * module *and* the cid of the dependent communicator
-         * turned out to be lower than of the parent one.
-         * In that case, the reference counter has been increased
-         * by one more, in order to handle the scenario,
-         * that the user did not free the communicator.
-         * Note, that if we enter this routine, we can
-         * decrease the counter by one more therefore. However,
-         * in ompi_comm_finalize, we only used OBJ_RELEASE instead
-         * of ompi_comm_free(), and the increased reference counter
-         * makes sure that the pointer to the dependent communicator
-         * still contains a valid object.
-         */
-        ompi_communicator_t *tmpcomm = ompi_comm_lookup(cid);
-        if ( NULL != tmpcomm ){
-            ompi_comm_free(&tmpcomm);
-        }
-    }
 
     *comm = MPI_COMM_NULL;
     return OMPI_SUCCESS;

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2020-2026 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,8 +61,6 @@
 /* for use when we don't have a PMIx that supports CID generation */
 opal_atomic_int64_t ompi_comm_next_base_cid = 1;
 
-/* A macro comparing two CIDs */
-#define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)
 
 struct ompi_comm_cid_context_t;
 
@@ -924,30 +923,6 @@ static int ompi_comm_activate_complete (ompi_comm_cid_context_t *context)
         OBJ_RELEASE(*newcomm);
         *newcomm = MPI_COMM_NULL;
         return ret;
-    }
-
-    /* For an inter communicator, we have to deal with the potential
-     * problem of what is happening if the local_comm that we created
-     * has a lower CID than the parent comm. This is not a problem
-     * as long as the user calls MPI_Comm_free on the inter communicator.
-     * However, if the communicators are not freed by the user but released
-     * by Open MPI in MPI_Finalize, we walk through the list of still available
-     * communicators and free them one by one. Thus, local_comm is freed before
-     * the actual inter-communicator. However, the local_comm pointer in the
-     * inter communicator will still contain the 'previous' address of the local_comm
-     * and thus this will lead to a segmentation violation. In order to prevent
-     * that from happening, we increase the reference counter local_comm
-     * by one if its CID is lower than the parent. We cannot increase however
-     *  its reference counter if the CID of local_comm is larger than
-     * the CID of the inter communicators, since a regular MPI_Comm_free would
-     * leave in that the case the local_comm hanging around and thus we would not
-     * recycle CID's properly, which was the reason and the cause for this trouble.
-     */
-    if (OMPI_COMM_IS_INTER(*newcomm)) {
-        if (OMPI_COMM_CID_IS_LOWER(*newcomm, comm)) {
-            OMPI_COMM_SET_EXTRA_RETAIN (*newcomm);
-            OBJ_RETAIN (*newcomm);
-        }
     }
 
     /* done */

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -26,7 +26,7 @@
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
- * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2023-2026 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -388,31 +388,25 @@ static int ompi_comm_finalize (void)
     for ( i=3; i<max; i++ ) {
         comm = ompi_comm_lookup(i);
         if ( NULL != comm ) {
-            /* Communicator has not been freed before finalize */
+            /* Release the communicator. Sub-communicators retained by
+             * their parent (e.g., c_local_comm of inter-communicators)
+             * will be properly released by the parent's destructor. */
             OBJ_RELEASE(comm);
-            comm = ompi_comm_lookup(i);
-            if ( NULL != comm ) {
-                /* Still here ? */
-                if ( !OMPI_COMM_IS_EXTRA_RETAIN(comm)) {
-
-                    /* For communicator that have been marked as "extra retain", we do not further
-                     * enforce to decrease the reference counter once more. These "extra retain"
-                     * communicators created e.g. by the hierarch or inter module did increase
-                     * the reference count by one more than other communicators, on order to
-                     * allow for deallocation with the parent communicator. Note, that
-                     * this only occurs if the cid of the local_comm is lower than of its
-                     * parent communicator. Read the comment in comm_activate for
-                     * a full explanation.
-                     */
-                    if ( ompi_debug_show_handle_leaks && !(OMPI_COMM_IS_FREED(comm)) ){
-                        opal_output(0,"WARNING: MPI_Comm still allocated in MPI_Finalize\n");
-                        ompi_comm_dump ( comm);
-                        OBJ_RELEASE(comm);
-                    }
-                }
-            }
         }
     }
+
+#if OPAL_ENABLE_DEBUG
+    if ( ompi_debug_show_handle_leaks ) {
+        max = ompi_comm_get_num_communicators();
+        for ( i=3; i<max; i++ ) {
+            comm = ompi_comm_lookup(i);
+            if (NULL == comm) continue;
+            opal_output(0, "WARNING: %d unnamed MPI_Comm handles still allocated at MPI_FINALIZE", comm->c_name);
+            ompi_comm_dump ( comm);
+            OBJ_RELEASE(comm);
+        }
+    }
+#endif  /* OPAL_ENABLE_DEBUG */
 
     OBJ_DESTRUCT (&ompi_mpi_communicators);
     OBJ_DESTRUCT (&ompi_comm_hash);
@@ -525,6 +519,12 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
     if (NULL != comm->c_topo) {
         OBJ_RELEASE(comm->c_topo);
         comm->c_topo = NULL;
+    }
+
+    if (OMPI_COMM_IS_INTER(comm) && NULL != comm->c_local_comm
+        && !OMPI_COMM_IS_INTRINSIC(comm->c_local_comm)) {
+        OBJ_RELEASE(comm->c_local_comm);
+        comm->c_local_comm = NULL;
     }
 
     if (NULL != comm->c_local_group) {

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -25,7 +25,7 @@
  * Copyright (c) 2018-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +69,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_GRAPH        0x00000200
 #define OMPI_COMM_DIST_GRAPH   0x00000400
 #define OMPI_COMM_PML_ADDED    0x00001000
-#define OMPI_COMM_EXTRA_RETAIN 0x00004000
 #define OMPI_COMM_MAPBY_NODE   0x00008000
 #define OMPI_COMM_GLOBAL_INDEX 0x00010000
 
@@ -86,7 +85,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_IS_DISJOINT_SET(comm) ((comm)->c_flags & OMPI_COMM_DISJOINT_SET)
 #define OMPI_COMM_IS_DISJOINT(comm) ((comm)->c_flags & OMPI_COMM_DISJOINT)
 #define OMPI_COMM_IS_PML_ADDED(comm) ((comm)->c_flags & OMPI_COMM_PML_ADDED)
-#define OMPI_COMM_IS_EXTRA_RETAIN(comm) ((comm)->c_flags & OMPI_COMM_EXTRA_RETAIN)
 #define OMPI_COMM_IS_TOPO(comm) (OMPI_COMM_IS_CART((comm)) || \
                                  OMPI_COMM_IS_GRAPH((comm)) || \
                                  OMPI_COMM_IS_DIST_GRAPH((comm)))
@@ -97,7 +95,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_SET_INVALID(comm) ((comm)->c_flags |= OMPI_COMM_INVALID)
 
 #define OMPI_COMM_SET_PML_ADDED(comm) ((comm)->c_flags |= OMPI_COMM_PML_ADDED)
-#define OMPI_COMM_SET_EXTRA_RETAIN(comm) ((comm)->c_flags |= OMPI_COMM_EXTRA_RETAIN)
 #define OMPI_COMM_SET_MAPBY_NODE(comm) ((comm)->c_flags |= OMPI_COMM_MAPBY_NODE)
 
 #define OMPI_COMM_ASSERT_NO_ANY_TAG     0x00000001
@@ -148,8 +145,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
  */
 #define OMPI_COMM_SENTINEL        0x00000001
 
-/* A macro comparing two CIDs */
-#define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)
 
 OMPI_DECLSPEC extern opal_hash_table_t ompi_comm_hash;
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_communicators;

--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026        NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -264,5 +265,25 @@ struct mca_coll_acoll_module_t {
 
 typedef struct mca_coll_acoll_module_t mca_coll_acoll_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_acoll_module_t);
+
+/**
+ * Free a sub-communicator that was OBJ_RETAIN'd by the module.
+ * Releases the ownership reference safely: ompi_comm_free handles
+ * attribute cleanup + one OBJ_RELEASE; if the sub-comm survives
+ * (ownership ref still held), ompi_comm_lookup finds it and
+ * OBJ_RELEASE drops it to zero.
+ */
+static inline void coll_acoll_subcomm_free(ompi_communicator_t **comm)
+{
+    if (NULL != *comm) {
+        int cid = (*comm)->c_index;
+        ompi_comm_free(comm);
+        ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+        if (NULL != tmp) {
+            OBJ_RELEASE(tmp);
+        }
+        *comm = NULL;
+    }
+}
 
 #endif /* MCA_COLL_ACOLL_EXPORT_H */

--- a/ompi/mca/coll/acoll/coll_acoll_component.c
+++ b/ompi/mca/coll/acoll/coll_acoll_component.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; c-acoll-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026        NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -322,48 +323,22 @@ static void mca_coll_acoll_module_destruct(mca_coll_acoll_module_t *module)
             }
         }
 
-        if (subc->local_comm != NULL) {
-            ompi_comm_free(&(subc->local_comm));
-            subc->local_comm = NULL;
-        }
-
-        if (subc->local_r_comm != NULL) {
-            ompi_comm_free(&(subc->local_r_comm));
-            subc->local_r_comm = NULL;
-        }
-
-        if (subc->leader_comm != NULL) {
-            ompi_comm_free(&(subc->leader_comm));
-            subc->leader_comm = NULL;
-        }
-
-        if (subc->subgrp_comm != NULL) {
-            ompi_comm_free(&(subc->subgrp_comm));
-            subc->subgrp_comm = NULL;
-        }
-        if (subc->socket_comm != NULL) {
-            ompi_comm_free(&(subc->socket_comm));
-            subc->socket_comm = NULL;
-        }
-
-        if (subc->socket_ldr_comm != NULL) {
-            ompi_comm_free(&(subc->socket_ldr_comm));
-            subc->socket_ldr_comm = NULL;
-        }
+        coll_acoll_subcomm_free(&(subc->local_comm));
+        coll_acoll_subcomm_free(&(subc->local_r_comm));
+        coll_acoll_subcomm_free(&(subc->leader_comm));
+        coll_acoll_subcomm_free(&(subc->subgrp_comm));
+        coll_acoll_subcomm_free(&(subc->socket_comm));
+        coll_acoll_subcomm_free(&(subc->socket_ldr_comm));
+        coll_acoll_subcomm_free(&(subc->numa_comm));
+        coll_acoll_subcomm_free(&(subc->numa_comm_ldrs));
         for (int k = 0; k < MCA_COLL_ACOLL_NUM_BASE_LYRS; k++) {
             for (int j = 0; j < MCA_COLL_ACOLL_NUM_LAYERS; j++) {
-                if (subc->base_comm[k][j] != NULL) {
-                    ompi_comm_free(&(subc->base_comm[k][j]));
-                    subc->base_comm[k][j] = NULL;
-                }
+                coll_acoll_subcomm_free(&(subc->base_comm[k][j]));
             }
         }
 
         for (int k = 0; k < MCA_COLL_ACOLL_SPLIT_FACTOR_LIST_LEN; ++k) {
-            if (subc->split_comm[k] != NULL) {
-                ompi_comm_free(&(subc->split_comm[k]));
-                subc->split_comm[k] = NULL;
-            }
+            coll_acoll_subcomm_free(&(subc->split_comm[k]));
         }
         subc->initialized = 0;
         free(subc);

--- a/ompi/mca/coll/acoll/coll_acoll_utils.h
+++ b/ompi/mca/coll/acoll/coll_acoll_utils.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026        NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -286,6 +287,7 @@ static inline int mca_coll_acoll_create_base_comm(ompi_communicator_t **parent_c
         err = ompi_comm_split(parent_comm[i], color, rank[i], &subc->base_comm[base_lyr][i], false);
         if (MPI_SUCCESS != err)
             return err;
+        OBJ_RETAIN(subc->base_comm[base_lyr][i]);
 
         /* Find out local rank of root in base comm */
         err = comm_grp_ranks_local(parent_comm[i], subc->base_comm[base_lyr][i], &is_root_node,
@@ -448,12 +450,14 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->local_comm);
         /* Create socket-level subcommunicator */
         err = ompi_comm_split_type(comm, OMPI_COMM_TYPE_SOCKET, 0, &comm_info,
                                    &(subc->socket_comm));
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->socket_comm);
         OBJ_DESTRUCT(&comm_info);
         OBJ_CONSTRUCT(&comm_info, opal_info_t);
         opal_info_set(&comm_info, "ompi_comm_coll_preference", "libnbc,basic,^acoll");
@@ -463,10 +467,12 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->subgrp_comm);
         err = ompi_comm_split_type(comm, OMPI_COMM_TYPE_NUMA, 0, &comm_info, &(subc->numa_comm));
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->numa_comm);
         subc->subgrp_size = ompi_comm_size(subc->subgrp_comm);
         OBJ_DESTRUCT(&comm_info);
 
@@ -514,18 +520,14 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
 
         if (subc->initialized) {
             if (subc->num_nodes > 1) {
-                ompi_comm_free(&(subc->leader_comm));
-                subc->leader_comm = NULL;
+                coll_acoll_subcomm_free(&(subc->leader_comm));
             }
-            ompi_comm_free(&(subc->socket_ldr_comm));
-            subc->socket_ldr_comm = NULL;
+            coll_acoll_subcomm_free(&(subc->socket_ldr_comm));
         }
         for (int i = 0; i < MCA_COLL_ACOLL_NUM_LAYERS; i++) {
             if (subc->initialized) {
-                ompi_comm_free(&(subc->base_comm[MCA_COLL_ACOLL_L3CACHE][i]));
-                subc->base_comm[MCA_COLL_ACOLL_L3CACHE][i] = NULL;
-                ompi_comm_free(&(subc->base_comm[MCA_COLL_ACOLL_NUMA][i]));
-                subc->base_comm[MCA_COLL_ACOLL_NUMA][i] = NULL;
+                coll_acoll_subcomm_free(&(subc->base_comm[MCA_COLL_ACOLL_L3CACHE][i]));
+                coll_acoll_subcomm_free(&(subc->base_comm[MCA_COLL_ACOLL_NUMA][i]));
             }
             subc->base_root[MCA_COLL_ACOLL_L3CACHE][i] = -1;
             subc->base_root[MCA_COLL_ACOLL_NUMA][i] = -1;
@@ -577,6 +579,7 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->leader_comm);
 
         /* Find out local rank of root in leader comm */
         err = comm_grp_ranks_local(comm, subc->leader_comm, &is_root_node, &subc->outer_grp_root,
@@ -596,6 +599,7 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         err = ompi_comm_split(comm, color, rank, &subc->socket_ldr_comm, false);
         if (MPI_SUCCESS != err)
             return err;
+        OBJ_RETAIN(subc->socket_ldr_comm);
 
         /* Find out local rank of root in socket leader comm */
         err = comm_grp_ranks_local(comm, subc->socket_ldr_comm, &is_root_socket,
@@ -661,6 +665,7 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         if (MPI_SUCCESS != err) {
             return err;
         }
+        OBJ_RETAIN(subc->socket_ldr_comm);
 
         /* Find out local rank of root in socket leader comm */
         err = comm_grp_ranks_local(comm, subc->socket_ldr_comm, &is_root_socket,
@@ -693,6 +698,10 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
         numa_rank = ompi_comm_rank(subc->numa_comm);
         color = (0 == numa_rank) ? 0 : 1;
         err = ompi_comm_split(subc->local_comm, color, rank, &subc->numa_comm_ldrs, false);
+        if (MPI_SUCCESS != err) {
+            return err;
+        }
+        OBJ_RETAIN(subc->numa_comm_ldrs);
 
         /* Find out local rank of root in numa comm */
         err = comm_grp_ranks_local(comm, subc->numa_comm, &subc->is_root_numa, &subc->numa_root,
@@ -745,6 +754,7 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
             if (MPI_SUCCESS != err) {
                 return err;
             }
+            OBJ_RETAIN(subc->local_r_comm);
         }
 
         err = mca_coll_acoll_derive_r2r_latency(comm, subc, acoll_module);
@@ -770,6 +780,7 @@ static inline int mca_coll_acoll_comm_split_init(ompi_communicator_t *comm,
             if (MPI_SUCCESS != err) {
                 return err;
             }
+            OBJ_RETAIN(subc->split_comm[ii]);
         }
 
         subc->derived_node_size = (size + subc->num_nodes - 1) / subc->num_nodes;

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * $COPYRIGHT$
  *
@@ -116,7 +116,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
 
     if (module->cached_low_comms != NULL) {
         for (i = 0; i < COLL_HAN_LOW_MODULES; i++) {
+            int cid = module->cached_low_comms[i]->c_index;
             ompi_comm_free(&(module->cached_low_comms[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
             module->cached_low_comms[i] = NULL;
         }
         free(module->cached_low_comms);
@@ -124,7 +129,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     }
     if (module->cached_up_comms != NULL) {
         for (i = 0; i < COLL_HAN_UP_MODULES; i++) {
+            int cid = module->cached_up_comms[i]->c_index;
             ompi_comm_free(&(module->cached_up_comms[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
             module->cached_up_comms[i] = NULL;
         }
         free(module->cached_up_comms);
@@ -140,7 +150,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     }
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {
+            int cid = module->sub_comm[i]->c_index;
             ompi_comm_free(&(module->sub_comm[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
         }
     }
 

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -7,7 +7,7 @@
  *                         Laboratory, ICS Forth. All rights reserved.
  * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,15 +44,6 @@
     {                                                                        \
         (COMM)->c_coll->coll_##COLL = (FALLBACKS).COLL.COLL;                 \
         (COMM)->c_coll->coll_##COLL##_module = (FALLBACKS).COLL.module;      \
-    } while (0)
-
-#define HAN_SUBCOM_EXTRA_RETAIN(COMM, PARENT_COMM)                           \
-    do                                                                       \
-    {                                                                        \
-        if (OMPI_COMM_CID_IS_LOWER(COMM, PARENT_COMM)) {                     \
-            OMPI_COMM_SET_EXTRA_RETAIN(COMM);                                \
-            OBJ_RETAIN(COMM);                                                \
-        }                                                                    \
     } while (0)
 
 /*
@@ -216,9 +207,9 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
 
     OBJ_DESTRUCT(&comm_info);
    
-    /* Ensure these communicators aren't released before the parent comm */
-    HAN_SUBCOM_EXTRA_RETAIN(*low_comm, comm);
-    HAN_SUBCOM_EXTRA_RETAIN(*up_comm, comm);
+    /* Retain sub-communicators so they survive finalize ordering */
+    OBJ_RETAIN(*low_comm);
+    OBJ_RETAIN(*up_comm);
 
     return OMPI_SUCCESS;
 
@@ -390,12 +381,12 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     han_module->cached_up_comms = up_comms;
     han_module->cached_vranks = vranks;
 
-    /* Ensure these communicators aren't released before the parent comm */
+    /* Retain sub-communicators so they survive finalize ordering */
     for(int i = 0; i < COLL_HAN_LOW_MODULES; i++) {
-        HAN_SUBCOM_EXTRA_RETAIN(low_comms[i], comm);
+        OBJ_RETAIN(low_comms[i]);
     }
     for(int i = 0; i < COLL_HAN_UP_MODULES; i++) {
-        HAN_SUBCOM_EXTRA_RETAIN(up_comms[i], comm);
+        OBJ_RETAIN(up_comms[i]);
     }
 
     /* Reset the saved collectives to point back to HAN */


### PR DESCRIPTION
comm: replace EXTRA_RETAIN mechanism with proper sub-communicator ownership

The OMPI_COMM_EXTRA_RETAIN flag was a workaround for a finalize-time ordering problem: during MPI_Finalize, the communicator table is walked in ascending CID order, and each communicator is OBJ_RELEASE'd. If a sub-communicator (e.g., c_local_comm of an inter-communicator, or a HAN/ACOLL sub-communicator) had a lower CID than its parent, it would be destroyed first, leaving the parent with a dangling pointer. EXTRA_RETAIN solved this by conditionally bumping the refcount (only when the sub-comm CID was lower than the parent's), setting a flag on the communicator, and adding matching release logic in ompi_comm_free and special-case handling in the finalize loop. This made the ownership model implicit and spread across multiple files.

Replace this with explicit reference-counted ownership, all subcommunicators have an additional refcount owned by their parent, that gets released when the parent gets destructed. As a result, sub communicators linger around until their parent gets destroyed, but eventually all communicators disappear in MPI_Finalize (even those not properly freed by the user).

Potential fix for #13794 

Signed-off-by: George Bosilca <gbosilca@nvidia.com>