### PR TITLE
Add pdeb modular process debugger helper

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -32,6 +32,19 @@ dist_amca_param_DATA += amca-param-sets/ft-mpi
 endif # WANT_FT_MPI
 
 EXTRA_DIST = \
+        pdb \
+        pdeb/commands/attach \
+        pdeb/commands/backtrace \
+        pdeb/commands/btlsm_dump \
+        pdeb/commands/detach \
+        pdeb/commands/do \
+        pdeb/commands/frame \
+        pdeb/commands/pml_dump \
+        pdeb/commands/req_dump \
+        pdeb/commands/select \
+        pdeb/commands/show \
+        pdeb/debugger/gdb \
+        pdeb/debugger/lldb \
         completion/mpirun.sh \
         completion/mpirun.zsh \
 	dist/make_dist_tarball \

--- a/contrib/pdb
+++ b/contrib/pdb
@@ -1,0 +1,1143 @@
+#!/bin/sh
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+set -u
+
+usage()
+{
+    cat <<EOF
+Usage: $0 [-d debugger] [--dump filename] [-p|--pids pid[,pid]...] [program-name]
+
+Find processes owned by the current user whose executable basename is
+program-name, resolve them to PIDs, attach a debugger to each one, and
+enter an interactive command loop.  Use the backtrace command to collect
+and summarize stacks.  Use --dump to save an initial raw stack archive.
+
+Instead of program-name, use -p/--pids to attach to an explicit list of
+PIDs.  The two forms are mutually exclusive.
+
+If neither program-name nor -p/--pids is given, the script starts
+unattached.  Use the attach command to attach to a list of PIDs.
+
+Options:
+  -d debugger        Use a debugger module, such as lldb or gdb.  Default:
+                     first available debugger module.
+  --dump file        Save the process list and raw debugger stacks to file.
+  -p, --pids pid[,pid]...
+                     Attach to an explicit, comma- or space-separated list
+                     of PIDs.
+  -h                 Show this help.
+EOF
+}
+
+debugger=auto
+dump_file=
+initial_pids=
+pids=
+selected_pids=
+attached=0
+PROMPT=ompi-stack
+prompt_stack=
+
+case "$0" in
+*/*)
+    script_path=$0
+    ;;
+*)
+script_path=$(command -v "$0" 2>/dev/null || printf "%s\n" "$0")
+    ;;
+esac
+script_dir=$(CDPATH= cd "$(dirname "$script_path")" 2>/dev/null && pwd)
+pdeb_command_dir=${PDEB_COMMAND_DIR:-"$script_dir/pdeb/commands"}
+pdeb_debugger_dir=${PDEB_DEBUGGER_DIR:-"$script_dir/pdeb/debugger"}
+
+while [ 0 -lt $# ] ; do
+    case "$1" in
+    -d)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        debugger=$1
+        ;;
+    --dump)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        dump_file=$1
+        ;;
+    -p|--pids)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        initial_pids="$initial_pids $1"
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
+    -*)
+        echo "Unsupported option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ 1 -lt $# ] ; then
+    usage >&2
+    exit 2
+fi
+
+if [ 1 -eq $# ] ; then
+    program=$1
+    program_base=$(basename "$program")
+else
+    program=
+    program_base=
+fi
+
+initial_pids=$(printf "%s" "$initial_pids" | tr ',' ' ')
+
+if [ -n "$initial_pids" ] && [ -n "$program_base" ] ; then
+    echo "--pids and program-name are mutually exclusive." >&2
+    usage >&2
+    exit 2
+fi
+
+uid=$(id -u)
+user_name=$(id -un)
+
+if [ -n "$dump_file" ] && [ -z "$program_base" ] && [ -z "$initial_pids" ] ; then
+    echo "--dump requires an initial program-name or --pids PID list." >&2
+    exit 2
+fi
+
+find_pids()
+{
+    if command -v pgrep >/dev/null 2>&1 ; then
+        pgrep_output=$(pgrep -U "$uid" -x "$program_base" 2>/dev/null)
+        pgrep_status=$?
+        if [ 0 -eq "$pgrep_status" ] || [ 1 -eq "$pgrep_status" ] ; then
+            printf "%s\n" "$pgrep_output" | awk -v self="$$" \
+                '0 < NF && $1 != self { print $1 }'
+            return 0
+        fi
+    fi
+
+    ps_output=$(ps -u "$uid" -o pid= -o comm=) || return 1
+
+    printf "%s\n" "$ps_output" | awk \
+        -v target="$program_base" \
+        -v self="$$" \
+        '{
+            if (1 > NF) {
+                next
+            }
+            pid = $1
+            $1 = ""
+            sub(/^[[:space:]]*/, "", $0)
+            n = split($0, path, "/")
+            base = path[n]
+            if (pid != self && base == target) {
+                print pid
+            }
+        }'
+}
+
+pid_exists()
+{
+    kill -0 "$1" 2>/dev/null
+}
+
+pid_command_base()
+{
+    pid_command=$(ps -p "$1" -o comm= 2>/dev/null) || return 1
+
+    if [ -z "$pid_command" ] ; then
+        return 1
+    fi
+
+    basename "$pid_command"
+}
+
+args_are_pids()
+{
+    if [ 0 -eq $# ] ; then
+        return 1
+    fi
+
+    for args_pid in "$@" ; do
+        case "$args_pid" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+        esac
+    done
+
+    return 0
+}
+
+pdeb_debugger_file()
+{
+    pdeb_debugger_name=$1
+
+    case "$pdeb_debugger_name" in
+    ""|.*|*/*)
+        return 1
+        ;;
+    esac
+
+    pdeb_debugger_path="$pdeb_debugger_dir/$pdeb_debugger_name"
+    if [ ! -f "$pdeb_debugger_path" ] ; then
+        return 1
+    fi
+
+    printf "%s\n" "$pdeb_debugger_path"
+}
+
+pdeb_debugger_names()
+{
+    for pdeb_debugger_path in "$pdeb_debugger_dir"/* ; do
+        if [ ! -f "$pdeb_debugger_path" ] ; then
+            continue
+        fi
+        pdeb_debugger_name=$(basename "$pdeb_debugger_path")
+        case "$pdeb_debugger_name" in
+        .*)
+            continue
+            ;;
+        esac
+        printf "%s\n" "$pdeb_debugger_name"
+    done | sort
+}
+
+pdeb_unload_debugger()
+{
+    unset -f debugger_available debugger_collect_stack debugger_marker_command \
+        debugger_backtrace_command debugger_current_backtrace_command \
+        debugger_select_frame_command debugger_start debugger_startup_commands \
+        debugger_find_frame_number debugger_parse_stack \
+        debugger_btlsm_dump_command debugger_req_dump_command \
+        debugger_pml_dump_command 2>/dev/null || true
+}
+
+load_debugger_module()
+{
+    pdeb_debugger_name=$1
+    pdeb_debugger_path=$(pdeb_debugger_file "$pdeb_debugger_name") || return 1
+
+    pdeb_unload_debugger
+    . "$pdeb_debugger_path"
+}
+
+ensure_debugger()
+{
+    case "$debugger" in
+    auto)
+        pdeb_seen_debuggers=
+        for pdeb_candidate in lldb gdb $(pdeb_debugger_names) ; do
+            case " $pdeb_seen_debuggers " in
+            *" $pdeb_candidate "*)
+                continue
+                ;;
+            esac
+            pdeb_seen_debuggers="$pdeb_seen_debuggers $pdeb_candidate"
+            if ! load_debugger_module "$pdeb_candidate" ; then
+                continue
+            fi
+            if debugger_available ; then
+                debugger=$pdeb_candidate
+                return 0
+            fi
+        done
+        pdeb_unload_debugger
+        echo "Could not find a supported debugger in PATH." >&2
+        return 1
+        ;;
+    *)
+        if ! load_debugger_module "$debugger" ; then
+            echo "Unsupported debugger: $debugger" >&2
+            return 1
+        fi
+        if ! debugger_available ; then
+            echo "Could not find $debugger in PATH." >&2
+            return 1
+        fi
+        ;;
+    esac
+}
+
+collect_stack()
+{
+    pid=$1
+
+    debugger_collect_stack "$pid"
+}
+
+write_dump_file()
+{
+    archive_file=$1
+
+    if ! : > "$archive_file" ; then
+        echo "Could not write dump file: $archive_file" >&2
+        return 1
+    fi
+
+    {
+        printf "OPENMPI_STACK_DUMP_V1\n"
+        printf "PROGRAM %s\n" "$program_base"
+        printf "USER %s\n" "$user_name"
+        printf "UID %s\n" "$uid"
+        printf "DEBUGGER %s\n" "$debugger"
+        printf "CAPTURED %s\n" "$(date)"
+
+        for pid in $pids ; do
+            raw_file="$tmpdir/$pid.raw"
+            failed_file="$tmpdir/$pid.failed"
+
+            printf "PID %s\n" "$pid"
+            if [ -f "$failed_file" ] ; then
+                sed 's/^/FAILTEXT /' "$failed_file"
+            fi
+            sed 's/^/RAW /' "$raw_file"
+            printf "ENDPID\n"
+        done
+    } > "$archive_file"
+}
+
+parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    debugger_parse_stack "$raw_file" "$funcs_file" "$details_file" "$labels_file"
+}
+
+find_common_sequence()
+{
+    common_file=$1
+    match_file=$2
+
+    shift 2
+
+    : > "$common_file"
+    : > "$match_file"
+
+    if [ 0 -eq $# ] ; then
+        return 0
+    fi
+
+    awk -v common_file="$common_file" -v match_file="$match_file" '
+        function same_at(file_number, pos, base_pos, candidate_len, i)
+        {
+            for (i = 0 ; i < candidate_len ; ++i) {
+                if (seq[file_number, pos + i] != seq[1, base_pos + i]) {
+                    return 0
+                }
+            }
+            return 1
+        }
+
+        function find_at(file_number, base_pos, candidate_len, pos)
+        {
+            if (len[file_number] < candidate_len) {
+                return 0
+            }
+
+            for (pos = 1 ; pos <= len[file_number] - candidate_len + 1 ; ++pos) {
+                if (same_at(file_number, pos, base_pos, candidate_len)) {
+                    return pos
+                }
+            }
+
+            return 0
+        }
+
+        FNR == 1 {
+            ++file_count
+            files[file_count] = FILENAME
+        }
+
+        {
+            seq[file_count, ++len[file_count]] = $0
+        }
+
+        END {
+            best_len = 0
+            best_start = 0
+
+            for (base_pos = 1 ; base_pos <= len[1] ; ++base_pos) {
+                for (candidate_len = len[1] - base_pos + 1 ;
+                     candidate_len > best_len ;
+                     --candidate_len) {
+                    ok = 1
+                    found_pos[1] = base_pos
+
+                    for (file_number = 2 ;
+                         file_number <= file_count ;
+                         ++file_number) {
+                        pos = find_at(file_number, base_pos, candidate_len)
+                        if (0 == pos) {
+                            ok = 0
+                            break
+                        }
+                        found_pos[file_number] = pos
+                    }
+
+                    if (ok) {
+                        best_len = candidate_len
+                        best_start = base_pos
+                        for (file_number = 1 ;
+                             file_number <= file_count ;
+                             ++file_number) {
+                            best_pos[file_number] = found_pos[file_number]
+                        }
+                        break
+                    }
+                }
+            }
+
+            for (i = 0 ; i < best_len ; ++i) {
+                print seq[1, best_start + i] > common_file
+            }
+
+            for (file_number = 1 ;
+                 file_number <= file_count ;
+                 ++file_number) {
+                printf "%s %d %d\n",
+                       files[file_number],
+                       best_pos[file_number],
+                       best_len > match_file
+            }
+        }
+    ' "$@"
+}
+
+line_count()
+{
+    awk 'END { print NR + 0 }' "$1"
+}
+
+print_function_stack()
+{
+    stack_file=$1
+
+    if [ ! -s "$stack_file" ] ; then
+        printf "  (no parsed frames)\n"
+        return
+    fi
+
+    awk '{ printf "  #%d %s\n", NR - 1, $0 }' "$stack_file"
+}
+
+print_different_frames()
+{
+    details_file=$1
+    funcs_file=$2
+    match_file=$3
+
+    match=$(awk -v funcs_file="$funcs_file" \
+        '$1 == funcs_file { print $2 " " $3 ; exit }' "$match_file")
+
+    start=$(printf "%s\n" "$match" | awk '{ print $1 + 0 }')
+    common_len=$(printf "%s\n" "$match" | awk '{ print $2 + 0 }')
+
+    awk -v start="$start" -v common_len="$common_len" '
+        {
+            if (0 < common_len && NR == start) {
+                printf "  [common frames #%d..#%d elided; see common stack above]\n",
+                       start - 1,
+                       start + common_len - 2
+            }
+
+            if (0 < common_len && start <= NR && NR < start + common_len) {
+                next
+            }
+
+            printf "  %s\n", $0
+            printed = 1
+        }
+
+        END {
+            if (0 == NR) {
+                print "  (no parsed frames)"
+            } else if (!printed) {
+                print "  (no different frames; parsed stack is entirely common)"
+            }
+        }
+    ' "$details_file"
+}
+
+start_debuggers()
+{
+    for pid in $pids ; do
+        command_file="$tmpdir/$pid.commands"
+        log_file="$tmpdir/$pid.log"
+        debugger_pid_file="$tmpdir/$pid.debugger_pid"
+        tail_pid_file="$tmpdir/$pid.tail_pid"
+
+        : > "$command_file"
+        : > "$log_file"
+
+        debugger_start "$pid" "$command_file" "$log_file" "$tail_pid_file" \
+            > "$debugger_pid_file"
+    done
+
+    for pid in $pids ; do
+        startup_commands=$(debugger_startup_commands)
+        if [ -n "$startup_commands" ] ; then
+            run_debugger_commands "$pid" "$startup_commands" \
+                "$tmpdir/$pid.startup" >/dev/null
+        fi
+    done
+}
+
+stop_debuggers()
+{
+    wait_status=0
+
+    for pid in $pids ; do
+        command_file="$tmpdir/$pid.commands"
+
+        if [ -f "$command_file" ] ; then
+            {
+                printf "detach\n"
+                printf "quit\n"
+            } >> "$command_file"
+        fi
+    done
+
+    for pid in $pids ; do
+        debugger_pid_file="$tmpdir/$pid.debugger_pid"
+        tail_pid_file="$tmpdir/$pid.tail_pid"
+
+        if [ -f "$tail_pid_file" ] ; then
+            sleep 0.5
+            kill "$(sed -n '1p' "$tail_pid_file")" 2>/dev/null || true
+        fi
+
+        if [ -f "$debugger_pid_file" ] ; then
+            debugger_pid=$(sed -n '1p' "$debugger_pid_file")
+            if ! wait "$debugger_pid" 2>/dev/null ; then
+                wait_status=1
+            fi
+        fi
+    done
+
+    return "$wait_status"
+}
+
+run_debugger_commands()
+{
+    run_pid=$1
+    run_commands=$2
+    run_output_file=$3
+    run_command_file="$tmpdir/$run_pid.commands"
+    run_log_file="$tmpdir/$run_pid.log"
+    run_sequence_file="$tmpdir/sequence"
+
+    if [ -s "$run_sequence_file" ] ; then
+        sequence=$(sed -n '1p' "$run_sequence_file")
+    else
+        sequence=0
+    fi
+    sequence=$((sequence + 1))
+    printf "%s\n" "$sequence" > "$run_sequence_file"
+
+    marker="__OMPI_STACK_DONE_${run_pid}_${sequence}__"
+    offset=$(wc -c < "$run_log_file" | awk '{ print $1 + 0 }')
+
+    {
+        printf "%s\n" "$run_commands"
+        debugger_marker_command "$marker"
+    } >> "$run_command_file"
+
+    waited=0
+    while : ; do
+        if dd if="$run_log_file" bs=1 skip="$offset" 2>/dev/null | grep -q "$marker" ; then
+            break
+        fi
+        waited=$((waited + 1))
+        if [ 400 -lt "$waited" ] ; then
+            echo "Timed out waiting for debugger output from PID $run_pid." >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+
+    dd if="$run_log_file" bs=1 skip="$offset" 2>/dev/null | awk -v marker="$marker" '
+        index($0, marker) {
+            exit
+        }
+        {
+            print
+        }
+    ' > "$run_output_file"
+}
+
+generate_backtrace_report()
+{
+    raw_dir=$1
+    report_file=$2
+    parsed_func_files=
+    parsed_pids=
+    common_file="$tmpdir/common.funcs"
+    match_file="$tmpdir/common.matches"
+    common_labels_file="$tmpdir/common.labels"
+
+    : > "$common_labels_file"
+
+    for pid in $pids ; do
+        raw_file="$raw_dir/$pid.raw"
+        funcs_file="$raw_dir/$pid.funcs"
+        details_file="$raw_dir/$pid.details"
+        labels_file="$raw_dir/$pid.labels"
+
+        parse_stack "$raw_file" "$funcs_file" "$details_file" "$labels_file"
+        if [ -s "$funcs_file" ] ; then
+            parsed_func_files="$parsed_func_files $funcs_file"
+            parsed_pids="$parsed_pids $pid"
+        fi
+    done
+
+    find_common_sequence "$common_file" "$match_file" $parsed_func_files
+    common_count=$(line_count "$common_file")
+
+    if [ 0 -lt "$common_count" ] && [ -s "$match_file" ] ; then
+        common_match=$(sed -n '1p' "$match_file")
+        common_funcs_file=$(printf "%s\n" "$common_match" | awk '{ print $1 }')
+        common_start=$(printf "%s\n" "$common_match" | awk '{ print $2 + 0 }')
+        common_len=$(printf "%s\n" "$common_match" | awk '{ print $3 + 0 }')
+        common_pid_labels_file=${common_funcs_file%.funcs}.labels
+
+        if [ -s "$common_pid_labels_file" ] ; then
+            awk -v start="$common_start" -v common_len="$common_len" \
+                'start <= NR && NR < start + common_len { print }' \
+                "$common_pid_labels_file" > "$common_labels_file"
+        fi
+    fi
+
+    {
+        printf "Program: %s\n" "$program_base"
+        printf "Debugger: %s\n" "$debugger"
+        printf "PIDs:%s\n" "$(printf " %s" $pids)"
+        if [ -n "$parsed_pids" ] ; then
+            printf "Parsed PIDs:%s\n" "$(printf " %s" $parsed_pids)"
+        else
+            printf "Parsed PIDs: none\n"
+        fi
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Common function stack\n"
+        printf "================================================================\n"
+        if [ 0 -eq "$common_count" ] ; then
+            printf "  (no common function-name frames found)\n"
+        else
+            printf "  Longest common contiguous sequence: %s frame(s)\n" "$common_count"
+            if [ -s "$common_labels_file" ] ; then
+                print_function_stack "$common_labels_file"
+            else
+                print_function_stack "$common_file"
+            fi
+        fi
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Per-PID different frames\n"
+        printf "================================================================\n"
+        for pid in $pids ; do
+            funcs_file="$raw_dir/$pid.funcs"
+            details_file="$raw_dir/$pid.details"
+
+            printf "\n"
+            printf "PID %s: %s\n" "$pid" "$program_base"
+            printf "%s\n" "----------------------------------------------------------------"
+            printf "  Parsed frames: %s\n" "$(line_count "$funcs_file")"
+            print_different_frames "$details_file" "$funcs_file" "$match_file"
+        done
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Trimmed function stacks\n"
+        printf "================================================================\n"
+        for pid in $pids ; do
+            labels_file="$raw_dir/$pid.labels"
+
+            printf "\n"
+            printf "PID %s: %s\n" "$pid" "$program_base"
+            printf "%s\n" "----------------------------------------------------------------"
+            print_function_stack "$labels_file"
+        done
+    } > "$report_file"
+}
+
+pdeb_command_file()
+{
+    pdeb_command_name=$1
+
+    case "$pdeb_command_name" in
+    ""|.*|*/*)
+        return 1
+        ;;
+    esac
+
+    pdeb_path="$pdeb_command_dir/$pdeb_command_name"
+    if [ ! -f "$pdeb_path" ] ; then
+        return 1
+    fi
+
+    printf "%s\n" "$pdeb_path"
+}
+
+pdeb_command_names()
+{
+    for pdeb_path in "$pdeb_command_dir"/* ; do
+        if [ ! -f "$pdeb_path" ] ; then
+            continue
+        fi
+        pdeb_name=$(basename "$pdeb_path")
+        case "$pdeb_name" in
+        .*)
+            continue
+            ;;
+        esac
+        printf "%s\n" "$pdeb_name"
+    done | sort
+}
+
+pdeb_unload_command()
+{
+    unset -f help detailed_help run output 2>/dev/null || true
+}
+
+pdeb_function_defined()
+{
+    pdeb_type=$(type "$1" 2>/dev/null) || return 1
+
+    case "$pdeb_type" in
+    *function*)
+        return 0
+        ;;
+    esac
+
+    return 1
+}
+
+pdeb_source_command()
+{
+    pdeb_command_name=$1
+
+    pdeb_path=$(pdeb_command_file "$pdeb_command_name") || return 1
+    pdeb_unload_command
+    . "$pdeb_path"
+}
+
+load_pdeb_helpers()
+{
+    if [ ! -d "$pdeb_command_dir" ] ; then
+        echo "Command directory does not exist: $pdeb_command_dir" >&2
+        return 1
+    fi
+
+    for pdeb_helper in "$pdeb_command_dir"/.* ; do
+        if [ ! -f "$pdeb_helper" ] ; then
+            continue
+        fi
+        pdeb_name=$(basename "$pdeb_helper")
+        case "$pdeb_name" in
+        .|..)
+            continue
+            ;;
+        esac
+        . "$pdeb_helper"
+    done
+}
+
+print_help()
+{
+    printf "Commands:\n"
+    for pdeb_command_name in $(pdeb_command_names) ; do
+        if ! pdeb_source_command "$pdeb_command_name" ; then
+            continue
+        fi
+        if pdeb_function_defined help ; then
+            help
+        else
+            printf "  %s\n" "$pdeb_command_name"
+        fi
+    done
+    pdeb_unload_command
+    cat <<EOF
+  help
+  <command> help
+  quit
+EOF
+}
+
+print_command_help()
+{
+    pdeb_command_name=$1
+
+    if [ "help" = "$pdeb_command_name" ] ; then
+        print_help
+        return 0
+    fi
+
+    if ! pdeb_source_command "$pdeb_command_name" ; then
+        echo "No such command: $pdeb_command_name" >&2
+        return 1
+    fi
+
+    if pdeb_function_defined detailed_help ; then
+        detailed_help
+    elif pdeb_function_defined help ; then
+        help
+    else
+        echo "No detailed help for command: $pdeb_command_name"
+    fi
+    pdeb_unload_command
+}
+
+pdeb_default_output()
+{
+    for pdeb_output_file in "$@" ; do
+        pdeb_output_pid=$(basename "$pdeb_output_file" .raw)
+        printf "\nPID %s: %s\n" "$pdeb_output_pid" "$program_base"
+        printf "%s\n" "----------------------------------------------------------------"
+        cat "$pdeb_output_file"
+    done
+}
+
+# If a command sets pdeb_debugger_commands, the infrastructure runs that
+# debugger command block once per selected PID. A command-specific output
+# function receives "$@" as raw-output file paths, one per selected PID, in
+# selected-PID order; pdeb_output_pids holds the matching PID list.
+pdeb_run_selected_debugger_commands()
+{
+    pdeb_use_command_output=$1
+
+    if [ -z "$pdeb_output_dir" ] ; then
+        pdeb_output_dir="$tmpdir/$pdeb_command_name.$$.$(date +%s)"
+    fi
+
+    mkdir -p "$pdeb_output_dir" || return 1
+    pdeb_output_pids=$selected_pids
+
+    set --
+    for pdeb_output_pid in $selected_pids ; do
+        pdeb_output_file="$pdeb_output_dir/$pdeb_output_pid.raw"
+        run_debugger_commands "$pdeb_output_pid" "$pdeb_debugger_commands" \
+            "$pdeb_output_file" || return 1
+        set -- "$@" "$pdeb_output_file"
+    done
+
+    if [ 1 -eq "$pdeb_use_command_output" ] && pdeb_function_defined output ; then
+        output "$@"
+    else
+        pdeb_default_output "$@"
+    fi
+}
+
+pdeb_execute_command()
+{
+    pdeb_command_name=$1
+    shift
+
+    if ! pdeb_source_command "$pdeb_command_name" ; then
+        echo "No such command: $pdeb_command_name" >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined run ; then
+        echo "Command does not define run: $pdeb_command_name" >&2
+        pdeb_unload_command
+        return 1
+    fi
+
+    pdeb_debugger_commands=
+    pdeb_output_dir=
+    pdeb_output_pids=
+
+    run "$@"
+    pdeb_status=$?
+    if [ 0 -ne "$pdeb_status" ] ; then
+        pdeb_unload_command
+        return "$pdeb_status"
+    fi
+
+    if [ -n "$pdeb_debugger_commands" ] ; then
+        pdeb_run_selected_debugger_commands 1
+        pdeb_status=$?
+    fi
+
+    pdeb_unload_command
+    return "$pdeb_status"
+}
+
+pid_is_attached()
+{
+    test_pid=$1
+
+    for pid in $pids ; do
+        if [ "$pid" = "$test_pid" ] ; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+require_selection()
+{
+    if [ -z "$selected_pids" ] ; then
+        echo "No PIDs selected. Use attach <pid> [pid...] first." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+pid_count()
+{
+    count=0
+
+    for pid in "$@" ; do
+        count=$((count + 1))
+    done
+
+    printf "%s\n" "$count"
+}
+
+prompt_push()
+{
+    if [ -z "$prompt_stack" ] ; then
+        prompt_stack=$PROMPT
+    else
+        prompt_stack=$(printf "%s\n%s" "$PROMPT" "$prompt_stack")
+    fi
+    PROMPT=$1
+}
+
+prompt_pop()
+{
+    if [ -z "$prompt_stack" ] ; then
+        return 1
+    fi
+
+    PROMPT=$(printf "%s\n" "$prompt_stack" | sed -n '1p')
+    prompt_stack=$(printf "%s\n" "$prompt_stack" | sed '1d')
+}
+
+compressed_pids()
+{
+    set -- $*
+
+    if [ 0 -eq $# ] ; then
+        printf "none"
+        return
+    fi
+
+    if [ 4 -ge $# ] ; then
+        compressed_out=$1
+        shift
+        for compressed_pid in "$@" ; do
+            compressed_out="$compressed_out,$compressed_pid"
+        done
+        printf "%s" "$compressed_out"
+        return
+    fi
+
+    compressed_count=$#
+    compressed_first=$1
+    eval compressed_last=\${$compressed_count}
+    printf "%s..%s(%s)" "$compressed_first" "$compressed_last" "$compressed_count"
+}
+
+detach_pid_list()
+{
+    detach_pids=$*
+    wait_status=0
+
+    for pid in $detach_pids ; do
+        command_file="$tmpdir/$pid.commands"
+
+        if [ -f "$command_file" ] ; then
+            {
+                printf "detach\n"
+                printf "quit\n"
+            } >> "$command_file"
+        fi
+    done
+
+    for pid in $detach_pids ; do
+        debugger_pid_file="$tmpdir/$pid.debugger_pid"
+        tail_pid_file="$tmpdir/$pid.tail_pid"
+
+        if [ -f "$tail_pid_file" ] ; then
+            sleep 0.5
+            kill "$(sed -n '1p' "$tail_pid_file")" 2>/dev/null || true
+        fi
+
+        if [ -f "$debugger_pid_file" ] ; then
+            debugger_pid=$(sed -n '1p' "$debugger_pid_file")
+            if ! wait "$debugger_pid" 2>/dev/null ; then
+                wait_status=1
+            fi
+        fi
+    done
+
+    return "$wait_status"
+}
+
+remove_detached_pids()
+{
+    detached_pids=$*
+    remaining_pids=
+    remaining_selected_pids=
+
+    for pid in $pids ; do
+        keep=1
+        for detached_pid in $detached_pids ; do
+            if [ "$pid" = "$detached_pid" ] ; then
+                keep=0
+                break
+            fi
+        done
+        if [ 1 -eq "$keep" ] ; then
+            remaining_pids="$remaining_pids $pid"
+        fi
+    done
+
+    for pid in $selected_pids ; do
+        keep=1
+        for detached_pid in $detached_pids ; do
+            if [ "$pid" = "$detached_pid" ] ; then
+                keep=0
+                break
+            fi
+        done
+        if [ 1 -eq "$keep" ] ; then
+            remaining_selected_pids="$remaining_selected_pids $pid"
+        fi
+    done
+
+    pids=$(printf "%s\n" "$remaining_pids" | sed 's/^ *//')
+    selected_pids=$(printf "%s\n" "$remaining_selected_pids" | sed 's/^ *//')
+
+    if [ -z "$pids" ] ; then
+        program=
+        program_base=
+        attached=0
+    fi
+}
+
+command_debugger_passthrough()
+{
+    require_selection || return 1
+
+    pdeb_command_name=passthrough
+    pdeb_debugger_commands=$1
+    pdeb_output_dir="$tmpdir/passthrough.$$.$(date +%s)"
+
+    pdeb_run_selected_debugger_commands 0
+}
+
+interactive_loop()
+{
+    print_help
+    while : ; do
+        printf "%s[%s]> " "$PROMPT" "$(compressed_pids $selected_pids)"
+        if ! IFS= read -r line ; then
+            break
+        fi
+
+        if [ "" = "$line" ] ; then
+            continue
+        fi
+
+        set -- $line
+        command_name=$1
+        shift
+
+        case "$command_name" in
+        quit|exit)
+            break
+            ;;
+        help)
+            print_help
+            ;;
+        *)
+            if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+                print_command_help "$command_name"
+            elif pdeb_command_file "$command_name" >/dev/null ; then
+                pdeb_execute_command "$command_name" "$@"
+            else
+                command_debugger_passthrough "$line"
+            fi
+            ;;
+        esac
+    done
+}
+
+temp_parent=${TMPDIR:-/tmp}
+if ! tmpdir=$(mktemp -d "$temp_parent/pdb.XXXXXX") ; then
+    echo "Could not create temporary directory." >&2
+    exit 1
+fi
+
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+if ! load_pdeb_helpers ; then
+    exit 1
+fi
+
+trap 'stop_debuggers; rm -rf "$tmpdir"' EXIT HUP INT TERM
+if [ -n "$initial_pids" ] ; then
+    pdeb_execute_command attach $initial_pids || exit 1
+elif [ -n "$program_base" ] ; then
+    if ! resolved_pids=$(find_pids) ; then
+        echo "Could not list processes for user $user_name." >&2
+        exit 1
+    fi
+    if [ -z "$resolved_pids" ] ; then
+        echo "No processes named '$program_base' owned by $user_name were found." >&2
+        exit 1
+    fi
+    pdeb_execute_command attach $resolved_pids || exit 1
+fi
+if [ -n "$dump_file" ] ; then
+    command=$(debugger_backtrace_command)
+    for pid in $pids ; do
+        run_debugger_commands "$pid" "$command" "$tmpdir/$pid.raw" || exit 1
+    done
+    if ! write_dump_file "$dump_file" ; then
+        exit 1
+    fi
+    printf "Wrote raw stack dump to %s\n" "$dump_file" >&2
+fi
+interactive_loop
+exit 0

