### PR TITLE
ob1: don't call btl_dump if the btl does not provide it

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -723,6 +723,8 @@ int mca_pml_ob1_dump(struct ompi_communicator_t* comm, int verbose)
         for( n = 0; n < ep->btl_eager.arr_size; n++ ) {
             mca_bml_base_btl_t* bml_btl = &ep->btl_eager.bml_btls[n];
             if (bml_btl->btl->btl_dump == NULL) {
+                opal_output(0, "BTL %s does not provide dump callback\n",
+                            bml_btl->btl->btl_component->btl_version.mca_component_name);
                 continue;
             }
             bml_btl->btl->btl_dump(bml_btl->btl, bml_btl->btl_endpoint, verbose);

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -27,6 +27,7 @@
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Stony Brook University. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -721,6 +722,9 @@ int mca_pml_ob1_dump(struct ompi_communicator_t* comm, int verbose)
         /* dump all btls used for eager messages */
         for( n = 0; n < ep->btl_eager.arr_size; n++ ) {
             mca_bml_base_btl_t* bml_btl = &ep->btl_eager.bml_btls[n];
+            if (bml_btl->btl->btl_dump == NULL) {
+                continue;
+            }
             bml_btl->btl->btl_dump(bml_btl->btl, bml_btl->btl_endpoint, verbose);
         }
     }

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -356,6 +356,7 @@ mca_btl_uct_module_t mca_btl_uct_module_template = {
         .btl_finalize = mca_btl_uct_finalize,
         .btl_put = mca_btl_uct_put,
         .btl_get = mca_btl_uct_get,
+        .btl_dump = mca_btl_base_dump,
         .btl_register_mem = mca_btl_uct_register_mem,
         .btl_deregister_mem = mca_btl_uct_deregister_mem,
         .btl_atomic_op = mca_btl_uct_aop,


### PR DESCRIPTION
We dump the btl during revoke, which leads to a Segfault if we're not careful.