### PR TITLE
[Backport v6.0.x] coll/han: Persistent buffer optimization for collectives

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -471,6 +471,38 @@ typedef struct mca_coll_han_module_t {
      * (e.g., allgather uses a gather buffer and a reorder buffer). */
     char *scratch_buf[2];
     size_t scratch_buf_size[2];
+
+    struct han_alltoall_cache {
+        char *bounce;
+        size_t bounce_size;
+        const void *cached_sbuf;
+        size_t cached_scount;
+        int cached_low_size;
+        char **low_bufs;
+        void **map_ctx;
+        void **gather_buf;
+        int cached_send_needs_bounce;
+        int cached_ii_push_data;
+        char *recv_buf;
+        size_t recv_buf_size;
+    } a2a_cache;
+
+    struct han_alltoallv_cache {
+        uint8_t *serial_buf;
+        size_t serial_buf_size;
+        void *gather_out;
+        void *peers;
+        void *peer_types;
+        int low_size;
+        void **send_from;
+        void **recv_to;
+        size_t *send_counts;
+        size_t *recv_counts;
+        void **send_types;
+        void **recv_types;
+        bool smsc_decided;
+        int use_smsc;
+    } a2av_cache;
 } mca_coll_han_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -152,6 +152,7 @@ struct mca_coll_han_scatter_args_s {
     ompi_communicator_t *up_comm;
     ompi_communicator_t *low_comm;
     ompi_request_t *req;
+    mca_coll_han_module_t *han_module;
     void *sbuf;
     void *sbuf_inter_free;
     void *sbuf_reorder_free;
@@ -165,6 +166,10 @@ struct mca_coll_han_scatter_args_s {
     int root_low_rank;
     int w_rank;
     bool noop;
+    opal_free_list_item_t *inter_fl_item;   /* freelist item for inter-node buf */
+    int inter_fl_src;                        /* HAN_ALLOC_{MALLOC,LARGE,SMALL} */
+    opal_free_list_item_t *reorder_fl_item; /* freelist item for reorder buf */
+    int reorder_fl_src;                      /* HAN_ALLOC_{MALLOC,LARGE,SMALL} */
 };
 typedef struct mca_coll_han_scatter_args_s mca_coll_han_scatter_args_t;
 
@@ -173,6 +178,7 @@ struct mca_coll_han_gather_args_s {
     ompi_communicator_t *up_comm;
     ompi_communicator_t *low_comm;
     ompi_request_t *req;
+    mca_coll_han_module_t *han_module;
     void *sbuf;
     void *sbuf_inter_free;
     void *rbuf;
@@ -437,6 +443,21 @@ typedef struct mca_coll_han_module_t {
     opal_free_list_t fragment_freelist;
     /* Large fragment pool for pipeline reorder buffers (1MB items) */
     opal_free_list_t large_fragment_freelist;
+    /* Cached gather buffer for three-tier allocation */
+    void *cached_gather_buf;
+    size_t cached_gather_buf_size;
+    /* Persistent buffer for scatter inter-node recv (realloc-to-HWM) */
+    char *scatter_persist;
+    size_t scatter_persist_size;
+    /* Persistent scatter root reorder buffer (realloc-to-HWM) */
+    char *scatter_reorder_persist;
+    size_t scatter_reorder_persist_size;
+    /* Persistent gather root reorder buffer (realloc-to-HWM) */
+    char *gather_reorder_persist;
+    size_t gather_reorder_persist_size;
+    /* Persistent reduce task-based tmp buffer (realloc-to-HWM) */
+    char *reduce_tmp_persist;
+    size_t reduce_tmp_persist_size;
 } mca_coll_han_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -144,6 +144,9 @@ struct mca_coll_han_allreduce_args_s {
 };
 typedef struct mca_coll_han_allreduce_args_s mca_coll_han_allreduce_args_t;
 
+/* Forward declaration needed by scatter and gather arg structs */
+typedef struct mca_coll_han_module_t mca_coll_han_module_t;
+
 struct mca_coll_han_scatter_args_s {
     mca_coll_task_t *cur_task;
     ompi_communicator_t *up_comm;
@@ -203,6 +206,8 @@ struct mca_coll_han_allgather_s {
     bool noop;
     bool is_mapbycore;
     int *topo;
+    mca_coll_han_module_t *han_module;
+    opal_free_list_item_t *inter_frag;  /* Fragment for inter-node buffer */
 };
 typedef struct mca_coll_han_allgather_s mca_coll_han_allgather_t;
 

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -455,6 +455,12 @@ typedef struct mca_coll_han_module_t {
     /* Persistent gather root reorder buffer (realloc-to-HWM) */
     char *gather_reorder_persist;
     size_t gather_reorder_persist_size;
+    /* Persistent allgather reorder buffer for task-based path (realloc-to-HWM) */
+    char *allgather_reorder_persist;
+    size_t allgather_reorder_persist_size;
+    /* Persistent allgather intra-node gather buffer (realloc-to-HWM) */
+    char *allgather_gather_persist;
+    size_t allgather_gather_persist_size;
     /* Persistent reduce task-based tmp buffer (realloc-to-HWM) */
     char *reduce_tmp_persist;
     size_t reduce_tmp_persist_size;

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -85,6 +85,34 @@ enum {
     HAN_ALLOC_SMALL  = 2
 };
 
+/**
+ * Grow a shared scratch buffer to at least 'needed' bytes (realloc-to-HWM).
+ * Returns the buffer pointer, or NULL on allocation failure.
+ */
+static inline char *han_scratch_alloc(char **buf, size_t *buf_size, size_t needed)
+{
+    if (*buf_size < needed) {
+        char *p = realloc(*buf, needed);
+        if (NULL == p) return NULL;
+        *buf = p;
+        *buf_size = needed;
+    }
+    return *buf;
+}
+
+/**
+ * Allocate from scratch buffer (persist mode) or malloc (non-persist).
+ * Returns NULL on allocation failure.
+ */
+static inline char *han_scratch_or_malloc(char **scratch, size_t *scratch_size,
+                                          size_t needed, bool persist)
+{
+    if (persist) {
+        return han_scratch_alloc(scratch, scratch_size, needed);
+    }
+    return (char *)malloc(needed);
+}
+
 
 struct mca_coll_han_bcast_args_s {
     mca_coll_task_t *cur_task;
@@ -166,8 +194,6 @@ struct mca_coll_han_scatter_args_s {
     int root_low_rank;
     int w_rank;
     bool noop;
-    opal_free_list_item_t *inter_fl_item;   /* freelist item for inter-node buf */
-    int inter_fl_src;                        /* HAN_ALLOC_{MALLOC,LARGE,SMALL} */
     opal_free_list_item_t *reorder_fl_item; /* freelist item for reorder buf */
     int reorder_fl_src;                      /* HAN_ALLOC_{MALLOC,LARGE,SMALL} */
 };
@@ -431,11 +457,6 @@ typedef struct mca_coll_han_module_t {
      */
     int dynamic_errors;
 
-    /* Persistent bounce buffer for alltoall — grows to high-water mark
-       via realloc so the NIC rcache registration stays valid. */
-    char *alltoall_bounce;
-    size_t alltoall_bounce_size;
-
     /* Sub-communicator */
     struct ompi_communicator_t *sub_comm[NB_TOPO_LVL];
 
@@ -443,27 +464,13 @@ typedef struct mca_coll_han_module_t {
     opal_free_list_t fragment_freelist;
     /* Large fragment pool for pipeline reorder buffers (1MB items) */
     opal_free_list_t large_fragment_freelist;
-    /* Cached gather buffer for three-tier allocation */
-    void *cached_gather_buf;
-    size_t cached_gather_buf_size;
-    /* Persistent buffer for scatter inter-node recv (realloc-to-HWM) */
-    char *scatter_persist;
-    size_t scatter_persist_size;
-    /* Persistent scatter root reorder buffer (realloc-to-HWM) */
-    char *scatter_reorder_persist;
-    size_t scatter_reorder_persist_size;
-    /* Persistent gather root reorder buffer (realloc-to-HWM) */
-    char *gather_reorder_persist;
-    size_t gather_reorder_persist_size;
-    /* Persistent allgather reorder buffer for task-based path (realloc-to-HWM) */
-    char *allgather_reorder_persist;
-    size_t allgather_reorder_persist_size;
-    /* Persistent allgather intra-node gather buffer (realloc-to-HWM) */
-    char *allgather_gather_persist;
-    size_t allgather_gather_persist_size;
-    /* Persistent reduce task-based tmp buffer (realloc-to-HWM) */
-    char *reduce_tmp_persist;
-    size_t reduce_tmp_persist_size;
+    /* Shared scratch buffers for all collectives (realloc-to-HWM).
+     * Since collectives don't run concurrently on the same communicator,
+     * all collectives share these two buffers. Two are needed because
+     * some collectives use two temporary buffers with overlapping lifetimes
+     * (e.g., allgather uses a gather buffer and a reorder buffer). */
+    char *scratch_buf[2];
+    size_t scratch_buf_size[2];
 } mca_coll_han_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 
@@ -642,7 +649,7 @@ ompi_coll_han_reorder_gather(const void *sbuf,
                              void *rbuf, size_t rcount,
                              struct ompi_datatype_t *rdtype,
                              struct ompi_communicator_t *comm,
-                             int * topo);
+                             const int * topo);
 
 static inline struct mca_smsc_endpoint_t *mca_coll_han_get_smsc_endpoint (struct ompi_proc_t *proc) {
     extern opal_mutex_t mca_coll_han_lock;

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -43,6 +43,7 @@
 #include "ompi/mca/mca.h"
 #include "opal/util/output.h"
 #include "opal/mca/smsc/smsc.h"
+#include "opal/class/opal_free_list.h"
 #include "ompi/mca/coll/base/coll_base_functions.h"
 #include "coll_han_trigger.h"
 #include "ompi/mca/coll/han/coll_han_dynamic.h"
@@ -56,6 +57,34 @@
 
 #define COLL_HAN_LOW_MODULES 3
 #define COLL_HAN_UP_MODULES 2
+
+/**
+ * Fragment item for freelist-based buffer pool
+ * Used to provide stable buffer addresses across collective calls
+ */
+typedef struct fragment_item_s {
+    opal_free_list_item_t super;
+    void *buffer;  /* Fixed-size buffer (han_fragment_size bytes) */
+} fragment_item_t;
+OBJ_CLASS_DECLARATION(fragment_item_t);
+
+/**
+ * Large fragment item for freelist-based buffer pool.
+ * Size controlled by han_large_fragment_size MCA parameter (0 = disabled).
+ */
+typedef struct large_fragment_item_s {
+    opal_free_list_item_t super;
+    void *buffer;
+} large_fragment_item_t;
+OBJ_CLASS_DECLARATION(large_fragment_item_t);
+
+/** Source tag for tiered allocation (used by alloc/free helpers). */
+enum {
+    HAN_ALLOC_MALLOC = 0,
+    HAN_ALLOC_LARGE  = 1,
+    HAN_ALLOC_SMALL  = 2
+};
+
 
 struct mca_coll_han_bcast_args_s {
     mca_coll_task_t *cur_task;
@@ -296,6 +325,13 @@ typedef struct mca_coll_han_component_t {
     opal_free_list_t pack_buffers;
     int64_t han_packbuf_max_count;
     int64_t han_packbuf_bytes;
+
+    /* Persist-buffer optimization (0 = disabled, use malloc/free) */
+    bool han_use_persist_buffers;
+
+    /* Fragment size for buffer reuse optimization (0 = disabled) */
+    size_t han_fragment_size;
+    size_t han_large_fragment_size;
 } mca_coll_han_component_t;
 
 /*
@@ -384,8 +420,18 @@ typedef struct mca_coll_han_module_t {
      */
     int dynamic_errors;
 
+    /* Persistent bounce buffer for alltoall — grows to high-water mark
+       via realloc so the NIC rcache registration stays valid. */
+    char *alltoall_bounce;
+    size_t alltoall_bounce_size;
+
     /* Sub-communicator */
     struct ompi_communicator_t *sub_comm[NB_TOPO_LVL];
+
+    /* Fragment pool for buffer reuse (64KB items) */
+    opal_free_list_t fragment_freelist;
+    /* Large fragment pool for pipeline reorder buffers (1MB items) */
+    opal_free_list_t large_fragment_freelist;
 } mca_coll_han_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -283,17 +283,15 @@ int mca_coll_han_allgather_lg_task(void *task_args)
                                          mca_coll_han_component.han_fragment_size,
                                          (size_t)rsize, &t->inter_frag);
             } else {
-                /* Too large for freelist — use realloc-to-HWM persist buffer */
-                if (t->han_module->allgather_gather_persist_size < (size_t)rsize) {
-                    char *p = realloc(t->han_module->allgather_gather_persist, rsize);
-                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                    t->han_module->allgather_gather_persist = p;
-                    t->han_module->allgather_gather_persist_size = rsize;
-                }
-                tmp_buf = t->han_module->allgather_gather_persist;
+                /* Too large for freelist — use shared scratch buffer */
+                tmp_buf = han_scratch_alloc(&t->han_module->scratch_buf[0],
+                                            &t->han_module->scratch_buf_size[0],
+                                            (size_t)rsize);
+                if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
             }
         } else {
             tmp_buf = (char *) malloc(rsize);
+            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
         }
         tmp_rbuf = tmp_buf - rgap;
 
@@ -327,7 +325,7 @@ int mca_coll_han_allgather_lg_task(void *task_args)
     /* When using persist gather buffer, don't free it in uag_task */
     if (mca_coll_han_component.han_use_persist_buffers
         && t->inter_frag == NULL && t->han_module != NULL
-        && tmp_buf == t->han_module->allgather_gather_persist) {
+        && tmp_buf == t->han_module->scratch_buf[0]) {
         t->sbuf_inter_free = NULL;
     }
 
@@ -374,13 +372,10 @@ int mca_coll_han_allgather_uag_task(void *task_args)
                                    (int64_t) t->rcount * low_size * up_size,
                                    &rgap);
             if (mca_coll_han_component.han_use_persist_buffers && t->han_module != NULL) {
-                if (t->han_module->allgather_reorder_persist_size < (size_t)rsize) {
-                    char *p = realloc(t->han_module->allgather_reorder_persist, rsize);
-                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                    t->han_module->allgather_reorder_persist = p;
-                    t->han_module->allgather_reorder_persist_size = rsize;
-                }
-                reorder_buf = t->han_module->allgather_reorder_persist;
+                reorder_buf = han_scratch_alloc(&t->han_module->scratch_buf[1],
+                                                &t->han_module->scratch_buf_size[1],
+                                                (size_t)rsize);
+                if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
             } else {
                 reorder_buf = (char *) malloc(rsize);
             }
@@ -433,6 +428,7 @@ int mca_coll_han_allgather_uag_task(void *task_args)
     }
 
 allgather_done:
+    ; /* empty statement required after label before declaration */
     /* Create lb (low level broadcast) task */
     mca_coll_task_t *lb = t->cur_task;
     /* Init and issue lb task */
@@ -567,6 +563,9 @@ han_allgather_single_frag(const void *sbuf, size_t scount,
 
         reorder_buf = han_alloc_frag(&han_module->fragment_freelist,
                                      frag_size, (size_t)rsize, &fl_item);
+        if (NULL == reorder_buf) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
         reorder_buf_start = reorder_buf - rgap;
         my_slot = reorder_buf_start
             + rextent * (ptrdiff_t)up_rank * (ptrdiff_t)total_count;
@@ -629,6 +628,12 @@ han_allgather_pipeline(const void *sbuf, size_t scount,
     ompi_datatype_get_extent(rdtype, &rlb, &rext);
     ompi_datatype_type_extent(rdtype, &rextent);
 
+    /* Pipeline requires non-blocking collectives on up_comm */
+    if (NULL == up_comm->c_coll->coll_ibcast
+        || NULL == up_comm->c_coll->coll_igather) {
+        return OMPI_ERR_NOT_SUPPORTED;
+    }
+
     /* Allocate double-buffered reorder buffers */
     char *frag_reorder[2] = {NULL, NULL};
     opal_free_list_item_t *frag_reorder_item[2] = {NULL, NULL};
@@ -642,6 +647,15 @@ han_allgather_pipeline(const void *sbuf, size_t scount,
                 &han_module->fragment_freelist, frag_size,
                 frag_reorder_size, &frag_reorder_item[b],
                 &frag_reorder_src[b]);
+            if (NULL == frag_reorder[b]) {
+                for (int i = 0; i < b; i++) {
+                    han_free_tiered(&han_module->large_fragment_freelist,
+                                    &han_module->fragment_freelist,
+                                    frag_reorder_item[i], frag_reorder[i],
+                                    frag_reorder_src[i]);
+                }
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
         }
     }
 
@@ -681,6 +695,19 @@ han_allgather_pipeline(const void *sbuf, size_t scount,
                                         frag_size,
                                         (size_t)this_count * low_size * rextent,
                                         &inter_frag_item);
+            if (NULL == gather_buf) {
+                /* Clean up any outstanding ibcast and double buffers */
+                if (ibcast_req != NULL) {
+                    ompi_request_wait(&ibcast_req, MPI_STATUS_IGNORE);
+                }
+                for (int b = 0; b < 2; b++) {
+                    han_free_tiered(&han_module->large_fragment_freelist,
+                                    &han_module->fragment_freelist,
+                                    frag_reorder_item[b], frag_reorder[b],
+                                    frag_reorder_src[b]);
+                }
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
             if (MPI_IN_PLACE == sbuf) {
                 char *my_data = ((char*)rbuf)
                     + ((ptrdiff_t)w_rank * (ptrdiff_t)rcount + (ptrdiff_t)frag_offset) * rext;
@@ -844,6 +871,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
             rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size, &rgap);
             /* intermediary buffer on node leaders to gather on low comm */
             tmp_buf = (char *) malloc(rsize);
+            if (NULL == tmp_buf) {
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
             tmp_buf_start = tmp_buf - rgap;
             if (MPI_IN_PLACE == sbuf) {
                 tmp_send = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
@@ -958,10 +988,17 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                 w_rank, low_rank, up_rank, low_size, up_size,
                 root_low_rank, frag_size, topo);
         } else {
-            return han_allgather_pipeline(sbuf, scount, sdtype, rbuf, rcount,
+            int rc = han_allgather_pipeline(sbuf, scount, sdtype, rbuf, rcount,
                 rdtype, han_module, up_comm, low_comm,
                 w_rank, low_rank, low_size, up_size,
                 root_low_rank, frag_size, frag_count, num_frags, topo);
+            if (OMPI_ERR_NOT_SUPPORTED == rc) {
+                return han_allgather_single_frag(sbuf, scount, sdtype, rbuf, rcount,
+                    rdtype, han_module, up_comm, low_comm, comm,
+                    w_rank, low_rank, up_rank, low_size, up_size,
+                    root_low_rank, frag_size, topo);
+            }
+            return rc;
         }
     }
 

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -239,15 +239,61 @@ int mca_coll_han_allgather_lg_task(void *task_args)
     if (!t->noop) {
         int low_size = ompi_comm_size(t->low_comm);
         ptrdiff_t rsize, rgap = 0;
+
+        /* Mapbycore in-place: gather directly into rbuf slot, skip tmp_buf */
+        if (t->is_mapbycore && mca_coll_han_component.han_use_persist_buffers) {
+            int up_rank = ompi_comm_rank(t->up_comm);
+            size_t total_count = t->rcount * low_size;
+            char *my_slot = (char *)t->rbuf
+                + (ptrdiff_t)up_rank * (ptrdiff_t)total_count * rext;
+
+            if (MPI_IN_PLACE == t->sbuf) {
+                char *my_data = ((char*)t->rbuf)
+                    + (ptrdiff_t)t->w_rank * (ptrdiff_t)t->rcount * rext;
+                ompi_datatype_copy_content_same_ddt(t->rdtype, t->rcount,
+                                                    my_slot, my_data);
+                t->low_comm->c_coll->coll_gather(MPI_IN_PLACE, t->scount, t->sdtype,
+                                                 my_slot, t->rcount, t->rdtype,
+                                                 t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_gather_module);
+            } else {
+                t->low_comm->c_coll->coll_gather((char *)t->sbuf, t->scount, t->sdtype,
+                                                 my_slot, t->rcount, t->rdtype,
+                                                 t->root_low_rank, t->low_comm,
+                                                 t->low_comm->c_coll->coll_gather_module);
+            }
+            t->sbuf = my_slot;
+            t->sbuf_inter_free = NULL;
+            t->inter_frag = NULL;
+
+            /* Create uag task */
+            mca_coll_task_t *uag = t->cur_task;
+            init_task(uag, mca_coll_han_allgather_uag_task, (void *) t);
+            issue_task(uag);
+            return OMPI_SUCCESS;
+        }
+
         rsize = opal_datatype_span(&t->rdtype->super, (int64_t) t->rcount * low_size, &rgap);
 
         t->inter_frag = NULL;
-        if (mca_coll_han_component.han_fragment_size == 0 || t->han_module == NULL) {
-            tmp_buf = (char *) malloc(rsize);
+        if (mca_coll_han_component.han_use_persist_buffers && t->han_module != NULL) {
+            if ((size_t)rsize <= mca_coll_han_component.han_fragment_size
+                && mca_coll_han_component.han_fragment_size > 0) {
+                tmp_buf = han_alloc_frag(&t->han_module->fragment_freelist,
+                                         mca_coll_han_component.han_fragment_size,
+                                         (size_t)rsize, &t->inter_frag);
+            } else {
+                /* Too large for freelist — use realloc-to-HWM persist buffer */
+                if (t->han_module->allgather_gather_persist_size < (size_t)rsize) {
+                    char *p = realloc(t->han_module->allgather_gather_persist, rsize);
+                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                    t->han_module->allgather_gather_persist = p;
+                    t->han_module->allgather_gather_persist_size = rsize;
+                }
+                tmp_buf = t->han_module->allgather_gather_persist;
+            }
         } else {
-            tmp_buf = han_alloc_frag(&t->han_module->fragment_freelist,
-                                     mca_coll_han_component.han_fragment_size,
-                                     (size_t)rsize, &t->inter_frag);
+            tmp_buf = (char *) malloc(rsize);
         }
         tmp_rbuf = tmp_buf - rgap;
 
@@ -278,6 +324,12 @@ int mca_coll_han_allgather_lg_task(void *task_args)
 
     t->sbuf = tmp_rbuf;
     t->sbuf_inter_free = tmp_buf;
+    /* When using persist gather buffer, don't free it in uag_task */
+    if (mca_coll_han_component.han_use_persist_buffers
+        && t->inter_frag == NULL && t->han_module != NULL
+        && tmp_buf == t->han_module->allgather_gather_persist) {
+        t->sbuf_inter_free = NULL;
+    }
 
     /* Create uag (upper level all-gather) task */
     mca_coll_task_t *uag = t->cur_task;
@@ -305,13 +357,33 @@ int mca_coll_han_allgather_uag_task(void *task_args)
             OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                                  "[%d]: HAN Allgather is bycore: ", t->w_rank));
             reorder_rbuf = (char *) t->rbuf;
+
+            /* When persist buffers gathered directly into rbuf, use in-place */
+            if (mca_coll_han_component.han_use_persist_buffers
+                && t->sbuf_inter_free == NULL) {
+                t->up_comm->c_coll->coll_allgather(MPI_IN_PLACE,
+                    t->scount * low_size, t->sdtype,
+                    reorder_rbuf, t->rcount * low_size, t->rdtype,
+                    t->up_comm, t->up_comm->c_coll->coll_allgather_module);
+                goto allgather_done;
+            }
         } else {
             ptrdiff_t rsize, rgap = 0;
             rsize =
                 opal_datatype_span(&t->rdtype->super,
                                    (int64_t) t->rcount * low_size * up_size,
                                    &rgap);
-            reorder_buf = (char *) malloc(rsize);
+            if (mca_coll_han_component.han_use_persist_buffers && t->han_module != NULL) {
+                if (t->han_module->allgather_reorder_persist_size < (size_t)rsize) {
+                    char *p = realloc(t->han_module->allgather_reorder_persist, rsize);
+                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                    t->han_module->allgather_reorder_persist = p;
+                    t->han_module->allgather_reorder_persist_size = rsize;
+                }
+                reorder_buf = t->han_module->allgather_reorder_persist;
+            } else {
+                reorder_buf = (char *) malloc(rsize);
+            }
             reorder_rbuf = reorder_buf - rgap;
         }
 
@@ -353,12 +425,14 @@ int mca_coll_han_allgather_uag_task(void *task_args)
                                                         (ptrdiff_t) t->rcount);
                 }
             }
