### PR TITLE
v5.0.x: docs: add MPI-4.0 and MPI-4.1 conformance gap analyses

### DIFF
--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -10,6 +10,8 @@ Release notes
    compilers
    run-time
    mpi
+   mpi-4.0
+   mpi-4.1
    openshmem
    mpi-collectives
    openshmem-collectives

--- a/docs/release-notes/mpi-4.0.rst
+++ b/docs/release-notes/mpi-4.0.rst
@@ -1,0 +1,170 @@
+MPI-4.0 conformance gap analysis
+================================
+
+This document analyzes what is required to claim full conformance with
+the `MPI-4.0 specification
+<https://www.mpi-forum.org/docs/mpi-4.0/mpi40-report.pdf>`_ and lists the
+APIs and functionality that are still missing from the Open MPI
+|ompi_series| series.
+
+.. note:: This is a *gap* analysis: it enumerates what is **not yet**
+   implemented.  For the list of MPI-4.0 features that *are* already
+   supported, see :ref:`the MPI Standard conformance section
+   <release-notes-mpi-standard-conformance-label>`.
+
+Summary
+-------
+
+The Open MPI |ompi_series| series formally advertises MPI-3.1
+conformance: ``mpi.h`` defines ``MPI_VERSION`` as ``3`` and
+``MPI_SUBVERSION`` as ``1``.  A large portion of MPI-4.0 is nonetheless
+implemented (Sessions, partitioned communication, persistent
+collectives, large-count *constants*, the new info routines, and the new
+error handlers).
+
+Two major feature families and a small number of supporting symbols are
+missing.  Until they are implemented, Open MPI cannot advertise
+``MPI_VERSION`` ``4`` / ``MPI_SUBVERSION`` ``0``:
+
+#. The **large-count ("embiggening") interface** — the entire family of
+   ``MPI_<fn>_c`` bindings.
+#. The **MPI tool information interface "events" interface** — the
+   callback-driven ``MPI_T_event_*`` / ``MPI_T_source_*`` interface.
+
+The two sections below describe these gaps in detail.  A final section
+lists the smaller supporting items.
+
+Missing: the large-count ("embiggening") interface
+--------------------------------------------------
+
+MPI-4.0 (Section 2.5.8) added large-count variants of every procedure
+that takes a count, size, displacement, or extent argument.  In C these
+are spelled with a ``_c`` suffix and use ``MPI_Count`` /
+``MPI_Aint`` arguments in place of ``int``; in the Fortran ``mpi_f08``
+module they are provided through function overloading (so no new Fortran
+names appear, with two explicit exceptions noted below).
+
+Open MPI |ompi_series| implements **none** of the ``_c`` bindings: there
+are zero ``_c`` prototypes in the installed ``mpi.h``.  This is the
+single largest MPI-4.0 conformance gap, affecting more than 150
+procedures, including (non-exhaustively):
+
+* Point-to-point: ``MPI_Send_c``, ``MPI_Recv_c``, ``MPI_Isend_c``,
+  ``MPI_Irecv_c``, ``MPI_Sendrecv_c``, ``MPI_Bsend_c``, ``MPI_Ssend_c``,
+  ``MPI_Rsend_c``, ``MPI_Send_init_c``, ``MPI_Recv_init_c``,
+  ``MPI_Isendrecv_c``, ``MPI_Get_count_c``, ``MPI_Get_elements_c``,
+  ``MPI_Pack_c``, ``MPI_Unpack_c``, ``MPI_Pack_size_c``, ``MPI_Mrecv_c``,
+  ``MPI_Imrecv_c``, and the partitioned ``MPI_Psend_init_c`` /
+  ``MPI_Precv_init_c``.
+* Collectives and their nonblocking / persistent forms:
+  ``MPI_Bcast_c``, ``MPI_Reduce_c``, ``MPI_Allreduce_c``,
+  ``MPI_Gather_c``, ``MPI_Gatherv_c``, ``MPI_Scatter_c``,
+  ``MPI_Scatterv_c``, ``MPI_Allgather_c``, ``MPI_Allgatherv_c``,
+  ``MPI_Alltoall_c``, ``MPI_Alltoallv_c``, ``MPI_Alltoallw_c``,
+  ``MPI_Scan_c``, ``MPI_Exscan_c``, ``MPI_Reduce_scatter_c``,
+  ``MPI_Reduce_scatter_block_c``, ``MPI_Reduce_local_c``, the
+  ``MPI_I*_c`` nonblocking variants, the ``MPI_*_init_c`` persistent
+  variants, and the ``MPI_Neighbor_*_c`` / ``MPI_Ineighbor_*_c`` /
+  ``MPI_Neighbor_*_init_c`` neighborhood variants.
+* Datatypes: ``MPI_Type_contiguous_c``, ``MPI_Type_vector_c``,
+  ``MPI_Type_create_hvector_c``, ``MPI_Type_indexed_c``,
+  ``MPI_Type_create_hindexed_c``, ``MPI_Type_create_indexed_block_c``,
+  ``MPI_Type_create_hindexed_block_c``, ``MPI_Type_create_struct_c``,
+  ``MPI_Type_create_subarray_c``, ``MPI_Type_create_darray_c``,
+  ``MPI_Type_create_resized_c``, ``MPI_Type_get_extent_c``,
+  ``MPI_Type_get_true_extent_c``, ``MPI_Type_size_c``,
+  ``MPI_Type_get_contents_c``, ``MPI_Type_get_envelope_c``.
+* One-sided (RMA): ``MPI_Put_c``, ``MPI_Get_c``, ``MPI_Accumulate_c``,
+  ``MPI_Get_accumulate_c``, ``MPI_Rput_c``, ``MPI_Rget_c``,
+  ``MPI_Raccumulate_c``, ``MPI_Rget_accumulate_c``,
+  ``MPI_Win_create_c``, ``MPI_Win_allocate_c``,
+  ``MPI_Win_allocate_shared_c``, ``MPI_Win_shared_query_c``.
+* I/O: the ``_c`` forms of all ``MPI_File_read*`` /
+  ``MPI_File_write*`` procedures, ``MPI_File_get_type_extent_c``.
+* Supporting routines: ``MPI_Op_create_c`` and
+  ``MPI_Register_datarep_c`` (these two *do* introduce new explicit
+  Fortran names, unlike the overloaded majority).
+
+The large-count interface also requires the following supporting
+symbols, which are likewise missing:
+
+* The callback prototypes ``MPI_User_function_c`` and
+  ``MPI_Datarep_conversion_function_c``.
+* The predefined conversion function ``MPI_CONVERSION_FN_NULL_C``.
+
+The supporting error class ``MPI_ERR_VALUE_TOO_LARGE`` **is** already
+defined in ``mpi.h``.
+
+Missing: the MPI tool information interface "events" interface
+--------------------------------------------------------------
+
+MPI-4.0 (Sections 15.3.8–15.3.9) added a callback-driven event interface
+to the MPI tool information interface ("MPI_T").  Open MPI
+|ompi_series| implements the control-variable, performance-variable, and
+category portions of MPI_T, but the entire events interface is absent
+(there are no event sources in ``ompi/mpi/tool/`` and no
+``MPI_T_event*`` symbols in ``mpi.h``).
+
+The following procedures are missing:
+
+* Event sources: ``MPI_T_source_get_num``, ``MPI_T_source_get_info``,
+  ``MPI_T_source_get_timestamp``.
+* Event types: ``MPI_T_event_get_num``, ``MPI_T_event_get_info``,
+  ``MPI_T_event_get_index``.
+* Event handles and registration: ``MPI_T_event_handle_alloc``,
+  ``MPI_T_event_handle_set_info``, ``MPI_T_event_handle_get_info``,
+  ``MPI_T_event_handle_free``, ``MPI_T_event_register_callback``,
+  ``MPI_T_event_callback_set_info``, ``MPI_T_event_callback_get_info``,
+  ``MPI_T_event_set_dropped_handler``.
+* Reading event data in a callback: ``MPI_T_event_read``,
+  ``MPI_T_event_copy``, ``MPI_T_event_get_timestamp``,
+  ``MPI_T_event_get_source``.
+* Category integration: ``MPI_T_category_get_num_events`` and
+  ``MPI_T_category_get_events``.
+
+The supporting types and callback prototypes are also missing:
+``MPI_T_cb_safety``, ``MPI_T_event_instance``,
+``MPI_T_event_registration``, ``MPI_T_source_order``, and the callback
+function prototypes ``MPI_T_event_cb_function``,
+``MPI_T_event_free_cb_function``, and
+``MPI_T_event_dropped_cb_function``.
+
+Other smaller gaps
+------------------
+
+* ``MPI_T_BIND_MPI_SESSION`` — this binding constant (introduced
+  alongside the Sessions model so that tool variables can be bound to a
+  session) is not defined in ``mpi.h``.
+
+What is already supported
+-------------------------
+
+For completeness, the following MPI-4.0 additions are **already**
+implemented in the Open MPI |ompi_series| series and are therefore *not*
+gaps:
+
+* The Sessions model: ``MPI_Session_init`` / ``MPI_Session_finalize``,
+  the ``MPI_Session_get_*`` query routines, the session error-handler
+  routines, ``MPI_Group_from_session_pset``,
+  ``MPI_Comm_create_from_group``,
+  ``MPI_Intercomm_create_from_groups``, and ``MPI_Session_c2f`` /
+  ``MPI_Session_f2c``.
+* Partitioned communication: ``MPI_Psend_init``, ``MPI_Precv_init``,
+  ``MPI_Pready``, ``MPI_Pready_range``, ``MPI_Pready_list``, and
+  ``MPI_Parrived``.
+* Persistent collectives (and persistent neighborhood collectives) in
+  the ``MPI_`` namespace, e.g. ``MPI_Bcast_init``, ``MPI_Reduce_init``,
+  ``MPI_Allreduce_init``, ``MPI_Neighbor_allgather_init``.
+* ``MPI_Isendrecv`` and ``MPI_Isendrecv_replace``.
+* ``MPI_Comm_idup_with_info``.
+* ``MPI_Info_get_string`` and ``MPI_Info_create_env``.
+* The ``MPI_ERRORS_ABORT`` error handler, ``MPI_COMM_SELF`` as the
+  default error-handling object for object-less calls, and the
+  ``mpi_initial_errhandler`` info key.
+* The ``MPI_COMM_TYPE_HW_GUIDED`` and ``MPI_COMM_TYPE_HW_UNGUIDED``
+  split types and the ``mpi_hw_resource_type`` info key.
+* The ``mpi_minimum_memory_alignment`` info key.
+* The ``MPI_ERR_VALUE_TOO_LARGE`` and ``MPI_ERR_PROC_ABORTED`` error
+  classes.
+* Deprecation of ``MPI_Sizeof``, of ``MPI_Cancel`` on send requests, and
+  of ``MPI_Info_get`` / ``MPI_Info_get_valuelen``.

