### PR TITLE
btl/sm: bound peer-supplied descriptor copy in endpoint destructor

### DIFF
--- a/opal/mca/btl/sm/btl_sm_module.c
+++ b/opal/mca/btl/sm/btl_sm_module.c
@@ -186,13 +186,32 @@ static int init_sm_endpoint(struct mca_btl_base_endpoint_t **ep_out, struct opal
             mca_btl_sm.super.btl_put = NULL;
             mca_btl_sm.super.btl_flags &= ~MCA_BTL_FLAGS_RDMA;
         }
-            /* store a copy of the segment information for detach */
-            ep->seg_ds = malloc(modex->seg_ds_size);
+            /* Validate the peer-supplied descriptor length before trusting it.
+             * The modex must actually contain seg_ds_size bytes of seg_ds, and
+             * that length must fit in opal_shmem_ds_t. */
+            const size_t modex_hdr_size = sizeof(*modex) - sizeof(modex->seg_ds);
+            if (modex->seg_ds_size <= 0
+                || (size_t) modex->seg_ds_size > sizeof(opal_shmem_ds_t)
+                || msg_size < modex_hdr_size
+                || (size_t) modex->seg_ds_size > msg_size - modex_hdr_size) {
+                free(modex);
+                return OPAL_ERR_BAD_PARAM;
+            }
+
+            /* Always allocate the full struct so later consumers (detach,
+             * opal_shmem_sizeof_shmem_ds) cannot read or write past the end
+             * of the heap object. */
+            ep->seg_ds = calloc(1, sizeof(opal_shmem_ds_t));
             if (NULL == ep->seg_ds) {
+                free(modex);
                 return OPAL_ERR_OUT_OF_RESOURCE;
             }
 
             memcpy(ep->seg_ds, &modex->seg_ds, modex->seg_ds_size);
+            /* Guarantee seg_name is NUL-terminated even if the peer sent an
+             * unterminated path, so opal_shmem_sizeof_shmem_ds()'s strlen
+             * cannot run past the buffer. */
+            ep->seg_ds->seg_name[OPAL_PATH_MAX - 1] = '\0';
 
             ep->segment_base = opal_shmem_segment_attach(ep->seg_ds);
             if (NULL == ep->segment_base) {
@@ -514,17 +533,11 @@ static void mca_btl_sm_endpoint_destructor(mca_btl_sm_endpoint_t *ep)
     OBJ_DESTRUCT(&ep->pending_frags_lock);
 
     if (ep->seg_ds) {
-        opal_shmem_ds_t seg_ds;
-
-        /* opal_shmem_segment_detach expects a opal_shmem_ds_t and will
-         * stomp past the end of the seg_ds if it is too small (which
-         * ep->seg_ds probably is) */
-        memcpy(&seg_ds, ep->seg_ds, opal_shmem_sizeof_shmem_ds(ep->seg_ds));
+        /* ep->seg_ds is allocated full-size in init_sm_endpoint, so detach
+         * cannot read or write past the end of it. */
+        opal_shmem_segment_detach(ep->seg_ds);
         free(ep->seg_ds);
         ep->seg_ds = NULL;
-
-        /* disconnect from the peer's segment */
-        opal_shmem_segment_detach(&seg_ds);
     }
 
     if (ep->fbox_out.fbox) {


### PR DESCRIPTION
mca_btl_sm_endpoint_destructor() copied the serialized shmem descriptor stored at ep->seg_ds into a fixed-size stack-local opal_shmem_ds_t using opal_shmem_sizeof_shmem_ds(ep->seg_ds) as the length. That length is `offsetof(seg_name) + strlen(seg_name)+ 1`, where seg_name is read from the heap allocation that was sized to whatever the peer announced via its modex. Two problems follow: strlen() can walk past the end of the heap object when the peer's serialized seg_name is not NULL-terminated within the allocated bytes, and the resulting length is then memcpy'd into the stack object with no clamp to its real size, so a sufficiently long walk overwrites adjacent stack data.

Fix it on the receiver side, where the buffer is allocated:

  - Validate modex->seg_ds_size: must be > 0, must fit in opal_shmem_ds_t, and must not exceed the bytes actually delivered by the modex (msg_size).
  - Allocate the full sizeof(opal_shmem_ds_t) and zero it with calloc() so a short copy leaves the tail well-defined.
  - Force seg_name[OPAL_PATH_MAX - 1] = '\0' so any later strlen() over the buffer terminates inside it.

With ep->seg_ds now always a full, well-formed struct, the destructor no longer needs the stack copy: detach reads the heap object directly and free() releases it afterwards.

Closes #13781