### PR TITLE
Add hook/fault_injector debugging tool

### DIFF
--- a/ompi/mca/hook/fault_injector/Makefile.am
+++ b/ompi/mca/hook/fault_injector/Makefile.am
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026      Sandia National Laboratories.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+	hook_fault_injector.h \
+	hook_fault_injector_component.c \
+	hook_fault_injector_fns.c
+
+# This component will only ever be built statically -- never as a DSO.
+
+noinst_LTLIBRARIES = libmca_hook_fault_injector.la
+
+libmca_hook_fault_injector_la_SOURCES = $(sources)
+libmca_hook_fault_injector_la_LDFLAGS = -module -avoid-version

--- a/ompi/mca/hook/fault_injector/configure.m4
+++ b/ompi/mca/hook/fault_injector/configure.m4
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2026      Sandia National Laboratories.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Make this a static component
+AC_DEFUN([MCA_ompi_hook_fault_injector_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+# MCA_hook_fault_injector_CONFIG([action-if-can-compile],
+#                      [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_hook_fault_injector_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/hook/fault_injector/Makefile])
+
+    $1
+])

--- a/ompi/mca/hook/fault_injector/hook_fault_injector.h
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#ifndef MCA_HOOK_FAULT_INJECTOR_H
+#define MCA_HOOK_FAULT_INJECTOR_H
+
+#include "ompi_config.h"
+
+#include "ompi/constants.h"
+
+#include "ompi/mca/hook/hook.h"
+#include "ompi/mca/hook/base/base.h"
+
+#include "opal/mca/timer/base/base.h"
+
+BEGIN_C_DECLS
+
+void mca_hook_fault_injector_mpi_init_top_post_opal(int argc, char **argv, int requested, int *provided);
+
+void mca_hook_fault_injector_mpi_init_bottom(int argc, char **argv, int requested, int *provided);
+
+int mca_hook_fault_injector_progress(void);
+
+struct mca_hook_fault_injector_module_t {
+    int global_seed;
+    unsigned rank_mttf_s;
+    unsigned injection_delay_ms;
+    bool inject_in_init;
+
+    // Time offset from start to fail
+    opal_timer_t target_injection_offset_us;
+    // Absolute time to fail
+    opal_timer_t target_injection_time_us;
+
+    int verbose;
+    int output;
+};
+typedef struct mca_hook_fault_injector_module_t mca_hook_fault_injector_module_t;
+
+
+OMPI_DECLSPEC extern ompi_hook_base_component_1_0_0_t mca_hook_fault_injector_component;
+
+OMPI_DECLSPEC extern mca_hook_fault_injector_module_t mca_hook_fault_injector_module;
+
+
+END_C_DECLS
+
+#endif /* MCA_HOOK_FAULT_INJECTOR_H */

--- a/ompi/mca/hook/fault_injector/hook_fault_injector.h
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector.h
@@ -20,17 +20,20 @@
 
 BEGIN_C_DECLS
 
-void mca_hook_fault_injector_mpi_init_top_post_opal(int argc, char **argv, int requested, int *provided);
+void ompi_hook_fault_injector_mpi_init_top_post_opal(int argc, char **argv, int requested, int *provided);
 
-void mca_hook_fault_injector_mpi_init_bottom(int argc, char **argv, int requested, int *provided);
+void ompi_hook_fault_injector_mpi_init_bottom(int argc, char **argv, int requested, int *provided);
 
-int mca_hook_fault_injector_progress(void);
+int ompi_hook_fault_injector_progress(void);
 