--- a/docs/release-notes/mpi-4.1.rst
+++ b/docs/release-notes/mpi-4.1.rst
@@ -1,0 +1,152 @@
+MPI-4.1 conformance gap analysis
+================================
+
+This document analyzes what is required to claim full conformance with
+the `MPI-4.1 specification
+<https://www.mpi-forum.org/docs/mpi-4.1/mpi41-report.pdf>`_ and lists the
+APIs and functionality that are still missing from the Open MPI
+|ompi_series| series.
+
+.. note:: MPI-4.1 is a superset of MPI-4.0.  Full MPI-4.1 conformance
+   therefore requires *everything* listed in the
+   :doc:`MPI-4.0 gap analysis <mpi-4.0>` (most importantly the
+   large-count ``_c`` interface and the ``MPI_T`` events interface) **in
+   addition to** the MPI-4.1-specific items below.  This document covers
+   only the items that MPI-4.1 adds on top of MPI-4.0.
+
+Summary
+-------
+
+The Open MPI |ompi_series| series advertises MPI-3.1 conformance
+(``MPI_VERSION`` ``3`` / ``MPI_SUBVERSION`` ``1``).  MPI-4.1 was largely
+a consolidation release, but it introduced a focused set of new
+procedures, constants, and deprecations.  **None** of the MPI-4.1
+procedures listed below are implemented in Open MPI |ompi_series|, and
+several of the MPI-4.1 deprecations are not yet reflected.
+
+Missing procedures
+------------------
+
+Status field accessors (Section 3.2.5)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MPI-4.1 added accessor procedures so that the ``MPI_Status`` fields can
+be queried and set without direct structure access (which is important
+for language interoperability and the large-count interface).  All six
+are missing:
+
+* ``MPI_Status_get_source`` / ``MPI_Status_set_source``
+* ``MPI_Status_get_tag`` / ``MPI_Status_set_tag``
+* ``MPI_Status_get_error`` / ``MPI_Status_set_error``
+
+Communicator- and session-level message buffering (Section 3.6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MPI-4.1 added automatic (unlimited) buffering and the ability to attach
+buffers at communicator and session scope rather than only globally.
+The following procedures are missing:
+
+* ``MPI_Comm_attach_buffer`` / ``MPI_Comm_detach_buffer``
+* ``MPI_Session_attach_buffer`` / ``MPI_Session_detach_buffer``
+* ``MPI_Comm_flush_buffer`` / ``MPI_Session_flush_buffer`` /
+  ``MPI_Buffer_flush``
+* The nonblocking variants ``MPI_Comm_iflush_buffer`` /
+  ``MPI_Session_iflush_buffer`` / ``MPI_Buffer_iflush``
+
+The associated predefined buffer constant ``MPI_BUFFER_AUTOMATIC`` is
+also missing.  (The existing ``MPI_Buffer_attach`` / ``MPI_Buffer_detach``
+remain, but their MPI-4.1 semantics — applying only to communicators
+that have no communicator- or session-level buffer attached — are not
+implemented.)
+
+Querying multiple request statuses (Section 3.7.6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MPI-4.1 added non-destructive multi-request status queries (analogous to
+``MPI_Testall`` / ``MPI_Testany`` / ``MPI_Testsome`` but without freeing
+the requests).  All three are missing:
+
+* ``MPI_Request_get_status_all``
+* ``MPI_Request_get_status_any``
+* ``MPI_Request_get_status_some``
+
+(The single-request ``MPI_Request_get_status`` already exists.)
+
+Value/index datatype query (Sections 5.1.13, 6.9.4)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``MPI_Type_get_value_index`` — query the predefined value-and-index
+  pair datatype handles used with ``MPI_MINLOC`` / ``MPI_MAXLOC``.
+* The associated combiner constant ``MPI_COMBINER_VALUE_INDEX`` is also
+  missing.
+
+Hardware resource information (Section 9.1.2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``MPI_Get_hw_resource_info`` — return an info object describing the
+  hardware resources available to the calling process.
+
+Error class / code / string removal (Section 9.5)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MPI-4.1 added the complements to the existing ``MPI_Add_error_*``
+procedures.  All three are missing:
+
+* ``MPI_Remove_error_class``
+* ``MPI_Remove_error_code``
+* ``MPI_Remove_error_string``
+
+The associated error class ``MPI_ERR_ERRHANDLER`` is also missing.
+
+Large-count status routine (Section 13.3)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MPI-4.1 added the large-count interface for ``MPI_Status_set_elements``
+that had been omitted from MPI-4.0:
+
+* ``MPI_Status_set_elements_c``
+
+This is part of the broader large-count gap described in the
+:doc:`MPI-4.0 gap analysis <mpi-4.0>`.
+
+Missing constants and info keys
+-------------------------------
+
+* ``MPI_COMM_TYPE_RESOURCE_GUIDED`` — a new ``split_type`` value for
+  ``MPI_Comm_split_type``, together with its ``mpi_pset_name`` info key.
+* ``MPI_BUFFER_AUTOMATIC`` (see above).
+* ``MPI_COMBINER_VALUE_INDEX`` (see above).
+* ``MPI_ERR_ERRHANDLER`` (see above).
+* New info keys that are not recognized:
+  ``mpi_memory_alloc_kinds`` and ``mpi_assert_memory_alloc_kinds``
+  (memory-allocation-kinds support/assertion),
+  ``mpi_accumulate_granularity`` (RMA accumulate granularity), and
+  ``mpi_assert_strict_persistent_collective_ordering``.
+
+Deprecations not yet reflected
+------------------------------
+
+MPI-4.1 deprecated a number of existing symbols.  These symbols still
+exist in Open MPI |ompi_series| (which is correct — deprecated symbols
+must remain usable), but they are not yet *marked* as deprecated, and
+the user-visible deprecation guidance has not been updated:
+
+* The ``_x`` element/extent routines, superseded by the large-count
+  ``_c`` routines: ``MPI_Type_size_x``, ``MPI_Type_get_extent_x``,
+  ``MPI_Type_get_true_extent_x``, ``MPI_Get_elements_x``, and
+  ``MPI_Status_set_elements_x``.
+* The ``MPI_HOST`` predefined attribute key.
+* The ``mpif.h`` Fortran support method.
+
+Other clarifications
+--------------------
+
+MPI-4.1 also contains many semantic clarifications that do not introduce
+new symbols but may require implementation review for full conformance —
+for example the relaxation of ``MPI_Win_shared_query`` to windows of
+flavor ``MPI_WIN_FLAVOR_CREATE`` and ``MPI_WIN_FLAVOR_ALLOCATE``,
+allowing ``MPI_COMM_NULL`` / ``MPI_DATATYPE_NULL`` / ``MPI_WIN_NULL`` to
+be passed to the corresponding ``MPI_*_get_name`` routines, and the
+clarified strong/weak progress rules for ``MPI_Request_get_status`` and
+``MPI_Win_test``.  These are behavioral and are not enumerated as
+missing APIs here.

--- a/docs/release-notes/mpi.rst
+++ b/docs/release-notes/mpi.rst
@@ -7,11 +7,13 @@ MPI Standard conformance
 ------------------------
 
 In the Open MPI |ompi_series| series, all MPI-|mpi_standard_version|
-functionality is supported.  *Some* MPI-4.0 functionality is
-supported.
+functionality is fully supported and conformant.  As such,
+``MPI_VERSION`` is set to 3 and ``MPI_SUBVERSION`` is set to 1.
 
-As such, ``MPI_VERSION`` is set to 3 and ``MPI_SUBVERSION`` is set
-to 1.
+Substantial portions of MPI-4.0 and MPI-4.1 are also implemented.
+However, neither standard is fully conformant, so Open MPI does not yet
+advertise an ``MPI_VERSION`` of 4.  The gaps are summarized below and
+enumerated in detail in dedicated documents.
 
 For historical reference:
 
@@ -33,37 +35,59 @@ For historical reference:
    * - MPI-3.1
      - Open MPI v2.0
 
-MPI-4.0 partial compliance
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+MPI-4.0 and MPI-4.1 partial conformance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the Open MPI |ompi_series| series, only partial MPI-4.0 functionality is
-supported. This section contains a list of features added for the release.
+The Open MPI |ompi_series| series implements a large fraction of
+MPI-4.0, including:
 
-* Added support for MPI Sessions.
-* Added partitioned communication using persistent sends and persistent receives.
-* Added persistent collectives to the ``MPI_`` namespace (they were previously
-  available via the ``MPIX_`` prefix).
-* Added support for :ref:`MPI_Isendrecv()<mpi_isendrecv>` and its variants.
-* Added support for :ref:`MPI_Comm_idup_with_info()<mpi_comm_idup_with_info>`.
-* Added support for :ref:`MPI_Info_get_string()<mpi_info_get_string>`.
-* Added support for ``initial_error_handler`` info key and the
-  ``MPI_ERRORS_ABORT`` infrastructure.
-* Added support for ``mpi_minimum_memory_alignment`` info key.
-* Added support for ``MPI_COMM_TYPE_HW_GUIDED`` and
-  ``MPI_COMM_TYPE_HW_UNGUIDED``.
-* Added support for :ref:`MPI_Info_create_env()<mpi_info_create_env>`.
-* Added error handling for "unbound" errors to ``MPI_COMM_SELF``.
-* Added ``MPI_F_STATUS_SIZE``, ``MPI_F_SOURCE``, ``MPI_F_TAG``, and
-  ``MPI_F_ERROR``.
-* Made :ref:`MPI_Comm_get_info()<mpi_comm_get_info>`,
-  :ref:`MPI_File_get_info()<mpi_file_get_info>`, and
-  :ref:`MPI_Win_get_info()<mpi_win_get_info>` MPI-4.0 compliant.
-* Info keys that are not understood by Open MPI will be silently ignored and
-  dropped on communicators, files, and windows.
-* Deprecated :ref:`MPI_Sizeof()<mpi_sizeof>`.
-* Deprecated :ref:`MPI_Cancel()<mpi_cancel>` on send requests.
-* Deprecated :ref:`MPI_Info_get()<mpi_info_get>` and
+* The Sessions model.
+* Partitioned communication (persistent sends and receives).
+* Persistent collective and neighborhood collective operations in the
+  ``MPI_`` namespace (these were previously available only via the
+  ``MPIX_`` prefix).
+* :ref:`MPI_Isendrecv()<mpi_isendrecv>` and its variants.
+* :ref:`MPI_Comm_idup_with_info()<mpi_comm_idup_with_info>`,
+  :ref:`MPI_Info_get_string()<mpi_info_get_string>`, and
+  :ref:`MPI_Info_create_env()<mpi_info_create_env>`.
+* The ``MPI_ERRORS_ABORT`` error handler, ``MPI_COMM_SELF``-based
+  handling of "unbound" errors, and the ``mpi_initial_errhandler``
+  info key.
+* The ``MPI_COMM_TYPE_HW_GUIDED`` and ``MPI_COMM_TYPE_HW_UNGUIDED``
+  communicator split types and the ``mpi_minimum_memory_alignment``
+  info key.
+* The ``MPI_F_STATUS_SIZE``, ``MPI_F_SOURCE``, ``MPI_F_TAG``, and
+  ``MPI_F_ERROR`` constants.
+* The MPI-4.0 deprecations of :ref:`MPI_Sizeof()<mpi_sizeof>`,
+  :ref:`MPI_Cancel()<mpi_cancel>` on send requests, and
+  :ref:`MPI_Info_get()<mpi_info_get>` /
   :ref:`MPI_Info_get_valuelen()<mpi_info_get_valuelen>`.
+
+Two major MPI-4.0 feature families are *not* yet implemented, and their
+absence is the primary reason Open MPI cannot advertise MPI-4.0
+conformance:
+
+* The **large-count ("embiggening") interface**: the entire family of
+  ``MPI_<fn>_c`` C bindings (and their Fortran ``mpi_f08`` overloads)
+  that accept ``MPI_Count`` arguments in place of ``int``.
+* The **MPI tool information interface "events" interface**: the
+  callback-driven ``MPI_T_event_*`` and ``MPI_T_source_*`` routines.
+
+MPI-4.1 is a superset of MPI-4.0.  Full MPI-4.1 conformance therefore
+requires closing the MPI-4.0 gaps above *and* implementing the
+procedures that MPI-4.1 newly introduced -- none of which are yet
+available.  These include the
+``MPI_Status_{get,set}_{source,tag,error}`` accessors, communicator-
+and session-level message buffering, the
+``MPI_Request_get_status_{all,any,some}`` queries,
+``MPI_Type_get_value_index``, ``MPI_Get_hw_resource_info``, and the
+``MPI_Remove_error_{class,code,string}`` routines.
+
+For the complete, itemized gap analyses -- including every missing
+procedure, constant, info key, and deprecation -- see:
+
+* :doc:`mpi-4.0`
+* :doc:`mpi-4.1`
 
 Removed MPI APIs
 ----------------


### PR DESCRIPTION
Similar to #13954, I had Claude analyze the `v5.0.x` branch vs. the MPI Forum 4.0 and 4.1 PDFs, and update our RST docs based on the actual conformance in the git branch.  This PR represents the results.

I have not (yet?) hand-edited this; I bring it to the community to see if this is even worth it. 

The initial results are fairly promising.  But I suspect we'll need some hand-editing in here, too.

**EDIT:** After further discussion, all we really want on the `v5.0.x` branch is to update the `mpi.rst` file with a summary of things that are missing from MPI-4.1 compliance (which is what the v5.0.x branch reports as `MPI_VERSION` / `MPI_SUBVERSION`).  All the analysis here should probably be distilled down / condensed into a significantly shorter form, and we'll call that "good enough" for the v`5.0.x` branch.

bot:notacherrypick

-----

Open MPI v5.0.x advertises MPI-3.1 conformance (MPI_VERSION 3, MPI_SUBVERSION 1) but already implements much of MPI-4.0 and some of MPI-4.1.  Until now there was no single place describing exactly what is still missing to claim full MPI-4.0 or MPI-4.1 conformance.

Derive that gap list from the MPI Forum change-log annexes and cross-check it against the installed mpi.h and the C bindings.  Add docs/release-notes/mpi-4.0.rst and mpi-4.1.rst enumerating the missing APIs: for MPI-4.0 the large-count "_c" interface and the MPI_T events interface; for MPI-4.1 the status-field accessors, communicator- and session-level message buffering, the multi-request status queries, and the other newly introduced procedures, constants, and deprecations.

Wire both documents into the release-notes toctree and rewrite the "MPI Standard conformance" section of mpi.rst to synthesize the two analyses and link to them.