### PR TITLE
v6.0.x fortran: fix problems with neighbor collectives

### DIFF
--- a/ompi/mpi/bindings/ompi_bindings/fortran.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Triad National Security, LLC. All rights
+# Copyright (c) 2024-2026 Triad National Security, LLC. All rights
 #                         reserved.
 #
 # $COPYRIGHT$
@@ -261,6 +261,7 @@ def print_c_source_header(out):
     out.dump('#include "ompi/mpi/fortran/mpif-h/status-conversion.h"')
     out.dump('#include "ompi/mpi/fortran/base/constants.h"')
     out.dump('#include "ompi/mpi/fortran/base/fint_2_int.h"')
+    out.dump('#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"')
     out.dump('#include "ompi/request/request.h"')
     out.dump('#include "ompi/communicator/communicator.h"')
     out.dump('#include "ompi/win/win.h"')

--- a/ompi/mpi/fortran/base/Makefile.am
+++ b/ompi/mpi/fortran/base/Makefile.am
@@ -13,6 +13,8 @@
 # Copyright (c) 2015-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2026      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -51,5 +53,7 @@ libmpi_fortran_base_la_SOURCES = \
         conversion_fn_null_f.c \
         f90_accessors.c \
         strings.c \
-        test_constants_f.c
+        test_constants_f.c \
+        fortran_base_topo_neighbors.h \
+        topo_neighbors.c
 endif

--- a/ompi/mpi/fortran/base/fortran_base_topo_neighbors.h
+++ b/ompi/mpi/fortran/base/fortran_base_topo_neighbors.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OMPI_FORTRAN_BASE_TOPO_NEIGHBORS_H
+#define OMPI_FORTRAN_BASE_TOPO_NEIGHBORS_H
+
+#include "mpi.h"
+#include "ompi_config.h"
+
+BEGIN_C_DECLS
+/**
+ * Return number of neighbors given a supplied communicator
+ *
+ * @param[in]  c_comm      MPI communicator (must have an associated topology)
+ * @param[out] indegree    number of neighbors directed in 
+ * @param[out] outdegree   number of neighbors directed out
+ *
+ * See 8.6 "Neighborhood Collective Communication on Virtual Topologies" of 
+ * the MPI 5 standard for additional info about number of neighbors for 
+ * the three different topology types supported by MPI as of that version
+ * of the standard.
+ *
+ * Note only top-level 'c' MPI interfaces are used here as the intent
+ * is for this function to work in the case that the OMPI fortran interface
+ * base is moved to an external package at some point.
+ */
+OMPI_DECLSPEC int ompi_fortran_neighbor_count(MPI_Comm comm, int *indegree, int *outdegree);
+
+END_C_DECLS
+
+#endif /* OMPI_FORTRAN_BASE_TOPO_NEIGHBORS_H */

