### PR TITLE
accelerator/cuda: skip VMM/mpool fallback for unrecognized pointers and add tunables to disable them entirely

### DIFF
--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -45,6 +45,12 @@ Open MPI version v6.0.0
   intra-node device-to-device transfers for AMD and NVIDIA GPUs
   (independent of UCX or Libfabric).
 
+- Added an address-classification cache to the CUDA accelerator
+  component to avoid repeated CUDA driver queries when classifying
+  pointers on the per-message hot path.  The cache can be tuned or
+  disabled with the new ``accelerator_cuda_addr_cache_enable`` and
+  ``accelerator_cuda_addr_cache_size`` MCA parameters.
+
 - Added support for MPI sessions when using UCX.
 
 - Added support for MPI-4.1 ``MPI_REQUEST_GET_STATUS_[ALL|ANY_SOME]`` functions.

--- a/opal/mca/accelerator/cuda/Makefile.am
+++ b/opal/mca/accelerator/cuda/Makefile.am
@@ -16,6 +16,8 @@ AM_CPPFLAGS = $(common_cuda_CPPFLAGS)
 EXTRA_DIST = help-accelerator-cuda.txt
 sources = \
         accelerator_cuda.h \
+        accelerator_cuda_addr_cache.h \
+        accelerator_cuda_addr_cache.c \
         accelerator_cuda_component.c \
         accelerator_cuda.c
 

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -359,8 +359,22 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         return 1;
     }
 
-    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
-    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+    if (0 == mem_type) {
+        /* CUDA is initialized but dbuf is not a valid CUDA pointer.
+         * Return early before paying the VMM/mpool fallback cost. */
+        return 0;
+    }
+
+    /* mem_type is HOST, or DEVICE with no context. Both cases may require
+     * VMM/mpool fallback to either reclassify or to determine the device
+     * id. The fallback paths each issue a CUDA driver call, so they are
+     * gated by tunables for users who do not use those allocators. */
+    if (opal_accelerator_cuda_enable_vmm_check) {
+        is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
+    }
+    if (opal_accelerator_cuda_enable_mpool_check) {
+        is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+    }
 
     if (CU_MEMORYTYPE_HOST == mem_type) {
         if (is_vmm && (vmm_mem_type == CU_MEMORYTYPE_DEVICE)) {
@@ -373,9 +387,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
             /* Host memory, nothing to do here */
             return 0;
         }
-    } else if (0 == mem_type) {
-        /* This can happen when CUDA is initialized but dbuf is not valid CUDA pointer */
-        return 0;
     } else {
         if (is_vmm) {
             *dev_id = vmm_dev_id;
@@ -387,9 +398,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         }
     }
 #else /* OPAL_CUDA_GET_ATTRIBUTES */
-    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
-    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
-
     result = cuPointerGetAttribute(&mem_type, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, dbuf);
     if (CUDA_SUCCESS != result) {
         /* If cuda is not initialized, assume it is a host buffer. */
@@ -398,7 +406,18 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         } else {
             return OPAL_ERROR;
         }
