### PR TITLE
opal/mca/base: fix var group lookup in component repository release

### DIFF
--- a/opal/mca/base/mca_base_component_repository.c
+++ b/opal/mca/base/mca_base_component_repository.c
@@ -296,7 +296,7 @@ static void mca_base_component_repository_release_internal(mca_base_component_re
 {
     int group_id;
 
-    group_id = mca_base_var_group_find(NULL, ri->ri_type, ri->ri_name);
+    group_id = mca_base_var_group_find("*", ri->ri_type, ri->ri_name);
     if (0 <= group_id) {
         /* ensure all variables are deregistered before we dlclose the component */
         mca_base_var_group_deregister(group_id);

--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
@@ -395,6 +396,7 @@ int mca_base_var_group_deregister(int group_index)
 int mca_base_var_group_find(const char *project_name, const char *framework_name,
                             const char *component_name)
 {
+    assert(NULL != project_name);
     return group_find(project_name, framework_name, component_name, false);
 }
 


### PR DESCRIPTION
mca_base_component_repository_release_internal() passed NULL as the project name to mca_base_var_group_find(). This generates a lookup key without the project prefix (e.g., "framework_component"), but groups are registered with the project prefix (e.g., "opal_framework_component"). The hash lookup fails, skipping var deregistration before dlclose. After the DSO is unloaded, mbv_storage becomes a dangling pointer, and var_destructor segfaults when accessing mbv_storage->stringval during MPI_Finalize.

Use "*" wildcard for the project name, which triggers the linear search path designed for cases where the project is unknown. This matches the pattern already used in opal_info_support.c for the same reason.