### PR TITLE
comm: add NVLink-domain communicator split support

### DIFF
--- a/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
@@ -103,6 +103,12 @@ OMPI_COMM_TYPE_CLUSTER
    This type splits the communicator into subcommunicators, each of
    which belongs to the same cluster.
 
+OMPI_COMM_TYPE_NVLINK
+   This type splits the communicator into subcommunicators based on
+   the NVLink domain associated with each process. It may also be
+   requested via ``MPI_COMM_TYPE_HW_GUIDED`` with
+   ``mpi_hw_resource_type`` set to ``nvlink``.
+
 
 NOTES
 -----

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -41,6 +41,8 @@
 #include <stdio.h>
 
 #include "ompi/constants.h"
+#include "opal/mca/accelerator/accelerator.h"
+#include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/mca/pmix/pmix-internal.h"
 #include "opal/util/string_copy.h"
@@ -65,6 +67,7 @@
 struct ompi_comm_split_type_hw_guided_t {
     const char *info_value;
     int split_type;
+    bool use_for_unguided;
 };
 typedef struct ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_t;
 
@@ -74,18 +77,19 @@ typedef struct ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_t
  * the order in this array must be from largest topology class to smallest.
  */
 static const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[] = {
-    {.info_value = "cluster",  .split_type = OMPI_COMM_TYPE_CLUSTER},
-    {.info_value = "cu",       .split_type = OMPI_COMM_TYPE_CU},
-    {.info_value = "host",     .split_type = OMPI_COMM_TYPE_HOST},
-    {.info_value = "mpi_shared_memory", .split_type = MPI_COMM_TYPE_SHARED},
-    {.info_value = "board",    .split_type = OMPI_COMM_TYPE_BOARD},
-    {.info_value = "numanode", .split_type = OMPI_COMM_TYPE_NUMA},
-    {.info_value = "socket",   .split_type = OMPI_COMM_TYPE_SOCKET},
-    {.info_value = "l3cache",  .split_type = OMPI_COMM_TYPE_L3CACHE},
-    {.info_value = "l2cache",  .split_type = OMPI_COMM_TYPE_L2CACHE},
-    {.info_value = "l1cache",  .split_type = OMPI_COMM_TYPE_L1CACHE},
-    {.info_value = "core",     .split_type = OMPI_COMM_TYPE_CORE},
-    {.info_value = "hwthread", .split_type = OMPI_COMM_TYPE_HWTHREAD},
+    {.info_value = "cluster",  .split_type = OMPI_COMM_TYPE_CLUSTER,  .use_for_unguided = false},
+    {.info_value = "nvlink",   .split_type = OMPI_COMM_TYPE_NVLINK,   .use_for_unguided = false},
+    {.info_value = "cu",       .split_type = OMPI_COMM_TYPE_CU,       .use_for_unguided = true},
+    {.info_value = "host",     .split_type = OMPI_COMM_TYPE_HOST,     .use_for_unguided = true},
+    {.info_value = "mpi_shared_memory", .split_type = MPI_COMM_TYPE_SHARED, .use_for_unguided = true},
+    {.info_value = "board",    .split_type = OMPI_COMM_TYPE_BOARD,    .use_for_unguided = true},
+    {.info_value = "numanode", .split_type = OMPI_COMM_TYPE_NUMA,     .use_for_unguided = true},
+    {.info_value = "socket",   .split_type = OMPI_COMM_TYPE_SOCKET,   .use_for_unguided = true},
+    {.info_value = "l3cache",  .split_type = OMPI_COMM_TYPE_L3CACHE,  .use_for_unguided = true},
+    {.info_value = "l2cache",  .split_type = OMPI_COMM_TYPE_L2CACHE,  .use_for_unguided = true},
+    {.info_value = "l1cache",  .split_type = OMPI_COMM_TYPE_L1CACHE,  .use_for_unguided = true},
+    {.info_value = "core",     .split_type = OMPI_COMM_TYPE_CORE,     .use_for_unguided = true},
+    {.info_value = "hwthread", .split_type = OMPI_COMM_TYPE_HWTHREAD, .use_for_unguided = true},
     {.info_value = NULL},
 };
 
