### PR TITLE
[v6.0.x] ompi: Fix remnants of req_complete being a bool

### DIFF
--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -525,7 +525,6 @@ mca_part_persist_start(size_t count, ompi_request_t** requests)
         req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
         req->req_ompi.req_status._cancelled = 0;
         req->req_part_complete = false;
-        req->req_ompi.req_complete = false;
         OPAL_ATOMIC_SWAP_PTR(&req->req_ompi.req_complete, REQUEST_PENDING);   
     }
 

--- a/ompi/mca/pml/cm/pml_cm_recvreq.h
+++ b/ompi/mca/pml/cm/pml_cm_recvreq.h
@@ -234,7 +234,7 @@ do {                                                                    \
 do {                                                                    \
     /* init/re-init the request */                                      \
     request->req_base.req_pml_complete = false;                         \
-    request->req_base.req_ompi.req_complete = false;                    \
+    request->req_base.req_ompi.req_complete = REQUEST_PENDING;          \
     request->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;         \
                                                                         \
     /* always set the req_status.MPI_TAG to ANY_TAG before starting the \
@@ -256,7 +256,7 @@ do {                                                                    \
 do {                                                                    \
     /* init/re-init the request */                                      \
     request->req_base.req_pml_complete = false;                         \
-    request->req_base.req_ompi.req_complete = false;                    \
+    request->req_base.req_ompi.req_complete = REQUEST_PENDING;          \
     request->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;         \
                                                                         \
     /* always set the req_status.MPI_TAG to ANY_TAG before starting the \
@@ -278,7 +278,7 @@ do {                                                                    \
 /*     opal_output(0, "posting hvy request %d\n", request);                */ \
     /* init/re-init the request */                                      \
     request->req_base.req_pml_complete = false;                         \
-    request->req_base.req_ompi.req_complete = false;                    \
+    request->req_base.req_ompi.req_complete = REQUEST_PENDING;          \
     request->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;         \
                                                                         \
     /* always set the req_status.MPI_TAG to ANY_TAG before starting the \


### PR DESCRIPTION
The CM PML and Persist Part components both still used the request object's req_complete field like a bool, despite it being a void*. Change both to use REQUEST_PENDING as expected. This fixes a number of warnings (errors on FreeBSD).


(cherry picked from commit 6a509ec08d558e27140f86d41e8a03e9b89d4970)