### PR TITLE
coll/han: Persistent buffers for MR cache optimization (scatterv, gatherv, alltoall, and alltoallv)

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -471,6 +471,38 @@ typedef struct mca_coll_han_module_t {
      * (e.g., allgather uses a gather buffer and a reorder buffer). */
     char *scratch_buf[2];
     size_t scratch_buf_size[2];
+
+    struct han_alltoall_cache {
+        char *bounce;
+        size_t bounce_size;
+        const void *cached_sbuf;
+        size_t cached_scount;
+        int cached_low_size;
+        char **low_bufs;
+        void **map_ctx;
+        void **gather_buf;
+        int cached_send_needs_bounce;
+        int cached_ii_push_data;
+        char *recv_buf;
+        size_t recv_buf_size;
+    } a2a_cache;
+
+    struct han_alltoallv_cache {
+        uint8_t *serial_buf;
+        size_t serial_buf_size;
+        void *gather_out;
+        void *peers;
+        void *peer_types;
+        int low_size;
+        void **send_from;
+        void **recv_to;
+        size_t *send_counts;
+        size_t *recv_counts;
+        void **send_types;
+        void **recv_types;
+        bool smsc_decided;
+        int use_smsc;
+    } a2av_cache;
 } mca_coll_han_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -91,6 +91,12 @@ enum {
  */
 static inline char *han_scratch_alloc(char **buf, size_t *buf_size, size_t needed)
 {
+    if (0 == needed) {
+        /* Return a valid non-NULL pointer for zero-size allocations,
+         * matching malloc(0) behavior that callers rely on. */
+        static char zero_len_sentinel;
+        return &zero_len_sentinel;
+    }
     if (*buf_size < needed) {
         char *p = realloc(*buf, needed);
         if (NULL == p) return NULL;

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -870,7 +870,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
             /* Compute the size to receive all the local data, including datatypes empty gaps */
             rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size, &rgap);
             /* intermediary buffer on node leaders to gather on low comm */
-            tmp_buf = (char *) malloc(rsize);
+            tmp_buf = han_scratch_or_malloc(&han_module->scratch_buf[1],
+                                            &han_module->scratch_buf_size[1],
+                                            rsize, mca_coll_han_component.han_use_persist_buffers);
             if (NULL == tmp_buf) {
                 return OMPI_ERR_OUT_OF_RESOURCE;
             }
@@ -918,7 +920,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                 }
                 ptrdiff_t rsize, rgap = 0;
                 rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size * up_size, &rgap);
-                reorder_buf = (char *) malloc(rsize);
+                reorder_buf = han_scratch_or_malloc(&han_module->scratch_buf[0],
+                                                     &han_module->scratch_buf_size[0],
+                                                     rsize, mca_coll_han_component.han_use_persist_buffers);
                 reorder_buf_start = reorder_buf - rgap;
             }
 
@@ -927,7 +931,7 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                             reorder_buf_start, rcount*low_size, rdtype,
                                             up_comm, up_comm->c_coll->coll_allgather_module);
 
