### PR TITLE
comm: replace EXTRA_RETAIN mechanism with proper sub-communicator ownerwhip

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -26,7 +26,9 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025      BULL S.A.S. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -273,10 +275,14 @@ int ompi_comm_set_nb (ompi_communicator_t **ncomm, ompi_communicator_t *oldcomm,
             /* NTH: use internal idup function that takes a local group argument */
             ompi_comm_idup_internal (old_localcomm, newcomm->c_local_group, NULL, NULL,
                                      &newcomm->c_local_comm, req);
+            if (NULL != newcomm->c_local_comm
+                && !OMPI_COMM_IS_INTRINSIC(newcomm->c_local_comm)) {
+                OBJ_RETAIN(newcomm->c_local_comm);
+            }
         } else {
-            /* take ownership of the old communicator (it must be an intracommunicator) */
             assert (OMPI_COMM_IS_INTRA(oldcomm));
             newcomm->c_local_comm = oldcomm;
+            OBJ_RETAIN(newcomm->c_local_comm);
         }
     } else {
         newcomm->c_remote_group = newcomm->c_local_group;
@@ -2120,8 +2126,6 @@ static int ompi_comm_allgather_emulate_intra( void *inbuf, int incount,
 int ompi_comm_free( ompi_communicator_t **comm )
 {
     int ret;
-    int cid = (*comm)->c_index;
-    int is_extra_retain = OMPI_COMM_IS_EXTRA_RETAIN(*comm);
 
     /* Release attributes.  We do this now instead of during the
        communicator destructor for 2 reasons:
@@ -2150,7 +2154,9 @@ int ompi_comm_free( ompi_communicator_t **comm )
     }
 
     if ( OMPI_COMM_IS_INTER(*comm) ) {
-        if ( ! OMPI_COMM_IS_INTRINSIC((*comm)->c_local_comm)) {
+        if (NULL != (*comm)->c_local_comm
+            && ! OMPI_COMM_IS_INTRINSIC((*comm)->c_local_comm)) {
+            OBJ_RELEASE((*comm)->c_local_comm);
             ompi_comm_free (&(*comm)->c_local_comm);
         }
     }
@@ -2172,29 +2178,6 @@ int ompi_comm_free( ompi_communicator_t **comm )
         ompi_comm_num_dyncomm --;
     }
     OBJ_RELEASE( (*comm) );
-
-    if ( is_extra_retain) {
-        /* This communicator has been marked as an "extra retain"
-         * communicator. This can happen if a communicator creates
-         * 'dependent' subcommunicators (e.g. for inter
-         * communicators or when using hierarch collective
-         * module *and* the cid of the dependent communicator
-         * turned out to be lower than of the parent one.
-         * In that case, the reference counter has been increased
-         * by one more, in order to handle the scenario,
-         * that the user did not free the communicator.
-         * Note, that if we enter this routine, we can
-         * decrease the counter by one more therefore. However,
-         * in ompi_comm_finalize, we only used OBJ_RELEASE instead
-         * of ompi_comm_free(), and the increased reference counter
-         * makes sure that the pointer to the dependent communicator
-         * still contains a valid object.
-         */
-        ompi_communicator_t *tmpcomm = ompi_comm_lookup(cid);
-        if ( NULL != tmpcomm ){
-            ompi_comm_free(&tmpcomm);
-        }
-    }
 
     *comm = MPI_COMM_NULL;
     return OMPI_SUCCESS;

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2020-2024 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,8 +61,6 @@
 /* for use when we don't have a PMIx that supports CID generation */
 opal_atomic_int64_t ompi_comm_next_base_cid = 1;
 
-/* A macro comparing two CIDs */
-#define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)
 
 struct ompi_comm_cid_context_t;
 
@@ -882,30 +881,6 @@ static int ompi_comm_activate_complete (ompi_communicator_t **newcomm, ompi_comm
         OBJ_RELEASE(*newcomm);
         *newcomm = MPI_COMM_NULL;
         return ret;
-    }
-
-    /* For an inter communicator, we have to deal with the potential
-     * problem of what is happening if the local_comm that we created
-     * has a lower CID than the parent comm. This is not a problem
-     * as long as the user calls MPI_Comm_free on the inter communicator.
-     * However, if the communicators are not freed by the user but released
-     * by Open MPI in MPI_Finalize, we walk through the list of still available
-     * communicators and free them one by one. Thus, local_comm is freed before
-     * the actual inter-communicator. However, the local_comm pointer in the
-     * inter communicator will still contain the 'previous' address of the local_comm
-     * and thus this will lead to a segmentation violation. In order to prevent
-     * that from happening, we increase the reference counter local_comm
-     * by one if its CID is lower than the parent. We cannot increase however
-     *  its reference counter if the CID of local_comm is larger than
-     * the CID of the inter communicators, since a regular MPI_Comm_free would
-     * leave in that the case the local_comm hanging around and thus we would not
-     * recycle CID's properly, which was the reason and the cause for this trouble.
-     */
-    if (OMPI_COMM_IS_INTER(*newcomm)) {
-        if (OMPI_COMM_CID_IS_LOWER(*newcomm, comm)) {
-            OMPI_COMM_SET_EXTRA_RETAIN (*newcomm);
-            OBJ_RETAIN (*newcomm);
-        }
     }
 
     /* done */

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -25,8 +25,9 @@
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
- * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023-2026 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -331,36 +332,25 @@ static int ompi_comm_finalize (void)
     for ( i=3; i<max; i++ ) {
         comm = ompi_comm_lookup(i);
         if ( NULL != comm ) {
-            /* Communicator has not been freed before finalize */
-            opal_output_verbose(10, ompi_comm_output,
-                                "ompi_comm_finalize: releasing comm %p name \"%s\" size %d cid %d refcnt %d",
-                                (void *)comm, comm->c_name, ompi_comm_size(comm),
-                                comm->c_index,
-                                ((opal_object_t *)comm)->obj_reference_count);
+            /* Release the communicator. Sub-communicators retained by
+             * their parent (e.g., c_local_comm of inter-communicators)
+             * will be properly released by the parent's destructor. */
             OBJ_RELEASE(comm);
-            comm = ompi_comm_lookup(i);
-            if ( NULL != comm ) {
-                /* Still here ? */
-                if ( !OMPI_COMM_IS_EXTRA_RETAIN(comm)) {
-
-                    /* For communicator that have been marked as "extra retain", we do not further
-                     * enforce to decrease the reference counter once more. These "extra retain"
-                     * communicators created e.g. by the hierarch or inter module did increase
-                     * the reference count by one more than other communicators, on order to
-                     * allow for deallocation with the parent communicator. Note, that
-                     * this only occurs if the cid of the local_comm is lower than of its
-                     * parent communicator. Read the comment in comm_activate for
-                     * a full explanation.
-                     */
-                    if ( ompi_debug_show_handle_leaks && !(OMPI_COMM_IS_FREED(comm)) ){
-                        opal_output(0,"WARNING: MPI_Comm still allocated in MPI_Finalize\n");
-                        ompi_comm_dump ( comm);
-                        OBJ_RELEASE(comm);
-                    }
-                }
-            }
         }
     }
+
+#if OPAL_ENABLE_DEBUG
+    if ( ompi_debug_show_handle_leaks ) {
+        max = ompi_comm_get_num_communicators();
+        for ( i=3; i<max; i++ ) {
+            comm = ompi_comm_lookup(i);
+            if (NULL == comm) continue;
+            opal_output(0, "WARNING: %d unnamed MPI_Comm handles still allocated at MPI_FINALIZE", comm->c_name);
+            ompi_comm_dump ( comm);
+            OBJ_RELEASE(comm);
+        }
+    }
+#endif  /* OPAL_ENABLE_DEBUG */
 
     if (ompi_comm_intrinsic_init) {
         /* tear down MPI-3 predefined communicators (not initialized unless using MPI_Init) */
@@ -516,6 +506,12 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
     if (NULL != comm->c_topo) {
         OBJ_RELEASE(comm->c_topo);
         comm->c_topo = NULL;
+    }
+
+    if (OMPI_COMM_IS_INTER(comm) && NULL != comm->c_local_comm
+        && !OMPI_COMM_IS_INTRINSIC(comm->c_local_comm)) {
+        OBJ_RELEASE(comm->c_local_comm);
+        comm->c_local_comm = NULL;
     }
 
     if (NULL != comm->c_local_group) {

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -25,7 +25,7 @@
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_GRAPH        0x00000200
 #define OMPI_COMM_DIST_GRAPH   0x00000400
 #define OMPI_COMM_PML_ADDED    0x00001000
-#define OMPI_COMM_EXTRA_RETAIN 0x00004000
 #define OMPI_COMM_MAPBY_NODE   0x00008000
 #define OMPI_COMM_GLOBAL_INDEX 0x00010000
 
@@ -82,7 +81,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_IS_DYNAMIC(comm) ((comm)->c_flags & OMPI_COMM_DYNAMIC)
 #define OMPI_COMM_IS_INVALID(comm) ((comm)->c_flags & OMPI_COMM_INVALID)
 #define OMPI_COMM_IS_PML_ADDED(comm) ((comm)->c_flags & OMPI_COMM_PML_ADDED)
-#define OMPI_COMM_IS_EXTRA_RETAIN(comm) ((comm)->c_flags & OMPI_COMM_EXTRA_RETAIN)
 #define OMPI_COMM_IS_TOPO(comm) (OMPI_COMM_IS_CART((comm)) || \
                                  OMPI_COMM_IS_GRAPH((comm)) || \
                                  OMPI_COMM_IS_DIST_GRAPH((comm)))
@@ -93,7 +91,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_SET_INVALID(comm) ((comm)->c_flags |= OMPI_COMM_INVALID)
 
 #define OMPI_COMM_SET_PML_ADDED(comm) ((comm)->c_flags |= OMPI_COMM_PML_ADDED)
-#define OMPI_COMM_SET_EXTRA_RETAIN(comm) ((comm)->c_flags |= OMPI_COMM_EXTRA_RETAIN)
 #define OMPI_COMM_SET_MAPBY_NODE(comm) ((comm)->c_flags |= OMPI_COMM_MAPBY_NODE)
 
 #define OMPI_COMM_ASSERT_NO_ANY_TAG     0x00000001
@@ -142,8 +139,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
  */
 #define OMPI_COMM_SENTINEL        0x00000001
 
-/* A macro comparing two CIDs */
-#define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)
 
 OMPI_DECLSPEC extern opal_hash_table_t ompi_comm_hash;
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_communicators;

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2021      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,7 +120,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
 
     if (module->cached_low_comms != NULL) {
         for (i = 0; i < COLL_HAN_LOW_MODULES; i++) {
+            int cid = module->cached_low_comms[i]->c_index;
             ompi_comm_free(&(module->cached_low_comms[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
             module->cached_low_comms[i] = NULL;
         }
         free(module->cached_low_comms);
@@ -126,7 +133,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     }
     if (module->cached_up_comms != NULL) {
         for (i = 0; i < COLL_HAN_UP_MODULES; i++) {
+            int cid = module->cached_up_comms[i]->c_index;
             ompi_comm_free(&(module->cached_up_comms[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
             module->cached_up_comms[i] = NULL;
         }
         free(module->cached_up_comms);
@@ -142,7 +154,12 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     }
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {
+            int cid = module->sub_comm[i]->c_index;
             ompi_comm_free(&(module->sub_comm[i]));
+            ompi_communicator_t *tmp = ompi_comm_lookup(cid);
+            if (NULL != tmp) {
+                OBJ_RELEASE(tmp);
+            }
         }
     }
 

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2020      Bull S.A.S. All rights reserved.
  *
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,15 +40,6 @@
         (COMM)->c_coll->coll_ ## COLL = (FALLBACKS).COLL.module_fn.COLL;         \
         (COMM)->c_coll->coll_ ## COLL ## _module = (FALLBACKS).COLL.module;      \
     } while(0)
-
-#define HAN_SUBCOM_EXTRA_RETAIN(COMM, PARENT_COMM)                           \
-    do                                                                       \
-    {                                                                        \
-        if (OMPI_COMM_CID_IS_LOWER(COMM, PARENT_COMM)) {                     \
-            OMPI_COMM_SET_EXTRA_RETAIN(COMM);                                \
-            OBJ_RETAIN(COMM);                                                \
-        }                                                                    \
-    } while (0)
 
 /*
  * Routine that creates the local hierarchical sub-communicators
@@ -194,9 +186,9 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
 
     OBJ_DESTRUCT(&comm_info);
    
-    /* Ensure these communicators aren't released before the parent comm */
-    HAN_SUBCOM_EXTRA_RETAIN(*low_comm, comm);
-    HAN_SUBCOM_EXTRA_RETAIN(*up_comm, comm);
+    /* Retain sub-communicators so they survive finalize ordering */
+    OBJ_RETAIN(*low_comm);
+    OBJ_RETAIN(*up_comm);
 
     return OMPI_SUCCESS;
 
@@ -352,12 +344,12 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     han_module->cached_up_comms = up_comms;
     han_module->cached_vranks = vranks;
 
-    /* Ensure these communicators aren't released before the parent comm */
+    /* Retain sub-communicators so they survive finalize ordering */
     for(int i = 0; i < COLL_HAN_LOW_MODULES; i++) {
-        HAN_SUBCOM_EXTRA_RETAIN(low_comms[i], comm);
+        OBJ_RETAIN(low_comms[i]);
     }
     for(int i = 0; i < COLL_HAN_UP_MODULES; i++) {
-        HAN_SUBCOM_EXTRA_RETAIN(up_comms[i], comm);
+        OBJ_RETAIN(up_comms[i]);
     }
 
     /* Reset the saved collectives to point back to HAN */


### PR DESCRIPTION
The OMPI_COMM_EXTRA_RETAIN flag was a workaround for a finalize-time ordering problem: during MPI_Finalize, the communicator table is walked in ascending CID order, and each communicator is OBJ_RELEASE'd. If a sub-communicator (e.g., c_local_comm of an inter-communicator, or a HAN sub-communicator) had a lower CID than its parent, it would be destroyed first, leaving the parent with a dangling pointer. EXTRA_RETAIN solved this by conditionally bumping the refcount (only when the sub-comm CID was lower than the parent's), setting a flag on the communicator, and adding matching release logic in ompi_comm_free and special-case handling in the finalize loop. This made the ownership model implicit and spread across multiple files.
Replace this with explicit reference-counted ownership:
- In ompi_comm_set_nb(), OBJ_RETAIN c_local_comm when it is assigned to the parent inter-communicator, regardless of CID ordering.
- In ompi_comm_destruct(), OBJ_RELEASE c_local_comm if the parent is an inter-communicator. This ensures proper cleanup in both the finalize path (where the destructor cascades the release) and the user path (where ompi_comm_free NULLs the field before the destructor runs).
- In ompi_comm_free(), release the ownership reference on c_local_comm (OBJ_RELEASE) before calling ompi_comm_free() on it recursively. The first release undoes the ownership retain; the recursive free handles attribute cleanup and releases the creation reference.
- Simplify the finalize loop in ompi_comm_finalize(): a single OBJ_RELEASE per communicator is sufficient.  Sub-communicators retained by their parent survive until the parent's destructor cascades the release, regardless of CID ordering.
- Remove the OMPI_COMM_EXTRA_RETAIN flag, OMPI_COMM_IS_EXTRA_RETAIN(), and OMPI_COMM_SET_EXTRA_RETAIN() from communicator.h.
- Remove the conditional EXTRA_RETAIN block from ompi_comm_activate_complete() in comm_cid.c.

For the HAN collective module:
- Replace the HAN_SUBCOM_EXTRA_RETAIN macro (conditional OBJ_RETAIN + flag set) with unconditional OBJ_RETAIN on sub-communicators.
- In the HAN module destructor, after ompi_comm_free() on each sub-communicator, use ompi_comm_lookup() to check whether the sub-comm survived (refcount > 0), and if so, OBJ_RELEASE it. This safely handles both the user path (sub-comm survives ompi_comm_free with refcount 1, lookup finds it, OBJ_RELEASE destroys it) and the finalize path (sub-comm is destroyed by ompi_comm_free, lookup returns NULL).