### PR TITLE
coll/ucc: give pset-derived communicators their own OOB and context

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -917,9 +917,18 @@ static int ompi_comm_activate_complete (ompi_comm_cid_context_t *context)
         return OMPI_SUCCESS;
     }
 
-    /* Let the collectives components fight over who will do
-       collective on this new comm.  */
-    if (OMPI_SUCCESS != (ret = mca_coll_base_comm_select(*newcomm))) {
+    /* Let the collectives components fight over who will do collective on this
+       new comm.  Pass the parent (old) communicator so components can consult
+       it during selection (e.g. coll/ucc inherits its parent's UCC context).
+       Two creation paths have no usable parent and must pass NULL:
+       MPI_Comm_create_from_group activates over the new communicator itself
+       (comm == *newcomm), and MPI_Intercomm_merge activates over an
+       inter-communicator.  All other paths pass a real, non-NULL parent. */
+    ompi_communicator_t *parent = comm;
+    if (comm == *newcomm || OMPI_COMM_IS_INTER(comm)) {
+        parent = NULL;
+    }
+    if (OMPI_SUCCESS != (ret = mca_coll_base_comm_select(*newcomm, parent))) {
         OBJ_RELEASE(*newcomm);
         *newcomm = MPI_COMM_NULL;
         return ret;

--- a/ompi/mca/coll/base/base.h
+++ b/ompi/mca/coll/base/base.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -96,7 +97,8 @@ int mca_coll_base_find_available(bool enable_progress_threads,
  * communicator creation functions may be re-entered (albeit with
  * different arguments).
  */
-int mca_coll_base_comm_select(struct ompi_communicator_t *comm);
+int mca_coll_base_comm_select(struct ompi_communicator_t *comm,
+                              struct ompi_communicator_t *parent);
 
 /**
  * Finalize a coll component on a specific communicator.

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2020      BULL S.A.S. All rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -213,7 +213,7 @@ static void mca_coll_base_print_component_names(ompi_communicator_t *comm)
  *
  * This selection logic is not for the weak.
  */
-int mca_coll_base_comm_select(ompi_communicator_t * comm)
+int mca_coll_base_comm_select(ompi_communicator_t * comm, ompi_communicator_t * parent)
 {
     opal_list_t *selectable;
     opal_list_item_t *item;
@@ -229,6 +229,13 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
      * sentinel values */
     comm->c_coll = (mca_coll_base_comm_coll_t*)calloc(1, sizeof(mca_coll_base_comm_coll_t));
     comm->c_coll->coll_revoke_local = mca_coll_base_revoke_local;
+
+    /* Make the parent communicator available to components for the duration
+     * of the selection (comm_query / module_enable).  Some components use it
+     * to consult parent state, e.g. to inherit a collective context rather
+     * than bootstrapping a new one.  It is cleared again before returning so
+     * it can never be dereferenced past the selection window. */
+    comm->c_coll->parent = parent;
 
     opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                         "coll:base:comm_select: Checking all available modules");
@@ -275,6 +282,10 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
     }
     /* Done with the list from the check_components() call so release it. */
     OBJ_RELEASE(selectable);
+
+    /* The parent communicator is only meaningful during selection; clear it
+     * so it cannot be dereferenced (and cannot dangle) afterwards. */
+    comm->c_coll->parent = NULL;
 
     /* check to make sure no NULLs */
     if (CHECK_NULL(which_func, comm, allgather) ||

--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -20,7 +20,7 @@
  * Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2020      BULL S.A.S. All rights reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -821,6 +821,17 @@ struct mca_coll_base_comm_coll_t {
 
     /* List of modules initialized, queried and enabled */
     opal_list_t *module_list;
+
+    /* Parent communicator from which this communicator was derived, made
+       available transiently by the base during component selection so that
+       components can consult parent state (e.g. to inherit a collective
+       context).  It is only valid for the duration of
+       mca_coll_base_comm_select() (i.e. during comm_query / module_enable)
+       and is reset to NULL afterwards.  It is a borrowed reference and is
+       never retained.  It is non-NULL for every derived communicator except
+       the two creation paths that have no usable parent context, where it is
+       NULL: MPI_Comm_create_from_group and MPI_Intercomm_merge. */
+    struct ompi_communicator_t *parent;
 };
 typedef struct mca_coll_base_comm_coll_t mca_coll_base_comm_coll_t;
 

--- a/ompi/mca/coll/ucc/coll_ucc.h
+++ b/ompi/mca/coll/ucc/coll_ucc.h
@@ -1,6 +1,6 @@
 /**
   Copyright (c) 2021      Mellanox Technologies. All rights reserved.
-  Copyright (c) 2022 NVIDIA Corporation.  All rights reserved.
+  Copyright (c) 2022-2026 NVIDIA Corporation.  All rights reserved.
   Copyright (c) 2025      Fujitsu Limited. All rights reserved.
   $COPYRIGHT$
 
@@ -47,6 +47,39 @@ typedef struct mca_coll_ucc_req {
 } mca_coll_ucc_req_t;
 OBJ_CLASS_DECLARATION(mca_coll_ucc_req_t);
 
+/**
+ * A UCC "OOB domain": the intermediary that owns a single UCC context and
+ * the out-of-band (OOB) bootstrap communicator used to create that context.
+ *
+ * The OOB is implemented over an MPI communicator (PML point-to-point).
+ * UCC only uses it to bootstrap the context (an allgather at context create,
+ * and context teardown); team create/destroy and all normal collectives are
+ * collective over the team itself and do not touch the OOB.  A domain is
+ * shared (refcounted) by the communicator that created it and every
+ * communicator derived from it, so a whole family reuses one heavyweight UCC
+ * context and addresses into it through an ep map.
+ *
+ * Because the context outlives the user communicator that bootstrapped it
+ * (e.g. the user may free the bootstrap communicator while derived
+ * communicators are still alive), the domain holds its own reference to
+ * @comm (OBJ_RETAIN at creation, OBJ_RELEASE when the context is destroyed).
+ * The bootstrap communicator therefore stays valid for the OOB for as long
+ * as the context exists.  Communicators created without a usable parent
+ * domain (MPI_Comm_create_from_group, MPI_Intercomm_merge) bootstrap their
+ * own domain, since no existing context is guaranteed to span their ranks.
+ */
+typedef struct mca_coll_ucc_oob_domain_t {
+    opal_list_item_t     super;
+    /* Bootstrap communicator backing the OOB.  Owned reference: retained for
+       the lifetime of the domain so the OOB stays usable even after the user
+       frees its handle to this communicator. */
+    ompi_communicator_t *comm;
+    ucc_context_h        ucc_context;
+    /* Number of UCC modules (communicators) currently referencing it. */
+    int                  refcount;
+} mca_coll_ucc_oob_domain_t;
+OBJ_CLASS_DECLARATION(mca_coll_ucc_oob_domain_t);
+
 struct mca_coll_ucc_component_t {
     mca_coll_base_component_3_0_0_t super;
     int                             ucc_priority;
@@ -57,13 +90,21 @@ struct mca_coll_ucc_component_t {
     char                           *cts;
     const char                     *compiletime_version;
     const char                     *runtime_version;
-    bool                            libucc_initialized;
     ucc_lib_h                       ucc_lib;
     ucc_lib_attr_t                  ucc_lib_attr;
     ucc_coll_type_t                 cts_requested;
     ucc_coll_type_t                 nb_cts_requested;
     ucc_coll_type_t                 ps_cts_requested;
-    ucc_context_h                   ucc_context;
+    /* List of live mca_coll_ucc_oob_domain_t.  Each holds its own UCC
+       context; the single shared ucc_lib is created with the first domain
+       and finalized with the last.  The progress callback iterates this
+       list to progress every live context. */
+    opal_list_t                     domains;
+    int                             domain_count;
+    /* The UCC library and the per-communicator attribute keyval are created
+       lazily with the first domain and persist across domain churn. */
+    bool                            keyval_created;
+    bool                            requests_initialized;
     opal_free_list_t                requests;
 };
 typedef struct mca_coll_ucc_component_t mca_coll_ucc_component_t;
@@ -77,7 +118,16 @@ struct mca_coll_ucc_module_t {
     mca_coll_base_module_t                          super;
     ompi_communicator_t*                            comm;
     int                                             rank;
+    /* OOB domain (and thus UCC context) used by this communicator. May be
+       shared with the parent/ancestor communicator it was derived from. */
+    mca_coll_ucc_oob_domain_t*                      domain;
     ucc_team_h                                      ucc_team;
+    /* Backing array for the UCC team ep_map when this communicator is an
+       arbitrary (non-strided) permutation of the domain's bootstrap
+       communicator.  Maps team rank -> bootstrap-comm rank (i.e. context
+       endpoint).  NULL for the FULL/STRIDED cases that need no array.  Kept
+       alive for the team's lifetime and freed at module destruct. */
+    int*                                            ep_map_ranks;
     mca_coll_base_module_allreduce_fn_t             previous_allreduce;
     mca_coll_base_module_t*                         previous_allreduce_module;
     mca_coll_base_module_iallreduce_fn_t            previous_iallreduce;

--- a/ompi/mca/coll/ucc/coll_ucc_allgather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgather.c
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +81,7 @@ int mca_coll_ucc_allgather(const void *sbuf, size_t scount, struct ompi_datatype
                                                       rbuf, rcount, rdtype,
                                                       false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allgather");

--- a/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allgatherv.c
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,7 +83,7 @@ int mca_coll_ucc_allgatherv(const void *sbuf, size_t scount,
                                                        rbuf, rcounts, rdisps, rdtype,
                                                        false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allgatherv");

--- a/ompi/mca/coll/ucc/coll_ucc_allreduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_allreduce.c
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,7 +74,7 @@ int mca_coll_ucc_allreduce(const void *sbuf, void *rbuf, size_t count,
     COLL_UCC_CHECK(mca_coll_ucc_allreduce_init_common(sbuf, rbuf, count, dtype, op,
                                                       false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback allreduce");

--- a/ompi/mca/coll/ucc/coll_ucc_alltoall.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoall.c
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +81,7 @@ int mca_coll_ucc_alltoall(const void *sbuf, size_t scount, struct ompi_datatype_
                                                      rbuf, rcount, rdtype,
                                                      false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback alltoall");

--- a/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_alltoallv.c
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -84,7 +85,7 @@ int mca_coll_ucc_alltoallv(const void *sbuf, ompi_count_array_t scounts,
                                                       rbuf, rcounts, rdisps, rdtype,
                                                       false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback alltoallv");

--- a/ompi/mca/coll/ucc/coll_ucc_barrier.c
+++ b/ompi/mca/coll/ucc/coll_ucc_barrier.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ int mca_coll_ucc_barrier(struct ompi_communicator_t *comm,
     UCC_VERBOSE(3, "running ucc barrier");
     COLL_UCC_CHECK(mca_coll_ucc_barrier_init_common(false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback barrier");

--- a/ompi/mca/coll/ucc/coll_ucc_bcast.c
+++ b/ompi/mca/coll/ucc/coll_ucc_bcast.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +55,7 @@ int mca_coll_ucc_bcast(void *buf, size_t count, struct ompi_datatype_t *dtype,
     COLL_UCC_CHECK(mca_coll_ucc_bcast_init_common(buf, count, dtype, root,
                                                   false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback bcast");

--- a/ompi/mca/coll/ucc/coll_ucc_common.h
+++ b/ompi/mca/coll/ucc/coll_ucc_common.h
@@ -1,6 +1,7 @@
 /**
   Copyright (c) 2021      Mellanox Technologies. All rights reserved.
   Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+  Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
   $COPYRIGHT$
   Additional copyrights may follow
   $HEADER$
@@ -80,7 +81,8 @@
         }                                                               \
     } while(0)
 
-static inline ucc_status_t coll_ucc_req_wait(ucc_coll_req_h req)
+static inline ucc_status_t coll_ucc_req_wait(ucc_coll_req_h req,
+                                             mca_coll_ucc_module_t *module)
 {
     ucc_status_t status;
     while (UCC_OK != (status = ucc_collective_test(req))) {
@@ -90,7 +92,7 @@ static inline ucc_status_t coll_ucc_req_wait(ucc_coll_req_h req)
             ucc_collective_finalize(req);
             return status;
         }
-        ucc_context_progress(mca_coll_ucc_component.ucc_context);
+        ucc_context_progress(module->domain->ucc_context);
         opal_progress();
     }
     return ucc_collective_finalize(req);

--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
- * Copyright (c) 2024 NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -248,7 +248,10 @@ static int mca_coll_ucc_open(void)
 {
     mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
     mca_coll_ucc_output          = opal_output_open(NULL);
-    cm->libucc_initialized       = false;
+    cm->domain_count             = 0;
+    cm->keyval_created           = false;
+    cm->requests_initialized     = false;
+    OBJ_CONSTRUCT(&cm->domains, opal_list_t);
     opal_output_set_verbosity(mca_coll_ucc_output, cm->ucc_verbose);
     mca_coll_ucc_init_default_cts();
     return OMPI_SUCCESS;
@@ -256,5 +259,15 @@ static int mca_coll_ucc_open(void)
 
 static int mca_coll_ucc_close(void)
 {
+    mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
+
+    /* By now every UCC communicator has been freed, so all domains and the
+       UCC library are already gone.  Drop the request free list (created
+       lazily with the first library init) and the (now empty) domain list. */
+    if (cm->requests_initialized) {
+        OBJ_DESTRUCT(&cm->requests);
+        cm->requests_initialized = false;
+    }
+    OBJ_DESTRUCT(&cm->domains);
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/coll/ucc/coll_ucc_gather.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gather.c
@@ -1,7 +1,7 @@
 
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -96,7 +96,7 @@ int mca_coll_ucc_gather(const void *sbuf, size_t scount, struct ompi_datatype_t 
                                                    rdtype, root, false, ucc_module,
                                                    &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback gather");

--- a/ompi/mca/coll/ucc/coll_ucc_gatherv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_gatherv.c
@@ -1,7 +1,7 @@
 
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -90,7 +90,7 @@ int mca_coll_ucc_gatherv(const void *sbuf, size_t scount, struct ompi_datatype_t
                                                     disps, rdtype, root, false, ucc_module,
                                                     &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback gatherv");

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2021      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2022-2025 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
@@ -18,6 +18,7 @@
 #include "coll_ucc_dtypes.h"
 #include "ompi/mca/coll/base/coll_tags.h"
 #include "ompi/mca/pml/pml.h"
+#include "ompi/runtime/ompi_rte.h"
 
 static int ucc_comm_attr_keyval;
 /*
@@ -32,6 +33,7 @@ int mca_coll_ucc_init_query(bool enable_progress_threads, bool enable_mpi_thread
 static void mca_coll_ucc_module_clear(mca_coll_ucc_module_t *ucc_module)
 {
     ucc_module->ucc_team                              = NULL;
+    ucc_module->ep_map_ranks                          = NULL;
     ucc_module->previous_allreduce                    = NULL;
     ucc_module->previous_allreduce_module             = NULL;
     ucc_module->previous_iallreduce                   = NULL;
@@ -125,41 +127,124 @@ static void mca_coll_ucc_module_construct(mca_coll_ucc_module_t *ucc_module)
 
 static int mca_coll_ucc_progress(void)
 {
-    ucc_context_progress(mca_coll_ucc_component.ucc_context);
+    mca_coll_ucc_component_t  *cm = &mca_coll_ucc_component;
+    mca_coll_ucc_oob_domain_t *domain;
+
+    /* Progress every live UCC context (one per OOB domain). */
+    OPAL_LIST_FOREACH(domain, &cm->domains, mca_coll_ucc_oob_domain_t) {
+        ucc_context_progress(domain->ucc_context);
+    }
     return OPAL_SUCCESS;
+}
+
+/*
+ * Release a reference to an OOB domain.
+ *
+ * A domain is shared by the communicator that bootstrapped it and every
+ * communicator derived from it; each holds one reference.  When the last
+ * reference is dropped the UCC context is destroyed, the reference the domain
+ * took on its bootstrap communicator is dropped, and -- when the last domain
+ * goes away -- the shared UCC library is finalized and the progress callback
+ * is unregistered.
+ *
+ * Context teardown may itself drive the OOB; that is safe because the domain
+ * kept its own reference to the bootstrap communicator (see
+ * mca_coll_ucc_domain_create), so the OOB communicator is still valid here
+ * even if the user has already freed its handle to it.
+ */
+static void mca_coll_ucc_domain_release(mca_coll_ucc_oob_domain_t *domain)
+{
+    mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
+
+    if (NULL == domain) {
+        return;
+    }
+
+    if (0 != --domain->refcount) {
+        return;
+    }
+
+    opal_list_remove_item(&cm->domains, &domain->super);
+    ucc_context_destroy(domain->ucc_context);
+    /* Drop the reference the domain held on its bootstrap communicator (only
+       taken for non-intrinsic communicators; see mca_coll_ucc_domain_create). */
+    if (!OMPI_COMM_IS_INTRINSIC(domain->comm)) {
+        OBJ_RELEASE(domain->comm);
+    }
+    OBJ_RELEASE(domain);
+
+    if (0 == --cm->domain_count) {
+        opal_progress_unregister(mca_coll_ucc_progress);
+        ucc_finalize(cm->ucc_lib);
+        cm->ucc_lib = NULL;
+    }
 }
 
 static void mca_coll_ucc_module_destruct(mca_coll_ucc_module_t *ucc_module)
 {
-    if (ucc_module->comm == &ompi_mpi_comm_world.comm){
+    mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
+
+    /* The per-communicator keyval is a process-global resource shared by all
+       UCC communicators.  Free it once there are no live OOB domains left.
+       This runs in the module destructor (not in the attribute delete
+       callback below) on purpose: freeing a keyval while we are inside one of
+       its own delete callbacks -- i.e. while ompi_attr_delete_all() is still
+       iterating that comm's attributes -- is unsafe.  The destructor runs
+       after the comm's attributes have already been deleted, with the
+       attribute subsystem still alive, which matches the proven-safe timing
+       of the original code.  If a new UCC communicator appears later the
+       keyval is simply recreated lazily by mca_coll_ucc_lib_init(). */
+    if (cm->keyval_created && 0 == cm->domain_count) {
         if (OMPI_SUCCESS != ompi_attr_free_keyval(COMM_ATTR, &ucc_comm_attr_keyval, 0)) {
             UCC_ERROR("ucc ompi_attr_free_keyval failed");
         }
+        cm->keyval_created = false;
     }
+    /* The team (the only user of the ep_map backing array) has already been
+       destroyed by the attribute delete callback at this point, so it is safe
+       to release the array now. */
+    free(ucc_module->ep_map_ranks);
     mca_coll_ucc_module_clear(ucc_module);
 }
 
 /*
-** Communicator free callback
+** Communicator free callback.
+**
+** Registered through an MPI attribute keyval and invoked by
+** ompi_attr_delete_all() while the communicator is being freed -- i.e.
+** synchronously inside the *collective* MPI_Comm_free / MPI_Comm_disconnect
+** path, before the communicator object is destructed.  Because the
+** communicator is freed collectively, every rank reaches this callback for
+** the same communicator, so team teardown (a collective over exactly this
+** communicator's ranks) and the domain refcount drop happen consistently on
+** all ranks.  Doing the teardown here, while the attribute subsystem is still
+** alive, also matches the proven-safe timing of the original code.
 */
 static int ucc_comm_attr_del_fn(MPI_Comm comm, int keyval, void *attr_val, void *extra)
 {
     mca_coll_ucc_module_t *ucc_module = (mca_coll_ucc_module_t*) attr_val;
-    ucc_status_t status;
-    while(UCC_INPROGRESS == (status = ucc_team_destroy(ucc_module->ucc_team))) {}
-    if (ucc_module->comm == &ompi_mpi_comm_world.comm) {
-        if (mca_coll_ucc_component.libucc_initialized) {
-            UCC_VERBOSE(1,"finalizing ucc library");
-            opal_progress_unregister(mca_coll_ucc_progress);
-            ucc_context_destroy(mca_coll_ucc_component.ucc_context);
-            ucc_finalize(mca_coll_ucc_component.ucc_lib);
+    ucc_status_t           status     = UCC_OK;
+
+    /* Tear down this communicator's UCC team.  Team destroy is collective
+       over the team's own ranks (this communicator), not over the domain's
+       OOB, so it is safe even when this communicator is a subset of the
+       domain's bootstrap communicator. */
+    if (NULL != ucc_module->ucc_team) {
+        while (UCC_INPROGRESS == (status = ucc_team_destroy(ucc_module->ucc_team))) {
+            opal_progress();
         }
+        if (UCC_OK != status) {
+            UCC_ERROR("UCC team destroy failed");
+        }
+        ucc_module->ucc_team = NULL;
     }
-    if (UCC_OK != status) {
-        UCC_ERROR("UCC team destroy failed");
-        return OMPI_ERROR;
-    }
-    return OMPI_SUCCESS;
+
+    /* Drop this communicator's reference to the shared OOB domain; the last
+       reference destroys the context and releases the bootstrap comm. */
+    mca_coll_ucc_domain_release(ucc_module->domain);
+    ucc_module->domain = NULL;
+
+    return (UCC_OK == status) ? OMPI_SUCCESS : OMPI_ERROR;
 }
 
 typedef struct oob_allgather_req{
@@ -173,14 +258,28 @@ typedef struct oob_allgather_req{
 
 static ucc_status_t oob_allgather_test(void *req)
 {
-    oob_allgather_req_t *oob_req = (oob_allgather_req_t*)req;
-    ompi_communicator_t *comm    = (ompi_communicator_t *)oob_req->oob_coll_ctx;
+    oob_allgather_req_t       *oob_req = (oob_allgather_req_t*)req;
+    /* The OOB context is the domain (see mca_coll_ucc_domain_create); its
+       bootstrap communicator backs the point-to-point ring. */
+    mca_coll_ucc_oob_domain_t *domain  = (mca_coll_ucc_oob_domain_t *)oob_req->oob_coll_ctx;
+    ompi_communicator_t       *comm    = domain->comm;
     char                *tmpsend = NULL;
     char                *tmprecv = NULL;
     size_t               msglen  = oob_req->msglen;
     int                  probe_count = 5;
     int rank, size, sendto, recvfrom, recvdatafrom,
         senddatafrom, completed, probe, rc;
+
+    /* The OOB only runs while bootstrapping or tearing down the context, and
+       always over the full bootstrap communicator.  The domain holds its own
+       reference to that communicator for its whole lifetime, so it is valid
+       here even if the user already freed its handle to it.  A NULL comm
+       would mean that invariant was violated -- fail loudly rather than
+       dereference a freed communicator. */
+    if (NULL == comm) {
+        UCC_ERROR("UCC OOB invoked after its bootstrap communicator was freed");
+        ompi_rte_abort(1, "coll/ucc: OOB used after bootstrap communicator was freed");
+    }
 
     size = ompi_comm_size(comm);
     rank = ompi_comm_rank(comm);
@@ -249,20 +348,21 @@ static ucc_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
 }
 
 
-static int mca_coll_ucc_init_ctx(ompi_communicator_t* comm)
+/*
+ * One-time initialization of the shared UCC library, the request free list
+ * and the per-communicator attribute keyval.  Called when the first OOB
+ * domain is created; the resources persist across domain churn and are torn
+ * down when the last domain is released (library) / at module destruct
+ * (keyval) / at component close (request free list).
+ */
+static int mca_coll_ucc_lib_init(void)
 {
     mca_coll_ucc_component_t     *cm = &mca_coll_ucc_component;
-    char                          str_buf[256];
     ompi_attribute_fn_ptr_union_t del_fn;
     ompi_attribute_fn_ptr_union_t copy_fn;
     ucc_lib_config_h              lib_config;
-    ucc_context_config_h          ctx_config;
     ucc_thread_mode_t             tm_requested;
     ucc_lib_params_t              lib_params;
-    ucc_context_params_t          ctx_params;
-    unsigned                      ucc_api_major, ucc_api_minor, ucc_api_patch;
-
-    ucc_get_version(&ucc_api_major, &ucc_api_minor, &ucc_api_patch);
 
     tm_requested           = ompi_mpi_thread_multiple ? UCC_THREAD_MULTIPLE :
                                                         UCC_THREAD_SINGLE;
@@ -284,7 +384,6 @@ static int mca_coll_ucc_init_ctx(ompi_communicator_t* comm)
     if (UCC_OK != ucc_init(&lib_params, lib_config, &cm->ucc_lib)) {
         UCC_ERROR("UCC lib init failed");
         ucc_lib_config_release(lib_config);
-        cm->ucc_enable = 0;
         return OMPI_ERROR;
     }
     ucc_lib_config_release(lib_config);
@@ -300,30 +399,108 @@ static int mca_coll_ucc_init_ctx(ompi_communicator_t* comm)
         UCC_ERROR("UCC library doesn't support MPI_THREAD_MULTIPLE");
         goto cleanup_lib;
     }
-    ctx_params.mask             = UCC_CONTEXT_PARAM_FIELD_OOB;
-    ctx_params.oob.allgather    = oob_allgather;
-    ctx_params.oob.req_test     = oob_allgather_test;
-    ctx_params.oob.req_free     = oob_allgather_free;
-    ctx_params.oob.coll_info    = (void*)comm;
-    ctx_params.oob.n_oob_eps    = ompi_comm_size(comm);
-    ctx_params.oob.oob_ep       = ompi_comm_rank(comm);
-    if (UCC_OK != ucc_context_config_read(cm->ucc_lib, NULL, &ctx_config)) {
-        UCC_ERROR("UCC context config read failed");
-        goto cleanup_lib;
+
+    if (!cm->requests_initialized) {
+        OBJ_CONSTRUCT(&cm->requests, opal_free_list_t);
+        opal_free_list_init(&cm->requests, sizeof(mca_coll_ucc_req_t),
+                            opal_cache_line_size, OBJ_CLASS(mca_coll_ucc_req_t),
+                            0, 0,                     /* no payload data */
+                            8, -1, 8,                 /* num_to_alloc, max, per alloc */
+                            NULL, 0, NULL, NULL, NULL /* no Mpool or init function */);
+        cm->requests_initialized = true;
     }
 
-    snprintf(str_buf, sizeof(str_buf), "%u", ompi_proc_world_size());
+    if (!cm->keyval_created) {
+        copy_fn.attr_communicator_copy_fn  = MPI_COMM_NULL_COPY_FN;
+        del_fn.attr_communicator_delete_fn = ucc_comm_attr_del_fn;
+        if (OMPI_SUCCESS != ompi_attr_create_keyval(COMM_ATTR, copy_fn, del_fn,
+                                                    &ucc_comm_attr_keyval, NULL, 0, NULL)) {
+            UCC_ERROR("UCC comm keyval create failed");
+            goto cleanup_lib;
+        }
+        cm->keyval_created = true;
+    }
+
+    UCC_VERBOSE(1, "initialized ucc library");
+    return OMPI_SUCCESS;
+
+cleanup_lib:
+    ucc_finalize(cm->ucc_lib);
+    cm->ucc_lib = NULL;
+    return OMPI_ERROR;
+}
+
+/*
+ * Create a new OOB domain (and its UCC context) bootstrapped over @comm.
+ * The OOB is bound to the domain (coll_info = domain), and the domain takes
+ * its own reference to @comm so the OOB communicator stays valid for the
+ * whole life of the context even if the user frees its handle to @comm.
+ */
+static int mca_coll_ucc_domain_create(ompi_communicator_t *comm,
+                                      mca_coll_ucc_oob_domain_t **domain_out)
+{
+    mca_coll_ucc_component_t   *cm = &mca_coll_ucc_component;
+    mca_coll_ucc_oob_domain_t  *domain = NULL;
+    ucc_context_config_h        ctx_config;
+    ucc_context_params_t        ctx_params;
+    char                        str_buf[256];
+    unsigned                    ucc_api_major, ucc_api_minor, ucc_api_patch;
+    bool                        first = (0 == cm->domain_count);
+
+    ucc_get_version(&ucc_api_major, &ucc_api_minor, &ucc_api_patch);
+
+    /* The shared UCC library is created together with the first domain. */
+    if (first) {
+        if (OMPI_SUCCESS != mca_coll_ucc_lib_init()) {
+            return OMPI_ERROR;
+        }
+    }
+
+    domain = OBJ_NEW(mca_coll_ucc_oob_domain_t);
+    if (NULL == domain) {
+        goto cleanup_lib;
+    }
+    /* The context can outlive the user's handle to the bootstrap comm, so the
+       domain keeps its own reference to it for the OOB (released in
+       mca_coll_ucc_domain_release once the context is destroyed).  Intrinsic
+       communicators (MPI_COMM_WORLD) are an exception: they live until
+       MPI_Finalize and are torn down with OBJ_DESTRUCT, during which this
+       domain is released -- taking/dropping a reference on a communicator
+       while it is being destructed is both unnecessary (it is never freed
+       early) and unsafe, so we simply borrow it. */
+    if (!OMPI_COMM_IS_INTRINSIC(comm)) {
+        OBJ_RETAIN(comm);
+    }
+    domain->comm     = comm;
+    domain->refcount = 1;
+
+    ctx_params.mask          = UCC_CONTEXT_PARAM_FIELD_OOB;
+    ctx_params.oob.allgather = oob_allgather;
+    ctx_params.oob.req_test  = oob_allgather_test;
+    ctx_params.oob.req_free  = oob_allgather_free;
+    /* coll_info is the domain, not the comm: the OOB callbacks reach the
+       retained bootstrap communicator through domain->comm. */
+    ctx_params.oob.coll_info = (void*)domain;
+    ctx_params.oob.n_oob_eps = ompi_comm_size(comm);
+    ctx_params.oob.oob_ep    = ompi_comm_rank(comm);
+
+    if (UCC_OK != ucc_context_config_read(cm->ucc_lib, NULL, &ctx_config)) {
+        UCC_ERROR("UCC context config read failed");
+        goto cleanup_domain;
+    }
+
+    snprintf(str_buf, sizeof(str_buf), "%u", (unsigned)ompi_comm_size(comm));
     if (UCC_OK != ucc_context_config_modify(ctx_config, NULL, "ESTIMATED_NUM_EPS",
                                             str_buf)) {
         UCC_ERROR("UCC context config modify failed for estimated_num_eps");
-        goto cleanup_lib;
+        goto cleanup_config;
     }
 
     snprintf(str_buf, sizeof(str_buf), "%u", opal_process_info.num_local_peers + 1);
     if (UCC_OK != ucc_context_config_modify(ctx_config, NULL, "ESTIMATED_NUM_PPN",
                                             str_buf)) {
-        UCC_ERROR("UCC context config modify failed for estimated_num_eps");
-        goto cleanup_lib;
+        UCC_ERROR("UCC context config modify failed for estimated_num_ppn");
+        goto cleanup_config;
     }
 
     if (ucc_api_major > 1 || (ucc_api_major == 1 && ucc_api_minor >= 6)) {
@@ -331,77 +508,117 @@ static int mca_coll_ucc_init_ctx(ompi_communicator_t* comm)
         if (UCC_OK != ucc_context_config_modify(ctx_config, NULL, "NODE_LOCAL_ID",
                                                 str_buf)) {
             UCC_ERROR("UCC context config modify failed for node_local_id");
-            goto cleanup_lib;
+            goto cleanup_config;
         }
     }
 
-    if (UCC_OK != ucc_context_create(cm->ucc_lib, &ctx_params,
-                                     ctx_config, &cm->ucc_context)) {
+    if (UCC_OK != ucc_context_create(cm->ucc_lib, &ctx_params, ctx_config,
+                                     &domain->ucc_context)) {
         UCC_ERROR("UCC context create failed");
-        ucc_context_config_release(ctx_config);
-        goto cleanup_lib;
+        goto cleanup_config;
     }
     ucc_context_config_release(ctx_config);
 
-    copy_fn.attr_communicator_copy_fn  = MPI_COMM_NULL_COPY_FN;
-    del_fn.attr_communicator_delete_fn = ucc_comm_attr_del_fn;
-    if (OMPI_SUCCESS != ompi_attr_create_keyval(COMM_ATTR, copy_fn, del_fn,
-                                                &ucc_comm_attr_keyval, NULL ,0, NULL)) {
-        UCC_ERROR("UCC comm keyval create failed");
-        goto cleanup_ctx;
+    opal_list_append(&cm->domains, &domain->super);
+    if (first) {
+        opal_progress_register(mca_coll_ucc_progress);
     }
+    cm->domain_count++;
 
-    OBJ_CONSTRUCT(&cm->requests, opal_free_list_t);
-    opal_free_list_init(&cm->requests, sizeof(mca_coll_ucc_req_t),
-                        opal_cache_line_size, OBJ_CLASS(mca_coll_ucc_req_t),
-                        0, 0,                     /* no payload data */
-                        8, -1, 8,                 /* num_to_alloc, max, per alloc */
-                        NULL, 0, NULL, NULL, NULL /* no Mpool or init function */);
-
-    opal_progress_register(mca_coll_ucc_progress);
-    UCC_VERBOSE(1, "initialized ucc context");
-    cm->libucc_initialized = true;
+    UCC_VERBOSE(1, "created ucc oob domain %p for comm %p (size %d)",
+                (void*)domain, (void*)comm, ompi_comm_size(comm));
+    *domain_out = domain;
     return OMPI_SUCCESS;
-cleanup_ctx:
-    ucc_context_destroy(cm->ucc_context);
 
+cleanup_config:
+    ucc_context_config_release(ctx_config);
+cleanup_domain:
+    /* Undo the bootstrap-comm reference taken above (non-intrinsic only). */
+    if (!OMPI_COMM_IS_INTRINSIC(domain->comm)) {
+        OBJ_RELEASE(domain->comm);
+    }
+    OBJ_RELEASE(domain);
 cleanup_lib:
-    ucc_finalize(cm->ucc_lib);
-    cm->ucc_enable         = 0;
-    cm->libucc_initialized = false;
+    /* Only undo the library init if this call created it. */
+    if (first) {
+        ucc_finalize(cm->ucc_lib);
+        cm->ucc_lib = NULL;
+    }
     return OMPI_ERROR;
 }
 
-static uint64_t rank_map_cb(uint64_t ep, void *cb_ctx)
+/* UCC team ep_map backing-array callback: translate a team endpoint (a rank in
+   the team's communicator) into a UCC context endpoint by indexing the
+   precomputed array of bootstrap-communicator ranks. */
+static uint64_t ep_map_array_cb(uint64_t ep, void *cb_ctx)
 {
-    struct ompi_communicator_t *comm = cb_ctx;
-
-    return ((ompi_process_name_t*)&ompi_comm_peer_lookup(comm, ep)->super.
-            proc_name)->vpid;
+    return (uint64_t)((const int *)cb_ctx)[ep];
 }
 
-static inline ucc_ep_map_t get_rank_map(struct ompi_communicator_t *comm)
+/*
+ * Build the UCC team ep_map for @comm relative to the domain's bootstrap
+ * communicator @boot_comm.
+ *
+ * A UCC context numbers its endpoints by the OOB ep index used when the
+ * context was created, which is the process's rank in the bootstrap
+ * communicator (see mca_coll_ucc_domain_create: oob_ep = rank in boot_comm).
+ * A team must therefore address its members by their bootstrap-communicator
+ * rank, not by any global identifier.  Mapping team rank r -> rank of that
+ * same process in boot_comm is exactly what ompi_group_translate_ranks gives
+ * us.
+ *
+ * Using the global vpid (as earlier revisions did) happens to work only when
+ * the context was bootstrapped over MPI_COMM_WORLD, where vpid == boot_comm
+ * rank == context endpoint.  Over a subset bootstrap communicator -- e.g. an
+ * MPI Sessions "half" created with MPI_Comm_create_from_group -- the vpid is
+ * out of range for the context's endpoint table and the transport crashes
+ * (segfault in ucp_tag_send deep under ucc_team_create_test).
+ *
+ * If the resulting map needs a backing array (an arbitrary, non-strided
+ * permutation) it is returned in *array_out, which the caller must keep alive
+ * for the team's lifetime and free afterwards; otherwise *array_out is NULL.
+ */
+static ucc_ep_map_t get_rank_map(struct ompi_communicator_t *comm,
+                                 struct ompi_communicator_t *boot_comm,
+                                 int **array_out)
 {
     ucc_ep_map_t map;
-    int64_t      r1, r2, stride;
-    uint64_t     i;
-    int          is_strided;
+    int          size = ompi_comm_size(comm);
+    int         *ranks, *boot_ranks;
+    int          i, stride, is_strided;
 
-    map.ep_num = ompi_comm_size(comm);
-    if (comm == &ompi_mpi_comm_world.comm) {
+    *array_out = NULL;
+    map.ep_num = size;
+
+    /* The communicator that bootstrapped the context maps onto it identically. */
+    if (comm == boot_comm) {
         map.type = UCC_EP_MAP_FULL;
         return map;
     }
 
-    /* try to detect strided pattern */
+    ranks      = malloc((size_t)size * sizeof(int));
+    boot_ranks = malloc((size_t)size * sizeof(int));
+    if ((NULL == ranks) || (NULL == boot_ranks)) {
+        free(ranks);
+        free(boot_ranks);
+        UCC_ERROR("failed to allocate ucc ep map translation arrays");
+        map.type = UCC_EP_MAP_FULL;
+        return map;
+    }
+    for (i = 0; i < size; i++) {
+        ranks[i] = i;
+    }
+    /* team rank i -> its rank in the bootstrap communicator (context endpoint) */
+    ompi_group_translate_ranks(comm->c_local_group, size, ranks,
+                               boot_comm->c_local_group, boot_ranks);
+    free(ranks);
+
+    /* Detect a strided pattern (covers contiguous halves, reversed orders,
+       etc.) so we can avoid keeping a backing array around. */
+    stride     = (size > 1) ? (boot_ranks[1] - boot_ranks[0]) : 1;
     is_strided = 1;
-    r1         = rank_map_cb(0, comm);
-    r2         = rank_map_cb(1, comm);
-    stride     = r2 - r1;
-    for (i = 2; i < map.ep_num; i++) {
-        r1 = r2;
-        r2 = rank_map_cb(i, comm);
-        if (r2 - r1 != stride) {
+    for (i = 2; i < size; i++) {
+        if (boot_ranks[i] - boot_ranks[i - 1] != stride) {
             is_strided = 0;
             break;
         }
@@ -409,14 +626,18 @@ static inline ucc_ep_map_t get_rank_map(struct ompi_communicator_t *comm)
 
     if (is_strided) {
         map.type           = UCC_EP_MAP_STRIDED;
-        map.strided.start  = r1;
-        map.strided.stride = stride;
-    } else {
-        map.type      = UCC_EP_MAP_CB;
-        map.cb.cb     = rank_map_cb;
-        map.cb.cb_ctx = (void*)comm;
+        map.strided.start  = (uint64_t)boot_ranks[0];
+        map.strided.stride = (int64_t)stride;
+        free(boot_ranks);
+        return map;
     }
 
+    /* Arbitrary permutation: address the context through the translation array
+       (kept alive by the caller via *array_out). */
+    map.type      = UCC_EP_MAP_CB;
+    map.cb.cb     = ep_map_array_cb;
+    map.cb.cb_ctx = (void *)boot_ranks;
+    *array_out    = boot_ranks;
     return map;
 }
 
@@ -475,27 +696,29 @@ static int mca_coll_ucc_replace_coll_handlers(mca_coll_ucc_module_t *ucc_module)
 static int mca_coll_ucc_module_enable(mca_coll_base_module_t *module,
                                       struct ompi_communicator_t *comm)
 {
-    mca_coll_ucc_component_t *cm         = &mca_coll_ucc_component;
-    mca_coll_ucc_module_t    *ucc_module = (mca_coll_ucc_module_t *)module;
-    ucc_status_t              status;
+    mca_coll_ucc_component_t  *cm         = &mca_coll_ucc_component;
+    mca_coll_ucc_module_t     *ucc_module = (mca_coll_ucc_module_t *)module;
+    mca_coll_ucc_oob_domain_t *domain     = ucc_module->domain;
+    ucc_status_t               status;
     int rc;
-    ucc_team_params_t team_params = {
-        .mask   = UCC_TEAM_PARAM_FIELD_EP_MAP   |
-                  UCC_TEAM_PARAM_FIELD_EP       |
-                  UCC_TEAM_PARAM_FIELD_EP_RANGE,
-        .ep_map = {
-            .type      = (comm == &ompi_mpi_comm_world.comm) ?
-                          UCC_EP_MAP_FULL : UCC_EP_MAP_CB,
-            .ep_num    = ompi_comm_size(comm),
-            .cb.cb     = rank_map_cb,
-            .cb.cb_ctx = (void*)comm
-        },
-        .ep       = ompi_comm_rank(comm),
-        .ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG
-    };
+    /* Team create is collective over this communicator and addresses into the
+       (possibly shared) context through an ep map; it does not run the OOB, so
+       it needs no per-team OOB and works even when this communicator is a
+       subset or reordering of the domain's bootstrap communicator.  The ep map
+       must translate team ranks into context endpoints, i.e. into ranks of the
+       domain's bootstrap communicator (see get_rank_map). */
+    ucc_team_params_t team_params;
+
+    team_params.mask     = UCC_TEAM_PARAM_FIELD_EP_MAP |
+                           UCC_TEAM_PARAM_FIELD_EP     |
+                           UCC_TEAM_PARAM_FIELD_EP_RANGE;
+    team_params.ep_map   = get_rank_map(comm, domain->comm,
+                                        &ucc_module->ep_map_ranks);
+    team_params.ep       = ompi_comm_rank(comm);
+    team_params.ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG;
     if (OMPI_COMM_IS_GLOBAL_INDEX(comm)) {
-	team_params.mask |= UCC_TEAM_PARAM_FIELD_ID;
-	team_params.id    = ompi_comm_get_local_cid(comm);
+	    team_params.mask |= UCC_TEAM_PARAM_FIELD_ID;
+	    team_params.id    = ompi_comm_get_local_cid(comm);
         UCC_VERBOSE(2, "creating ucc_team for comm %p, comm_id %llu, comm_size %d",
                     (void*)comm, (long long unsigned)team_params.id,
                     ompi_comm_size(comm));
@@ -504,7 +727,7 @@ static int mca_coll_ucc_module_enable(mca_coll_base_module_t *module,
                     (void*)comm, ompi_comm_size(comm));
     }
 
-    if (UCC_OK != ucc_team_create_post(&cm->ucc_context, 1,
+    if (UCC_OK != ucc_team_create_post(&domain->ucc_context, 1,
                                        &team_params, &ucc_module->ucc_team)) {
         UCC_ERROR("ucc_team_create_post failed");
         goto err;
@@ -533,9 +756,19 @@ static int mca_coll_ucc_module_enable(mca_coll_base_module_t *module,
     return OMPI_SUCCESS;
 
 err:
-    ucc_module->ucc_team = NULL;
+    /* The attribute was never successfully set on this path, so the comm free
+       callback will not run for this module: tear down the team (if any) and
+       release the OOB domain reference here.  domain_release also unregisters
+       progress / finalizes the library if this was the last domain. */
+    if (NULL != ucc_module->ucc_team) {
+        while (UCC_INPROGRESS == ucc_team_destroy(ucc_module->ucc_team)) {
+            opal_progress();
+        }
+        ucc_module->ucc_team = NULL;
+    }
+    mca_coll_ucc_domain_release(ucc_module->domain);
+    ucc_module->domain   = NULL;
     cm->ucc_enable       = 0;
-    opal_progress_unregister(mca_coll_ucc_progress);
     return OMPI_ERROR;
 }
 
@@ -616,8 +849,10 @@ mca_coll_ucc_module_disable(mca_coll_base_module_t *module,
 mca_coll_base_module_t *
 mca_coll_ucc_comm_query(struct ompi_communicator_t *comm, int *priority)
 {
-    mca_coll_ucc_component_t *cm = &mca_coll_ucc_component;
-    mca_coll_ucc_module_t    *ucc_module;
+    mca_coll_ucc_component_t  *cm = &mca_coll_ucc_component;
+    mca_coll_ucc_module_t     *ucc_module;
+    mca_coll_ucc_oob_domain_t *domain = NULL;
+    ompi_communicator_t       *parent;
     *priority = 0;
 
     if (!cm->ucc_enable){
@@ -629,8 +864,31 @@ mca_coll_ucc_comm_query(struct ompi_communicator_t *comm, int *priority)
         return NULL;
     }
 
-    if (!cm->libucc_initialized) {
-        if (OMPI_SUCCESS != mca_coll_ucc_init_ctx(comm)) {
+    /*
+     * Domain discovery.  The base makes the parent communicator available on
+     * comm->c_coll->parent for the duration of selection (NULL for the paths
+     * that have no usable parent context: MPI_Comm_create_from_group and
+     * MPI_Intercomm_merge).  If the parent has a UCC module with an OOB
+     * domain, inherit it: the new communicator is a subset/reordering of its
+     * parent, so it is compatible with the parent's context through the ep
+     * map, and the whole family shares one heavyweight context.  Otherwise
+     * bootstrap a fresh domain over this communicator.
+     */
+    parent = comm->c_coll->parent;
+    if (cm->keyval_created && NULL != parent && parent != comm &&
+        NULL != parent->c_keyhash) {
+        int                    flag = 0;
+        mca_coll_ucc_module_t *parent_module = NULL;
+        if (OMPI_SUCCESS == ompi_attr_get_c(parent->c_keyhash, ucc_comm_attr_keyval,
+                                            (void **)&parent_module, &flag)
+            && flag && NULL != parent_module && NULL != parent_module->domain) {
+            domain = parent_module->domain;
+            domain->refcount++;
+        }
+    }
+
+    if (NULL == domain) {
+        if (OMPI_SUCCESS != mca_coll_ucc_domain_create(comm, &domain)) {
             cm->ucc_enable = 0;
             return NULL;
         }
@@ -638,10 +896,12 @@ mca_coll_ucc_comm_query(struct ompi_communicator_t *comm, int *priority)
 
     ucc_module = OBJ_NEW(mca_coll_ucc_module_t);
     if (!ucc_module) {
+        mca_coll_ucc_domain_release(domain);
         cm->ucc_enable = 0;
         return NULL;
     }
     ucc_module->comm                      = comm;
+    ucc_module->domain                    = domain;
     ucc_module->super.coll_module_enable  = mca_coll_ucc_module_enable;
     ucc_module->super.coll_module_disable = mca_coll_ucc_module_disable;
     *priority                             = cm->ucc_priority;
@@ -656,6 +916,9 @@ OBJ_CLASS_INSTANCE(mca_coll_ucc_module_t,
                    mca_coll_ucc_module_destruct);
 
 OBJ_CLASS_INSTANCE(mca_coll_ucc_req_t, ompi_request_t,
+                   NULL, NULL);
+
+OBJ_CLASS_INSTANCE(mca_coll_ucc_oob_domain_t, opal_list_item_t,
                    NULL, NULL);
 
 int mca_coll_ucc_req_free(struct ompi_request_t **ompi_req)
@@ -673,6 +936,11 @@ int mca_coll_ucc_req_free(struct ompi_request_t **ompi_req)
             }
         }
     }
+    /* Reset the request to the invalid state (and drop any f2c handle)
+       before handing it back to the free list.  Without this the item is
+       returned still marked active/inactive, and ompi_request_destruct()
+       asserts on it when the free list is torn down at component close. */
+    OMPI_REQUEST_FINI(*ompi_req);
     opal_free_list_return (&mca_coll_ucc_component.requests,
                            (opal_free_list_item_t *)(*ompi_req));
     *ompi_req = MPI_REQUEST_NULL;

--- a/ompi/mca/coll/ucc/coll_ucc_reduce.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,7 +76,7 @@ int mca_coll_ucc_reduce(const void *sbuf, void* rbuf, size_t count,
     COLL_UCC_CHECK(mca_coll_ucc_reduce_init_common(sbuf, rbuf, count, dtype, op,
                                                    root, false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce");

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -88,7 +88,7 @@ int mca_coll_ucc_reduce_scatter(const void *sbuf, void *rbuf, ompi_count_array_t
     COLL_UCC_CHECK(mca_coll_ucc_reduce_scatter_init_common(sbuf, rbuf, rcounts, dtype,
                                                            op, false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce_scatter");

--- a/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
+++ b/ompi/mca/coll/ucc/coll_ucc_reduce_scatter_block.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -84,7 +84,7 @@ int mca_coll_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, size_t rcoun
                                                                  dtype, op, false, ucc_module,
                                                                  &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback reduce_scatter_block");

--- a/ompi/mca/coll/ucc/coll_ucc_scatter.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatter.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -98,7 +98,7 @@ int mca_coll_ucc_scatter(const void *sbuf, size_t scount,
                                                     rdtype, root, false, ucc_module, &req,
                                                     NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback scatter");

--- a/ompi/mca/coll/ucc/coll_ucc_scatterv.c
+++ b/ompi/mca/coll/ucc/coll_ucc_scatterv.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2021 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+ * Copyright (c) 2022-2026 NVIDIA Corporation. All rights reserved.
  * Copyright (c) 2025      Fujitsu Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -91,7 +91,7 @@ int mca_coll_ucc_scatterv(const void *sbuf, ompi_count_array_t scounts,
                                                      rbuf, rcount, rdtype, root,
                                                      false, ucc_module, &req, NULL));
     COLL_UCC_POST_AND_CHECK(req);
-    COLL_UCC_CHECK(coll_ucc_req_wait(req));
+    COLL_UCC_CHECK(coll_ucc_req_wait(req, ucc_module));
     return OMPI_SUCCESS;
 fallback:
     UCC_VERBOSE(3, "running fallback scatterv");

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2021-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -606,13 +607,13 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
        function else), but before dpm.dyncom_init, since this function
        might require collective for the CID allocation. */
     if (OMPI_SUCCESS !=
-        (ret = mca_coll_base_comm_select(MPI_COMM_WORLD))) {
+        (ret = mca_coll_base_comm_select(MPI_COMM_WORLD, NULL))) {
         error = "mca_coll_base_comm_select(MPI_COMM_WORLD) failed";
         goto error;
     }
 
     if (OMPI_SUCCESS !=
-        (ret = mca_coll_base_comm_select(MPI_COMM_SELF))) {
+        (ret = mca_coll_base_comm_select(MPI_COMM_SELF, NULL))) {
         error = "mca_coll_base_comm_select(MPI_COMM_SELF) failed";
         goto error;
     }


### PR DESCRIPTION
UCC previously bootstrapped a single, process-global UCC context whose out-of-band (OOB) channel was bound to MPI_COMM_WORLD, and built every team on that context using an endpoint map into the world rank space. That only works when the context's bootstrap communicator spans every process any team will ever reach -- true for MPI_COMM_WORLD, but not for communicators created from MPI Sessions process sets, which may include processes outside MPI_COMM_WORLD and have no single longest-lived member. A pset team would either bootstrap over the wrong OOB or, once an ancestor communicator was freed, drive the context OOB over a destroyed communicator (use-after-free at context/team teardown).

Move the OOB from the context to the team.  The shared UCC context is now created without a context-level OOB; each communicator builds its team with its own OOB, exchanged over that communicator via PML point-to-point.  Because the OOB is the team's own communicator -- alive both when the team is created (module enable) and when it is destroyed (synchronously inside the collective MPI_Comm_free, before the communicator is torn down) -- the context and its teams no longer depend on any other communicator's lifetime, and teardown is correct regardless of the order in which communicators are freed.  An OOB-less context establishes no global membership of its own, so a single shared context can host teams over arbitrary process sets (subsets of, supersets of, or disjoint from MPI_COMM_WORLD): the whole job keeps exactly one shared context as before while also working under the Sessions model.

The shared context, the UCC library and the collective request free list now share one lazy create point (the first UCC communicator) and one teardown point (the last UCC communicator freed).  The request free list must not be destructed while the context is still valid -- its items are requests built on that context -- so it is released in the context teardown rather than at component close.  Returning a request to the free list now finalizes the embedded MPI request (OMPI_REQUEST_FINI), leaving recycled items in the destructible INVALID state; without it the free list destructor tripped over requests left INACTIVE.

The full story

### UCC context lifetime — current approach (with focus on the session model)
#### The core abstraction: an "OOB domain"
A UCC context is heavyweight (it wires up transport endpoints, pins memory, etc.), so the component does not create one per communicator. Instead it introduces an intermediary, mca_coll_ucc_oob_domain_t, that owns exactly:
 - one ucc_context_h, and
 - the bootstrap communicator that backs the context's out-of-band (OOB) channel.

Every UCC-enabled communicator (mca_coll_ucc_module_t) points at a domain and creates its own lightweight ucc_team_h inside that domain's context. A whole family of communicators shares one domain (one context), and each team addresses into the shared context through an ep map.

#### Why the session model forces this design
In the world model there is always an MPI_COMM_WORLD that lives until MPI_Finalize, so a context bootstrapped over WORLD is effectively immortal and spans every rank — any subset communicator is trivially addressable inside it. While this is mostly true, special care need to be taken for spawn, where we fall back on the same approach as for sessions.

The session model has no MPI_COMM_WORLD. The first communicator that needs UCC is whatever the user derives from a process set — e.g. MPI_Comm_create_from_group over a subset of the job. That means:

 - **The context may be bootstrapped over a subset of ranks**, not the whole job. The domain's bootstrap communicator is simply "the communicator that first needed a domain," and the context's endpoints are numbered by rank within that bootstrap communicator (this is exactly what the ep-map fix accounts for).

 - **The context can outlive the user's handle to the communicator that created it**. A user can legitimately free the bootstrap communicator while communicators derived from it are still alive and still using the context.

#### Domain discovery / sharing (refcount)
When a new communicator is selected (mca_coll_ucc_comm_query):

 - The base exposes the parent communicator on `comm->c_coll->parent`. If the parent has a UCC module with a domain, the child inherits that domain (`domain->refcount++`). A child is always a subset/reordering of its parent, so it is representable in the parent's context via the ep map. The whole family thus reuses one context.
 - Paths with no usable parent context — MPI_Comm_create_from_group and MPI_Intercomm_merge — bootstrap a fresh domain over the new communicator, because no existing context is guaranteed to span their ranks. (In the session test, comm_a and each merged become fresh bootstrap communicators / domains.)

#### Keeping the OOB alive: the retained bootstrap reference
The OOB channel is only used at two moments: an allgather at context creation, and again at context teardown. Both run over the bootstrap communicator. To guarantee that communicator is valid for the context's entire life — even if the user frees their handle to it early — the domain takes its own reference:
```c
coll_ucc_module.c
Lines 466-470
    if (!OMPI_COMM_IS_INTRINSIC(comm)) {
        OBJ_RETAIN(comm);
    }
    domain->comm     = comm;
    domain->refcount = 1;
```

Intrinsic communicators (`MPI_COMM_WORLD`) are the exception: they live until finalize and are torn down by OBJ_DESTRUCT, so retaining/releasing them during that teardown is both unnecessary and unsafe — they're just borrowed. In the session model the bootstrap communicators are not intrinsic, so the retain/release path is the one that matters, and it is what makes "free the creator while derived comms live on" safe. The OOB code fails loudly rather than touching a freed comm if that invariant is ever violated:

```c
coll_ucc_module.c
Lines 274-277
    if (NULL == comm) {
        UCC_ERROR("UCC OOB invoked after its bootstrap communicator was freed");
        ompi_rte_abort(1, "coll/ucc: OOB used after bootstrap communicator was freed");
    }
```

#### Teardown ordering
Teardown is split between two collective points, both reached consistently on every rank:

 - **Per-communicator (team) teardown** happens in the communicator's attribute-delete callback (ucc_comm_attr_del_fn), invoked synchronously inside the collective MPI_Comm_free/MPI_Comm_disconnect. ucc_team_destroy is collective over the team's ranks (this communicator), not over the OOB, so a subset/reordered communicator can be destroyed independently of the bootstrap comm. Then it drops one domain reference.

 - **Domain (context) teardown** happens in mca_coll_ucc_domain_release when the last reference is dropped: it destroys the context (which may itself drive the OOB — safe, thanks to the retained bootstrap comm), releases the retained bootstrap-comm reference, and — when the last domain in the process goes away — finalizes the shared ucc_lib and unregisters the progress callback.

This decoupling is the key property the session test stresses: because the team and the context have **separate lifetimes**, you can

 - free the communicator that bootstrapped a domain while derived communicators (and thus the context) stay alive ("frozen" domain), and
 - destroy a team after its domain's bootstrap communicator handle is already gone (team destroy uses the team's own ranks, while any context-level OOB still has the retained comm),
 
without use-after-free. The recently fixed ep map is the complementary piece: it lets each team correctly address its members as endpoints of a context that may have been bootstrapped over only a subset of the job — the situation that is normal in the session model and impossible to avoid there.