### PR TITLE
[v5.0.x] pml/ob1: ARM64 memory ordering fixes and stale send range drain

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -233,6 +233,9 @@ mca_pml_ob1_imrecv( void *buf,
     recvreq->req_rdma_idx = 0;
     recvreq->req_pending = false;
     recvreq->req_ack_sent = false;
+    recvreq->req_match_received = false;
+    /* release: pair with rmb in recv_request_pml_complete_check */
+    opal_atomic_wmb();
 
     MCA_PML_BASE_RECV_START(&recvreq->req_recv);
 
@@ -325,6 +328,10 @@ mca_pml_ob1_mrecv( void *buf,
     recvreq->req_rdma_cnt = 0;
     recvreq->req_rdma_idx = 0;
     recvreq->req_pending = false;
+    recvreq->req_ack_sent = false;
+    recvreq->req_match_received = false;
+    /* release: pair with rmb in recv_request_pml_complete_check */
+    opal_atomic_wmb();
 
     MCA_PML_BASE_RECV_START(&recvreq->req_recv);
 

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -768,6 +768,10 @@ void mca_pml_ob1_recv_frag_callback_ack (mca_btl_base_module_t *btl,
         sendreq->req_send.req_base.req_convertor.stream = stream;
     }
 
+    /* ensure all prior stores (copy_in_out, rdma_frag, throttle_sends,
+     * req_state, accelerator flags) are visible before complete_check
+     * may recycle the request */
+    opal_atomic_wmb();
     if (send_request_pml_complete_check(sendreq) == false)
         mca_pml_ob1_send_request_schedule(sendreq);
 }

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -228,6 +228,9 @@ static void mca_pml_ob1_put_completion (mca_pml_ob1_rdma_frag_t *frag, int64_t r
 
     if (OPAL_LIKELY(0 < rdma_size)) {
 
+        /* ensure pipeline_depth and frag cleanup are visible before
+         * bytes_received update that complete_check observes */
+        opal_atomic_wmb();
         /* check completion status */
         OPAL_THREAD_ADD_FETCH_SIZE_T(&recvreq->req_bytes_received, rdma_size);
         SPC_USER_OR_MPI(recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)rdma_size,
@@ -443,6 +446,9 @@ static void mca_pml_ob1_rget_completion (mca_btl_base_module_t* btl, struct mca_
         MCA_PML_OB1_RDMA_FRAG_RETURN(frag);
     }
 
+    /* ensure all prior stores (bytes_received, error status, frag cleanup)
+     * are visible before complete_check may recycle the request */
+    opal_atomic_wmb();
     recv_request_pml_complete_check(recvreq);
 
     MCA_PML_OB1_PROGRESS_PENDING(bml_btl);
@@ -596,6 +602,9 @@ void mca_pml_ob1_recv_request_progress_frag( mca_pml_ob1_recv_request_t* recvreq
                                recvreq->req_recv.req_base.req_datatype);
                );
 
+    /* ensure unpack stores are visible before bytes_received update
+     * that complete_check observes */
+    opal_atomic_wmb();
     OPAL_THREAD_ADD_FETCH_SIZE_T(&recvreq->req_bytes_received, bytes_received);
     SPC_USER_OR_MPI(recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)bytes_received,
                     OMPI_SPC_BYTES_RECEIVED_USER, OMPI_SPC_BYTES_RECEIVED_MPI);
@@ -674,6 +683,9 @@ void mca_pml_ob1_recv_request_frag_copy_finished( mca_btl_base_module_t* btl,
      * known that the data has been copied out of the descriptor. */
     des->des_cbfunc(NULL, NULL, des, 0);
 
+    /* ensure copy and descriptor cleanup are visible before
+     * bytes_received update that complete_check observes */
+    opal_atomic_wmb();
     OPAL_THREAD_ADD_FETCH_SIZE_T(&recvreq->req_bytes_received, bytes_received);
     SPC_USER_OR_MPI(recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)bytes_received,
                     OMPI_SPC_BYTES_RECEIVED_USER, OMPI_SPC_BYTES_RECEIVED_MPI);
@@ -887,6 +899,9 @@ void mca_pml_ob1_recv_request_progress_rndv( mca_pml_ob1_recv_request_t* recvreq
         SPC_USER_OR_MPI(recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)bytes_received,
                         OMPI_SPC_BYTES_RECEIVED_USER, OMPI_SPC_BYTES_RECEIVED_MPI);
     }