-struct mca_hook_fault_injector_module_t {
-    int global_seed;
-    unsigned rank_mttf_s;
-    unsigned injection_delay_ms;
+struct ompi_hook_fault_injector_module_t {
+    int injection_signal;
+    uint32_t global_seed;
+    uint32_t rank_mttf_s;
+    uint32_t injection_delay_ms;
+    bool high_priority;
     bool inject_in_init;
+    bool pause_injection;
 
     // Time offset from start to fail
     opal_timer_t target_injection_offset_us;
@@ -40,12 +43,12 @@ struct mca_hook_fault_injector_module_t {
     int verbose;
     int output;
 };
-typedef struct mca_hook_fault_injector_module_t mca_hook_fault_injector_module_t;
+typedef struct ompi_hook_fault_injector_module_t ompi_hook_fault_injector_module_t;
 
 
 OMPI_DECLSPEC extern ompi_hook_base_component_1_0_0_t mca_hook_fault_injector_component;
 
-OMPI_DECLSPEC extern mca_hook_fault_injector_module_t mca_hook_fault_injector_module;
+OMPI_DECLSPEC extern ompi_hook_fault_injector_module_t ompi_hook_fault_injector_module;
 
 
 END_C_DECLS

--- a/ompi/mca/hook/fault_injector/hook_fault_injector_component.c
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector_component.c
@@ -12,9 +12,9 @@
 #include "hook_fault_injector.h"
 #include "opal/runtime/opal_progress.h"
 
-static int fault_injector_open(void){ return OMPI_SUCCESS; }
-static int fault_injector_close(void);
-static int fault_injector_register(void);
+static int ompi_hook_fault_injector_open(void){ return OMPI_SUCCESS; }
+static int ompi_hook_fault_injector_close(void);
+static int ompi_hook_fault_injector_register(void);
 
 ompi_hook_base_component_1_0_0_t mca_hook_fault_injector_component = {
     /* First, the mca_component_t struct containing meta information
@@ -25,26 +25,25 @@ ompi_hook_base_component_1_0_0_t mca_hook_fault_injector_component = {
         MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
                               OMPI_RELEASE_VERSION),
 
-        .mca_open_component = fault_injector_open,
-        .mca_close_component = fault_injector_close,
-        .mca_register_component_params = fault_injector_register,
+        .mca_open_component = ompi_hook_fault_injector_open,
+        .mca_close_component = ompi_hook_fault_injector_close,
+        .mca_register_component_params = ompi_hook_fault_injector_register,
     },
     .hookm_data = { MCA_BASE_METADATA_PARAM_CHECKPOINT },
 
     /* Component functions */
-    .hookm_mpi_init_top_post_opal = mca_hook_fault_injector_mpi_init_top_post_opal,
-    .hookm_mpi_init_bottom = mca_hook_fault_injector_mpi_init_bottom,
+    .hookm_mpi_init_top_post_opal = ompi_hook_fault_injector_mpi_init_top_post_opal,
+    .hookm_mpi_init_bottom = ompi_hook_fault_injector_mpi_init_bottom,
 };
 MCA_BASE_COMPONENT_INIT(ompi, hook, fault_injector)
 
 
+ompi_hook_fault_injector_module_t ompi_hook_fault_injector_module = { 0 };
 
-mca_hook_fault_injector_module_t mca_hook_fault_injector_module = { 0 };
-
-static int fault_injector_register(void)
+static int ompi_hook_fault_injector_register(void)
 {
     ompi_hook_base_component_1_0_0_t *component = &mca_hook_fault_injector_component;
-    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
 
     // Inherit verbosity of the base framework but allow to be overridden
     module->verbose = ompi_hook_base_framework.framework_verbose;
@@ -57,6 +56,28 @@ static int fault_injector_register(void)
     module->output = opal_output_open(NULL);
     opal_output_set_verbosity(module->output, module->verbose);
 
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "pause",
+        "Pause fault injection while true. Faults that should have been "
+        "injected while paused will be injected once unpaused.",
+        MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+        OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL, &module->pause_injection
+    );
+
+    module->injection_signal = SIGKILL;
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "signal",
+        "Signal to be raised for simulating a failure. Default is SIGKILL.",
+        MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+        OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_LOCAL, &module->injection_signal
+    );
+
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "high_priority",
+        "More frequent fault injection checks. Will impact message latency.",
+        MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_3,
+        MCA_BASE_VAR_SCOPE_READONLY, &module->high_priority
+    );
 
     (void) mca_base_component_var_register(
         &component->hookm_version, "inject_in_init",
@@ -69,14 +90,14 @@ static int fault_injector_register(void)
         &component->hookm_version, "global_seed",
         "Random number seed to use for generating each rank's fault time. "
         "A value of zero indicates that a random seed should be generated.",
-        MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_3,
+        MCA_BASE_VAR_TYPE_UINT32_T, NULL, 0, 0, OPAL_INFO_LVL_3,
         MCA_BASE_VAR_SCOPE_READONLY, &module->global_seed
     );
 
     (void) mca_base_component_var_register(
-        &component->hookm_version, "injection_delay_ms",
+        &component->hookm_version, "delay_ms",
         "Milliseconds of delay to add to the generated fault times "
-        "(to avoid failures during app setup)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+        "(to avoid failures during app setup)", MCA_BASE_VAR_TYPE_UINT32_T,
         NULL, 0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
         &module->injection_delay_ms
     );
