### PR TITLE
rocm/accelerator: add HIP Virtual Memory Management (VMM) IPC support

### DIFF
--- a/opal/mca/accelerator/rocm/accelerator_rocm.h
+++ b/opal/mca/accelerator/rocm/accelerator_rocm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023  Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022-2026  Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2024      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -35,6 +35,9 @@
 /* Restore warnings to original state */
 #pragma GCC diagnostic pop
 
+#if HIP_VERSION >= 70100000
+#    define OPAL_ROCM_VMM_SUPPORT 1
+#endif
 
 #include "opal/mca/accelerator/accelerator.h"
 #include "opal/mca/threads/mutex.h"
@@ -70,13 +73,19 @@ struct opal_accelerator_rocm_ipc_event_handle_t {
 typedef struct opal_accelerator_rocm_ipc_event_handle_t opal_accelerator_rocm_ipc_event_handle_t;
 OBJ_CLASS_DECLARATION(opal_accelerator_rocm_ipc_event_handle_t);
 
-extern hipStream_t *opal_accelerator_rocm_MemcpyStream;
+extern hipStream_t *opal_accelerator_rocm_MemcpyStreams;
 extern int opal_accelerator_rocm_memcpy_async;
 extern int opal_accelerator_rocm_verbose;
 extern size_t opal_accelerator_rocm_memcpyH2D_limit;
 extern size_t opal_accelerator_rocm_memcpyD2H_limit;
 extern int opal_accelerator_rocm_num_devices;
 extern float *opal_accelerator_rocm_mem_bw;
+
+#if OPAL_ROCM_VMM_SUPPORT
+extern int opal_accelerator_rocm_vmm_support;
+extern void mca_accelerator_rocm_vmm_cache_init(void);
+extern void mca_accelerator_rocm_vmm_cache_fini(void);
+#endif
 
 extern int opal_accelerator_rocm_lazy_init(void);
 

--- a/opal/mca/accelerator/rocm/accelerator_rocm_component.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_component.c
@@ -6,7 +6,7 @@
  *                         reserved.
  * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All Rights reserved.
+ * Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All Rights reserved.
  * Copyright (c) 2024      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -20,6 +20,7 @@
 #include "opal_config.h"
 
 #include <stdio.h>
+#include <sys/utsname.h>
 
 #include "opal/mca/dl/base/base.h"
 #include "opal/mca/accelerator/base/base.h"
@@ -32,6 +33,13 @@ int opal_accelerator_rocm_verbose = 0;
 size_t opal_accelerator_rocm_memcpyD2H_limit=1024;
 size_t opal_accelerator_rocm_memcpyH2D_limit=1048576;
 
+#if OPAL_ROCM_VMM_SUPPORT
+/* MCA parameter to enable/disable VMM IPC support at runtime
+ * Enable with: --mca mpi_accelerator_rocm_vmm_support 1  (default is 0 - disabled)
+ */
+int opal_accelerator_rocm_vmm_support = 0;
+#endif
+
 /* Initialization lock for lazy rocm initialization */
 static opal_mutex_t accelerator_rocm_init_lock;
 static bool accelerator_rocm_init_complete = false;
@@ -39,7 +47,7 @@ static bool accelerator_rocm_init_complete = false;
 /* Define global variables, used in accelerator_rocm.c */
 int opal_accelerator_rocm_num_devices = 0;
 float *opal_accelerator_rocm_mem_bw = NULL;
-hipStream_t *opal_accelerator_rocm_MemcpyStream = NULL;
+hipStream_t *opal_accelerator_rocm_MemcpyStreams = NULL;
 
 /*
  * Public string showing the accelerator rocm component version number
@@ -177,6 +185,21 @@ static int accelerator_rocm_component_register(void)
                                               &opal_accelerator_rocm_memcpy_async);
     (void) mca_base_var_register_synonym (var_id, "ompi", "mpi", "accelerator_rocm", "memcpy_async",
                                           MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
+#if OPAL_ROCM_VMM_SUPPORT
+    /* Enable/disable VMM-based IPC support */
+    opal_accelerator_rocm_vmm_support = 0;
+    var_id = mca_base_component_var_register (&mca_accelerator_rocm_component.super.base_version,
+                                              "vmm_support",
+                                              "Enable VMM-based IPC support (0=disabled, 1=enabled). "
+                                              "Default is disabled.",
+                                              MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                              MCA_BASE_VAR_SCOPE_READONLY,
+                                              &opal_accelerator_rocm_vmm_support);
+    (void) mca_base_var_register_synonym (var_id, "ompi", "mpi", "accelerator_rocm", "vmm_support",
+                                          MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+#endif
+
     return OPAL_SUCCESS;
 }
 
@@ -206,22 +229,43 @@ int opal_accelerator_rocm_lazy_init()
         goto out;
     }
 