-            free(reorder_buf);
+            if (!mca_coll_han_component.han_use_persist_buffers) {
+                free(reorder_buf);
+            }
             reorder_buf = NULL;
         }
     }
 
-
+allgather_done:
     /* Create lb (low level broadcast) task */
     mca_coll_task_t *lb = t->cur_task;
     /* Init and issue lb task */

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -870,7 +870,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
             /* Compute the size to receive all the local data, including datatypes empty gaps */
             rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size, &rgap);
             /* intermediary buffer on node leaders to gather on low comm */
-            tmp_buf = (char *) malloc(rsize);
+            tmp_buf = han_scratch_or_malloc(&han_module->scratch_buf[1],
+                                            &han_module->scratch_buf_size[1],
+                                            rsize, mca_coll_han_component.han_use_persist_buffers);
             if (NULL == tmp_buf) {
                 return OMPI_ERR_OUT_OF_RESOURCE;
             }
@@ -918,7 +920,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                 }
                 ptrdiff_t rsize, rgap = 0;
                 rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size * up_size, &rgap);
-                reorder_buf = (char *) malloc(rsize);
+                reorder_buf = han_scratch_or_malloc(&han_module->scratch_buf[0],
+                                                     &han_module->scratch_buf_size[0],
+                                                     rsize, mca_coll_han_component.han_use_persist_buffers);
                 reorder_buf_start = reorder_buf - rgap;
             }
 
@@ -927,7 +931,7 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                             reorder_buf_start, rcount*low_size, rdtype,
                                             up_comm, up_comm->c_coll->coll_allgather_module);
 
-            if (tmp_buf != NULL) {
+            if (tmp_buf != NULL && !mca_coll_han_component.han_use_persist_buffers) {
                 free(tmp_buf);
                 tmp_buf = NULL;
                 tmp_buf_start = NULL;
@@ -941,7 +945,9 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                 ompi_coll_han_reorder_gather(reorder_buf_start,
                                              rbuf, rcount, rdtype,
                                              comm, topo);
-                free(reorder_buf);
+                if (!mca_coll_han_component.han_use_persist_buffers) {
+                    free(reorder_buf);
+                }
                 reorder_buf = NULL;
             }
 

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -24,9 +24,94 @@
 #include "ompi/mca/pml/pml.h"
 #include "coll_han_trigger.h"
 
+/* Minimum number of fragments before the pipeline path is used.
+ * Below this threshold the simple path avoids pipeline setup overhead. */
+#define HAN_MIN_PIPELINE_FRAGS 4
+
 static int mca_coll_han_allgather_lb_task(void *task_args);
 static int mca_coll_han_allgather_lg_task(void *task_args);
 static int mca_coll_han_allgather_uag_task(void *task_args);
+
+/**
+ * Allocate a buffer from the small fragment freelist, falling back to malloc.
+ * On return, *item is non-NULL if the buffer came from the freelist.
+ */
+static char *han_alloc_frag(opal_free_list_t *fl, size_t frag_size,
+                            size_t needed, opal_free_list_item_t **item)
+{
+    *item = NULL;
+    if (mca_coll_han_component.han_use_persist_buffers
+        && frag_size > 0 && needed <= frag_size) {
+        fragment_item_t *fi = (fragment_item_t *)opal_free_list_get(fl);
+        if (fi != NULL) {
+            *item = (opal_free_list_item_t *)fi;
+            return (char *)fi->buffer;
+        }
+    }
+    return (char *)malloc(needed);
+}
+
+/**
+ * Free a buffer: return to freelist if item is non-NULL, else free().
+ */
+static void han_free_frag(opal_free_list_t *fl, opal_free_list_item_t *item,
+                          char *buf)
+{
+    if (item != NULL) {
+        opal_free_list_return(fl, item);
+    } else {
+        free(buf);
+    }
+}
+
+/**
+ * Tiered allocation: try large freelist, then small freelist, then malloc.
+ * Sets *item and *src (1=large, 2=small, 0=malloc) for han_free_tiered().
+ */
+static char *han_alloc_tiered(opal_free_list_t *large_fl, size_t large_size,
+                              opal_free_list_t *small_fl, size_t small_size,
+                              size_t needed, opal_free_list_item_t **item,
+                              int *src)
+{
+    *item = NULL;
+    *src = HAN_ALLOC_MALLOC;
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        return (char *)malloc(needed);
+    }
+    if (large_size > 0 && needed <= large_size) {
+        large_fragment_item_t *lfi = (large_fragment_item_t *)opal_free_list_get(large_fl);
+        if (lfi != NULL) {
+            *item = (opal_free_list_item_t *)lfi;
+            *src = HAN_ALLOC_LARGE;
+            return (char *)lfi->buffer;
+        }
+    }
+    if (small_size > 0 && needed <= small_size) {
+        fragment_item_t *fi = (fragment_item_t *)opal_free_list_get(small_fl);
+        if (fi != NULL) {
+            *item = (opal_free_list_item_t *)fi;
+            *src = HAN_ALLOC_SMALL;
+            return (char *)fi->buffer;
+        }
+    }
+    return (char *)malloc(needed);
+}
+
+/**
+ * Free a tiered allocation based on src tag.
+ */
+static void han_free_tiered(opal_free_list_t *large_fl,
+                            opal_free_list_t *small_fl,
+                            opal_free_list_item_t *item, char *buf, int src)
+{
+    if (src == HAN_ALLOC_LARGE) {
+        opal_free_list_return(large_fl, item);
+    } else if (src == HAN_ALLOC_SMALL) {
+        opal_free_list_return(small_fl, item);
+    } else {
+        free(buf);
+    }
+}
 
 static inline void
 mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
@@ -45,7 +130,8 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
                                 bool noop,
                                 bool is_mapbycore,
                                 int *topo,
-                                ompi_request_t * req)
+                                ompi_request_t * req,
+                                mca_coll_han_module_t *han_module)
 {
     args->cur_task = cur_task;
     args->sbuf = sbuf;
@@ -63,6 +149,8 @@ mca_coll_han_set_allgather_args(mca_coll_han_allgather_t * args,
     args->is_mapbycore = is_mapbycore;
     args->topo = topo;
     args->req = req;
+    args->han_module = han_module;
+    args->inter_frag = NULL;
 }
 
 
@@ -120,7 +208,7 @@ mca_coll_han_allgather_intra(const void *sbuf, size_t scount,
     mca_coll_han_set_allgather_args(lg_args, lg, (char *) sbuf, NULL, scount, sdtype, rbuf, rcount,
                                     rdtype, root_low_rank, up_comm, low_comm, w_rank,
                                     low_rank != root_low_rank, han_module->is_mapbycore, topo,
-                                    temp_request);
+                                    temp_request, han_module);
     /* Init and issue lg task */
     init_task(lg, mca_coll_han_allgather_lg_task, (void *) (lg_args));
     issue_task(lg);
@@ -140,19 +228,29 @@ int mca_coll_han_allgather_lg_task(void *task_args)
     OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output, "[%d] HAN Allgather:  lg\n",
                          t->w_rank));
 
-    /* If the process is one of the node leader */
     ptrdiff_t rlb, rext;
     ompi_datatype_get_extent (t->rdtype, &rlb, &rext);
     if (MPI_IN_PLACE == t->sbuf) {
         t->sdtype = t->rdtype;
         t->scount = t->rcount;
     }