-    } else if (CU_MEMORYTYPE_HOST == mem_type) {
+    }
+
+    /* Same pattern as above: defer the VMM/mpool fallback until after we
+     * know mem_type, and gate it on the tunables. */
+    if (opal_accelerator_cuda_enable_vmm_check) {
+        is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
+    }
+    if (opal_accelerator_cuda_enable_mpool_check) {
+        is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+    }
+
+    if (CU_MEMORYTYPE_HOST == mem_type) {
         if (is_vmm && (vmm_mem_type == CU_MEMORYTYPE_DEVICE)) {
             mem_type = CU_MEMORYTYPE_DEVICE;
             *dev_id = vmm_dev_id;

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -22,6 +22,7 @@
 #include <cuda.h>
 
 #include "accelerator_cuda.h"
+#include "accelerator_cuda_addr_cache.h"
 #include "opal/mca/accelerator/base/base.h"
 #include "opal/mca/rcache/rcache.h"
 #include "opal/util/show_help.h"
@@ -137,6 +138,39 @@ static inline int opal_accelerator_cuda_delayed_init_check(void)
         return opal_accelerator_cuda_delayed_init();
     }
     return OPAL_SUCCESS;
+}
+
+/*
+ * Insert a positive (device-memory) classification into the address cache.
+ * Best-effort: any failure leaves the cache untouched and check_addr keeps
+ * functioning via the cold path. Caller passes the device pointer being
+ * classified; we look up its full allocation extent via cuMemGetAddressRange
+ * so any future probe inside the allocation hits the cache.
+ */
+static void cache_device_classification(const void *addr, int dev_id, uint64_t flags)
+{
+    if (!opal_accelerator_cuda_addr_cache_enabled) {
+        return;
+    }
+    CUdeviceptr   base = 0;
+    size_t        size = 0;
+    unsigned long long buf_id = 0;
+    if (CUDA_SUCCESS != cuMemGetAddressRange(&base, &size, (CUdeviceptr) addr)) {
+        return;
+    }
+    if (CUDA_SUCCESS != cuPointerGetAttribute(&buf_id,
+                                              CU_POINTER_ATTRIBUTE_BUFFER_ID,
+                                              (CUdeviceptr) addr)) {
+        return;
+    }
+    opal_accelerator_cuda_addr_class_t cls = {
+        .mem_type      = 1,
+        .dev_id        = dev_id,
+        .flags         = flags,
+        .buffer_id     = (uint64_t) buf_id,
+        .has_buffer_id = true,
+    };
+    opal_accelerator_cuda_addr_cache_insert((const void *) (uintptr_t) base, size, &cls);
 }
 
 static int accelerator_cuda_get_device_id(CUcontext mem_ctx) {
@@ -321,6 +355,18 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
 
     *flags = 0;
 
+    /* Fast path: previously-classified pointer. The cache validates
+     * device entries via BUFFER_ID and host entries via opal_mem_hooks
+     * release notifications, so a hit is safe to act on. */
+    {
+        opal_accelerator_cuda_addr_class_t cached;
+        if (opal_accelerator_cuda_addr_cache_lookup(addr, &cached)) {
+            *dev_id = cached.dev_id;
+            *flags  = cached.flags;
+            return cached.mem_type;
+        }
+    }
+
 #if OPAL_CUDA_GET_ATTRIBUTES
     uint32_t is_managed = 0;
     /* With CUDA 7.0, we can get multiple attributes with a single call */
@@ -356,6 +402,7 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         if (OPAL_UNLIKELY(NULL == ctx)) {
             cuCtxSetCurrent(mem_ctx);
         }
+        cache_device_classification(addr, *dev_id, *flags);
         return 1;
     }
 
@@ -522,6 +569,7 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
     }
     /* First access on a device pointer finalizes CUDA support initialization. */
     (void)opal_accelerator_cuda_delayed_init_check();
+    cache_device_classification(addr, *dev_id, *flags);
     return 1;
 }
 

--- a/opal/mca/accelerator/cuda/accelerator_cuda.h
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2024      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -57,6 +57,15 @@ OBJ_CLASS_DECLARATION(opal_accelerator_cuda_ipc_event_handle_t);
 extern opal_accelerator_cuda_stream_t opal_accelerator_cuda_memcpy_stream;
 extern opal_mutex_t opal_accelerator_cuda_stream_lock;
 extern bool mca_accelerator_cuda_init_complete;
+
+/* Tunables for accelerator_cuda_check_addr fast path. When the CUDA driver
+ * cannot classify a pointer via cuPointerGetAttributes(), check_addr falls
+ * back to per-allocation queries for VMM (cuMemRetainAllocationHandle) and
+ * stream-ordered memory pools (cuPointerGetAttribute(MEMPOOL_HANDLE)). These
+ * are expensive on the per-message hot path; users who do not use those
+ * allocators can disable the fallbacks. */
+extern bool opal_accelerator_cuda_enable_vmm_check;
+extern bool opal_accelerator_cuda_enable_mpool_check;
 
 OPAL_DECLSPEC extern opal_accelerator_cuda_component_t mca_accelerator_cuda_component;
 