-            if (tmp_buf != NULL) {
+            if (tmp_buf != NULL && !mca_coll_han_component.han_use_persist_buffers) {
                 free(tmp_buf);
                 tmp_buf = NULL;
                 tmp_buf_start = NULL;
@@ -941,7 +945,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                 ompi_coll_han_reorder_gather(reorder_buf_start,
                                              rbuf, rcount, rdtype,
                                              comm, topo);
-                free(reorder_buf);
+                if (!mca_coll_han_component.han_use_persist_buffers) {
+                    free(reorder_buf);
+                }
                 reorder_buf = NULL;
             }
 

--- a/ompi/mca/coll/han/coll_han_alltoall.c
+++ b/ompi/mca/coll/han/coll_han_alltoall.c
@@ -63,7 +63,9 @@ static inline int ring_partner(int rank, int round, int comm_size) {
 
 /**
  * Set up or reuse cached SMSC arrays for alltoall.
- * Returns true if cache was valid (allgather + map can be skipped).
+ * Returns 1 if cache was valid (allgather + map can be skipped),
+ * 0 on cache miss (arrays allocated, caller must populate),
+ * or -1 on allocation failure.
  */
 static int alltoall_cache_setup(
     mca_coll_han_module_t *han_module,

--- a/ompi/mca/coll/han/coll_han_alltoall.c
+++ b/ompi/mca/coll/han/coll_han_alltoall.c
@@ -60,6 +60,60 @@ static inline int ring_partner(int rank, int round, int comm_size) {
         return ring_partner_no_skip(rank, round+1, comm_size);
 }
 
+
+/**
+ * Set up or reuse cached SMSC arrays for alltoall.
+ * Returns true if cache was valid (allgather + map can be skipped).
+ */
+static int alltoall_cache_setup(
+    mca_coll_han_module_t *han_module,
+    const void *sbuf, size_t scount, int low_size,
+    char ***low_bufs_out, void ***map_ctx_out, void ***gather_buf_out,
+    int *send_needs_bounce_out, int *ii_push_data_out)
+{
+    struct han_alltoall_cache *c = &han_module->a2a_cache;
+    const int nptrs_gather = 3;
+
+    if (c->cached_sbuf == sbuf
+        && c->cached_scount == scount
+        && c->cached_low_size == low_size
+        && c->low_bufs != NULL) {
+        *low_bufs_out = c->low_bufs;
+        *map_ctx_out = c->map_ctx;
+        *gather_buf_out = c->gather_buf;
+        *send_needs_bounce_out = c->cached_send_needs_bounce;
+        *ii_push_data_out = c->cached_ii_push_data;
+        return 1; /* cache valid */
+    }
+
+    /* Invalidate old cache — unmap old SMSC regions */
+    if (c->map_ctx) {
+        for (int i = 0; i < c->cached_low_size; i++) {
+            if (c->map_ctx[i])
+                mca_smsc->unmap_peer_region(c->map_ctx[i]);
+        }
+    }
+    /* Allocate/reuse persistent arrays */
+    if (c->cached_low_size < low_size) {
+        free(c->low_bufs);
+        free(c->map_ctx);
+        free(c->gather_buf);
+        c->cached_low_size = 0;
+        c->low_bufs = malloc(low_size * sizeof(char*));
+        c->map_ctx = malloc(low_size * sizeof(void*));
+        c->gather_buf = calloc(low_size * nptrs_gather, sizeof(void*));
+        if (NULL == c->low_bufs || NULL == c->map_ctx || NULL == c->gather_buf) {
+            return -1; /* allocation failure */
+        }
+    }
+    *low_bufs_out = c->low_bufs;
+    *map_ctx_out = c->map_ctx;
+    *gather_buf_out = c->gather_buf;
+    memset(c->map_ctx, 0, low_size * sizeof(void*));
+    memset(c->gather_buf, 0, low_size * nptrs_gather * sizeof(void*));
+    return 0; /* cache miss */
+}
+
 int mca_coll_han_alltoall_using_smsc(
         const void *sbuf, size_t scount,
         struct ompi_datatype_t *sdtype,
@@ -218,13 +272,30 @@ int mca_coll_han_alltoall_using_smsc(
     int64_t send_bytes_per_fan = low_size * packed_size;
     inter_send_reqs = malloc(sizeof(*inter_send_reqs) * fanout);
     inter_recv_reqs = malloc(sizeof(*inter_recv_reqs) * up_size );
-    char **low_bufs = malloc(low_size * sizeof(*low_bufs));
-    void **sbuf_map_ctx = malloc(low_size * sizeof(&sbuf_map_ctx));
-    opal_free_list_item_t *send_fl_item = NULL;
 
+    /* Check if cached SMSC mappings are still valid */
+    int a2a_cache_valid;
+    char **low_bufs = NULL;
+    void **sbuf_map_ctx = NULL;
+    opal_free_list_item_t *send_fl_item = NULL;
     const int nptrs_gather = 3;
-    void **gather_buf_out = calloc(low_size*nptrs_gather, sizeof(void*));
+    void **gather_buf_out = NULL;
     int send_bounce_status = BOUNCE_NOT_INITIALIZED;
+
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        int cache_rc = alltoall_cache_setup(
+            han_module, sbuf, scount, low_size,
+            &low_bufs, &sbuf_map_ctx, &gather_buf_out,
+            &send_needs_bounce, &ii_push_data);
+        if (cache_rc < 0) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+        a2a_cache_valid = (cache_rc == 1);
+    } else {
+        /* Original upstream path — fresh allocations per call */
+        a2a_cache_valid = 0;
+        low_bufs = malloc(low_size * sizeof(*low_bufs));
+        sbuf_map_ctx = malloc(low_size * sizeof(*sbuf_map_ctx));
+        gather_buf_out = calloc(low_size * nptrs_gather, sizeof(void*));
+    }
 
     do {
 start_allgather:
@@ -233,70 +304,96 @@ start_allgather:
             send_bounce_status = BOUNCE_IS_FROM_RBUF;
         } else {
             if (send_bounce_status == BOUNCE_NOT_INITIALIZED || send_bounce_status == BOUNCE_IS_FROM_RBUF) {
-                if (send_bytes_per_fan * fanout < mca_coll_han_component.han_packbuf_bytes) {
-                    send_fl_item = opal_free_list_get(&mca_coll_han_component.pack_buffers);
-                    if (send_fl_item) {
-                        send_bounce_status = BOUNCE_IS_FROM_FREELIST;
-                        send_bounce = send_fl_item->ptr;
+                if (mca_coll_han_component.han_use_persist_buffers) {
+                    /* Persistent bounce: realloc-to-HWM avoids munmap on free
+                     * which would invalidate NIC memory registration cache entries. */
+                    size_t needed = send_bytes_per_fan * fanout;
+                    if (han_module->a2a_cache.bounce_size < needed) {
+                        char *p = realloc(han_module->a2a_cache.bounce, needed);
+                        if (NULL == p) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+                        han_module->a2a_cache.bounce = p;
+                        han_module->a2a_cache.bounce_size = needed;
+                    }
+                    send_bounce = han_module->a2a_cache.bounce;
+                    send_bounce_status = BOUNCE_IS_FROM_MALLOC;
+                } else {
+                    if (send_bytes_per_fan * fanout < mca_coll_han_component.han_packbuf_bytes) {
+                        send_fl_item = opal_free_list_get(&mca_coll_han_component.pack_buffers);
+                        if (send_fl_item) {
+                            send_bounce_status = BOUNCE_IS_FROM_FREELIST;
+                            send_bounce = send_fl_item->ptr;
+                        }
+                    }
+                    if (!send_fl_item) {
+                        send_bounce = malloc(send_bytes_per_fan * fanout);
+                        send_bounce_status = BOUNCE_IS_FROM_MALLOC;
                     }
                 }
-                if (!send_fl_item) {
-                    send_bounce = malloc(send_bytes_per_fan * fanout);
-                    send_bounce_status = BOUNCE_IS_FROM_MALLOC;
+            }
+        }
+
+        if (!a2a_cache_valid) {
+            if (ii_push_data) {
+                /* all ranks will push to the other ranks' bounce buffer */
+                gather_buf_in[0] = send_bounce;
+            } else {
+                /* all ranks will pull from the other ranks' sbuf */
+                gather_buf_in[0] = (void*)sbuf;
+            }
+            gather_buf_in[1] = (void*)(intptr_t)send_needs_bounce;
+            gather_buf_in[2] = (void*)(intptr_t)ii_push_data;
+
+            rc = low_comm->c_coll->coll_allgather(gather_buf_in, nptrs_gather, MPI_AINT,
+                        gather_buf_out, nptrs_gather, MPI_AINT, low_comm,
+                        low_comm->c_coll->coll_allgather_module);
+
+            if (rc != 0) {
+                OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
+                "Allgather failed with %d\n",rc));
+                goto cleanup;
+            }
+
+            for (int jother=0; jother<low_size; jother++) {
+                int other_push_data = (uintptr_t)gather_buf_out[nptrs_gather*jother + 2] & 0x1;
+                if (ii_push_data != other_push_data) {
+                    ii_push_data = 1;
+                    goto start_allgather;
                 }
+                send_needs_bounce  |= (uintptr_t)gather_buf_out[nptrs_gather*jother + 1] & 0x1;
+                ii_push_data       |= other_push_data;
             }
-        }
-
-        if (ii_push_data) {
-            /* all ranks will push to the other ranks' bounce buffer */
-            gather_buf_in[0] = send_bounce;
-        } else {
-            /* all ranks will pull from the other ranks' sbuf */
-            gather_buf_in[0] = (void*)sbuf;
-        }
-        gather_buf_in[1] = (void*)(intptr_t)send_needs_bounce;
-        gather_buf_in[2] = (void*)(intptr_t)ii_push_data;
-
-        rc = low_comm->c_coll->coll_allgather(gather_buf_in, nptrs_gather, MPI_AINT,
-                    gather_buf_out, nptrs_gather, MPI_AINT, low_comm,
-                    low_comm->c_coll->coll_allgather_module);
-
-        if (rc != 0) {
-            OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
-            "Allgather failed with %d\n",rc));
-            goto cleanup;
-        }
-
-        for (int jother=0; jother<low_size; jother++) {
-            int other_push_data = (uintptr_t)gather_buf_out[nptrs_gather*jother + 2] & 0x1;
-            if (ii_push_data != other_push_data) {
-                ii_push_data = 1;
-                goto start_allgather;
-            }
-            send_needs_bounce  |= (uintptr_t)gather_buf_out[nptrs_gather*jother + 1] & 0x1;
-            ii_push_data       |= other_push_data;
-        }
+        } /* !a2a_cache_valid */
     } while (0);
 
     use_isend = fanout > 1 || ii_push_data;
 
-    for (int jother=0; jother<low_size; jother++) {
-        low_bufs[jother] = gather_buf_out[nptrs_gather*jother];
-        if (jother == low_rank) {
-            sbuf_map_ctx[low_rank] = NULL;
-        } else {
-            struct ompi_proc_t* ompi_proc = ompi_comm_peer_lookup(low_comm, jother);
-            mca_smsc_endpoint_t *smsc_ep;
-            smsc_ep = mca_coll_han_get_smsc_endpoint(ompi_proc);
+    if (!a2a_cache_valid) {
+        for (int jother=0; jother<low_size; jother++) {
+            low_bufs[jother] = gather_buf_out[nptrs_gather*jother];
+            if (jother == low_rank) {
+                sbuf_map_ctx[low_rank] = NULL;
+            } else {
+                struct ompi_proc_t* ompi_proc = ompi_comm_peer_lookup(low_comm, jother);
+                mca_smsc_endpoint_t *smsc_ep;
+                smsc_ep = mca_coll_han_get_smsc_endpoint(ompi_proc);
 
-            sbuf_map_ctx[jother] = mca_smsc->map_peer_region(
-                smsc_ep,
-                MCA_RCACHE_FLAGS_PERSIST,
-                low_bufs[jother],
-                sextent*w_size*scount,
-                (void**) &low_bufs[jother] );
+                sbuf_map_ctx[jother] = mca_smsc->map_peer_region(
+                    smsc_ep,
+                    MCA_RCACHE_FLAGS_PERSIST,
+                    low_bufs[jother],
+                    sextent*w_size*scount,
+                    (void**) &low_bufs[jother] );
+            }
         }
-    }
+        /* Update cache (only when persist buffers enabled) */
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            han_module->a2a_cache.cached_sbuf = sbuf;
+            han_module->a2a_cache.cached_scount = scount;
+            han_module->a2a_cache.cached_low_size = low_size;
+            han_module->a2a_cache.cached_send_needs_bounce = send_needs_bounce;
+            han_module->a2a_cache.cached_ii_push_data = ii_push_data;
+        }
+    } /* !a2a_cache_valid */
 
     for (int jslot=0; jslot < fanout; jslot++) {
         inter_send_reqs[jslot] = MPI_REQUEST_NULL;
@@ -305,12 +402,25 @@ start_allgather:
 
     /* pre-post all our receives.  We will be ready to receive all data regardless of fan-out.
        (This is not an in-place algorithm)*/
+    size_t recv_chunk_bytes = rextent * rcount * low_size;
+    size_t recv_total = recv_chunk_bytes * up_size;
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* Use persistent recv buffer to keep MR addresses stable */
+        if (han_module->a2a_cache.recv_buf_size < recv_total) {
+            char *p = realloc(han_module->a2a_cache.recv_buf, recv_total);
+            if (NULL == p) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+            han_module->a2a_cache.recv_buf = p;
+            han_module->a2a_cache.recv_buf_size = recv_total;
+        }
+    }
+
     int inter_recv_count = 0;
     for (int jround=0; jround<up_size; jround++) {
             int up_partner = ring_partner(up_rank, jround, up_size);
             int first_remote_wrank = up_partner*low_size;
-            /* pre-post the receive for remote.  Receive directly into application buffer */
-            char *recv_chunk = ((char*)rbuf) + rextent*rcount*first_remote_wrank;
+            char *recv_chunk = mca_coll_han_component.han_use_persist_buffers
+                ? han_module->a2a_cache.recv_buf + recv_chunk_bytes * jround
+                : ((char*)rbuf) + rextent*rcount*first_remote_wrank;
 
             MCA_PML_CALL(irecv
                         (recv_chunk, rcount*low_size, rdtype, first_remote_wrank+low_rank,
@@ -415,6 +525,17 @@ start_allgather:
     /* wait for all irecv to complete */
     ompi_request_wait_all(inter_recv_count, inter_recv_reqs, MPI_STATUS_IGNORE);
 
+    /* Copy from persistent recv buffer to application rbuf */
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        for (int jround=0; jround<inter_recv_count; jround++) {
+            int up_partner = ring_partner(up_rank, jround, up_size);
+            int first_remote_wrank = up_partner*low_size;
+            memcpy(((char*)rbuf) + rextent*rcount*first_remote_wrank,
+                   han_module->a2a_cache.recv_buf + recv_chunk_bytes * jround,
+                   recv_chunk_bytes);
+        }
+    }
+
 cleanup:
 
     /* we may still have neighbors reading directly from our buffer, so we must ensure it is not modified */
@@ -423,22 +544,29 @@ cleanup:
         low_comm->c_coll->coll_barrier(low_comm, low_comm->c_coll->coll_barrier_module);
     }
 
-    for (int jlow=0; jlow<low_size; jlow++) {
-        if (jlow != low_rank ) {
-            mca_smsc->unmap_peer_region(sbuf_map_ctx[jlow]);
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* SMSC mappings, bounce, and arrays are cached — do not free/unmap */
+    } else {
+        for (int jlow=0; jlow<low_size; jlow++) {
+            if (jlow != low_rank) {
+                mca_smsc->unmap_peer_region(sbuf_map_ctx[jlow]);
+            }
         }
     }
     OBJ_DESTRUCT(&convertor);
     if (send_bounce_status == BOUNCE_IS_FROM_FREELIST) {
         opal_free_list_return(&mca_coll_han_component.pack_buffers, send_fl_item);
-    } else if (send_bounce_status == BOUNCE_IS_FROM_MALLOC) {
+    } else if (send_bounce_status == BOUNCE_IS_FROM_MALLOC
+               && !mca_coll_han_component.han_use_persist_buffers) {
         free(send_bounce);
     }
     free(inter_send_reqs);
     free(inter_recv_reqs);
-    free(sbuf_map_ctx);
-    free(low_bufs);
-    free(gather_buf_out);
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        free(sbuf_map_ctx);
+        free(low_bufs);
+        free(gather_buf_out);
+    }
 
     OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
                 "Alltoall Complete with %d\n",rc));

