### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -130,7 +130,7 @@ jobs:
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Checkout repository (full history)
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -21,7 +21,7 @@ jobs:
         sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt update
         sudo apt install -y cuda-toolkit
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -9,7 +9,7 @@ jobs:
   compile-ignored:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Remove .opal_ignore files so that we build all examples

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -19,7 +19,7 @@ jobs:
         wget https://repo.radeon.com/amdgpu-install/7.2/ubuntu/jammy/amdgpu-install_7.2.70200-1_all.deb
         sudo apt install -y ./amdgpu-install_7.2.70200-1_all.deb
         sudo amdgpu-install --usecase=rocmdev
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/compile-ze.yaml
+++ b/.github/workflows/compile-ze.yaml
@@ -23,7 +23,7 @@ jobs:
         cd build
         cmake ../ -DCMAKE_INSTALL_PREFIX=/opt/ze
         sudo make -j1 install
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI (VPATH)

--- a/.github/workflows/hdf5-tests.yaml
+++ b/.github/workflows/hdf5-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y --no-install-recommends wget
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/macos-checks.yaml
+++ b/.github/workflows/macos-checks.yaml
@@ -22,7 +22,7 @@ jobs:
         brew install libtool
         # unlink libevent
         brew unlink libevent || true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -35,7 +35,7 @@ jobs:
       if:   ${{ runner.os == 'Linux' }}
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
        path: mpi-build
        submodules: recursive
@@ -105,7 +105,7 @@ jobs:
               numpy cffi pyyaml
 
     - name: Checkout mpi4py
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository || 'mpi4py/mpi4py' }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/ompi_mpi4py_asan.yaml
+++ b/.github/workflows/ompi_mpi4py_asan.yaml
@@ -42,7 +42,7 @@ jobs:
       if:   ${{ runner.os == 'Linux' }}
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
        path: mpi-build
        submodules: recursive
@@ -106,7 +106,7 @@ jobs:
               numpy cffi pyyaml
 
     - name: Checkout mpi4py
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository || 'mpi4py/mpi4py' }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Checkout CI scripts
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: Mellanox/jenkins_scripts
         path: ompi_ci

--- a/.github/workflows/riscv64-qemu-test.yaml
+++ b/.github/workflows/riscv64-qemu-test.yaml
@@ -20,7 +20,7 @@ jobs:
         sed -i "s|libdir='/mnt/riscv/riscv64-unknown-linux-gnu/lib'|libdir='/opt/riscv/riscv64-unknown-linux-gnu/lib'|g" /opt/riscv/riscv64-unknown-linux-gnu/lib/libatomic.la
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
        submodules: recursive
     


### PR DESCRIPTION
Node 20 will be deprecated in June, actions/checkout@6 uses Node 24.

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/