--- a/contrib/pdb
+++ b/contrib/pdb
@@ -1,0 +1,1200 @@
+#!/bin/sh
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+set -u
+
+usage()
+{
+    cat <<EOF
+Usage: $0 [-d debugger] [--dump filename] [-p|--pids pid[,pid]...] [program-name]
+
+Find processes owned by the current user whose executable basename is
+program-name, resolve them to PIDs, attach a debugger to each one, and
+enter an interactive command loop.  Use the backtrace command to collect
+and summarize stacks.  Use --dump to save an initial raw stack archive.
+
+Instead of program-name, use -p/--pids to attach to an explicit list of
+PIDs.  The two forms are mutually exclusive.
+
+If neither program-name nor -p/--pids is given, the script starts
+unattached.  Use the attach command to attach to a list of PIDs.
+
+Options:
+  -d debugger        Use a debugger module, such as lldb or gdb.  Default:
+                     first available debugger module.
+  --dump file        Save the process list and raw debugger stacks to file.
+  -p, --pids pid[,pid]...
+                     Attach to an explicit, comma- or space-separated list
+                     of PIDs.
+  -h                 Show this help.
+EOF
+}
+
+debugger=auto
+dump_file=
+initial_pids=
+pids=
+selected_pids=
+attached=0
+PROMPT=ompi-stack
+prompt_stack=
+pdeb_output_dir_seq=0
+
+case "$0" in
+*/*)
+    script_path=$0
+    ;;
+*)
+script_path=$(command -v "$0" 2>/dev/null || printf "%s\n" "$0")
+    ;;
+esac
+script_dir=$(CDPATH= cd "$(dirname "$script_path")" 2>/dev/null && pwd)
+pdeb_command_dir=${PDEB_COMMAND_DIR:-"$script_dir/pdeb/commands"}
+pdeb_debugger_dir=${PDEB_DEBUGGER_DIR:-"$script_dir/pdeb/debugger"}
+
+while [ 0 -lt $# ] ; do
+    case "$1" in
+    -d)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        debugger=$1
+        ;;
+    --dump)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        dump_file=$1
+        ;;
+    -p|--pids)
+        shift
+        if [ 0 -eq $# ] ; then
+            usage >&2
+            exit 2
+        fi
+        initial_pids="$initial_pids $1"
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
+    -*)
+        echo "Unsupported option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ 1 -lt $# ] ; then
+    usage >&2
+    exit 2
+fi
+
+if [ 1 -eq $# ] ; then
+    program=$1
+    program_base=$(basename "$program")
+else
+    program=
+    program_base=
+fi
+
+initial_pids=$(printf "%s" "$initial_pids" | tr ',' ' ')
+
+if [ -n "$initial_pids" ] && [ -n "$program_base" ] ; then
+    echo "--pids and program-name are mutually exclusive." >&2
+    usage >&2
+    exit 2
+fi
+
+uid=$(id -u)
+user_name=$(id -un)
+
+if [ -n "$dump_file" ] && [ -z "$program_base" ] && [ -z "$initial_pids" ] ; then
+    echo "--dump requires an initial program-name or --pids PID list." >&2
+    exit 2
+fi
+
+find_pids()
+{
+    if command -v pgrep >/dev/null 2>&1 ; then
+        pgrep_output=$(pgrep -U "$uid" -x "$program_base" 2>/dev/null)
+        pgrep_status=$?
+        if [ 0 -eq "$pgrep_status" ] || [ 1 -eq "$pgrep_status" ] ; then
+            result=$(printf "%s\n" "$pgrep_output" | awk -v self="$$" \
+                '0 < NF && $1 != self { print $1 }')
+            if [ -n "$result" ] ; then
+                printf "%s\n" "$result"
+                return 0
+            fi
+        fi
+        program_base_re=$(printf '%s' "$program_base" | sed 's/[].[\*^$(){}|+?]/\\&/g')
+        pgrep_out1=$(pgrep -U "$uid" -f "[/ ]${program_base_re}$" 2>/dev/null)
+        pgrep_s1=$?
+        pgrep_out2=$(pgrep -U "$uid" -f "[/ ]${program_base_re} " 2>/dev/null)
+        pgrep_s2=$?
+        if [ 0 -eq "$pgrep_s1" ] || [ 1 -eq "$pgrep_s1" ] || \
+           [ 0 -eq "$pgrep_s2" ] || [ 1 -eq "$pgrep_s2" ] ; then
+            printf "%s\n%s\n" "$pgrep_out1" "$pgrep_out2" | awk -v self="$$" \
+                '0 < NF && $1 != self && !seen[$1]++ { print $1 }'
+        fi
+        return 0
+    fi
+
+    ps_output=$(ps -u "$uid" -o pid= -o comm=) || return 1
+
+    printf "%s\n" "$ps_output" | awk \
+        -v target="$program_base" \
+        -v self="$$" \
+        '{
+            if (1 > NF) {
+                next
+            }
+            pid = $1
+            $1 = ""
+            sub(/^[[:space:]]*/, "", $0)
+            n = split($0, path, "/")
+            base = path[n]
+            if (pid != self && base == target) {
+                print pid
+            }
+        }'
+}
+
+pid_exists()
+{
+    kill -0 "$1" 2>/dev/null
+}
+
+pid_command_base()
+{
+    pid_command=$(ps -p "$1" -o comm= 2>/dev/null) || return 1
+
+    if [ -z "$pid_command" ] ; then
+        return 1
+    fi
+
+    basename "$pid_command"
+}
+
+args_are_pids()
+{
+    if [ 0 -eq $# ] ; then
+        return 1
+    fi
+
+    for args_pid in "$@" ; do
+        case "$args_pid" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+        esac
+    done
+
+    return 0
+}
+
+pdeb_debugger_file()
+{
+    pdeb_debugger_name=$1
+
+    case "$pdeb_debugger_name" in
+    ""|.*|*/*)
+        return 1
+        ;;
+    esac
+
+    pdeb_debugger_path="$pdeb_debugger_dir/$pdeb_debugger_name"
+    if [ ! -f "$pdeb_debugger_path" ] ; then
+        return 1
+    fi
+
+    printf "%s\n" "$pdeb_debugger_path"
+}
+
+pdeb_debugger_names()
+{
+    for pdeb_debugger_path in "$pdeb_debugger_dir"/* ; do
+        if [ ! -f "$pdeb_debugger_path" ] ; then
+            continue
+        fi
+        pdeb_debugger_name=$(basename "$pdeb_debugger_path")
+        case "$pdeb_debugger_name" in
+        .*)
+            continue
+            ;;
+        esac
+        printf "%s\n" "$pdeb_debugger_name"
+    done | sort
+}
+
+pdeb_unload_debugger()
+{
+    unset -f debugger_available debugger_marker_command \
+        debugger_backtrace_command debugger_current_backtrace_command \
+        debugger_select_frame_command debugger_start debugger_startup_commands \
+        debugger_find_frame_number debugger_parse_stack \
+        debugger_btlsm_dump_command debugger_req_dump_command \
+        debugger_pml_dump_command 2>/dev/null || true
+}
+
+load_debugger_module()
+{
+    pdeb_debugger_name=$1
+    pdeb_debugger_path=$(pdeb_debugger_file "$pdeb_debugger_name") || return 1
+
+    pdeb_unload_debugger
+    . "$pdeb_debugger_path"
+}
+
+ensure_debugger()
+{
+    case "$debugger" in
+    auto)
+        pdeb_seen_debuggers=
+        pdeb_auto_list="$tmpdir/debugger_auto_list"
+        printf 'gdb\nlldb\n' > "$pdeb_auto_list"
+        pdeb_debugger_names >> "$pdeb_auto_list"
+        while IFS= read -r pdeb_candidate ; do
+            case " $pdeb_seen_debuggers " in
+            *" $pdeb_candidate "*)
+                continue
+                ;;
+            esac
+            pdeb_seen_debuggers="$pdeb_seen_debuggers $pdeb_candidate"
+            if ! load_debugger_module "$pdeb_candidate" ; then
+                continue
+            fi
+            if debugger_available ; then
+                debugger=$pdeb_candidate
+                rm -f "$pdeb_auto_list"
+                return 0
+            fi
+        done < "$pdeb_auto_list"
+        rm -f "$pdeb_auto_list"
+        pdeb_unload_debugger
+        echo "Could not find a supported debugger in PATH." >&2
+        return 1
+        ;;
+    *)
+        if ! load_debugger_module "$debugger" ; then
+            echo "Unsupported debugger: $debugger" >&2
+            return 1
+        fi
+        if ! debugger_available ; then
+            echo "Could not find $debugger in PATH." >&2
+            return 1
+        fi
+        ;;
+    esac
+}
+
+write_dump_file()
+{
+    archive_file=$1
+
+    if ! : > "$archive_file" ; then
+        echo "Could not write dump file: $archive_file" >&2
+        return 1
+    fi
+
+    {
+        printf "OPENMPI_STACK_DUMP_V1\n"
+        printf "PROGRAM %s\n" "$(printf '%s' "$program_base" | tr '\n' ' ')"
+        printf "USER %s\n" "$user_name"
+        printf "UID %s\n" "$uid"
+        printf "DEBUGGER %s\n" "$debugger"
+        printf "CAPTURED %s\n" "$(date)"
+
+        for pid in $pids ; do
+            raw_file="$tmpdir/$pid.raw"
+            failed_file="$tmpdir/$pid.failed"
+
+            printf "PID %s\n" "$pid"
+            if [ -f "$failed_file" ] ; then
+                sed 's/^/FAILTEXT /' "$failed_file"
+            fi
+            if [ -f "$raw_file" ] ; then
+                sed 's/^/RAW /' "$raw_file"
+            fi
+            printf "ENDPID\n"
+        done
+    } > "$archive_file"
+}
+
+parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    debugger_parse_stack "$raw_file" "$funcs_file" "$details_file" "$labels_file"
+}
+
+find_common_sequence()
+{
+    common_file=$1
+    match_file=$2
+
+    shift 2
+
+    : > "$common_file"
+    : > "$match_file"
+
+    if [ 0 -eq $# ] ; then
+        return 0
+    fi
+
+    awk -v common_file="$common_file" -v match_file="$match_file" '
+        function same_at(file_number, pos, base_pos, candidate_len, i)
+        {
+            for (i = 0 ; i < candidate_len ; ++i) {
+                if (seq[file_number, pos + i] != seq[1, base_pos + i]) {
+                    return 0
+                }
+            }
+            return 1
+        }
+
+        function find_at(file_number, base_pos, candidate_len, pos)
+        {
+            if (len[file_number] < candidate_len) {
+                return 0
+            }
+
+            for (pos = 1 ; pos <= len[file_number] - candidate_len + 1 ; ++pos) {
+                if (same_at(file_number, pos, base_pos, candidate_len)) {
+                    return pos
+                }
+            }
+
+            return 0
+        }
+
+        FNR == 1 {
+            ++file_count
+            files[file_count] = FILENAME
+        }
+
+        {
+            seq[file_count, ++len[file_count]] = $0
+        }
+
+        END {
+            best_len = 0
+            best_start = 0
+
+            for (base_pos = 1 ; base_pos <= len[1] ; ++base_pos) {
+                for (candidate_len = len[1] - base_pos + 1 ;
+                     candidate_len > best_len ;
+                     --candidate_len) {
+                    ok = 1
+                    found_pos[1] = base_pos
+
+                    for (file_number = 2 ;
+                         file_number <= file_count ;
+                         ++file_number) {
+                        pos = find_at(file_number, base_pos, candidate_len)
+                        if (0 == pos) {
+                            ok = 0
+                            break
+                        }
+                        found_pos[file_number] = pos
+                    }
+
+                    if (ok) {
+                        best_len = candidate_len
+                        best_start = base_pos
+                        for (file_number = 1 ;
+                             file_number <= file_count ;
+                             ++file_number) {
+                            best_pos[file_number] = found_pos[file_number]
+                        }
+                        break
+                    }
+                }
+            }
+
+            for (i = 0 ; i < best_len ; ++i) {
+                print seq[1, best_start + i] > common_file
+            }
+
+            for (file_number = 1 ;
+                 file_number <= file_count ;
+                 ++file_number) {
+                printf "%s\t%d\t%d\n",
+                       files[file_number],
+                       best_pos[file_number],
+                       best_len > match_file
+            }
+        }
+    ' "$@"
+}
+
+line_count()
+{
+    awk 'END { print NR + 0 }' "$1"
+}
+
+print_function_stack()
+{
+    stack_file=$1
+
+    if [ ! -s "$stack_file" ] ; then
+        printf "  (no parsed frames)\n"
+        return
+    fi
+
+    awk '{ printf "  #%d %s\n", NR - 1, $0 }' "$stack_file"
+}
+
+print_different_frames()
+{
+    details_file=$1
+    funcs_file=$2
+    match_file=$3
+
+    match=$(awk -F'\t' -v funcs_file="$funcs_file" \
+        '$1 == funcs_file { print $2 " " $3 ; exit }' "$match_file")
+
+    start=$(printf "%s\n" "$match" | awk '{ print $1 + 0 }')
+    common_len=$(printf "%s\n" "$match" | awk '{ print $2 + 0 }')
+
+    awk -v start="$start" -v common_len="$common_len" '
+        {
+            if (0 < common_len && NR == start) {
+                printf "  [common frames #%d..#%d elided; see common stack above]\n",
+                       start - 1,
+                       start + common_len - 2
+                printed = 1
+            }
+
+            if (0 < common_len && start <= NR && NR < start + common_len) {
+                next
+            }
+
+            printf "  %s\n", $0
+            printed = 1
+        }
+
+        END {
+            if (0 == NR) {
+                print "  (no parsed frames)"
+            } else if (!printed) {
+                print "  (no different frames; parsed stack is entirely common)"
+            }
+        }
+    ' "$details_file"
+}
+
+start_debuggers()
+{
+    start_status=0
+
+    for pid in $pids ; do
+        command_file="$tmpdir/$pid.commands"
+        log_file="$tmpdir/$pid.log"
+        debugger_pid_file="$tmpdir/$pid.debugger_pid"
+        tail_pid_file="$tmpdir/$pid.tail_pid"
+
+        : > "$command_file"
+        : > "$log_file"
+
+        debugger_start "$pid" "$command_file" "$log_file" "$tail_pid_file" \
+            > "$debugger_pid_file"
+    done
+
+    for pid in $pids ; do
+        startup_commands=$(debugger_startup_commands)
+        if [ -n "$startup_commands" ] ; then
+            if ! run_debugger_commands "$pid" "$startup_commands" \
+                "$tmpdir/$pid.startup" >/dev/null ; then
+                echo "Failed to initialize debugger for PID $pid." >&2
+                printf "Debugger startup failed for PID %s.\n" "$pid" \
+                    > "$tmpdir/$pid.failed"
+                start_status=1
+            fi
+        fi
+    done
+
+    return "$start_status"
+}
+
+stop_debuggers()
+{
+    detach_pid_list $pids
+}
+
+run_debugger_commands()
+{
+    run_pid=$1
+    run_commands=$2
+    run_output_file=$3
+    run_command_file="$tmpdir/$run_pid.commands"
+    run_log_file="$tmpdir/$run_pid.log"
+    run_sequence_file="$tmpdir/sequence"
+
+    if [ -s "$run_sequence_file" ] ; then
+        sequence=$(sed -n '1p' "$run_sequence_file")
+    else
+        sequence=0
+    fi
+    sequence=$((sequence + 1))
+    printf "%s\n" "$sequence" > "$run_sequence_file"
+
+    marker="__OMPI_STACK_DONE_${run_pid}_${sequence}__"
+    marker_len=$(printf "%s" "$marker" | wc -c | awk '{ print $1 + 0 }')
+    offset=$(wc -c < "$run_log_file" | awk '{ print $1 + 0 }')
+
+    {
+        printf "%s\n" "$run_commands"
+        debugger_marker_command "$marker"
+    } >> "$run_command_file"
+
+    waited=0
+    poll_offset=$offset
+    while : ; do
+        new_end=$(wc -c < "$run_log_file" | awk '{ print $1 + 0 }')
+        if [ "$new_end" -gt "$poll_offset" ] ; then
+            if tail -c "+$((poll_offset + 1))" "$run_log_file" 2>/dev/null | grep -q "$marker" ; then
+                break
+            fi
+            # Leave marker_len-1 bytes of overlap so a marker that straddles
+            # two polling intervals is not permanently missed.
+            safe_advance=$((new_end - marker_len + 1))
+            if [ "$safe_advance" -gt "$poll_offset" ] ; then
+                poll_offset=$safe_advance
+            fi
+        fi
+        run_debugger_pid=$(sed -n '1p' "$tmpdir/$run_pid.debugger_pid" 2>/dev/null)
+        if [ -n "$run_debugger_pid" ] && ! kill -0 "$run_debugger_pid" 2>/dev/null ; then
+            echo "Debugger for PID $run_pid exited unexpectedly." >&2
+            if [ -s "$run_log_file" ] ; then
+                tail -c "+$((offset + 1))" "$run_log_file" >&2
+            fi
+            return 1
+        fi
+        waited=$((waited + 1))
+        if [ 400 -lt "$waited" ] ; then
+            echo "Timed out waiting for debugger output from PID $run_pid." >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+
+    tail -c "+$((offset + 1))" "$run_log_file" 2>/dev/null | awk -v marker="$marker" '
+        index($0, marker) {
+            exit
+        }
+        {
+            print
+        }
+    ' > "$run_output_file"
+}
+
+generate_backtrace_report()
+{
+    raw_dir=$1
+    report_file=$2
+    shift 2
+    report_pids=${*:-$pids}
+    parsed_pids=
+    common_file="$tmpdir/common.funcs"
+    match_file="$tmpdir/common.matches"
+    common_labels_file="$tmpdir/common.labels"
+
+    : > "$common_labels_file"
+
+    # Use positional parameters as a POSIX-portable array for funcs file paths
+    # so that paths with spaces (e.g. from TMPDIR=/my work/tmp) are handled safely.
+    set --
+    for pid in $report_pids ; do
+        raw_file="$raw_dir/$pid.raw"
+        funcs_file="$raw_dir/$pid.funcs"
+        details_file="$raw_dir/$pid.details"
+        labels_file="$raw_dir/$pid.labels"
+
+        parse_stack "$raw_file" "$funcs_file" "$details_file" "$labels_file"
+        if [ -s "$funcs_file" ] ; then
+            set -- "$@" "$funcs_file"
+            parsed_pids="$parsed_pids $pid"
+        fi
+    done
+
+    find_common_sequence "$common_file" "$match_file" "$@"
+    common_count=$(line_count "$common_file")
+
+    if [ 0 -lt "$common_count" ] && [ -s "$match_file" ] ; then
+        common_match=$(sed -n '1p' "$match_file")
+        common_funcs_file=$(printf "%s\n" "$common_match" | awk -F'\t' '{ print $1 }')
+        common_start=$(printf "%s\n" "$common_match" | awk -F'\t' '{ print $2 + 0 }')
+        common_len=$(printf "%s\n" "$common_match" | awk -F'\t' '{ print $3 + 0 }')
+        common_pid_labels_file=${common_funcs_file%.funcs}.labels
+
+        if [ -s "$common_pid_labels_file" ] ; then
+            awk -v start="$common_start" -v common_len="$common_len" \
+                'start <= NR && NR < start + common_len { print }' \
+                "$common_pid_labels_file" > "$common_labels_file"
+        fi
+    fi
+
+    {
+        printf "Program: %s\n" "$program_base"
+        printf "Debugger: %s\n" "$debugger"
+        printf "PIDs:%s\n" "$(printf " %s" $report_pids)"
+        if [ -n "$parsed_pids" ] ; then
+            printf "Parsed PIDs:%s\n" "$(printf " %s" $parsed_pids)"
+        else
+            printf "Parsed PIDs: none\n"
+        fi
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Common function stack\n"
+        printf "================================================================\n"
+        if [ 0 -eq "$common_count" ] ; then
+            printf "  (no common function-name frames found)\n"
+        else
+            printf "  Longest common contiguous sequence: %s frame(s)\n" "$common_count"
+            if [ -s "$common_labels_file" ] ; then
+                print_function_stack "$common_labels_file"
+            else
+                print_function_stack "$common_file"
+            fi
+        fi
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Per-PID different frames\n"
+        printf "================================================================\n"
+        for pid in $report_pids ; do
+            funcs_file="$raw_dir/$pid.funcs"
+            details_file="$raw_dir/$pid.details"
+
+            printf "\n"
+            printf "PID %s: %s\n" "$pid" "$program_base"
+            printf "%s\n" "----------------------------------------------------------------"
+            printf "  Parsed frames: %s\n" "$(line_count "$funcs_file")"
+            print_different_frames "$details_file" "$funcs_file" "$match_file"
+        done
+
+        printf "\n"
+        printf "================================================================\n"
+        printf "Trimmed function stacks\n"
+        printf "================================================================\n"
+        for pid in $report_pids ; do
+            labels_file="$raw_dir/$pid.labels"
+
+            printf "\n"
+            printf "PID %s: %s\n" "$pid" "$program_base"
+            printf "%s\n" "----------------------------------------------------------------"
+            print_function_stack "$labels_file"
+        done
+    } > "$report_file"
+}
+
+pdeb_command_file()
+{
+    pdeb_command_name=$1
+
+    case "$pdeb_command_name" in
+    ""|.*|*/*)
+        return 1
+        ;;
+    esac
+
+    pdeb_path="$pdeb_command_dir/$pdeb_command_name"
+    if [ ! -f "$pdeb_path" ] ; then
+        return 1
+    fi
+
+    printf "%s\n" "$pdeb_path"
+}
+
+pdeb_command_names()
+{
+    for pdeb_path in "$pdeb_command_dir"/* ; do
+        if [ ! -f "$pdeb_path" ] ; then
+            continue
+        fi
+        pdeb_name=$(basename "$pdeb_path")
+        case "$pdeb_name" in
+        .*)
+            continue
+            ;;
+        esac
+        printf "%s\n" "$pdeb_name"
+    done | sort
+}
+
+pdeb_unload_command()
+{
+    unset -f help detailed_help run output 2>/dev/null || true
+}
+
+pdeb_function_defined()
+{
+    pdeb_type=$(type "$1" 2>/dev/null) || return 1
+
+    case "$pdeb_type" in
+    *function*)
+        return 0
+        ;;
+    esac
+
+    return 1
+}
+
+pdeb_source_command()
+{
+    pdeb_command_name=$1
+
+    pdeb_path=$(pdeb_command_file "$pdeb_command_name") || return 1
+    pdeb_unload_command
+    . "$pdeb_path"
+}
+
+load_pdeb_helpers()
+{
+    if [ ! -d "$pdeb_command_dir" ] ; then
+        echo "Command directory does not exist: $pdeb_command_dir" >&2
+        return 1
+    fi
+
+    for pdeb_helper in "$pdeb_command_dir"/.* ; do
+        if [ ! -f "$pdeb_helper" ] ; then
+            continue
+        fi
+        pdeb_name=$(basename "$pdeb_helper")
+        case "$pdeb_name" in
+        .|..)
+            continue
+            ;;
+        esac
+        if ! . "$pdeb_helper" ; then
+            echo "Failed to source helper: $pdeb_helper" >&2
+            return 1
+        fi
+    done
+}
+
+print_help()
+{
+    printf "Commands:\n"
+    pdeb_help_names="$tmpdir/pdeb_help_names"
+    pdeb_command_names > "$pdeb_help_names"
+    while IFS= read -r pdeb_command_name ; do
+        if ! pdeb_source_command "$pdeb_command_name" ; then
+            continue
+        fi
+        if pdeb_function_defined help ; then
+            help
+        else
+            printf "  %s\n" "$pdeb_command_name"
+        fi
+    done < "$pdeb_help_names"
+    rm -f "$pdeb_help_names"
+    pdeb_unload_command
+    cat <<EOF
+  help
+  <command> help
+  quit
+EOF
+}
+
+print_command_help()
+{
+    pdeb_command_name=$1
+
+    if [ "help" = "$pdeb_command_name" ] ; then
+        print_help
+        return 0
+    fi
+
+    if ! pdeb_source_command "$pdeb_command_name" ; then
+        echo "No such command: $pdeb_command_name" >&2
+        return 1
+    fi
+
+    if pdeb_function_defined detailed_help ; then
+        detailed_help
+    elif pdeb_function_defined help ; then
+        help
+    else
+        echo "No detailed help for command: $pdeb_command_name"
+    fi
+    pdeb_unload_command
+}
+
+pdeb_default_output()
+{
+    for pdeb_output_file in "$@" ; do
+        pdeb_output_pid=$(basename "$pdeb_output_file" .raw)
+        printf "\nPID %s: %s\n" "$pdeb_output_pid" "$program_base"
+        printf "%s\n" "----------------------------------------------------------------"
+        cat "$pdeb_output_file"
+    done
+}
+
+# If a command sets pdeb_debugger_commands, the infrastructure runs that
+# debugger command block once per selected PID. A command-specific output
+# function receives "$@" as raw-output file paths, one per selected PID, in
+# selected-PID order; pdeb_output_pids holds the matching PID list.
+pdeb_run_selected_debugger_commands()
+{
+    pdeb_use_command_output=$1
+
+    if [ -z "$pdeb_output_dir" ] ; then
+        pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+        pdeb_output_dir="$tmpdir/$pdeb_command_name.$pdeb_output_dir_seq"
+    fi
+
+    mkdir -p "$pdeb_output_dir" || return 1
+    pdeb_output_pids=$selected_pids
+
+    pdeb_run_errors=0
+    set --
+    for pdeb_output_pid in $selected_pids ; do
+        pdeb_output_file="$pdeb_output_dir/$pdeb_output_pid.raw"
+        if run_debugger_commands "$pdeb_output_pid" "$pdeb_debugger_commands" \
+                "$pdeb_output_file" ; then
+            set -- "$@" "$pdeb_output_file"
+        else
+            pdeb_run_errors=$((pdeb_run_errors + 1))
+        fi
+    done
+
+    if [ 1 -eq "$pdeb_use_command_output" ] && pdeb_function_defined output ; then
+        output "$@"
+    else
+        pdeb_default_output "$@"
+    fi
+
+    [ 0 -eq "$pdeb_run_errors" ]
+}
+
+pdeb_execute_command()
+{
+    pdeb_command_name=$1
+    shift
+
+    if ! pdeb_source_command "$pdeb_command_name" ; then
+        echo "No such command: $pdeb_command_name" >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined run ; then
+        echo "Command does not define run: $pdeb_command_name" >&2
+        pdeb_unload_command
+        return 1
+    fi
+
+    pdeb_debugger_commands=
+    pdeb_output_dir=
+    pdeb_output_pids=
+
+    run "$@"
+    pdeb_status=$?
+    if [ 0 -ne "$pdeb_status" ] ; then
+        pdeb_unload_command
+        return "$pdeb_status"
+    fi
+
+    if [ -n "$pdeb_debugger_commands" ] ; then
+        pdeb_run_selected_debugger_commands 1
+        pdeb_status=$?
+    fi
+
+    pdeb_unload_command
+    return "$pdeb_status"
+}
+
+pid_is_attached()
+{
+    test_pid=$1
+
+    for pid in $pids ; do
+        if [ "$pid" = "$test_pid" ] ; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+require_selection()
+{
+    if [ -z "$selected_pids" ] ; then
+        echo "No PIDs selected. Use attach <pid> [pid...] first." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+pid_count()
+{
+    count=0
+
+    for pid in "$@" ; do
+        count=$((count + 1))
+    done
+
+    printf "%s\n" "$count"
+}
+
+prompt_push()
+{
+    if [ -z "$prompt_stack" ] ; then
+        prompt_stack=$PROMPT
+    else
+        prompt_stack=$(printf "%s\n%s" "$PROMPT" "$prompt_stack")
+    fi
+    PROMPT=$1
+}
+
+prompt_pop()
+{
+    if [ -z "$prompt_stack" ] ; then
+        return 1
+    fi
+
+    PROMPT=$(printf "%s\n" "$prompt_stack" | sed -n '1p')
+    prompt_stack=$(printf "%s\n" "$prompt_stack" | sed '1d')
+}
+
+compressed_pids()
+{
+    set -- "$@"
+
+    if [ 0 -eq $# ] ; then
+        printf "none"
+        return
+    fi
+
+    if [ 4 -ge $# ] ; then
+        compressed_out=$1
+        shift
+        for compressed_pid in "$@" ; do
+            compressed_out="$compressed_out,$compressed_pid"
+        done
+        printf "%s" "$compressed_out"
+        return
+    fi
+
+    compressed_count=$#
+    compressed_first=$1
+    eval compressed_last=\${$compressed_count}
+    printf "%s..%s(%s)" "$compressed_first" "$compressed_last" "$compressed_count"
+}
+
+detach_pid_list()
+{
+    detach_pids=$*
+    wait_status=0
+
+    for pid in $detach_pids ; do
+        command_file="$tmpdir/$pid.commands"
+
+        if [ -f "$command_file" ] ; then
+            {
+                printf "detach\n"
+                printf "quit\n"
+            } >> "$command_file"
+        fi
+    done
+
+    sleep 1
+    for pid in $detach_pids ; do
+        debugger_pid_file="$tmpdir/$pid.debugger_pid"
+        tail_pid_file="$tmpdir/$pid.tail_pid"
+
+        if [ -f "$tail_pid_file" ] ; then
+            kill "$(sed -n '1p' "$tail_pid_file")" 2>/dev/null || true
+        fi
+
+        if [ -f "$debugger_pid_file" ] ; then
+            debugger_pid=$(sed -n '1p' "$debugger_pid_file")
+            # Kill the debugger after 5 s if it does not exit on its own,
+            # so pdeb_cleanup is never blocked indefinitely.
+            ( sleep 5 && kill "$debugger_pid" 2>/dev/null ) &
+            watchdog=$!
+            wait "$debugger_pid" 2>/dev/null || wait_status=1
+            kill "$watchdog" 2>/dev/null
+            wait "$watchdog" 2>/dev/null || true
+        fi
+    done
+
+    return "$wait_status"
+}
+
+remove_detached_pids()
+{
+    detached_pids=$*
+    remaining_pids=
+    remaining_selected_pids=
+
+    for pid in $pids ; do
+        keep=1
+        for detached_pid in $detached_pids ; do
+            if [ "$pid" = "$detached_pid" ] ; then
+                keep=0
+                break
+            fi
+        done
+        if [ 1 -eq "$keep" ] ; then
+            remaining_pids="$remaining_pids $pid"
+        fi
+    done
+
+    for pid in $selected_pids ; do
+        keep=1
+        for detached_pid in $detached_pids ; do
+            if [ "$pid" = "$detached_pid" ] ; then
+                keep=0
+                break
+            fi
+        done
+        if [ 1 -eq "$keep" ] ; then
+            remaining_selected_pids="$remaining_selected_pids $pid"
+        fi
+    done
+
+    pids=$(printf "%s\n" "$remaining_pids" | sed 's/^ *//')
+    selected_pids=$(printf "%s\n" "$remaining_selected_pids" | sed 's/^ *//')
+
+    if [ -z "$pids" ] ; then
+        program=
+        program_base=
+        attached=0
+    fi
+}
+
+command_debugger_passthrough()
+{
+    require_selection || return 1
+
+    pdeb_command_name=passthrough
+    pdeb_debugger_commands=$1
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/passthrough.$pdeb_output_dir_seq"
+
+    pdeb_run_selected_debugger_commands 0
+}
+
+interactive_loop()
+{
+    print_help
+    while : ; do
+        printf "%s[%s]> " "$PROMPT" "$(compressed_pids $selected_pids)"
+        if ! IFS= read -r line ; then
+            break
+        fi
+
+        set -f
+        set -- $line
+        set +f
+        if [ 0 -eq $# ] ; then
+            continue
+        fi
+        command_name=$1
+        shift
+
+        case "$command_name" in
+        quit|exit)
+            break
+            ;;
+        help)
+            print_help
+            ;;
+        *)
+            if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+                print_command_help "$command_name"
+            elif pdeb_command_file "$command_name" >/dev/null ; then
+                pdeb_execute_command "$command_name" "$@"
+            else
+                command_debugger_passthrough "$line"
+            fi
+            ;;
+        esac
+    done
+}
+
+temp_parent=${TMPDIR:-/tmp}
+tmpdir=
+trap '[ -n "$tmpdir" ] && rm -rf "$tmpdir"' EXIT
+if ! tmpdir=$(mktemp -d "$temp_parent/pdb.XXXXXX") ; then
+    echo "Could not create temporary directory." >&2
+    exit 1
+fi
+
+if ! load_pdeb_helpers ; then
+    exit 1
+fi
+
+pdeb_cleanup_running=0
+pdeb_cleanup()
+{
+    if [ 1 -eq "$pdeb_cleanup_running" ] ; then
+        return
+    fi
+    pdeb_cleanup_running=1
+    stop_debuggers
+    rm -rf "$tmpdir"
+}
+
+trap 'pdeb_cleanup' EXIT
+trap 'pdeb_cleanup; trap - EXIT; exit 130' HUP INT TERM
+if [ -n "$initial_pids" ] ; then
+    pdeb_execute_command attach $initial_pids || exit 1
+elif [ -n "$program_base" ] ; then
+    if ! resolved_pids=$(find_pids) ; then
+        echo "Could not list processes for user $user_name." >&2
+        exit 1
+    fi
+    if [ -z "$resolved_pids" ] ; then
+        echo "No processes named '$program_base' owned by $user_name were found." >&2
+        exit 1
+    fi
+    pdeb_execute_command attach $resolved_pids || exit 1
+fi
+if [ -n "$dump_file" ] ; then
+    command=$(debugger_backtrace_command)
+    dump_errors=0
+    for pid in $pids ; do
+        run_debugger_commands "$pid" "$command" "$tmpdir/$pid.raw" || {
+            printf "Warning: backtrace collection failed for PID %s.\n" "$pid" >&2
+            dump_errors=$((dump_errors + 1))
+        }
+    done
+    if ! write_dump_file "$dump_file" ; then
+        exit 1
+    fi
+    printf "Wrote raw stack dump to %s\n" "$dump_file" >&2
+    if [ 0 -lt "$dump_errors" ] ; then
+        printf "Warning: %d PID(s) failed; their entries in the dump may be incomplete.\n" \
+            "$dump_errors" >&2
+    fi
+fi
+interactive_loop
+exit 0