@@ -837,6 +841,7 @@ static int ompi_comm_split_type_get_part (ompi_group_t *group, const int split_t
         case OMPI_COMM_TYPE_CLUSTER:
             include = OPAL_PROC_ON_LOCAL_CLUSTER(locality);
             break;
+        case OMPI_COMM_TYPE_NVLINK:
         case MPI_COMM_TYPE_HW_GUIDED:
         case MPI_COMM_TYPE_HW_UNGUIDED:
         case MPI_COMM_TYPE_RESOURCE_GUIDED:
@@ -916,6 +921,270 @@ static int ompi_comm_split_verify (ompi_communicator_t *comm, int split_type, in
     free (results);
 
     return OMPI_SUCCESS;
+}
+
+static int ompi_comm_split_type_nvlink_domain_compare(const void *a, const void *b)
+{
+    return memcmp(a, b, OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN);
+}
+
+static int ompi_comm_split_type_nvlink_hex_nibble(char digit)
+{
+    if ('0' <= digit && digit <= '9') {
+        return digit - '0';
+    }
+    if ('a' <= digit && digit <= 'f') {
+        return digit - 'a' + 10;
+    }
+    if ('A' <= digit && digit <= 'F') {
+        return digit - 'A' + 10;
+    }
+    return -1;
+}
+
+static int ompi_comm_split_type_parse_nvlink_domain(
+    const char *value, opal_accelerator_cuda_nvlink_domain_t *domain)
+{
+    char uuid_string[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN + 1] = {0};
+    unsigned int clique_id;
+    int cuda_device;
+    int end = 0;
+
+    if (NULL == value ||
+        3 != sscanf(value, "cuda_device=%d,cluster_uuid=%32[0123456789abcdefABCDEF],clique_id=%u%n",
+                    &cuda_device, uuid_string, &clique_id, &end) ||
+        '\0' != value[end] ||
+        2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN != strlen(uuid_string)) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    domain->cuda_device = cuda_device;
+    domain->clique_id = (uint32_t) clique_id;
+    for (int i = 0; i < OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN; ++i) {
+        int high = ompi_comm_split_type_nvlink_hex_nibble(uuid_string[2 * i]);
+        int low = ompi_comm_split_type_nvlink_hex_nibble(uuid_string[2 * i + 1]);
+
+        if (0 > high || 0 > low) {
+            return OMPI_ERR_BAD_PARAM;
+        }
+        domain->cluster_uuid[i] = (uint8_t) ((high << 4) | low);
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int ompi_comm_split_type_get_nvlink_domain(
+    opal_accelerator_cuda_nvlink_domain_t *domain)
+{
+    char **value = NULL;
+    int var_id, rc;
+
+    domain->cuda_device = MCA_ACCELERATOR_NO_DEVICE_ID;
+    memset(domain->cluster_uuid, 0, sizeof(domain->cluster_uuid));
+    domain->clique_id = 0;
+
+    /* The CUDA accelerator owns the cache and exposes it through this
+     * read-only MCA variable. If CUDA did not register or fill it, the default
+     * no-device domain above keeps the split color MPI_UNDEFINED. */
+    var_id = mca_base_var_find("opal", "accelerator", NULL, "nvlink_domain");
+    if (0 > var_id) {
+        return OMPI_ERR_NOT_FOUND;
+    }
+
+    rc = mca_base_var_get_value(var_id, &value, NULL, NULL);
+    if (OMPI_SUCCESS != rc || NULL == value) {
+        return rc;
+    }
+
+    return ompi_comm_split_type_parse_nvlink_domain(*value, domain);
+}
+
+#if OPAL_ENABLE_DEBUG
+static void ompi_comm_split_type_nvlink_uuid_to_hex(
+    const uint8_t uuid[OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN],
+    char hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN + 1])
+{
+    static const char hex[] = "0123456789abcdef";
+
+    for (int i = 0; i < OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN; ++i) {
+        hex_uuid[2 * i] = hex[uuid[i] >> 4];
+        hex_uuid[2 * i + 1] = hex[uuid[i] & 0x0f];
+    }
+    hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN] = '\0';
+}
+#endif
+
+#define OMPI_COMM_SPLIT_TYPE_NVLINK_UUID_WORDS 4
+#define OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS OMPI_COMM_SPLIT_TYPE_NVLINK_UUID_WORDS
+#define OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_SIZE \
+    (OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS * sizeof(int))
+
+static int ompi_comm_split_type_nvlink(ompi_communicator_t *comm, int local_split_type,
+                                       opal_info_t *info, ompi_communicator_t **newcomm)
+{
+    opal_accelerator_cuda_nvlink_domain_t my_domain = {
+        .cuda_device = MCA_ACCELERATOR_NO_DEVICE_ID,
+    };
+    int my_token[OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS] = {0};
+    int *domains = NULL;
+    int local_size = ompi_comm_size(comm), remote_size = 0, max_domains;
+    int inter, send_first = 0, local_offset = 0, remote_offset = 0;
+    int color = MPI_UNDEFINED, rc = OMPI_SUCCESS;
+    bool have_domain = false;
+
+    /* The allgather payload is only the 16-byte color identifier, carried as
+     * MPI_INTs through the split-time allgather/broadcast exchange. The
+     * communicator uses the MCA-backed NVLink domain cache exactly as stored.
+     * Its default is an all-zero UUID with cuda_device set to
+     * MCA_ACCELERATOR_NO_DEVICE_ID; ranks in that state still enter the
+     * collective exchange with a zero token, but keep MPI_UNDEFINED as their
+     * split color because the default does not imply an NVLink domain. Only the
+     * CUDA accelerator may replace NVML's active single-node all-zero
+     * clusterUuid with a hostname-derived token.
+     */
+    inter = OMPI_COMM_IS_INTER(comm);
+    if (inter) {
+        remote_size = ompi_comm_remote_size(comm);
+        send_first = ompi_comm_determine_first_auto(comm);
+        if (send_first) {
+            remote_offset = local_size * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+        } else {
+            local_offset = remote_size * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+        }
+    }
+
+    max_domains = local_size + remote_size;
+    domains = malloc(max_domains * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_SIZE);
+    /* Do not add a collective allocation check here: all ranks must enter the
+     * same split-time allgather sequence. For now assume the local allocations
+     * succeed. */
+
+    if (MPI_UNDEFINED != local_split_type) {
+        (void) ompi_comm_split_type_get_nvlink_domain(&my_domain);
+        if (MCA_ACCELERATOR_NO_DEVICE_ID != my_domain.cuda_device) {
+            memcpy(my_token, my_domain.cluster_uuid,
+                   OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_SIZE);
+            have_domain = true;
+        }
+    }
+
+    rc = comm->c_coll->coll_allgather(my_token,
+                                      OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS,
+                                      MPI_INT, domains + remote_offset,
+                                      OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS,
+                                      MPI_INT, comm,
+                                      comm->c_coll->coll_allgather_module);
+    if (OMPI_SUCCESS != rc) {
+        goto failure;
+    }
+
+    if (inter) {
+        int local_root = 0 == ompi_comm_rank(comm) ? MPI_ROOT : MPI_PROC_NULL;
+        int *bcast_domains;
+        int bcast_count, bcast_root;
+
+        /* Intercommunicator allgather gives each group the peer group's tokens.
+         * Use the deterministic send_first value to establish one global order
+         * for the domains array on both groups: all ranks from the "first" side
+         * followed by all ranks from the "second" side. The allgather writes
+         * the peer block directly into its final global-order position. The two
+         * broadcasts then send each peer block back to its owning side so every
+         * process ends with an identical domains[] layout. The conditional
+         * expressions below pick the block, count, and root for each direction:
+         * first the second-side block, then the first-side block. This common
+         * order is what lets the color assignment below avoid sorting. */
+        bcast_domains = domains + (send_first ? remote_offset : local_offset);
+        bcast_count = (send_first ? remote_size : local_size)
+                      * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+        bcast_root = send_first ? local_root : 0;
+        rc = comm->c_coll->coll_bcast(bcast_domains, bcast_count, MPI_INT,
+                                      bcast_root, comm,
+                                      comm->c_coll->coll_bcast_module);
+        if (OMPI_SUCCESS != rc) {
+            goto failure;
+        }
+
+        bcast_domains = domains + (send_first ? local_offset : remote_offset);
+        bcast_count = (send_first ? local_size : remote_size)
+                      * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+        bcast_root = send_first ? 0 : local_root;
+        rc = comm->c_coll->coll_bcast(bcast_domains, bcast_count, MPI_INT,
+                                      bcast_root, comm,
+                                      comm->c_coll->coll_bcast_module);
+        if (OMPI_SUCCESS != rc) {
+            goto failure;
+        }
+    }
+
+#if OPAL_ENABLE_DEBUG
+    for (int i = 0; i < max_domains; ++i) {
+        int *domain = domains + i * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+        char hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN + 1];
+
+        ompi_comm_split_type_nvlink_uuid_to_hex((const uint8_t *) domain,
+                                                hex_uuid);
+        OPAL_OUTPUT_VERBOSE((10, ompi_comm_output, "rank %d: nvlink domain[%d] uuid=%s",
+                             ompi_comm_rank(comm), i, hex_uuid));
+    }
+#endif
+
+    if (have_domain) {
+        int unique_count = 0;
+
+        /* Build the color map in global domain order without sorting. The
+         * domains array is identical on all processes after the exchange above,
+         * so the first occurrence of each token is globally deterministic.
+         *
+         * As we scan domains[], keep the unique tokens compacted in the prefix
+         * domains[0..unique_count). A candidate token is unique only if it does
+         * not match any token already in that prefix. Once a candidate is known
+         * to be unique, check whether it is the local token before moving it
+         * into domains[unique_count]; unique_count is then exactly the color for
+         * that token. Stop as soon as the local token is assigned, because later
+         * colors do not affect this process. */
+        for (int i = 0; MPI_UNDEFINED == color && i < max_domains; ++i) {
+            int *domain = domains + i * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+            int *unique_domain = domains + unique_count * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+            bool seen = false;
+
+            for (int j = 0; j < unique_count; ++j) {
+                int *prior_domain = domains + j * OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_INTS;
+
+                if (0 == ompi_comm_split_type_nvlink_domain_compare(domain, prior_domain)) {
+                    seen = true;
+                    break;
+                }
+            }
+
+            if (seen) {
+                continue;
+            }
+
+            if (0 == ompi_comm_split_type_nvlink_domain_compare(my_token, domain)) {
+                color = unique_count;
+                /* We only need to enumerate colors up to the local process'
+                 * NVLink domain. */
+                break;
+            }
+            if (domain != unique_domain) {
+                memcpy(unique_domain, domain, OMPI_COMM_SPLIT_TYPE_NVLINK_TOKEN_SIZE);
+            }
+            ++unique_count;
+        }
+    }
+
+    free(domains);
+
+    return ompi_comm_split_with_info(comm, color, (int) my_domain.clique_id, info, newcomm,
+                                     false);
+
+failure:
+    /* Reaching this path means the split-time collective exchange failed, so
+     * the collective behavior of this function is already compromised. A future
+     * failure path should revoke the input communicator and return MPI_COMM_NULL
+     * as the new communicator. */
+    free(domains);
+    return ompi_comm_split_with_info(comm, MPI_UNDEFINED, 0, info, newcomm, false);
 }
 
 /**
@@ -1121,13 +1390,16 @@ static int ompi_comm_split_unguided(ompi_communicator_t *comm, int split_type, i
      * calling ompi_comm_split_type specifying the split type as
      * MPI_COMM_TYPE_HW_GUIDED using the next lower topology class until a
      * split results in a smaller size communicator than the input communicator.
-     * The search starts with OMPI_COMM_TYPE_CU since that is the highest possible
-     * topology class where the communicator size can be smaller than MPI_COMM_WORLD.
      */
     original_size = ompi_comm_size(unguided_comm);
     split_info = OBJ_NEW(opal_info_t);
