### PR TITLE
Reserve dist graph tags outside the libnbc tag range

### DIFF
--- a/ompi/mca/coll/base/coll_tags.h
+++ b/ompi/mca/coll/base/coll_tags.h
@@ -61,9 +61,13 @@
 
 #define MCA_COLL_BASE_TAG_UCC                    (MCA_COLL_BASE_TAG_FT_END - 1)
 
-#define MCA_COLL_BASE_TAG_STATIC_END             (MCA_COLL_BASE_TAG_UCC - 1)
+/* Distributed graph construction uses PML messages before the new
+ * communicator is fully created. Keep these tags out of the nonblocking
+ * collective tag range. */
+#define MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN      (MCA_COLL_BASE_TAG_UCC - 1)
+#define MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT     (MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN - 1)
 
-
+#define MCA_COLL_BASE_TAG_STATIC_END             (MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT)
 
 #define MCA_COLL_BASE_TAG_NONBLOCKING_BASE (MCA_COLL_BASE_TAG_STATIC_END - 1)
 #define MCA_COLL_BASE_TAG_NONBLOCKING_END ((-1 * INT_MAX/2) + 1)

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -19,6 +19,7 @@
 #include "ompi_config.h"
 
 #include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/base/coll_tags.h"
 #include "ompi/info/info.h"
 #include "ompi/mca/topo/base/base.h"
 #include "ompi/datatype/ompi_datatype.h"
@@ -27,8 +28,6 @@
 
 #define IN_INDEX   0
 #define OUT_INDEX  1
-#define MCA_TOPO_BASE_TAG_DIST_EDGE_IN    -50
-#define MCA_TOPO_BASE_TAG_DIST_EDGE_OUT   -51
 
 typedef struct _dist_graph_elem {
     int in;
@@ -172,7 +171,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
                 position *= 2;
             }
             err = MCA_PML_CALL(isend( &rin[position], count, (ompi_datatype_t*)&ompi_mpi_int,
-                                      i, MCA_TOPO_BASE_TAG_DIST_EDGE_IN, MCA_PML_BASE_SEND_STANDARD,
+                                      i, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN, MCA_PML_BASE_SEND_STANDARD,
                                       comm, &reqs[pending_reqs]));
             pending_reqs++;
         }
@@ -183,7 +182,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
                 position *= 2;
             }
             err = MCA_PML_CALL(isend(&rout[position], count, (ompi_datatype_t*)&ompi_mpi_int,
-                                     i, MCA_TOPO_BASE_TAG_DIST_EDGE_OUT, MCA_PML_BASE_SEND_STANDARD,
+                                     i, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT, MCA_PML_BASE_SEND_STANDARD,
                                      comm, &reqs[pending_reqs]));
             pending_reqs++;
         }
@@ -210,7 +209,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
     for( left_over = count, current_pos = i = 0; left_over > 0; i++ ) {
 
         MCA_PML_CALL(recv( &temp[count - left_over], left_over, (ompi_datatype_t*)&ompi_mpi_int,  /* keep receiving in the same buffer */
-                           MPI_ANY_SOURCE, MCA_TOPO_BASE_TAG_DIST_EDGE_IN,
+                           MPI_ANY_SOURCE, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN,
                            comm, &status ));
         how_much = status._ucount / int_size;
         if (MPI_UNWEIGHTED != weights) {
@@ -246,7 +245,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
     for( left_over = count, current_pos = i = 0; left_over > 0; i++ ) {
 
         MCA_PML_CALL(recv( &temp[count - left_over], left_over, (ompi_datatype_t*)&ompi_mpi_int,  /* keep receiving in the same buffer */
-                           MPI_ANY_SOURCE, MCA_TOPO_BASE_TAG_DIST_EDGE_OUT,
+                           MPI_ANY_SOURCE, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT,
                            comm, &status ));
         how_much = status._ucount / int_size;
 


### PR DESCRIPTION
MPI_Dist_graph_create exchanges distributed-graph edge metadata with PML sends and receives on the parent communicator before the new communicator is fully created.  The topo base code used hard-coded internal tags -50 and -51 for this exchange.

Those tags are reachable by the dynamic nonblocking collective tag allocator.  In repeated communicator creation, `comm->c_nbc_tag` can count down into -50/-51.  This creates a race where some ranks may still be matching distributed-graph edge traffic while other ranks have already entered ompi_comm_nextcid and started its nonblocking allreduce on the same parent communicator.  The resulting tag collision can leave the CID allocation request waiting forever.

Reserve the distributed-graph edge tags in coll_tags.h as static internal tags, before MCA_COLL_BASE_TAG_STATIC_END, so the libnbc nonblocking collective range starts below them.

This keeps distributed-graph construction traffic disjoint from nonblocking collective traffic on the parent communicator and avoids the loop-triggered deadlock in MPI_Dist_graph_create.

Fixes #13918