--- a/contrib/pdeb/commands/attach
+++ b/contrib/pdeb/commands/attach
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  attach <pid> [pid...]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+attach <pid> [pid...]
+  Attach one debugger to each of the given PIDs and select all attached
+  PIDs.  The PIDs do not have to share an executable name.  If debuggers
+  are already attached, detach them first.  On success the prompt changes
+  to attach[<selected-pids>].
+EOF
+}
+
+run()
+{
+    if [ 0 -eq $# ] || [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if ! args_are_pids "$@" ; then
+        echo "attach requires one or more PIDs." >&2
+        return 1
+    fi
+
+    if ! ensure_debugger ; then
+        return 1
+    fi
+
+    if [ 1 -eq "$attached" ] ; then
+        if ! detach_pid_list $pids ; then
+            echo "One or more debugger subprocesses did not exit cleanly." >&2
+        fi
+        remove_detached_pids $pids
+        prompt_pop
+    fi
+
+    attach_pids=
+    attach_first_pid=
+    for attach_pid in "$@" ; do
+        if ! pid_exists "$attach_pid" ; then
+            echo "No such process or not permitted: $attach_pid" >&2
+            return 1
+        fi
+        if [ -z "$attach_first_pid" ] ; then
+            attach_first_pid=$attach_pid
+        fi
+        attach_pids="$attach_pids $attach_pid"
+    done
+
+    pids=$(printf "%s\n" "$attach_pids" | sed 's/^ *//')
+    program_base=$(pid_command_base "$attach_first_pid")
+    if [ -z "$program_base" ] ; then
+        program_base=pids
+    fi
+    program=$program_base
+
+    start_debuggers || return 1
+    selected_pids=$pids
+    attached=1
+    prompt_push "attach"
+    printf "Attached %s to PIDs:%s\n" "$debugger" "$(printf " %s" $pids)"
+}

--- a/contrib/pdeb/commands/attach
+++ b/contrib/pdeb/commands/attach
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  attach <pid> [pid...]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+attach <pid> [pid...]
+  Attach one debugger to each of the given PIDs and select all attached
+  PIDs.  The PIDs do not have to share an executable name.  If debuggers
+  are already attached, detach them first.  On success the prompt changes
+  to attach[<selected-pids>].
+EOF
+}
+
+run()
+{
+    if [ 0 -eq $# ] || [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if ! args_are_pids "$@" ; then
+        echo "attach requires one or more PIDs." >&2
+        return 1
+    fi
+
+    if ! ensure_debugger ; then
+        return 1
+    fi
+
+    attach_pids=
+    attach_first_pid=
+    for attach_pid in "$@" ; do
+        if ! pid_exists "$attach_pid" ; then
+            echo "No such process or not permitted: $attach_pid" >&2
+            return 1
+        fi
+        case " $attach_pids " in
+        *" $attach_pid "*)
+            continue
+            ;;
+        esac
+        if [ -z "$attach_first_pid" ] ; then
+            attach_first_pid=$attach_pid
+        fi
+        attach_pids="$attach_pids $attach_pid"
+    done
+
+    if [ 1 -eq "$attached" ] ; then
+        if ! detach_pid_list $pids ; then
+            echo "One or more debugger subprocesses did not exit cleanly." >&2
+        fi
+        remove_detached_pids $pids
+        prompt_pop
+    fi
+
+    pids=$(printf "%s\n" "$attach_pids" | sed 's/^ *//')
+    program_base=$(pid_command_base "$attach_first_pid")
+    if [ -z "$program_base" ] ; then
+        program_base=pids
+    fi
+    program=$program_base
+
+    if ! start_debuggers ; then
+        stop_debuggers
+        pids=
+        selected_pids=
+        program=
+        program_base=
+        attached=0
+        return 1
+    fi
+    selected_pids=$pids
+    attached=1
+    prompt_push "attach"
+    printf "Attached %s to PIDs:%s\n" "$debugger" "$(printf " %s" $pids)"
+}