-    i = 1;
+    i = 0;
     while (NULL != ompi_comm_split_type_hw_guided_support[i].info_value) {
+        if (!ompi_comm_split_type_hw_guided_support[i].use_for_unguided) {
+            i = i + 1;
+            continue;
+        }
+
         /* MPI_COMM_TYPE_HW_GUIDED splits require mpi_hw_resource_type to be set */
         opal_info_set(split_info, "mpi_hw_resource_type",
                       ompi_comm_split_type_hw_guided_support[i].info_value);
@@ -1310,6 +1582,8 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
         return ompi_comm_split_unguided( comm, split_type,
                                          key, need_split, no_reorder,
                                          no_undefined, info, newcomm );
+    } else if (OMPI_COMM_TYPE_NVLINK == global_split_type) {
+        return ompi_comm_split_type_nvlink(comm, split_type, info, newcomm);
     } else {
         return ompi_comm_split_type_core( comm, global_split_type, split_type,
                                           key, need_split, no_reorder,

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -30,6 +30,7 @@
  * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved
  * Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2025      UT-Battelle, LLC.  All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -868,7 +869,8 @@ enum {
   OMPI_COMM_TYPE_CLUSTER,
   MPI_COMM_TYPE_HW_UNGUIDED,
   MPI_COMM_TYPE_HW_GUIDED,
-  MPI_COMM_TYPE_RESOURCE_GUIDED
+  MPI_COMM_TYPE_RESOURCE_GUIDED,
+  OMPI_COMM_TYPE_NVLINK
 };
 #define OMPI_COMM_TYPE_NODE MPI_COMM_TYPE_SHARED
 

--- a/ompi/include/mpif-values.py
+++ b/ompi/include/mpif-values.py
@@ -11,6 +11,7 @@
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
 # Copyright (c) 2025      Triad National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -342,6 +343,7 @@ constants = {
     'MPI_COMM_TYPE_HW_UNGUIDED': 12,
     'MPI_COMM_TYPE_HW_GUIDED': 13,
     'MPI_COMM_TYPE_RESOURCE_GUIDED': 14,
+    'OMPI_COMM_TYPE_NVLINK': 15,
 }
 
 # IO Constants

--- a/ompi/mpi/c/comm_split_type.c.in
+++ b/ompi/mpi/c/comm_split_type.c.in
@@ -17,6 +17,7 @@
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,6 +62,7 @@ PROTOTYPE ERROR_CLASS comm_split_type(COMM comm, INT split_type, INT key,
              MPI_COMM_TYPE_HW_GUIDED != split_type &&
              MPI_COMM_TYPE_RESOURCE_GUIDED != split_type &&
 	     OMPI_COMM_TYPE_CLUSTER != split_type &&
+	     OMPI_COMM_TYPE_NVLINK != split_type &&
 	     OMPI_COMM_TYPE_CU != split_type &&
 	     OMPI_COMM_TYPE_HOST != split_type &&
 	     OMPI_COMM_TYPE_BOARD != split_type &&

--- a/opal/mca/accelerator/accelerator.h
+++ b/opal/mca/accelerator/accelerator.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2024      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -147,6 +148,17 @@ struct opal_accelerator_pci_attr_t {
 };
 typedef struct opal_accelerator_pci_attr_t opal_accelerator_pci_attr_t;
 
+#define OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN 16
+
+/*
+ * CUDA NVLink domain information used by OMPI_COMM_TYPE_NVLINK. Only the CUDA
+ * accelerator fills this structure.
+ */
+typedef struct {
+    int cuda_device;
+    uint8_t cluster_uuid[OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN];
+    uint32_t clique_id;
+} opal_accelerator_cuda_nvlink_domain_t;
 
 struct opal_accelerator_event_t {
     opal_object_t super;

--- a/opal/mca/accelerator/cuda/accelerator_cuda_component.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_component.c
@@ -6,7 +6,7 @@
  *                         reserved.
  * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2024      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -26,9 +26,15 @@
 #include "opal_config.h"
 
 #include <cuda.h>
+#include <nvml.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "accelerator_cuda.h"
 #include "opal/mca/accelerator/base/base.h"
+#include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/dl/base/base.h"
 #include "opal/runtime/opal_params.h"
 #include "opal/util/argv.h"
@@ -47,8 +53,40 @@ bool mca_accelerator_cuda_init_complete = false;
 
 float *opal_accelerator_cuda_mem_bw = NULL;
 
+/*
+ * CUDA owns the NVLink domain cache. The MCA variable below is a read-only
+ * string mirror used by OMPI_COMM_TYPE_NVLINK, with
+ * opal_accelerator_nvlink_domain registered as a synonym so the communicator
+ * does not depend on a CUDA symbol.
+ */
+static opal_accelerator_cuda_nvlink_domain_t accelerator_cuda_nvlink_domain = {
+    .cuda_device = MCA_ACCELERATOR_NO_DEVICE_ID,
+};
+static char *accelerator_cuda_nvlink_domain_mca_string =
+    "cuda_device=-1,cluster_uuid=00000000000000000000000000000000,clique_id=0";
+static bool accelerator_cuda_nvlink_domain_mca_string_owned = false;
+
 #define STRINGIFY2(x) #x
 #define STRINGIFY(x)  STRINGIFY2(x)
+
+typedef nvmlReturn_t (*opal_cuda_nvmlInit_v2_fn_t)(void);
+typedef nvmlReturn_t (*opal_cuda_nvmlShutdown_fn_t)(void);
+typedef nvmlReturn_t (*opal_cuda_nvmlDeviceGetHandleByPciBusId_v2_fn_t)(
+    const char *pciBusId, nvmlDevice_t *device);
+typedef nvmlReturn_t (*opal_cuda_nvmlDeviceGetGpuFabricInfoV_fn_t)(
+    nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo);
+typedef nvmlReturn_t (*opal_cuda_nvmlDeviceGetNvLinkState_fn_t)(
+    nvmlDevice_t device, unsigned int link, nvmlEnableState_t *isActive);
+
+#define OPAL_CUDA_NVML_ASSIGN_FN(type, dst, sym) \
+    do {                                         \
+        union {                                  \
+            void *object;                        \
+            type function;                       \
+        } converter;                             \
+        converter.object = (sym);                \
+        *(dst) = converter.function;             \
+    } while (0)
 
 /* Unused variable that we register at init time and unregister at fini time.
  * This is used to detect if user has done a device reset prior to MPI_Finalize.
@@ -71,6 +109,7 @@ static int accelerator_cuda_close(void);
 static int accelerator_cuda_component_register(void);
 static opal_accelerator_base_module_t* accelerator_cuda_init(void);
 static void accelerator_cuda_finalize(opal_accelerator_base_module_t* module);
+static int accelerator_cuda_cache_nvlink_domain(void);
 /*
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
@@ -123,6 +162,316 @@ static int accelerator_cuda_close(void)
 
 static int accelerator_cuda_component_register(void)
 {
+    int ret;
+
+    ret = mca_base_component_var_register(&mca_accelerator_cuda_component.super.base_version,
+                                          "nvlink_domain",
+                                          "Cached CUDA NVLink domain used by OMPI_COMM_TYPE_NVLINK",
+                                          MCA_BASE_VAR_TYPE_STRING, NULL, 0,
+                                          MCA_BASE_VAR_FLAG_DEFAULT_ONLY, OPAL_INFO_LVL_9,
+                                          MCA_BASE_VAR_SCOPE_READONLY,
+                                          &accelerator_cuda_nvlink_domain_mca_string);
+    if (0 > ret) {
+        return ret;
+    }
+    (void) mca_base_var_register_synonym(ret, "opal", "accelerator", NULL,
+                                         "nvlink_domain", 0);
+    accelerator_cuda_nvlink_domain_mca_string_owned = true;
+
+    return OPAL_SUCCESS;
+}
+
+static int accelerator_cuda_load_nvml(opal_dl_handle_t **handle,
+                                      opal_cuda_nvmlInit_v2_fn_t *dyn_nvml_init,
+                                      opal_cuda_nvmlShutdown_fn_t *dyn_nvml_shutdown,
+                                      opal_cuda_nvmlDeviceGetHandleByPciBusId_v2_fn_t
+                                          *dyn_nvml_device_get_handle_by_pci_bus_id,
+                                      opal_cuda_nvmlDeviceGetGpuFabricInfoV_fn_t
+                                          *dyn_nvml_device_get_gpu_fabric_info_v,
+                                      opal_cuda_nvmlDeviceGetNvLinkState_fn_t
+                                          *dyn_nvml_device_get_nvlink_state)
+{
+    const char *nvml_libraries[] = {"libnvidia-ml.so.1", "libnvidia-ml.so", NULL};
+    void *symbol;
+    char *err_msg = NULL;
+    int rc = OPAL_ERROR;
+
+    *handle = NULL;
+
+#if !OPAL_HAVE_DL_SUPPORT
+    return OPAL_ERR_NOT_AVAILABLE;
+#endif
+    if (NULL == opal_dl) {
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    for (int i = 0; NULL != nvml_libraries[i]; ++i) {
+        rc = opal_dl_open(nvml_libraries[i], false, true, handle, &err_msg);
+        if (OPAL_SUCCESS == rc) {
+            break;
+        }
+    }
+
+    if (OPAL_SUCCESS != rc) {
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    rc = opal_dl_lookup(*handle, "nvmlInit_v2", &symbol, NULL);
+    if (OPAL_SUCCESS != rc) {
+        goto error;
+    }
+    OPAL_CUDA_NVML_ASSIGN_FN(opal_cuda_nvmlInit_v2_fn_t, dyn_nvml_init, symbol);
+
+    rc = opal_dl_lookup(*handle, "nvmlShutdown", &symbol, NULL);
+    if (OPAL_SUCCESS != rc) {
+        goto error;
+    }
+    OPAL_CUDA_NVML_ASSIGN_FN(opal_cuda_nvmlShutdown_fn_t, dyn_nvml_shutdown, symbol);
+
+    rc = opal_dl_lookup(*handle, "nvmlDeviceGetHandleByPciBusId_v2", &symbol, NULL);
+    if (OPAL_SUCCESS != rc) {
+        goto error;
+    }
+    OPAL_CUDA_NVML_ASSIGN_FN(opal_cuda_nvmlDeviceGetHandleByPciBusId_v2_fn_t,
+                             dyn_nvml_device_get_handle_by_pci_bus_id, symbol);
+
+    rc = opal_dl_lookup(*handle, "nvmlDeviceGetGpuFabricInfoV", &symbol, NULL);
+    if (OPAL_SUCCESS != rc) {
+        goto error;
+    }
+    OPAL_CUDA_NVML_ASSIGN_FN(opal_cuda_nvmlDeviceGetGpuFabricInfoV_fn_t,
+                             dyn_nvml_device_get_gpu_fabric_info_v, symbol);
+
+    rc = opal_dl_lookup(*handle, "nvmlDeviceGetNvLinkState", &symbol, NULL);
+    if (OPAL_SUCCESS != rc) {
+        goto error;
+    }
+    OPAL_CUDA_NVML_ASSIGN_FN(opal_cuda_nvmlDeviceGetNvLinkState_fn_t,
+                             dyn_nvml_device_get_nvlink_state, symbol);
+
+    return OPAL_SUCCESS;
+
+error:
+    opal_dl_close(*handle);
+    *handle = NULL;
+    return OPAL_ERR_NOT_AVAILABLE;
+}
+
+static bool accelerator_cuda_nvlink_fabric_info_has_domain(const nvmlGpuFabricInfoV_t *fabric_info)
+{
+    return NVML_GPU_FABRIC_STATE_COMPLETED == fabric_info->state &&
+           NVML_SUCCESS == fabric_info->status;
+}
+
+static bool accelerator_cuda_nvlink_cluster_uuid_is_zero(const unsigned char *cluster_uuid)
+{
+    for (int i = 0; i < NVML_GPU_FABRIC_UUID_LEN; ++i) {
+        if (0 != cluster_uuid[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool accelerator_cuda_nvlink_has_active_link(
+    opal_cuda_nvmlDeviceGetNvLinkState_fn_t dyn_nvml_device_get_nvlink_state,
+    nvmlDevice_t nvml_device)
+{
+    for (unsigned int link = 0; link < NVML_NVLINK_MAX_LINKS; ++link) {
+        nvmlEnableState_t state;
+        nvmlReturn_t rc;
+
+        rc = dyn_nvml_device_get_nvlink_state(nvml_device, link, &state);
+        if (NVML_SUCCESS == rc && NVML_FEATURE_ENABLED == state) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static uint64_t accelerator_cuda_nvlink_hash_hostname(const char *hostname)
+{
+    uint64_t hash = 1469598103934665603ULL;
+
+    if (NULL == hostname) {
+        hostname = "unknown";
+    }
+
+    while ('\0' != *hostname) {
+        hash ^= (uint8_t) *hostname++;
+        hash *= 1099511628211ULL;
+    }
+
+    return hash;
+}
+
+static void accelerator_cuda_nvlink_make_single_node_uuid(unsigned char *uuid,
+                                                          const char *hostname)
+{
+    /* Encode an active single-node NVLink domain reported by NVML with an
+     * all-zero cluster UUID. OMPI_COMM_TYPE_NVLINK does not synthesize this
+     * token; CUDA is the only producer of the node-local NVLink encoding. */
+    static const unsigned char signature[8] = {'O', 'M', 'P', 'I',
+                                               'N', 'V', 'L', '0'};
+    uint64_t hash = accelerator_cuda_nvlink_hash_hostname(hostname);
+
+    for (int i = 0; i < 8; ++i) {
+        uuid[i] = (hash >> (56 - i * 8)) & 0xff;
+    }
+    memcpy(uuid + 8, signature, sizeof(signature));
+}
+
+static void accelerator_cuda_nvlink_domain_uuid_to_hex(
+    const uint8_t uuid[OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN],
+    char hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN + 1])
+{
+    static const char hex[] = "0123456789abcdef";
+
+    for (int i = 0; i < OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN; ++i) {
+        hex_uuid[2 * i] = hex[uuid[i] >> 4];
+        hex_uuid[2 * i + 1] = hex[uuid[i] & 0x0f];
+    }
+    hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN] = '\0';
+}
+
+static int accelerator_cuda_update_nvlink_domain_mca_string(void)
+{
+    char hex_uuid[2 * OPAL_ACCELERATOR_NVLINK_CLUSTER_UUID_LEN + 1];
+    char value[128];
+    char *new_value;
+    int written;
+
+    accelerator_cuda_nvlink_domain_uuid_to_hex(accelerator_cuda_nvlink_domain.cluster_uuid,
+                                               hex_uuid);
+    written = snprintf(value, sizeof(value), "cuda_device=%d,cluster_uuid=%s,clique_id=%u",
+                       accelerator_cuda_nvlink_domain.cuda_device, hex_uuid,
+                       accelerator_cuda_nvlink_domain.clique_id);
+    if (0 > written || sizeof(value) <= (size_t) written) {
+        return OPAL_ERROR;
+    }
+
+    new_value = strdup(value);
+    if (NULL == new_value) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    if (accelerator_cuda_nvlink_domain_mca_string_owned) {
+        free(accelerator_cuda_nvlink_domain_mca_string);
+    }
+    accelerator_cuda_nvlink_domain_mca_string = new_value;
+    accelerator_cuda_nvlink_domain_mca_string_owned = true;
+
+    return OPAL_SUCCESS;
+}
+
+static nvmlReturn_t accelerator_cuda_get_gpu_fabric_info(
+    opal_cuda_nvmlDeviceGetGpuFabricInfoV_fn_t dyn_nvml_device_get_gpu_fabric_info_v,
+    nvmlDevice_t nvml_device, nvmlGpuFabricInfoV_t *fabric_info)
+{
+    nvmlReturn_t rc;
+
+#if defined(nvmlGpuFabricInfo_v3)
+    memset(fabric_info, 0, sizeof(*fabric_info));
+    fabric_info->version = nvmlGpuFabricInfo_v3;
+    rc = dyn_nvml_device_get_gpu_fabric_info_v(nvml_device, fabric_info);
+    if (NVML_SUCCESS == rc && accelerator_cuda_nvlink_fabric_info_has_domain(fabric_info)) {
+        return NVML_SUCCESS;
+    }
+#endif
+
+    memset(fabric_info, 0, sizeof(*fabric_info));
+    fabric_info->version = nvmlGpuFabricInfo_v2;
+    return dyn_nvml_device_get_gpu_fabric_info_v(nvml_device, fabric_info);
+}
+
+static int accelerator_cuda_cache_nvlink_domain(void)
+{
+    opal_cuda_nvmlDeviceGetGpuFabricInfoV_fn_t dyn_nvml_device_get_gpu_fabric_info_v;
+    opal_cuda_nvmlDeviceGetHandleByPciBusId_v2_fn_t dyn_nvml_device_get_handle_by_pci_bus_id;
+    opal_cuda_nvmlDeviceGetNvLinkState_fn_t dyn_nvml_device_get_nvlink_state;
+    nvmlGpuFabricInfoV_t fabric_info;
+    opal_accelerator_cuda_nvlink_domain_t domain = {
+        .cuda_device = MCA_ACCELERATOR_NO_DEVICE_ID,
+    };
+    opal_cuda_nvmlShutdown_fn_t dyn_nvml_shutdown;
+    nvmlDevice_t nvml_device;
+    opal_cuda_nvmlInit_v2_fn_t dyn_nvml_init;
+    opal_dl_handle_t *nvml_handle = NULL;
+    char pci_bus_id[16] = {0};
+    CUdevice cuDevice;
+    CUresult cu_rc;
+    nvmlReturn_t nvml_rc;
+    int rc;
+
+    accelerator_cuda_nvlink_domain = domain;
+    (void) accelerator_cuda_update_nvlink_domain_mca_string();
+
+    cu_rc = cuCtxGetDevice(&cuDevice);
+    if (CUDA_SUCCESS != cu_rc) {
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    cu_rc = cuDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), cuDevice);
+    if (CUDA_SUCCESS != cu_rc) {
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    rc = accelerator_cuda_load_nvml(&nvml_handle, &dyn_nvml_init, &dyn_nvml_shutdown,
+                                    &dyn_nvml_device_get_handle_by_pci_bus_id,
+                                    &dyn_nvml_device_get_gpu_fabric_info_v,
+                                    &dyn_nvml_device_get_nvlink_state);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    nvml_rc = dyn_nvml_init();
+    if (NVML_SUCCESS != nvml_rc) {
+        goto out;
+    }
+
+    nvml_rc = dyn_nvml_device_get_handle_by_pci_bus_id(pci_bus_id, &nvml_device);
+    if (NVML_SUCCESS != nvml_rc) {
+        goto shutdown;
+    }
+
+    if (!accelerator_cuda_nvlink_has_active_link(dyn_nvml_device_get_nvlink_state,
+                                                 nvml_device)) {
+        goto shutdown;
+    }
+
+    nvml_rc = accelerator_cuda_get_gpu_fabric_info(dyn_nvml_device_get_gpu_fabric_info_v,
+                                                   nvml_device, &fabric_info);
+    if (NVML_SUCCESS != nvml_rc ||
+        !accelerator_cuda_nvlink_fabric_info_has_domain(&fabric_info)) {
+        goto shutdown;
+    }
+
+    domain.cuda_device = (int) cuDevice;
+    if (accelerator_cuda_nvlink_cluster_uuid_is_zero(fabric_info.clusterUuid)) {
+        /* NVML reports an all-zero cluster UUID for single-node NVLink domains.
+         * Store a nonzero hostname-derived token only from the CUDA component,
+         * so the MCA default can remain all zero without suggesting a
+         * node-local NVLink domain. In this case, use the CUDA device ordinal
+         * as the split key. */
+        domain.clique_id = (uint32_t) cuDevice;
+        accelerator_cuda_nvlink_make_single_node_uuid(domain.cluster_uuid,
+                                                      OPAL_PROC_MY_HOSTNAME);
+    } else {
+        /* Multi-node/fabric domains provide a real nonzero clusterUuid and a
+         * cliqueId, which become the split color token and key respectively. */
+        domain.clique_id = fabric_info.cliqueId;
+        memcpy(domain.cluster_uuid, fabric_info.clusterUuid, sizeof(domain.cluster_uuid));
+    }
+
+    accelerator_cuda_nvlink_domain = domain;
+    (void) accelerator_cuda_update_nvlink_domain_mca_string();
+
+shutdown:
+    dyn_nvml_shutdown();
+out:
+    opal_dl_close(nvml_handle);
     return OPAL_SUCCESS;
 }
 
