### PR TITLE
Update 05/2026: UBCL components with latest Bull cleaning

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -139,3 +139,6 @@ Brian Barrett <brian@bbarrett.org>
 Andrii Bilokur <abilokur@nvidia.com> B-a-S <abilokur@nvidia.com>
 
 Kento Hasegawa <hasegawa.kento@fujitsu.com> hasegawa.kento <hasegawa.kento@fujitsu.com>
+
+Brelle Emmanuel <emmanuel.brelle@bull.com> Brelle Emmanuel <emmanuel.brelle@atos.net>
+Brelle Emmanuel <emmanuel.brelle@bull.com> Brelle Emmanuel <emmanuel.brelle@eviden.com>

--- a/config/ompi_check_ubcl.m4
+++ b/config/ompi_check_ubcl.m4
@@ -8,7 +8,7 @@
 #                         reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
-# Copyright (c) 2024-2025 Bull S.A.S.  All rights reserved.
+# Copyright (c) 2024-2026 Bull S.A.S.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +43,9 @@ AC_DEFUN([OMPI_CHECK_UBCL],[
 
           [ompi_check_ubcl_happy="yes"
            $1_CPPFLAGS="${$1_CPPFLAGS} -I$with_ubcl/include/"
-           AC_MSG_NOTICE([$1_CPPFLAGS is set to: ${$1_CPPFLAGS}])])
+           AC_MSG_NOTICE([$1_CPPFLAGS is set to: ${$1_CPPFLAGS}])
+           $1_LDFLAGS="${$1_LDFLAGS} -lubcl -L$with_ubcl/lib/"
+           AC_MSG_NOTICE([$1_LDFLAGS is set to: ${$1_LDFLAGS}])])
 
 
     OPAL_SUMMARY_ADD([Transports],[UBCL],[],[$ompi_check_ubcl_happy])

--- a/ompi/mca/common/ubcl/Makefile.am
+++ b/ompi/mca/common/ubcl/Makefile.am
@@ -36,6 +36,7 @@ libmca_common_ubcl_la_LIBADD = $(common_ubcl_LIBS) \
 
 libmca_common_ubcl_noinst_la_SOURCES = $(common_ubcl_sources)
 libmca_common_ubcl_noinst_la_CPPFLAGS = $(common_ubcl_CPPFLAGS)
+libmca_common_ubcl_noinst_la_LDFLAGS = $(common_ubcl_LDFLAGS)
 
 # Conditionally install the header files
 

--- a/ompi/mca/common/ubcl/Makefile.am
+++ b/ompi/mca/common/ubcl/Makefile.am
@@ -8,7 +8,7 @@
 
 #AM_CPPFLAGS = $(common_ubcl_CPPFLAGS)
 
-common_ubcl_sources  = \
+ompi_common_ubcl_sources  = \
 	common_ubcl.c \
 	common_ubcl.h
 
@@ -27,16 +27,16 @@ else
 noinst_LTLIBRARIES += $(comp_noinst)
 endif
 
-libmca_common_ubcl_la_SOURCES = $(common_ubcl_sources)
-libmca_common_ubcl_la_CFLAGS = $(common_ubcl_CFLAGS)
-libmca_common_ubcl_la_CPPFLAGS = $(common_ubcl_CPPFLAGS)
-libmca_common_ubcl_la_LDFLAGS = $(common_ubcl_LDFLAGS)
-libmca_common_ubcl_la_LIBADD = $(common_ubcl_LIBS) \
+libmca_common_ubcl_la_SOURCES = $(ompi_common_ubcl_sources)
+libmca_common_ubcl_la_CFLAGS = $(ompi_common_ubcl_CFLAGS)
+libmca_common_ubcl_la_CPPFLAGS = $(ompi_common_ubcl_CPPFLAGS)
+libmca_common_ubcl_la_LDFLAGS = $(ompi_common_ubcl_LDFLAGS)
+libmca_common_ubcl_la_LIBADD = $(ompi_common_ubcl_LIBS) \
 	$(OPAL_TOP_BUILDDIR)/opal/mca/common/ubcl/lib@OPAL_LIB_NAME@mca_common_ubcl.la
 