--- a/contrib/pdeb/commands/backtrace
+++ b/contrib/pdeb/commands/backtrace
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  backtrace [raw] [file <filename>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+backtrace [raw] [file <filename>]
+  Collect a backtrace from every selected debugger.
+  Without raw, output is parsed into the common/different stack report.
+  With raw, debugger output is printed per PID without interpretation.
+  With file, output is written to filename instead of stdout.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    bt_raw=0
+    bt_output_file=
+
+    while [ 0 -lt $# ] ; do
+        case "$1" in
+        raw)
+            bt_raw=1
+            ;;
+        file)
+            shift
+            if [ 0 -eq $# ] ; then
+                echo "backtrace file requires a filename." >&2
+                return 1
+            fi
+            bt_output_file=$1
+            ;;
+        help)
+            detailed_help
+            return 0
+            ;;
+        *)
+            echo "Unsupported backtrace argument: $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+
+    pdeb_output_dir="$tmpdir/backtrace.$$.$(date +%s)"
+    pdeb_debugger_commands=$(debugger_backtrace_command)
+}
+
+output()
+{
+    if [ -z "$bt_output_file" ] ; then
+        bt_output_file="$tmpdir/backtrace.out"
+        bt_print_to_stdout=1
+    else
+        bt_print_to_stdout=0
+    fi
+
+    if [ 1 -eq "$bt_raw" ] ; then
+        {
+            for bt_raw_file in "$@" ; do
+                bt_pid=$(basename "$bt_raw_file" .raw)
+                printf "\nPID %s: %s\n" "$bt_pid" "$program_base"
+                printf "%s\n" "----------------------------------------------------------------"
+                cat "$bt_raw_file"
+            done
+        } > "$bt_output_file"
+    else
+        bt_saved_pids=$pids
+        pids=$pdeb_output_pids
+        generate_backtrace_report "$pdeb_output_dir" "$bt_output_file"
+        pids=$bt_saved_pids
+    fi
+
+    if [ 1 -eq "$bt_print_to_stdout" ] ; then
+        cat "$bt_output_file"
+    else
+        printf "Wrote backtrace output to %s\n" "$bt_output_file"
+    fi
+}

--- a/contrib/pdeb/commands/backtrace
+++ b/contrib/pdeb/commands/backtrace
@@ -1,0 +1,90 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  backtrace [raw] [file <filename>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+backtrace [raw] [file <filename>]
+  Collect a backtrace from every selected debugger.
+  Without raw, output is parsed into the common/different stack report.
+  With raw, debugger output is printed per PID without interpretation.
+  With file, output is written to filename instead of stdout.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    bt_raw=0
+    bt_output_file=
+
+    while [ 0 -lt $# ] ; do
+        case "$1" in
+        raw)
+            bt_raw=1
+            ;;
+        file)
+            shift
+            if [ 0 -eq $# ] ; then
+                echo "backtrace file requires a filename." >&2
+                return 1
+            fi
+            bt_output_file=$1
+            ;;
+        help)
+            detailed_help
+            return 0
+            ;;
+        *)
+            echo "Unsupported backtrace argument: $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/backtrace.$pdeb_output_dir_seq"
+    pdeb_debugger_commands=$(debugger_backtrace_command)
+}
+
+output()
+{
+    if [ -z "$bt_output_file" ] ; then
+        bt_output_file="$tmpdir/backtrace.out"
+        bt_print_to_stdout=1
+    else
+        bt_print_to_stdout=0
+    fi
+
+    if [ 1 -eq "$bt_raw" ] ; then
+        {
+            for bt_raw_file in "$@" ; do
+                bt_pid=$(basename "$bt_raw_file" .raw)
+                printf "\nPID %s: %s\n" "$bt_pid" "$program_base"
+                printf "%s\n" "----------------------------------------------------------------"
+                cat "$bt_raw_file"
+            done
+        } > "$bt_output_file"
+    else
+        generate_backtrace_report "$pdeb_output_dir" "$bt_output_file" $pdeb_output_pids
+    fi
+
+    if [ 1 -eq "$bt_print_to_stdout" ] ; then
+        cat "$bt_output_file"
+    else
+        printf "Wrote backtrace output to %s\n" "$bt_output_file"
+    fi
+}

--- a/contrib/pdeb/commands/btlsm_dump
+++ b/contrib/pdeb/commands/btlsm_dump
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  btlsm_dump\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+btlsm_dump
+  Inspect the shared-memory BTL state for every selected PID.  This reports
+  incoming FIFO state, fragment free-list allocation counters, endpoint pending
+  send state, and pending endpoint list length.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] ; then
+        echo "btlsm_dump accepts no arguments." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_btlsm_dump_command ; then
+        echo "btlsm_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_btlsm_dump_command)
+    pdeb_output_dir="$tmpdir/btlsm_dump.$$.$(date +%s)"
+}

--- a/contrib/pdeb/commands/btlsm_dump
+++ b/contrib/pdeb/commands/btlsm_dump
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  btlsm_dump\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+btlsm_dump
+  Inspect the shared-memory BTL state for every selected PID.  This reports
+  incoming FIFO state, fragment free-list allocation counters, endpoint pending
+  send state, and pending endpoint list length.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] ; then
+        echo "btlsm_dump accepts no arguments." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_btlsm_dump_command ; then
+        echo "btlsm_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_btlsm_dump_command)
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/btlsm_dump.$pdeb_output_dir_seq"
+}

--- a/contrib/pdeb/commands/detach
+++ b/contrib/pdeb/commands/detach
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  detach [all]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+detach
+detach all
+  By default, send detach and quit to selected debuggers, stop their command
+  feeders, wait for them to exit, and remove them from the attached set.
+  Use detach all to detach every attached debugger.  When the last debugger
+  is detached, the attach prompt is removed; otherwise the prompt's PID list
+  updates to the PIDs that remain selected.
+EOF
+}
+
+run()
+{
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -eq "$attached" ] && [ -z "$pids" ] ; then
+        echo "No debuggers are attached."
+        return 0
+    fi
+
+    if [ 0 -eq $# ] ; then
+        detach_pids=$selected_pids
+        detach_label=selected
+    elif [ 1 -eq $# ] && { [ "all" = "$1" ] || [ "*" = "$1" ] ; } ; then
+        detach_pids=$pids
+        detach_label=all
+    else
+        echo "detach accepts no argument or 'all'." >&2
+        return 1
+    fi
+
+    if [ -z "$detach_pids" ] ; then
+        echo "No selected debuggers to detach."
+        return 0
+    fi
+
+    if ! detach_pid_list $detach_pids ; then
+        echo "One or more debugger subprocesses did not exit cleanly." >&2
+    fi
+
+    remove_detached_pids $detach_pids
+
+    if [ -z "$pids" ] ; then
+        prompt_pop
+    fi
+
+    if [ "all" = "$detach_label" ] ; then
+        echo "Detached all debuggers."
+    else
+        printf "Detached selected debuggers:%s\n" "$(printf " %s" $detach_pids)"
+    fi
+}

--- a/contrib/pdeb/commands/do
+++ b/contrib/pdeb/commands/do
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  do\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+do
+  Read debugger commands until two consecutive empty lines, then execute the
+  whole block in every selected debugger and print raw output per PID.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    block_file="$tmpdir/do.commands"
+    : > "$block_file"
+    empty_count=0
+
+    printf "Enter debugger commands. Finish with two empty lines.\n"
+    while IFS= read -r command_line ; do
+        if [ -z "$command_line" ] ; then
+            empty_count=$((empty_count + 1))
+            if [ 2 -eq "$empty_count" ] ; then
+                break
+            fi
+        else
+            empty_count=0
+        fi
+        printf "%s\n" "$command_line" >> "$block_file"
+    done
+
+    pdeb_debugger_commands=$(cat "$block_file")
+    pdeb_output_dir="$tmpdir/do.$$.$(date +%s)"
+}

--- a/contrib/pdeb/commands/do
+++ b/contrib/pdeb/commands/do
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  do\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+do
+  Read debugger commands until two consecutive empty lines, then execute the
+  whole block in every selected debugger and print raw output per PID.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    block_file="$tmpdir/do.commands"
+    : > "$block_file"
+    pending_empties=0
+
+    printf "Enter debugger commands. Finish with two empty lines.\n"
+    while IFS= read -r command_line ; do
+        if [ -z "$command_line" ] ; then
+            pending_empties=$((pending_empties + 1))
+            if [ 2 -eq "$pending_empties" ] ; then
+                break
+            fi
+        else
+            # Flush any buffered empty lines that preceded this non-empty line.
+            while [ 0 -lt "$pending_empties" ] ; do
+                printf "\n" >> "$block_file"
+                pending_empties=$((pending_empties - 1))
+            done
+            printf "%s\n" "$command_line" >> "$block_file"
+        fi
+    done
+
+    pdeb_debugger_commands=$(cat "$block_file")
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/do.$pdeb_output_dir_seq"
+}

--- a/contrib/pdeb/commands/frame
+++ b/contrib/pdeb/commands/frame
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  frame <function>\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+frame <function>
+  Find the first frame in the current thread whose debugger backtrace line
+  contains <function>, then select that frame in every selected debugger.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -eq $# ] || [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    function_name=$*
+    frame_command=$(debugger_current_backtrace_command)
+
+    for pid in $selected_pids ; do
+        raw_file="$tmpdir/$pid.frame.bt"
+        run_debugger_commands "$pid" "$frame_command" "$raw_file" || return 1
+
+        frame_number=$(debugger_find_frame_number "$raw_file" "$function_name")
+
+        printf "\nPID %s: %s\n" "$pid" "$program_base"
+        printf "%s\n" "----------------------------------------------------------------"
+        if [ -z "$frame_number" ] ; then
+            printf "No frame matching %s\n" "$function_name"
+            continue
+        fi
+
+        select_command=$(debugger_select_frame_command "$frame_number")
+        run_debugger_commands "$pid" "$select_command" \
+            "$tmpdir/$pid.frame.select" || return 1
+        cat "$tmpdir/$pid.frame.select"
+    done
+}

--- a/contrib/pdeb/commands/pml_dump
+++ b/contrib/pdeb/commands/pml_dump
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  pml_dump [<start> <count>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+pml_dump
+pml_dump <start> <count>
+  Decode OB1 PML global pending lists and selected send request fields for
+  every selected PID.  With no arguments, the first few incomplete requests in
+  the active wait_all frame are shown.  With arguments, requests in the range
+  [start, start + count) are shown.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] && [ 2 -ne $# ] ; then
+        echo "pml_dump accepts no arguments or exactly: <start> <count>." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_pml_dump_command ; then
+        echo "pml_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_pml_dump_command "$*")
+    pdeb_output_dir="$tmpdir/pml_dump.$$.$(date +%s)"
+}

--- a/contrib/pdeb/commands/pml_dump
+++ b/contrib/pdeb/commands/pml_dump
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  pml_dump [<requests_ptr> <count>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+pml_dump
+pml_dump <requests_ptr> <count>
+  Decode OB1 PML global pending lists and selected send request fields for
+  every selected PID.  With no arguments, the first few incomplete requests in
+  the active wait_all frame are shown.  With arguments, requests_ptr and count
+  are evaluated by the debugger (same semantics as req_dump).
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] && [ 2 -ne $# ] ; then
+        echo "pml_dump accepts no arguments or exactly: <requests_ptr> <count>." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_pml_dump_command ; then
+        echo "pml_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_pml_dump_command "$*")
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/pml_dump.$pdeb_output_dir_seq"
+}

--- a/contrib/pdeb/commands/req_dump
+++ b/contrib/pdeb/commands/req_dump
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  req_dump [<requests_ptr> <count>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+req_dump
+req_dump <requests_ptr> <count>
+  Report every non-completed request for every selected PID.  With no
+  arguments, the command finds the active ompi_request_default_wait_all frame
+  and uses its requests/count locals.  With arguments, requests_ptr and count
+  are evaluated by the debugger.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] && [ 2 -ne $# ] ; then
+        echo "req_dump accepts no arguments or exactly: <requests_ptr> <count>." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_req_dump_command ; then
+        echo "req_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_req_dump_command "$*")
+    pdeb_output_dir="$tmpdir/req_dump.$$.$(date +%s)"
+}

--- a/contrib/pdeb/commands/req_dump
+++ b/contrib/pdeb/commands/req_dump
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  req_dump [<requests_ptr> <count>]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+req_dump
+req_dump <requests_ptr> <count>
+  Report every non-completed request for every selected PID.  With no
+  arguments, the command finds the active ompi_request_default_wait_all frame
+  and uses its requests/count locals.  With arguments, requests_ptr and count
+  are evaluated by the debugger.
+EOF
+}
+
+run()
+{
+    require_selection || return 1
+
+    if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    if [ 0 -ne $# ] && [ 2 -ne $# ] ; then
+        echo "req_dump accepts no arguments or exactly: <requests_ptr> <count>." >&2
+        return 1
+    fi
+
+    if ! pdeb_function_defined debugger_req_dump_command ; then
+        echo "req_dump is not supported by debugger: $debugger" >&2
+        return 1
+    fi
+
+    pdeb_debugger_commands=$(debugger_req_dump_command "$*")
+    pdeb_output_dir_seq=$((pdeb_output_dir_seq + 1))
+    pdeb_output_dir="$tmpdir/req_dump.$pdeb_output_dir_seq"
+}

--- a/contrib/pdeb/commands/select
+++ b/contrib/pdeb/commands/select
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  select all|<pid> [pid...]\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+select all
+select <pid> [pid...]
+  Select which attached PIDs receive subsequent backtrace, frame, do, and
+  debugger passthrough commands.  The initial selection is all attached PIDs.
+EOF
+}
+
+run()
+{
+    if [ 0 -eq $# ] || [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    case "$1" in
+    all|"*")
+        selected_pids=$pids
+        printf "Selected PIDs:%s\n" "$(printf " %s" $selected_pids)"
+        return 0
+        ;;
+    esac
+
+    new_selection=
+    for requested_pid in "$@" ; do
+        if ! pid_is_attached "$requested_pid" ; then
+            echo "PID is not attached: $requested_pid" >&2
+            return 1
+        fi
+        new_selection="$new_selection $requested_pid"
+    done
+
+    selected_pids=$(printf "%s\n" "$new_selection" | sed 's/^ *//')
+    printf "Selected PIDs:%s\n" "$(printf " %s" $selected_pids)"
+}

