### PR TITLE
spc: add missing per-function counters for partitioned communication

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -74,7 +74,7 @@ EXAMPLES = \
 # others if we have the appropriate Open MPI / OpenSHMEM language
 # bindings.
 
-all: hello_c ring_c connectivity_c spc_example hello_sessions_c
+all: hello_c ring_c connectivity_c hello_sessions_c
 	@ if which ompi_info >/dev/null 2>&1 ; then \
 	    $(MAKE) mpi; \
 	fi
@@ -96,6 +96,9 @@ mpi:
 	fi
 	@ if ompi_info --parsable | grep -q bindings:java:yes >/dev/null; then \
 	    $(MAKE) Hello.class Ring.class; \
+	fi
+	@ if ompi_info --parsable | grep -q enable-spc >/dev/null; then \
+	    $(MAKE) spc_example; \
 	fi
 
 # OpenSHMEM examples

--- a/ompi/mpi/c/pready_list.c.in
+++ b/ompi/mpi/c/pready_list.c.in
@@ -38,7 +38,8 @@
 PROTOTYPE ERROR_CLASS pready_list(INT length, INT_ARRAY partitions, REQUEST request)
 {
     int rc = OMPI_SUCCESS;
-    SPC_RECORD(OMPI_SPC_PREADY, 1);
+
+    SPC_RECORD(OMPI_SPC_PREADY_LIST, 1);
 
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;

--- a/ompi/mpi/c/pready_range.c.in
+++ b/ompi/mpi/c/pready_range.c.in
@@ -39,7 +39,7 @@ PROTOTYPE ERROR_CLASS pready_range(INT partition_low, INT partition_high, REQUES
 {
     int rc;
 
-    SPC_RECORD(OMPI_SPC_PREADY, 1);
+    SPC_RECORD(OMPI_SPC_PREADY_RANGE, 1);
 
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;

--- a/ompi/mpi/c/precv_init.c.in
+++ b/ompi/mpi/c/precv_init.c.in
@@ -42,6 +42,8 @@ PROTOTYPE ERROR_CLASS precv_init(BUFFER_OUT buf, INT partitions, PARTITIONED_COU
 {
     int rc;
 
+    SPC_RECORD(OMPI_SPC_PRECV_INIT, 1);
+
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/mpi/c/psend_init.c.in
+++ b/ompi/mpi/c/psend_init.c.in
@@ -42,6 +42,8 @@ PROTOTYPE ERROR_CLASS psend_init(BUFFER buf, INT partitions, PARTITIONED_COUNT c
 {
     int rc;
 
+    SPC_RECORD(OMPI_SPC_PSEND_INIT, 1);
+
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/runtime/ompi_spc.c
+++ b/ompi/runtime/ompi_spc.c
@@ -170,7 +170,11 @@ static const ompi_spc_event_t ompi_spc_events_desc[OMPI_SPC_NUM_COUNTERS] = {
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV, "The number of times MPI_Isendrecv was called.", false, false),
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV_REPLACE, "The number of times MPI_Isendrecv_replace was called.", false, false),
     SET_COUNTER_ARRAY(OMPI_SPC_PARRIVED, "The number of times MPI_Parrived was called.", false, false),
-    SET_COUNTER_ARRAY(OMPI_SPC_PREADY, "The number of times MPI_Pready (or similar functions) was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY, "The number of times MPI_Pready was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY_LIST, "The number of times MPI_Pready_list was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY_RANGE, "The number of times MPI_Pready_range was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PRECV_INIT, "The number of times MPI_Precv_init was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PSEND_INIT, "The number of times MPI_Psend_init was called.", false, false)
 };
 
 /* An array of event structures to store the event data (value, attachments, flags) */

--- a/ompi/runtime/ompi_spc.h
+++ b/ompi/runtime/ompi_spc.h
@@ -156,6 +156,10 @@ typedef enum ompi_spc_counters {
     OMPI_SPC_ISENDRECV_REPLACE,
     OMPI_SPC_PARRIVED,
     OMPI_SPC_PREADY,
+    OMPI_SPC_PREADY_LIST,
+    OMPI_SPC_PREADY_RANGE,
+    OMPI_SPC_PRECV_INIT,
+    OMPI_SPC_PSEND_INIT,
     OMPI_SPC_NUM_COUNTERS /* This serves as the number of counters.  It must be last. */
 } ompi_spc_counters_t;
 


### PR DESCRIPTION
The five MPI partitioned communication functions were either recording to the wrong SPC counter or had no counter at all:

- MPI_Pready_list and MPI_Pready_range were both recording to OMPI_SPC_PREADY (the MPI_Pready counter) instead of their own dedicated counters.  Add OMPI_SPC_PREADY_LIST and OMPI_SPC_PREADY_RANGE and update the .c.in templates accordingly.

- MPI_Precv_init and MPI_Psend_init had no SPC_RECORD call at all. Add OMPI_SPC_PRECV_INIT and OMPI_SPC_PSEND_INIT counters and wire them into the corresponding .c.in templates.

- Update the OMPI_SPC_PREADY description in ompi_spc.c to refer only to MPI_Pready now that the list/range variants have their own entry.

Also guard spc_example in examples/Makefile behind a runtime check so it is only compiled when the installation was built with --enable-spc. Previously it was an unconditional dependency of the 'all' target, causing build failures when SPC support was absent.

Closes #9490 (rebased and corrected version of the closed PR; fixes applied to the .c.in templates rather than the generated .c files, and only the four genuinely missing enum values are added since OMPI_SPC_PARRIVED and OMPI_SPC_PREADY already landed on main).