+    
+    /* If the process is one of the node leaders, allocate receive buffer */
     if (!t->noop) {
         int low_size = ompi_comm_size(t->low_comm);
         ptrdiff_t rsize, rgap = 0;
         rsize = opal_datatype_span(&t->rdtype->super, (int64_t) t->rcount * low_size, &rgap);
-        tmp_buf = (char *) malloc(rsize);
+
+        t->inter_frag = NULL;
+        if (mca_coll_han_component.han_fragment_size == 0 || t->han_module == NULL) {
+            tmp_buf = (char *) malloc(rsize);
+        } else {
+            tmp_buf = han_alloc_frag(&t->han_module->fragment_freelist,
+                                     mca_coll_han_component.han_fragment_size,
+                                     (size_t)rsize, &t->inter_frag);
+        }
         tmp_rbuf = tmp_buf - rgap;
+
         if (MPI_IN_PLACE == t->sbuf) {
             tmp_send = ((char*)t->rbuf) + (ptrdiff_t)t->w_rank * (ptrdiff_t)t->rcount * rext;
             ompi_datatype_copy_content_same_ddt(t->rdtype, t->rcount, tmp_rbuf, tmp_send);
@@ -223,7 +321,9 @@ int mca_coll_han_allgather_uag_task(void *task_args)
                                            t->up_comm, t->up_comm->c_coll->coll_allgather_module);
 
         if (t->sbuf_inter_free != NULL) {
-            free(t->sbuf_inter_free);
+            han_free_frag(&t->han_module->fragment_freelist,
+                          t->inter_frag, t->sbuf_inter_free);
+            t->inter_frag = NULL;
             t->sbuf_inter_free = NULL;
         }
 
@@ -289,6 +389,309 @@ int mca_coll_han_allgather_lb_task(void *task_args)
 }
 
 /**
+ * Reorder a fragment from gathered layout into rbuf at the correct offset.
+ * Used by the pipeline and single-fragment paths.
+ */
+static inline void
+han_reorder_frag(char *rbuf, const char *src_buf,
+                 struct ompi_datatype_t *rdtype, ptrdiff_t rextent,
+                 size_t frag_count, size_t frag_offset, size_t rcount,
+                 int up_size, int low_size, const int *topo)
+{
+    for (int i = 0; i < up_size; i++) {
+        for (int j = 0; j < low_size; j++) {
+            int global_idx = i * low_size + j;
+            int dest_rank = topo[global_idx * 2 + 1];
+            ompi_datatype_copy_content_same_ddt(rdtype,
+                (ptrdiff_t)frag_count,
+                rbuf + rextent * ((ptrdiff_t)dest_rank * (ptrdiff_t)rcount
+                                  + (ptrdiff_t)frag_offset),
+                (char *)src_buf + rextent * (ptrdiff_t)global_idx
+                                * (ptrdiff_t)frag_count);
+        }
+    }
+}
+
+/**
+ * Mapbycore fast path: gather directly into rbuf, in-place allgather,
+ * single bcast. No temporary buffers needed.
+ */
+static int
+han_allgather_mapbycore(const void *sbuf, size_t scount,
+                        struct ompi_datatype_t *sdtype,
+                        void *rbuf, size_t rcount,
+                        struct ompi_datatype_t *rdtype,
+                        struct ompi_communicator_t *up_comm,
+                        struct ompi_communicator_t *low_comm,
+                        int w_rank, int low_rank, int up_rank,
+                        int low_size, int up_size, int root_low_rank)
+{
+    ptrdiff_t rlb, rext;
+    ompi_datatype_get_extent(rdtype, &rlb, &rext);
+    size_t total_count = rcount * low_size;
+    char *my_slot = (char *)rbuf + (ptrdiff_t)up_rank * (ptrdiff_t)total_count * rext;
+
+    if (MPI_IN_PLACE == sbuf) {
+        if (low_rank == root_low_rank) {
+            low_comm->c_coll->coll_gather(MPI_IN_PLACE, scount, sdtype,
+                                          my_slot, rcount, rdtype, root_low_rank,
+                                          low_comm, low_comm->c_coll->coll_gather_module);
+        } else {
+            char *my_data = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
+            low_comm->c_coll->coll_gather(my_data, rcount, rdtype,
+                                          NULL, rcount, rdtype, root_low_rank,
+                                          low_comm, low_comm->c_coll->coll_gather_module);
+        }
+    } else {
+        low_comm->c_coll->coll_gather((char *)sbuf, scount, sdtype,
+                                      my_slot, rcount, rdtype, root_low_rank,
+                                      low_comm, low_comm->c_coll->coll_gather_module);
+    }
+
+    if (low_rank == root_low_rank) {
+        up_comm->c_coll->coll_allgather(MPI_IN_PLACE, total_count, rdtype,
+                                        rbuf, total_count, rdtype,
+                                        up_comm, up_comm->c_coll->coll_allgather_module);
+    }
+
+    low_comm->c_coll->coll_bcast(rbuf, rcount*low_size*up_size, rdtype,
+                                 root_low_rank, low_comm,
+                                 low_comm->c_coll->coll_bcast_module);
+    return OMPI_SUCCESS;
+}
+
+/**
+ * Single-fragment freelist path: gather into reorder_buf, in-place
+ * allgather, reorder into rbuf, bcast.
+ */
+static int
+han_allgather_single_frag(const void *sbuf, size_t scount,
+                          struct ompi_datatype_t *sdtype,
+                          void *rbuf, size_t rcount,
+                          struct ompi_datatype_t *rdtype,
+                          mca_coll_han_module_t *han_module,
+                          struct ompi_communicator_t *up_comm,
+                          struct ompi_communicator_t *low_comm,
+                          struct ompi_communicator_t *comm,
+                          int w_rank, int low_rank, int up_rank,
+                          int low_size, int up_size, int root_low_rank,
+                          size_t frag_size, const int *topo)
+{
+    ptrdiff_t rlb, rext, rextent;
+    ompi_datatype_get_extent(rdtype, &rlb, &rext);
+    ompi_datatype_type_extent(rdtype, &rextent);
+    size_t total_count = rcount * low_size;
+    char *reorder_buf = NULL;
+    char *reorder_buf_start = NULL;
+    char *my_slot = NULL;
+    opal_free_list_item_t *fl_item = NULL;
+
+    if (low_rank == root_low_rank) {
+        ptrdiff_t rsize, rgap = 0;
+        rsize = opal_datatype_span(&rdtype->super,
+            (int64_t)rcount * low_size * up_size, &rgap);
+
+        reorder_buf = han_alloc_frag(&han_module->fragment_freelist,
+                                     frag_size, (size_t)rsize, &fl_item);
+        reorder_buf_start = reorder_buf - rgap;
+        my_slot = reorder_buf_start
+            + rextent * (ptrdiff_t)up_rank * (ptrdiff_t)total_count;
+        if (MPI_IN_PLACE == sbuf) {
+            char *my_data = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
+            ompi_datatype_copy_content_same_ddt(rdtype, rcount, my_slot, my_data);
+        }
+    }
+
+    if (MPI_IN_PLACE == sbuf) {
+        if (low_rank == root_low_rank) {
+            low_comm->c_coll->coll_gather(MPI_IN_PLACE, scount, sdtype,
+                my_slot, rcount, rdtype, root_low_rank,
+                low_comm, low_comm->c_coll->coll_gather_module);
+        } else {
+            char *my_data = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
+            low_comm->c_coll->coll_gather(my_data, rcount, rdtype,
+                NULL, rcount, rdtype, root_low_rank,
+                low_comm, low_comm->c_coll->coll_gather_module);
+        }
+    } else {
+        low_comm->c_coll->coll_gather((char *)sbuf, scount, sdtype,
+            my_slot, rcount, rdtype, root_low_rank,
+            low_comm, low_comm->c_coll->coll_gather_module);
+    }
+
+    if (low_rank == root_low_rank) {
+        up_comm->c_coll->coll_allgather(MPI_IN_PLACE, total_count, rdtype,
+            reorder_buf_start, total_count, rdtype,
+            up_comm, up_comm->c_coll->coll_allgather_module);
+
+        ompi_coll_han_reorder_gather(reorder_buf_start, rbuf, rcount, rdtype, comm, topo);
+        han_free_frag(&han_module->fragment_freelist, fl_item, reorder_buf);
+    }
+
+    low_comm->c_coll->coll_bcast(rbuf, rcount * low_size * up_size, rdtype,
+        root_low_rank, low_comm, low_comm->c_coll->coll_bcast_module);
+    return OMPI_SUCCESS;
+}
+
+/**
+ * Pipeline path: double-buffered igather+ibcast with blocking low_comm
+ * gather as the sync point.
+ */
+static int
+han_allgather_pipeline(const void *sbuf, size_t scount,
+                       struct ompi_datatype_t *sdtype,
+                       void *rbuf, size_t rcount,
+                       struct ompi_datatype_t *rdtype,
+                       mca_coll_han_module_t *han_module,
+                       struct ompi_communicator_t *up_comm,
+                       struct ompi_communicator_t *low_comm,
+                       int w_rank, int low_rank,
+                       int low_size, int up_size, int root_low_rank,
+                       size_t frag_size, size_t frag_count, size_t num_frags,
+                       const int *topo)
+{
+    ptrdiff_t rlb, rext, rextent;
+    int root_up_rank = 0;
+    ompi_datatype_get_extent(rdtype, &rlb, &rext);
+    ompi_datatype_type_extent(rdtype, &rextent);
+
+    /* Allocate double-buffered reorder buffers */
+    char *frag_reorder[2] = {NULL, NULL};
+    opal_free_list_item_t *frag_reorder_item[2] = {NULL, NULL};
+    int frag_reorder_src[2] = {HAN_ALLOC_MALLOC, HAN_ALLOC_MALLOC};
+    if (low_rank == root_low_rank) {
+        size_t frag_reorder_size = (size_t)frag_count * low_size * up_size * rextent;
+        size_t large_frag_size = mca_coll_han_component.han_large_fragment_size;
+        for (int b = 0; b < 2; b++) {
+            frag_reorder[b] = han_alloc_tiered(
+                &han_module->large_fragment_freelist, large_frag_size,
+                &han_module->fragment_freelist, frag_size,
+                frag_reorder_size, &frag_reorder_item[b],
+                &frag_reorder_src[b]);
+        }
+    }
+
+    opal_free_list_item_t *inter_frag_item = NULL;
+    char *gather_buf = NULL;
+    ompi_request_t *igather_req = NULL;
+    ompi_request_t *ibcast_req = NULL;
+    size_t prev_frag_count = 0;
+    size_t prev_frag_offset = 0;
+    int cur_buf = 0;
+
+    for (size_t frag = 0; frag < num_frags; frag++) {
+        size_t frag_offset = frag * frag_count;
+        size_t this_count = frag_count;
+        if (frag_offset + this_count > rcount)
+            this_count = rcount - frag_offset;
+
+        int prev_buf = 1 - cur_buf;
+
+        if (frag > 0 && low_rank == root_low_rank) {
+            ompi_request_wait(&igather_req, MPI_STATUS_IGNORE);
+            igather_req = NULL;
+
+            han_free_frag(&han_module->fragment_freelist,
+                          inter_frag_item, gather_buf);
+            inter_frag_item = NULL;
+            gather_buf = NULL;
+
+            size_t prev_ag = prev_frag_count * low_size * up_size;
+            up_comm->c_coll->coll_ibcast(frag_reorder[prev_buf], prev_ag, rdtype,
+                root_up_rank, up_comm, &ibcast_req,
+                up_comm->c_coll->coll_ibcast_module);
+        }
+
+        if (low_rank == root_low_rank) {
+            gather_buf = han_alloc_frag(&han_module->fragment_freelist,
+                                        frag_size,
+                                        (size_t)this_count * low_size * rextent,
+                                        &inter_frag_item);
+            if (MPI_IN_PLACE == sbuf) {
+                char *my_data = ((char*)rbuf)
+                    + ((ptrdiff_t)w_rank * (ptrdiff_t)rcount + (ptrdiff_t)frag_offset) * rext;
+                ompi_datatype_copy_content_same_ddt(rdtype, this_count,
+                    gather_buf, my_data);
+            }
+        }
+
+        /* ALL ranks: blocking low_comm gather — SYNC POINT */
+        if (MPI_IN_PLACE == sbuf) {
+            if (low_rank == root_low_rank) {
+                low_comm->c_coll->coll_gather(MPI_IN_PLACE, this_count, rdtype,
+                    gather_buf, this_count, rdtype, root_low_rank,
+                    low_comm, low_comm->c_coll->coll_gather_module);
+            } else {
+                char *my_data = ((char*)rbuf)
+                    + ((ptrdiff_t)w_rank * (ptrdiff_t)rcount + (ptrdiff_t)frag_offset) * rext;
+                low_comm->c_coll->coll_gather(my_data, this_count, rdtype,
+                    NULL, this_count, rdtype, root_low_rank,
+                    low_comm, low_comm->c_coll->coll_gather_module);
+            }
+        } else {
+            low_comm->c_coll->coll_gather(
+                (char *)sbuf + (ptrdiff_t)frag_offset * rext, this_count, sdtype,
+                gather_buf, this_count, rdtype, root_low_rank,
+                low_comm, low_comm->c_coll->coll_gather_module);
+        }
+
+        if (low_rank == root_low_rank) {
+            size_t ag_count = this_count * low_size;
+            up_comm->c_coll->coll_igather(gather_buf, ag_count, rdtype,
+                frag_reorder[cur_buf], ag_count, rdtype, root_up_rank,
+                up_comm, &igather_req, up_comm->c_coll->coll_igather_module);
+        }
+
+        if (frag > 0 && low_rank == root_low_rank) {
+            ompi_request_wait(&ibcast_req, MPI_STATUS_IGNORE);
+            ibcast_req = NULL;
+
+            han_reorder_frag(rbuf, frag_reorder[prev_buf], rdtype, rextent,
+                             prev_frag_count, prev_frag_offset, rcount,
+                             up_size, low_size, topo);
+        }
+
+        prev_frag_count = this_count;
+        prev_frag_offset = frag_offset;
+        cur_buf = 1 - cur_buf;
+    }
+
+    /* Epilogue: last frag */
+    if (low_rank == root_low_rank) {
+        int last_buf = 1 - cur_buf;
+
+        if (igather_req != NULL) {
+            ompi_request_wait(&igather_req, MPI_STATUS_IGNORE);
+        }
+
+        han_free_frag(&han_module->fragment_freelist,
+                      inter_frag_item, gather_buf);
+
+        size_t last_ag = prev_frag_count * low_size * up_size;
+        up_comm->c_coll->coll_ibcast(frag_reorder[last_buf], last_ag, rdtype,
+            root_up_rank, up_comm, &ibcast_req,
+            up_comm->c_coll->coll_ibcast_module);
+        ompi_request_wait(&ibcast_req, MPI_STATUS_IGNORE);
+
+        han_reorder_frag(rbuf, frag_reorder[last_buf], rdtype, rextent,
+                         prev_frag_count, prev_frag_offset, rcount,
+                         up_size, low_size, topo);
+
+        for (int b = 0; b < 2; b++) {
+            han_free_tiered(&han_module->large_fragment_freelist,
+                            &han_module->fragment_freelist,
+                            frag_reorder_item[b], frag_reorder[b],
+                            frag_reorder_src[b]);
+        }
+    }
+
+    low_comm->c_coll->coll_bcast(rbuf, rcount * low_size * up_size, rdtype,
+                                 root_low_rank, low_comm,
+                                 low_comm->c_coll->coll_bcast_module);
+    return OMPI_SUCCESS;
+}
+
+/**
  * Short implementation of allgather that only does hierarchical
  * communications without tasks.
  */
@@ -299,6 +702,7 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
                                     struct ompi_datatype_t *rdtype,
                                     struct ompi_communicator_t *comm,
                                     mca_coll_base_module_t *module){
+
 
     /* create the subcommunicators */
     mca_coll_han_module_t *han_module = (mca_coll_han_module_t *)module;
@@ -336,101 +740,156 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, size_t scount,
     int up_size = ompi_comm_size(up_comm);
     int root_low_rank = 0; // node leader will be 0 on each rank
 
-    /* allocate the intermediary buffer
-     * to gather on leaders on the low sub communicator */
-    ptrdiff_t rlb, rext;
-    ompi_datatype_get_extent (rdtype, &rlb, &rext);
-    char *tmp_buf = NULL;
-    char *tmp_buf_start = NULL;
-    char *tmp_send = NULL;
-    if (MPI_IN_PLACE == sbuf) {
-        scount = rcount;
-        sdtype = rdtype;
-    }
-    if (low_rank == root_low_rank) {
-        ptrdiff_t rsize, rgap = 0;
-        /* Compute the size to receive all the local data, including datatypes empty gaps */
-        rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size, &rgap);
-        /* intermediary buffer on node leaders to gather on low comm */
-        tmp_buf = (char *) malloc(rsize);
-        tmp_buf_start = tmp_buf - rgap;
+    /* Check if freelist-based optimization is enabled.
+     * Only use optimized path when the gathered data per node is large
+     * enough that pipeline/mapbycore benefit outweighs setup overhead.
+     * With MIN_PIPELINE_FRAGS=4, the threshold ensures at least 4
+     * fragments worth of data, so the pipeline has enough stages to
+     * overlap igather and ibcast effectively. */
+    size_t frag_size = mca_coll_han_component.han_fragment_size;
+    ptrdiff_t rextent_check;
+    ompi_datatype_type_extent(rdtype, &rextent_check);
+    size_t gathered_size = (size_t)rcount * (size_t)low_size * (size_t)rextent_check;
+    if (frag_size == 0 || gathered_size <= (HAN_MIN_PIPELINE_FRAGS * frag_size)) {
+        /*
+         * Simple path: gather to tmp_buf, allgather between leaders,
+         * reorder if needed, bcast to all ranks.
+         */
+        ptrdiff_t rlb, rext;
+        ompi_datatype_get_extent (rdtype, &rlb, &rext);
+        char *tmp_buf = NULL;
+        char *tmp_buf_start = NULL;
+        char *tmp_send = NULL;
         if (MPI_IN_PLACE == sbuf) {
-            tmp_send = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
-            ompi_datatype_copy_content_same_ddt(rdtype, rcount, tmp_buf_start, tmp_send);
+            scount = rcount;
+            sdtype = rdtype;
         }
-    }
-
-    /* 1. low gather on node leaders into tmp_buf */
-    if (MPI_IN_PLACE == sbuf) {
         if (low_rank == root_low_rank) {
-            low_comm->c_coll->coll_gather(MPI_IN_PLACE, scount, sdtype,
+            ptrdiff_t rsize, rgap = 0;
+            /* Compute the size to receive all the local data, including datatypes empty gaps */
+            rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size, &rgap);
+            /* intermediary buffer on node leaders to gather on low comm */
+            tmp_buf = (char *) malloc(rsize);
+            tmp_buf_start = tmp_buf - rgap;
+            if (MPI_IN_PLACE == sbuf) {
+                tmp_send = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
+                ompi_datatype_copy_content_same_ddt(rdtype, rcount, tmp_buf_start, tmp_send);
+            }
+        }
+
+        /* 1. low gather on node leaders into tmp_buf */
+        if (MPI_IN_PLACE == sbuf) {
+            if (low_rank == root_low_rank) {
+                low_comm->c_coll->coll_gather(MPI_IN_PLACE, scount, sdtype,
+                                              tmp_buf_start, rcount, rdtype, root_low_rank,
+                                              low_comm, low_comm->c_coll->coll_gather_module);
+            }
+            else {
+                tmp_send = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
+                low_comm->c_coll->coll_gather(tmp_send, rcount, rdtype,
+                                              NULL, rcount, rdtype, root_low_rank,
+                                              low_comm, low_comm->c_coll->coll_gather_module);
+            }
+        }
+        else {
+            low_comm->c_coll->coll_gather((char *)sbuf, scount, sdtype,
                                           tmp_buf_start, rcount, rdtype, root_low_rank,
                                           low_comm, low_comm->c_coll->coll_gather_module);
         }
-        else {
-            tmp_send = ((char*)rbuf) + (ptrdiff_t)w_rank * (ptrdiff_t)rcount * rext;
-            low_comm->c_coll->coll_gather(tmp_send, rcount, rdtype,
-                                          NULL, rcount, rdtype, root_low_rank,
-                                          low_comm, low_comm->c_coll->coll_gather_module);
-        }
-    }
-    else {
-        low_comm->c_coll->coll_gather((char *)sbuf, scount, sdtype,
-                                      tmp_buf_start, rcount, rdtype, root_low_rank,
-                                      low_comm, low_comm->c_coll->coll_gather_module);
-    }
-    /* 2. allgather between node leaders, from tmp_buf to reorder_buf */
-    if (low_rank == root_low_rank) {
-        /* allocate buffer to store unordered result on node leaders
-         * if the processes are mapped-by core, no need to reorder:
-         * distribution of ranks on core first and node next,
-         * in a increasing order for both patterns.
-         */
-        char *reorder_buf = NULL;
-        char *reorder_buf_start = NULL;
-        if (han_module->is_mapbycore) {
-            reorder_buf_start = rbuf;
-        } else {
-            if (0 == low_rank && 0 == up_rank) { // first rank displays message
-                OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
-                                     "[%d]: Future Allgather needs reordering: ", up_rank));
+        /* 2. allgather between node leaders, from tmp_buf to reorder_buf */
+        if (low_rank == root_low_rank) {
+            /* allocate buffer to store unordered result on node leaders
+             * if the processes are mapped-by core, no need to reorder:
+             * distribution of ranks on core first and node next,
+             * in a increasing order for both patterns.
+             */
+            char *reorder_buf = NULL;
+            char *reorder_buf_start = NULL;
+            if (han_module->is_mapbycore) {
+                reorder_buf_start = rbuf;
+            } else {
+                if (0 == low_rank && 0 == up_rank) { // first rank displays message
+                    OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                                         "[%d]: Future Allgather needs reordering: ", up_rank));
+                }
+                ptrdiff_t rsize, rgap = 0;
+                rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size * up_size, &rgap);
+                reorder_buf = (char *) malloc(rsize);
+                reorder_buf_start = reorder_buf - rgap;
             }