--- a/opal/mca/accelerator/cuda/accelerator_cuda_addr_cache.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_addr_cache.c
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include <cuda.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "accelerator_cuda_addr_cache.h"
+#include "opal/class/opal_list.h"
+#include "opal/class/opal_object.h"
+#include "opal/class/opal_rb_tree.h"
+#include "opal/mca/accelerator/accelerator.h"
+#include "opal/mca/threads/mutex.h"
+#include "opal/memoryhooks/memory.h"
+#include "opal/util/output.h"
+
+#define DEFAULT_MAX_ENTRIES 4096
+
+bool     opal_accelerator_cuda_addr_cache_enabled       = true;
+int      opal_accelerator_cuda_addr_cache_max_entries   = DEFAULT_MAX_ENTRIES;
+uint64_t opal_accelerator_cuda_addr_cache_hits          = 0;
+uint64_t opal_accelerator_cuda_addr_cache_misses        = 0;
+uint64_t opal_accelerator_cuda_addr_cache_stale_evictions = 0;
+uint64_t opal_accelerator_cuda_addr_cache_lru_evictions = 0;
+
+/*
+ * Implementation notes:
+ *
+ *  - The store is an rb_tree keyed by the range base. The comparator
+ *    treats the lookup key (a probe address) as "in range" when it
+ *    falls within [base, base+size). This works because we maintain
+ *    the invariant that ranges in the tree never overlap — overlapping
+ *    inserts evict colliding entries first.
+ *
+ *  - A doubly-linked LRU list runs in parallel for eviction. The list
+ *    is protected by the same mutex; no separate lock.
+ *
+ *  - One global mutex. check_addr is on the per-message hot path, so a
+ *    rwlock would be a clear win, but the OMPI thread layer does not
+ *    expose one yet. Revisit if profiles show contention. Practically
+ *    the critical sections are short (tree walk + 1 driver call on hit,
+ *    tree update on miss/insert).
+ */
+
+typedef struct addr_cache_entry_s {
+    /* tree key: const void *base. Stored here so we can re-derive on evict. */
+    const void *base;
+    size_t      size;
+    opal_accelerator_cuda_addr_class_t cls;
+    /* LRU list links */
+    struct addr_cache_entry_s *lru_prev;
+    struct addr_cache_entry_s *lru_next;
+} addr_cache_entry_t;
+
+static opal_rb_tree_t    s_tree;
+static opal_mutex_t      s_lock;
+static addr_cache_entry_t *s_lru_head = NULL;  /* most recently used */
+static addr_cache_entry_t *s_lru_tail = NULL;  /* least recently used */
+static size_t            s_n_entries = 0;
+static size_t            s_max_entries = DEFAULT_MAX_ENTRIES;
+static bool              s_initialized = false;
+static bool              s_release_hook_registered = false;
+
+/*
+ * Comparator for range-membership lookup.
+ *
+ * key1 is the probe address (a const void *) passed to opal_rb_tree_find.
+ * key2 is the entry's base pointer (since we insert with base as the key).
+ * On lookup we need to know the entry's full extent, but the rb_tree only
+ * gives us the key, so for lookup we use a separate compfn that knows how
+ * to dereference the entry.
+ *
+ * The trick: we insert the entry's address (not its base) as the key, so
+ * key2 in the lookup compfn is the entry pointer. That lets the comparator
+ * do range membership against entry->base / entry->size.
+ */
+static int range_compare_for_lookup(void *probe, void *entry_ptr)
+{
+    const char         *p = (const char *) probe;
+    addr_cache_entry_t *e = (addr_cache_entry_t *) entry_ptr;
+    if (p < (const char *) e->base)             return -1;
+    if (p >= (const char *) e->base + e->size)  return  1;
+    return 0;
+}
+
+/*
+ * Comparator for non-overlapping insertion ordering. key1 and key2 are
+ * both addr_cache_entry_t * (entry pointers). We order by base address;
+ * since ranges are non-overlapping after eviction, base ordering is
+ * total.
+ */
+static int entry_compare_for_insert(void *a, void *b)
+{
+    addr_cache_entry_t *ea = (addr_cache_entry_t *) a;
+    addr_cache_entry_t *eb = (addr_cache_entry_t *) b;
+    if (ea->base < eb->base) return -1;
+    if (ea->base > eb->base) return  1;
+    return 0;
+}
+
+/* LRU helpers; caller must hold s_lock. */
+static inline void lru_unlink(addr_cache_entry_t *e)
+{
+    if (e->lru_prev) e->lru_prev->lru_next = e->lru_next;
+    else             s_lru_head = e->lru_next;
+    if (e->lru_next) e->lru_next->lru_prev = e->lru_prev;
+    else             s_lru_tail = e->lru_prev;
+    e->lru_prev = e->lru_next = NULL;
+}
+
+static inline void lru_push_front(addr_cache_entry_t *e)
+{
+    e->lru_prev = NULL;
+    e->lru_next = s_lru_head;
+    if (s_lru_head) s_lru_head->lru_prev = e;
+    s_lru_head = e;
+    if (NULL == s_lru_tail) s_lru_tail = e;
+}
+
+static inline void lru_touch(addr_cache_entry_t *e)
+{
+    if (s_lru_head == e) return;
+    lru_unlink(e);
+    lru_push_front(e);
+}
+
+static void evict_entry_locked(addr_cache_entry_t *e)
+{
+    /* tree key is the entry pointer itself (see entry_compare_for_insert) */
+    opal_rb_tree_delete(&s_tree, e);
+    lru_unlink(e);
+    s_n_entries--;
+    free(e);
+}
+
+static void evict_lru_locked(void)
+{
+    if (NULL == s_lru_tail) return;
+    addr_cache_entry_t *victim = s_lru_tail;
+    evict_entry_locked(victim);
+    opal_accelerator_cuda_addr_cache_lru_evictions++;
+}
+
+/*
+ * On opal_mem_hooks release: any cached range overlapping [buf, buf+length)
+ * is now invalid. Walk and evict.
+ */
+static void mem_release_callback(void *buf, size_t length, void *cbdata, bool from_alloc)
+{
+    (void) cbdata;
+    (void) from_alloc;
+    opal_accelerator_cuda_addr_cache_invalidate(buf, length);
+}
+
+int opal_accelerator_cuda_addr_cache_init(void)
+{
+    if (s_initialized) {
+        return OPAL_SUCCESS;
+    }
+
+    OBJ_CONSTRUCT(&s_lock, opal_mutex_t);
+
+    s_max_entries = (opal_accelerator_cuda_addr_cache_max_entries > 0)
+                        ? (size_t) opal_accelerator_cuda_addr_cache_max_entries
+                        : DEFAULT_MAX_ENTRIES;
+
+    int rc = opal_rb_tree_init(&s_tree, entry_compare_for_insert);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_DESTRUCT(&s_lock);
+        return rc;
+    }
+
+    /* Best-effort munmap notifications. Without OPAL_MEMORY_FREE_SUPPORT we
+     * still work — host (negative) entries become slightly stale-prone, but
+     * device entries are still validated by BUFFER_ID. */
+    if (opal_mem_hooks_support_level() & OPAL_MEMORY_FREE_SUPPORT) {
+        if (OPAL_SUCCESS == opal_mem_hooks_register_release(mem_release_callback, NULL)) {
+            s_release_hook_registered = true;
+        }
+    }
+
+    s_initialized = true;
+    return OPAL_SUCCESS;
+}
+
+void opal_accelerator_cuda_addr_cache_finalize(void)
+{
+    if (!s_initialized) return;
+
+    if (s_release_hook_registered) {
+        opal_mem_hooks_unregister_release(mem_release_callback);
+        s_release_hook_registered = false;
+    }
+
+    /* Drain the LRU list, freeing each entry. The rb_tree's nodes hold no
+     * separately-allocated memory beyond the value pointers, so destroying
+     * the tree after this is sufficient. */
+    OPAL_THREAD_LOCK(&s_lock);
+    while (NULL != s_lru_head) {
+        addr_cache_entry_t *e = s_lru_head;
+        evict_entry_locked(e);
+    }
+    OPAL_THREAD_UNLOCK(&s_lock);
+
+    opal_rb_tree_destroy(&s_tree);
+    OBJ_DESTRUCT(&s_lock);
+    s_initialized = false;
+}
+
+int opal_accelerator_cuda_addr_cache_lookup(const void *addr,
+                                            opal_accelerator_cuda_addr_class_t *out)
+{
+    if (!opal_accelerator_cuda_addr_cache_enabled || !s_initialized) {
+        return 0;
+    }
+
+    opal_accelerator_cuda_addr_class_t snapshot;
+
+    OPAL_THREAD_LOCK(&s_lock);
+    addr_cache_entry_t *e = (addr_cache_entry_t *)
+        opal_rb_tree_find_with(&s_tree, (void *) addr, range_compare_for_lookup);
+    if (NULL == e) {
+        opal_accelerator_cuda_addr_cache_misses++;
+        OPAL_THREAD_UNLOCK(&s_lock);
+        return 0;
+    }
+
+    /* Snapshot the classification and promote it in the LRU list while the
+     * entry is guaranteed live (we hold the lock). Count the hit optimistically;
+     * it is undone below if device revalidation fails. After this unlock we must
+     * not dereference 'e', as a concurrent insert/evict/finalize may free it. */
+    snapshot = e->cls;
+    lru_touch(e);
+    opal_accelerator_cuda_addr_cache_hits++;
+    OPAL_THREAD_UNLOCK(&s_lock);
+
+    /* Host entries carry no BUFFER_ID and rely solely on mem_hooks
+     * invalidation, so the snapshot is authoritative. */
+    if (!snapshot.has_buffer_id) {
+        *out = snapshot;
+        return 1;
+    }
+
+    /* Device entries: revalidate the BUFFER_ID outside the lock so the driver
+     * round-trip does not serialize concurrent classifications. A mismatch
+     * means the allocation was freed and its virtual address reused. */
+    unsigned long long cur_id = 0;
+    CUresult r = cuPointerGetAttribute(&cur_id, CU_POINTER_ATTRIBUTE_BUFFER_ID,
+                                       (CUdeviceptr) addr);
+    if (CUDA_SUCCESS == r && (uint64_t) cur_id == snapshot.buffer_id) {
+        *out = snapshot;
+        return 1;
+    }
+
+    /* Stale: undo the optimistic hit and evict the entry if it is still the
+     * one we validated (it may already be gone or replaced). Re-find by addr
+     * rather than reusing the now-untrusted 'e' pointer. */
+    OPAL_THREAD_LOCK(&s_lock);
+    opal_accelerator_cuda_addr_cache_hits--;
+    addr_cache_entry_t *stale = (addr_cache_entry_t *)
+        opal_rb_tree_find_with(&s_tree, (void *) addr, range_compare_for_lookup);
+    if (NULL != stale && stale->cls.has_buffer_id
+        && stale->cls.buffer_id == snapshot.buffer_id) {
+        evict_entry_locked(stale);
+        opal_accelerator_cuda_addr_cache_stale_evictions++;
+    }
+    opal_accelerator_cuda_addr_cache_misses++;
+    OPAL_THREAD_UNLOCK(&s_lock);
+    return 0;
+}
+
+void opal_accelerator_cuda_addr_cache_insert(const void *base, size_t size,
+                                             const opal_accelerator_cuda_addr_class_t *cls)
+{
+    if (!opal_accelerator_cuda_addr_cache_enabled || !s_initialized) {
+        return;
+    }
+    if (NULL == base || 0 == size || NULL == cls) {
+        return;
+    }
+
+    addr_cache_entry_t *e = (addr_cache_entry_t *) malloc(sizeof(*e));
+    if (NULL == e) return;
+    e->base = base;
+    e->size = size;
+    e->cls  = *cls;
+    e->lru_prev = e->lru_next = NULL;
+
+    OPAL_THREAD_LOCK(&s_lock);
+
+    /* Evict any existing overlap. We can only find one overlap per probe
+     * (ranges are non-overlapping by invariant), so re-probing in a loop
+     * handles the (rare) case where multiple existing entries fall inside
+     * the new range. */
+    for (;;) {
+        addr_cache_entry_t *ov = (addr_cache_entry_t *)
+            opal_rb_tree_find_with(&s_tree, (void *) base, range_compare_for_lookup);
+        if (NULL == ov) break;
+        evict_entry_locked(ov);
+    }
+
+    if (s_n_entries >= s_max_entries) {
+        evict_lru_locked();
+    }
+
+    if (OPAL_SUCCESS != opal_rb_tree_insert(&s_tree, e, e)) {
+        free(e);
+        OPAL_THREAD_UNLOCK(&s_lock);
+        return;
+    }
+    lru_push_front(e);
+    s_n_entries++;
+
+    OPAL_THREAD_UNLOCK(&s_lock);
+}
+
+void opal_accelerator_cuda_addr_cache_invalidate(const void *addr, size_t size)
+{
+    if (!s_initialized || NULL == addr || 0 == size) return;
+
+    const char *lo = (const char *) addr;
+    const char *hi = lo + size;
+
+    OPAL_THREAD_LOCK(&s_lock);
+
+    /*
+     * Walk the LRU list (cheap, already O(N)) and evict every entry whose
+     * range overlaps [addr, addr+size). The rb_tree doesn't support range
+     * iteration directly. The release callback is on the slow path, so
+     * O(N) is acceptable; if it ever shows up in profiles, switch the
+     * store to an explicit interval tree.
+     */
+    addr_cache_entry_t *e = s_lru_head;
+    while (NULL != e) {
+        addr_cache_entry_t *next = e->lru_next;
+        const char *e_lo = (const char *) e->base;
+        const char *e_hi = e_lo + e->size;
+        if (e_lo < hi && e_hi > lo) {
+            evict_entry_locked(e);
+        }
+        e = next;
+    }
+
+    OPAL_THREAD_UNLOCK(&s_lock);
+}

