### PR TITLE
ci: Run test enabling DSO components

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -59,7 +59,8 @@ def prepare_check_stages() {
 	"--disable-dlopen",
 	"--disable-oshmem",
 	"--enable-builtin-atomic",
-	"--enable-ipv6"
+	"--enable-ipv6",
+	"--enable-mca-dso"
     ]
     def compilers = [
 	"gcc14",

--- a/.ci/community-jenkins/pr-builder.sh
+++ b/.ci/community-jenkins/pr-builder.sh
@@ -241,10 +241,13 @@ fi
 
 echo "--> running make ${MAKE_J} ${MAKE_ARGS} all"
 make ${MAKE_J} ${MAKE_ARGS} all
-echo "--> running make check"
-make ${MAKE_ARGS} check
+# while backwards, it is important to run "make install" before "make check",
+# because many of the tests call opal_init(), which will fail unless it can find
+# components.
 echo "--> running make install"
 make ${MAKE_ARGS} install
+echo "--> running make check"
+make ${MAKE_ARGS} check
 
 export PATH="${PREFIX}/bin":${PATH}
 


### PR DESCRIPTION
We have not been testing that building components as DSOs works properly and it had broken.  818a7baab6 fixes the underlying issue, so add a test to keep us from breaking it again.