-            ptrdiff_t rsize, rgap = 0;
-            rsize = opal_datatype_span(&rdtype->super, (int64_t)rcount * low_size * up_size, &rgap);
-            reorder_buf = (char *) malloc(rsize);
-            reorder_buf_start = reorder_buf - rgap;
+
+            /* 2a. inter node allgather */
+            up_comm->c_coll->coll_allgather(tmp_buf_start, scount*low_size, sdtype,
+                                            reorder_buf_start, rcount*low_size, rdtype,
+                                            up_comm, up_comm->c_coll->coll_allgather_module);
+
+            if (tmp_buf != NULL) {
+                free(tmp_buf);
+                tmp_buf = NULL;
+                tmp_buf_start = NULL;
+            }
+
+            /* 2b. reorder the node leader's into rbuf.
+             * if ranks are not mapped in topological order, data needs to be reordered
+             * (see reorder_gather)
+             */
+            if (!han_module->is_mapbycore) {
+                ompi_coll_han_reorder_gather(reorder_buf_start,
+                                             rbuf, rcount, rdtype,
+                                             comm, topo);
+                free(reorder_buf);
+                reorder_buf = NULL;
+            }
+
         }
 
-        /* 2a. inter node allgather */
-        up_comm->c_coll->coll_allgather(tmp_buf_start, scount*low_size, sdtype,
-                                        reorder_buf_start, rcount*low_size, rdtype,
-                                        up_comm, up_comm->c_coll->coll_allgather_module);
+        /* 3. up broadcast: leaders broadcast on their nodes */
+        low_comm->c_coll->coll_bcast(rbuf, rcount*low_size*up_size, rdtype,
+                                     root_low_rank, low_comm,
+                                     low_comm->c_coll->coll_bcast_module);
 
-        if (tmp_buf != NULL) {
-            free(tmp_buf);
-            tmp_buf = NULL;
-            tmp_buf_start = NULL;
-        }
-
-        /* 2b. reorder the node leader's into rbuf.
-         * if ranks are not mapped in topological order, data needs to be reordered
-         * (see reorder_gather)
+    } else {
+        /*
+         * Freelist path: uses pre-allocated buffers and mapbycore/pipeline
+         * optimizations for large messages.
          */
-        if (!han_module->is_mapbycore) {
-            ompi_coll_han_reorder_gather(reorder_buf_start,
-                                         rbuf, rcount, rdtype,
-                                         comm, topo);
-            free(reorder_buf);
-            reorder_buf = NULL;
+        ptrdiff_t rextent;
+        size_t frag_count;
+        size_t num_frags;
+        size_t max_elems;
+
+        ompi_datatype_type_extent(rdtype, &rextent);
+
+        if (MPI_IN_PLACE == sbuf) {
+            scount = rcount;
+            sdtype = rdtype;
         }
 
+        /* Compute per-fragment element count */
+        frag_count = rcount;
+        if (frag_size > 0 && rextent > 0) {
+            max_elems = frag_size / ((size_t)low_size * (size_t)rextent);
+            if (max_elems < 1) max_elems = 1;
+            if (max_elems < rcount) frag_count = max_elems;
+        }
+        num_frags = (rcount + frag_count - 1) / frag_count;
+
+        if (han_module->is_mapbycore) {
+            return han_allgather_mapbycore(sbuf, scount, sdtype, rbuf, rcount,
+                rdtype, up_comm, low_comm, w_rank, low_rank, up_rank,
+                low_size, up_size, root_low_rank);
+        } else if (num_frags == 1) {
+            return han_allgather_single_frag(sbuf, scount, sdtype, rbuf, rcount,
+                rdtype, han_module, up_comm, low_comm, comm,
+                w_rank, low_rank, up_rank, low_size, up_size,
+                root_low_rank, frag_size, topo);
+        } else {
+            return han_allgather_pipeline(sbuf, scount, sdtype, rbuf, rcount,
+                rdtype, han_module, up_comm, low_comm,
+                w_rank, low_rank, low_size, up_size,
+                root_low_rank, frag_size, frag_count, num_frags, topo);
+        }
     }
-
-    /* 3. up broadcast: leaders broadcast on their nodes */
-    low_comm->c_coll->coll_bcast(rbuf, rcount*low_size*up_size, rdtype,
-                                 root_low_rank, low_comm,
-                                 low_comm->c_coll->coll_bcast_module);
-
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/coll/han/coll_han_alltoall.c
+++ b/ompi/mca/coll/han/coll_han_alltoall.c
@@ -60,6 +60,60 @@ static inline int ring_partner(int rank, int round, int comm_size) {
         return ring_partner_no_skip(rank, round+1, comm_size);
 }
 
+
+/**
+ * Set up or reuse cached SMSC arrays for alltoall.
+ * Returns true if cache was valid (allgather + map can be skipped).
+ */
+static int alltoall_cache_setup(
+    mca_coll_han_module_t *han_module,
+    const void *sbuf, size_t scount, int low_size,
+    char ***low_bufs_out, void ***map_ctx_out, void ***gather_buf_out,
+    int *send_needs_bounce_out, int *ii_push_data_out)
+{
+    struct han_alltoall_cache *c = &han_module->a2a_cache;
+    const int nptrs_gather = 3;
+
+    if (c->cached_sbuf == sbuf
+        && c->cached_scount == scount
+        && c->cached_low_size == low_size
+        && c->low_bufs != NULL) {
+        *low_bufs_out = c->low_bufs;
+        *map_ctx_out = c->map_ctx;
+        *gather_buf_out = c->gather_buf;
+        *send_needs_bounce_out = c->cached_send_needs_bounce;
+        *ii_push_data_out = c->cached_ii_push_data;
+        return 1; /* cache valid */
+    }
+
+    /* Invalidate old cache — unmap old SMSC regions */
+    if (c->map_ctx) {
+        for (int i = 0; i < c->cached_low_size; i++) {
+            if (c->map_ctx[i])
+                mca_smsc->unmap_peer_region(c->map_ctx[i]);
+        }
+    }
+    /* Allocate/reuse persistent arrays */
+    if (c->cached_low_size < low_size) {
+        free(c->low_bufs);
+        free(c->map_ctx);
+        free(c->gather_buf);
+        c->cached_low_size = 0;
+        c->low_bufs = malloc(low_size * sizeof(char*));
+        c->map_ctx = malloc(low_size * sizeof(void*));
+        c->gather_buf = calloc(low_size * nptrs_gather, sizeof(void*));
+        if (NULL == c->low_bufs || NULL == c->map_ctx || NULL == c->gather_buf) {
+            return -1; /* allocation failure */
+        }
+    }
+    *low_bufs_out = c->low_bufs;
+    *map_ctx_out = c->map_ctx;
+    *gather_buf_out = c->gather_buf;
+    memset(c->map_ctx, 0, low_size * sizeof(void*));
+    memset(c->gather_buf, 0, low_size * nptrs_gather * sizeof(void*));
+    return 0; /* cache miss */
+}
+
 int mca_coll_han_alltoall_using_smsc(
         const void *sbuf, size_t scount,
         struct ompi_datatype_t *sdtype,
@@ -218,13 +272,30 @@ int mca_coll_han_alltoall_using_smsc(
     int64_t send_bytes_per_fan = low_size * packed_size;
     inter_send_reqs = malloc(sizeof(*inter_send_reqs) * fanout);
     inter_recv_reqs = malloc(sizeof(*inter_recv_reqs) * up_size );
-    char **low_bufs = malloc(low_size * sizeof(*low_bufs));
-    void **sbuf_map_ctx = malloc(low_size * sizeof(&sbuf_map_ctx));
-    opal_free_list_item_t *send_fl_item = NULL;
 
+    /* Check if cached SMSC mappings are still valid */
+    int a2a_cache_valid;
+    char **low_bufs = NULL;
+    void **sbuf_map_ctx = NULL;
+    opal_free_list_item_t *send_fl_item = NULL;
     const int nptrs_gather = 3;
-    void **gather_buf_out = calloc(low_size*nptrs_gather, sizeof(void*));
+    void **gather_buf_out = NULL;
     int send_bounce_status = BOUNCE_NOT_INITIALIZED;
+
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        int cache_rc = alltoall_cache_setup(
+            han_module, sbuf, scount, low_size,
+            &low_bufs, &sbuf_map_ctx, &gather_buf_out,
+            &send_needs_bounce, &ii_push_data);
+        if (cache_rc < 0) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+        a2a_cache_valid = (cache_rc == 1);
+    } else {
+        /* Original upstream path — fresh allocations per call */
+        a2a_cache_valid = 0;
+        low_bufs = malloc(low_size * sizeof(*low_bufs));
+        sbuf_map_ctx = malloc(low_size * sizeof(*sbuf_map_ctx));
+        gather_buf_out = calloc(low_size * nptrs_gather, sizeof(void*));
+    }
 
     do {
 start_allgather:
@@ -233,70 +304,96 @@ start_allgather:
             send_bounce_status = BOUNCE_IS_FROM_RBUF;
         } else {
             if (send_bounce_status == BOUNCE_NOT_INITIALIZED || send_bounce_status == BOUNCE_IS_FROM_RBUF) {
-                if (send_bytes_per_fan * fanout < mca_coll_han_component.han_packbuf_bytes) {
-                    send_fl_item = opal_free_list_get(&mca_coll_han_component.pack_buffers);
-                    if (send_fl_item) {
-                        send_bounce_status = BOUNCE_IS_FROM_FREELIST;
-                        send_bounce = send_fl_item->ptr;
+                if (mca_coll_han_component.han_use_persist_buffers) {
+                    /* Persistent bounce: realloc-to-HWM avoids munmap on free
+                     * which would invalidate NIC memory registration cache entries. */
+                    size_t needed = send_bytes_per_fan * fanout;
+                    if (han_module->a2a_cache.bounce_size < needed) {
+                        char *p = realloc(han_module->a2a_cache.bounce, needed);
+                        if (NULL == p) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+                        han_module->a2a_cache.bounce = p;
+                        han_module->a2a_cache.bounce_size = needed;
+                    }
+                    send_bounce = han_module->a2a_cache.bounce;
+                    send_bounce_status = BOUNCE_IS_FROM_MALLOC;
+                } else {
+                    if (send_bytes_per_fan * fanout < mca_coll_han_component.han_packbuf_bytes) {
+                        send_fl_item = opal_free_list_get(&mca_coll_han_component.pack_buffers);
+                        if (send_fl_item) {
+                            send_bounce_status = BOUNCE_IS_FROM_FREELIST;
+                            send_bounce = send_fl_item->ptr;
+                        }
+                    }
+                    if (!send_fl_item) {
+                        send_bounce = malloc(send_bytes_per_fan * fanout);
+                        send_bounce_status = BOUNCE_IS_FROM_MALLOC;
                     }
                 }
-                if (!send_fl_item) {
-                    send_bounce = malloc(send_bytes_per_fan * fanout);
-                    send_bounce_status = BOUNCE_IS_FROM_MALLOC;
+            }
+        }
+
+        if (!a2a_cache_valid) {
+            if (ii_push_data) {
+                /* all ranks will push to the other ranks' bounce buffer */
+                gather_buf_in[0] = send_bounce;
+            } else {
+                /* all ranks will pull from the other ranks' sbuf */
+                gather_buf_in[0] = (void*)sbuf;
+            }
+            gather_buf_in[1] = (void*)(intptr_t)send_needs_bounce;
+            gather_buf_in[2] = (void*)(intptr_t)ii_push_data;
+
+            rc = low_comm->c_coll->coll_allgather(gather_buf_in, nptrs_gather, MPI_AINT,
+                        gather_buf_out, nptrs_gather, MPI_AINT, low_comm,
+                        low_comm->c_coll->coll_allgather_module);
+
+            if (rc != 0) {
+                OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
+                "Allgather failed with %d\n",rc));
+                goto cleanup;
+            }
+
+            for (int jother=0; jother<low_size; jother++) {
+                int other_push_data = (uintptr_t)gather_buf_out[nptrs_gather*jother + 2] & 0x1;
+                if (ii_push_data != other_push_data) {
+                    ii_push_data = 1;
+                    goto start_allgather;
                 }
+                send_needs_bounce  |= (uintptr_t)gather_buf_out[nptrs_gather*jother + 1] & 0x1;
+                ii_push_data       |= other_push_data;
             }
-        }
-
-        if (ii_push_data) {
-            /* all ranks will push to the other ranks' bounce buffer */
-            gather_buf_in[0] = send_bounce;
-        } else {
-            /* all ranks will pull from the other ranks' sbuf */
-            gather_buf_in[0] = (void*)sbuf;
-        }
-        gather_buf_in[1] = (void*)(intptr_t)send_needs_bounce;
-        gather_buf_in[2] = (void*)(intptr_t)ii_push_data;
-
-        rc = low_comm->c_coll->coll_allgather(gather_buf_in, nptrs_gather, MPI_AINT,
-                    gather_buf_out, nptrs_gather, MPI_AINT, low_comm,
-                    low_comm->c_coll->coll_allgather_module);
-
-        if (rc != 0) {
-            OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
-            "Allgather failed with %d\n",rc));
-            goto cleanup;
-        }
-
-        for (int jother=0; jother<low_size; jother++) {
-            int other_push_data = (uintptr_t)gather_buf_out[nptrs_gather*jother + 2] & 0x1;
-            if (ii_push_data != other_push_data) {
-                ii_push_data = 1;
-                goto start_allgather;
-            }
-            send_needs_bounce  |= (uintptr_t)gather_buf_out[nptrs_gather*jother + 1] & 0x1;
-            ii_push_data       |= other_push_data;
-        }
+        } /* !a2a_cache_valid */
     } while (0);
 
     use_isend = fanout > 1 || ii_push_data;
 
