### PR TITLE
lsf: add note to docs about problems with

### DIFF
--- a/docs/launching-apps/lsf.rst
+++ b/docs/launching-apps/lsf.rst
@@ -1,7 +1,12 @@
 Launching with LSF
 ==================
 
-Open MPI supports the LSF resource manager.
+Open MPI supports some versions of the LSF resource manager.
+
+Problems have been reported with using the most recent releases of LSF, in particular
+the version supplied with IBM Spectrum LSF Version 10.1 Fix Pack 15.
+The suggested workaround is to use an older release of the LSF 10.1 package or to
+configure Open MPI without LSF support.
 
 Verify LSF support
 ------------------


### PR DESCRIPTION
using most recent release of IBM's LSF product with Open MPI. This problem goes back to the 4.1.x branch at least.

related to #13902


(cherry picked from commit 744f29c1a16fa74f381a90787bcb69451552f405)