--- a/contrib/pdeb/commands/show
+++ b/contrib/pdeb/commands/show
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+help()
+{
+    printf "  show pids\n"
+}
+
+detailed_help()
+{
+    cat <<EOF
+show pids
+  Print all attached PIDs and the currently selected PIDs.
+EOF
+}
+
+run()
+{
+    if [ 0 -eq $# ] || [ "help" = "$1" ] ; then
+        detailed_help
+        return 0
+    fi
+
+    case "$1" in
+    pids)
+        printf "Attached PIDs:%s\n" "$(printf " %s" $pids)"
+        printf "Selected PIDs:%s\n" "$(printf " %s" $selected_pids)"
+        ;;
+    *)
+        echo "Unsupported show argument: $1" >&2
+        return 1
+        ;;
+    esac
+}

--- a/contrib/pdeb/debugger/gdb
+++ b/contrib/pdeb/debugger/gdb
@@ -1,0 +1,447 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+debugger_available()
+{
+    command -v gdb >/dev/null 2>&1
+}
+
+debugger_collect_stack()
+{
+    pid=$1
+
+    gdb -q -batch -p "$pid" \
+        -ex "info threads" \
+        -ex "thread apply all bt" \
+        -ex "detach"
+}
+
+debugger_marker_command()
+{
+    marker=$1
+
+    printf "printf \"%s\\\\n\"\n" "$marker"
+}
+
+debugger_backtrace_command()
+{
+    printf "thread apply all bt\n"
+}
+
+debugger_current_backtrace_command()
+{
+    printf "bt\n"
+}
+
+debugger_select_frame_command()
+{
+    frame_number=$1
+
+    printf "frame %s\n" "$frame_number"
+}
+
+debugger_start()
+{
+    pid=$1
+    command_file=$2
+    log_file=$3
+    tail_pid_file=$4
+
+    { tail -f "$command_file" & printf "%s\n" "$!" > "$tail_pid_file"; wait "$!" 2>/dev/null; } 2>/dev/null |
+        gdb -q -p "$pid" > "$log_file" 2>&1 &
+    printf "%s\n" "$!"
+}
+
+debugger_startup_commands()
+{
+    cat <<EOF
+set pagination off
+set confirm off
+EOF
+}
+
+debugger_find_frame_number()
+{
+    raw_file=$1
+    function_name=$2
+
+    awk -v function_name="$function_name" '
+        index($0, function_name) && match($0, /^#[0-9]+/) {
+            frame = substr($0, RSTART + 1, RLENGTH - 1)
+            print frame
+            exit
+        }
+    ' "$raw_file"
+}
+
+debugger_parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    : > "$funcs_file"
+    : > "$details_file"
+    : > "$labels_file"
+
+    awk -v funcs_file="$funcs_file" \
+        -v details_file="$details_file" \
+        -v labels_file="$labels_file" '
+        function trim(s)
+        {
+            sub(/^[[:space:]]*/, "", s)
+            sub(/[[:space:]]*$/, "", s)
+            return s
+        }
+
+        function strip_function(s)
+        {
+            s = trim(s)
+            sub(/[[:space:]]+at[[:space:]].*/, "", s)
+            sub(/[[:space:]]+from[[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][0-9].*/, "", s)
+            sub(/\(.*/, "", s)
+            return trim(s)
+        }
+
+        function gdb_function(line, s)
+        {
+            s = line
+            sub(/^[[:space:]]*#[0-9]+[[:space:]]*/, "", s)
+            if (match(s, / in /)) {
+                s = substr(s, RSTART + RLENGTH)
+            } else {
+                sub(/^0x[0-9a-fA-F]+[[:space:]]*/, "", s)
+            }
+            return strip_function(s)
+        }
+
+        function frame_location(line, location)
+        {
+            if (match(line, /[[:space:]]at[[:space:]][^[:space:]]+:[0-9][0-9]*/)) {
+                location = substr(line, RSTART + 4, RLENGTH - 4)
+                return trim(location)
+            }
+
+            return ""
+        }
+
+        function emit_frame(function_name, detail)
+        {
+            if (done) {
+                return
+            }
+            if ("" == function_name) {
+                return
+            }
+            location = frame_location(detail)
+            print function_name >> funcs_file
+            print trim(detail) >> details_file
+            if ("" == location) {
+                print function_name >> labels_file
+            } else {
+                printf "%s (%s)\n", function_name, location >> labels_file
+            }
+            if ("main" == function_name) {
+                done = 1
+            }
+        }
+
+        /^[[:space:]]*#[0-9]+[[:space:]]/ {
+            emit_frame(gdb_function($0), $0)
+            next
+        }
+    ' "$raw_file"
+}
+
+debugger_gdb_python_quote()
+{
+    printf "%s" "$1" |
+        sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g" -e "s/^/'/" -e "s/$/'/"
+}
+
+debugger_gdb_openmpi_inspector_prelude()
+{
+    cat <<'EOF'
+python
+import gdb
+
+OFFSET_MASK = 0xffffffff
+OFFSET_BITS = 32
+SM_FIFO_FREE = -2
+FLAG_SINGLE_COPY = 1
+FLAG_COMPLETE = 2
+FLAG_SETUP_FBOX = 4
+
+REQUEST_COMPLETED = 1
+REQ_STATE = {0: 'INVALID', 1: 'INACTIVE', 2: 'ACTIVE', 3: 'CANCELLED'}
+
+def ompi_pdb_comp():
+    return gdb.parse_and_eval('mca_btl_sm_component')
+
+def ompi_pdb_ep_array():
+    return ompi_pdb_comp()['endpoints']
+
+def ompi_pdb_rel2virt(offset):
+    offset = int(offset)
+    idx = (offset >> OFFSET_BITS) & 0xffff
+    segbase = int(ompi_pdb_ep_array()[idx]['segment_base'])
+    addr = (offset & OFFSET_MASK) + segbase
+    hdr_t = gdb.lookup_type('mca_btl_sm_hdr_t').pointer()
+    return gdb.Value(addr).cast(hdr_t), idx
+
+def ompi_pdb_flagstr(f):
+    f = int(f)
+    parts = []
+    if f & FLAG_SINGLE_COPY:
+        parts.append('SINGLE_COPY')
+    if f & FLAG_COMPLETE:
+        parts.append('COMPLETE')
+    if f & FLAG_SETUP_FBOX:
+        parts.append('SETUP_FBOX')
+    if f == 0:
+        parts.append('INLINE/0')
+    return '|'.join(parts) + ' (0x%x)' % f
+
+def ompi_pdb_list_len(l):
+    try:
+        return int(l['opal_list_length'])
+    except gdb.error:
+        return -1
+
+def ompi_pdb_find_waitall_frame():
+    f = gdb.newest_frame()
+    while f is not None:
+        name = f.name() or ''
+        if 'ompi_request_default_wait_all' in name:
+            return f
+        f = f.older()
+    return None
+
+def ompi_pdb_field(val, path):
+    cur = val
+    try:
+        for p in path.split('.'):
+            cur = cur[p]
+        return str(cur)
+    except gdb.error:
+        return '<%s?>' % path
+
+def ompi_pdb_btlsm_dump():
+    c = ompi_pdb_comp()
+    print('============================================================')
+    try:
+        pi = gdb.parse_and_eval('opal_process_info')
+        print('local_rank=%s node_rank=%s num_local_peers=%s' % (
+            pi['my_local_rank'], pi['my_node_rank'], pi['num_local_peers']))
+    except gdb.error:
+        print('(opal_process_info unavailable)')
+
+    fifo = c['my_fifo']
+    head = int(fifo['fifo_head'])
+    tail = int(fifo['fifo_tail'])
+    print('my_fifo: head=%d tail=%d fbox_available=%s' % (
+        head, tail, fifo['fbox_available']))
+
+    print('--- incoming FIFO contents (what THIS rank has not yet consumed) ---')
+    if head == SM_FIFO_FREE:
+        print('  <empty>  => no returns/sends queued for us (points at case B)')
+    else:
+        n = 0
+        cur = head
+        while cur != SM_FIFO_FREE and n < 200:
+            try:
+                hdr, owner = ompi_pdb_rel2virt(cur)
+                h = hdr.dereference()
+                print('  [%3d] off=0x%x owner_rank=%d flags=%s tag=%s len=%s next=%d' % (
+                    n, cur & OFFSET_MASK, owner, ompi_pdb_flagstr(h['flags']),
+                    h['tag'], h['len'], int(h['next'])))
+                cur = int(h['next'])
+            except gdb.error as e:
+                print('  [%3d] <decode error: %s>' % (n, e))
+                break
+            n += 1
+        print('  total queued (capped 200): %d  => returns ARE waiting (case A)' % n)
+
+    print('--- fragment free lists (allocated vs free) ---')
+    for name in ('sm_frags_user', 'sm_frags_eager', 'sm_frags_max_send'):
+        try:
+            fl = c[name]
+            alloc = int(fl['fl_num_allocated'])
+            print('  %-18s fl_num_allocated=%d' % (name, alloc))
+        except gdb.error as e:
+            print('  %-18s <unavailable: %s>' % (name, e))
+
+    print('--- endpoints (pending sends / peer fifo head-tail) ---')
+    npeers = int(gdb.parse_and_eval('opal_process_info')['num_local_peers']) + 1
+    eps = ompi_pdb_ep_array()
+    for i in range(npeers):
+        try:
+            ep = eps[i]
+            psr = int(ep['peer_smp_rank'])
+            if psr < 0:
+                continue
+            pend = ompi_pdb_list_len(ep['pending_frags'])
+            pf = ep['fifo']
+            if int(pf) != 0:
+                ph = int(pf['fifo_head'])
+                pt = int(pf['fifo_tail'])
+            else:
+                ph = pt = 0
+            fbo = 'fbox' if int(ep['fbox_out']['buffer']) != 0 else '----'
+            print('  ep[%2d] peer=%2d pending_frags=%d peer_fifo(head=%d tail=%d) %s' % (
+                i, psr, pend, ph, pt, fbo))
+        except gdb.error as e:
+            print('  ep[%2d] <error: %s>' % (i, e))
+
+    print('--- pending_endpoints list length = %d ---' %
+          ompi_pdb_list_len(c['pending_endpoints']))
+    print('============================================================')
+
+def ompi_pdb_req_dump(arg):
+    args = arg.split()
+    if len(args) == 2:
+        base = gdb.parse_and_eval(args[0])
+        count = int(gdb.parse_and_eval(args[1]))
+        req_t = gdb.lookup_type('ompi_request_t').pointer().pointer()
+        requests = base.cast(req_t)
+    else:
+        f = ompi_pdb_find_waitall_frame()
+        if f is None:
+            print('req_dump: no ompi_request_default_wait_all frame; '
+                  'pass: req_dump <requests_ptr> <count>')
+            return
+        requests = f.read_var('requests')
+        count = int(f.read_var('count'))
+
+    print('============================================================')
+    print('req_dump: count=%d requests=%s' % (count, requests))
+    incomplete = 0
+    for i in range(count):
+        try:
+            r = requests[i]
+            if int(r) == 0:
+                print('  [%3d] <NULL request>' % i)
+                incomplete += 1
+                continue
+            rd = r.dereference()
+            comp = int(rd['req_complete'])
+            state = int(rd['req_state'])
+            if comp == REQUEST_COMPLETED:
+                continue
+            incomplete += 1
+            st = rd['req_status']
+            try:
+                rtype = str(rd['req_type'])
+            except gdb.error:
+                rtype = '?'
+            comp_s = {0: 'PENDING', 1: 'COMPLETED'}.get(comp, 'SYNC@0x%x' % comp)
+            print('  [%3d] type=%s state=%s(%d) complete=%s '
+                  'status{SOURCE=%s TAG=%s err=%s _ucount=%s _cancelled=%s}' % (
+                      i, rtype, REQ_STATE.get(state, '?'), state, comp_s,
+                      st['MPI_SOURCE'], st['MPI_TAG'], st['MPI_ERROR'],
+                      st['_ucount'], st['_cancelled']))
+        except gdb.error as e:
+            print('  [%3d] <error: %s>' % (i, e))
+    print('--- incomplete/non-completed requests: %d / %d ---' %
+          (incomplete, count))
+    print('============================================================')
+
+def ompi_pdb_pml_dump(arg):
+    print('============================================================')
+    try:
+        ob1 = gdb.parse_and_eval('mca_pml_ob1')
+        for nm in ('send_pending', 'recv_pending', 'rdma_pending',
+                   'pckt_pending', 'non_existing_communicator_pending'):
+            try:
+                print('  mca_pml_ob1.%-34s size=%s' % (
+                    nm, ob1[nm]['opal_list_length']))
+            except gdb.error:
+                pass
+        print('  mca_pml_ob1.enabled = %s' % ob1['enabled'])
+    except gdb.error as e:
+        print('  <mca_pml_ob1 unavailable: %s>' % e)
+
+    f = ompi_pdb_find_waitall_frame()
+    if f is None:
+        print('pml_dump: no wait_all frame found')
+        print('============================================================')
+        return
+    requests = f.read_var('requests')
+    count = int(f.read_var('count'))
+
+    args = arg.split()
+    if len(args) >= 2:
+        start = int(args[0])
+        n = int(args[1])
+        idxs = range(start, min(start + n, count))
+    else:
+        idxs = []
+        for i in range(count):
+            r = requests[i]
+            if int(r) and int(r.dereference()['req_complete']) != 1:
+                idxs.append(i)
+                if len(idxs) >= 4:
+                    break
+
+    sr_t = gdb.lookup_type('mca_pml_ob1_send_request_t').pointer()
+    for i in idxs:
+        r = requests[i]
+        sr = r.cast(sr_t)
+        print('  --- request[%d] @%s ---' % (i, r))
+        print('      req_pending        = %s' % ompi_pdb_field(sr, 'req_pending'))
+        print('      req_state          = %s' % ompi_pdb_field(sr, 'req_state'))
+        print('      req_lock           = %s' % ompi_pdb_field(sr, 'req_lock'))
+        print('      req_pipeline_depth = %s' %
+              ompi_pdb_field(sr, 'req_pipeline_depth'))
+        print('      req_bytes_delivered= %s' %
+              ompi_pdb_field(sr, 'req_bytes_delivered'))
+        print('      req_rdma_cnt       = %s' % ompi_pdb_field(sr, 'req_rdma_cnt'))
+        print('      bytes_packed       = %s' %
+              ompi_pdb_field(sr, 'req_send.req_bytes_packed'))
+        print('      send_mode          = %s' %
+              ompi_pdb_field(sr, 'req_send.req_send_mode'))
+        print('      peer/tag/seq       = %s / %s / %s' % (
+            ompi_pdb_field(sr, 'req_send.req_base.req_peer'),
+            ompi_pdb_field(sr, 'req_send.req_base.req_tag'),
+            ompi_pdb_field(sr, 'req_send.req_base.req_sequence')))
+        print('      pml_complete       = %s' %
+              ompi_pdb_field(sr, 'req_send.req_base.req_pml_complete'))
+    print('============================================================')
+end
+EOF
+}
+
+debugger_btlsm_dump_command()
+{
+    debugger_gdb_openmpi_inspector_prelude
+    cat <<'EOF'
+python
+ompi_pdb_btlsm_dump()
+end
+EOF
+}
+
+debugger_req_dump_command()
+{
+    arg=$(debugger_gdb_python_quote "${1-}")
+
+    debugger_gdb_openmpi_inspector_prelude
+    printf "python\nompi_pdb_req_dump(%s)\nend\n" "$arg"
+}
+
+debugger_pml_dump_command()
+{
+    arg=$(debugger_gdb_python_quote "${1-}")
+
+    debugger_gdb_openmpi_inspector_prelude
+    printf "python\nompi_pdb_pml_dump(%s)\nend\n" "$arg"
+}

--- a/contrib/pdeb/debugger/gdb
+++ b/contrib/pdeb/debugger/gdb
@@ -1,0 +1,531 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+debugger_available()
+{
+    command -v gdb >/dev/null 2>&1
+}
+
+debugger_marker_command()
+{
+    marker=$1
+
+    printf "printf \"%s\\\\n\"\n" "$marker"
+}
+
+debugger_backtrace_command()
+{
+    printf "thread apply all bt\n"
+}
+
+debugger_current_backtrace_command()
+{
+    printf "bt\n"
+}
+
+debugger_select_frame_command()
+{
+    frame_number=$1
+
+    printf "frame %s\n" "$frame_number"
+}
+
+debugger_start()
+{
+    pid=$1
+    command_file=$2
+    log_file=$3
+    tail_pid_file=$4
+
+    feeder_fifo="$tmpdir/$pid.feeder"
+    mkfifo "$feeder_fifo"
+    # Hold both ends of the FIFO open so that tail and gdb can start without
+    # blocking on each other.  O_RDWR on a FIFO is non-blocking on Linux and
+    # macOS (the primary supported platforms).
+    exec 9<>"$feeder_fifo"
+    tail -f "$command_file" 9>&- >"$feeder_fifo" 2>/dev/null &
+    printf "%s\n" "$!" > "$tail_pid_file"
+    gdb -nx -q -p "$pid" 9>&- <"$feeder_fifo" > "$log_file" 2>&1 &
+    exec 9>&-
+    rm -f "$feeder_fifo"
+    printf "%s\n" "$!"
+}
+
+debugger_startup_commands()
+{
+    cat <<'STARTUP_EOF'
+set pagination off
+set confirm off
+STARTUP_EOF
+    debugger_gdb_openmpi_inspector_prelude
+}
+
+debugger_find_frame_number()
+{
+    raw_file=$1
+    function_name=$2
+
+    awk -v function_name="$function_name" '
+        { sub(/^(\(gdb\) )+/, "") }
+        index($0, function_name) && match($0, /^#[0-9]+/) {
+            frame = substr($0, RSTART + 1, RLENGTH - 1)
+            print frame
+            exit
+        }
+    ' "$raw_file"
+}
+
+debugger_parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    : > "$funcs_file"
+    : > "$details_file"
+    : > "$labels_file"
+
+    awk -v funcs_file="$funcs_file" \
+        -v details_file="$details_file" \
+        -v labels_file="$labels_file" '
+        function trim(s)
+        {
+            sub(/^[[:space:]]*/, "", s)
+            sub(/[[:space:]]*$/, "", s)
+            return s
+        }
+
+        function strip_function(s)
+        {
+            s = trim(s)
+            sub(/[[:space:]]+at[[:space:]].*/, "", s)
+            sub(/[[:space:]]+from[[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][0-9].*/, "", s)
+            sub(/\(.*/, "", s)
+            return trim(s)
+        }
+
+        function gdb_function(line, s)
+        {
+            s = line
+            sub(/^[[:space:]]*#[0-9]+[[:space:]]*/, "", s)
+            if (match(s, / in /)) {
+                s = substr(s, RSTART + RLENGTH)
+            } else {
+                sub(/^0x[0-9a-fA-F]+[[:space:]]*/, "", s)
+            }
+            return strip_function(s)
+        }
+
+        function frame_location(line, location)
+        {
+            if (match(line, /[[:space:]]at[[:space:]][^[:space:]]+:[0-9][0-9]*/)) {
+                location = substr(line, RSTART + 4, RLENGTH - 4)
+                return trim(location)
+            }
+
+            return ""
+        }
+
+        function emit_frame(function_name, detail)
+        {
+            if (done) {
+                return
+            }
+            if ("" == function_name) {
+                return
+            }
+            location = frame_location(detail)
+            print function_name >> funcs_file
+            print trim(detail) >> details_file
+            if ("" == location) {
+                print function_name >> labels_file
+            } else {
+                printf "%s (%s)\n", function_name, location >> labels_file
+            }
+            if ("main" == function_name) {
+                done = 1
+            }
+        }
+
+        {
+            sub(/^(\(gdb\) )+/, "")
+        }
+
+        /^[[:space:]]*(Thread [0-9]+[[:space:]])/ {
+            ++thread_count
+            if (1 < thread_count) {
+                done = 1
+            }
+            next
+        }
+
+        /^[[:space:]]*#[0-9]+[[:space:]]/ {
+            emit_frame(gdb_function($0), $0)
+            next
+        }
+    ' "$raw_file"
+}
+
+debugger_gdb_python_quote()
+{
+    printf "%s\n" "$1" |
+        tr '\n' ' ' |
+        sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g" -e "s/^/'/" -e "s/$/'/"
+}
+
+debugger_gdb_openmpi_inspector_prelude()
+{
+    cat <<'EOF'
+python
+import gdb
+
+SM_FIFO_FREE = -2
+FLAG_SINGLE_COPY = 1
+FLAG_COMPLETE = 2
+FLAG_SETUP_FBOX = 4
+
+REQUEST_COMPLETED = 1
+REQ_STATE = {0: 'INVALID', 1: 'INACTIVE', 2: 'ACTIVE', 3: 'CANCELLED'}
+
+_ompi_pdb_offset_bits = None
+_ompi_pdb_offset_mask = None
+
+def ompi_pdb_offset_bits():
+    global _ompi_pdb_offset_bits, _ompi_pdb_offset_mask
+    if _ompi_pdb_offset_bits is None:
+        try:
+            if 8 == gdb.lookup_type('fifo_value_t').sizeof:
+                _ompi_pdb_offset_bits, _ompi_pdb_offset_mask = 32, 0xffffffff
+            else:
+                _ompi_pdb_offset_bits, _ompi_pdb_offset_mask = 24, 0x00ffffff
+        except gdb.error:
+            _ompi_pdb_offset_bits, _ompi_pdb_offset_mask = 32, 0xffffffff
+    return _ompi_pdb_offset_bits, _ompi_pdb_offset_mask
+
+def ompi_pdb_comp():
+    return gdb.parse_and_eval('mca_btl_sm_component')
+
+def ompi_pdb_ep_array():
+    return ompi_pdb_comp()['endpoints']
+
+def ompi_pdb_rel2virt(offset):
+    offset_bits, offset_mask = ompi_pdb_offset_bits()
+    offset = int(offset)
+    idx = (offset >> offset_bits) & 0xffff
+    segbase = int(ompi_pdb_ep_array()[idx]['segment_base'])
+    addr = (offset & offset_mask) + segbase
+    hdr_t = gdb.lookup_type('mca_btl_sm_hdr_t').pointer()
+    # Use parse_and_eval to construct the pointer so GDB uses the correct
+    # pointer width for the target rather than the Python-default int width.
+    return gdb.parse_and_eval('(mca_btl_sm_hdr_t *)0x%x' % addr), idx
+
+def ompi_pdb_flagstr(f):
+    f = int(f)
+    parts = []
+    if f & FLAG_SINGLE_COPY:
+        parts.append('SINGLE_COPY')
+    if f & FLAG_COMPLETE:
+        parts.append('COMPLETE')
+    if f & FLAG_SETUP_FBOX:
+        parts.append('SETUP_FBOX')
+    if f == 0:
+        parts.append('INLINE/0')
+    return '|'.join(parts) + ' (0x%x)' % f
+
+def ompi_pdb_list_len(l):
+    try:
+        return int(l['opal_list_length'])
+    except gdb.error:
+        return -1
+
+def ompi_pdb_find_waitall_frame():
+    # Fast path: check the currently selected thread.
+    f = gdb.newest_frame()
+    while f is not None:
+        if 'ompi_request_default_wait_all' in (f.name() or ''):
+            return f
+        f = f.older()
+    # Slow path: search all other threads (covers hybrid OpenMP+MPI programs).
+    # On success, leaves the found thread selected so that callers can call
+    # read_var() against the frame's register context.  On failure, restores
+    # the original thread.
+    orig_thread = gdb.selected_thread()
+    for thr in gdb.selected_inferior().threads():
+        if thr == orig_thread:
+            continue
+        try:
+            thr.switch()
+            f = gdb.newest_frame()
+            while f is not None:
+                if 'ompi_request_default_wait_all' in (f.name() or ''):
+                    return f
+                f = f.older()
+        except gdb.error:
+            pass
+    if orig_thread and orig_thread.is_valid():
+        orig_thread.switch()
+    return None
+
+def ompi_pdb_field(val, path):
+    cur = val
+    try:
+        for p in path.split('.'):
+            cur = cur[p]
+        return str(cur)
+    except gdb.error:
+        return '<%s?>' % path
+
+def ompi_pdb_btlsm_dump():
+    try:
+        c = ompi_pdb_comp()
+    except gdb.error as e:
+        print('btlsm_dump: sm BTL state unavailable (%s); '
+              'is the sm BTL in use and are debug symbols loaded?' % e)
+        return
+    print('============================================================')
+    npeers = None
+    try:
+        pi = gdb.parse_and_eval('opal_process_info')
+        print('local_rank=%s node_rank=%s num_local_peers=%s' % (
+            pi['my_local_rank'], pi['my_node_rank'], pi['num_local_peers']))
+        npeers = int(pi['num_local_peers']) + 1
+    except gdb.error:
+        print('(opal_process_info unavailable)')
+
+    try:
+        fifo = c['my_fifo']
+        head = int(fifo['fifo_head'])
+        tail = int(fifo['fifo_tail'])
+        print('my_fifo: head=%d tail=%d fbox_available=%s' % (
+            head, tail, fifo['fbox_available']))
+
+        print('--- incoming FIFO contents (what THIS rank has not yet consumed) ---')
+        if head == SM_FIFO_FREE:
+            print('  <empty>')
+        else:
+            _, offset_mask = ompi_pdb_offset_bits()
+            n = 0
+            cur = head
+            while cur != SM_FIFO_FREE and n < 200:
+                try:
+                    hdr, owner = ompi_pdb_rel2virt(cur)
+                    h = hdr.dereference()
+                    print('  [%3d] off=0x%x owner_rank=%d flags=%s tag=%s len=%s next=%d' % (
+                        n, cur & offset_mask, owner, ompi_pdb_flagstr(h['flags']),
+                        h['tag'], h['len'], int(h['next'])))
+                    cur = int(h['next'])
+                except gdb.error as e:
+                    print('  [%3d] <decode error: %s>' % (n, e))
+                    break
+                n += 1
+            print('  total queued (capped 200): %d' % n)
+    except gdb.error as e:
+        print('  <FIFO unavailable: %s>' % e)
+
+    print('--- fragment free lists (allocated) ---')
+    for name in ('sm_frags_user', 'sm_frags_eager', 'sm_frags_max_send'):
+        try:
+            fl = c[name]
+            alloc = int(fl['fl_num_allocated'])
+            print('  %-18s fl_num_allocated=%d' % (name, alloc))
+        except gdb.error as e:
+            print('  %-18s <unavailable: %s>' % (name, e))
+
+    if npeers is None:
+        print('--- endpoints: (opal_process_info unavailable; skipping) ---')
+    else:
+        print('--- endpoints (pending sends / peer fifo head-tail) ---')
+        eps = ompi_pdb_ep_array()
+        for i in range(npeers):
+            try:
+                ep = eps[i]
+                psr = int(ep['peer_smp_rank'])
+                pend = ompi_pdb_list_len(ep['pending_frags'])
+                pf = ep['fifo']
+                if int(pf) != 0:
+                    ph = int(pf['fifo_head'])
+                    pt = int(pf['fifo_tail'])
+                else:
+                    ph = pt = 0
+                fbo = 'fbox' if int(ep['fbox_out']['buffer']) != 0 else '----'
+                print('  ep[%2d] peer=%2d pending_frags=%d peer_fifo(head=%d tail=%d) %s' % (
+                    i, psr, pend, ph, pt, fbo))
+            except gdb.error as e:
+                print('  ep[%2d] <error: %s>' % (i, e))
+
+    print('--- pending_endpoints list length = %d ---' %
+          ompi_pdb_list_len(c['pending_endpoints']))
+    print('============================================================')
+
+def ompi_pdb_req_dump(arg=''):
+    args = arg.split()
+    if len(args) == 2:
+        try:
+            base = gdb.parse_and_eval(args[0])
+            count = int(gdb.parse_and_eval(args[1]))
+            req_t = gdb.lookup_type('ompi_request_t').pointer().pointer()
+            requests = base.cast(req_t)
+        except (gdb.error, ValueError) as e:
+            print('req_dump: cannot evaluate args: %s' % e)
+            return
+    else:
+        f = ompi_pdb_find_waitall_frame()
+        if f is None:
+            print('req_dump: no ompi_request_default_wait_all frame; '
+                  'pass: req_dump <requests_ptr> <count>')
+            return
+        requests = f.read_var('requests')
+        count = int(f.read_var('count'))
+
+    print('============================================================')
+    print('req_dump: count=%d requests=%s' % (count, requests))
+    incomplete = 0
+    for i in range(count):
+        try:
+            r = requests[i]
+            if int(r) == 0:
+                print('  [%3d] <NULL request>' % i)
+                incomplete += 1
+                continue
+            rd = r.dereference()
+            comp = int(rd['req_complete'])
+            state = int(rd['req_state'])
+            if comp == REQUEST_COMPLETED:
+                continue
+            incomplete += 1
+            st = rd['req_status']
+            try:
+                rtype = str(rd['req_type'])
+            except gdb.error:
+                rtype = '?'
+            comp_s = {0: 'PENDING', 1: 'COMPLETED'}.get(comp, 'SYNC@0x%x' % comp)
+            print('  [%3d] type=%s state=%s(%d) complete=%s '
+                  'status{SOURCE=%s TAG=%s err=%s _ucount=%s _cancelled=%s}' % (
+                      i, rtype, REQ_STATE.get(state, '?'), state, comp_s,
+                      st['MPI_SOURCE'], st['MPI_TAG'], st['MPI_ERROR'],
+                      st['_ucount'], st['_cancelled']))
+        except gdb.error as e:
+            print('  [%3d] <error: %s>' % (i, e))
+    print('--- incomplete/non-completed requests: %d / %d ---' %
+          (incomplete, count))
+    print('============================================================')
+
+def ompi_pdb_pml_dump(arg=''):
+    print('============================================================')
+    try:
+        ob1 = gdb.parse_and_eval('mca_pml_ob1')
+        for nm in ('send_pending', 'recv_pending', 'rdma_pending',
+                   'pckt_pending', 'non_existing_communicator_pending'):
+            try:
+                print('  mca_pml_ob1.%-34s size=%s' % (
+                    nm, ob1[nm]['opal_list_length']))
+            except gdb.error:
+                pass
+        print('  mca_pml_ob1.enabled = %s' % ob1['enabled'])
+    except gdb.error as e:
+        print('  <mca_pml_ob1 unavailable: %s>' % e)
+
+    args = arg.split()
+    if len(args) >= 2:
+        # Explicit requests_ptr + count: bypass the wait_all frame, same
+        # semantics as req_dump <requests_ptr> <count>.
+        try:
+            req_t = gdb.lookup_type('ompi_request_t').pointer().pointer()
+            requests = gdb.parse_and_eval(args[0]).cast(req_t)
+            count = int(gdb.parse_and_eval(args[1]))
+        except gdb.error as e:
+            print('pml_dump: cannot evaluate args: %s' % e)
+            print('============================================================')
+            return
+        idxs = range(count)
+    else:
+        f = ompi_pdb_find_waitall_frame()
+        if f is None:
+            print('pml_dump: no wait_all frame found; '
+                  'pass: pml_dump <requests_ptr> <count>')
+            print('============================================================')
+            return
+        requests = f.read_var('requests')
+        count = int(f.read_var('count'))
+        idxs = []
+        for i in range(count):
+            r = requests[i]
+            if int(r) and int(r.dereference()['req_complete']) != 1:
+                idxs.append(i)
+                if len(idxs) >= 4:
+                    break
+
+    try:
+        base_t = gdb.lookup_type('mca_pml_base_request_t').pointer()
+        sr_t = gdb.lookup_type('mca_pml_ob1_send_request_t').pointer()
+    except gdb.error as e:
+        print('pml_dump: cannot look up request types (%s); '
+              'are OB1 PML debug symbols loaded?' % e)
+        print('============================================================')
+        return
+
+    for i in idxs:
+        try:
+            r = requests[i]
+            try:
+                rtype = str(r.cast(base_t)['req_type'])
+            except gdb.error:
+                rtype = '?'
+            if 'SEND' not in rtype:
+                print('  --- request[%d] @%s is %s; not an OB1 send request ---'
+                      % (i, r, rtype))
+                continue
+            sr = r.cast(sr_t)
+            print('  --- request[%d] @%s ---' % (i, r))
+            print('      req_pending        = %s' % ompi_pdb_field(sr, 'req_pending'))
+            print('      req_state          = %s' % ompi_pdb_field(sr, 'req_state'))
+            print('      req_lock           = %s' % ompi_pdb_field(sr, 'req_lock'))
+            print('      req_pipeline_depth = %s' %
+                  ompi_pdb_field(sr, 'req_pipeline_depth'))
+            print('      req_bytes_delivered= %s' %
+                  ompi_pdb_field(sr, 'req_bytes_delivered'))
+            print('      req_rdma_cnt       = %s' % ompi_pdb_field(sr, 'req_rdma_cnt'))
+            print('      bytes_packed       = %s' %
+                  ompi_pdb_field(sr, 'req_send.req_bytes_packed'))
+            print('      send_mode          = %s' %
+                  ompi_pdb_field(sr, 'req_send.req_send_mode'))
+            print('      peer/tag/seq       = %s / %s / %s' % (
+                ompi_pdb_field(sr, 'req_send.req_base.req_peer'),
+                ompi_pdb_field(sr, 'req_send.req_base.req_tag'),
+                ompi_pdb_field(sr, 'req_send.req_base.req_sequence')))
+            print('      pml_complete       = %s' %
+                  ompi_pdb_field(sr, 'req_send.req_base.req_pml_complete'))
+        except gdb.error as e:
+            print('  [%d] <error: %s>' % (i, e))
+    print('============================================================')
+end
+EOF
+}
+
+debugger_btlsm_dump_command()
+{
+    printf "python\nompi_pdb_btlsm_dump()\nend\n"
+}
+
+debugger_req_dump_command()
+{
+    arg=$(debugger_gdb_python_quote "${1-}")
+
+    printf "python\nompi_pdb_req_dump(%s)\nend\n" "$arg"
+}
+
+debugger_pml_dump_command()
+{
+    arg=$(debugger_gdb_python_quote "${1-}")
+
+    printf "python\nompi_pdb_pml_dump(%s)\nend\n" "$arg"
+}

--- a/contrib/pdeb/debugger/lldb
+++ b/contrib/pdeb/debugger/lldb
@@ -1,0 +1,162 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+debugger_available()
+{
+    command -v lldb >/dev/null 2>&1
+}
+
+debugger_collect_stack()
+{
+    pid=$1
+
+    lldb --batch -p "$pid" \
+        -o "process status" \
+        -o "thread backtrace all" \
+        -o "detach" \
+        -o "quit"
+}
+
+debugger_marker_command()
+{
+    marker=$1
+
+    printf "script print(\"%s\")\n" "$marker"
+}
+
+debugger_backtrace_command()
+{
+    printf "thread backtrace all\n"
+}
+
+debugger_current_backtrace_command()
+{
+    printf "thread backtrace\n"
+}
+
+debugger_select_frame_command()
+{
+    frame_number=$1
+
+    printf "frame select %s\n" "$frame_number"
+}
+
+debugger_start()
+{
+    pid=$1
+    command_file=$2
+    log_file=$3
+    tail_pid_file=$4
+
+    { tail -f "$command_file" & printf "%s\n" "$!" > "$tail_pid_file"; wait "$!" 2>/dev/null; } 2>/dev/null |
+        lldb -p "$pid" > "$log_file" 2>&1 &
+    printf "%s\n" "$!"
+}
+
+debugger_startup_commands()
+{
+    printf "settings set interpreter.prompt-on-quit false\n"
+}
+
+debugger_find_frame_number()
+{
+    raw_file=$1
+    function_name=$2
+
+    awk -v function_name="$function_name" '
+        index($0, function_name) && match($0, /frame #[0-9]+/) {
+            frame = substr($0, RSTART + 7, RLENGTH - 7)
+            print frame
+            exit
+        }
+    ' "$raw_file"
+}
+
+debugger_parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    : > "$funcs_file"
+    : > "$details_file"
+    : > "$labels_file"
+
+    awk -v funcs_file="$funcs_file" \
+        -v details_file="$details_file" \
+        -v labels_file="$labels_file" '
+        function trim(s)
+        {
+            sub(/^[[:space:]]*/, "", s)
+            sub(/[[:space:]]*$/, "", s)
+            return s
+        }
+
+        function strip_function(s)
+        {
+            s = trim(s)
+            sub(/[[:space:]]+at[[:space:]].*/, "", s)
+            sub(/[[:space:]]+from[[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][0-9].*/, "", s)
+            sub(/\(.*/, "", s)
+            return trim(s)
+        }
+
+        function lldb_function(line, parts, n, s)
+        {
+            if (0 < index(line, "`")) {
+                n = split(line, parts, "`")
+                return strip_function(parts[n])
+            }
+
+            s = line
+            sub(/^.*frame #[0-9]+:[[:space:]]*/, "", s)
+            sub(/^0x[0-9a-fA-F]+[[:space:]]*/, "", s)
+            return strip_function(s)
+        }
+
+        function frame_location(line, location)
+        {
+            if (match(line, /[[:space:]]at[[:space:]][^[:space:]]+:[0-9][0-9]*/)) {
+                location = substr(line, RSTART + 4, RLENGTH - 4)
+                return trim(location)
+            }
+
+            return ""
+        }
+
+        function emit_frame(function_name, detail)
+        {
+            if (done) {
+                return
+            }
+            if ("" == function_name) {
+                return
+            }
+            location = frame_location(detail)
+            print function_name >> funcs_file
+            print trim(detail) >> details_file
+            if ("" == location) {
+                print function_name >> labels_file
+            } else {
+                printf "%s (%s)\n", function_name, location >> labels_file
+            }
+            if ("main" == function_name) {
+                done = 1
+            }
+        }
+
+        /^[[:space:]*]*frame #[0-9]+:/ {
+            emit_frame(lldb_function($0), $0)
+            next
+        }
+    ' "$raw_file"
+}

--- a/contrib/pdeb/debugger/lldb
+++ b/contrib/pdeb/debugger/lldb
@@ -1,0 +1,172 @@
+#
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+debugger_available()
+{
+    command -v lldb >/dev/null 2>&1
+}
+
+debugger_marker_command()
+{
+    marker=$1
+
+    safe=$(printf '%s' "$marker" | sed "s/'/\\\\'/g")
+    printf "script print('%s')\n" "$safe"
+}
+
+debugger_backtrace_command()
+{
+    printf "thread backtrace all\n"
+}
+
+debugger_current_backtrace_command()
+{
+    printf "thread backtrace\n"
+}
+
+debugger_select_frame_command()
+{
+    frame_number=$1
+
+    printf "frame select %s\n" "$frame_number"
+}
+
+debugger_start()
+{
+    pid=$1
+    command_file=$2
+    log_file=$3
+    tail_pid_file=$4
+
+    feeder_fifo="$tmpdir/$pid.feeder"
+    mkfifo "$feeder_fifo"
+    exec 9<>"$feeder_fifo"
+    tail -f "$command_file" 9>&- >"$feeder_fifo" 2>/dev/null &
+    printf "%s\n" "$!" > "$tail_pid_file"
+    lldb --no-lldbinit -p "$pid" 9>&- <"$feeder_fifo" > "$log_file" 2>&1 &
+    exec 9>&-
+    rm -f "$feeder_fifo"
+    printf "%s\n" "$!"
+}
+
+debugger_startup_commands()
+{
+    printf "settings set interpreter.prompt-on-quit false\n"
+    printf "settings set auto-confirm true\n"
+}
+
+debugger_find_frame_number()
+{
+    raw_file=$1
+    function_name=$2
+
+    awk -v function_name="$function_name" '
+        index($0, function_name) && match($0, /frame #[0-9]+/) {
+            frame = substr($0, RSTART + 7, RLENGTH - 7)
+            print frame
+            exit
+        }
+    ' "$raw_file"
+}
+
+debugger_parse_stack()
+{
+    raw_file=$1
+    funcs_file=$2
+    details_file=$3
+    labels_file=$4
+
+    : > "$funcs_file"
+    : > "$details_file"
+    : > "$labels_file"
+
+    awk -v funcs_file="$funcs_file" \
+        -v details_file="$details_file" \
+        -v labels_file="$labels_file" '
+        function trim(s)
+        {
+            sub(/^[[:space:]]*/, "", s)
+            sub(/[[:space:]]*$/, "", s)
+            return s
+        }
+
+        function strip_function(s)
+        {
+            s = trim(s)
+            sub(/[[:space:]]+at[[:space:]].*/, "", s)
+            sub(/[[:space:]]+from[[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][[:space:]].*/, "", s)
+            sub(/[[:space:]]+[+][0-9].*/, "", s)
+            sub(/\(.*/, "", s)
+            return trim(s)
+        }
+
+        function lldb_function(line, parts, n, s)
+        {
+            if (0 < index(line, "`")) {
+                n = split(line, parts, "`")
+                return strip_function(parts[n])
+            }
+
+            s = line
+            sub(/^.*frame #[0-9]+:[[:space:]]*/, "", s)
+            sub(/^0x[0-9a-fA-F]+[[:space:]]*/, "", s)
+            return strip_function(s)
+        }
+
+        function frame_location(line, location)
+        {
+            if (match(line, /[[:space:]]at[[:space:]][^[:space:]]+:[0-9][0-9]*/)) {
+                location = substr(line, RSTART + 4, RLENGTH - 4)
+                # LLDB appends a column number (file:line:col); strip only the
+                # column when there are two colon-numeric suffixes.
+                if (match(location, /:[0-9][0-9]*:[0-9][0-9]*$/)) {
+                    sub(/:[0-9][0-9]*$/, "", location)
+                }
+                return trim(location)
+            }
+
+            return ""
+        }
+
+        function emit_frame(function_name, detail)
+        {
+            if (done) {
+                return
+            }
+            if ("" == function_name) {
+                return
+            }
+            location = frame_location(detail)
+            print function_name >> funcs_file
+            print trim(detail) >> details_file
+            if ("" == location) {
+                print function_name >> labels_file
+            } else {
+                printf "%s (%s)\n", function_name, location >> labels_file
+            }
+            if ("main" == function_name) {
+                done = 1
+            }
+        }
+
+        /^[[:space:]]*[*]?[[:space:]]*thread #[0-9]+,/ {
+            ++thread_count
+            if (1 < thread_count) {
+                done = 1
+            }
+            next
+        }
+
+        /^[[:space:]]*[*]?[[:space:]]*frame #[0-9]+:/ {
+            emit_frame(lldb_function($0), $0)
+            next
+        }
+    ' "$raw_file"
+}

--- a/docs/app-debug/index.rst
+++ b/docs/app-debug/index.rst
@@ -24,6 +24,7 @@ that can aid debugging.
    debug-options
    serial-debug
    parallel-debug
+   pdb
    lost-output
    memchecker
    valgrind

--- a/docs/app-debug/index.rst
+++ b/docs/app-debug/index.rst
@@ -24,6 +24,7 @@ that can aid debugging.
    debug-options
    serial-debug
    parallel-debug
+   pdeb
    lost-output
    memchecker
    valgrind

--- a/docs/app-debug/pdb.rst
+++ b/docs/app-debug/pdb.rst
@@ -1,0 +1,418 @@
+.. _pdb-label:
+
+Inspecting Hung MPI Jobs with the ``pdb`` Helper
+================================================
+
+Open MPI ships a small, dependency-free shell tool,
+``contrib/pdb``, that attaches a serial debugger (``gdb`` or
+``lldb``) to *every* local process of an MPI job owned by the current
+user, then drops you into a single interactive command loop that drives
+all of those debuggers at once.  It is intended for the common
+"my job is stuck |mdash| where is everybody?" situation: instead of
+attaching to ranks one at a time, you collect and compare all of the
+stacks together, and you can run a few Open-MPI-aware inspection
+commands that decode internal request and shared-memory state.
+
+The tool is deliberately written in portable POSIX ``sh`` and does not
+require Open MPI to be installed; it only needs a supported debugger in
+your ``PATH``.
+
+Running the tool
+----------------
+
+The general form is:
+
+.. code-block:: sh
+
+   shell$ contrib/pdb [-d debugger] [--dump filename] [-p|--pids pid[,pid]...] [program-name]
+
+``program-name``
+   The basename of the executable to find.  ``pdb`` looks for local
+   processes owned by the current user whose executable basename matches
+   ``program-name``, resolves them to PIDs, attaches a debugger to each,
+   and selects all of them.  If neither ``program-name`` nor ``--pids``
+   is given, ``pdb`` starts unattached and you can use the ``attach``
+   command later.
+
+``-d debugger``
+   Use a specific debugger module by name (for example, ``-d gdb`` or
+   ``-d lldb``).  The default is ``auto``, which uses the first available
+   debugger module.
+
+``--dump filename``
+   Before entering the interactive loop, save the process list and the
+   raw debugger backtraces to ``filename`` as a simple text archive.
+   This requires an initial ``program-name`` or ``--pids`` PID list.
+
+``-p pid[,pid]...``, ``--pids pid[,pid]...``
+   Attach to an explicit list of PIDs instead of searching by program
+   name (``-p`` and ``--pids`` are equivalent).  The PIDs are passed
+   straight to the ``attach`` command.  The list may be comma- or
+   space-separated, and the option may be given more than once.  ``-p`` /
+   ``--pids`` and ``program-name`` are mutually exclusive.  This is useful
+   when several ranks share an executable name but you only want a subset,
+   or when the processes you care about do not all share a basename.  For
+   example:
+
+   .. code-block:: sh
+
+      shell$ contrib/pdb --pids 140122,140123,140124
+      shell$ contrib/pdb -p 140122 -p 140123           # repeated also works
+
+``-h``, ``--help``
+   Print usage and exit.
+
+For example, to attach to every local ``my_app`` process and start
+exploring:
+
+.. code-block:: sh
+
+   shell$ contrib/pdb my_app
+   Attached gdb to PIDs: 140122 140123 140124 140125
+   ...
+   attach[140122..140125(4)]> backtrace
+
+The prompt has the form ``<PROMPT>[<selection>]>``.  The ``<selection>``
+part is the *compressed PID list* of the currently *selected* PIDs (the
+targets of the next command): a short list is shown verbatim (for
+example, ``140122,140123``), a long list is summarized as
+``first..last(count)``, and ``none`` means nothing is selected.
+
+The ``<PROMPT>`` part is held in the shell variable ``PROMPT`` and
+defaults to ``ompi-stack``.  When you ``attach``, it becomes ``attach``
+(so the prompt reads ``attach[<selected-pids>]``); when the last debugger
+is detached it returns to ``ompi-stack``.  Commands can change the prompt
+for other contexts too |mdash| see :ref:`Changing the prompt
+<pdb-prompt-label>` in the command-author guide below.
+
+How the command loop works
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At the prompt, the first word is the command name and the rest are its
+arguments.  Name resolution happens in this order:
+
+#. ``quit`` / ``exit`` leaves the loop, and ``help`` prints the command
+   list.
+#. ``<command> help`` prints the detailed help for that command.
+#. If the first word matches a file in the command directory, that
+   command is executed.
+#. Otherwise, the entire line is sent verbatim to every selected
+   debugger as a *passthrough* command, and the raw output is printed per
+   PID.
+
+The passthrough fallback means you can issue native ``gdb``/``lldb``
+commands (for example, ``print some_global``) without leaving ``pdb``;
+they simply run in all selected debuggers at once.
+
+.. _pdb-commands-label:
+
+Existing commands
+-----------------
+
+The commands below are the built-in commands shipped under
+``contrib/pdeb/commands/``.  In all cases, ``<command> help`` prints
+more detailed usage at the prompt.
+
+Session and selection
+~~~~~~~~~~~~~~~~~~~~~~
+
+``attach <pid> [pid...]``
+   Attach one debugger to each of the given PIDs and select all of them
+   (the PIDs do not have to share an executable name).  If debuggers are
+   already attached, they are detached first.  On success the prompt
+   becomes ``attach[<selected-pids>]``.  To attach by program name, pass
+   the name on the ``pdb`` command line (or via ``-p`` / ``--pids`` for
+   explicit PIDs); ``pdb`` resolves a program name to PIDs before calling
+   ``attach``.
+
+``detach [all]``
+   Detach the *selected* debuggers (the default), or every attached
+   debugger with ``detach all``.  Detached debuggers are sent ``detach``
+   and ``quit``, their feeders are stopped, and they are removed from the
+   attached set.  When the last debugger is detached the ``attach`` prompt
+   is removed; otherwise the prompt's PID list updates to the PIDs that
+   remain selected.
+
+``select all`` / ``select <pid> [pid...]``
+   Choose which attached PIDs receive subsequent ``backtrace``,
+   ``frame``, ``do``, and passthrough commands.  The initial selection is
+   all attached PIDs.
+
+``show pids``
+   Print all attached PIDs and the currently selected PIDs.
+
+Stacks and frames
+~~~~~~~~~~~~~~~~~
+
+``backtrace [raw] [file <filename>]``
+   Collect a backtrace from every selected debugger.  By default the
+   output is parsed into a report that shows the *longest common
+   contiguous* stack shared by all parsed PIDs, followed by the frames
+   that differ per PID and the trimmed per-PID stacks |mdash| this makes
+   it easy to see at a glance whether all ranks are stuck in the same
+   place.  ``raw`` prints the unparsed debugger output per PID instead,
+   and ``file <filename>`` writes the output to a file rather than
+   ``stdout``.
+
+``frame <function>``
+   In each selected debugger, find the first frame in the current thread
+   whose backtrace line contains ``<function>`` and select that frame.
+   This is handy for jumping all debuggers to the same routine before
+   inspecting locals.
+
+``do``
+   Read debugger commands from your terminal until two consecutive empty
+   lines, then run the whole block in every selected debugger and print
+   the raw output per PID.  Use this when you want to send several native
+   debugger commands as one batch.
+
+Open MPI internal state
+~~~~~~~~~~~~~~~~~~~~~~~
+
+These commands decode Open MPI internal data structures.  They are only
+available when the active debugger module implements them (currently
+``gdb``), and they require debug symbols for the Open MPI libraries.
+
+``req_dump [<requests_ptr> <count>]``
+   Report every non-completed request for each selected PID.  With no
+   arguments, the command locates the active
+   ``ompi_request_default_wait_all`` frame and uses its ``requests`` and
+   ``count`` locals.  With arguments, ``requests_ptr`` and ``count`` are
+   evaluated by the debugger.
+
+``pml_dump [<start> <count>]``
+   Decode the OB1 PML global pending lists and selected send-request
+   fields for each selected PID.  With no arguments, the first few
+   incomplete requests in the active ``wait_all`` frame are shown; with
+   arguments, requests in the range ``[start, start + count)`` are shown.
+
+``btlsm_dump``
+   Inspect the shared-memory BTL state for each selected PID: the
+   incoming FIFO contents, fragment free-list allocation counters,
+   per-endpoint pending-send state, and the pending-endpoint list length.
+
+Built-in commands
+~~~~~~~~~~~~~~~~~
+
+In addition to the files above, the loop itself provides ``help``,
+``<command> help``, and ``quit`` (also spelled ``exit``).
+
+.. _pdb-writing-commands-label:
+
+Writing new commands
+--------------------
+
+``pdb`` is intentionally extensible: every command is just a file in the
+command directory, and the tool discovers commands by listing that
+directory.  You do not edit the ``pdb`` script itself to add a command.
+
+Where commands live
+~~~~~~~~~~~~~~~~~~~
+
+Commands are loaded from ``contrib/pdeb/commands/``.  The directory can
+be overridden with the ``PDEB_COMMAND_DIR`` environment variable, which
+is convenient while developing a command out of tree:
+
+.. code-block:: sh
+
+   shell$ PDEB_COMMAND_DIR=$HOME/my-pdb-commands contrib/pdb my_app
+
+The file's basename is the command name typed at the prompt, so a file
+named ``mycmd`` is invoked as ``mycmd``.  Files whose names begin with a
+dot are treated as shared helpers: they are *sourced once* at startup
+(before any command runs), which is the place to put functions shared by
+several commands.
+
+Anatomy of a command file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A command file is a POSIX ``sh`` fragment that is sourced on demand.  It
+may define up to four functions:
+
+``help`` (recommended)
+   Print a one-line summary, indented by two spaces, for the ``help``
+   listing.  If absent, only the command name is shown.
+
+``detailed_help`` (recommended)
+   Print multi-line usage for ``<command> help``.  If absent, ``pdb``
+   falls back to ``help``.
+
+``run`` (**required**)
+   The command body.  It receives the command's arguments as ``"$@"``.
+   A non-zero return aborts the command.
+
+``output`` (optional)
+   Custom formatting of debugger output; see below.
+
+To keep the namespace clean, each of these well-known function names is
+unset before a command is sourced and after it finishes, so commands do
+not leak definitions into each other.  Any *other* function or variable
+your command defines should be prefixed to avoid clashing with the
+infrastructure (the internal helpers use the ``pdeb_`` prefix).
+
+A minimal command looks like this:
+
+.. code-block:: sh
+
+   #
+   # Copyright (c) 2026      Your Institution.  All rights reserved.
+   # $COPYRIGHT$
+   #
+   # Additional copyrights may follow
+   #
+   # $HEADER$
+   #
+
+   help()
+   {
+       printf "  hello\n"
+   }
+
+   detailed_help()
+   {
+       cat <<EOF
+   hello
+     Print a greeting and the list of selected PIDs.
+   EOF
+   }
+
+   run()
+   {
+       require_selection || return 1
+
+       if [ 0 -lt $# ] && [ "help" = "$1" ] ; then
+           detailed_help
+           return 0
+       fi
+
+       printf "Hello from pdb; selected PIDs:%s\n" "$(printf " %s" $selected_pids)"
+   }
+
+Two kinds of commands
+~~~~~~~~~~~~~~~~~~~~~
+
+There are two ways a command can do its work:
+
+#. **Drive the debuggers yourself.**  Your ``run`` function does
+   everything and prints its own output, like the ``frame`` command.
+   This is the most flexible style and is appropriate when the logic is
+   per-PID and sequential.
+
+#. **Let the infrastructure run a debugger command block.**  If ``run``
+   sets the variable ``pdeb_debugger_commands`` to a block of debugger
+   commands, the infrastructure runs that block once per *selected* PID
+   after ``run`` returns, collecting each PID's output into a file.  This
+   is how ``backtrace``, ``req_dump``, ``pml_dump``, and ``btlsm_dump``
+   work.  Set ``pdeb_output_dir`` to a unique directory for the captured
+   output (a common idiom is
+   ``"$tmpdir/<name>.$$.$(date +%s)"``).
+
+When you use the second style and want to format the result yourself,
+define an ``output`` function.  It is called with one raw-output file
+path per selected PID, in selected-PID order, and the matching PID list
+is available in ``pdeb_output_pids``.  If you do not define ``output``,
+each PID's raw output is printed under a ``PID <pid>:`` header.
+
+Infrastructure available to commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because commands are sourced into the running ``pdb`` process, they can
+call its helper functions and read its state variables directly.  The
+most useful ones are:
+
+State variables
+   * ``pids`` |mdash| all attached PIDs.
+   * ``selected_pids`` |mdash| the PIDs the command should act on.
+   * ``program_base`` |mdash| basename of the attached program.
+   * ``debugger`` |mdash| name of the active debugger module.
+   * ``tmpdir`` |mdash| per-session scratch directory (cleaned up on
+     exit).
+
+Helper functions
+   * ``require_selection`` |mdash| return non-zero (with a message) if no
+     PIDs are selected; call this first in commands that act on PIDs.
+   * ``pdeb_function_defined <name>`` |mdash| test whether a function
+     (for example, an optional debugger hook) exists.
+   * ``run_debugger_commands <pid> <commands> <output-file>`` |mdash| run
+     a block of debugger commands in one PID's debugger and capture the
+     output.
+   * ``ensure_debugger`` |mdash| make sure a debugger module is loaded and
+     available.
+   * ``prompt_push <text>`` / ``prompt_pop`` |mdash| change the interactive
+     prompt for the current context; see below.
+   * ``compressed_pids <pid...>`` |mdash| format a PID list compactly (a
+     short list verbatim, a long one as ``first..last(count)``); used to
+     render the selected PIDs inside the prompt's brackets.
+
+.. _pdb-prompt-label:
+
+Changing the prompt
+~~~~~~~~~~~~~~~~~~~
+
+The text before the ``[<selection>]>`` part of the prompt is held in the
+shell variable ``PROMPT`` (default ``ompi-stack``).  A command that
+enters a sub-mode |mdash| for example, a nested read loop that collects
+its own input |mdash| can change the prompt so the user knows where they
+are, then restore it on exit.
+
+The built-in ``attach`` and ``detach`` commands use this mechanism: an
+``attach`` pushes the ``attach`` label (so the prompt reads
+``attach[<selected-pids>]``), and detaching the last debugger pops it.
+
+``PROMPT`` is backed by a stack with two accessors:
+
+   * ``prompt_push <text>`` |mdash| save the current ``PROMPT`` and set it
+     to ``<text>``.
+   * ``prompt_pop`` |mdash| restore the most recently pushed ``PROMPT``.
+     It returns non-zero (and leaves ``PROMPT`` unchanged) if the stack is
+     empty.
+
+Always pair every ``prompt_push`` with a ``prompt_pop`` so the prompt is
+restored even on early exits:
+
+.. code-block:: sh
+
+   run()
+   {
+       prompt_push "mycmd"
+
+       # ... interact with the user in a sub-mode ...
+
+       prompt_pop
+   }
+
+You may also set ``PROMPT`` directly for a permanent change, but using
+the push/pop pair keeps contexts properly nested.
+
+Using the active debugger portably
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To stay portable across ``gdb`` and ``lldb``, do not hard-code debugger
+syntax.  Instead, ask the active debugger module to produce the right
+command text through its ``debugger_*`` functions, which live in
+``contrib/pdeb/debugger/`` (overridable with ``PDEB_DEBUGGER_DIR``).
+For example, ``debugger_backtrace_command`` returns the
+"backtrace all threads" command for the current debugger, and
+``debugger_select_frame_command <n>`` returns the "select frame" command.
+
+If your command relies on a debugger feature that only some modules
+implement (as the Open-MPI-aware dumps do), guard it with
+``pdeb_function_defined`` and fail gracefully:
+
+.. code-block:: sh
+
+   if ! pdeb_function_defined debugger_my_dump_command ; then
+       echo "mycmd is not supported by debugger: $debugger" >&2
+       return 1
+   fi
+
+   pdeb_debugger_commands=$(debugger_my_dump_command)
+   pdeb_output_dir="$tmpdir/mycmd.$$.$(date +%s)"
+
+You would then add a matching ``debugger_my_dump_command`` to each
+debugger module under ``contrib/pdeb/debugger/`` that can support it.
+Adding a whole new debugger is the same idea at a larger scale: drop a
+new file in the debugger directory that implements the ``debugger_*``
+contract (``debugger_available``, ``debugger_start``,
+``debugger_backtrace_command``, ``debugger_parse_stack``, and so on),
+modeled on the existing ``gdb`` and ``lldb`` modules.

--- a/docs/app-debug/pdeb.rst
+++ b/docs/app-debug/pdeb.rst
@@ -1,0 +1,435 @@
+.. _pdeb-label:
+
+Inspecting Hung MPI Jobs with the ``pdb`` Helper
+================================================
+
+Open MPI's source tree includes a small, dependency-free shell tool,
+``$OMPI_SRC/contrib/pdb``, that attaches a serial debugger (``gdb`` or ``lldb``)
+to the local processes of an MPI job that are owned by the current user
+and share a given executable basename, then drops you into a single
+interactive command loop that drives all of those debuggers at once.
+It is intended for the common "my job is stuck |mdash| where is
+everybody?" situation: instead of attaching to ranks one at a time, you
+collect and compare all of the stacks together, and you can run a few
+Open-MPI-aware inspection commands that decode internal request and
+shared-memory state.
+
+The tool is written in ``sh`` and does not require Open MPI to be
+installed; it only needs a supported debugger in your ``PATH``.
+
+.. note:: ``$OMPI_SRC/contrib/pdb`` is not installed by ``make install``;
+          run it directly from the Open MPI source tree.
+
+In the examples below, ``$OMPI_SRC`` stands for the top-level Open MPI
+source directory (i.e., wherever you cloned or unpacked the source).
+
+Running the tool
+----------------
+
+The general form is:
+
+.. code-block:: sh
+
+   shell$ $OMPI_SRC/contrib/pdb [-d debugger] [--dump filename] [-p|--pids pid[,pid]...] [program-name]
+
+``program-name``
+   The basename of the executable to find.  ``pdb`` looks for local
+   processes owned by the current user whose executable basename matches
+   ``program-name``, resolves them to PIDs, attaches a debugger to each,
+   and selects all of them.  If neither ``program-name`` nor ``--pids``
+   is given, ``pdb`` starts unattached and you can use the ``attach``
+   command later.
+
+``-d debugger``
+   Use a specific debugger module by name (for example, ``-d gdb`` or
+   ``-d lldb``).  The default is ``auto``, which uses the first available
+   debugger module.
+
+``--dump filename``
+   Before entering the interactive loop, save the process list and the
+   raw debugger backtraces to ``filename`` as a simple text archive.
+   This requires an initial ``program-name`` or ``--pids`` PID list.
+
+``-p pid[,pid]...``, ``--pids pid[,pid]...``
+   Attach to an explicit list of PIDs instead of searching by program
+   name (``-p`` and ``--pids`` are equivalent).  The PIDs are passed
+   straight to the ``attach`` command.  The list may be comma- or
+   space-separated, and the option may be given more than once.  ``-p`` /
+   ``--pids`` and ``program-name`` are mutually exclusive.  This is useful
+   when several ranks share an executable name but you only want a subset,
+   or when the processes you care about do not all share a basename.  For
+   example:
+
+   .. code-block:: sh
+
+      shell$ $OMPI_SRC/contrib/pdb --pids 140122,140123,140124
+      shell$ $OMPI_SRC/contrib/pdb -p 140122 -p 140123           # repeated also works
+
+``-h``, ``--help``
+   Print usage and exit.
+
+For example, to attach to every local ``my_app`` process and start
+exploring:
+
+.. code-block:: sh
+
+   shell$ $OMPI_SRC/contrib/pdb my_app
+   Attached gdb to PIDs: 140122 140123 140124 140125 140126
+   ...
+   attach[140122..140126(5)]> backtrace
+
+The prompt has the form ``<PROMPT>[<selection>]>``.  The ``<selection>``
+part is the *compressed PID list* of the currently *selected* PIDs (the
+targets of the next command): up to four PIDs are shown verbatim (for
+example, ``140122,140123``), a longer list is summarized as
+``first..last(count)``, and ``none`` means nothing is selected.
+
+The ``<PROMPT>`` part is held in the shell variable ``PROMPT`` and
+defaults to ``ompi-stack``.  When you ``attach``, it becomes ``attach``
+(so the prompt reads ``attach[<selected-pids>]``); when the last debugger
+is detached it returns to ``ompi-stack``.  Commands can change the prompt
+for other contexts too |mdash| see :ref:`Changing the prompt
+<pdeb-prompt-label>` in the command-author guide below.
+
+How the command loop works
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At the prompt, the first word is the command name and the rest are its
+arguments.  Name resolution happens in this order:
+
+#. ``quit`` / ``exit`` leaves the loop, and ``help`` prints the command
+   list.
+#. ``<command> help`` prints the detailed help for that command.
+#. If the first word matches a file in the command directory, that
+   command is executed.
+#. Otherwise, the entire line is sent verbatim to every selected
+   debugger as a *passthrough* command, and the raw output is printed per
+   PID.
+
+The passthrough fallback means you can issue native ``gdb``/``lldb``
+commands (for example, ``print some_global``) without leaving ``pdb``;
+they simply run in all selected debuggers at once.
+
+.. _pdeb-commands-label:
+
+Existing commands
+-----------------
+
+The commands below are the built-in commands shipped under
+``$OMPI_SRC/contrib/pdeb/commands/``.  In all cases, ``<command> help`` prints
+more detailed usage at the prompt.
+
+Session and selection
+~~~~~~~~~~~~~~~~~~~~~~
+
+``attach <pid> [pid...]``
+   Attach one debugger to each of the given PIDs and select all of them
+   (the PIDs do not have to share an executable name).  If debuggers are
+   already attached, they are detached first.  On success the prompt
+   becomes ``attach[<selected-pids>]``.  To attach by program name, pass
+   the name on the ``pdb`` command line (or via ``-p`` / ``--pids`` for
+   explicit PIDs); ``pdb`` resolves a program name to PIDs before calling
+   ``attach``.
+
+``detach [all]``
+   Detach the *selected* debuggers (the default), or every attached
+   debugger with ``detach all`` (``detach *`` is an accepted synonym).  Detached debuggers are sent ``detach``
+   and ``quit``, their feeders are stopped, and they are removed from the
+   attached set.  When the last debugger is detached the ``attach`` prompt
+   is removed; otherwise the prompt's PID list updates to the PIDs that
+   remain selected.
+
+``select all`` / ``select <pid> [pid...]``
+   Choose which attached PIDs receive subsequent ``backtrace``,
+   ``frame``, ``do``, and passthrough commands.  The initial selection is
+   all attached PIDs.  (``select *`` is an accepted synonym for
+   ``select all``.)
+
+``show pids``
+   Print all attached PIDs and the currently selected PIDs.
+
+Stacks and frames
+~~~~~~~~~~~~~~~~~
+
+``backtrace [raw] [file <filename>]``
+   Collect a backtrace from every selected debugger.  By default the
+   output is parsed into a report that shows the *longest common
+   contiguous* stack shared by all parsed PIDs, followed by the frames
+   that differ per PID and the trimmed per-PID stacks |mdash| this makes
+   it easy to see at a glance whether all ranks are stuck in the same
+   place.  Note that the parser considers only the first thread per PID;
+   ``raw`` prints the full unparsed debugger output per PID (all threads)
+   instead.  ``file <filename>`` writes the output to a file rather than
+   ``stdout``.
+
+``frame <function>``
+   In each selected debugger, find the first frame in the current thread
+   whose backtrace line contains ``<function>`` and select that frame.
+   This is handy for jumping all debuggers to the same routine before
+   inspecting locals.
+
+``do``
+   Read debugger commands from standard input until two consecutive empty
+   lines, then run the whole block in every selected debugger and print
+   the raw output per PID.  Use this when you want to send several native
+   debugger commands as one batch.  Intermediate blank lines within the
+   block are preserved and sent to the debugger.
+
+Open MPI internal state
+~~~~~~~~~~~~~~~~~~~~~~~
+
+These commands decode Open MPI internal data structures.  They are only
+available when the active debugger module implements them (currently
+``gdb``), and they require debug symbols for the Open MPI libraries.
+They are also specific to particular components: ``req_dump`` and
+``pml_dump`` require the process to be in
+``ompi_request_default_wait_all`` unless you pass an explicit requests
+pointer and count; ``pml_dump`` additionally requires the OB1 PML
+(``--mca pml ob1``); and ``btlsm_dump`` requires the ``sm`` BTL.
+On a UCX or OFI run, ``pml_dump`` and ``btlsm_dump`` will report that
+the relevant symbols are unavailable.
+
+``req_dump [<requests_ptr> <count>]``
+   Report every non-completed request for each selected PID.  With no
+   arguments, the command locates the active
+   ``ompi_request_default_wait_all`` frame and uses its ``requests`` and
+   ``count`` locals.  With arguments, ``requests_ptr`` and ``count`` are
+   evaluated by the debugger.
+
+``pml_dump [<requests_ptr> <count>]``
+   Decode the OB1 PML global pending lists and selected send-request
+   fields for each selected PID.  With no arguments, the first few
+   incomplete requests in the active ``wait_all`` frame are shown; with
+   arguments, ``requests_ptr`` and ``count`` are evaluated by the
+   debugger to select the array to inspect (similar to ``req_dump``).
+   Unlike ``req_dump``, ``pml_dump`` shows all send requests in the
+   range regardless of completion status.
+
+``btlsm_dump``
+   Inspect the shared-memory BTL state for each selected PID: the
+   incoming FIFO contents, fragment free-list allocation counters,
+   per-endpoint pending-send state, and the pending-endpoint list length.
+
+Built-in commands
+~~~~~~~~~~~~~~~~~
+
+In addition to the files above, the loop itself provides ``help``,
+``<command> help``, and ``quit`` (also spelled ``exit``).
+
+.. _pdeb-writing-commands-label:
+
+Writing new commands
+--------------------
+
+``pdb`` is intentionally extensible: every command is just a file in the
+command directory, and the tool discovers commands by listing that
+directory.  You do not edit the ``pdb`` script itself to add a command.
+
+Where commands live
+~~~~~~~~~~~~~~~~~~~
+
+Commands are loaded from ``$OMPI_SRC/contrib/pdeb/commands/``.  The directory can
+be overridden with the ``PDEB_COMMAND_DIR`` environment variable, which
+is convenient while developing a command out of tree:
+
+.. code-block:: sh
+
+   shell$ PDEB_COMMAND_DIR=$HOME/my-pdb-commands $OMPI_SRC/contrib/pdb my_app
+
+The file's basename is the command name typed at the prompt, so a file
+named ``mycmd`` is invoked as ``mycmd``.  Files whose names begin with a
+dot are treated as shared helpers: they are *sourced once* at startup
+(before any command runs), which is the place to put functions shared by
+several commands.
+
+Anatomy of a command file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A command file is a POSIX ``sh`` fragment that is sourced on demand.  It
+may define up to four functions:
+
+``help`` (recommended)
+   Print a one-line summary, indented by two spaces, for the ``help``
+   listing.  If absent, only the command name is shown.
+
+``detailed_help`` (recommended)
+   Print multi-line usage for ``<command> help``.  If absent, ``pdb``
+   falls back to ``help``.
+
+``run`` (**required**)
+   The command body.  It receives the command's arguments as ``"$@"``.
+   A non-zero return aborts the command.
+
+``output`` (optional)
+   Custom formatting of debugger output; see below.
+
+To keep the namespace clean, each of these well-known function names is
+unset before a command is sourced and after it finishes, so commands do
+not leak definitions into each other.  Any *other* function or variable
+your command defines should be prefixed to avoid clashing with the
+infrastructure (the internal helpers use the ``pdeb_`` prefix).
+
+A minimal command looks like this:
+
+.. code-block:: sh
+
+   #
+   # Copyright (c) 2026      Your Institution.  All rights reserved.
+   # $COPYRIGHT$
+   #
+   # Additional copyrights may follow
+   #
+   # $HEADER$
+   #
+
+   help()
+   {
+       printf "  hello\n"
+   }
+
+   detailed_help()
+   {
+       cat <<EOF
+   hello
+     Print a greeting and the list of selected PIDs.
+   EOF
+   }
+
+   run()
+   {
+       require_selection || return 1
+
+       printf "Hello from pdb; selected PIDs:%s\n" "$(printf " %s" $selected_pids)"
+   }
+
+.. note:: The interactive loop intercepts ``<command> help`` before
+          dispatching to ``run``, so you do not need to handle
+          ``[ "help" = "$1" ]`` in ``run`` yourself.
+
+Two kinds of commands
+~~~~~~~~~~~~~~~~~~~~~
+
+There are two ways a command can do its work:
+
+#. **Drive the debuggers yourself.**  Your ``run`` function does
+   everything and prints its own output, like the ``frame`` command.
+   This is the most flexible style and is appropriate when the logic is
+   per-PID and sequential.
+
+#. **Let the infrastructure run a debugger command block.**  If ``run``
+   sets the variable ``pdeb_debugger_commands`` to a block of debugger
+   commands, the infrastructure runs that block once per *selected* PID
+   after ``run`` returns, collecting each PID's output into a file.  This
+   is how ``backtrace``, ``req_dump``, ``pml_dump``, and ``btlsm_dump``
+   work.  You may set ``pdeb_output_dir`` to choose where the captured
+   output lands; if you leave it unset, the infrastructure picks a unique
+   per-invocation directory under ``$tmpdir`` for you.
+
+When you use the second style and want to format the result yourself,
+define an ``output`` function.  It is called with one raw-output file
+path per selected PID, in selected-PID order, and the matching PID list
+is available in ``pdeb_output_pids``.  If you do not define ``output``,
+each PID's raw output is printed under a ``PID <pid>:`` header.
+
+Infrastructure available to commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because commands are sourced into the running ``pdb`` process, they can
+call its helper functions and read its state variables directly.  The
+most useful ones are:
+
+State variables
+   * ``pids`` |mdash| all attached PIDs.
+   * ``selected_pids`` |mdash| the PIDs the command should act on.
+   * ``program_base`` |mdash| basename of the attached program.
+   * ``debugger`` |mdash| name of the active debugger module.
+   * ``tmpdir`` |mdash| per-session scratch directory (cleaned up on
+     exit).
+
+Helper functions
+   * ``require_selection`` |mdash| return non-zero (with a message) if no
+     PIDs are selected; call this first in commands that act on PIDs.
+   * ``pdeb_function_defined <name>`` |mdash| test whether a function
+     (for example, an optional debugger hook) exists.
+   * ``run_debugger_commands <pid> <commands> <output-file>`` |mdash| run
+     a block of debugger commands in one PID's debugger and capture the
+     output.
+   * ``ensure_debugger`` |mdash| make sure a debugger module is loaded and
+     available.
+   * ``prompt_push <text>`` / ``prompt_pop`` |mdash| change the interactive
+     prompt for the current context; see below.
+   * ``compressed_pids <pid...>`` |mdash| format a PID list compactly (a
+     short list verbatim, a long one as ``first..last(count)``); used to
+     render the selected PIDs inside the prompt's brackets.
+
+.. _pdeb-prompt-label:
+
+Changing the prompt
+~~~~~~~~~~~~~~~~~~~
+
+The text before the ``[<selection>]>`` part of the prompt is held in the
+shell variable ``PROMPT`` (default ``ompi-stack``).  A command that
+enters a sub-mode |mdash| for example, a nested read loop that collects
+its own input |mdash| can change the prompt so the user knows where they
+are, then restore it on exit.
+
+The built-in ``attach`` and ``detach`` commands use this mechanism: an
+``attach`` pushes the ``attach`` label (so the prompt reads
+``attach[<selected-pids>]``), and detaching the last debugger pops it.
+
+``PROMPT`` is backed by a stack with two accessors:
+
+   * ``prompt_push <text>`` |mdash| save the current ``PROMPT`` and set it
+     to ``<text>``.
+   * ``prompt_pop`` |mdash| restore the most recently pushed ``PROMPT``.
+     It returns non-zero (and leaves ``PROMPT`` unchanged) if the stack is
+     empty.
+
+Always pair every ``prompt_push`` with a ``prompt_pop`` so the prompt is
+restored even on early exits:
+
+.. code-block:: sh
+
+   run()
+   {
+       prompt_push "mycmd"
+
+       # ... interact with the user in a sub-mode ...
+
+       prompt_pop
+   }
+
+You may also set ``PROMPT`` directly for a permanent change, but using
+the push/pop pair keeps contexts properly nested.
+
+Using the active debugger portably
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To stay portable across ``gdb`` and ``lldb``, do not hard-code debugger
+syntax.  Instead, ask the active debugger module to produce the right
+command text through its ``debugger_*`` functions, which live in
+``$OMPI_SRC/contrib/pdeb/debugger/`` (overridable with ``PDEB_DEBUGGER_DIR``).
+For example, ``debugger_backtrace_command`` returns the
+"backtrace all threads" command for the current debugger, and
+``debugger_select_frame_command <n>`` returns the "select frame" command.
+
+If your command relies on a debugger feature that only some modules
+implement (as the Open-MPI-aware dumps do), guard it with
+``pdeb_function_defined`` and fail gracefully:
+
+.. code-block:: sh
+
+   if ! pdeb_function_defined debugger_my_dump_command ; then
+       echo "mycmd is not supported by debugger: $debugger" >&2
+       return 1
+   fi
+
+   pdeb_debugger_commands=$(debugger_my_dump_command)
+
+You would then add a matching ``debugger_my_dump_command`` to each
+debugger module under ``$OMPI_SRC/contrib/pdeb/debugger/`` that can support it.
+Adding a whole new debugger is the same idea at a larger scale: drop a
+new file in the debugger directory that implements the ``debugger_*``
+contract (``debugger_available``, ``debugger_start``,
+``debugger_backtrace_command``, ``debugger_parse_stack``, and so on),
+modeled on the existing ``gdb`` and ``lldb`` modules.


### PR DESCRIPTION
I developed these tools over the years to compensate for the lack of parallel debuggers and to help debug OMPI internals. It now seems like the right time to contribute them back to the community, in case others find them useful.

I usually run the tool either in batch mode from a srun batch or by hand on a node, passing the process name I want to debug. On each node, the tool attaches to all local processes with the right name and drive lldb or gdb to extract information from the process.

As an example, I used it to debug the SM BTL internals to find the solution to #13939. This is one of the output that helped me pinpoint the problem, by showing the insanely large `mca_pml_ob1.pckt_pending size`. In this output we have:
1. the btlsm_dump showing the internal counters of the BTL, and the status of each packet FIFO;
2. reqdump, scout the backtrace for an MPI_Waitall and dump the status of all requests in the array;
3. the PML dump that show the internal status of the PML including the sizes of the different pending FIFOs;
4. a full backtrace of the process, but the backtrace command can also do a pretty print compressed backtrace of all processes.

```
0x00007f9a874b11d7 in mca_part_persist_progress () at /root/unstable/fortran/ompi/main/ompi/mca/part/persist/part_persist.h:166
166 int block_entry = opal_atomic_add_fetch_32(&(ompi_part_persist.block_entry), 1);
============================================================
local_rank=0 node_rank=0 num_local_peers=31
my_fifo: head=-2 tail=-2 fbox_available=-31
--- incoming FIFO contents (what THIS rank has not yet consumed) ---
<empty> => no returns/sends queued for us (points at case B)
--- fragment free lists (allocated vs free) ---
sm_frags_user fl_num_allocated=524
sm_frags_eager fl_num_allocated=8
sm_frags_max_send fl_num_allocated=8
--- endpoints (pending sends / peer fifo head-tail) ---
ep[ 0] peer= 0 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 1] peer= 1 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 2] peer= 2 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 3] peer= 3 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 4] peer= 4 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 5] peer= 5 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 6] peer= 6 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 7] peer= 7 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 8] peer= 8 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[ 9] peer= 9 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[10] peer=10 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[11] peer=11 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[12] peer=12 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[13] peer=13 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[14] peer=14 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[15] peer=15 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[16] peer=16 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[17] peer=17 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[18] peer=18 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[19] peer=19 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[20] peer=20 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[21] peer=21 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[22] peer=22 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[23] peer=23 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[24] peer=24 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[25] peer=25 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[26] peer=26 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[27] peer=27 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[28] peer=28 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[29] peer=29 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[30] peer=30 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
ep[31] peer=31 pending_frags=0 peer_fifo(head=-2 tail=-2) ----
--- pending_endpoints list length = 0 ---
============================================================

reqdump: count=261 requests=0x561750b48000
[ 32] type=OMPI_REQUEST_PML state=ACTIVE(2) complete=SYNC@0x7ffcf90ec3f0 status{SOURCE=0 TAG=0 err=0 _ucount=0 _cancelled=0}
[ 33] type=OMPI_REQUEST_PML state=ACTIVE(2) complete=SYNC@0x7ffcf90ec3f0 status{SOURCE=0 TAG=0 err=0 _ucount=0 _cancelled=0}
[ 34] type=OMPI_REQUEST_PML state=ACTIVE(2) complete=SYNC@0x7ffcf90ec3f0 status{SOURCE=0 TAG=0 err=0 _ucount=0 _cancelled=0}

============================================================
mca_pml_ob1.send_pending size=0
mca_pml_ob1.recv_pending size=0
mca_pml_ob1.rdma_pending size=0
mca_pml_ob1.pckt_pending size=7047
mca_pml_ob1.non_existing_communicator_pending size=0
mca_pml_ob1.enabled = true
pmldump: no wait_all frame found
============================================================

--- backtrace ---
#0 0x00007f9a874b11d7 in mca_part_persist_progress () at /root/unstable/fortran/ompi/main/ompi/mca/part/persist/part_persist.h:166
#1 0x00007f9a86dd0749 in opal_progress () at /root/unstable/fortran/ompi/main/opal/runtime/opal_progress.c:224
#2 0x00007f9a871d2b69 in ompi_request_wait_completion (req=0x56321008fdc0) at /root/unstable/fortran/ompi/main/ompi/request/request.h:493
#3 0x00007f9a871d2bea in ompi_request_default_wait (req_ptr=0x7ffd110cec18, status=0x7ffd110cec20) at /root/unstable/fortran/ompi/main/ompi/request/req_wait.c:41
#4 0x00007f9a872ed38d in ompi_coll_base_sendrecv_zero (dest=1, stag=-16, source=1, rtag=-16, comm=0x5631ed38b200 <ompi_mpi_comm_world>) at /root/unstable/fortran/ompi/main/ompi/mca/coll/base/coll_base_barrier.c:64
#5 0x00007f9a872ed8a3 in ompi_coll_base_barrier_intra_recursivedoubling (comm=0x5631ed38b200 <ompi_mpi_comm_world>, module=0x56320f856110) at /root/unstable/fortran/ompi/main/ompi/mca/coll/base/coll_base_barrier.c:235
#6 0x00007f9a873867f1 in ompi_coll_tuned_barrier_intra_do_this (comm=0x5631ed38b200 <ompi_mpi_comm_world>, module=0x56320f856110, algorithm=3, faninout=0, segsize=0) at /root/unstable/fortran/ompi/main/ompi/mca/coll/tuned/coll_tuned_barrier_decision.c:104
#7 0x00007f9a873797d7 in ompi_coll_tuned_barrier_intra_dec_fixed (comm=0x5631ed38b200 <ompi_mpi_comm_world>, module=0x56320f856110) at /root/unstable/fortran/ompi/main/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c:503
#8 0x00007f9a87200ae7 in PMPI_Barrier (comm=0x5631ed38b200 <ompi_mpi_comm_world>) at barrier_generated.c:77
#9 0x00005631ed366fbf in rt_barrier_sync () at ../src/parallel.c:80
#10 0x00005631ed36b0ca in renderscene (scene=0x56320f85d180) at ../src/render.c:386
#11 0x00005631ed361676 in rt_renderscene (voidscene=0x56320f85d180) at ../src/api.c:98
#12 0x00005631ed3526b7 in main (argc=2, argv=0x7ffd110d30b8) at ../demosrc/main.c:440
[Inferior 1 (process 319072) detached]
````