-    for (int jother=0; jother<low_size; jother++) {
-        low_bufs[jother] = gather_buf_out[nptrs_gather*jother];
-        if (jother == low_rank) {
-            sbuf_map_ctx[low_rank] = NULL;
-        } else {
-            struct ompi_proc_t* ompi_proc = ompi_comm_peer_lookup(low_comm, jother);
-            mca_smsc_endpoint_t *smsc_ep;
-            smsc_ep = mca_coll_han_get_smsc_endpoint(ompi_proc);
+    if (!a2a_cache_valid) {
+        for (int jother=0; jother<low_size; jother++) {
+            low_bufs[jother] = gather_buf_out[nptrs_gather*jother];
+            if (jother == low_rank) {
+                sbuf_map_ctx[low_rank] = NULL;
+            } else {
+                struct ompi_proc_t* ompi_proc = ompi_comm_peer_lookup(low_comm, jother);
+                mca_smsc_endpoint_t *smsc_ep;
+                smsc_ep = mca_coll_han_get_smsc_endpoint(ompi_proc);
 
-            sbuf_map_ctx[jother] = mca_smsc->map_peer_region(
-                smsc_ep,
-                MCA_RCACHE_FLAGS_PERSIST,
-                low_bufs[jother],
-                sextent*w_size*scount,
-                (void**) &low_bufs[jother] );
+                sbuf_map_ctx[jother] = mca_smsc->map_peer_region(
+                    smsc_ep,
+                    MCA_RCACHE_FLAGS_PERSIST,
+                    low_bufs[jother],
+                    sextent*w_size*scount,
+                    (void**) &low_bufs[jother] );
+            }
         }
-    }
+        /* Update cache (only when persist buffers enabled) */
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            han_module->a2a_cache.cached_sbuf = sbuf;
+            han_module->a2a_cache.cached_scount = scount;
+            han_module->a2a_cache.cached_low_size = low_size;
+            han_module->a2a_cache.cached_send_needs_bounce = send_needs_bounce;
+            han_module->a2a_cache.cached_ii_push_data = ii_push_data;
+        }
+    } /* !a2a_cache_valid */
 
     for (int jslot=0; jslot < fanout; jslot++) {
         inter_send_reqs[jslot] = MPI_REQUEST_NULL;
@@ -305,12 +402,25 @@ start_allgather:
 
     /* pre-post all our receives.  We will be ready to receive all data regardless of fan-out.
        (This is not an in-place algorithm)*/
+    size_t recv_chunk_bytes = rextent * rcount * low_size;
+    size_t recv_total = recv_chunk_bytes * up_size;
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* Use persistent recv buffer to keep MR addresses stable */
+        if (han_module->a2a_cache.recv_buf_size < recv_total) {
+            char *p = realloc(han_module->a2a_cache.recv_buf, recv_total);
+            if (NULL == p) { rc = OMPI_ERR_OUT_OF_RESOURCE; goto cleanup; }
+            han_module->a2a_cache.recv_buf = p;
+            han_module->a2a_cache.recv_buf_size = recv_total;
+        }
+    }
+
     int inter_recv_count = 0;
     for (int jround=0; jround<up_size; jround++) {
             int up_partner = ring_partner(up_rank, jround, up_size);
             int first_remote_wrank = up_partner*low_size;
-            /* pre-post the receive for remote.  Receive directly into application buffer */
-            char *recv_chunk = ((char*)rbuf) + rextent*rcount*first_remote_wrank;
+            char *recv_chunk = mca_coll_han_component.han_use_persist_buffers
+                ? han_module->a2a_cache.recv_buf + recv_chunk_bytes * jround
+                : ((char*)rbuf) + rextent*rcount*first_remote_wrank;
 
             MCA_PML_CALL(irecv
                         (recv_chunk, rcount*low_size, rdtype, first_remote_wrank+low_rank,
@@ -415,6 +525,17 @@ start_allgather:
     /* wait for all irecv to complete */
     ompi_request_wait_all(inter_recv_count, inter_recv_reqs, MPI_STATUS_IGNORE);
 
+    /* Copy from persistent recv buffer to application rbuf */
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        for (int jround=0; jround<inter_recv_count; jround++) {
+            int up_partner = ring_partner(up_rank, jround, up_size);
+            int first_remote_wrank = up_partner*low_size;
+            memcpy(((char*)rbuf) + rextent*rcount*first_remote_wrank,
+                   han_module->a2a_cache.recv_buf + recv_chunk_bytes * jround,
+                   recv_chunk_bytes);
+        }
+    }
+
 cleanup:
 
     /* we may still have neighbors reading directly from our buffer, so we must ensure it is not modified */
@@ -423,22 +544,29 @@ cleanup:
         low_comm->c_coll->coll_barrier(low_comm, low_comm->c_coll->coll_barrier_module);
     }
 
-    for (int jlow=0; jlow<low_size; jlow++) {
-        if (jlow != low_rank ) {
-            mca_smsc->unmap_peer_region(sbuf_map_ctx[jlow]);
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* SMSC mappings, bounce, and arrays are cached — do not free/unmap */
+    } else {
+        for (int jlow=0; jlow<low_size; jlow++) {
+            if (jlow != low_rank) {
+                mca_smsc->unmap_peer_region(sbuf_map_ctx[jlow]);
+            }
         }
     }
     OBJ_DESTRUCT(&convertor);
     if (send_bounce_status == BOUNCE_IS_FROM_FREELIST) {
         opal_free_list_return(&mca_coll_han_component.pack_buffers, send_fl_item);
-    } else if (send_bounce_status == BOUNCE_IS_FROM_MALLOC) {
+    } else if (send_bounce_status == BOUNCE_IS_FROM_MALLOC
+               && !mca_coll_han_component.han_use_persist_buffers) {
         free(send_bounce);
     }
     free(inter_send_reqs);
     free(inter_recv_reqs);
-    free(sbuf_map_ctx);
-    free(low_bufs);
-    free(gather_buf_out);
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        free(sbuf_map_ctx);
+        free(low_bufs);
+        free(gather_buf_out);
+    }
 
     OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
                 "Alltoall Complete with %d\n",rc));

--- a/ompi/mca/coll/han/coll_han_alltoallv.c
+++ b/ompi/mca/coll/han/coll_han_alltoallv.c
@@ -582,6 +582,52 @@ static int alltoallv_sendrecv_w(
     return 0;
 }
 
+
+/**
+ * Set up persistent allocations for alltoallv.
+ * Grows arrays to high-water mark to avoid per-call malloc/free.
+ * Returns 0 on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
+ */
+static int alltoallv_cache_setup(
+    struct han_alltoallv_cache *c,
+    size_t serialization_buf_length, int low_size)
+{
+    if (c->serial_buf_size < serialization_buf_length) {
+        free(c->serial_buf);
+        c->serial_buf = malloc(serialization_buf_length);
+        if (NULL == c->serial_buf) {
+            c->serial_buf_size = 0;
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        c->serial_buf_size = serialization_buf_length;
+    }
+    if (c->low_size < low_size) {
+        free(c->gather_out);  free(c->peers);      free(c->peer_types);
+        free(c->send_from);   free(c->recv_to);
+        free(c->send_counts); free(c->recv_counts);
+        free(c->send_types);  free(c->recv_types);
+        c->low_size = 0;
+        c->gather_out  = malloc(sizeof(struct gathered_data) * low_size);
+        c->peers       = malloc(sizeof(struct peer_data) * low_size);
+        c->peer_types  = malloc(sizeof(opal_datatype_t) * low_size);
+        c->send_from   = malloc(sizeof(void*) * low_size);
+        c->recv_to     = malloc(sizeof(void*) * low_size);
+        c->send_counts = malloc(sizeof(size_t) * low_size);
+        c->recv_counts = malloc(sizeof(size_t) * low_size);
+        c->send_types  = malloc(sizeof(opal_datatype_t*) * low_size);
+        c->recv_types  = malloc(sizeof(opal_datatype_t*) * low_size);
+        if (NULL == c->gather_out || NULL == c->peers ||
+            NULL == c->peer_types || NULL == c->send_from ||
+            NULL == c->recv_to    || NULL == c->send_counts ||
+            NULL == c->recv_counts|| NULL == c->send_types ||
+            NULL == c->recv_types) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        c->low_size = low_size;
+    }
+    return OMPI_SUCCESS;
+}
+
 static int decide_to_use_smsc_alg(
     int *use_smsc,
     const void *sbuf,
@@ -769,11 +815,30 @@ int mca_coll_han_alltoallv_using_smsc(
     int w_size = ompi_comm_size(comm);
 
     int use_smsc;
-    rc = decide_to_use_smsc_alg(&use_smsc,
-        sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype, comm);
-    if (rc != 0) {
-        opal_output_verbose(1, mca_coll_han_component.han_output,
-            "decide_to_use_smsc_alg failed during execution! rc=%d\n", rc);
+    if (sbuf == MPI_IN_PLACE) {
+        return han_module->previous_alltoallv(sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype,
+                                             comm, han_module->previous_alltoallv_module);
+    }
+
+    /* Cache the decide_to_use_smsc_alg result to avoid per-call allreduce.
+     * The first call runs the allreduce (all ranks participate). Every
+     * subsequent call reuses the cached result. This is safe because the
+     * decision depends on buffer types (GPU, contiguous) which don't change
+     * between calls, and the MCA parameter is globally consistent. */
+    if (mca_coll_han_component.han_use_persist_buffers
+        && han_module->a2av_cache.smsc_decided) {
+        use_smsc = han_module->a2av_cache.use_smsc;
+    } else {
+        rc = decide_to_use_smsc_alg(&use_smsc,
+            sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype, comm);
+        if (rc != 0) {
+            opal_output_verbose(1, mca_coll_han_component.han_output,
+                "decide_to_use_smsc_alg failed during execution! rc=%d\n", rc);
+        }
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            han_module->a2av_cache.smsc_decided = true;
+            han_module->a2av_cache.use_smsc = use_smsc;
+        }
     }
     if (!use_smsc) {
         return han_module->previous_alltoallv(sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype,
@@ -790,21 +855,35 @@ int mca_coll_han_alltoallv_using_smsc(
     int up_rank = ompi_comm_rank(up_comm);
 
     struct gathered_data low_gather_in;
-    struct gathered_data *low_gather_out;
+    struct gathered_data *low_gather_out = NULL;
 
 
     low_gather_in.stype_serialized_length = ddt_pack_datatype(&sdtype->super, NULL);
-    uint8_t *serialization_buf;
+    uint8_t *serialization_buf = NULL;
 
     size_t serialization_buf_length = low_gather_in.stype_serialized_length
         + sizeof(struct peer_counts)*w_size;
 
-    /* allocate data */
-    serialization_buf = malloc(serialization_buf_length);
-    low_gather_out = malloc(sizeof(*low_gather_out) * low_size);
-    struct peer_data *peers = malloc(sizeof(*peers) * low_size);
-    opal_datatype_t *peer_send_types = malloc(sizeof(*peer_send_types) * low_size);
+    struct peer_data *peers = NULL;
+    opal_datatype_t *peer_send_types = NULL;
     bool have_bufs_and_types = false;
+
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        /* Persistent allocations (realloc-to-HWM) */
+        rc = alltoallv_cache_setup(&han_module->a2av_cache,
+                                   serialization_buf_length, low_size);
+        if (rc != OMPI_SUCCESS) { goto cleanup; }
+        serialization_buf = han_module->a2av_cache.serial_buf;
+        low_gather_out = han_module->a2av_cache.gather_out;
+        peers = han_module->a2av_cache.peers;
+        peer_send_types = han_module->a2av_cache.peer_types;
+    } else {
+        /* Original upstream path — fresh allocations per call */
+        serialization_buf = malloc(serialization_buf_length);
+        low_gather_out = malloc(sizeof(*low_gather_out) * low_size);
+        peers = malloc(sizeof(*peers) * low_size);
+        peer_send_types = malloc(sizeof(*peer_send_types) * low_size);
+    }
 
     low_gather_in.serialization_buffer = serialization_buf;
     low_gather_in.sbuf = (void*)sbuf; // cast to discard the const
@@ -831,6 +910,7 @@ int mca_coll_han_alltoallv_using_smsc(
     buf_packed += ddt_pack_datatype(&sdtype->super, serialization_buf + buf_packed);
     assert(buf_packed == serialization_buf_length);
 
+    /* Always run allgather — all ranks must participate (collective) */
     rc = low_comm->c_coll->coll_allgather(&low_gather_in, sizeof(low_gather_in), MPI_BYTE,
             low_gather_out, sizeof(low_gather_in), MPI_BYTE, low_comm,
             low_comm->c_coll->coll_allgather_module);
@@ -898,12 +978,21 @@ int mca_coll_han_alltoallv_using_smsc(
     }
 
     have_bufs_and_types = true;
-    send_from_addrs = malloc(sizeof(*send_from_addrs)*low_size);
-    recv_to_addrs = malloc(sizeof(*recv_to_addrs)*low_size);
-    send_counts = malloc(sizeof(*send_counts)*low_size);
-    recv_counts = malloc(sizeof(*recv_counts)*low_size);
-    send_types = malloc(sizeof(*send_types)*low_size);
-    recv_types = malloc(sizeof(*recv_types)*low_size);
+    if (mca_coll_han_component.han_use_persist_buffers) {
+        send_from_addrs = han_module->a2av_cache.send_from;
+        recv_to_addrs = han_module->a2av_cache.recv_to;
+        send_counts = han_module->a2av_cache.send_counts;
+        recv_counts = han_module->a2av_cache.recv_counts;
+        send_types = (opal_datatype_t **)han_module->a2av_cache.send_types;
+        recv_types = (opal_datatype_t **)han_module->a2av_cache.recv_types;
+    } else {
+        send_from_addrs = malloc(sizeof(*send_from_addrs)*low_size);
+        recv_to_addrs = malloc(sizeof(*recv_to_addrs)*low_size);
+        send_counts = malloc(sizeof(*send_counts)*low_size);
+        recv_counts = malloc(sizeof(*recv_counts)*low_size);
+        send_types = malloc(sizeof(*send_types)*low_size);
+        recv_types = malloc(sizeof(*recv_types)*low_size);
+    }
 
     /****
      *  Main exchange loop
@@ -957,7 +1046,7 @@ int mca_coll_han_alltoallv_using_smsc(
     cleanup:
     low_comm->c_coll->coll_barrier(low_comm, low_comm->c_coll->coll_barrier_module);
 
-    if (send_from_addrs) {
+    if (send_from_addrs && !mca_coll_han_component.han_use_persist_buffers) {
         free(send_from_addrs);
         free(recv_to_addrs);
         free(send_counts);
@@ -971,7 +1060,6 @@ int mca_coll_han_alltoallv_using_smsc(
             if (jlow != low_rank) {
                 OBJ_DESTRUCT(&peer_send_types[jlow]);
             }
-
             for (int jbuf=0; jbuf<2; jbuf++) {
                 if (peers[jlow].map_ctx[jbuf]) {
                     mca_smsc->unmap_peer_region(peers[jlow].map_ctx[jbuf]);
@@ -979,10 +1067,12 @@ int mca_coll_han_alltoallv_using_smsc(
             }
         }
     }
-    free(serialization_buf);
-    free(low_gather_out);
-    free(peers);
-    free(peer_send_types);
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        free(serialization_buf);
+        free(low_gather_out);
+        free(peers);
+        free(peer_send_types);
+    }
 
     OPAL_OUTPUT_VERBOSE((40, mca_coll_han_component.han_output,
                 "Alltoall Complete with %d\n",rc));

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -652,7 +652,7 @@ static int han_register(void)
     cs->han_fragment_size = 0;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "fragment_size",
-                                           "Size of freelist fragment buffers for collective operations (currently used by allgather, 0 = disabled)",
+                                           "Size of freelist fragment buffers for collective operations (0 = disabled)",
                                            MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_6,
                                            MCA_BASE_VAR_SCOPE_ALL,

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -640,7 +640,7 @@ static int han_register(void)
                                            &(cs->max_dynamic_errors));
 
 
-    cs->han_use_persist_buffers = false;
+    cs->han_use_persist_buffers = true;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "use_persist_buffers",
                                            "Use persistent/freelist buffers to avoid malloc/free in collectives (0 = disabled)",
@@ -649,7 +649,7 @@ static int han_register(void)
                                            MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->han_use_persist_buffers));
 
-    cs->han_fragment_size = 0;
+    cs->han_fragment_size = 65536;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "fragment_size",
                                            "Size of freelist fragment buffers for collective operations (0 = disabled)",
@@ -658,7 +658,7 @@ static int han_register(void)
                                            MCA_BASE_VAR_SCOPE_ALL,
                                            &(cs->han_fragment_size));
 
-    cs->han_large_fragment_size = 0;
+    cs->han_large_fragment_size = 1048576;
     (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
                                            "large_fragment_size",
                                            "Size of large freelist buffers for pipeline reorder (0 = use small fragments or malloc)",

--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -640,5 +640,32 @@ static int han_register(void)
                                            &(cs->max_dynamic_errors));
 
 
+    cs->han_use_persist_buffers = false;
+    (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
+                                           "use_persist_buffers",
+                                           "Use persistent/freelist buffers to avoid malloc/free in collectives (0 = disabled)",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_ALL,
+                                           &(cs->han_use_persist_buffers));
+
+    cs->han_fragment_size = 0;
+    (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
+                                           "fragment_size",
+                                           "Size of freelist fragment buffers for collective operations (currently used by allgather, 0 = disabled)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_ALL,
+                                           &(cs->han_fragment_size));
+
+    cs->han_large_fragment_size = 0;
+    (void) mca_base_component_var_register(&mca_coll_han_component.super.collm_version,
+                                           "large_fragment_size",
+                                           "Size of large freelist buffers for pipeline reorder (0 = use small fragments or malloc)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_ALL,
+                                           &(cs->han_large_fragment_size));
+
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -46,7 +46,8 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
                              int root_low_rank,
                              struct ompi_communicator_t *up_comm,
                              struct ompi_communicator_t *low_comm,
-                             int w_rank, bool noop, bool is_mapbycore, ompi_request_t * req)
+                             int w_rank, bool noop, bool is_mapbycore, ompi_request_t * req,
+                             mca_coll_han_module_t *han_module)
 {
     args->cur_task = cur_task;
     args->sbuf = sbuf;
@@ -65,6 +66,7 @@ mca_coll_han_set_gather_args(mca_coll_han_gather_args_t * args,
     args->noop = noop;
     args->is_mapbycore = is_mapbycore;
     args->req = req;
+    args->han_module = han_module;
 }
 
 
@@ -156,7 +158,18 @@ mca_coll_han_gather_intra(const void *sbuf, size_t scount,
             rsize = opal_datatype_span(&rdtype->super,
                                        (int64_t)rcount * w_size,
                                        &rgap);
-            reorder_buf = (char *)malloc(rsize);        //TODO:free
+            if (mca_coll_han_component.han_use_persist_buffers) {
+                if (han_module->gather_reorder_persist_size < (size_t)rsize) {
+                    char *p = realloc(han_module->gather_reorder_persist, rsize);
+                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                    han_module->gather_reorder_persist = p;
+                    han_module->gather_reorder_persist_size = rsize;
+                }
+                reorder_buf = han_module->gather_reorder_persist;
+            } else {
+                reorder_buf = (char *)malloc(rsize);
+                if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+            }
             /* rgap is the size of unused space at the start of the datatype */
             reorder_rbuf = reorder_buf - rgap;
 
@@ -180,7 +193,8 @@ mca_coll_han_gather_intra(const void *sbuf, size_t scount,
     mca_coll_han_gather_args_t *lg_args = malloc(sizeof(mca_coll_han_gather_args_t));
     mca_coll_han_set_gather_args(lg_args, lg, (char *) sbuf, NULL, scount, sdtype, reorder_rbuf,
                                  rcount, rdtype, root, root_up_rank, root_low_rank, up_comm,
-                                 low_comm, w_rank, low_rank != root_low_rank, han_module->is_mapbycore, temp_request);
+                                 low_comm, w_rank, low_rank != root_low_rank, han_module->is_mapbycore, temp_request,
+                                 han_module);
     /* Init lg task */
     init_task(lg, mca_coll_han_gather_lg_task, (void *) (lg_args));
     /* Issure lg task */
@@ -193,7 +207,9 @@ mca_coll_han_gather_intra(const void *sbuf, size_t scount,
         ompi_coll_han_reorder_gather(reorder_buf,
                                      rbuf, rcount, rdtype,
                                      comm, topo);
-        free(reorder_buf);
+        if (!mca_coll_han_component.han_use_persist_buffers) {
+            free(reorder_buf);
+        }
     }
 
     return OMPI_SUCCESS;
@@ -212,15 +228,25 @@ int mca_coll_han_gather_lg_task(void *task_args)
     char *tmp_buf = NULL;
     char *tmp_rbuf = NULL;
     if (!t->noop) {
-        /* if the process is one of the node leader, allocate the intermediary
-         * buffer to gather on the low sub communicator */
+        /* Intra-node gather buffer: persistent realloc-to-HWM or malloc */
         int low_size = ompi_comm_size(t->low_comm);
         int low_rank = ompi_comm_rank(t->low_comm);
         ptrdiff_t rsize, rgap = 0;
         rsize = opal_datatype_span(&dtype->super,
                                    count * low_size,
                                    &rgap);
-        tmp_buf = (char *) malloc(rsize);
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            if (t->han_module->cached_gather_buf_size < (size_t)rsize) {
+                char *p = realloc(t->han_module->cached_gather_buf, rsize);
+                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                t->han_module->cached_gather_buf = p;
+                t->han_module->cached_gather_buf_size = rsize;
+            }
+            tmp_buf = (char *)t->han_module->cached_gather_buf;
+        } else {
+            tmp_buf = (char *)malloc(rsize);
+            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+        }
         tmp_rbuf = tmp_buf - rgap;
         if (t->w_rank == t->root && MPI_IN_PLACE == t->sbuf) {
             ptrdiff_t rextent;
@@ -286,9 +312,12 @@ int mca_coll_han_gather_ug_task(void *task_args)
                                         t->up_comm,
                                         t->up_comm->c_coll->coll_gather_module);
 
-        if (t->sbuf_inter_free != NULL) {
-            free(t->sbuf_inter_free);
-            t->sbuf_inter_free = NULL;
+        /* Free intra-node buffer when not using persist buffers */
+        if (!mca_coll_han_component.han_use_persist_buffers) {
+            if (t->sbuf_inter_free != NULL) {
+                free(t->sbuf_inter_free);
+                t->sbuf_inter_free = NULL;
+            }
         }
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "[%d] Han Gather:  ug gather finish\n", t->w_rank));
@@ -371,23 +400,44 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
             ptrdiff_t rsize = opal_datatype_span(&rdtype->super,
                                                  (int64_t)rcount * w_size,
                                                  &rgap);
-            reorder_buf = (char *)malloc(rsize);
+            if (mca_coll_han_component.han_use_persist_buffers) {
+                if (han_module->gather_reorder_persist_size < (size_t)rsize) {
+                    char *p = realloc(han_module->gather_reorder_persist, rsize);
+                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                    han_module->gather_reorder_persist = p;
+                    han_module->gather_reorder_persist_size = rsize;
+                }
+                reorder_buf = han_module->gather_reorder_persist;
+            } else {
+                reorder_buf = (char *)malloc(rsize);
+                if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+            }
             /* rgap is the size of unused space at the start of the datatype */
             reorder_buf_start = reorder_buf - rgap;
         }
 
     }
 
-    /* allocate the intermediary buffer
-     * to gather on leaders on the low sub communicator */
-    char *tmp_buf = NULL; // allocated memory
-    char *tmp_buf_start = NULL; // start of the data
+    /* Intra-node gather buffer: persistent realloc-to-HWM or malloc */
+    char *tmp_buf = NULL;
+    char *tmp_buf_start = NULL;
     if (low_rank == root_low_rank) {
         ptrdiff_t rsize, rgap = 0;
         rsize = opal_datatype_span(&dtype->super,
                                    count * low_size,
                                    &rgap);
-        tmp_buf = (char *) malloc(rsize);
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            if (han_module->cached_gather_buf_size < (size_t)rsize) {
+                char *p = realloc(han_module->cached_gather_buf, rsize);
+                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                han_module->cached_gather_buf = p;
+                han_module->cached_gather_buf_size = rsize;
+            }
+            tmp_buf = (char *)han_module->cached_gather_buf;
+        } else {
+            tmp_buf = (char *)malloc(rsize);
+            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+        }
         tmp_buf_start = tmp_buf - rgap;
     }
 
@@ -414,10 +464,10 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                      up_comm,
                                      up_comm->c_coll->coll_gather_module);
 
-        if (tmp_buf != NULL) {
+        /* Free intra-node buffer when not using persist buffers */
+        if (!mca_coll_han_component.han_use_persist_buffers) {
             free(tmp_buf);
             tmp_buf = NULL;
-            tmp_buf_start = NULL;
         }
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "[%d] Future Gather:  ug gather finish\n", w_rank));
@@ -431,7 +481,9 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
         ompi_coll_han_reorder_gather(reorder_buf_start,
                                      rbuf, rcount, rdtype,
                                      comm, topo);
