### PR TITLE
Reply to "Update 05/2026: UBCL components"

### DIFF
--- a/config/ompi_check_ubcl.m4
+++ b/config/ompi_check_ubcl.m4
@@ -44,6 +44,10 @@ AC_DEFUN([OMPI_CHECK_UBCL],[
           [ompi_check_ubcl_happy="yes"
            $1_CPPFLAGS="${$1_CPPFLAGS} -I$with_ubcl/include/"
            AC_MSG_NOTICE([$1_CPPFLAGS is set to: ${$1_CPPFLAGS}])
+           # Let define UBCL linking flags even if they will be ignored afterwards
+           # as ubcl components are very likely compiled in dynamic mode
+           # See ompi/mca/common/ubcl/configure.m4 comment explaining why UBCL linking
+           # flags are removed only in dynamic mode
            $1_LDFLAGS="${$1_LDFLAGS} -lubcl -L$with_ubcl/lib/"
            AC_MSG_NOTICE([$1_LDFLAGS is set to: ${$1_LDFLAGS}])])
 

--- a/config/ompi_check_ubcl.m4
+++ b/config/ompi_check_ubcl.m4
@@ -32,6 +32,18 @@ AC_DEFUN([OMPI_CHECK_UBCL],[
 
     # UBCL is dlopen'd to avoid direct link to libubcl.so.
     # OAC_CHECK_PACKAGE would add this explicit link, so it cannot be used.
+
+    # No option means no dso and with-ubcl=""
+    AS_IF([test "$with_ubcl" = "yes" || test "x$with_ubcl" = "x"],
+          [AC_MSG_NOTICE([Unspecified UBCL path])
+           guessed_path="`find /opt/ubcl -name ubcl_api.h 2>/dev/null \
+                          | sort | tail -n1                          \
+                          | cut -d "/" -f1-4`"
+           AS_IF([test "x$guessed_path" != "x"],
+                 [with_ubcl=$guessed_path
+                 AC_MSG_NOTICE([Guessed that UBCL is $guessed_path])])
+           ])
+
     # OPAL_CHECK_WITHDIR prints an error if the given path is invalid
     OPAL_CHECK_WITHDIR([ubcl], [$with_ubcl], [include/ubcl_api.h])
 

--- a/ompi/mca/common/ubcl/configure.m4
+++ b/ompi/mca/common/ubcl/configure.m4
@@ -15,12 +15,24 @@ AC_DEFUN([MCA_ompi_common_ubcl_CONFIG],[
                     [common_ubcl_happy="yes"],
                     [common_ubcl_happy="no"])
 
-    # common/ubcl let endusers provide a more recent version of UBCL
+    # By default the tarball build goes through a 'make dist check' step.
+    # It runs first a configure without any options and OMPI_CHECK_UBCL may find UBCL.
+    # In that case, UBCL symbols will be included inside binaries such as ompi_info,
+    # therefore UBCL linking flags are needed in static mode to resolve symbols.
+    #
+    # In dynamic mode, UBCL symbols are resolved at runtime: ompi components
+    # are dlopen-ed lazily and UBCL components initialization starts with a dlopen
+    # of libubcl.so to load symbols. If it fails UBCL components init returns an error and
+    # Open MPI will search for other components. UBCL linking flags become optional.
+    #
+    # In dynamic mode, linking to the UBCL library is delayed. So common/ubcl can let
+    # endusers provide a more recent version of UBCL.
+    # This mode should be preferably selected for UBCL components.
     # An mca parameter is exposed to select a specific UBCL path that is dlopen
-    # at runtime. We don't want any previous linking on DSO files.
+    # at runtime.
     AS_IF([test "$compile_mode" = "dso"],
           [common_ubcl_LDFLAGS=""],
-          [AC_MSG_WARN([Only DSO mode of common/ubcl is tested])])
+          [AC_MSG_WARN([Only DSO mode of common/ubcl is tested (see --enable-mca-dso)])])
 
     AC_REQUIRE([MCA_opal_common_ubcl_CONFIG])
 

--- a/ompi/mca/osc/ubcl/configure.m4
+++ b/ompi/mca/osc/ubcl/configure.m4
@@ -21,6 +21,8 @@ AC_DEFUN([MCA_ompi_osc_ubcl_CONFIG], [
         [osc_ubcl_happy="yes"],
         [osc_ubcl_happy="no"])
 
+    # See ompi/mca/common/ubcl/configure.m4 comment explaining why UBCL linking
+    # flags are removed only in dynamic mode
     AS_IF([test "$compile_mode" = "dso"],
           [osc_ubcl_LDFLAGS=""],
           [AC_MSG_WARN([Only DSO mode of osc/ubcl is tested (see --enable-mca-dso)])])

--- a/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
@@ -18,6 +18,7 @@
  * of these functions, refer to ompi/mca/osc/osc.h.
  */
 
+#include "opal/include/opal_config.h"
 #include "ompi/mca/osc/ubcl/osc_ubcl.h"
 #include "opal/mca/common/ubcl/common_ubcl.h"
 #include "ompi/mca/osc/ubcl/osc_ubcl_info.h"

--- a/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
@@ -212,8 +212,11 @@ static int get_logical_ubcl_type(struct ompi_datatype_t *origin_dt,
 #if OMPI_HAVE_FORTRAN_LOGICAL8
                || MPI_LOGICAL8 == origin_dt
 #endif
+/* To ease backport to older ompi versions */
+#if defined OMPI_HAVE_FORTRAN_LOGICAL16
 #if OMPI_HAVE_FORTRAN_LOGICAL16
                || MPI_LOGICAL16 == origin_dt
+#endif
 #endif
     ) {
         ret = OMPI_ERR_NOT_IMPLEMENTED;

--- a/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_accumulate.c
@@ -25,7 +25,6 @@
 #include "ompi/mca/osc/ubcl/osc_ubcl_sync.h"
 #include "ompi/mca/osc/ubcl/osc_ubcl_request.h"
 #include "ompi/mca/common/ubcl/common_ubcl.h"
-#include "opal/include/opal_config.h"
 
 static int get_ubcl_int_type(size_t size, bool is_signed, ubcl_win_atomic_datatype_t *ubcl_type)
 {
@@ -211,6 +210,9 @@ static int get_logical_ubcl_type(struct ompi_datatype_t *origin_dt,
 #endif
 #if OMPI_HAVE_FORTRAN_LOGICAL8
                || MPI_LOGICAL8 == origin_dt
+#endif
+#if OMPI_HAVE_FORTRAN_LOGICAL16
+               || MPI_LOGICAL16 == origin_dt
 #endif
     ) {
         ret = OMPI_ERR_NOT_IMPLEMENTED;

--- a/ompi/mca/osc/ubcl/osc_ubcl_get.c
+++ b/ompi/mca/osc/ubcl/osc_ubcl_get.c
@@ -114,7 +114,7 @@ int ompi_osc_ubcl_rget(void *origin_addr, size_t origin_count,
         opal_free_list_return(&mca_osc_ubcl_component.req_free_list, &(osc_req->super));
         mca_osc_ubcl_error(
             OPAL_ERR_NOT_SUPPORTED,
-            "GPU buffer not supported by osc/ubcl: cannot cannot perform MPI_Get of buffer %p",
+            "GPU buffer not supported by osc/ubcl: cannot perform MPI_Get of buffer %p",
             origin_addr);
         ret = OPAL_ERR_NOT_SUPPORTED;
         goto exit;

--- a/ompi/mca/pml/ubcl/configure.m4
+++ b/ompi/mca/pml/ubcl/configure.m4
@@ -19,8 +19,11 @@ AC_DEFUN([MCA_ompi_pml_ubcl_CONFIG], [
                    [pml_ubcl_happy="yes"],
                    [pml_ubcl_happy="no"])
 
+    # See ompi/mca/common/ubcl/configure.m4 comment explaining why UBCL linking
+    # flags are removed only in dynamic mode
     AS_IF([test "$compile_mode" = "dso"],
           [pml_ubcl_LDFLAGS=""],
+          # Static mode should work, but Bull provides support only for dynamic components
           [AC_MSG_WARN([Only DSO mode of pml/ubcl is tested (see --enable-mca-dso)])])
 
     AC_REQUIRE([MCA_ompi_common_ubcl_CONFIG])

--- a/opal/mca/common/ubcl/configure.m4
+++ b/opal/mca/common/ubcl/configure.m4
@@ -15,6 +15,7 @@ AC_DEFUN([MCA_opal_common_ubcl_CONFIG],[
                     [common_ubcl_happy="yes"],
                     [common_ubcl_happy="no"])
 
+    # opal/mca/common/ubcl does not handle any UBCL symbols
     common_ubcl_LDFLAGS=""
 
     AS_IF([test "$common_ubcl_happy" = "yes"],


### PR DESCRIPTION
Replies to comments in [PR-13916](https://github.com/open-mpi/ompi/pull/13916)
Thanks for your feedback. Code missed some comments.
This PR details UBCL components expected configurations
It also fixes a few typos from the recent UBCL update.

If you are fine with this PR, another one should be open targeting v6.0.x with https://github.com/open-mpi/ompi/pull/13916 et these commits