### PR TITLE
configury: fix --with-knem=PATH

### DIFF
--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -36,7 +36,7 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
           [opal_check_knem_happy="yes"])
 
     AS_IF([test "${opal_check_knem_happy}" = "yes"],
-          [AS_IF([test -a "${with_knem}" != "yes"],
+          [AS_IF([test -n "${with_knem}" -a "${with_knem}" != "yes"],
                  [$1_CPPFLAGS="-I${with_knem}/include"
                   CPPFLAGS="$CPPFLAGS ${$1_CPPFLAGS}"])
            AC_CHECK_HEADER([knem_io.h], [opal_check_knem_happy="yes"], [opal_check_knem_happy="no"])])


### PR DESCRIPTION
Fixes the error below.

```
$ ./configure --with-knem=PATH

...

--- MCA component smsc:knem (m4 configuration macro)
checking for MCA component smsc:knem compile mode... static
./configure: line 118606: test: too many arguments
checking for knem_io.h... no
configure: error: KNEM support requested but not found.  Aborting
```