-        free(reorder_buf);
+        if (!mca_coll_han_component.han_use_persist_buffers) {
+            free(reorder_buf);
+        }
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -158,18 +158,11 @@ mca_coll_han_gather_intra(const void *sbuf, size_t scount,
             rsize = opal_datatype_span(&rdtype->super,
                                        (int64_t)rcount * w_size,
                                        &rgap);
-            if (mca_coll_han_component.han_use_persist_buffers) {
-                if (han_module->gather_reorder_persist_size < (size_t)rsize) {
-                    char *p = realloc(han_module->gather_reorder_persist, rsize);
-                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                    han_module->gather_reorder_persist = p;
-                    han_module->gather_reorder_persist_size = rsize;
-                }
-                reorder_buf = han_module->gather_reorder_persist;
-            } else {
-                reorder_buf = (char *)malloc(rsize);
-                if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
-            }
+            reorder_buf = han_scratch_or_malloc(&han_module->scratch_buf[0],
+                                                 &han_module->scratch_buf_size[0],
+                                                 (size_t)rsize,
+                                                 mca_coll_han_component.han_use_persist_buffers);
+            if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
             /* rgap is the size of unused space at the start of the datatype */
             reorder_rbuf = reorder_buf - rgap;
 
@@ -235,18 +228,11 @@ int mca_coll_han_gather_lg_task(void *task_args)
         rsize = opal_datatype_span(&dtype->super,
                                    count * low_size,
                                    &rgap);
-        if (mca_coll_han_component.han_use_persist_buffers) {
-            if (t->han_module->cached_gather_buf_size < (size_t)rsize) {
-                char *p = realloc(t->han_module->cached_gather_buf, rsize);
-                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                t->han_module->cached_gather_buf = p;
-                t->han_module->cached_gather_buf_size = rsize;
-            }
-            tmp_buf = (char *)t->han_module->cached_gather_buf;
-        } else {
-            tmp_buf = (char *)malloc(rsize);
-            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
-        }
+        tmp_buf = han_scratch_or_malloc(&t->han_module->scratch_buf[1],
+                                        &t->han_module->scratch_buf_size[1],
+                                        (size_t)rsize,
+                                        mca_coll_han_component.han_use_persist_buffers);
+        if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
         tmp_rbuf = tmp_buf - rgap;
         if (t->w_rank == t->root && MPI_IN_PLACE == t->sbuf) {
             ptrdiff_t rextent;
@@ -400,18 +386,11 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
             ptrdiff_t rsize = opal_datatype_span(&rdtype->super,
                                                  (int64_t)rcount * w_size,
                                                  &rgap);
-            if (mca_coll_han_component.han_use_persist_buffers) {
-                if (han_module->gather_reorder_persist_size < (size_t)rsize) {
-                    char *p = realloc(han_module->gather_reorder_persist, rsize);
-                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                    han_module->gather_reorder_persist = p;
-                    han_module->gather_reorder_persist_size = rsize;
-                }
-                reorder_buf = han_module->gather_reorder_persist;
-            } else {
-                reorder_buf = (char *)malloc(rsize);
-                if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
-            }
+            reorder_buf = han_scratch_or_malloc(&han_module->scratch_buf[0],
+                                                 &han_module->scratch_buf_size[0],
+                                                 (size_t)rsize,
+                                                 mca_coll_han_component.han_use_persist_buffers);
+            if (NULL == reorder_buf) return OMPI_ERR_OUT_OF_RESOURCE;
             /* rgap is the size of unused space at the start of the datatype */
             reorder_buf_start = reorder_buf - rgap;
         }
@@ -426,18 +405,11 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
         rsize = opal_datatype_span(&dtype->super,
                                    count * low_size,
                                    &rgap);
-        if (mca_coll_han_component.han_use_persist_buffers) {
-            if (han_module->cached_gather_buf_size < (size_t)rsize) {
-                char *p = realloc(han_module->cached_gather_buf, rsize);
-                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                han_module->cached_gather_buf = p;
-                han_module->cached_gather_buf_size = rsize;
-            }
-            tmp_buf = (char *)han_module->cached_gather_buf;
-        } else {
-            tmp_buf = (char *)malloc(rsize);
-            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
-        }
+        tmp_buf = han_scratch_or_malloc(&han_module->scratch_buf[1],
+                                        &han_module->scratch_buf_size[1],
+                                        (size_t)rsize,
+                                        mca_coll_han_component.han_use_persist_buffers);
+        if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
         tmp_buf_start = tmp_buf - rgap;
     }
 
