### PR TITLE
[v5.0.x] Drop __opal_attribute_always_inline__ for mca_part_persist_start (fix…

### DIFF
--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -480,7 +480,7 @@ mca_part_persist_psend_init(const void* buf,
     return err;
 }
 
-__opal_attribute_always_inline__ static inline int
+static inline int
 mca_part_persist_start(size_t count, ompi_request_t** requests)
 {
     int err = OMPI_SUCCESS;


### PR DESCRIPTION
…es #13721)

(cherry picked from commit aa024ac73d624611cfe3af6f541b5d28dedf07bb)