### PR TITLE
docs: fix shmem_wait argument descriptions

### DIFF
--- a/docs/man-openshmem/man3/shmem_wait.3.rst
+++ b/docs/man-openshmem/man3/shmem_wait.3.rst
@@ -81,24 +81,6 @@ processor that it has completed some action.
 
 The arguments are as follows:
 
-target
-   The remotely accessible integer data object to be updated on the
-   remote PE. If you are using C/C++, the type of target should match
-   that implied in the SYNOPSIS section. If you are using the Fortran
-   compiler, it must be of type integer with an element size of 4 bytes
-   for SHMEM_INT4_ADD and 8 bytes for SHMEM_INT8_ADD.
-
-value
-   The value to be atomically added to target. If you are using C/C++,
-   the type of value should match that implied in the SYNOPSIS section.
-   If you are using Fortran, it must be of type integer with an element
-   size of target.
-
-pe
-   An integer that indicates the PE number upon which target is to be
-   updated. If you are using Fortran, it must be a default integer
-   value.
-
 ivar
    A remotely accessible integer variable that is being updated by
    another PE. If you are using C/C++, the type of ivar should match


### PR DESCRIPTION
Fixes #7148.

Context:

The OpenSHMEM `shmem_wait` man page documents `target`, `value`, and `pe` arguments, but those are not part of the `shmem_wait` or `shmem_wait_until` interfaces.

This PR removes those copied argument descriptions and keep the argument list focused on `ivar`, `cmp`, and `cmp_value`.

Validation:
- `git diff --check`

Not performed:
- Full Open MPI build
- Runtime OpenSHMEM test
- Docs build