--- a/opal/mca/accelerator/cuda/accelerator_cuda_addr_cache.h
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_addr_cache.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Address-classification cache for accelerator_cuda_check_addr.
+ *
+ * The cache stores the result of a previous classification keyed by
+ * the allocation's base/size range. A successful lookup returns the
+ * cached (mem_type, dev_id, flags) and avoids the up-to-three CUDA
+ * driver calls that the cold path issues.
+ *
+ * Two correctness mechanisms guard against stale entries:
+ *
+ *   1. For CUDA-tracked pointers, each entry stores the
+ *      CU_POINTER_ATTRIBUTE_BUFFER_ID at insert time. On lookup we
+ *      re-query BUFFER_ID and evict if it has changed (allocation was
+ *      freed and the address was reused).
+ *
+ *   2. For host pointers (caching a negative result), invalidation is
+ *      driven by opal_mem_hooks_register_release: any munmap that
+ *      overlaps a cached range evicts the affected entries.
+ */
+
+#ifndef OPAL_ACCELERATOR_CUDA_ADDR_CACHE_H
+#define OPAL_ACCELERATOR_CUDA_ADDR_CACHE_H
+
+#include "opal_config.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+BEGIN_C_DECLS
+
+typedef struct {
+    int      mem_type;     /* check_addr return: 0 host, 1 device */
+    int      dev_id;       /* MCA_ACCELERATOR_NO_DEVICE_ID for host */
+    uint64_t flags;        /* MCA_ACCELERATOR_FLAGS_* (e.g. UNIFIED_MEMORY) */
+    uint64_t buffer_id;    /* CU_POINTER_ATTRIBUTE_BUFFER_ID at insert; 0 for host */
+    bool     has_buffer_id;/* false for host entries (no CUDA buffer id) */
+} opal_accelerator_cuda_addr_class_t;
+
+/* Lifecycle. Init is safe to call multiple times. */
+int  opal_accelerator_cuda_addr_cache_init(void);
+void opal_accelerator_cuda_addr_cache_finalize(void);
+
+/*
+ * Look up addr in the cache.
+ *
+ * Returns 1 on a verified hit (out is filled). Returns 0 on miss or
+ * when the cache is disabled. Stale entries (BUFFER_ID mismatch) are
+ * evicted as a side effect of a miss.
+ */
+int  opal_accelerator_cuda_addr_cache_lookup(const void *addr,
+                                             opal_accelerator_cuda_addr_class_t *out);
+
+/*
+ * Insert a classification for the [base, base+size) range.
+ *
+ * base/size should typically come from cuMemGetAddressRange() so the
+ * entry covers the whole allocation. For host (negative) caching,
+ * pass the page-aligned region returned by opal_mem_hooks if known,
+ * or a conservative single-page range.
+ *
+ * Idempotent: a duplicate or overlapping insert evicts any existing
+ * overlapping entries first.
+ */
+void opal_accelerator_cuda_addr_cache_insert(const void *base, size_t size,
+                                             const opal_accelerator_cuda_addr_class_t *cls);
+
+/*
+ * Evict any cached entries overlapping [addr, addr+size). Called from
+ * the opal_mem_hooks release callback and may also be called directly
+ * if the caller knows an allocation has been freed.
+ */
+void opal_accelerator_cuda_addr_cache_invalidate(const void *addr, size_t size);
+
+/* Tunable, registered as accelerator_cuda_addr_cache_enable. Default true. */
+extern bool opal_accelerator_cuda_addr_cache_enabled;
+
+/* Tunable, registered as accelerator_cuda_addr_cache_size. Maximum number of
+ * ranges retained before LRU eviction. Read once at init; values < 1 select
+ * the built-in default. */
+extern int opal_accelerator_cuda_addr_cache_max_entries;
+
+/* Statistics, useful for debugging and tuning. Updated under the cache lock. */
+extern uint64_t opal_accelerator_cuda_addr_cache_hits;
+extern uint64_t opal_accelerator_cuda_addr_cache_misses;
+extern uint64_t opal_accelerator_cuda_addr_cache_stale_evictions;
+extern uint64_t opal_accelerator_cuda_addr_cache_lru_evictions;
+
+END_C_DECLS
+
+#endif /* OPAL_ACCELERATOR_CUDA_ADDR_CACHE_H */