-    hipStream_t memcpy_stream;
-    hip_err = hipStreamCreate(&memcpy_stream);
+    int saved_dev;
+    hip_err = hipGetDevice(&saved_dev);
     if (hipSuccess != hip_err) {
-        opal_output(0, "Could not create hipStream, err=%d %s\n",
+        opal_output(0, "Could not get current device, err=%d %s\n",
                 hip_err, hipGetErrorString(hip_err));
-        err = OPAL_ERROR;  // we got hipErrorInvalidValue, pretty bad
+        err = OPAL_ERROR;
         goto out;
     }
 
-    opal_accelerator_rocm_MemcpyStream = malloc(sizeof(hipStream_t));
-    if (NULL == opal_accelerator_rocm_MemcpyStream) {
-        opal_output(0, "Could not allocate hipStream\n");
+    opal_accelerator_rocm_MemcpyStreams = malloc(opal_accelerator_rocm_num_devices * sizeof(hipStream_t));
+    if (NULL == opal_accelerator_rocm_MemcpyStreams) {
+        opal_output(0, "Could not allocate MemcpyStreams array\n");
         err = OPAL_ERR_OUT_OF_RESOURCE;
         goto out;
     }
-    *opal_accelerator_rocm_MemcpyStream = memcpy_stream;
+
+    for (int i = 0; i < opal_accelerator_rocm_num_devices; i++) {
+        hip_err = hipSetDevice(i);
+        if (hipSuccess != hip_err) {
+            opal_output(0, "Could not set device %d, err=%d %s\n",
+                    i, hip_err, hipGetErrorString(hip_err));
+            free(opal_accelerator_rocm_MemcpyStreams);
+            opal_accelerator_rocm_MemcpyStreams = NULL;
+            err = OPAL_ERROR;
+            goto out;
+        }
+        hip_err = hipStreamCreate(&opal_accelerator_rocm_MemcpyStreams[i]);
+        if (hipSuccess != hip_err) {
+            opal_output(0, "Could not create hipStream for device %d, err=%d %s\n",
+                    i, hip_err, hipGetErrorString(hip_err));
+            free(opal_accelerator_rocm_MemcpyStreams);
+            opal_accelerator_rocm_MemcpyStreams = NULL;
+            err = OPAL_ERROR;
+            goto out;
+        }
+    }
+    hipSetDevice(saved_dev);
 
     opal_accelerator_rocm_mem_bw = malloc(sizeof(float)*opal_accelerator_rocm_num_devices);
     if (NULL == opal_accelerator_rocm_mem_bw) {
@@ -311,21 +355,77 @@ static opal_accelerator_base_module_t* accelerator_rocm_init(void)
         return NULL;
     }
 
+#if OPAL_ROCM_VMM_SUPPORT
+    /* Warn if the Linux kernel is older than 6.8 */
+    {
+        struct utsname kernel_info;
+        if (uname(&kernel_info) == 0) {
+            int kmajor = 0, kminor = 0;
+            if (sscanf(kernel_info.release, "%d.%d", &kmajor, &kminor) == 2) {
+                if (kmajor < 6 || (kmajor == 6 && kminor < 8)) {
+                    opal_output_verbose(1, opal_accelerator_base_framework.framework_output,
+                                        "ROCm accelerator: Linux kernel %d.%d detected. "
+                                        "VMM IPC via pidfd requires kernel 6.8 or higher "
+                                        "for reliable operation.",
+                                        kmajor, kminor);
+                }
+            }
+        }
+    }
+
+    /* Verify hardware VMM support before honouring the vmm_support MCA param.
+     * Require ALL devices to support VMM: if even one device does not report
+     * hipDeviceAttributeVirtualMemoryManagementSupported, disable VMM IPC for
+     * the whole job.  A mixed-capability node would silently corrupt IPC for
+     * any transfer involving the incapable device. */
+    if (opal_accelerator_rocm_vmm_support) {
+        int first_no_vmm = -1;
+        for (int i = 0; i < count; i++) {
+            int vmm_supported = 0;
+            hipError_t vmm_err = hipDeviceGetAttribute(
+                &vmm_supported,
+                hipDeviceAttributeVirtualMemoryManagementSupported, i);
+            if (hipSuccess != vmm_err || !vmm_supported) {
+                first_no_vmm = i;
+                break;
+            }
+        }
+        if (first_no_vmm >= 0) {
+            opal_output(0, "ROCm accelerator: VMM IPC requested "
+                        "(accelerator_rocm_vmm_support=1) but device %d does not "
+                        "report hipDeviceAttributeVirtualMemoryManagementSupported. "
+                        "All devices must support VMM. Disabling VMM IPC.",
+                        first_no_vmm);
+            opal_accelerator_rocm_vmm_support = 0;
+        }
+    }
+#endif
+
     opal_atomic_mb();
     opal_rocm_runtime_initialized = true;
+
+#if OPAL_ROCM_VMM_SUPPORT
+    mca_accelerator_rocm_vmm_cache_init();
+#endif
 
     return &opal_accelerator_rocm_module;
 }
 
 static void accelerator_rocm_finalize(opal_accelerator_base_module_t* module)
 {
-    if (NULL != opal_accelerator_rocm_MemcpyStream) {
-        hipError_t err = hipStreamDestroy(*opal_accelerator_rocm_MemcpyStream);
-        if (hipSuccess != err) {
-            opal_output_verbose(10, 0, "hip_dl_finalize: error while destroying the hipStream\n");
+#if OPAL_ROCM_VMM_SUPPORT
+    mca_accelerator_rocm_vmm_cache_fini();
+#endif
+
+    if (NULL != opal_accelerator_rocm_MemcpyStreams) {
+        for (int i = 0; i < opal_accelerator_rocm_num_devices; i++) {
+            hipError_t err = hipStreamDestroy(opal_accelerator_rocm_MemcpyStreams[i]);
+            if (hipSuccess != err) {
+                opal_output_verbose(10, 0, "hip_dl_finalize: error destroying hipStream for device %d\n", i);
+            }
         }
-        free(opal_accelerator_rocm_MemcpyStream);
-        opal_accelerator_rocm_MemcpyStream = NULL;
+        free(opal_accelerator_rocm_MemcpyStreams);
+        opal_accelerator_rocm_MemcpyStreams = NULL;
 
         free(opal_accelerator_rocm_mem_bw);
         opal_accelerator_rocm_mem_bw = NULL;

--- a/opal/mca/accelerator/rocm/accelerator_rocm_component.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_component.c
@@ -365,7 +365,7 @@ static opal_accelerator_base_module_t* accelerator_rocm_init(void)
                 if (kmajor < 6 || (kmajor == 6 && kminor < 8)) {
                     opal_output_verbose(1, opal_accelerator_base_framework.framework_output,
                                         "ROCm accelerator: Linux kernel %d.%d detected. "
-                                        "VMM IPC via pidfd requires kernel 6.8 or higher "
+                                        "VMM IPC requires kernel 6.8 or higher "
                                         "for reliable operation.",
                                         kmajor, kminor);
                 }

--- a/opal/mca/accelerator/rocm/accelerator_rocm_component.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_component.c
@@ -19,7 +19,9 @@
 
 #include "opal_config.h"
 
+#include <errno.h>
 #include <stdio.h>
+#include <sys/prctl.h>
 #include <sys/utsname.h>
 
 #include "opal/mca/dl/base/base.h"
@@ -406,6 +408,15 @@ static opal_accelerator_base_module_t* accelerator_rocm_init(void)
 
 #if OPAL_ROCM_VMM_SUPPORT
     mca_accelerator_rocm_vmm_cache_init();
+    if (opal_accelerator_rocm_vmm_support) {
+        if (prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0) != 0) {
+            opal_output_verbose(1, opal_accelerator_base_framework.framework_output,
+                                "prctl(PR_SET_PTRACER_ANY) failed (errno=%d): "
+                                "VMM IPC peers may need CAP_SYS_PTRACE or "
+                                "pidfd_getfd will be denied on the receiver.",
+                                errno);
+        }
+    }
 #endif
 
     return &opal_accelerator_rocm_module;

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -15,8 +15,42 @@
 #include "opal/mca/accelerator/base/base.h"
 #include "opal/constants.h"
 #include "opal/util/output.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/mca/threads/mutex.h"
 #include "ompi/info/info_memkind.h"
 #include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/prctl.h>
+
+#if OPAL_ROCM_VMM_SUPPORT
+/* VMM IPC descriptor structure for file descriptor-based IPC
+ *
+ * The structure uses __attribute__((packed)) to ensure consistent
+ * memory layout across compilers and platforms. The layout must be:
+ *   - Total size: exactly 64 bytes (IPC_MAX_HANDLE_SIZE)
+ *   - handle_type field: at byte offset 48 (overlaps with pid in traditional IPC handle)
+ * 
+ * Traditional hipIpcMemHandle_t stores the process ID at byte offset 48.
+ * We use this location as a discriminator:
+ *   - handle_type = 0: VMM handle (pid 0 is reserved by kernel, never used by user process)
+ *   - handle_type != 0: Traditional handle
+ *
+ * Memory layout verification:
+ *   sizeof(struct vmm_ipc_descriptor) must equal 64
+ *   offsetof(struct vmm_ipc_descriptor, handle_type) must equal 48
+ */
+struct vmm_ipc_descriptor {
+    int32_t fd;            /* Bytes 0-3:   File descriptor (shareable) */
+    uint32_t pid;          /* Bytes 4-7:   Sender's process ID */
+    void *base_addr;       /* Bytes 8-15:  Base address in sender's VA space */
+    size_t alloc_size;     /* Bytes 16-23: Total allocation size */
+    size_t offset;         /* Bytes 24-31: Offset from base to actual pointer */
+    uint8_t padding[16];   /* Bytes 32-47: Explicit padding to reach byte 48 */
+    uint32_t handle_type;  /* Bytes 48-51: 0=VMM */
+    uint8_t reserved[12];  /* Bytes 52-63: Reserved for future use */
+} __attribute__((packed));
+#endif
 
 /* Accelerator API's */
 static int mca_accelerator_rocm_check_addr(const void *addr, int *dev_id, uint64_t *flags);
@@ -124,6 +158,121 @@ opal_accelerator_base_module_t opal_accelerator_rocm_module =
     .get_memkind = mca_accelerator_rocm_get_memkind
 };
 
+#if OPAL_ROCM_VMM_SUPPORT
+/* Track if prctl was called for FD exchange permission */
+static int mca_accelerator_rocm_vmm_prctl_set = 0;
+
+/*
+ * Key for vmm_region_cache: identifies a remote VMM allocation by the sender's
+ * (pid, base_addr) pair.  base_addr is always the allocation base returned by
+ * hipMemGetAddressRange on the sender, so it is the same regardless of which
+ * offset within the allocation is being communicated.  Using base_addr here
+ * (rather than fd) means one cache entry covers all offsets into the same
+ * remote allocation.
+ *
+ * The struct must be zeroed before use (memset to 0) so that compiler-inserted
+ * padding bytes do not produce spurious cache misses in opal_hash_table_*_ptr.
+ */
+typedef struct {
+    uint32_t pid;
+    void    *base_addr;
+} vmm_cache_key_t;
+
+/*
+ * Value stored in vmm_region_cache: the local mapping of a remote VMM
+ * allocation.  local_base_addr is the VA returned by hipMemAddressReserve +
+ * hipMemMap on this process.
+ */
+typedef struct {
+    void    *local_base_addr;
+    size_t   alloc_size;
+    uint32_t refcount;
+} vmm_mapped_region_t;
+
+/*
+ * vmm_export_cache: base_addr -> exported FD (sender side).
+ * Caches the FD produced by hipMemExportToShareableHandle for each local VMM
+ * allocation.
+ * Key:   void* (base_addr from hipMemGetAddressRange)
+ * Value: int fd, stored as void* via uintptr_t cast
+ */
+static opal_hash_table_t vmm_export_cache;
+
+/*
+ * pidfd_cache: pid -> pid_fd (the receiver's pidfd handle for a peer process).
+ * Avoids calling pidfd_open() more than once per peer.
+ * Key:   uint64_t (sender pid, widened from uint32_t)
+ * Value: int pid_fd, stored as void* via uintptr_t cast
+ */
+static opal_hash_table_t vmm_pidfd_cache;
+
+/*
+ * vmm_region_cache: (pid, base_addr) -> vmm_mapped_region_t*
+ * Avoids re-importing and re-mapping an allocation already visible in this
+ * process.  Entries are never evicted while the process is alive.
+ */
+static opal_hash_table_t vmm_region_cache;
+
+/* Single lock protecting both caches */
+static opal_mutex_t vmm_cache_lock;
+
+/* Track whether caches have been initialized */
+static bool vmm_cache_initialized = false;
+
+void mca_accelerator_rocm_vmm_cache_init(void)
+{
+    OBJ_CONSTRUCT(&vmm_cache_lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&vmm_pidfd_cache, opal_hash_table_t);
+    opal_hash_table_init(&vmm_pidfd_cache, 64);
+    OBJ_CONSTRUCT(&vmm_region_cache, opal_hash_table_t);
+    opal_hash_table_init(&vmm_region_cache, 256);
+    OBJ_CONSTRUCT(&vmm_export_cache, opal_hash_table_t);
+    opal_hash_table_init(&vmm_export_cache, 64);
+    vmm_cache_initialized = true;
+}
+
+void mca_accelerator_rocm_vmm_cache_fini(void)
+{
+    if (!vmm_cache_initialized) {
+        return;
+    }
+
+    /* Walk vmm_region_cache and unmap any still-live entries */
+    vmm_cache_key_t *rkey;
+    vmm_mapped_region_t *region;
+    OPAL_HASH_TABLE_FOREACH_PTR(rkey, region, &vmm_region_cache, {
+        hipMemUnmap(region->local_base_addr, region->alloc_size);
+        hipMemAddressFree(region->local_base_addr, region->alloc_size);
+        free(region);
+    });
+
+    /* Walk export_cache and close any cached sender FDs */
+    void *exp_key;
+    void *exp_fd_val;
+    OPAL_HASH_TABLE_FOREACH_PTR(exp_key, exp_fd_val, &vmm_export_cache, {
+        int exp_fd = (int)(uintptr_t)exp_fd_val;
+        if (exp_fd >= 0) {
+            close(exp_fd);
+        }
+    });
+
+    /* Walk pidfd_cache and close any open pidfds */
+    uint64_t pid_key;
+    void *pid_fd_val;
+    OPAL_HASH_TABLE_FOREACH(pid_key, uint64, pid_fd_val, &vmm_pidfd_cache) {
+        int pid_fd = (int)(uintptr_t)pid_fd_val;
+        if (pid_fd >= 0) {
+            close(pid_fd);
+        }
+    }
+
+    OBJ_DESTRUCT(&vmm_export_cache);
+    OBJ_DESTRUCT(&vmm_region_cache);
+    OBJ_DESTRUCT(&vmm_pidfd_cache);
+    OBJ_DESTRUCT(&vmm_cache_lock);
+    vmm_cache_initialized = false;
+}
+#endif
 
 static int mca_accelerator_rocm_check_addr (const void *addr, int *dev_id, uint64_t *flags)
 {
@@ -138,21 +287,20 @@ static int mca_accelerator_rocm_check_addr (const void *addr, int *dev_id, uint6
     }
 
     *flags = 0;
+
     err = hipPointerGetAttributes(&srcAttr, addr);
     if (hipSuccess == err) {
 #if HIP_VERSION >= 50731921
-        if (hipMemoryTypeDevice == srcAttr.type) {
+        hipMemoryType mem_type = srcAttr.type;
 #else
-        if (hipMemoryTypeDevice == srcAttr.memoryType) {
+        hipMemoryType mem_type = srcAttr.memoryType;
 #endif
+
+        if (hipMemoryTypeDevice == mem_type) {
             opal_accelerator_rocm_lazy_init();
             *dev_id = srcAttr.device;
             ret = 1;
-#if HIP_VERSION >= 50731921
-        } else if (hipMemoryTypeUnified == srcAttr.type) {
-#else
-        } else if (hipMemoryTypeUnified == srcAttr.memoryType) {
-#endif
+        } else if (hipMemoryTypeUnified == mem_type) {
             *flags |= MCA_ACCELERATOR_FLAGS_UNIFIED_MEMORY;
             opal_accelerator_rocm_lazy_init();
             *dev_id = srcAttr.device;
@@ -351,36 +499,44 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
                                        opal_accelerator_transfer_type_t type)
 {
     hipError_t err;
-
     if (NULL == src || NULL == dest || size < 0) {
         return OPAL_ERR_BAD_PARAM;
     }
     if (0 == size) {
         return OPAL_SUCCESS;
     }
-
-    if ((type == MCA_ACCELERATOR_TRANSFER_DTOH ||
-	 type == MCA_ACCELERATOR_TRANSFER_UNSPEC) &&
-	size <= opal_accelerator_rocm_memcpyD2H_limit) {
+    if (!opal_accelerator_rocm_vmm_support &&
+        (type == MCA_ACCELERATOR_TRANSFER_DTOH ||
+         type == MCA_ACCELERATOR_TRANSFER_UNSPEC) &&
+        size <= opal_accelerator_rocm_memcpyD2H_limit) {
         memcpy(dest, src, size);
         return OPAL_SUCCESS;
     }
 
-    if (type == MCA_ACCELERATOR_TRANSFER_HTOD && size <= opal_accelerator_rocm_memcpyH2D_limit) {
+    if (!opal_accelerator_rocm_vmm_support &&
+        type == MCA_ACCELERATOR_TRANSFER_HTOD &&
+        size <= opal_accelerator_rocm_memcpyH2D_limit) {
         memcpy(dest, src, size);
         return OPAL_SUCCESS;
     }
 
     if (opal_accelerator_rocm_memcpy_async) {
-        err = hipMemcpyAsync(dest, src, size, hipMemcpyDefault,
-                                       *opal_accelerator_rocm_MemcpyStream);
+        int delayed_init = opal_accelerator_rocm_lazy_init();
+        if (OPAL_UNLIKELY(0 != delayed_init)) {
+            return delayed_init;
+        }
+        int dev = (src_dev_id != MCA_ACCELERATOR_NO_DEVICE_ID) ? src_dev_id : dest_dev_id;
+        if (dev == MCA_ACCELERATOR_NO_DEVICE_ID) {
+            hipGetDevice(&dev);
+        }
+        hipStream_t stream = opal_accelerator_rocm_MemcpyStreams[dev];
+        err = hipMemcpyAsync(dest, src, size, hipMemcpyDefault, stream);
         if (hipSuccess != err ) {
             opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                                 "error starting async copy\n");
             return OPAL_ERROR;
         }
-
-        err = hipStreamSynchronize(*opal_accelerator_rocm_MemcpyStream);
+        err = hipStreamSynchronize(stream);
         if (hipSuccess != err ) {
             opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                                 "error synchronizing stream after async copy\n");
@@ -461,23 +617,30 @@ static int mca_accelerator_rocm_memmove(int dest_dev_id, int src_dev_id, void *d
     }
 
     if (opal_accelerator_rocm_memcpy_async) {
-        err = hipMemcpyAsync(tmp, src, size, hipMemcpyDefault,
-                                       *opal_accelerator_rocm_MemcpyStream);
+        int delayed_init = opal_accelerator_rocm_lazy_init();
+        if (OPAL_UNLIKELY(0 != delayed_init)) {
+            return delayed_init;
+        }
+        int dev = (src_dev_id != MCA_ACCELERATOR_NO_DEVICE_ID) ? src_dev_id : dest_dev_id;
+        if (dev == MCA_ACCELERATOR_NO_DEVICE_ID) {
+            hipGetDevice(&dev);
+        }
+        hipStream_t stream = opal_accelerator_rocm_MemcpyStreams[dev];
+        err = hipMemcpyAsync(tmp, src, size, hipMemcpyDefault, stream);
         if (hipSuccess != err ) {
             opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                                 "error in async memcpy for memmove\n");
             return OPAL_ERROR;
         }
 
-        err = hipMemcpyAsync(dest, tmp, size, hipMemcpyDefault,
-                                       *opal_accelerator_rocm_MemcpyStream);
+        err = hipMemcpyAsync(dest, tmp, size, hipMemcpyDefault, stream);
         if (hipSuccess != err ) {
             opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                                 "error in async memcpy for memmove\n");
             return OPAL_ERROR;
         }
 
-        err = hipStreamSynchronize(*opal_accelerator_rocm_MemcpyStream);
+        err = hipStreamSynchronize(stream);
         if (hipSuccess != err ) {
             opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                                 "error synchronizing stream for memmove\n");
@@ -572,8 +735,45 @@ static bool mca_accelerator_rocm_is_ipc_enabled(void)
 static void mca_accelerator_rocm_ipc_handle_destruct(opal_accelerator_rocm_ipc_handle_t *handle)
 {
     if (NULL != handle && NULL != handle->base.dev_ptr) {
+#if OPAL_ROCM_VMM_SUPPORT
+        /* Check if vmm handle type */
+        uint32_t *handle_type = (uint32_t *)&handle->base.handle[48];
+
+        if (*handle_type == 0) {
+            /* VMM handle: decrement the region cache refcount.
+             *
+             * We deliberately do NOT unmap when refcount reaches zero.  Unmapping
+             * and re-importing the same remote allocation on the next receive would
+             * cost two syscalls (pidfd_open/pidfd_getfd) plus hipMemAddressReserve,
+             * hipMemMap, and hipMemSetAccess.  For iterative algorithms that reuse
+             * the same buffers across many messages this would negate the cache.
+             * VA reservations are cheap; leave the mapping live until process exit,
+             * at which point mca_accelerator_rocm_vmm_cache_fini() unmaps everything.
+             */
+            struct vmm_ipc_descriptor vmm_desc;
+            memcpy(&vmm_desc, handle->base.handle, sizeof(vmm_desc));
+
+            vmm_cache_key_t region_key;
+            memset(&region_key, 0, sizeof(region_key));
+            region_key.pid       = vmm_desc.pid;
+            region_key.base_addr = vmm_desc.base_addr;
+
+            OPAL_THREAD_LOCK(&vmm_cache_lock);
+            vmm_mapped_region_t *region = NULL;
+            opal_hash_table_get_value_ptr(&vmm_region_cache, &region_key, sizeof(region_key),
+                                          (void **)&region);
+            if (NULL != region && region->refcount > 0) {
+                region->refcount--;
+            }
+            OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+
+            handle->base.dev_ptr = NULL;
+            return;
+        }
+#endif
+        /* Traditional IPC cleanup */
         hipIpcCloseMemHandle((hipDeviceptr_t) handle->base.dev_ptr);
-	handle->base.dev_ptr = NULL;
+        handle->base.dev_ptr = NULL;
     }
 }
 
@@ -586,19 +786,121 @@ OBJ_CLASS_INSTANCE(
 static int mca_accelerator_rocm_get_ipc_handle(int dev_id, void *dev_ptr,
                                                opal_accelerator_ipc_handle_t *handle)
 {
+    hipError_t err;
+    opal_accelerator_rocm_ipc_handle_t *rocm_handle;
+
     if (NULL == dev_ptr || NULL == handle) {
         return OPAL_ERR_BAD_PARAM;
     }
 
-    hipIpcMemHandle_t rocm_ipc_handle;
-    opal_accelerator_rocm_ipc_handle_t *rocm_handle = (opal_accelerator_rocm_ipc_handle_t *) handle;
+    /* Check if pointer supports legacy IPC */
+    int is_legacy_ipc = 0;
+    err = hipPointerGetAttribute(&is_legacy_ipc,
+                                HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE,
+                                (hipDeviceptr_t)dev_ptr);
 
+    rocm_handle = (opal_accelerator_rocm_ipc_handle_t *) handle;
     OBJ_CONSTRUCT(rocm_handle, opal_accelerator_rocm_ipc_handle_t);
     rocm_handle->base.dev_ptr = NULL;
 
+#if OPAL_ROCM_VMM_SUPPORT
+    /* Try to get allocation handle - only works for VMM allocations */
+    /* Only attempt VMM detection if explicitly enabled via MCA parameter */
+    if (opal_accelerator_rocm_vmm_support && !is_legacy_ipc) {
+        /* Set prctl permission for FD exchange (only once per process) */
+        if (!mca_accelerator_rocm_vmm_prctl_set) {
+            if (prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0) != 0) {
+                opal_output_verbose(1, opal_accelerator_base_framework.framework_output,
+                                    "prctl(PR_SET_PTRACER_ANY) failed (errno=%d): "
+                                    "VMM IPC peers may need CAP_SYS_PTRACE or "
+                                    "pidfd_getfd will be denied on the receiver.",
+                                    errno);
+            }
+            mca_accelerator_rocm_vmm_prctl_set = 1;
+        }
+
+        /* hipMemRetainAllocationHandle succeeds only for VMM pointers.
+         * It must be called with the allocation base — passing a mid-allocation
+         * offset returns a handle that may crash on hipMemRelease.
+         */
+        struct vmm_ipc_descriptor vmm_desc;
+        void *base_addr = NULL;
+        size_t alloc_size = 0;
+        int fd = -1;
+
+        err = hipMemGetAddressRange(&base_addr, &alloc_size, (hipDeviceptr_t)dev_ptr);
+        if (hipSuccess != err) {
+            /* Not a VMM pointer and not legacy-IPC-capable: no valid export path */
+            OBJ_DESTRUCT(rocm_handle);
+            return OPAL_ERROR;
+        }
+
+        OPAL_THREAD_LOCK(&vmm_cache_lock);
+
+        /* Cache the exported fd so each VMM allocation is exported exactly once across all registrations. */
+        void *cached_fd_val = NULL;
+        opal_hash_table_get_value_ptr(&vmm_export_cache, &base_addr, sizeof(base_addr),
+                                      &cached_fd_val);
+        if (NULL != cached_fd_val) {
+            fd = (int)(uintptr_t)cached_fd_val;
+        } else {
+            hipMemGenericAllocationHandle_t alloc_handle;
+            err = hipMemRetainAllocationHandle(&alloc_handle, base_addr);
+            if (hipSuccess != err) {
+                OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+                OBJ_DESTRUCT(rocm_handle);
+                return OPAL_ERROR;
+            }
+
+            err = hipMemExportToShareableHandle((void*)&fd, alloc_handle,
+                                                hipMemHandleTypePosixFileDescriptor, 0);
+            hipMemRelease(alloc_handle);
+            if (hipSuccess != err) {
+                opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                    "Failed to export VMM handle as FD");
+                OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+                OBJ_DESTRUCT(rocm_handle);
+                return OPAL_ERROR;
+            }
+
+            opal_hash_table_set_value_ptr(&vmm_export_cache, &base_addr, sizeof(base_addr),
+                                          (void *)(uintptr_t)fd);
+        }
+        /* Pack VMM IPC descriptor */
+        vmm_desc.fd = fd;
+        vmm_desc.pid = getpid();
+        vmm_desc.base_addr = base_addr;
+        vmm_desc.alloc_size = alloc_size;
+        vmm_desc.offset = (char*)dev_ptr - (char*)base_addr;
+        vmm_desc.handle_type = 0;  /* 0 indicates VMM handle */
+        memset(vmm_desc.padding, 0, sizeof(vmm_desc.padding));
+        memset(vmm_desc.reserved, 0, sizeof(vmm_desc.reserved));
+
+        /* Ensure it fits in handle */
+        if (sizeof(vmm_desc) > IPC_MAX_HANDLE_SIZE) {
+            opal_output(0, "VMM IPC descriptor too large for handle");
+            OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+            OBJ_DESTRUCT(rocm_handle);
+            return OPAL_ERROR;
+        }
+
+        /* Copy to handle */
+        memcpy(rocm_handle->base.handle, &vmm_desc, sizeof(vmm_desc));
+        OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+
+        opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                            "VMM IPC handle created: fd=%d, pid=%u, offset=%zu, handle_type=0",
+                            fd, vmm_desc.pid, vmm_desc.offset);
+
+        return OPAL_SUCCESS;
+    }
+#endif
+
+    /* Traditional IPC for non-VMM allocations */
+    hipIpcMemHandle_t rocm_ipc_handle;
     memset(rocm_ipc_handle.reserved, 0, HIP_IPC_HANDLE_SIZE);
-    hipError_t err = hipIpcGetMemHandle(&rocm_ipc_handle,
-                                        (hipDeviceptr_t)dev_ptr);
+
+    err = hipIpcGetMemHandle(&rocm_ipc_handle, (hipDeviceptr_t)dev_ptr);
     if (hipSuccess != err) {
         opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
                             "Error in hipIpcGetMemHandle dev_ptr %p", dev_ptr);
@@ -623,13 +925,164 @@ static int mca_accelerator_rocm_import_ipc_handle(int dev_id, uint8_t ipc_handle
 static int mca_accelerator_rocm_open_ipc_handle(int dev_id, opal_accelerator_ipc_handle_t *handle,
                                                 void **dev_ptr)
 {
+    hipError_t err;
+
     if (NULL == dev_ptr || NULL == handle) {
         return OPAL_ERR_BAD_PARAM;
     }
 
-    hipError_t err = hipIpcOpenMemHandle((hipDeviceptr_t *) &handle->dev_ptr,
-                                         *(hipIpcMemHandle_t*)handle->handle,
-                                         hipIpcMemLazyEnablePeerAccess);
+#if OPAL_ROCM_VMM_SUPPORT
+    /* Check if handle_type is a vmm handle */
+    uint32_t *handle_type = (uint32_t *)&handle->handle[48];
+
+    if (*handle_type == 0) {
+        /* VMM handle detected */
+        if (!opal_accelerator_rocm_vmm_support) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "VMM IPC handle received but VMM support is disabled. "
+                                "Enable with: --mca accelerator_rocm_vmm_support 1");
+            return OPAL_ERROR;
+        }
+
+        struct vmm_ipc_descriptor vmm_desc;
+        memcpy(&vmm_desc, handle->handle, sizeof(vmm_desc));
+
+        /* Check region cache: (pid, base_addr) identifies the remote allocation.
+         * Using base_addr (not fd) as part of the key means one entry covers every
+         * offset within the same allocation, regardless of how many fds were used
+         * to export it. */
+        vmm_cache_key_t region_key;
+        memset(&region_key, 0, sizeof(region_key));
+        region_key.pid       = vmm_desc.pid;
+        region_key.base_addr = vmm_desc.base_addr;
+
+        vmm_mapped_region_t *region = NULL;
+        OPAL_THREAD_LOCK(&vmm_cache_lock);
+        opal_hash_table_get_value_ptr(&vmm_region_cache, &region_key, sizeof(region_key),
+                                      (void **)&region);
+        if (NULL != region) {
+            /* Cache hit: allocation already mapped in this process */
+            region->refcount++;
+            *dev_ptr      = region->local_base_addr;
+            handle->dev_ptr = *dev_ptr;
+            OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "VMM cache hit: pid=%u base=%p offset=%zu ptr=%p",
+                                vmm_desc.pid, vmm_desc.base_addr, vmm_desc.offset, *dev_ptr);
+            return OPAL_SUCCESS;
+        }
+        OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+
+        /* Cache miss: perform the full import sequence */
+        void *local_base_addr = NULL;
+        int local_fd = -1;
+
+        /* Get the sender's pid_fd, reusing a cached one if available */
+        OPAL_THREAD_LOCK(&vmm_cache_lock);
+        void *cached_pidfd_val = NULL;
+        int pid_fd = -1;
+        opal_hash_table_get_value_uint64(&vmm_pidfd_cache, (uint64_t)vmm_desc.pid,
+                                         &cached_pidfd_val);
+        if (NULL != cached_pidfd_val) {
+            pid_fd = (int)(uintptr_t)cached_pidfd_val;
+        }
+        OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+
+        if (pid_fd < 0) {
+            pid_fd = syscall(__NR_pidfd_open, vmm_desc.pid, 0);
+            if (pid_fd == -1) {
+                opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                    "pidfd_open failed for pid=%u: errno=%d", vmm_desc.pid, errno);
+                return OPAL_ERROR;
+            }
+            OPAL_THREAD_LOCK(&vmm_cache_lock);
+            opal_hash_table_set_value_uint64(&vmm_pidfd_cache, (uint64_t)vmm_desc.pid,
+                                             (void *)(uintptr_t)pid_fd);
+            OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+        }
+
+        local_fd = syscall(__NR_pidfd_getfd, pid_fd, (int)vmm_desc.fd, 0);
+        if (local_fd == -1) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "pidfd_getfd failed: errno=%d (sender may need prctl)", errno);
+            return OPAL_ERROR;
+        }
+
+        /* Import the allocation handle from the local fd copy */
+        hipMemGenericAllocationHandle_t imported_handle;
+        err = hipMemImportFromShareableHandle(&imported_handle, (void*)(uintptr_t)local_fd, hipMemHandleTypePosixFileDescriptor);
+        close(local_fd);
+        if (hipSuccess != err) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "hipMemImportFromShareableHandle failed");
+            return OPAL_ERROR;
+        }
+
+        err = hipMemAddressReserve(&local_base_addr, vmm_desc.alloc_size, 0, 0, 0);
+        if (hipSuccess != err) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "hipMemAddressReserve failed");
+            hipMemRelease(imported_handle);
+            return OPAL_ERROR;
+        }
+
+        err = hipMemMap(local_base_addr, vmm_desc.alloc_size, 0, imported_handle, 0);
+        hipMemRelease(imported_handle);
+        if (hipSuccess != err) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "hipMemMap failed");
+            hipMemAddressFree(local_base_addr, vmm_desc.alloc_size);
+            return OPAL_ERROR;
+        }
+
+        int actual_dev_id = dev_id;
+        if (actual_dev_id == MCA_ACCELERATOR_NO_DEVICE_ID) {
+            if (hipSuccess != hipGetDevice(&actual_dev_id)) {
+                actual_dev_id = 0;
+            }
+        }
+
+        hipMemAccessDesc access_desc;
+        access_desc.location.type = hipMemLocationTypeDevice;
+        access_desc.location.id   = actual_dev_id;
+        access_desc.flags         = hipMemAccessFlagsProtReadWrite;
+        err = hipMemSetAccess(local_base_addr, vmm_desc.alloc_size, &access_desc, 1);
+        if (hipSuccess != err) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "hipMemSetAccess failed");
+            hipMemUnmap(local_base_addr, vmm_desc.alloc_size);
+            hipMemAddressFree(local_base_addr, vmm_desc.alloc_size);
+            return OPAL_ERROR;
+        }
+
+        /* Insert into region cache */
+        region = malloc(sizeof(*region));
+        if (NULL == region) {
+            hipMemUnmap(local_base_addr, vmm_desc.alloc_size);
+            hipMemAddressFree(local_base_addr, vmm_desc.alloc_size);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+        region->local_base_addr = local_base_addr;
+        region->alloc_size      = vmm_desc.alloc_size;
+        region->refcount        = 1;
+
+        OPAL_THREAD_LOCK(&vmm_cache_lock);
+        opal_hash_table_set_value_ptr(&vmm_region_cache, &region_key, sizeof(region_key), region);
+        OPAL_THREAD_UNLOCK(&vmm_cache_lock);
+
+        *dev_ptr        = local_base_addr;
+        handle->dev_ptr = *dev_ptr;
+        opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                            "VMM IPC handle opened: local_base=%p offset=%zu ptr=%p",
+                            local_base_addr, vmm_desc.offset, *dev_ptr);
+        return OPAL_SUCCESS;
+    }
+#endif
+
+    /* Traditional IPC path for non-VMM allocations */
+    err = hipIpcOpenMemHandle((hipDeviceptr_t *) &handle->dev_ptr,
+                             *(hipIpcMemHandle_t*)handle->handle,
+                             hipIpcMemLazyEnablePeerAccess);
     if (hipErrorMapFailed == err) {
         return OPAL_ERR_WOULD_BLOCK;
     }