@@ -187,6 +536,7 @@ int opal_accelerator_cuda_delayed_init()
 
     } else {
         opal_output_verbose(20, opal_accelerator_base_framework.framework_output, "CUDA: cuCtxGetCurrent succeeded");
+        (void) accelerator_cuda_cache_nvlink_domain();
     }
 
     /* Create stream for use in cuMemcpyAsync synchronous copies */


### PR DESCRIPTION
Add OMPI_COMM_TYPE_NVLINK, also available through
MPI_COMM_TYPE_HW_GUIDED with mpi_hw_resource_type=nvlink.

The CUDA accelerator detects the local NVLink domain after lazy CUDA initialization and caches it in OPAL state instead of publishing it in the PMIx modex. This avoids relying on MPI_Init-time data, since CUDA accelerator initialization may happen later.

NVLink domains are detected with NVML. If NVML reports an active NVLink domain with a nonzero clusterUuid, that UUID is used as the split color identifier and the NVML cliqueId is used as the split key. If NVML reports an all-zero clusterUuid for a single-node NVLink domain, generate a nonzero 16-byte host-derived token with an Open MPI signature and use the CUDA device ordinal as the split key. An all-zero token is reserved to mean that the process has no local NVLink domain information.

At MPI_Comm_split_type time, collectively allgather only the 16-byte domain token across the communicator. Build a global color map by sorting the unique nonzero tokens, including both local and remote groups for intercommunicators. Processes without local NVLink domain information split with MPI_UNDEFINED.

Update the MPI_Comm_split_type documentation for OMPI_COMM_TYPE_NVLINK.