@@ -504,7 +476,7 @@ ompi_coll_han_reorder_gather(const void *sbuf,
                              void *rbuf, size_t count,
                              struct ompi_datatype_t *dtype,
                              struct ompi_communicator_t *comm,
-                             int * topo)
+                             const int * topo)
 {
     int i, topolevel = 2; // always 2 levels in topo
 #if OPAL_ENABLE_DEBUG

--- a/ompi/mca/coll/han/coll_han_gatherv.c
+++ b/ompi/mca/coll/han/coll_han_gatherv.c
@@ -219,7 +219,10 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         if (need_bounce_buf) {
             ptrdiff_t rsize, rgap;
             rsize = opal_datatype_span(&rdtype->super, total_up_rcounts, &rgap);
-            bounce_buf = malloc(rsize);
+            bounce_buf = han_scratch_or_malloc(
+                &han_module->scratch_buf[0],
+                &han_module->scratch_buf_size[0],
+                rsize, mca_coll_han_component.han_use_persist_buffers);
             if (!bounce_buf) {
                 err = OMPI_ERR_OUT_OF_RESOURCE;
                 goto root_out;
@@ -276,7 +279,7 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         if (up_peer_ub) {
             free(up_peer_ub);
         }
-        if (bounce_buf) {
+        if (bounce_buf && !mca_coll_han_component.han_use_persist_buffers) {
             free(bounce_buf);
         }
 
@@ -338,7 +341,10 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
         total_rsize += low_rcounts[i];
     }
 
-    tmp_buf = (char *) malloc(total_rsize); /* tmp_buf is still valid if total_rsize is 0 */
+    tmp_buf = han_scratch_or_malloc(
+        &han_module->scratch_buf[1],
+        &han_module->scratch_buf_size[1],
+        total_rsize, mca_coll_han_component.han_use_persist_buffers);
     if (!tmp_buf) {
         err = OMPI_ERR_OUT_OF_RESOURCE;
         goto node_leader_out;
@@ -363,7 +369,7 @@ node_leader_out:
     if (low_displs) {
         free(low_displs);
     }
-    if (tmp_buf) {
+    if (tmp_buf && !mca_coll_han_component.han_use_persist_buffers) {
         free(tmp_buf);
     }
 

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -197,6 +197,10 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     module->gather_reorder_persist_size = 0;
     module->reduce_tmp_persist = NULL;
     module->reduce_tmp_persist_size = 0;
+    module->allgather_reorder_persist = NULL;
+    module->allgather_reorder_persist_size = 0;
+    module->allgather_gather_persist = NULL;
+    module->allgather_gather_persist_size = 0;
     module->is_mapbycore = false;
     module->storage_initialized = false;
     for( i = 0; i < NB_TOPO_LVL; i++ ) {
@@ -278,6 +282,14 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     free(module->reduce_tmp_persist);
     module->reduce_tmp_persist = NULL;
     module->reduce_tmp_persist_size = 0;
+
+    free(module->allgather_reorder_persist);
+    module->allgather_reorder_persist = NULL;
+    module->allgather_reorder_persist_size = 0;
+
+    free(module->allgather_gather_persist);
+    module->allgather_gather_persist = NULL;
+    module->allgather_gather_persist_size = 0;
 
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -22,6 +22,113 @@
 #include "coll_han.h"
 #include "coll_han_dynamic.h"
 
+/*
+ * Fragment item class for freelist-based buffer pool (64KB)
+ */
+static void fragment_item_constructor(fragment_item_t *item)
+{
+    item->buffer = NULL;
+    if (mca_coll_han_component.han_fragment_size > 0) {
+        if (posix_memalign(&item->buffer, 4096, mca_coll_han_component.han_fragment_size) != 0) {
+            item->buffer = NULL;
+        }
+    }
+}
+
+static void fragment_item_destructor(fragment_item_t *item)
+{
+    if (item->buffer) {
+        free(item->buffer);
+        item->buffer = NULL;
+    }
+}
+
+OBJ_CLASS_INSTANCE(fragment_item_t,
+                   opal_free_list_item_t,
+                   fragment_item_constructor,
+                   fragment_item_destructor);
+
+/*
+ * Large fragment item class for freelist-based buffer pool (1MB)
+ */
+static void large_fragment_item_constructor(large_fragment_item_t *item)
+{
+    item->buffer = NULL;
+    if (mca_coll_han_component.han_large_fragment_size > 0) {
+        if (posix_memalign(&item->buffer, 4096, mca_coll_han_component.han_large_fragment_size) != 0) {
+            item->buffer = NULL;
+        }
+    }
+}
+
+static void large_fragment_item_destructor(large_fragment_item_t *item)
+{
+    if (item->buffer) {
+        free(item->buffer);
+        item->buffer = NULL;
+    }
+}
+
+OBJ_CLASS_INSTANCE(large_fragment_item_t,
+                   opal_free_list_item_t,
+                   large_fragment_item_constructor,
+                   large_fragment_item_destructor);
+
+/**
+ * Initialize fragment freelists on a HAN module.
+ */
+#define HAN_FRAG_INITIAL_COUNT   32
+#define HAN_FRAG_MAX_COUNT       (-1)  /* unlimited */
+#define HAN_FRAG_GROWTH_BATCH    64
+#define HAN_LARGE_FRAG_INITIAL    4
+#define HAN_LARGE_FRAG_MAX       20
+#define HAN_LARGE_FRAG_GROWTH     4
+
+static void han_init_freelists(mca_coll_han_module_t *han_module)
+{
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        return;
+    }
+    if (mca_coll_han_component.han_fragment_size > 0) {
+        OBJ_CONSTRUCT(&han_module->fragment_freelist, opal_free_list_t);
+        opal_free_list_init(&han_module->fragment_freelist,
+                            sizeof(fragment_item_t),
+                            opal_cache_line_size,
+                            OBJ_CLASS(fragment_item_t),
+                            0, opal_cache_line_size,
+                            HAN_FRAG_INITIAL_COUNT,
+                            HAN_FRAG_MAX_COUNT,
+                            HAN_FRAG_GROWTH_BATCH,
+                            NULL, 0, NULL, NULL, NULL);
+    }
+    OBJ_CONSTRUCT(&han_module->large_fragment_freelist, opal_free_list_t);
+    if (mca_coll_han_component.han_large_fragment_size > 0) {
+        opal_free_list_init(&han_module->large_fragment_freelist,
+                            sizeof(large_fragment_item_t),
+                            opal_cache_line_size,
+                            OBJ_CLASS(large_fragment_item_t),
+                            0, opal_cache_line_size,
+                            HAN_LARGE_FRAG_INITIAL,
+                            HAN_LARGE_FRAG_MAX,
+                            HAN_LARGE_FRAG_GROWTH,
+                            NULL, 0, NULL, NULL, NULL);
+    }
+}
+
+/**
+ * Destroy fragment freelists on a HAN module.
+ */
+static void han_destroy_freelists(mca_coll_han_module_t *han_module)
+{
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        return;
+    }
+    if (mca_coll_han_component.han_fragment_size > 0) {
+        OBJ_DESTRUCT(&han_module->fragment_freelist);
+    }
+    OBJ_DESTRUCT(&han_module->large_fragment_freelist);
+}
+
 
 /*
  *@file
@@ -90,6 +197,8 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     }
 
     module->dynamic_errors = 0;
+    module->alltoall_bounce = NULL;
+    module->alltoall_bounce_size = 0;
 
     han_module_clear(module);
 
@@ -143,6 +252,10 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
             ompi_comm_free(&(module->sub_comm[i]));
         }
     }
+
+    free(module->alltoall_bounce);
+    module->alltoall_bounce = NULL;
+    module->alltoall_bounce_size = 0;
 
     han_module_clear(module);
 }
@@ -300,6 +413,8 @@ mca_coll_han_module_enable(mca_coll_base_module_t * module,
 {
     mca_coll_han_module_t * han_module = (mca_coll_han_module_t*) module;
 
+    han_init_freelists(han_module);
+
     HAN_INSTALL_COLL_API(comm, han_module, alltoall);
     HAN_INSTALL_COLL_API(comm, han_module, alltoallv);
     HAN_INSTALL_COLL_API(comm, han_module, allgather);
@@ -328,6 +443,8 @@ mca_coll_han_module_disable(mca_coll_base_module_t * module,
                             struct ompi_communicator_t *comm)
 {
     mca_coll_han_module_t * han_module = (mca_coll_han_module_t *) module;
+
+    han_destroy_freelists(han_module);
 
     HAN_UNINSTALL_COLL_API(comm, han_module, alltoall);
     HAN_UNINSTALL_COLL_API(comm, han_module, alltoallv);

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -86,12 +86,13 @@ OBJ_CLASS_INSTANCE(large_fragment_item_t,
 
 static void han_init_freelists(mca_coll_han_module_t *han_module)
 {
+    int rc;
     if (!mca_coll_han_component.han_use_persist_buffers) {
         return;
     }
     if (mca_coll_han_component.han_fragment_size > 0) {
         OBJ_CONSTRUCT(&han_module->fragment_freelist, opal_free_list_t);
-        opal_free_list_init(&han_module->fragment_freelist,
+        rc = opal_free_list_init(&han_module->fragment_freelist,
                             sizeof(fragment_item_t),
                             opal_cache_line_size,
                             OBJ_CLASS(fragment_item_t),
@@ -100,10 +101,17 @@ static void han_init_freelists(mca_coll_han_module_t *han_module)
                             HAN_FRAG_MAX_COUNT,
                             HAN_FRAG_GROWTH_BATCH,
                             NULL, 0, NULL, NULL, NULL);
+        if (OPAL_SUCCESS != rc) {
+            OBJ_DESTRUCT(&han_module->fragment_freelist);
+            opal_output_verbose(0, mca_coll_han_component.han_output,
+                "coll:han: fragment freelist init failed, disabling persist buffers\n");
+            mca_coll_han_component.han_use_persist_buffers = false;
+            return;
+        }
     }
     OBJ_CONSTRUCT(&han_module->large_fragment_freelist, opal_free_list_t);
     if (mca_coll_han_component.han_large_fragment_size > 0) {
-        opal_free_list_init(&han_module->large_fragment_freelist,
+        rc = opal_free_list_init(&han_module->large_fragment_freelist,
                             sizeof(large_fragment_item_t),
                             opal_cache_line_size,
                             OBJ_CLASS(large_fragment_item_t),
@@ -112,6 +120,16 @@ static void han_init_freelists(mca_coll_han_module_t *han_module)
                             HAN_LARGE_FRAG_MAX,
                             HAN_LARGE_FRAG_GROWTH,
                             NULL, 0, NULL, NULL, NULL);
+        if (OPAL_SUCCESS != rc) {
+            OBJ_DESTRUCT(&han_module->large_fragment_freelist);
+            if (mca_coll_han_component.han_fragment_size > 0) {
+                OBJ_DESTRUCT(&han_module->fragment_freelist);
+            }
+            opal_output_verbose(0, mca_coll_han_component.han_output,
+                "coll:han: large fragment freelist init failed, disabling persist buffers\n");
+            mca_coll_han_component.han_use_persist_buffers = false;
+            return;
+        }
     }
 }
 
@@ -187,20 +205,10 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     module->cached_up_comms = NULL;
     module->cached_vranks = NULL;
     module->cached_topo = NULL;
-    module->cached_gather_buf = NULL;
-    module->cached_gather_buf_size = 0;
-    module->scatter_persist = NULL;
-    module->scatter_persist_size = 0;
-    module->scatter_reorder_persist = NULL;
-    module->scatter_reorder_persist_size = 0;
-    module->gather_reorder_persist = NULL;
-    module->gather_reorder_persist_size = 0;
-    module->reduce_tmp_persist = NULL;
-    module->reduce_tmp_persist_size = 0;
-    module->allgather_reorder_persist = NULL;
-    module->allgather_reorder_persist_size = 0;
-    module->allgather_gather_persist = NULL;
-    module->allgather_gather_persist_size = 0;
+    module->scratch_buf[0] = NULL;
+    module->scratch_buf_size[0] = 0;
+    module->scratch_buf[1] = NULL;
+    module->scratch_buf_size[1] = 0;
     module->is_mapbycore = false;
     module->storage_initialized = false;
     for( i = 0; i < NB_TOPO_LVL; i++ ) {
@@ -211,8 +219,6 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     }
 
     module->dynamic_errors = 0;
-    module->alltoall_bounce = NULL;
-    module->alltoall_bounce_size = 0;
 
     han_module_clear(module);
 
@@ -261,45 +267,18 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
         free(module->cached_topo);
         module->cached_topo = NULL;
     }
-    if (module->cached_gather_buf != NULL) {
-        free(module->cached_gather_buf);
-        module->cached_gather_buf = NULL;
-        module->cached_gather_buf_size = 0;
-    }
-
-    free(module->scatter_persist);
-    module->scatter_persist = NULL;
-    module->scatter_persist_size = 0;
-
-    free(module->scatter_reorder_persist);
-    module->scatter_reorder_persist = NULL;
-    module->scatter_reorder_persist_size = 0;
-
-    free(module->gather_reorder_persist);
-    module->gather_reorder_persist = NULL;
-    module->gather_reorder_persist_size = 0;
-
-    free(module->reduce_tmp_persist);
-    module->reduce_tmp_persist = NULL;
-    module->reduce_tmp_persist_size = 0;
-
-    free(module->allgather_reorder_persist);
-    module->allgather_reorder_persist = NULL;
-    module->allgather_reorder_persist_size = 0;
-
-    free(module->allgather_gather_persist);
-    module->allgather_gather_persist = NULL;
-    module->allgather_gather_persist_size = 0;
+    free(module->scratch_buf[0]);
+    module->scratch_buf[0] = NULL;
+    module->scratch_buf_size[0] = 0;
+    free(module->scratch_buf[1]);
+    module->scratch_buf[1] = NULL;
+    module->scratch_buf_size[1] = 0;
 
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {
             ompi_comm_free(&(module->sub_comm[i]));
         }
     }
-
-    free(module->alltoall_bounce);
-    module->alltoall_bounce = NULL;
-    module->alltoall_bounce_size = 0;
 
     han_module_clear(module);
 }

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -187,6 +187,16 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     module->cached_up_comms = NULL;
     module->cached_vranks = NULL;
     module->cached_topo = NULL;
+    module->cached_gather_buf = NULL;
+    module->cached_gather_buf_size = 0;
+    module->scatter_persist = NULL;
+    module->scatter_persist_size = 0;
+    module->scatter_reorder_persist = NULL;
+    module->scatter_reorder_persist_size = 0;
+    module->gather_reorder_persist = NULL;
+    module->gather_reorder_persist_size = 0;
+    module->reduce_tmp_persist = NULL;
+    module->reduce_tmp_persist_size = 0;
     module->is_mapbycore = false;
     module->storage_initialized = false;
     for( i = 0; i < NB_TOPO_LVL; i++ ) {
@@ -247,6 +257,28 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
         free(module->cached_topo);
         module->cached_topo = NULL;
     }
+    if (module->cached_gather_buf != NULL) {
+        free(module->cached_gather_buf);
+        module->cached_gather_buf = NULL;
+        module->cached_gather_buf_size = 0;
+    }
+
+    free(module->scatter_persist);
+    module->scatter_persist = NULL;
+    module->scatter_persist_size = 0;
+
+    free(module->scatter_reorder_persist);
+    module->scatter_reorder_persist = NULL;
+    module->scatter_reorder_persist_size = 0;
+
+    free(module->gather_reorder_persist);
+    module->gather_reorder_persist = NULL;
+    module->gather_reorder_persist_size = 0;
+
+    free(module->reduce_tmp_persist);
+    module->reduce_tmp_persist = NULL;
+    module->reduce_tmp_persist_size = 0;
+
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {
             ompi_comm_free(&(module->sub_comm[i]));

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -209,6 +209,8 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
     module->scratch_buf_size[0] = 0;
     module->scratch_buf[1] = NULL;
     module->scratch_buf_size[1] = 0;
+    memset(&module->a2a_cache, 0, sizeof(module->a2a_cache));
+    memset(&module->a2av_cache, 0, sizeof(module->a2av_cache));
     module->is_mapbycore = false;
     module->storage_initialized = false;
     for( i = 0; i < NB_TOPO_LVL; i++ ) {
@@ -273,6 +275,33 @@ mca_coll_han_module_destruct(mca_coll_han_module_t * module)
     free(module->scratch_buf[1]);
     module->scratch_buf[1] = NULL;
     module->scratch_buf_size[1] = 0;
+
+    /* Alltoall cache cleanup */
+    free(module->a2a_cache.bounce);
+    if (module->a2a_cache.map_ctx) {
+        if (mca_smsc) {
+            for (i = 0; i < module->a2a_cache.cached_low_size; i++) {
+                if (module->a2a_cache.map_ctx[i])
+                    mca_smsc->unmap_peer_region(module->a2a_cache.map_ctx[i]);
+            }
+        }
+        free(module->a2a_cache.map_ctx);
+    }
+    free(module->a2a_cache.low_bufs);
+    free(module->a2a_cache.gather_buf);
+    free(module->a2a_cache.recv_buf);
+
+    /* Alltoallv cache cleanup */
+    free(module->a2av_cache.serial_buf);
+    free(module->a2av_cache.gather_out);
+    free(module->a2av_cache.peers);
+    free(module->a2av_cache.peer_types);
+    free(module->a2av_cache.send_from);
+    free(module->a2av_cache.recv_to);
+    free(module->a2av_cache.send_counts);
+    free(module->a2av_cache.recv_counts);
+    free(module->a2av_cache.send_types);
+    free(module->a2av_cache.recv_types);
 
     for(i=0 ; i<NB_TOPO_LVL ; i++) {
         if(NULL != module->sub_comm[i]) {

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -143,17 +143,16 @@ mca_coll_han_reduce_intra(const void *sbuf,
 
     /* node leaders require a buffer to store intermediate results */
     void *tmp_rbuf = NULL;
-    void *tmp_rbuf_to_free = NULL;
+    bool is_tmp_rbuf = false;
     if (w_rank == root) {
         /* the global root already has one */
         tmp_rbuf = rbuf;
     } else if (low_rank == root_low_rank) {
         /* allocate 2 temporary segments on node leaders that are not the global root */
-        tmp_rbuf = malloc(2*extent*seg_count);
-        if (NULL == tmp_rbuf) {
-            return OMPI_ERR_OUT_OF_RESOURCE;
-        }
-        tmp_rbuf_to_free = tmp_rbuf;
+        size_t needed = 2*extent*seg_count;
+        tmp_rbuf = malloc(needed);
+        if (NULL == tmp_rbuf) return OMPI_ERR_OUT_OF_RESOURCE;
+        is_tmp_rbuf = true;
     }
 
     /* Create t0 tasks for the first segment */
@@ -163,7 +162,7 @@ mca_coll_han_reduce_intra(const void *sbuf,
     mca_coll_han_set_reduce_args(t, t0, (char *) sbuf, (char *) tmp_rbuf, seg_count, dtype,
                                  op, root_up_rank, root_low_rank, up_comm, low_comm,
                                  num_segments, 0, w_rank, count - (num_segments - 1) * seg_count,
-                                 low_rank != root_low_rank, (NULL != tmp_rbuf_to_free));
+                                 low_rank != root_low_rank, is_tmp_rbuf);
     /* Init the first task */
     init_task(t0, mca_coll_han_reduce_t0_task, (void *) t);
     issue_task(t0);
@@ -195,7 +194,9 @@ mca_coll_han_reduce_intra(const void *sbuf,
     }
 
     free(t);
-    free(tmp_rbuf_to_free);
+    if (is_tmp_rbuf) {
+        free(tmp_rbuf);
+    }
 
     return OMPI_SUCCESS;
 
@@ -296,7 +297,8 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
     int ret;
     int *vranks, low_rank, low_size;
     ptrdiff_t rsize, rgap = 0;
-    void * tmp_buf;
+    void * tmp_buf = NULL;
+    opal_free_list_item_t *tmp_fl_item = NULL;
 
     mca_coll_han_module_t *han_module = (mca_coll_han_module_t *)module;
 
@@ -345,11 +347,25 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
     /* Get root ranks for low and up comms */
     mca_coll_han_get_ranks(vranks, root, low_size, &root_low_rank, &root_up_rank);
 
+    /* Freelist-backed simple reduce: low_comm reduce → up_comm reduce */
     if (root_low_rank == low_rank && w_rank != root) {
         rsize = opal_datatype_span(&dtype->super, (int64_t)count, &rgap);
-        tmp_buf = malloc(rsize);
-        if (NULL == tmp_buf) {
-            return OMPI_ERROR;
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            size_t frag_size = mca_coll_han_component.han_fragment_size;
+            if (frag_size > 0 && (size_t)rsize <= frag_size) {
+                fragment_item_t *fi = (fragment_item_t*)opal_free_list_get(
+                                          &han_module->fragment_freelist);
+                if (fi != NULL) {
+                    tmp_buf = (char *)fi->buffer;
+                    tmp_fl_item = (opal_free_list_item_t*)fi;
+                }
+            }
+        }
+        if (tmp_buf == NULL) {
+            tmp_buf = malloc(rsize);
+            if (NULL == tmp_buf) {
+                return OMPI_ERROR;
+            }
         }
     } else {
         /* global root rbuf is valid, local non-root do not need buffers */
@@ -364,7 +380,11 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
                 low_comm, low_comm->c_coll->coll_reduce_module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)){
         if (root_low_rank == low_rank && w_rank != root){
-            free(tmp_buf);
+            if (tmp_fl_item != NULL) {
+                opal_free_list_return(&han_module->fragment_freelist, tmp_fl_item);
+            } else {
+                free(tmp_buf);
+            }
         }
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "HAN/REDUCE: low comm reduce failed. "
@@ -378,7 +398,11 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
             ret = up_comm->c_coll->coll_reduce((char *)tmp_buf, NULL,
                         count, dtype, op, root_up_rank,
                         up_comm, up_comm->c_coll->coll_reduce_module);
-            free(tmp_buf);
+            if (tmp_fl_item != NULL) {
+                opal_free_list_return(&han_module->fragment_freelist, tmp_fl_item);
+            } else {
+                free(tmp_buf);
+            }
         } else {
             /* Take advantage of any optimisation made for IN_PLACE
              * communications */

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -112,8 +112,6 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
     args->noop = noop;
     args->req = req;
     args->han_module = han_module;
-    args->inter_fl_item = NULL;
-    args->inter_fl_src = HAN_ALLOC_MALLOC;
     args->reorder_fl_item = NULL;
     args->reorder_fl_src = HAN_ALLOC_MALLOC;
 }
@@ -214,6 +212,9 @@ mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
             } else {
                 reorder_buf = (char *)malloc(ssize);
             }
+            if (NULL == reorder_buf) {
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
             reorder_sbuf = reorder_buf - sgap;
             for (int i = 0; i < up_size; i++) {
                 for (int j = 0; j < low_size; j++) {
@@ -278,18 +279,11 @@ int mca_coll_han_scatter_us_task(void *task_args)
 
         /* Inter-node receive buffer: persistent realloc-to-HWM or malloc */
         char *tmp_buf;
-        if (mca_coll_han_component.han_use_persist_buffers) {
-            if (t->han_module->scatter_persist_size < (size_t)rsize) {
-                char *p = realloc(t->han_module->scatter_persist, rsize);
-                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                t->han_module->scatter_persist = p;
-                t->han_module->scatter_persist_size = rsize;
-            }
-            tmp_buf = t->han_module->scatter_persist;
-        } else {
-            tmp_buf = (char *)malloc(rsize);
-            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
-        }
+        tmp_buf = han_scratch_or_malloc(&t->han_module->scratch_buf[1],
+                                        &t->han_module->scratch_buf_size[1],
+                                        (size_t)rsize,
+                                        mca_coll_han_component.han_use_persist_buffers);
+        if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
         char *tmp_rbuf = tmp_buf - rgap;
 
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
@@ -438,26 +432,19 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                                  "[%d]: Han scatter: needs reordering or compacting: ", w_rank));
 
             size_t reorder_size = (size_t)block_size * w_size;
-            if (mca_coll_han_component.han_use_persist_buffers) {
-                if (han_module->scatter_reorder_persist_size < reorder_size) {
-                    char *p = realloc(han_module->scatter_reorder_persist, reorder_size);
-                    if (NULL == p) return OMPI_ERROR;
-                    han_module->scatter_reorder_persist = p;
-                    han_module->scatter_reorder_persist_size = reorder_size;
-                }
-                reorder_buf = han_module->scatter_reorder_persist;
-            } else {
-                reorder_buf = (char *)malloc(reorder_size);
-                if (NULL == reorder_buf) return OMPI_ERROR;
-            }
+            reorder_buf = han_scratch_or_malloc(&han_module->scratch_buf[0],
+                                                 &han_module->scratch_buf_size[0],
+                                                 reorder_size,
+                                                 mca_coll_han_component.han_use_persist_buffers);
+            if (NULL == reorder_buf) return OMPI_ERROR;
 
             ptrdiff_t extent, block_extent;
             ompi_datatype_type_extent(dtype, &extent);
             block_extent = extent * (ptrdiff_t)count;
 
-            for (int i = 0; i < w_size; ++i) {
-                ompi_datatype_sndrcv((char *)sbuf + block_extent * topo[2 * i + 1], count, dtype,
-                                     reorder_buf + block_size * i, block_size, MPI_BYTE);
+            for(int i = 0 ; i < w_size ; ++i){
+                ompi_datatype_sndrcv((char*)sbuf + block_extent*topo[2*i+1], count, dtype,
+                                     reorder_buf + block_size*i, block_size, MPI_BYTE);
             }
             dtype = MPI_BYTE;
             count = block_size;
@@ -492,13 +479,10 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
                 tmp_buf = NULL;
             }
             if (tmp_fl_src == HAN_ALLOC_MALLOC) {
-                if (han_module->scatter_persist_size < tmp_total) {
-                    char *p = realloc(han_module->scatter_persist, tmp_total);
-                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
-                    han_module->scatter_persist = p;
-                    han_module->scatter_persist_size = tmp_total;
-                }
-                tmp_buf = han_module->scatter_persist;
+                tmp_buf = han_scratch_alloc(&han_module->scratch_buf[1],
+                                                &han_module->scratch_buf_size[1],
+                                                tmp_total);
+                if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
             }
         } else {
             tmp_buf = (char *)malloc(tmp_total);

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2022      IBM Corporation. All rights reserved
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +28,51 @@
 static int mca_coll_han_scatter_us_task(void *task_args);
 static int mca_coll_han_scatter_ls_task(void *task_args);
 
+/**
+ * Allocate from tiered freelists (large then small), falling back to malloc.
+ */
+static char *scatter_alloc_tiered(opal_free_list_t *large_fl, size_t large_size,
+                                  opal_free_list_t *small_fl, size_t small_size,
+                                  size_t needed, opal_free_list_item_t **item,
+                                  int *src)
+{
+    *item = NULL;
+    *src = HAN_ALLOC_MALLOC;
+    if (large_size > 0 && needed <= large_size) {
+        large_fragment_item_t *lfi = (large_fragment_item_t *)opal_free_list_get(large_fl);
+        if (lfi != NULL) {
+            *item = (opal_free_list_item_t *)lfi;
+            *src = HAN_ALLOC_LARGE;
+            return (char *)lfi->buffer;
+        }
+    }
+    if (small_size > 0 && needed <= small_size) {
+        fragment_item_t *fi = (fragment_item_t *)opal_free_list_get(small_fl);
+        if (fi != NULL) {
+            *item = (opal_free_list_item_t *)fi;
+            *src = HAN_ALLOC_SMALL;
+            return (char *)fi->buffer;
+        }
+    }
+    return (char *)malloc(needed);
+}
+
+/**
+ * Free a tiered allocation based on src tag.
+ */
+static void scatter_free_tiered(opal_free_list_t *large_fl,
+                                opal_free_list_t *small_fl,
+                                opal_free_list_item_t *item, char *buf, int src)
+{
+    if (src == HAN_ALLOC_LARGE) {
+        opal_free_list_return(large_fl, item);
+    } else if (src == HAN_ALLOC_SMALL) {
+        opal_free_list_return(small_fl, item);
+    } else {
+        free(buf);
+    }
+}
+
 /* Only work with regular situation (each node has equal number of processes) */
 
 static inline void
@@ -44,7 +91,8 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
                               int root_low_rank,
                               struct ompi_communicator_t *up_comm,
                               struct ompi_communicator_t *low_comm,
-                              int w_rank, bool noop, ompi_request_t * req)
+                              int w_rank, bool noop, ompi_request_t * req,
+                              mca_coll_han_module_t *han_module)
 {
     args->cur_task = cur_task;
     args->sbuf = sbuf;
@@ -63,6 +111,11 @@ mca_coll_han_set_scatter_args(mca_coll_han_scatter_args_t * args,
     args->w_rank = w_rank;
     args->noop = noop;
     args->req = req;
+    args->han_module = han_module;
+    args->inter_fl_item = NULL;
+    args->inter_fl_src = HAN_ALLOC_MALLOC;
+    args->reorder_fl_item = NULL;
+    args->reorder_fl_src = HAN_ALLOC_MALLOC;
 }
 
 /*
@@ -138,6 +191,8 @@ mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
      */
     char *reorder_buf = NULL;
     char *reorder_sbuf = NULL;
+    opal_free_list_item_t *reorder_fl_item = NULL;
+    int reorder_fl_src = HAN_ALLOC_MALLOC;
 
     if (w_rank == root) {
         /* If the processes are mapped-by core, no need to reorder */
@@ -149,7 +204,16 @@ mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
             ptrdiff_t ssize, sgap = 0, sextent;
             ompi_datatype_type_extent(sdtype, &sextent);
             ssize = opal_datatype_span(&sdtype->super, (int64_t) scount * w_size, &sgap);
-            reorder_buf = (char *) malloc(ssize);
+            if (mca_coll_han_component.han_use_persist_buffers) {
+                reorder_buf = scatter_alloc_tiered(
+                    &han_module->large_fragment_freelist,
+                    mca_coll_han_component.han_large_fragment_size,
+                    &han_module->fragment_freelist,
+                    mca_coll_han_component.han_fragment_size,
+                    ssize, &reorder_fl_item, &reorder_fl_src);
+            } else {
+                reorder_buf = (char *)malloc(ssize);
+            }
             reorder_sbuf = reorder_buf - sgap;
             for (int i = 0; i < up_size; i++) {
                 for (int j = 0; j < low_size; j++) {
@@ -177,7 +241,9 @@ mca_coll_han_scatter_intra(const void *sbuf, size_t scount,
     mca_coll_han_set_scatter_args(us_args, us, reorder_sbuf, NULL, reorder_buf, scount, sdtype,
                                   (char *) rbuf, rcount, rdtype, root, root_up_rank, root_low_rank,
                                   up_comm, low_comm, w_rank, low_rank != root_low_rank,
-                                  temp_request);
+                                  temp_request, han_module);
+    us_args->reorder_fl_item = reorder_fl_item;
+    us_args->reorder_fl_src = reorder_fl_src;
     /* Init us task */
     init_task(us, mca_coll_han_scatter_us_task, (void *) (us_args));
     /* Issure us task */
@@ -209,8 +275,23 @@ int mca_coll_han_scatter_us_task(void *task_args)
         int low_size = ompi_comm_size(t->low_comm);
         ptrdiff_t rsize, rgap = 0;
         rsize = opal_datatype_span(&dtype->super, (int64_t) count * low_size, &rgap);
-        char *tmp_buf = (char *) malloc(rsize);
+
+        /* Inter-node receive buffer: persistent realloc-to-HWM or malloc */
+        char *tmp_buf;
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            if (t->han_module->scatter_persist_size < (size_t)rsize) {
+                char *p = realloc(t->han_module->scatter_persist, rsize);
+                if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                t->han_module->scatter_persist = p;
+                t->han_module->scatter_persist_size = rsize;
+            }
+            tmp_buf = t->han_module->scatter_persist;
+        } else {
+            tmp_buf = (char *)malloc(rsize);
+            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+        }
         char *tmp_rbuf = tmp_buf - rgap;
+
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "[%d] Han Scatter:  us scatter\n", t->w_rank));
         /* Inter node scatter */
@@ -223,9 +304,18 @@ int mca_coll_han_scatter_us_task(void *task_args)
         t->scount = count;
     }
 
+    /* Free reorder buffer (root only) */
     if (t->sbuf_reorder_free != NULL && t->root == t->w_rank) {
-        free(t->sbuf_reorder_free);
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            scatter_free_tiered(&t->han_module->large_fragment_freelist,
+                                &t->han_module->fragment_freelist,
+                                t->reorder_fl_item, t->sbuf_reorder_free,
+                                t->reorder_fl_src);
+        } else {
+            free(t->sbuf_reorder_free);
+        }
         t->sbuf_reorder_free = NULL;
+        t->reorder_fl_item = NULL;
     }
     /* Create ls tasks for the current union segment */
     mca_coll_task_t *ls = t->cur_task;
@@ -249,9 +339,12 @@ int mca_coll_han_scatter_ls_task(void *task_args)
                                       t->rcount, t->rdtype, t->root_low_rank, t->low_comm,
                                       t->low_comm->c_coll->coll_scatter_module);
 
-    if (t->sbuf_inter_free != NULL && t->noop != true) {
-        free(t->sbuf_inter_free);
-        t->sbuf_inter_free = NULL;
+    /* Free inter-node buffer when not using persist buffers */
+    if (!mca_coll_han_component.han_use_persist_buffers) {
+        if (t->sbuf_inter_free != NULL && !t->noop) {
+            free(t->sbuf_inter_free);
+            t->sbuf_inter_free = NULL;
+        }
     }
     OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output, "[%d] Han Scatter:  ls finish\n",
                          t->w_rank));
@@ -308,7 +401,7 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
     int low_rank = ompi_comm_rank(low_comm);
     int low_size = ompi_comm_size(low_comm);
     /* Get root ranks for low and up comms */
-    int root_low_rank, root_up_rank; /* root ranks for both sub-communicators */
+    int root_low_rank, root_up_rank;
     mca_coll_han_get_ranks(vranks, root, low_size, &root_low_rank, &root_up_rank);
 
     if (w_rank == root) {
@@ -323,7 +416,8 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
      * if the processes are mapped-by core, no need to reorder:
      * distribution of ranks on core first and node next,
      * in a increasing order for both patterns */
-    char *reorder_buf = NULL;  // allocated memory
+    char *reorder_buf = NULL;
+    bool reorder_is_sbuf = false;
     size_t block_size;
 
     ompi_datatype_type_size(dtype, &block_size);
@@ -337,73 +431,110 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
             OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                                  "[%d]: Han scatter: no need to reorder: ", w_rank));
             reorder_buf = (char *)sbuf;