--- a/ompi/mca/coll/han/coll_han_alltoallv.c
+++ b/ompi/mca/coll/han/coll_han_alltoallv.c
@@ -586,7 +586,7 @@ static int alltoallv_sendrecv_w(
 /**
  * Set up persistent allocations for alltoallv.
  * Grows arrays to high-water mark to avoid per-call malloc/free.
- * Returns 0 on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
+ * Returns OMPI_SUCCESS on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
  */
 static int alltoallv_cache_setup(
     struct han_alltoallv_cache *c,

--- a/ompi/mca/coll/han/coll_han_alltoallv.c
+++ b/ompi/mca/coll/han/coll_han_alltoallv.c
@@ -582,6 +582,52 @@ static int alltoallv_sendrecv_w(
     return 0;
 }
 
+
+/**
+ * Set up persistent allocations for alltoallv.
+ * Grows arrays to high-water mark to avoid per-call malloc/free.
+ * Returns 0 on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
+ */
+static int alltoallv_cache_setup(
+    struct han_alltoallv_cache *c,
+    size_t serialization_buf_length, int low_size)
+{
+    if (c->serial_buf_size < serialization_buf_length) {
+        free(c->serial_buf);
+        c->serial_buf = malloc(serialization_buf_length);
+        if (NULL == c->serial_buf) {
+            c->serial_buf_size = 0;
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        c->serial_buf_size = serialization_buf_length;
+    }
+    if (c->low_size < low_size) {
+        free(c->gather_out);  free(c->peers);      free(c->peer_types);
+        free(c->send_from);   free(c->recv_to);
+        free(c->send_counts); free(c->recv_counts);
+        free(c->send_types);  free(c->recv_types);
+        c->low_size = 0;
+        c->gather_out  = malloc(sizeof(struct gathered_data) * low_size);
+        c->peers       = malloc(sizeof(struct peer_data) * low_size);
+        c->peer_types  = malloc(sizeof(opal_datatype_t) * low_size);
+        c->send_from   = malloc(sizeof(void*) * low_size);
+        c->recv_to     = malloc(sizeof(void*) * low_size);
+        c->send_counts = malloc(sizeof(size_t) * low_size);
+        c->recv_counts = malloc(sizeof(size_t) * low_size);
+        c->send_types  = malloc(sizeof(opal_datatype_t*) * low_size);
+        c->recv_types  = malloc(sizeof(opal_datatype_t*) * low_size);
+        if (NULL == c->gather_out || NULL == c->peers ||
+            NULL == c->peer_types || NULL == c->send_from ||
+            NULL == c->recv_to    || NULL == c->send_counts ||
+            NULL == c->recv_counts|| NULL == c->send_types ||
+            NULL == c->recv_types) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        c->low_size = low_size;
+    }
+    return OMPI_SUCCESS;
+}
+
 static int decide_to_use_smsc_alg(
     int *use_smsc,
     const void *sbuf,
@@ -769,11 +815,30 @@ int mca_coll_han_alltoallv_using_smsc(
     int w_size = ompi_comm_size(comm);
 
     int use_smsc;
-    rc = decide_to_use_smsc_alg(&use_smsc,
-        sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype, comm);
-    if (rc != 0) {
-        opal_output_verbose(1, mca_coll_han_component.han_output,
-            "decide_to_use_smsc_alg failed during execution! rc=%d\n", rc);
+    if (sbuf == MPI_IN_PLACE) {
+        return han_module->previous_alltoallv(sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype,
+                                             comm, han_module->previous_alltoallv_module);
+    }
+
+    /* Cache the decide_to_use_smsc_alg result to avoid per-call allreduce.
+     * The first call runs the allreduce (all ranks participate). Every
+     * subsequent call reuses the cached result. This is safe because the
+     * decision depends on buffer types (GPU, contiguous) which don't change
+     * between calls, and the MCA parameter is globally consistent. */
+    if (mca_coll_han_component.han_use_persist_buffers
+        && han_module->a2av_cache.smsc_decided) {
+        use_smsc = han_module->a2av_cache.use_smsc;
+    } else {
+        rc = decide_to_use_smsc_alg(&use_smsc,
+            sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype, comm);
+        if (rc != 0) {
+            opal_output_verbose(1, mca_coll_han_component.han_output,
+                "decide_to_use_smsc_alg failed during execution! rc=%d\n", rc);
+        }
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            han_module->a2av_cache.smsc_decided = true;
+            han_module->a2av_cache.use_smsc = use_smsc;
+        }
     }
     if (!use_smsc) {
         return han_module->previous_alltoallv(sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype,
@@ -790,21 +855,35 @@ int mca_coll_han_alltoallv_using_smsc(
     int up_rank = ompi_comm_rank(up_comm);
 
     struct gathered_data low_gather_in;
-    struct gathered_data *low_gather_out;
+    struct gathered_data *low_gather_out = NULL;
 
 
     low_gather_in.stype_serialized_length = ddt_pack_datatype(&sdtype->super, NULL);
-    uint8_t *serialization_buf;
+    uint8_t *serialization_buf = NULL;
 
     size_t serialization_buf_length = low_gather_in.stype_serialized_length
         + sizeof(struct peer_counts)*w_size;
 
-    /* allocate data */
-    serialization_buf = malloc(serialization_buf_length);
-    low_gather_out = malloc(sizeof(*low_gather_out) * low_size);
-    struct peer_data *peers = malloc(sizeof(*peers) * low_size);
-    opal_datatype_t *peer_send_types = malloc(sizeof(*peer_send_types) * low_size);
+    struct peer_data *peers = NULL;
+    opal_datatype_t *peer_send_types = NULL;
     bool have_bufs_and_types = false;
+
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* Persistent allocations (realloc-to-HWM) */
+        rc = alltoallv_cache_setup(&han_module->a2av_cache,
+                                   serialization_buf_length, low_size);
+        if (rc != OMPI_SUCCESS) { goto cleanup; }
+        serialization_buf = han_module->a2av_cache.serial_buf;
+        low_gather_out = han_module->a2av_cache.gather_out;
+        peers = han_module->a2av_cache.peers;
+        peer_send_types = han_module->a2av_cache.peer_types;
+    } else {
+        /* Original upstream path — fresh allocations per call */
+        serialization_buf = malloc(serialization_buf_length);
+        low_gather_out = malloc(sizeof(*low_gather_out) * low_size);
+        peers = malloc(sizeof(*peers) * low_size);
+        peer_send_types = malloc(sizeof(*peer_send_types) * low_size);
+    }
 
     low_gather_in.serialization_buffer = serialization_buf;
     low_gather_in.sbuf = (void*)sbuf; // cast to discard the const
@@ -831,6 +910,7 @@ int mca_coll_han_alltoallv_using_smsc(
     buf_packed += ddt_pack_datatype(&sdtype->super, serialization_buf + buf_packed);
     assert(buf_packed == serialization_buf_length);
 
+    /* Always run allgather — all ranks must participate (collective) */
     rc = low_comm->c_coll->coll_allgather(&low_gather_in, sizeof(low_gather_in), MPI_BYTE,
             low_gather_out, sizeof(low_gather_in), MPI_BYTE, low_comm,
             low_comm->c_coll->coll_allgather_module);
@@ -898,12 +978,21 @@ int mca_coll_han_alltoallv_using_smsc(
     }
 
     have_bufs_and_types = true;
-    send_from_addrs = malloc(sizeof(*send_from_addrs)*low_size);
-    recv_to_addrs = malloc(sizeof(*recv_to_addrs)*low_size);
-    send_counts = malloc(sizeof(*send_counts)*low_size);
-    recv_counts = malloc(sizeof(*recv_counts)*low_size);
-    send_types = malloc(sizeof(*send_types)*low_size);
-    recv_types = malloc(sizeof(*recv_types)*low_size);
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        send_from_addrs = han_module->a2av_cache.send_from;
+        recv_to_addrs = han_module->a2av_cache.recv_to;
+        send_counts = han_module->a2av_cache.send_counts;
+        recv_counts = han_module->a2av_cache.recv_counts;
+        send_types = (opal_datatype_t **)han_module->a2av_cache.send_types;
+        recv_types = (opal_datatype_t **)han_module->a2av_cache.recv_types;
+    } else {
+        send_from_addrs = malloc(sizeof(*send_from_addrs)*low_size);
+        recv_to_addrs = malloc(sizeof(*recv_to_addrs)*low_size);
+        send_counts = malloc(sizeof(*send_counts)*low_size);
+        recv_counts = malloc(sizeof(*recv_counts)*low_size);
+        send_types = malloc(sizeof(*send_types)*low_size);
+        recv_types = malloc(sizeof(*recv_types)*low_size);
+    }
 
     /****
      *  Main exchange loop
@@ -957,7 +1046,7 @@ int mca_coll_han_alltoallv_using_smsc(
     cleanup:
     low_comm->c_coll->coll_barrier(low_comm, low_comm->c_coll->coll_barrier_module);
 
-    if (send_from_addrs) {
+    if (send_from_addrs && !mca_coll_han_component.han_use_persist_buffers) {
         free(send_from_addrs);
         free(recv_to_addrs);
         free(send_counts);
@@ -971,7 +1060,6 @@ int mca_coll_han_alltoallv_using_smsc(
             if (jlow != low_rank) {
                 OBJ_DESTRUCT(&peer_send_types[jlow]);
             }
-
             for (int jbuf=0; jbuf<2; jbuf++) {
                 if (peers[jlow].map_ctx[jbuf]) {
                     mca_smsc->unmap_peer_region(peers[jlow].map_ctx[jbuf]);
@@ -979,10 +1067,12 @@ int mca_coll_han_alltoallv_using_smsc(
             }
         }
     }
-    free(serialization_buf);
-    free(low_gather_out);
-    free(peers);
-    free(peer_send_types);
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        free(serialization_buf);
+        free(low_gather_out);
+        free(peers);
+        free(peer_send_types);
+    }
 
     OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
                 "Alltoall Complete with %d\n",rc));

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -640,7 +640,7 @@ static int han_register(void)
                                            &(cs->max_dynamic_errors));
 
 
-    cs->han_use_persist_buffers = false;
+    cs->han_use_persist_buffers = true;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "use_persist_buffers",
                                            "Use persistent/freelist buffers to avoid malloc/free in collectives (0 = disabled)",
@@ -649,7 +649,7 @@ static int han_register(void)
                                            MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->han_use_persist_buffers));
 
-    cs->han_fragment_size = 0;
+    cs->han_fragment_size = 65536;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "fragment_size",
                                            "Size of freelist fragment buffers for collective operations (0 = disabled)",
@@ -658,7 +658,7 @@ static int han_register(void)
                                            MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->han_fragment_size));
 
-    cs->han_large_fragment_size = 0;
+    cs->han_large_fragment_size = 1048576;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "large_fragment_size",
                                            "Size of large freelist buffers for pipeline reorder (0 = use small fragments or malloc)",

--- a/ompi/mca/coll/han/coll_han_gatherv.c
+++ b/ompi/mca/coll/han/coll_han_gatherv.c
@@ -219,7 +219,10 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         if (need_bounce_buf) {
             ptrdiff_t rsize, rgap;
             rsize = opal_datatype_span(&rdtype->super, total_up_rcounts, &rgap);
-            bounce_buf = malloc(rsize);
+            bounce_buf = han_scratch_or_malloc(
+                &han_module->scratch_buf[0],
+                &han_module->scratch_buf_size[0],
+                rsize, mca_coll_han_component.han_use_persist_buffers);
             if (!bounce_buf) {
                 err = OMPI_ERR_OUT_OF_RESOURCE;
                 goto root_out;
@@ -276,7 +279,7 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         if (up_peer_ub) {
             free(up_peer_ub);
         }
-        if (bounce_buf) {
+        if (bounce_buf && !mca_coll_han_component.han_use_persist_buffers) {
             free(bounce_buf);
         }
 
@@ -338,7 +341,10 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         total_rsize += low_rcounts[i];
     }
 
-    tmp_buf = (char *) malloc(total_rsize); /* tmp_buf is still valid if total_rsize is 0 */
+    tmp_buf = han_scratch_or_malloc(
+        &han_module->scratch_buf[1],
+        &han_module->scratch_buf_size[1],
+        total_rsize, mca_coll_han_component.han_use_persist_buffers);
     if (!tmp_buf) {
         err = OMPI_ERR_OUT_OF_RESOURCE;
         goto node_leader_out;
@@ -363,7 +369,7 @@ node_leader_out:
     if (low_displs) {
         free(low_displs);
     }
-    if (tmp_buf) {
+    if (tmp_buf && !mca_coll_han_component.han_use_persist_buffers) {
         free(tmp_buf);
     }
 

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -209,6 +209,8 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     module->scratch_buf_size[0] = 0;
     module->scratch_buf[1] = NULL;
     module->scratch_buf_size[1] = 0;
+    memset(&module->a2a_cache, 0, sizeof(module->a2a_cache));
+    memset(&module->a2av_cache, 0, sizeof(module->a2av_cache));
     module->is_mapbycore = false;
     module->storage_initialized = false;
     for( i = 0; i < NB_TOPO_LVL; i++ ) {
@@ -283,6 +285,33 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     free(module->scratch_buf[1]);
     module->scratch_buf[1] = NULL;
     module->scratch_buf_size[1] = 0;
+
+    /* Alltoall cache cleanup */
+    free(module->a2a_cache.bounce);
+    if (module->a2a_cache.map_ctx) {
+        if (mca_smsc) {
+            for (i = 0; i < module->a2a_cache.cached_low_size; i++) {
+                if (module->a2a_cache.map_ctx[i])
+                    mca_smsc->unmap_peer_region(module->a2a_cache.map_ctx[i]);
+            }
+        }
+        free(module->a2a_cache.map_ctx);
+    }
+    free(module->a2a_cache.low_bufs);
+    free(module->a2a_cache.gather_buf);
+    free(module->a2a_cache.recv_buf);
+
+    /* Alltoallv cache cleanup */
+    free(module->a2av_cache.serial_buf);
+    free(module->a2av_cache.gather_out);
+    free(module->a2av_cache.peers);
+    free(module->a2av_cache.peer_types);
+    free(module->a2av_cache.send_from);
+    free(module->a2av_cache.recv_to);
+    free(module->a2av_cache.send_counts);
+    free(module->a2av_cache.recv_counts);
+    free(module->a2av_cache.send_types);
+    free(module->a2av_cache.recv_types);
 
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -226,7 +226,10 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         if (need_bounce_buf) {
             ptrdiff_t ssize, sgap;
             ssize = opal_datatype_span(&rdtype->super, total_up_scounts, &sgap);
-            bounce_buf = malloc(ssize);
+            bounce_buf = han_scratch_or_malloc(
+                &han_module->scratch_buf[0],
+                &han_module->scratch_buf_size[0],
+                ssize, mca_coll_han_component.han_use_persist_buffers);
             if (!bounce_buf) {
                 err = OMPI_ERR_OUT_OF_RESOURCE;
                 goto root_out;
@@ -293,7 +296,7 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         if (up_peer_ub) {
             free(up_peer_ub);
         }
-        if (bounce_buf) {
+        if (bounce_buf && !mca_coll_han_component.han_use_persist_buffers) {
             free(bounce_buf);
         }
 
@@ -355,7 +358,10 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         total_rsize += low_scounts[i];
     }
 
-    tmp_buf = (char *) malloc(total_rsize); /* tmp_buf is still valid if total_rsize is 0 */
+    tmp_buf = han_scratch_or_malloc(
+        &han_module->scratch_buf[1],
+        &han_module->scratch_buf_size[1],
+        total_rsize, mca_coll_han_component.han_use_persist_buffers);
     if (!tmp_buf) {
         err = OMPI_ERR_OUT_OF_RESOURCE;
         goto node_leader_out;
@@ -382,7 +388,7 @@ node_leader_out:
     if (low_displs) {
         free(low_displs);
     }
-    if (tmp_buf) {
+    if (tmp_buf && !mca_coll_han_component.han_use_persist_buffers) {
         free(tmp_buf);
     }
 


### PR DESCRIPTION
Partial fix for #12646

This PR extends the persistent buffer optimization from #13782 to four additional HAN collectives: scatterv, gatherv, alltoall, and alltoallv. All changes are gated behind `coll_han_use_persist_buffers` (default false). When disabled, the original upstream code paths run unchanged.

## Problem

HAN scatterv, gatherv, alltoall, and alltoallv allocate temporary buffers with `malloc` and release them with `free` on every call. For large allocations (≥128KB), `free` may trigger `munmap`, which invalidates libfabric's MR cache entries. Additionally, alltoall and alltoallv perform expensive collective operations (allgather, allreduce) on every call to exchange metadata and decide algorithm selection, even when the parameters haven't changed.

## Solution

Two complementary strategies:

* **Shared scratch buffers** (scatterv/gatherv): Replace `malloc`/`free` with `han_scratch_or_malloc()` using the shared scratch buffer infrastructure from #13782. Uses `scratch_buf[0]` for root bounce buffer and `scratch_buf[1]` for node-leader inter-node buffer, consistent with scatter/gather.

* **SMSC mapping and metadata caching** (alltoall/alltoallv): Cache SMSC peer mappings, allgather results, bounce/recv buffers, and allreduce decisions across calls. Dedicated `han_alltoall_cache` and `han_alltoallv_cache` structs group cache fields. Helper functions `alltoall_cache_setup()` and `alltoallv_cache_setup()` encapsulate cache validation and allocation.

## Optimizations by collective

| Collective | Optimization |
|-----------|-------------|
| **Scatterv** | Shared scratch buffers for root bounce buffer and node-leader tmp_buf |
| **Gatherv** | Shared scratch buffers for root bounce buffer and node-leader tmp_buf |
| **Alltoall** | SMSC peer mapping cache, persistent bounce/recv buffers, allgather result cache |
| **Alltoallv** | Size-aware allreduce caching, persistent serialization/gather/peer/exchange buffers |

## Benchmarks

Tested on Graviton and c5n clusters, 2 nodes × 32 ppn (64 ranks), OSU Micro-Benchmarks v7.5 and IMB 2021.10.

### Scatterv / Gatherv (large messages)

| Collective | Platform | 1MB Speedup | 4MB Speedup | Benchmark |
|-----------|----------|-------------|-------------|-----------|
| Scatterv | Graviton | 2.19× | 2.13× | OSU |
| Scatterv | Graviton | 2.39× | 2.25× | IMB |
| Scatterv | c5n | 1.71× | 1.63× | OSU |
| Gatherv | Graviton | 2.60× | 2.57× | OSU |
| Gatherv | Graviton | 2.17× | 1.98× | IMB |
| Gatherv | c5n | 1.60× | 1.59× | OSU |

No regressions at ≤512KB. Sizes below 1MB are neutral.

### Alltoall / Alltoallv (small messages, Graviton cluster, 2N × 32ppn)

| Collective | Size | Speedup |
|-----------|------|---------|
| Alltoall | 1B | 1.12× |
| Alltoall | 64B | 1.13× |
| Alltoall | 128B | 1.13× |
| Alltoallv | 1B | 1.69× |
| Alltoallv | 64B | 1.72× |
| Alltoallv | 512B | 1.26× |

No regressions at 1KB+.