@@ -84,16 +105,19 @@ static int fault_injector_register(void)
     (void) mca_base_component_var_register(
         &component->hookm_version, "rank_mttf",
         "Mean time to failure for an individual rank, in seconds. A value of "
-        "zero disables injection.", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
+        "zero disables injection.", MCA_BASE_VAR_TYPE_UINT32_T, NULL, 0, 0,
         OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_READONLY, &module->rank_mttf_s
     );
 
     return OMPI_SUCCESS;
 }
 
-static int fault_injector_close(void)
+static int ompi_hook_fault_injector_close(void)
 {
-    if (0 != mca_hook_fault_injector_module.rank_mttf_s)
-        opal_progress_unregister(mca_hook_fault_injector_progress);
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
+    opal_output_close(module->output);
+    if (0 != module->rank_mttf_s)
+        opal_progress_unregister(ompi_hook_fault_injector_progress);
+    *module = (ompi_hook_fault_injector_module_t) {0};
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/hook/fault_injector/hook_fault_injector_component.c
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector_component.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "hook_fault_injector.h"
+#include "opal/runtime/opal_progress.h"
+
+static int fault_injector_open(void){ return OMPI_SUCCESS; }
+static int fault_injector_close(void);
+static int fault_injector_register(void);
+
+ompi_hook_base_component_1_0_0_t mca_hook_fault_injector_component = {
+    /* First, the mca_component_t struct containing meta information
+     * about the component itself */
+    .hookm_version = {
+        OMPI_HOOK_BASE_VERSION_1_0_0,
+        .mca_component_name = "fault_injector",
+        MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
+                              OMPI_RELEASE_VERSION),
+
+        .mca_open_component = fault_injector_open,
+        .mca_close_component = fault_injector_close,
+        .mca_register_component_params = fault_injector_register,
+    },
+    .hookm_data = { MCA_BASE_METADATA_PARAM_CHECKPOINT },
+
+    /* Component functions */
+    .hookm_mpi_init_top_post_opal = mca_hook_fault_injector_mpi_init_top_post_opal,
+    .hookm_mpi_init_bottom = mca_hook_fault_injector_mpi_init_bottom,
+};
+MCA_BASE_COMPONENT_INIT(ompi, hook, fault_injector)
+
+
+
+mca_hook_fault_injector_module_t mca_hook_fault_injector_module = { 0 };
+
+static int fault_injector_register(void)
+{
+    ompi_hook_base_component_1_0_0_t *component = &mca_hook_fault_injector_component;
+    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+
+    // Inherit verbosity of the base framework but allow to be overridden
+    module->verbose = ompi_hook_base_framework.framework_verbose;
+    if( MCA_BASE_VERBOSE_NONE > module->verbose ) module->verbose = MCA_BASE_VERBOSE_NONE;
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "verbose", NULL, MCA_BASE_VAR_TYPE_INT, NULL,
+        0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_READONLY, &module->verbose
+    );
+
+    module->output = opal_output_open(NULL);
+    opal_output_set_verbosity(module->output, module->verbose);
+
+
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "inject_in_init",
+        "Enable fault injections during MPI_Init", MCA_BASE_VAR_TYPE_BOOL, NULL,
+        0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
+        &module->inject_in_init
+    );
+
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "global_seed",
+        "Random number seed to use for generating each rank's fault time. "
+        "A value of zero indicates that a random seed should be generated.",
+        MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_3,
+        MCA_BASE_VAR_SCOPE_READONLY, &module->global_seed
+    );
+
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "injection_delay_ms",
+        "Milliseconds of delay to add to the generated fault times "
+        "(to avoid failures during app setup)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+        NULL, 0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
+        &module->injection_delay_ms
+    );
+
+    (void) mca_base_component_var_register(
+        &component->hookm_version, "rank_mttf",
+        "Mean time to failure for an individual rank, in seconds. A value of "
+        "zero disables injection.", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
+        OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_READONLY, &module->rank_mttf_s
+    );
+
+    return OMPI_SUCCESS;
+}
+
+static int fault_injector_close(void)
+{
+    if (0 != mca_hook_fault_injector_module.rank_mttf_s)
+        opal_progress_unregister(mca_hook_fault_injector_progress);
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/hook/fault_injector/hook_fault_injector_fns.c
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector_fns.c
@@ -15,16 +15,17 @@
 #include "opal/mca/timer/base/base.h"
 #include "ompi/runtime/ompi_rte.h"
 #include "opal/util/output.h"
+#include "opal/util/alfg.h"
 
 #include <stdlib.h>
 #include <math.h>   // log()
 
-static void init_injection_checks(void);
+static void ompi_hook_fault_injector_init_injection_checks(void);
 
-void mca_hook_fault_injector_mpi_init_top_post_opal(
+void ompi_hook_fault_injector_mpi_init_top_post_opal(
     int argc, char **argv, int requested, int *provided
 ) {
-    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
     if( 0 == module->rank_mttf_s ) return;
 
     if( !module->global_seed ) module->global_seed = OMPI_PROC_MY_NAME->jobid;
@@ -35,45 +36,53 @@ void mca_hook_fault_injector_mpi_init_top_post_opal(
         module->inject_in_init ? "on" : "off"
     );
 
-    srand(module->global_seed);
-    int local_seed = rand() ^ OMPI_PROC_MY_NAME->vpid;
-    srand(local_seed);
-    double prob = rand() / (RAND_MAX+1.0);
+    opal_rng_buff_t r;
+    opal_srand(&r, module->global_seed);
+    uint32_t local_seed = opal_rand(&r) ^ OMPI_PROC_MY_NAME->vpid;
+    opal_srand(&r, local_seed);
+    double prob = opal_rand(&r) / (UINT32_MAX+1.0);
     
     double mttf_us = ((double)module->rank_mttf_s)*1000000;
     double target_offset =
         -log(1-prob)*mttf_us + module->injection_delay_ms*1000;
     module->target_injection_offset_us = target_offset;
-
-    if( module->inject_in_init ) init_injection_checks();
+    
+    if( module->inject_in_init )
+        ompi_hook_fault_injector_init_injection_checks();
 }
 
-void mca_hook_fault_injector_mpi_init_bottom(
+void ompi_hook_fault_injector_mpi_init_bottom(
     int argc, char **argv, int requested, int *provided
 ) {
-    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
     if( 0 != module->rank_mttf_s && !module->inject_in_init )
-        init_injection_checks();
+        ompi_hook_fault_injector_init_injection_checks();
 }
 
-void init_injection_checks(void)
+static void ompi_hook_fault_injector_init_injection_checks(void)
 {
-    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
 
     opal_output_verbose(
         4, module->output, "%s hook:fault_injector fault after %f seconds\n",
         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
         ((double)module->target_injection_offset_us)/1000000
     );
-    
+
     module->target_injection_time_us =
         opal_timer_base_get_usec() + module->target_injection_offset_us;
-    opal_progress_register(mca_hook_fault_injector_progress);
+
+    if( module->high_priority ){
+        opal_progress_register(ompi_hook_fault_injector_progress);
+    } else {
+        opal_progress_register_lp(ompi_hook_fault_injector_progress);
+    }
 }
 
-int mca_hook_fault_injector_progress(void)
+int ompi_hook_fault_injector_progress(void)
 {
-    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    ompi_hook_fault_injector_module_t *module = &ompi_hook_fault_injector_module;
+    if( module->pause_injection ) return 0;
 
     opal_timer_t cur_time = opal_timer_base_get_usec();
     if( cur_time < module->target_injection_time_us ) return 0;
@@ -93,6 +102,6 @@ int mca_hook_fault_injector_progress(void)
         );
     }
 
-    exit(1);
+    raise(module->injection_signal);
     return 0;
 }

--- a/ompi/mca/hook/fault_injector/hook_fault_injector_fns.c
+++ b/ompi/mca/hook/fault_injector/hook_fault_injector_fns.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Sandia National Laboratories. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "hook_fault_injector.h"
+
+#include "opal/runtime/opal_progress.h"
+#include "opal/mca/timer/base/base.h"
+#include "ompi/runtime/ompi_rte.h"
+#include "opal/util/output.h"
+
+#include <stdlib.h>
+#include <math.h>   // log()
+
+static void init_injection_checks(void);
+
+void mca_hook_fault_injector_mpi_init_top_post_opal(
+    int argc, char **argv, int requested, int *provided
+) {
+    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    if( 0 == module->rank_mttf_s ) return;
+
+    if( !module->global_seed ) module->global_seed = OMPI_PROC_MY_NAME->jobid;
+    if( 0 == OMPI_PROC_MY_NAME->vpid ) opal_output_verbose(
+        1, module->output, "hook:fault_injector using global seed %d, rank mttf"
+        " %u seconds, injection delay %u ms, init injections %s",
+        module->global_seed, module->rank_mttf_s, module->injection_delay_ms,
+        module->inject_in_init ? "on" : "off"
+    );
+
+    srand(module->global_seed);
+    int local_seed = rand() ^ OMPI_PROC_MY_NAME->vpid;
+    srand(local_seed);
+    double prob = rand() / (RAND_MAX+1.0);
+    
+    double mttf_us = ((double)module->rank_mttf_s)*1000000;
+    double target_offset =
+        -log(1-prob)*mttf_us + module->injection_delay_ms*1000;
+    module->target_injection_offset_us = target_offset;
+
+    if( module->inject_in_init ) init_injection_checks();
+}
+
+void mca_hook_fault_injector_mpi_init_bottom(
+    int argc, char **argv, int requested, int *provided
+) {
+    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+    if( 0 != module->rank_mttf_s && !module->inject_in_init )
+        init_injection_checks();
+}
+
+void init_injection_checks(void)
+{
+    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+
+    opal_output_verbose(
+        4, module->output, "%s hook:fault_injector fault after %f seconds\n",
+        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+        ((double)module->target_injection_offset_us)/1000000
+    );
+    
+    module->target_injection_time_us =
+        opal_timer_base_get_usec() + module->target_injection_offset_us;
+    opal_progress_register(mca_hook_fault_injector_progress);
+}
+
+int mca_hook_fault_injector_progress(void)
+{
+    mca_hook_fault_injector_module_t *module = &mca_hook_fault_injector_module;
+
+    opal_timer_t cur_time = opal_timer_base_get_usec();
+    if( cur_time < module->target_injection_time_us ) return 0;
+
+    if( opal_output_check_verbosity(3, module->output) ){
+        opal_output_verbose(
+            3, module->output, "%s hook:fault_injector injecting failure %f "
+            "seconds after targetted %f seconds\n",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+            ((double)cur_time - module->target_injection_time_us)/1000000,
+            ((double)module->target_injection_offset_us)/1000000
+        );
+    } else {
+        opal_output_verbose(
+            2, module->output, "%s hook:fault_injector injecting failure",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME)
+        );
+    }
+
+    exit(1);
+    return 0;
+}

--- a/ompi/mca/hook/fault_injector/owner.txt
+++ b/ompi/mca/hook/fault_injector/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: Sandia National Laboratories
+status: active


### PR DESCRIPTION
Any interest in making this a core ompi feature? edit: I'm really asking if there's any willingness to let this be an ompi feature - I can supply the interest :)

It's a helpful tool for debugging fault tolerance functionality inside and outside of ompi. Generates a time for each rank to fail based on a per-rank MTTF and a global random number seed (which is used to construct local random number seeds). Assumes an exponential failure distribution (i.e. constant failure rate).

It would probably be handy to expose an "injection_paused" mca to MPI_T and to offer a skip counter to avoid checking the time on every progress call (or registering as a low priority progress function). I also have no idea how the fault injection would interact with multithreading. I want to check on interest before looking into any of these, though.