### PR TITLE
Bump actions/checkout to v6 [v5.0.x]

### DIFF
--- a/.github/workflows/compile-cuda.yaml
+++ b/.github/workflows/compile-cuda.yaml
@@ -21,7 +21,7 @@ jobs:
         sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt update
         sudo apt install -y cuda-toolkit
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/compile-rocm.yaml
+++ b/.github/workflows/compile-rocm.yaml
@@ -24,7 +24,7 @@ jobs:
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
         sudo apt update
         sudo apt install -y rocm-hip-runtime
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/macos-checks.yaml
+++ b/.github/workflows/macos-checks.yaml
@@ -22,7 +22,7 @@ jobs:
         brew install libtool
         # unlink libevent
         brew unlink libevent || true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build Open MPI

--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -16,7 +16,7 @@ jobs:
       if:   ${{ runner.os == 'Linux' }}
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
        path: mpi-build
        submodules: recursive
@@ -74,7 +74,7 @@ jobs:
               numpy cffi pyyaml
 
     - name: Checkout mpi4py
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: "mpi4py/mpi4py"
 

--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Checkout CI scripts
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: Mellanox/jenkins_scripts
         path: ompi_ci


### PR DESCRIPTION
Node 20 will be deprecated in June, actions/checkout@6 uses Node 24.


(cherry picked from commit d368fa2c4632b8b00493335cadc9eb399861e307)