-libmca_common_ubcl_noinst_la_SOURCES = $(common_ubcl_sources)
-libmca_common_ubcl_noinst_la_CPPFLAGS = $(common_ubcl_CPPFLAGS)
-libmca_common_ubcl_noinst_la_LDFLAGS = $(common_ubcl_LDFLAGS)
+libmca_common_ubcl_noinst_la_SOURCES = $(ompi_common_ubcl_sources)
+libmca_common_ubcl_noinst_la_CPPFLAGS = $(ompi_common_ubcl_CPPFLAGS)
+libmca_common_ubcl_noinst_la_LDFLAGS = $(ompi_common_ubcl_LDFLAGS)
 
 # Conditionally install the header files
 

--- a/ompi/mca/common/ubcl/Makefile.am
+++ b/ompi/mca/common/ubcl/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright (c) 2025      Bull SAS.  All rights reserved.
+# Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,6 +35,7 @@ libmca_common_ubcl_la_LIBADD = $(common_ubcl_LIBS) \
 	$(OPAL_TOP_BUILDDIR)/opal/mca/common/ubcl/lib@OPAL_LIB_NAME@mca_common_ubcl.la
 
 libmca_common_ubcl_noinst_la_SOURCES = $(common_ubcl_sources)
+libmca_common_ubcl_noinst_la_CPPFLAGS = $(common_ubcl_CPPFLAGS)
 
 # Conditionally install the header files
 

--- a/ompi/mca/common/ubcl/configure.m4
+++ b/ompi/mca/common/ubcl/configure.m4
@@ -29,7 +29,7 @@ AC_DEFUN([MCA_ompi_common_ubcl_CONFIG],[
           [$2])
 
     # substitute in the things needed to build ubcl
-    AC_SUBST([common_ubcl_CPPFLAGS])
-    AC_SUBST([common_ubcl_LDFLAGS])
-    AC_SUBST([common_ubcl_LIBS])
+    AC_SUBST([ompi_common_ubcl_CPPFLAGS])
+    AC_SUBST([ompi_common_ubcl_LDFLAGS])
+    AC_SUBST([ompi_common_ubcl_LIBS])
 ])dnl

--- a/ompi/mca/common/ubcl/configure.m4
+++ b/ompi/mca/common/ubcl/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2025      Bull S.A.S. All rights reserved.
+# Copyright (c) 2025-2026 Bull S.A.S. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -15,6 +15,12 @@ AC_DEFUN([MCA_ompi_common_ubcl_CONFIG],[
                     [common_ubcl_happy="yes"],
                     [common_ubcl_happy="no"])
 
+    # common/ubcl let endusers provide a more recent version of UBCL
+    # An mca parameter is exposed to select a specific UBCL path that is dlopen
+    # at runtime. We don't want any previous linking on DSO files.
+    AS_IF([test "$compile_mode" = "dso"],
+          [common_ubcl_LDFLAGS=""],
+          [AC_MSG_WARN([Only DSO mode of common/ubcl is tested])])
 
     AC_REQUIRE([MCA_opal_common_ubcl_CONFIG])
 

--- a/ompi/mca/osc/ubcl/configure.m4
+++ b/ompi/mca/osc/ubcl/configure.m4
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Bull SAS.  All rights reserved.
+# Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,6 +20,10 @@ AC_DEFUN([MCA_ompi_osc_ubcl_CONFIG], [
     OMPI_CHECK_UBCL([osc_ubcl],
         [osc_ubcl_happy="yes"],
         [osc_ubcl_happy="no"])
