### PR TITLE
Fix scheduled CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,8 +6,11 @@
 #
 # $HEADER$
 #
-# CodeQL configuration for Open MPI, referenced by both analysis jobs
-# in .github/workflows/codeql.yml via their `config-file:` input.
+# CodeQL configuration for Open MPI.  Push / PR scans load this file
+# locally from the checked-out branch.  The scheduled cross-branch scan
+# loads this same file from the default branch via CodeQL's remote
+# config-file syntax, so the release-branch scans do not require a local
+# copy of this file to already exist.
 
 name: "Open MPI CodeQL config"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -145,8 +145,54 @@ jobs:
           make -j $(nproc)
 
       - name: Perform CodeQL Analysis
+        if: matrix.language != 'c-cpp'
         uses: github/codeql-action/analyze@v4
         with:
+          category: "/language:${{ matrix.language }}"
+
+      # CodeQL's paths-ignore setting does not filter C/C++ code that is
+      # compiled by a manual build.  Open MPI's normal build compiles
+      # bundled third-party projects, which gives CodeQL complete build
+      # context but can also produce alerts in code we do not maintain.
+      # For C/C++ only, write SARIF locally, remove alerts whose primary
+      # locations are under 3rd-party/, and then upload the filtered SARIF.
+      - name: Perform CodeQL Analysis
+        if: matrix.language == 'c-cpp'
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+          output: c-cpp-sarif-results
+          upload: failure-only
+
+      - name: Locate C/C++ SARIF
+        if: matrix.language == 'c-cpp'
+        id: cpp_sarif
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          sarif_files=(c-cpp-sarif-results/*.sarif)
+          if test ${#sarif_files[@]} -ne 1; then
+              echo "::error::Expected one C/C++ SARIF file, found ${#sarif_files[@]}"
+              exit 1
+          fi
+          echo "file=${sarif_files[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Filter third-party C/C++ SARIF results
+        if: matrix.language == 'c-cpp'
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -3rd-party/**
+            -**/3rd-party/**
+          input: ${{ steps.cpp_sarif.outputs.file }}
+          output: ${{ steps.cpp_sarif.outputs.file }}
+
+      - name: Upload filtered C/C++ SARIF
+        if: matrix.language == 'c-cpp'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.cpp_sarif.outputs.file }}
           category: "/language:${{ matrix.language }}"
 
   # -------------------------------------------------------------------
@@ -215,6 +261,7 @@ jobs:
           make -j $(nproc)
 
       - name: Perform CodeQL Analysis
+        if: matrix.language != 'c-cpp'
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
@@ -223,6 +270,62 @@ jobs:
           # against).  The category is keyed on language only -- NOT on
           # branch -- so each branch's results update in place and the
           # weekly main scan stays consistent with its push/PR scans.
+          ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.commit.outputs.sha }}
+
+      # CodeQL's paths-ignore setting does not filter C/C++ code that is
+      # compiled by a manual build.  Open MPI's normal build compiles
+      # bundled third-party projects, which gives CodeQL complete build
+      # context but can also produce alerts in code we do not maintain.
+      # For C/C++ only, write SARIF locally, remove alerts whose primary
+      # locations are under 3rd-party/, and then upload the filtered SARIF.
+      - name: Perform CodeQL Analysis
+        if: matrix.language == 'c-cpp'
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+          output: c-cpp-sarif-results
+          upload: failure-only
+          # Attribute results to the checked-out branch rather than to
+          # main (which is what a schedule event would otherwise report
+          # against).  The category is keyed on language only -- NOT on
+          # branch -- so each branch's results update in place and the
+          # weekly main scan stays consistent with its push/PR scans.
+          ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.commit.outputs.sha }}
+
+      - name: Locate C/C++ SARIF
+        if: matrix.language == 'c-cpp'
+        id: cpp_sarif
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          sarif_files=(c-cpp-sarif-results/*.sarif)
+          if test ${#sarif_files[@]} -ne 1; then
+              echo "::error::Expected one C/C++ SARIF file, found ${#sarif_files[@]}"
+              exit 1
+          fi
+          echo "file=${sarif_files[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Filter third-party C/C++ SARIF results
+        if: matrix.language == 'c-cpp'
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -3rd-party/**
+            -**/3rd-party/**
+          input: ${{ steps.cpp_sarif.outputs.file }}
+          output: ${{ steps.cpp_sarif.outputs.file }}
+
+      - name: Upload filtered C/C++ SARIF
+        if: matrix.language == 'c-cpp'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.cpp_sarif.outputs.file }}
+          category: "/language:${{ matrix.language }}"
+          # Match the scheduled analyze attribution above when uploading
+          # the filtered SARIF.
           ref: refs/heads/${{ matrix.branch }}
           sha: ${{ steps.commit.outputs.sha }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,15 +47,18 @@
 #     release branches (it never fires there); only the copy on main
 #     drives the weekly scans.
 #
-# Why inline (and not a composite action or reusable workflow): the two
-# jobs below intentionally duplicate the init / build / analyze steps.
+# Why mostly inline (and not a composite action or reusable workflow):
+# the two jobs below intentionally duplicate the init / build / analyze
+# steps.
 # Because per-branch CI requires this file to be cherry-picked onto each
-# release branch anyway, a single self-contained file (one file per
-# branch, with nothing else to keep in sync) is simpler than factoring
-# the shared steps out. Sharing them would not buy a cross-branch single
-# source of truth, and a local composite action would actually break the
-# weekly scan, since `uses: ./...` resolves from the checked-out branch
-# rather than from main.
+# release branch anyway, keeping the workflow logic here is simpler than
+# factoring the shared steps out. Sharing them would not buy a
+# cross-branch single source of truth, and local workflow/action paths
+# would actually break the weekly scan, since they resolve from the
+# checked-out branch rather than from main. The CodeQL config sidecar is
+# the exception: the scheduled job uses CodeQL's remote config-file
+# syntax to load the sidecar file from main, so the config stays
+# single-sourced while the analyzed worktree is a release branch.
 #
 # We started running CodeQL on the main, v5.0.x, and v6.0.x branches in
 # June 2026.  Subsequent release branches are matched by the branch
@@ -200,7 +203,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          config-file: ./.github/codeql/codeql-config.yml
+          config-file: >-
+            ${{ github.repository }}/.github/codeql/codeql-config.yml@${{ github.event.repository.default_branch }}
 
       - name: Run manual build steps
         if: matrix.build-mode == 'manual'


### PR DESCRIPTION
This PR fixes the scheduled CodeQL workflow. 

Summary:
- load the shared CodeQL config from the default branch during scheduled cross-branch scans
- filter C/C++ SARIF results so bundled 3rd-party alerts are not reported as Open MPI findings

Validation:
- ruby YAML parse of .github/workflows/codeql.yml
- git diff --check
- manually invoked CodeQL scheduled-scan workflow after the SARIF filtering change

Specifically, I ran the scheduled workflow manually a few times on `main`, `v5.0.x`, and `v6.0.x` to ensure that it now seems to be working as intended.