### PR TITLE
ci: Update distro/compiler list

### DIFF
--- a/.ci/community-jenkins/Jenkinsfile
+++ b/.ci/community-jenkins/Jenkinsfile
@@ -62,20 +62,25 @@ def prepare_check_stages() {
 	"--enable-ipv6",
 	"--enable-mca-dso"
     ]
+    // explicitly list the newest and oldest versions of GCC that are included
+    // in the distros listed below to try and give us good version coverage.
     def compilers = [
-	"gcc14",
-	"clang18"
+	"gcc9",
+	"gcc15",
+	"clang11",
+	"clang21"
     ]
     def platforms = [
-	"amazon_linux_2",
-	"amazon_linux_2-arm64",
 	"rhel8",
+	"rhel9",
+	"rhel10",
 	"amazon_linux_2023-arm64",
 	"amazon_linux_2023-x86_64",
 	"freebsd_15",
-	"ubuntu_20.04",
 	"ubuntu_24.04-arm64",
-	"ubuntu_24.04-x86_64"
+	"ubuntu_24.04-x86_64",
+	"ubuntu_26.04-arm64",
+	"ubuntu_26.04-x86_64"
     ]
     def check_stages_list = []
 

--- a/.ci/community-jenkins/pr-builder.sh
+++ b/.ci/community-jenkins/pr-builder.sh
@@ -145,13 +145,16 @@ if test "${COMPILER}" != "" ; then
         exit 1
     fi
 
+    set +u
     . ${HOME}/ompi-compiler-setup.sh
     activate_compiler ${COMPILER}
+    set -u
 
-    CONFIGURE_ARGS="${CONFIGURE_ARGS} CC=${CC} CPP=${CPP} CXX=${CXX} FC=${FC}"
-    if test "$FC" = "" ; then
+    CONFIGURE_ARGS="${CONFIGURE_ARGS} CC=${CC} CPP=${CPP} CXX=${CXX}"
+    if [ -z "${FC:-}" ] ; then
         CONFIGURE_ARGS="${CONFIGURE_ARGS} --disable-mpi-fortran"
     else
+        CONFIGURE_ARGS="${CONFIGURE_ARGS} FC=${FC}"
         # Flang doesn't seem good enough (yet) to compile our Fortran bindings,
         # so skip for now.
         case "${COMPILER}" in


### PR DESCRIPTION
Update the distro list to remove EOL (or soon to be EOL) distros in Ubuntu 20 (EOL May 31, 2025) and AL2 (EOL June 30, 2026).  Add more recent versions of distros (RHEL 9, RHEL 10, Ubuntu 26.04).

Update the compilers list to make sure we explicitly test the newest and oldest versions of GCC and Clang available in the supported Ubuntu distros.