### PR TITLE
Accelerator rocm compiler fixes

### DIFF
--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -352,7 +352,7 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
 {
     hipError_t err;
 
-    if (NULL == src || NULL == dest || size < 0) {
+    if (NULL == src || NULL == dest) {
         return OPAL_ERR_BAD_PARAM;
     }
     if (0 == size) {

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -652,8 +652,8 @@ static int mca_accelerator_rocm_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HAN
      * and the process ID for comparison.
      * We definitily need to exclude the offset component in the comparison.
      */
-    static const int rocr_ipc_handle_size = 32;
-    static const int pos = rocr_ipc_handle_size + 2*sizeof(size_t);
+    const int rocr_ipc_handle_size = 32;
+    const int pos = rocr_ipc_handle_size + 2*sizeof(size_t);
     int *pid_1 = (int *)&handle_1[pos];
     int *pid_2 = (int *)&handle_2[pos];
 


### PR DESCRIPTION
One error, one warning brought up by GCC 7.5.0. 

- There is no good reason why the variables in mca_accelerator_rocm_memcpy are static so make them local
- Don't check is `size_t` is less than zero.