@@ -646,12 +1099,22 @@ static int mca_accelerator_rocm_open_ipc_handle(int dev_id, opal_accelerator_ipc
 static int mca_accelerator_rocm_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HANDLE_SIZE],
                                                     uint8_t handle_2[IPC_MAX_HANDLE_SIZE])
 {
-    /*
-     * The HIP IPC handles consists of multiple elements.
-     * We will only use the ROCr IPC handle (32 bytes, starting at pos 0)
-     * and the process ID for comparison.
-     * We definitily need to exclude the offset component in the comparison.
+#if OPAL_ROCM_VMM_SUPPORT
+    /* VMM handles are identified by handle_type == 0 at byte 48.
+     * Two VMM handles refer to the same allocation when they share the same
+     * pid (bytes 4-7) and base_addr (bytes 8-15).  The fd (bytes 0-3) differs
+     * on every hipMemExportToShareableHandle call for the same allocation and
+     * must be excluded from the comparison.
      */
+    uint32_t *type_1 = (uint32_t *)&handle_1[48];
+    uint32_t *type_2 = (uint32_t *)&handle_2[48];
+    if (*type_1 == 0 && *type_2 == 0) {
+        return memcmp(&handle_1[4], &handle_2[4], sizeof(uint32_t) + sizeof(void *));
+    }
+#endif
+
+    /* Traditional IPC: compare the 32-byte ROCr handle and the pid.
+     * We exclude the offset component in the comparison. */
     static const int rocr_ipc_handle_size = 32;
     static const int pos = rocr_ipc_handle_size + 2*sizeof(size_t);
     int *pid_1 = (int *)&handle_1[pos];
@@ -850,23 +1313,28 @@ static int mca_accelerator_rocm_get_buffer_id(int dev_id, const void *addr, opal
     *buf_id = 0;
 
 #if HIP_VERSION >= 50120531
-    hipError_t result = hipPointerGetAttribute((unsigned long long *)buf_id, HIP_POINTER_ATTRIBUTE_BUFFER_ID,
-                                               (hipDeviceptr_t)addr);
-    if (hipSuccess != result) {
-        opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
-                            "error in hipPointerGetAttribute, could not retrieve buffer_id");
-        return OPAL_ERROR;
+    {
+        hipError_t result = hipPointerGetAttribute((unsigned long long *)buf_id,
+                                                   HIP_POINTER_ATTRIBUTE_BUFFER_ID,
+                                                   (hipDeviceptr_t)addr);
+        if (hipSuccess != result) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "error in hipPointerGetAttribute, could not retrieve buffer_id");
+            return OPAL_ERROR;
+        }
     }
 #endif
 
 #if HIP_VERSION >= 50530201