--- a/opal/mca/accelerator/cuda/accelerator_cuda_component.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_component.c
@@ -65,6 +65,8 @@ static opal_accelerator_cuda_nvlink_domain_t accelerator_cuda_nvlink_domain = {
 static char *accelerator_cuda_nvlink_domain_mca_string =
     "cuda_device=-1,cluster_uuid=00000000000000000000000000000000,clique_id=0";
 static bool accelerator_cuda_nvlink_domain_mca_string_owned = false;
+bool opal_accelerator_cuda_enable_vmm_check = true;
+bool opal_accelerator_cuda_enable_mpool_check = true;
 
 #define STRINGIFY2(x) #x
 #define STRINGIFY(x)  STRINGIFY2(x)
@@ -177,6 +179,28 @@ static int accelerator_cuda_component_register(void)
     (void) mca_base_var_register_synonym(ret, "opal", "accelerator", NULL,
                                          "nvlink_domain", 0);
     accelerator_cuda_nvlink_domain_mca_string_owned = true;
+
+    (void) mca_base_component_var_register(&mca_accelerator_cuda_component.super.base_version,
+                                           "enable_vmm_check",
+                                           "Enable fallback classification of pointers via "
+                                           "cuMemRetainAllocationHandle for CUDA Virtual Memory "
+                                           "Management allocations. Disable if the application "
+                                           "does not use cuMemMap-based allocations to avoid the "
+                                           "per-call cost in check_addr.",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                           &opal_accelerator_cuda_enable_vmm_check);
+
+    (void) mca_base_component_var_register(&mca_accelerator_cuda_component.super.base_version,
+                                           "enable_mpool_check",
+                                           "Enable fallback classification of pointers via "
+                                           "cuPointerGetAttribute(MEMPOOL_HANDLE) for CUDA "
+                                           "stream-ordered memory pool allocations. Disable if "
+                                           "the application does not use cuMemAllocAsync to avoid "
+                                           "the per-call cost in check_addr.",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                           &opal_accelerator_cuda_enable_mpool_check);
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/accelerator/cuda/accelerator_cuda_component.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda_component.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "accelerator_cuda.h"
+#include "accelerator_cuda_addr_cache.h"
 #include "opal/mca/accelerator/base/base.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/dl/base/base.h"
@@ -201,6 +202,28 @@ static int accelerator_cuda_component_register(void)
                                            MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                            OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
                                            &opal_accelerator_cuda_enable_mpool_check);
