### PR TITLE
coll/accelerator: stage full input for MPI_IN_PLACE in reduce_scatter and rs_block

### DIFF
--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter.c
@@ -43,7 +43,7 @@ mca_coll_accelerator_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_arr
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
     int sbuf_dev, rbuf_dev;
-    size_t sbufsize, rbufsize, elemsize;
+    size_t sbufsize, rbufsize, rbuf_in_size, elemsize;
     int rc, i;
     int comm_size = ompi_comm_size(comm);
     int total_count = 0;
@@ -73,13 +73,17 @@ mca_coll_accelerator_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_arr
         goto exit;
     }
     rbufsize = elemsize * ompi_count_array_get(rcounts, ompi_comm_rank(comm));
+    /* With MPI_IN_PLACE the input lives entirely in rbuf and spans the full
+     * sum(rcounts); stage that span device->host so the fallback collective
+     * doesn't read past the host allocation. */
+    rbuf_in_size = (MPI_IN_PLACE == sbuf) ? sbufsize : rbufsize;
     if (0 < rc) {
-        rbuf1 = (char*)malloc(rbufsize);
+        rbuf1 = (char*)malloc(rbuf_in_size);
         if (NULL == rbuf1) {
             rc = OMPI_ERR_OUT_OF_RESOURCE;
 	    goto exit;
         }
-        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbufsize,
+        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbuf_in_size,
                                     MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;

--- a/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
+++ b/ompi/mca/coll/accelerator/coll_accelerator_reduce_scatter_block.c
@@ -43,12 +43,16 @@ mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t r
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
     int sbuf_dev, rbuf_dev;
-    size_t sbufsize, rbufsize;
+    size_t sbufsize, rbufsize, rbuf_in_size;
     int rc;
 
     rbufsize = opal_datatype_span(&dtype->super, rcount, &gap);
 
     sbufsize = rbufsize * ompi_comm_size(comm);
+    /* With MPI_IN_PLACE the input lives entirely in rbuf and spans
+     * comm_size * rcount elements; stage the full span device->host so the
+     * fallback collective doesn't read past the host allocation. */
+    rbuf_in_size = (MPI_IN_PLACE == sbuf) ? sbufsize : rbufsize;
     rc = mca_coll_accelerator_check_buf((void *)sbuf, &sbuf_dev);
     if (rc < 0) {
         return rc;
@@ -67,12 +71,12 @@ mca_coll_accelerator_reduce_scatter_block(const void *sbuf, void *rbuf, size_t r
         return rc;
     }
     if (rc > 0) {
-        rbuf1 = (char*)malloc(rbufsize);
+        rbuf1 = (char*)malloc(rbuf_in_size);
         if (NULL == rbuf1) {
             if (NULL != sbuf1) free(sbuf1);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbufsize,
+        mca_coll_accelerator_memcpy(rbuf1, MCA_ACCELERATOR_NO_DEVICE_ID, rbuf, rbuf_dev, rbuf_in_size,
                                     MCA_ACCELERATOR_TRANSFER_DTOH);
         rbuf2 = rbuf; /* save away original buffer */
         rbuf = rbuf1 - gap;


### PR DESCRIPTION
When sbuf == MPI_IN_PLACE, the input lives entirely in rbuf:

* reduce_scatter_block: rbuf holds comm_size * rcount elements
* reduce_scatter:       rbuf holds sum(rcounts) elements (same on every rank)

Both wrappers were sizing the host staging buffer at the local-share size (rbufsize = one rank's output) and copying only that many bytes device->host. The fallback collective then read past the malloc'd region: SIGSEGV inside the convertor pack/copy when the read crossed an unmapped page, or ibv_reg_mr "Bad address" when the read stayed mapped but the peer-side registration walked into invalid pages.

For the IN_PLACE path, stage the full input span (sbufsize) device->host before invoking the fallback. The result write-back stays at rbufsize since only the local share is meaningful after the call. The non-IN_PLACE path is unchanged (sbuf is staged separately at sbufsize).