-    int enable = 1;
-    hipError_t err = hipPointerSetAttribute(&enable, HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                            (hipDeviceptr_t)addr);
-    if (hipSuccess != err) {
-        opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
-                            "error in hipPointerSetAttribute, could not set SYNC_MEMOPS");
-        return OPAL_ERROR;
+    {
+        int enable = 1;
+        hipError_t err = hipPointerSetAttribute(&enable, HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                                (hipDeviceptr_t)addr);
+        if (hipSuccess != err) {
+            opal_output_verbose(10, opal_accelerator_base_framework.framework_output,
+                                "error in hipPointerSetAttribute, could not set SYNC_MEMOPS");
+            return OPAL_ERROR;
+        }
     }
 #endif
     return OPAL_SUCCESS;

--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
@@ -159,8 +159,6 @@ opal_accelerator_base_module_t opal_accelerator_rocm_module =
 };
 
 #if OPAL_ROCM_VMM_SUPPORT
-/* Track if prctl was called for FD exchange permission */
-static int mca_accelerator_rocm_vmm_prctl_set = 0;
 
 /*
  * Key for vmm_region_cache: identifies a remote VMM allocation by the sender's
@@ -527,7 +525,9 @@ static int mca_accelerator_rocm_memcpy(int dest_dev_id, int src_dev_id, void *de
         }
         int dev = (src_dev_id != MCA_ACCELERATOR_NO_DEVICE_ID) ? src_dev_id : dest_dev_id;
         if (dev == MCA_ACCELERATOR_NO_DEVICE_ID) {
-            hipGetDevice(&dev);
+            if (hipSuccess != hipGetDevice(&dev)) {
+                return OPAL_ERROR;
+            }
         }
         hipStream_t stream = opal_accelerator_rocm_MemcpyStreams[dev];
         err = hipMemcpyAsync(dest, src, size, hipMemcpyDefault, stream);
@@ -623,7 +623,9 @@ static int mca_accelerator_rocm_memmove(int dest_dev_id, int src_dev_id, void *d
         }
         int dev = (src_dev_id != MCA_ACCELERATOR_NO_DEVICE_ID) ? src_dev_id : dest_dev_id;
         if (dev == MCA_ACCELERATOR_NO_DEVICE_ID) {
-            hipGetDevice(&dev);
+            if (hipSuccess != hipGetDevice(&dev)) {
+                return OPAL_ERROR;
+            }
         }
         hipStream_t stream = opal_accelerator_rocm_MemcpyStreams[dev];
         err = hipMemcpyAsync(tmp, src, size, hipMemcpyDefault, stream);
@@ -806,19 +808,7 @@ static int mca_accelerator_rocm_get_ipc_handle(int dev_id, void *dev_ptr,
 #if OPAL_ROCM_VMM_SUPPORT
     /* Try to get allocation handle - only works for VMM allocations */
     /* Only attempt VMM detection if explicitly enabled via MCA parameter */