+
+    AS_IF([test "$compile_mode" = "dso"],
+          [osc_ubcl_LDFLAGS=""],
+          [AC_MSG_WARN([Only DSO mode of osc/ubcl is tested (see --enable-mca-dso)])])
 
     AS_IF([test "$osc_ubcl_happy" = "yes"],
         [$1],

--- a/ompi/mca/osc/ubcl/osc_ubcl.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -250,7 +250,9 @@ static int component_query(struct ompi_win_t *win, void **base, size_t size, ptr
     if (MPI_WIN_FLAVOR_ALLOCATE != flavor && MPI_WIN_FLAVOR_DYNAMIC != flavor
         && 0 < size && NULL != base && NULL != *base
         && opal_accelerator.check_addr(*base, &dev_id, &flags) > 0) {
-        mca_osc_ubcl_log(20, "GPU buffer not supported by osc/ubcl");
+        mca_osc_ubcl_warn(
+            OPAL_ERR_NOT_SUPPORTED,
+            "GPU buffer not supported by osc/ubcl: disqualifying UBCL for this window creation");
         return OPAL_ERR_NOT_SUPPORTED;
     }
 
@@ -478,8 +480,11 @@ static int win_attach(struct ompi_win_t *win, void *base, size_t size)
     wid = (ubcl_wid_t) module->wid;
 
     /* Accelerator buffer is not supported as attached buffer */
-    if (opal_accelerator.check_addr(base, &dev_id, &flags)) {
-        mca_osc_ubcl_warn(OPAL_ERR_NOT_SUPPORTED, "GPU buffer not supported by osc/ubcl");
+    if (0 < size && NULL != base && opal_accelerator.check_addr(base, &dev_id, &flags)) {
+        mca_osc_ubcl_error(
+            OPAL_ERR_NOT_SUPPORTED,
+            "GPU buffer not supported by osc/ubcl: UBCL fail to attach %zu B starting at %p", size,
+            base);
         return OPAL_ERR_NOT_SUPPORTED;
     }
 

--- a/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -25,6 +25,7 @@
 #include "ompi/mca/osc/ubcl/osc_ubcl_sync.h"
 #include "ompi/mca/osc/ubcl/osc_ubcl_request.h"
 #include "ompi/mca/common/ubcl/common_ubcl.h"
+#include "opal/include/opal_config.h"
 
 static int get_ubcl_int_type(size_t size, bool is_signed, ubcl_win_atomic_datatype_t *ubcl_type)
 {
@@ -210,9 +211,6 @@ static int get_logical_ubcl_type(struct ompi_datatype_t *origin_dt,
 #endif
 #if OMPI_HAVE_FORTRAN_LOGICAL8
                || MPI_LOGICAL8 == origin_dt
-#endif
-#if OMPI_HAVE_FORTRAN_LOGICAL16
-               || MPI_LOGICAL16 == origin_dt
 #endif
     ) {
         ret = OMPI_ERR_NOT_IMPLEMENTED;

--- a/ompi/mca/osc/ubcl/osc_ubcl_get.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_get.c
@@ -41,7 +41,7 @@ int ompi_osc_ubcl_rget(void *origin_addr, size_t origin_count,
     size_t target_span;
     size_t target_iov_count;
     struct iovec *target_iov;
-    void *target_addr;
+    char *target_addr;
     mca_common_ubcl_endpoint_t *endpoint;
     ubcl_memory_descriptor_t sbuf_md;
     mca_osc_ubcl_module_t *module;

--- a/ompi/mca/osc/ubcl/osc_ubcl_get.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -112,7 +112,10 @@ int ompi_osc_ubcl_rget(void *origin_addr, size_t origin_count,
 
     if (opal_convertor_on_device(&osc_req->origin_convertor)) {
         opal_free_list_return(&mca_osc_ubcl_component.req_free_list, &(osc_req->super));
-        mca_osc_ubcl_warn(OPAL_ERR_NOT_SUPPORTED, "GPU buffer not supported by osc/ubcl");
+        mca_osc_ubcl_error(
+            OPAL_ERR_NOT_SUPPORTED,
+            "GPU buffer not supported by osc/ubcl: cannot cannot perform MPI_Get of buffer %p",
+            origin_addr);
         ret = OPAL_ERR_NOT_SUPPORTED;
         goto exit;
     }

--- a/ompi/mca/osc/ubcl/osc_ubcl_put.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_put.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2025-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -120,7 +120,10 @@ int ompi_osc_ubcl_rput(const void *origin_addr, size_t origin_count,
 
     if (opal_convertor_on_device(&osc_req->origin_convertor)) {
         opal_free_list_return(&mca_osc_ubcl_component.req_free_list, &(osc_req->super));
-        mca_osc_ubcl_warn(OPAL_ERR_NOT_SUPPORTED, "GPU buffer not supported by osc/ubcl");
+        mca_osc_ubcl_error(
+            OPAL_ERR_NOT_SUPPORTED,
+            "GPU buffer not supported by osc/ubcl: cannot perform MPI_Put of buffer %p",
+            origin_addr);
         ret = OPAL_ERR_NOT_SUPPORTED;
         goto exit;
     }

--- a/ompi/mca/osc/ubcl/osc_ubcl_put.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_put.c
@@ -50,7 +50,7 @@ int ompi_osc_ubcl_rput(const void *origin_addr, size_t origin_count,
     size_t span;
     size_t target_iov_count;
     struct iovec *target_iov;
-    void *target_addr;
+    char *target_addr;
     mca_common_ubcl_endpoint_t *endpoint;
     ubcl_memory_descriptor_t sbuf_md;
     mca_osc_ubcl_module_t *module = (mca_osc_ubcl_module_t *) win->w_osc_module;

--- a/ompi/mca/pml/ubcl/configure.m4
+++ b/ompi/mca/pml/ubcl/configure.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Bull SAS.  All rights reserved.
+# Copyright (c) 2024-2026 Bull SAS.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,6 +18,10 @@ AC_DEFUN([MCA_ompi_pml_ubcl_CONFIG], [
     OMPI_CHECK_UBCL([pml_ubcl],
                    [pml_ubcl_happy="yes"],
                    [pml_ubcl_happy="no"])
+
+    AS_IF([test "$compile_mode" = "dso"],
+          [pml_ubcl_LDFLAGS=""],
+          [AC_MSG_WARN([Only DSO mode of pml/ubcl is tested (see --enable-mca-dso)])])
 
     AC_REQUIRE([MCA_ompi_common_ubcl_CONFIG])
     AC_REQUIRE([MCA_opal_common_ubcl_CONFIG])

--- a/ompi/mca/pml/ubcl/pml_ubcl_iprobe.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_iprobe.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2019-2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2019-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -32,6 +32,7 @@ int mca_pml_ubcl_iprobe(int src, int tag, struct ompi_communicator_t *comm,
     OPAL_OUTPUT_VERBOSE((75, mca_pml_ubcl_component.output,
                         "UBCL_MODULE_IPROBE\n"));
     ubcl_status_t ubcl_status;
+    ubcl_error_t err;
     uint64_t cid;
     uint64_t rank;
 
@@ -45,10 +46,13 @@ int mca_pml_ubcl_iprobe(int src, int tag, struct ompi_communicator_t *comm,
     }
 
     cid = ompi_comm_get_local_cid(comm);
-    ubcl_cid_t ubcl_cid= mca_pml_ubcl_compute_ubcl_cid(tag, cid);
+    ubcl_cid_t ubcl_cid = mca_pml_ubcl_compute_ubcl_cid(tag, cid);
 
     /* Call the UBCL api for iprobe */
-    ubcl_iprobe(rank, tag, ubcl_cid, matched, &ubcl_status);
+    err = ubcl_iprobe(rank, tag, ubcl_cid, matched, &ubcl_status);
+    if (UBCL_SUCCESS != err) {
+        return ubcl_error_to_ompi(err);
+    }
     if (*matched) {
         mca_common_ubcl_status_to_ompi(status, ubcl_status, comm, src);
     }
@@ -78,6 +82,7 @@ int mca_pml_ubcl_improbe(int src, int tag, struct ompi_communicator_t *comm,
     OPAL_OUTPUT_VERBOSE((75, mca_pml_ubcl_component.output,
                         "UBCL_MODULE_IMPROBE\n"));
     ubcl_status_t ubcl_status;
+    ubcl_error_t err;
     uint64_t rank;
     uint64_t cid;
     if (OMPI_ANY_SOURCE == src) {
@@ -95,7 +100,10 @@ int mca_pml_ubcl_improbe(int src, int tag, struct ompi_communicator_t *comm,
     ubcl_message_t *ubcl_message;
 
     /* Call the UBCL api for improbe */
-    ubcl_improbe(rank, tag, ubcl_cid, matched, &ubcl_message, &ubcl_status);
+    err = ubcl_improbe(rank, tag, ubcl_cid, matched, &ubcl_message, &ubcl_status);
+    if (UBCL_SUCCESS != err) {
+        return ubcl_error_to_ompi(err);
+    }
     if (*matched) {
         mca_common_ubcl_status_to_ompi(status, ubcl_status, comm, src);
         *message = ompi_message_alloc();

--- a/ompi/mca/pml/ubcl/pml_ubcl_irecv.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_irecv.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2019-2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2019-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -91,17 +91,16 @@ void mca_pml_ubcl_irecv_start(struct ompi_request_t **request)
                                               mca_pml_ubcl_request_t, ompi_req);
     void *output_buf = (void *) req->buf;
 
-    ubcl_memory_descriptor_t rbuf_md;
     ubcl_error_t err = 0;
     size_t size;
 
     /* Init UBCL MD */
-    err = ubcl_memory_descriptor_init(&rbuf_md);
+    err = ubcl_memory_descriptor_init(&req->md);
     if (UBCL_SUCCESS != err) {
         mca_pml_ubcl_error(ubcl_error_to_ompi(err), "Failed to initialize ubcl MD");
     }
     if (pml_ubcl_request_is_cuda_buf(req)) {
-        err = ubcl_memory_descriptor_set_properties(UBCL_BUF_IS_CUDA, &rbuf_md);
+        err = ubcl_memory_descriptor_set_properties(UBCL_BUF_IS_CUDA, &req->md);
         if (UBCL_SUCCESS != err) {
             mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                                "Failed to set MD properties, got error: %d", err);
@@ -113,7 +112,7 @@ void mca_pml_ubcl_irecv_start(struct ompi_request_t **request)
         ompi_datatype_type_size(req->datatype, &size);
         size *= req->count;
 
-        err = ubcl_memory_descriptor_build_contiguous(output_buf, size, &rbuf_md);
+        err = ubcl_memory_descriptor_build_contiguous(output_buf, size, &req->md);
         if (UBCL_SUCCESS != err) {
             mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                                "Failed to build memory descriptor for output buffer");
@@ -121,12 +120,9 @@ void mca_pml_ubcl_irecv_start(struct ompi_request_t **request)
     }
 
     /* Always build a custom MD representation so that we have a fallback */
-    err = ubcl_memory_descriptor_build_custom((void *) &req->convertor,
-                                              pml_ubcl_datatype_pack,
-                                              pml_ubcl_datatype_unpack,
-                                              pml_ubcl_datatype_mem_size,
-                                              pml_ubcl_datatype_finish,
-                                              &rbuf_md);
+    err = ubcl_memory_descriptor_build_custom((void *) &req->convertor, pml_ubcl_datatype_pack,
+                                              pml_ubcl_datatype_unpack, pml_ubcl_datatype_mem_size,
+                                              pml_ubcl_datatype_finish, &req->md);
     if (UBCL_SUCCESS != err) {
         mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                            "Failed to build custom memory descriptor for input buffer");
@@ -136,9 +132,8 @@ void mca_pml_ubcl_irecv_start(struct ompi_request_t **request)
     MCA_PML_UBCL_REQUEST_ACTIVATE(req);
 
     if (req->message != NULL) {
-        err = ubcl_imrecv(rbuf_md, (ubcl_message_t **) &req->message,
-                          (ubcl_completion_callback_fct) &ubcl_request_recv_complete_cb,
-                          *request);
+        err = ubcl_imrecv(req->md, (ubcl_message_t **) &req->message,
+                          (ubcl_completion_callback_fct) ubcl_request_recv_complete_cb, *request);
     } else {
         uint64_t rank;
         uint64_t cid;
@@ -158,9 +153,9 @@ void mca_pml_ubcl_irecv_start(struct ompi_request_t **request)
 
         OPAL_OUTPUT_VERBOSE(
                 (50, mca_pml_ubcl_component.output, "PML/UBCL IRECV: recv from rank=%zu\n", rank));
-        err = ubcl_irecv(rbuf_md, tag, ubcl_cid, rank,
-                         (ubcl_completion_callback_fct) &ubcl_request_recv_complete_cb,
-                         *request, &req->ubcl_operation_handle);
+        err = ubcl_irecv(req->md, tag, ubcl_cid, rank,
+                         (ubcl_completion_callback_fct) &ubcl_request_recv_complete_cb, *request,
+                         &req->ubcl_operation_handle);
     }
 
     if (UBCL_ERROR == err) {

--- a/ompi/mca/pml/ubcl/pml_ubcl_isend.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_isend.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2019-2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2019-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -106,7 +106,6 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
 
     char *input_buf = NULL;
     mca_common_ubcl_endpoint_t *endpoint = NULL;
-    ubcl_memory_descriptor_t sbuf_md;
     ubcl_error_t err = 0;
     ubcl_send_mode_t send_mode;
     uint64_t cid;
@@ -127,12 +126,12 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
     endpoint = (mca_common_ubcl_endpoint_t *) req->proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PML];
 
     /* Init UBCL MD */
-    err = ubcl_memory_descriptor_init(&sbuf_md);
+    err = ubcl_memory_descriptor_init(&req->md);
     if (UBCL_SUCCESS != err) {
         mca_pml_ubcl_error(ubcl_error_to_ompi(err), "Failed to initialize ubcl MD");
     }
     if (pml_ubcl_request_is_cuda_buf(req)) {
-        err = ubcl_memory_descriptor_set_properties(UBCL_BUF_IS_CUDA, &sbuf_md);
+        err = ubcl_memory_descriptor_set_properties(UBCL_BUF_IS_CUDA, &req->md);
         if (UBCL_SUCCESS != err) {
             mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                                "Failed to set MD properties, got error: %d", err);
@@ -143,7 +142,7 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
     if (! MCA_PML_UBCL_REQUEST_NEED_XPACK(req)) {
         ptrdiff_t gap = 0;
         size_t span = opal_datatype_span(&req->datatype->super, req->count, &gap);
-        err = ubcl_memory_descriptor_build_contiguous(input_buf+gap, span, &sbuf_md);
+        err = ubcl_memory_descriptor_build_contiguous(input_buf + gap, span, &req->md);
         if (UBCL_SUCCESS != err) {
             mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                                "Failed to build contiguous memory descriptor for input buffer");
@@ -151,11 +150,9 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
     }
 
     /* Always build a custom MD representation so that we have a fallback */
-    err = ubcl_memory_descriptor_build_custom((void *) &req->convertor,
-                                              pml_ubcl_datatype_pack,
-                                              pml_ubcl_datatype_unpack,
-                                              pml_ubcl_datatype_mem_size,
-                                              pml_ubcl_datatype_finish, &sbuf_md);
+    err = ubcl_memory_descriptor_build_custom((void *) &req->convertor, pml_ubcl_datatype_pack,
+                                              pml_ubcl_datatype_unpack, pml_ubcl_datatype_mem_size,
+                                              pml_ubcl_datatype_finish, &req->md);
     if (UBCL_SUCCESS != err) {
         mca_pml_ubcl_error(ubcl_error_to_ompi(err),
                            "Failed to build custom memory descriptor for input buffer");
@@ -171,9 +168,9 @@ void mca_pml_ubcl_isend_start(struct ompi_request_t **request)
     OPAL_OUTPUT_VERBOSE(
         (50, mca_pml_ubcl_component.output, "PML/UBCL ISEND: sending to rank=%zu\n", endpoint->rank));
 
-    err = ubcl_isend(sbuf_md, tag, ubcl_cid, endpoint->rank, send_mode,
-                     (ubcl_completion_callback_fct) &ubcl_request_send_complete_cb,
-                     *request, &req->ubcl_operation_handle);
+    err = ubcl_isend(req->md, tag, ubcl_cid, endpoint->rank, send_mode,
+                     (ubcl_completion_callback_fct) ubcl_request_send_complete_cb, *request,
+                     &req->ubcl_operation_handle);
     if (UBCL_ERROR == err) {
         mca_pml_ubcl_error(ubcl_error_to_ompi(err), "Failed to send data");
     }

--- a/ompi/mca/pml/ubcl/pml_ubcl_request.c
+++ b/ompi/mca/pml/ubcl/pml_ubcl_request.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2019-2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2019-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -216,7 +216,6 @@ int mca_pml_ubcl_request_complete_cb(struct ompi_request_t *request)
     return mca_pml_ubcl_request_complete(request);
 }
 
-/* TODO: Get a pointer to status and not a cpy ? */
 void ubcl_request_send_complete_cb(ubcl_status_t status, void *cb_data)
 {
     if (UBCL_SUCCESS != status.status) {
@@ -232,7 +231,9 @@ void ubcl_request_send_complete_cb(ubcl_status_t status, void *cb_data)
     /* This lock cannot be removed, even in thread single mode */
     opal_atomic_lock(&req->req_lock);
     req->completed = 1;
+    ubcl_memory_descriptor_destruct(&req->md);
     opal_atomic_unlock(&req->req_lock);
+
     if (req->is_buffered) {
         mca_pml_base_bsend_request_free(req->comm, (void*)req->buf);
         /* Bsend started completed, but could not be freed, now that UBCL is
@@ -280,6 +281,7 @@ void ubcl_request_recv_complete_cb(ubcl_status_t status, void *cb_data)
     /* This lock cannot be removed, even in thread single mode */
     opal_atomic_lock(&req->req_lock);
     req->completed = 1;
+    ubcl_memory_descriptor_destruct(&req->md);
     opal_atomic_unlock(&req->req_lock);
     ompi_request_complete(&(req->ompi_req), true);
 

--- a/ompi/mca/pml/ubcl/pml_ubcl_request.h
+++ b/ompi/mca/pml/ubcl/pml_ubcl_request.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2019-2025 Bull SAS.  All rights reserved.
+ * Copyright (c) 2019-2026 Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -85,6 +85,7 @@ struct mca_pml_ubcl_request_t {
     struct ompi_communicator_t *comm; /**< Communicator */
     struct ompi_proc_t *proc;         /**< Remote ompi proc */
     opal_convertor_t convertor;       /**< Data convertor */
+    ubcl_memory_descriptor_t md;
     ompi_request_complete_fn_t saved_complete_cb; /**< Saved callback from another component (e.g OSC pt2pt) */
     void *saved_complete_cb_data; /**< Saved callback data from another component (e.g OSC pt2pt) */
 

--- a/opal/mca/common/ubcl/configure.m4
+++ b/opal/mca/common/ubcl/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2024      Bull S.A.S. All rights reserved.
+# Copyright (c) 2024-2026 Bull S.A.S. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -15,6 +15,7 @@ AC_DEFUN([MCA_opal_common_ubcl_CONFIG],[
                     [common_ubcl_happy="yes"],
                     [common_ubcl_happy="no"])
 
+    common_ubcl_LDFLAGS=""
 
     AS_IF([test "$common_ubcl_happy" = "yes"],
           [$1],


### PR DESCRIPTION
This Pull Request contains Bull updates to UBCL components for the last 6 months:
- Probe functions from pml/ubcl returns error codes based on UBCL probe calls
- UBCL memory descriptors are freed
- Fixing osc/ubcl pointer arithmetic
- Cleaning of compilation flags to remove explicit link to libubcl.so (all symbols are dlsym)
- Cleaning of compilation flags names to avoid conflict between ompi/mcac/common/ubcl and opal/mca/common/ubcl
- Refining the non-supported case of RMA communications over GPU buffer (0-size is OK)
- Cleaning deadcode is osc/ubcl
- More detailed logs in osc/ubcl