### PR TITLE
coll/cuda fixes

### DIFF
--- a/ompi/mca/coll/cuda/coll_cuda.h
+++ b/ompi/mca/coll/cuda/coll_cuda.h
@@ -2,7 +2,9 @@
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2014-2024 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,24 +90,26 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
  * @retval >0                The buffer belongs to a managed buffer in
  *                           device memory.
  */
-static inline int mca_coll_cuda_check_buf(void *addr)
+static inline int mca_coll_cuda_check_buf(void *addr, int *dev_id)
 {
     uint64_t flags;
-    int dev_id;
+
     if (OPAL_LIKELY(NULL != addr)) {
-        return opal_accelerator.check_addr(addr, &dev_id, &flags);
+        return opal_accelerator.check_addr(addr, dev_id, &flags);
     } else {
+        *dev_id = MCA_ACCELERATOR_NO_DEVICE_ID;
         return 0;
     }
 }
 
-static inline void *mca_coll_cuda_memcpy(void *dest, const void *src, size_t size)
+static inline void *mca_coll_cuda_memcpy(void *dest, int dest_dev, const void *src, int src_dev, size_t size,
+                                         opal_accelerator_transfer_type_t type)
 {
     int res;
-    res = opal_accelerator.mem_copy(MCA_ACCELERATOR_NO_DEVICE_ID, MCA_ACCELERATOR_NO_DEVICE_ID,
-                                    dest, src, size, MCA_ACCELERATOR_TRANSFER_UNSPEC);
+
+    res = opal_accelerator.mem_copy(dest_dev, src_dev, dest, src, size, type);
     if (res != 0) {
-        opal_output(0, "CUDA: Error in cuMemcpy: res=%d, dest=%p, src=%p, size=%d", res, dest, src,
+        opal_output(0, "coll/cuda: Error in in accelerator memcpy: res=%d, dest=%p, src=%p, size=%d", res, dest, src,
                     (int) size);
         abort();
     } else {

--- a/ompi/mca/coll/cuda/coll_cuda_allreduce.c
+++ b/ompi/mca/coll/cuda/coll_cuda_allreduce.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,11 +38,12 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
     size_t bufsize;
     int rc;
 
     bufsize = opal_datatype_span(&dtype->super, count, &gap);
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -49,10 +52,11 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, bufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev,
+                             bufsize, MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -62,7 +66,8 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, bufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev,
+                             bufsize, MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -72,7 +77,8 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, bufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;

--- a/ompi/mca/coll/cuda/coll_cuda_exscan.c
+++ b/ompi/mca/coll/cuda/coll_cuda_exscan.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,11 +30,12 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
     size_t bufsize;
     int rc;
 
     bufsize = opal_datatype_span(&dtype->super, count, &gap);
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -42,10 +45,11 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, bufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -55,7 +59,8 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, bufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -67,7 +72,8 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, bufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;

--- a/ompi/mca/coll/cuda/coll_cuda_reduce.c
+++ b/ompi/mca/coll/cuda/coll_cuda_reduce.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,12 +39,13 @@ mca_coll_cuda_reduce(const void *sbuf, void *rbuf, int count,
     int rank = ompi_comm_rank(comm);
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int rbuf_dev, sbuf_dev;
     size_t bufsize;
     int rc;
 
     bufsize = opal_datatype_span(&dtype->super, count, &gap);
 
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -51,11 +54,12 @@ mca_coll_cuda_reduce(const void *sbuf, void *rbuf, int count,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, bufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
 
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -65,7 +69,8 @@ mca_coll_cuda_reduce(const void *sbuf, void *rbuf, int count,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, bufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -78,7 +83,8 @@ mca_coll_cuda_reduce(const void *sbuf, void *rbuf, int count,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, bufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;
@@ -92,12 +98,13 @@ mca_coll_cuda_reduce_local(const void *sbuf, void *rbuf, int count,
 {
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
     size_t bufsize;
     int rc;
 
     bufsize = opal_datatype_span(&dtype->super, count, &gap);
 
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -107,11 +114,12 @@ mca_coll_cuda_reduce_local(const void *sbuf, void *rbuf, int count,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, bufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
 
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -122,7 +130,8 @@ mca_coll_cuda_reduce_local(const void *sbuf, void *rbuf, int count,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, bufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -135,7 +144,8 @@ mca_coll_cuda_reduce_local(const void *sbuf, void *rbuf, int count,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, bufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;

--- a/ompi/mca/coll/cuda/coll_cuda_reduce_scatter_block.c
+++ b/ompi/mca/coll/cuda/coll_cuda_reduce_scatter_block.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,13 +42,14 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
     size_t sbufsize, rbufsize;
     int rc;
 
     rbufsize = opal_datatype_span(&dtype->super, rcount, &gap);
 
     sbufsize = rbufsize * ompi_comm_size(comm);
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -55,10 +58,11 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, sbufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, sbufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -68,7 +72,8 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, rbufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -79,7 +84,8 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, rbufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;

--- a/ompi/mca/coll/cuda/coll_cuda_scan.c
+++ b/ompi/mca/coll/cuda/coll_cuda_scan.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2024      Advanced Micro Devices, Inc. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,11 +37,12 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
+    int sbuf_dev, rbuf_dev;
     size_t bufsize;
     int rc;
 
     bufsize = opal_datatype_span(&dtype->super, count, &gap);
-    rc = mca_coll_cuda_check_buf((void *)sbuf);
+    rc = mca_coll_cuda_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -48,10 +51,11 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
         if (NULL == sbuf1) {
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(sbuf1, sbuf, bufsize);
+        mca_coll_cuda_memcpy(sbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, sbuf, sbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         sbuf = sbuf1 - gap;
     }
-    rc = mca_coll_cuda_check_buf(rbuf);
+    rc = mca_coll_cuda_check_buf(rbuf, &rbuf_dev);
     if (rc < 0) {
         return rc;
     }
@@ -61,7 +65,8 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_cuda_memcpy(rbuf1, rbuf, bufsize);
+        mca_coll_cuda_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;
     }
@@ -72,7 +77,8 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
     }
     if (NULL != rbuf1) {
         rbuf = rbuf2;
-        mca_coll_cuda_memcpy(rbuf, rbuf1, bufsize);
+        mca_coll_cuda_memcpy(rbuf, rbuf_dev, rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, bufsize,
+                             MCA_ACCELERATOR_TRANSFER_HTOD);
         free(rbuf1);
     }
     return rc;

--- a/ompi/mca/coll/cuda/configure.m4
+++ b/ompi/mca/coll/cuda/configure.m4
@@ -17,11 +17,12 @@
 AC_DEFUN([MCA_ompi_coll_cuda_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/coll/cuda/Makefile])
 
-    # make sure that CUDA-aware checks have been done
+    # make sure that CUDA-aware and ROCM-aware checks have been done
     AC_REQUIRE([OPAL_CHECK_CUDA])
+    AC_REQUIRE([OPAL_CHECK_ROCM])
 
-    # Only build if CUDA support is available
-    AS_IF([test "x$CUDA_SUPPORT" = "x1"],
+    # Only build if CUDA or ROCM support is available
+    AS_IF([test "x$CUDA_SUPPORT" = "x1" -o "x$ROCM_SUPPORT" = "x1"],
           [$1],
           [$2])
 


### PR DESCRIPTION
This is a partial cherry pick and a fix for the 5.0.x
 - adjust the component copy routine to take the copy direction and the device ID into account. This is an adjusted cherry-pick of PR https://github.com/open-mpi/ompi/pull/12986 
 - modify the configure logic of coll/cuda to also accept ROCm devices. The component has been fully converted to use the accelerator framework functionality, so the fact that the configure logic still only checks for cuda is probably an oversight. THis is not a cherry-pick, but has also been fixed on main

bot:notacherrypick