-    if (opal_accelerator_rocm_vmm_support && !is_legacy_ipc) {
-        /* Set prctl permission for FD exchange (only once per process) */
-        if (!mca_accelerator_rocm_vmm_prctl_set) {
-            if (prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0) != 0) {
-                opal_output_verbose(1, opal_accelerator_base_framework.framework_output,
-                                    "prctl(PR_SET_PTRACER_ANY) failed (errno=%d): "
-                                    "VMM IPC peers may need CAP_SYS_PTRACE or "
-                                    "pidfd_getfd will be denied on the receiver.",
-                                    errno);
-            }
-            mca_accelerator_rocm_vmm_prctl_set = 1;
-        }
-
+    if (opal_accelerator_rocm_vmm_support && hipSuccess == err && !is_legacy_ipc) {
         /* hipMemRetainAllocationHandle succeeds only for VMM pointers.
          * It must be called with the allocation base — passing a mid-allocation
          * offset returns a handle that may crash on hipMemRelease.
@@ -1038,7 +1028,9 @@ static int mca_accelerator_rocm_open_ipc_handle(int dev_id, opal_accelerator_ipc
         int actual_dev_id = dev_id;
         if (actual_dev_id == MCA_ACCELERATOR_NO_DEVICE_ID) {
             if (hipSuccess != hipGetDevice(&actual_dev_id)) {
-                actual_dev_id = 0;
+                hipMemUnmap(local_base_addr, vmm_desc.alloc_size);
+                hipMemAddressFree(local_base_addr, vmm_desc.alloc_size);
+                return OPAL_ERROR;
             }
         }
 
@@ -1108,7 +1100,7 @@ static int mca_accelerator_rocm_compare_ipc_handles(uint8_t handle_1[IPC_MAX_HAN
      */
     uint32_t *type_1 = (uint32_t *)&handle_1[48];
     uint32_t *type_2 = (uint32_t *)&handle_2[48];
-    if (*type_1 == 0 && *type_2 == 0) {
+    if (opal_accelerator_rocm_vmm_support && *type_1 == 0 && *type_2 == 0) {
         return memcmp(&handle_1[4], &handle_2[4], sizeof(uint32_t) + sizeof(void *));
     }
 #endif


### PR DESCRIPTION
Implements HIP VMM-based IPC for the ROCm accelerator component and fixes misc bugs.