+
+    (void) mca_base_component_var_register(&mca_accelerator_cuda_component.super.base_version,
+                                           "addr_cache_enable",
+                                           "Cache pointer classifications in check_addr to avoid "
+                                           "repeated CUDA driver queries on the per-message hot "
+                                           "path. Hits are validated by CU_POINTER_ATTRIBUTE_BUFFER_ID "
+                                           "for device memory and by opal_mem_hooks munmap "
+                                           "notifications for host memory. Disable to bypass the "
+                                           "cache, e.g. when comparing performance.",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                           &opal_accelerator_cuda_addr_cache_enabled);
+
+    (void) mca_base_component_var_register(&mca_accelerator_cuda_component.super.base_version,
+                                           "addr_cache_size",
+                                           "Maximum number of allocation ranges retained by the "
+                                           "check_addr classification cache. Least-recently-used "
+                                           "entries are evicted once this many are cached. Values "
+                                           "less than 1 restore the built-in default.",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_READONLY,
+                                           &opal_accelerator_cuda_addr_cache_max_entries);
 
     return OPAL_SUCCESS;
 }
@@ -610,6 +633,11 @@ int opal_accelerator_cuda_delayed_init()
         opal_accelerator_cuda_mem_bw[i] = bw;
     }
 
+    /* Address-classification cache. Best-effort: any failure here
+     * leaves the cache disabled and check_addr falls back to the
+     * cold path. */
+    (void) opal_accelerator_cuda_addr_cache_init();
+
     result = OPAL_SUCCESS;
     opal_atomic_wmb();
     mca_accelerator_cuda_init_complete = true;