--- a/ompi/mpi/fortran/base/topo_neighbors.c
+++ b/ompi/mpi/fortran/base/topo_neighbors.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "mpi.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
+
+int ompi_fortran_neighbor_count(MPI_Comm comm, int *indegree, int *outdegree)
+{
+    int ret;
+    int topo_type, ndims, nneighbors, weighted, my_rank;
+
+    if ((NULL == indegree) || (NULL == outdegree)) {
+        ret = MPI_ERR_ARG;
+        goto fn_exit;
+    }
+        
+    ret = PMPI_Topo_test(comm, &topo_type);
+    if (MPI_SUCCESS != ret) {
+        goto fn_exit;
+    }
+
+    switch (topo_type) {
+        case MPI_CART:
+            ret = PMPI_Cartdim_get(comm, &ndims);
+            if (MPI_SUCCESS != ret) {
+                goto fn_exit;
+            }
+            *outdegree = *indegree = 2 * ndims; 
+            break;
+        case MPI_GRAPH:
+            ret = PMPI_Comm_rank(comm, &my_rank);
+            if (MPI_SUCCESS != ret) {
+                goto fn_exit;
+            }
+            ret = PMPI_Graph_neighbors_count(comm, my_rank, &nneighbors);
+            if (MPI_SUCCESS != ret) {
+                goto fn_exit;
+            }
+            *outdegree = *indegree = nneighbors;
+            break;
+        case MPI_DIST_GRAPH:
+            ret = PMPI_Dist_graph_neighbors_count(comm, indegree, outdegree, &weighted);
+            if (MPI_SUCCESS != ret) {
+                goto fn_exit;
+            }
+            break;
+        case MPI_UNDEFINED:
+        default:
+            break;
+    }
+
+fn_exit:
+    return ret;
+}

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoallv_f.c
@@ -14,7 +14,8 @@
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +27,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -79,7 +81,7 @@ void ompi_ineighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *s
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, idx = 0, c_ierr;
+    int indegree, outdegree, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -89,11 +91,16 @@ void ompi_ineighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *s
     c_sendtype = PMPI_Type_f2c(*sendtype);
     c_recvtype = PMPI_Type_f2c(*recvtype);
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(sdispls, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
-    OMPI_ARRAY_FINT_2_INT(rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(sdispls, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
+    OMPI_ARRAY_FINT_2_INT(rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +29,7 @@
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -80,23 +83,31 @@ void ompi_ineighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     MPI_Comm c_comm;
     MPI_Datatype *c_sendtypes, *c_recvtypes;
     MPI_Request c_request;
-    int size, idx = 0, c_ierr;
+    int indegree, outdegree, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(recvcounts);
 
     c_comm = PMPI_Comm_f2c(*comm);
-    PMPI_Comm_size(c_comm, &size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
 
-    c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
 
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     /* Ineighbor_alltoallw does not support MPI_IN_PLACE */

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_f.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +28,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -77,7 +80,7 @@ void ompi_neighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sd
 {
     MPI_Comm c_comm;
     MPI_Datatype c_sendtype, c_recvtype;
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -87,11 +90,16 @@ void ompi_neighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sd
     c_sendtype = PMPI_Type_f2c(*sendtype);
     c_recvtype = PMPI_Type_f2c(*recvtype);
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(sdispls, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
-    OMPI_ARRAY_FINT_2_INT(rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(sdispls, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
+    OMPI_ARRAY_FINT_2_INT(rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_init_f.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +28,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -80,7 +83,7 @@ void ompi_neighbor_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fin
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, idx = 0, c_ierr;
+    int indegree, outdegree, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(sdispls);
     OMPI_ARRAY_NAME_DECL(recvcounts);
@@ -91,11 +94,16 @@ void ompi_neighbor_alltoallv_init_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fin
     c_recvtype = PMPI_Type_f2c(*recvtype);
     c_info = PMPI_Info_f2c(*info);
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(sdispls, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
-    OMPI_ARRAY_FINT_2_INT(rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(sdispls, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
+    OMPI_ARRAY_FINT_2_INT(rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_f.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +28,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -78,23 +81,31 @@ void ompi_neighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
 {
     MPI_Comm c_comm;
     MPI_Datatype *c_sendtypes, *c_recvtypes;
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(recvcounts);
 
     c_comm = PMPI_Comm_f2c(*comm);
-    PMPI_Comm_size(c_comm, &size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
 
-    c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
 
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     /* Alltoallw does not support MPI_IN_PLACE */

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_init_f.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +28,7 @@
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 #include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpi/fortran/base/fortran_base_topo_neighbors.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -81,24 +84,33 @@ void ompi_neighbor_alltoallw_init_f(char *sendbuf, MPI_Fint *sendcounts,
     MPI_Datatype *c_sendtypes, *c_recvtypes;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, idx = 0, c_ierr;
+    int indegree, outdegree, idx = 0, c_ierr;
     OMPI_ARRAY_NAME_DECL(sendcounts);
     OMPI_ARRAY_NAME_DECL(recvcounts);
 
     c_comm = PMPI_Comm_f2c(*comm);
     c_info = PMPI_Info_f2c(*info);
-    PMPI_Comm_size(c_comm, &size);
 
-    c_sendtypes = (MPI_Datatype *) malloc(2* size * sizeof(MPI_Datatype));
-    c_recvtypes = c_sendtypes + size;
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
 
-    OMPI_ARRAY_FINT_2_INT(sendcounts, size);
-    OMPI_ARRAY_FINT_2_INT(recvcounts, size);
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    OMPI_ARRAY_FINT_2_INT(sendcounts, outdegree);
+    OMPI_ARRAY_FINT_2_INT(recvcounts, indegree);
+
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     /* Neighbor_alltoallw_init does not support MPI_IN_PLACE */

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallv_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,7 @@ PROTOTYPE VOID ineighbor_alltoallv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts, DISP
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_sendtype, c_recvtype;
     MPI_Request c_request;
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @DISP_TYPE@ *tmp_sdispls = NULL;
@@ -55,11 +55,17 @@ PROTOTYPE VOID ineighbor_alltoallv(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts, DISP
     c_sendtype = PMPI_Type_f2c(*sendtype);
     c_recvtype = PMPI_Type_f2c(*recvtype);
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallw_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallw_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -33,7 +33,7 @@ PROTOTYPE VOID ineighbor_alltoallw(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype *c_sendtypes, *c_recvtypes;
     MPI_Request c_request;
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @COUNT_TYPE@ *tmp_recvcounts = NULL;
@@ -50,18 +50,28 @@ PROTOTYPE VOID ineighbor_alltoallw(BUFFER_ASYNC x1, COUNT_ARRAY sendcounts,
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
         return;
     }
-    PMPI_Comm_size(c_comm, &size);
 
-    c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
 
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     /* Ineighbor_alltoallw does not support MPI_IN_PLACE */

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -36,7 +36,7 @@ PROTOTYPE VOID neighbor_alltoallv_init(BUFFER x1, COUNT_ARRAY sendcounts, DISP_A
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);;
     MPI_Info c_info;
     MPI_Request c_request;
-    int size, c_ierr, idx = 0;
+    int indegree, outdegree, c_ierr, idx = 0;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @DISP_TYPE@ *tmp_sdispls = NULL;
@@ -58,11 +58,17 @@ PROTOTYPE VOID neighbor_alltoallv_init(BUFFER x1, COUNT_ARRAY sendcounts, DISP_A
         return;
     }
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,7 @@ PROTOTYPE VOID neighbor_alltoallv(BUFFER x1, COUNT_ARRAY sendcounts, DISP_ARRAY 
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_sendtype = PMPI_Type_f2c(*sendtype);
     MPI_Datatype c_recvtype = PMPI_Type_f2c(*recvtype);
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @DISP_TYPE@ *tmp_sdispls = NULL;
@@ -52,11 +52,17 @@ PROTOTYPE VOID neighbor_alltoallv(BUFFER x1, COUNT_ARRAY sendcounts, DISP_ARRAY 
         return;
     }
 
-    PMPI_Comm_size(c_comm, &size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, indegree);
 
     sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_init_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_init_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2021 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -36,7 +36,7 @@ PROTOTYPE VOID neighbor_alltoallw_init(BUFFER x1, COUNT_ARRAY sendcounts,
     MPI_Datatype *c_sendtypes, *c_recvtypes;
     MPI_Request c_request;
     MPI_Info c_info;
-    int size, c_ierr, idx = 0;
+    int indegree, outdegree,  c_ierr, idx = 0;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @COUNT_TYPE@ *tmp_recvcounts = NULL;
@@ -56,24 +56,34 @@ PROTOTYPE VOID neighbor_alltoallw_init(BUFFER x1, COUNT_ARRAY sendcounts,
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    PMPI_Comm_size(c_comm, &size);
 
-    c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
 
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, size);
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
+
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sdispls, tmp_sdispls, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(rdispls, tmp_rdispls, indegree);
 
     /* Alltoallw does not support MPI_IN_PLACE */
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     c_ierr = @INNER_CALL@(sendbuf,

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallw_ts.c.in
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,7 @@ PROTOTYPE VOID neighbor_alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
 {
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype *c_sendtypes, *c_recvtypes;
-    int size, c_ierr;
+    int indegree, outdegree, c_ierr;
     char *sendbuf = OMPI_CFI_BASE_ADDR(x1), *recvbuf = OMPI_CFI_BASE_ADDR(x2);
     @COUNT_TYPE@ *tmp_sendcounts = NULL;
     @COUNT_TYPE@ *tmp_recvcounts = NULL;
@@ -49,18 +49,27 @@ PROTOTYPE VOID neighbor_alltoallw(BUFFER x1, COUNT_ARRAY sendcounts,
         OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME)
         return;
     }
-    PMPI_Comm_size(c_comm, &size);
 
-    c_sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-    c_recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    c_ierr = ompi_fortran_neighbor_count(c_comm, &indegree, &outdegree);
+    if (MPI_SUCCESS != c_ierr) {
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        OMPI_ERRHANDLER_INVOKE(c_comm, c_ierr, FUNC_NAME);
+        return;
+    }
 
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, size);
-    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, size);
+    c_sendtypes = (MPI_Datatype *) malloc(outdegree * sizeof(MPI_Datatype));
+    c_recvtypes = (MPI_Datatype *) malloc(indegree * sizeof(MPI_Datatype));
 
-    while (size > 0) {
-        c_sendtypes[size - 1] = PMPI_Type_f2c(sendtypes[size - 1]);
-        c_recvtypes[size - 1] = PMPI_Type_f2c(recvtypes[size - 1]);
-        --size;
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(sendcounts, tmp_sendcounts, outdegree);
+    OMPI_FORTRAN_BIGCOUNT_ARRAY_SET(recvcounts, tmp_recvcounts, indegree);
+
+    while (outdegree > 0) {
+        c_sendtypes[outdegree - 1] = PMPI_Type_f2c(sendtypes[outdegree - 1]);
+        --outdegree;
+    }
+    while (indegree > 0) {
+        c_recvtypes[indegree - 1] = PMPI_Type_f2c(recvtypes[indegree - 1]);
+        --indegree;
     }
 
     /* Alltoallw does not support MPI_IN_PLACE */


### PR DESCRIPTION
The calculation of the sizes needed for various arrays, esp. of datatypes for neighbor collectives, was completely wrong.

Related to issue #13790


(cherry picked from commit 7290eaf63c1214bd506b1f1e6f2b99133bca6bfe)