+    /* ensure all prior stores (unpack, match, bytes_received) are visible
+     * before complete_check may recycle the request */
+    opal_atomic_wmb();
     /* check completion status */
     if(recv_request_pml_complete_check(recvreq) == false &&
        recvreq->req_rdma_offset < recvreq->req_send_offset) {

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -65,11 +65,14 @@ OBJ_CLASS_DECLARATION(mca_pml_ob1_recv_request_t);
 
 static inline bool lock_recv_request(mca_pml_ob1_recv_request_t *recvreq)
 {
-        return OPAL_THREAD_ADD_FETCH32(&recvreq->req_lock,  1) == 1;
+        bool ret = OPAL_THREAD_ADD_FETCH32(&recvreq->req_lock,  1) == 1;
+        opal_atomic_rmb();
+        return ret;
 }
 
 static inline bool unlock_recv_request(mca_pml_ob1_recv_request_t *recvreq)
 {
+        opal_atomic_wmb();
         return OPAL_THREAD_ADD_FETCH32(&recvreq->req_lock, -1) == 0;
 }
 

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -250,9 +250,10 @@ static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
 {
     req->req_recv.req_base.req_ompi.req_status.MPI_SOURCE = hdr->hdr_src;
     req->req_recv.req_base.req_ompi.req_status.MPI_TAG = hdr->hdr_tag;
-    req->req_match_received = true;
-
+    /* ensure MPI_SOURCE, MPI_TAG, and req_bytes_packed (set by caller)
+     * are visible before req_match_received signals complete_check */
     opal_atomic_wmb();
+    req->req_match_received = true;
 
     if(req->req_recv.req_bytes_packed > 0) {
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -261,6 +261,10 @@ mca_pml_ob1_rndv_completion_request( mca_bml_base_btl_t* bml_btl,
     SPC_USER_OR_MPI(sendreq->req_send.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)req_bytes_delivered,
                     OMPI_SPC_BYTES_SENT_USER, OMPI_SPC_BYTES_SENT_MPI);
 
+    /* ensure bytes_delivered is visible before req_state update, so that
+     * another thread's complete_check sees consistent state */
+    opal_atomic_wmb();
+
     /* advance the request */
     OPAL_THREAD_ADD_FETCH32(&sendreq->req_state, -1);
 
@@ -360,6 +364,9 @@ mca_pml_ob1_rget_completion (mca_pml_ob1_rdma_frag_t *frag, int64_t rdma_length)
         MCA_PML_OB1_RDMA_FRAG_RETURN(frag);
     }
 
+    /* ensure all prior stores (bytes_delivered, rdma_frag, error status)
+     * are visible before complete_check may recycle the request */
+    opal_atomic_wmb();
     send_request_pml_complete_check(sendreq);
 
     if( OPAL_LIKELY(0 < rdma_length) ) {
@@ -440,6 +447,9 @@ mca_pml_ob1_frag_completion( mca_btl_base_module_t* btl,
                                                                        sizeof(mca_pml_ob1_frag_hdr_t));
     }
 
+    /* ensure prior non-atomic stores (e.g. error status) are visible
+     * before atomic updates that complete_check will observe */
+    opal_atomic_wmb();
     OPAL_THREAD_ADD_FETCH32(&sendreq->req_pipeline_depth, -1);
     OPAL_THREAD_ADD_FETCH_SIZE_T(&sendreq->req_bytes_delivered, req_bytes_delivered);
     SPC_USER_OR_MPI(sendreq->req_send.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)req_bytes_delivered,
@@ -1318,11 +1328,13 @@ static void mca_pml_ob1_put_completion (mca_btl_base_module_t* btl, struct mca_b
 
     /* check completion status */
     if( OPAL_UNLIKELY(OMPI_SUCCESS == status) ) {
-        /* TODO -- read ordering */
         mca_pml_ob1_send_fin (sendreq->req_send.req_base.req_proc, bml_btl,
                               frag->rdma_hdr.hdr_rdma.hdr_frag, frag->rdma_length,
                               0, 0);
 
+        /* ensure send_fin stores are visible before bytes_delivered
+         * update that complete_check observes */
+        opal_atomic_wmb();
         /* check for request completion */
         OPAL_THREAD_ADD_FETCH_SIZE_T(&sendreq->req_bytes_delivered, frag->rdma_length);
         SPC_USER_OR_MPI(sendreq->req_send.req_base.req_ompi.req_status.MPI_TAG, (ompi_spc_value_t)frag->rdma_length,
@@ -1411,6 +1423,7 @@ void mca_pml_ob1_send_request_put (mca_pml_ob1_send_request_t *sendreq,
     mca_pml_ob1_rdma_frag_t* frag;
 
     if(hdr->hdr_common.hdr_flags & MCA_PML_OB1_HDR_TYPE_ACK) {
+        opal_atomic_wmb();  /* ensure prior stores visible before req_state update */
         OPAL_THREAD_ADD_FETCH32(&sendreq->req_state, -1);
     }
 
@@ -1434,6 +1447,10 @@ void mca_pml_ob1_send_request_put (mca_pml_ob1_send_request_t *sendreq,
         /* rget fallback on put */
         frag = sendreq->rdma_frag;
         sendreq->rdma_frag = NULL;
+        /* ensure rdma_frag = NULL is visible before req_state signals
+         * completion — plain store of 0 is the completion trigger that
+         * complete_check observes */
+        opal_atomic_wmb();
         sendreq->req_state = 0;
     }
 

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -79,11 +79,14 @@ OBJ_CLASS_DECLARATION(mca_pml_ob1_send_range_t);
 
 static inline bool lock_send_request(mca_pml_ob1_send_request_t *sendreq)
 {
-    return OPAL_THREAD_ADD_FETCH32(&sendreq->req_lock,  1) == 1;
+    bool ret = OPAL_THREAD_ADD_FETCH32(&sendreq->req_lock,  1) == 1;
+    opal_atomic_rmb();
+    return ret;
 }
 
 static inline bool unlock_send_request(mca_pml_ob1_send_request_t *sendreq)
 {
+    opal_atomic_wmb();
     return OPAL_THREAD_ADD_FETCH32(&sendreq->req_lock, -1) == 0;
 }
 

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -471,6 +471,17 @@ mca_pml_ob1_send_request_start_seq (mca_pml_ob1_send_request_t* sendreq, mca_bml
     sendreq->req_pending = MCA_PML_OB1_SEND_PENDING_NONE;
     sendreq->req_send.req_base.req_sequence = seqn;
 
+    /* drain any stale send ranges left from a previous lifecycle;
+     * not protected by a lock as the sendreq is owned exclusively
+     * by the current thread at this point in the lifecycle. */
+    if (OPAL_UNLIKELY(!opal_list_is_empty(&sendreq->req_send_ranges))) {
+        opal_list_item_t *item;
+        OPAL_OUTPUT_VERBOSE((1, mca_pml_ob1_output, "stale send ranges on reused sendreq"));
+        while (NULL != (item = opal_list_remove_first(&sendreq->req_send_ranges))) {
+            opal_free_list_return(&mca_pml_ob1.send_ranges, (opal_free_list_item_t *)item);
+        }
+    }
+
     MCA_PML_BASE_SEND_START( &sendreq->req_send );
 
     for(size_t i = 0; i < mca_bml_base_btl_array_get_size(&endpoint->btl_eager); i++) {


### PR DESCRIPTION
Backport of https://github.com/open-mpi/ompi/pull/13800 to v5.0.x.