@@ -637,6 +665,12 @@ static opal_accelerator_base_module_t* accelerator_cuda_init(void)
 static void accelerator_cuda_finalize(opal_accelerator_base_module_t* module)
 {
     CUresult result;
+
+    /* Tear down the address cache before any further CUDA calls so that
+     * its mem_hooks release callback is unregistered before opal teardown
+     * runs. Safe to call regardless of init state. */
+    opal_accelerator_cuda_addr_cache_finalize();
+
     /* This call is in here to make sure the context is still valid.
      * This was the one way of checking which did not cause problems
      * while calling into the CUDA library.  This check will detect if


### PR DESCRIPTION
Builds on a312180b43 ("defer VMM/mpool checks in check_addr fast path"), which short-circuits classification of cudaMalloc pointers reported as CU_MEMORYTYPE_DEVICE with a valid context. Two further reductions to the per-message overhead of accelerator_cuda_check_addr:

1. Hoist the `mem_type == 0` early return ahead of the VMM/mpool fallback. cuPointerGetAttributes can succeed with mem_type==0 for pointers CUDA recognizes but cannot classify; the existing code reached the early return only after issuing two more driver calls (cuMemRetainAllocationHandle, cuPointerGetAttribute(MEMPOOL_HANDLE)). Move the early return before the fallback so these pointers cost a single driver call instead of three.

2. Gate the VMM and mpool fallback queries behind two new MCA params, accelerator_cuda_enable_vmm_check and accelerator_cuda_enable_mpool_check (default true, preserving current behavior). Applications that do not use cuMemMap-backed (VMM) or cuMemAllocAsync-backed (mempool) allocations can disable these and avoid the per-call cost on every send/recv buffer. This is the workload pattern reported in #13708, where cuPointerGetAttribute and cuMemRetainAllocationHandle traffic dominated profiles via cudbgMain / cuEGLApiInit / cuVDPAUCtxCreate internal driver paths.

Same treatment applied to the legacy !OPAL_CUDA_GET_ATTRIBUTES branch, which previously called the VMM and mpool helpers *before* cuPointerGetAttribute and so paid the cost even when CUDA was not initialized.

Note: when both tunables are disabled, the rare CU_MEMORYTYPE_DEVICE with NULL context path falls through to accelerator_cuda_get_device_id with a NULL context. That combination is only legitimate for VMM/mpool allocations, so disabling both checks while using such allocations is user error.

Refs #13708