### PR TITLE
pml/ob1: drain pckt_pending from mca_pml_ob1_progress to avoid orphaned FINs

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -255,6 +255,12 @@ do {                                                            \
         (opal_free_list_item_t*)pckt);                          \
 } while(0)
 
+/**
+ * A thread-safe function that should be called every time we need the OB1
+ * progress to be turned (or kept) on.
+ */
+int mca_pml_ob1_enable_progress(int32_t count);
+
 static inline void mca_pml_ob1_add_to_pending (ompi_proc_t *proc, mca_bml_base_btl_t *bml_btl,
                                                int order, mca_pml_ob1_hdr_t *hdr, size_t hdr_size)
 {
@@ -270,6 +276,10 @@ static inline void mca_pml_ob1_add_to_pending (ompi_proc_t *proc, mca_bml_base_b
     OPAL_THREAD_SCOPED_LOCK(&mca_pml_ob1.lock, {
             opal_list_append(&mca_pml_ob1.pckt_pending, &pckt->super.super);
         });
+    /* Drive mca_pml_ob1_progress() so the queue is retried from opal_progress()
+     * even if no further BTL completion fires to call
+     * MCA_PML_OB1_PROGRESS_PENDING. */
+    mca_pml_ob1_enable_progress(1);
 }
 
 #define OB1_MATCHING_LOCK(lock)                                  \
@@ -410,12 +420,6 @@ mca_pml_ob1_calc_weighted_length( mca_pml_ob1_com_btl_t *btls, int num_btls, siz
     /* account for rounding errors */
     btls[0].length += length_left;
 }
-
-/**
- * A thread-safe function that should be called every time we need the OB1
- * progress to be turned (or kept) on.
- */
-int mca_pml_ob1_enable_progress(int32_t count);
 
 int mca_pml_ob1_send_control_any (ompi_proc_t *proc, int order, mca_pml_ob1_hdr_t *hdr, size_t hdr_size,
                                   bool add_to_pending);

--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
+++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
@@ -71,6 +71,21 @@ int mca_pml_ob1_progress(void)
 
     completed_requests += mca_pml_ob1_process_pending_accelerator_async_copies();
 
+    /* Drain the FIN/ACK control-packet retry queue. It is otherwise drained
+     * only as a side effect of BTL completion callbacks (see
+     * MCA_PML_OB1_PROGRESS_PENDING). If the BTL goes idle while packets are
+     * still queued -- e.g. the tail of an incast where btl_sendi() repeatedly
+     * returned OPAL_ERR_OUT_OF_RESOURCE -- no further completion fires, the
+     * queue is never revisited, and every peer waiting on those FINs hangs
+     * forever. Retrying it here, driven by mca_pml_ob1_progress_needed (which
+     * mca_pml_ob1_add_to_pending() bumps via mca_pml_ob1_enable_progress()),
+     * guarantees the queue makes progress even with no BTL traffic in flight. */
+    if( opal_list_get_size(&mca_pml_ob1.pckt_pending) ) {
+        int pckt_before = (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
+        mca_pml_ob1_process_pending_packets(NULL);
+        completed_requests += pckt_before - (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
+    }
+
     for( i = 0; i < queue_length; i++ ) {
         mca_pml_ob1_send_pending_t pending_type = MCA_PML_OB1_SEND_PENDING_NONE;
         mca_pml_ob1_send_request_t* sendreq;


### PR DESCRIPTION
The FIN/ACK control-packet retry queue (mca_pml_ob1.pckt_pending) was drained only as a side effect of BTL completion callbacks, via MCA_PML_OB1_PROGRESS_PENDING(). A FIN whose btl_sendi() fails with OPAL_ERR_OUT_OF_RESOURCE is parked on pckt_pending and retried the next time a send/recv/control fragment completes on some bml_btl.

That assumption breaks at the tail of an incast. When a receiver has consumed all incoming data the BTL goes idle: no fragments remain in flight, no completion callback fires, and MCA_PML_OB1_PROGRESS_PENDING() is never invoked again. Any FINs still queued on pckt_pending are orphaned. The senders' RGET requests stay ACTIVE forever (req_pending NONE, req_bytes_delivered 0) and block in MPI_Waitall, while the receiver spins in opal_progress() with a non-empty pckt_pending and an otherwise idle PML/BTL.

Treat a queued control packet like any other pending PML work instead of relying on BTL completions. mca_pml_ob1_add_to_pending() now calls mca_pml_ob1_enable_progress(1), reusing the existing progress counter and the already-registered mca_pml_ob1_progress() callback, which is extended to drain pckt_pending alongside send_pending and to fold the drained packets into its completed-request accounting. No second progress function and no second atomic are introduced; the callback unregisters itself once all pending work (sends and control packets) is gone, so there is no steady-state overhead. Because the BTL is idle when this path matters, fragments are available and the queued FINs are sent, completing the peers' sends.

Reproduced with an all-to-one incast of 80KB rendezvous (RGET) messages over the sm BTL on a single node; aggravated by btl_sm_fbox_max=0, which increases btl_sendi() resource-exhaustion failures. Switching to another BTL hid the issue because their completion/async-progress patterns kept firing MCA_PML_OB1_PROGRESS_PENDING().

Fixes #12979