### PR TITLE
[v5.0.x] Use acquire/release barrier to synchronize completion of request and test/wait

### DIFF
--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -38,7 +38,6 @@ int ompi_request_default_test(ompi_request_t ** rptr,
 
 recheck_request_status:
 #endif
-    opal_atomic_mb();
     if( request->req_state == OMPI_REQUEST_INACTIVE ) {
         *completed = true;
         if (MPI_STATUS_IGNORE != status) {
@@ -56,6 +55,8 @@ recheck_request_status:
             ompi_grequest_invoke_query(request, &request->req_status);
         }
         if (MPI_STATUS_IGNORE != status) {
+            /* make sure we get the correct status */
+            opal_atomic_rmb();
             OMPI_COPY_STATUS(status, request->req_status, false);
         }
         if( request->req_persistent ) {
@@ -109,7 +110,6 @@ int ompi_request_default_test_any(
     ompi_request_t **rptr;
     ompi_request_t *request;
 
-    opal_atomic_mb();
     rptr = requests;
     for (i = 0; i < count; i++, rptr++) {
         request = *rptr;
@@ -130,6 +130,8 @@ int ompi_request_default_test_any(
                 ompi_grequest_invoke_query(request, &request->req_status);
             }
             if (MPI_STATUS_IGNORE != status) {
+                /* make sure we get the correct status */
+                opal_atomic_rmb();
                 OMPI_COPY_STATUS(status, request->req_status, false);
             }
 
@@ -187,7 +189,6 @@ int ompi_request_default_test_all(
     ompi_request_t *request;
     int do_it_once = 0;
 
-    opal_atomic_mb();
     for (i = 0; i < count; i++) {
         request = requests[i];
 
@@ -232,6 +233,8 @@ int ompi_request_default_test_all(
 
     rc = MPI_SUCCESS;
     if (MPI_STATUSES_IGNORE != statuses) {
+        /* make sure we get the correct statuses */
+        opal_atomic_rmb();
         /* fill out completion status and free request if required */
         for( i = 0; i < count; i++, rptr++ ) {
             request  = *rptr;
@@ -317,7 +320,6 @@ int ompi_request_default_test_some(
     ompi_request_t **rptr;
     ompi_request_t *request;
 
-    opal_atomic_mb();
     rptr = requests;
     for (i = 0; i < count; i++, rptr++) {
         request = *rptr;
@@ -355,6 +357,9 @@ int ompi_request_default_test_some(
 #endif
         return OMPI_SUCCESS;
     }
+
+    /* make sure we get the correct statuses */
+    opal_atomic_rmb();
 
     /* fill out completion status and free request if required */
     for( i = 0; i < num_requests_done; i++) {

--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -40,6 +40,9 @@ int ompi_request_default_wait(
 
     ompi_request_wait_completion(req);
 
+    /* make sure we get the correct status */
+    opal_atomic_rmb();
+
 #if OPAL_ENABLE_FT_MPI
     /* Special case for MPI_ANY_SOURCE */
     if( MPI_ERR_PROC_FAILED_PENDING == req->req_status.MPI_ERROR ) {
@@ -199,6 +202,8 @@ recheck:
         rc = ompi_grequest_invoke_query(request, &request->req_status);
     }
     if (MPI_STATUS_IGNORE != status) {
+        /* make sure we get the correct status */
+        opal_atomic_rmb();
         OMPI_COPY_STATUS(status, request->req_status, false);
     }
     rc = request->req_status.MPI_ERROR;
@@ -303,6 +308,9 @@ recheck:
  finish:
     rptr = requests;
     if (MPI_STATUSES_IGNORE != statuses) {
+        /* make sure we get the correct status */
+        opal_atomic_rmb();
+
         /* fill out status and free request if required */
         for( i = 0; i < count; i++, rptr++ ) {
             void *_tmp_ptr = &sync;
@@ -568,6 +576,9 @@ int ompi_request_default_wait_some(size_t count,
     }
 
     *outcount = num_requests_done;
+
+    /* make sure we get the correct status */
+    opal_atomic_rmb();
 
     for (size_t i = 0; i < num_requests_done; i++) {
         request = requests[indices[i]];

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -528,6 +528,8 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
     if (0 == rc) {
         if (OPAL_LIKELY(with_signal)) {
+            /* make sure everything in the request is visible before we mark it complete */
+            opal_atomic_wmb();
 
             ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                     REQUEST_COMPLETED);


### PR DESCRIPTION
Backport of #11665 to v5.0.x

Identified as missing in 5.0.x by @blkqi in https://github.com/open-mpi/ompi/pull/13791#issuecomment-4380257005. 