+            reorder_is_sbuf = true;
         } else {
             /* Data must be copied, let's be efficient packing it */
             OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                                  "[%d]: Han scatter: needs reordering or compacting: ", w_rank));
 
-            reorder_buf = malloc(block_size * w_size);
-            if ( NULL == reorder_buf){
-                return OMPI_ERROR;
+            size_t reorder_size = (size_t)block_size * w_size;
+            if (mca_coll_han_component.han_use_persist_buffers) {
+                if (han_module->scatter_reorder_persist_size < reorder_size) {
+                    char *p = realloc(han_module->scatter_reorder_persist, reorder_size);
+                    if (NULL == p) return OMPI_ERROR;
+                    han_module->scatter_reorder_persist = p;
+                    han_module->scatter_reorder_persist_size = reorder_size;
+                }
+                reorder_buf = han_module->scatter_reorder_persist;
+            } else {
+                reorder_buf = (char *)malloc(reorder_size);
+                if (NULL == reorder_buf) return OMPI_ERROR;
             }
 
-            /** Reorder and packing:
-             * Suppose, the message is 0 1 2 3 4 5 6 7 but the processes are
-             * mapped on 2 nodes, for example |0 2 4 6| |1 3 5 7|. The messages to
-             * leaders must be 0 2 4 6 and 1 3 5 7.
-             * So the upper scatter must send 0 2 4 6 1 3 5 7.
-             * In general, the topo[i*topolevel +1]  must be taken.
-             */
             ptrdiff_t extent, block_extent;
             ompi_datatype_type_extent(dtype, &extent);
             block_extent = extent * (ptrdiff_t)count;
 
-            for(int i = 0 ; i < w_size ; ++i){
-                ompi_datatype_sndrcv((char*)sbuf + block_extent*topo[2*i+1], count, dtype,
-                                     reorder_buf + block_size*i, block_size, MPI_BYTE);
+            for (int i = 0; i < w_size; ++i) {
+                ompi_datatype_sndrcv((char *)sbuf + block_extent * topo[2 * i + 1], count, dtype,
+                                     reorder_buf + block_size * i, block_size, MPI_BYTE);
             }
             dtype = MPI_BYTE;
             count = block_size;
         }
     }
 
-    /* allocate the intermediary buffer
-     * to scatter from leaders on the low sub communicators */
-    char *tmp_buf = NULL; // allocated memory
-    if (low_rank == root_low_rank) {
-        tmp_buf = (char *) malloc(block_size * low_size);
+    /*
+     * Persistent inter-node receive buffer.
+     * Grows to high-water mark via realloc so the virtual address
+     * stabilises after the first large call, keeping the NIC MR cache
+     * entry valid across iterations.
+     *
+     * When the total fits in a freelist item, use the freelist instead
+     * (the item address is also stable across get/return cycles).
+     */
+    size_t tmp_total = block_size * low_size;
+    char *tmp_buf = NULL;
+    opal_free_list_item_t *tmp_fl_item = NULL;
+    int tmp_fl_src = HAN_ALLOC_MALLOC;
 
-        /* 1. up scatter (internode) between node leaders */
-        up_comm->c_coll->coll_scatter((char*) reorder_buf,
-                    count * low_size,
-                    dtype,
-                    (char *)tmp_buf,
-                    block_size * low_size,
-                    MPI_BYTE,
-                    root_up_rank,
-                    up_comm,
+    if (low_rank == root_low_rank) {
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            tmp_buf = scatter_alloc_tiered(
+                &han_module->large_fragment_freelist,
+                mca_coll_han_component.han_large_fragment_size,
+                &han_module->fragment_freelist,
+                mca_coll_han_component.han_fragment_size,
+                tmp_total, &tmp_fl_item, &tmp_fl_src);
+            /* If tiered alloc fell back to malloc (src==0), use persist instead */
+            if (tmp_fl_src == HAN_ALLOC_MALLOC && tmp_buf != NULL) {
+                free(tmp_buf);
+                tmp_buf = NULL;
+            }
+            if (tmp_fl_src == HAN_ALLOC_MALLOC) {
+                if (han_module->scatter_persist_size < tmp_total) {
+                    char *p = realloc(han_module->scatter_persist, tmp_total);
+                    if (NULL == p) return OMPI_ERR_OUT_OF_RESOURCE;
+                    han_module->scatter_persist = p;
+                    han_module->scatter_persist_size = tmp_total;
+                }
+                tmp_buf = han_module->scatter_persist;
+            }
+        } else {
+            tmp_buf = (char *)malloc(tmp_total);
+            if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+
+        up_comm->c_coll->coll_scatter((char *)reorder_buf,
+                    count * low_size, dtype,
+                    tmp_buf,
+                    block_size * low_size, MPI_BYTE,
+                    root_up_rank, up_comm,
                     up_comm->c_coll->coll_scatter_module);
     }
 
-    /* 2. low scatter on nodes leaders */
-    low_comm->c_coll->coll_scatter((char *)tmp_buf,
-                     block_size,
-                     MPI_BYTE,
-                     (char*)rbuf,
-                     rcount,
-                     rdtype,
-                     root_low_rank,
-                     low_comm,
+    low_comm->c_coll->coll_scatter(tmp_buf,
+                     block_size, MPI_BYTE,
+                     (char *)rbuf, rcount, rdtype,
+                     root_low_rank, low_comm,
                      low_comm->c_coll->coll_scatter_module);
 
     if (low_rank == root_low_rank) {
-        free(tmp_buf);
-        tmp_buf = NULL;
+        if (mca_coll_han_component.han_use_persist_buffers) {
+            if (tmp_fl_src != HAN_ALLOC_MALLOC) {
+                scatter_free_tiered(&han_module->large_fragment_freelist,
+                                    &han_module->fragment_freelist,
+                                    tmp_fl_item, tmp_buf, tmp_fl_src);
+            }
+            /* persist buffer (src==0) is not freed */
+        } else {
+            free(tmp_buf);
+        }
     }
-    if (reorder_buf != sbuf) {
+
+    if (!mca_coll_han_component.han_use_persist_buffers && !reorder_is_sbuf) {
         free(reorder_buf);
     }
 
     return OMPI_SUCCESS;
-
 }

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -226,7 +226,10 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         if (need_bounce_buf) {
             ptrdiff_t ssize, sgap;
             ssize = opal_datatype_span(&rdtype->super, total_up_scounts, &sgap);
-            bounce_buf = malloc(ssize);
+            bounce_buf = han_scratch_or_malloc(
+                &han_module->scratch_buf[0],
+                &han_module->scratch_buf_size[0],
+                ssize, mca_coll_han_component.han_use_persist_buffers);
             if (!bounce_buf) {
                 err = OMPI_ERR_OUT_OF_RESOURCE;
                 goto root_out;
@@ -293,7 +296,7 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         if (up_peer_ub) {
             free(up_peer_ub);
         }
-        if (bounce_buf) {
+        if (bounce_buf && !mca_coll_han_component.han_use_persist_buffers) {
             free(bounce_buf);
         }
 
@@ -355,7 +358,10 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
         total_rsize += low_scounts[i];
     }
 
-    tmp_buf = (char *) malloc(total_rsize); /* tmp_buf is still valid if total_rsize is 0 */
+    tmp_buf = han_scratch_or_malloc(
+        &han_module->scratch_buf[1],
+        &han_module->scratch_buf_size[1],
+        total_rsize, mca_coll_han_component.han_use_persist_buffers);
     if (!tmp_buf) {
         err = OMPI_ERR_OUT_OF_RESOURCE;
         goto node_leader_out;
@@ -382,7 +388,7 @@ node_leader_out:
     if (low_displs) {
         free(low_displs);
     }
-    if (tmp_buf) {
+    if (tmp_buf && !mca_coll_han_component.han_use_persist_buffers) {
         free(tmp_buf);
     }
 


### PR DESCRIPTION
Backport of PRs #13782 and #13824 from main to v6.0.x.

  Adds persistent buffer reuse (realloc-to-HWM) and SMSC/allreduce caching
  for HAN collectives, gated behind `coll_han_use_persist_buffers` (default: true).

  Performance gains on a Graviton (2N, 64ppn, OSU benchmarks):
  - Scatter: 2.5-2.6× at 512KB-4MB
  - Gatherv: 2.2-2.3× at 512KB-4MB
  - Scatterv: 1.9-2.0× at 512KB-4MB
  - Allgather: 1.2-1.5× at 256KB-4MB
  - Alltoall/Alltoallv: 1.1-1.8× at 1B-128B (requires xpmem)

  Zero regressions at any message size.

  Original PRs:
  - #13782 (freelist + scatter/gather/reduce/allgather)
  - #13824 (scatterv/gatherv + alltoall/alltoallv)