### PR TITLE
docs: on the front page, link back to the v4.1.x FAQ

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,8 @@ Documentation for Open MPI can be found in the following locations:
 
        For example:
 
-       * `v4.1.x README file <https://github.com/open-mpi/ompi/blob/v4.1.x/README>`_
+       * `v4.1.x README file <https://github.com/open-mpi/ompi/blob/v4.1.x/README>`_,
+         `v4.1.x FAQ <https://www.open-mpi.org/faq/>`_
        * `v4.0.x README file <https://github.com/open-mpi/ompi/blob/v4.0.x/README>`_
 
 Release announcements


### PR DESCRIPTION
Because we don't have all of that content here on the docs site, and that's now the only surviving link to https://www.open-mpi.org/faq/ (all other links on www.open-mpi.org now point out to docs.open-mpi.org).