### PR TITLE
OMPIO: Support MPI_Info file hints in OMPIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,6 +338,7 @@ test/simple/mpi_barrier
 test/simple/mpi_no_op
 test/simple/mpi_spin
 test/simple/multi_abort
+test/simple/ompio_file_info
 test/simple/parallel_r8
 test/simple/parallel_r64
 test/simple/parallel_w8

--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,7 @@ test/simple/attach
 test/simple/bad_exit
 test/simple/bcast_loop
 test/simple/binding
+test/simple/comm_abort
 test/simple/concurrent_spawn
 test/simple/connect
 test/simple/crisscross
@@ -330,6 +331,7 @@ test/simple/hello_output
 test/simple/hello_show_help
 test/simple/hello
 test/simple/hello++
+test/simple/initial_errh
 test/simple/intercomm1
 test/simple/interlib
 test/simple/loop_child

--- a/.gitignore
+++ b/.gitignore
@@ -479,6 +479,11 @@ test/mpool/mpool_memkind
 
 test/mpi/environment/chello
 
+test/mpi/file/file_info_defaults
+test/mpi/file/file_info_hints
+test/mpi/file/file_info_memkind
+test/mpi/file/file_info_set_view
+
 test/runtime/parse_context
 test/runtime/sigchld
 test/runtime/start_shut

--- a/configure.ac
+++ b/configure.ac
@@ -1544,7 +1544,7 @@ AC_CONFIG_FILES([
     test/util/Makefile
 ])
 
-m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile test/mpi/Makefile test/mpi/t/Makefile])])
+m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile test/mpi/Makefile test/mpi/t/Makefile test/mpi/file/Makefile])])
 
 AC_CONFIG_FILES([contrib/dist/mofed/debian/rules],
                 [chmod +x contrib/dist/mofed/debian/rules])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -332,8 +332,8 @@ templates_path = ['_templates']
 # html/llms/ contains generated Markdown, html/ (and man/, for symmetry) must
 # also be excluded so Sphinx does not re-parse those copies as source.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv', 'py*/**',
-                    'prrte-rst-content', 'llms-src', 'llms-build',
-                    'html', 'man' ]
+                    'tuning-apps/_include', 'prrte-rst-content',
+                    'llms-src', 'llms-build', 'html', 'man' ]
 
 
 # Clarify the language for verbatim blocks (::)

--- a/docs/man-openmpi/man3/MPI_File_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_get_info.3.rst
@@ -44,62 +44,7 @@ hints that can be set.
 HINTS
 -----
 
-The following hints can be used as values for the *info_used* argument.
-
-**SETTABLE HINTS**
-
-* ``shared_file_timeout``: Amount of time (in seconds) to wait for
-  access to the shared file pointer before exiting with
-  ``MPI_ERR_TIMEDOUT``.
-
-* ``rwlock_timeout``: Amount of time (in seconds) to wait for
-  obtaining a read or write lock on a contiguous chunk of a UNIX file
-  before exiting with ``MPI_ERR_TIMEDOUT``.
-
-* ``noncoll_read_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy read requests in the noncollective data-access
-  routines.
-
-  .. note:: A buffer size smaller than the distance (in bytes) in a
-            UNIX file between the first byte and the last byte of the
-            access request causes MPI I/O to iterate and perform
-            multiple UNIX ``read()`` or ``write()`` calls. If the
-            request includes multiple noncontiguous chunks of data,
-            and the buffer size is greater than the size of those
-            chunks, then the UNIX ``read()`` or ``write()`` (made at
-            the MPI I/O level) will access data not requested by this
-            process in order to reduce the total number of ``write()``
-            calls made. If this is not desirable behavior, you should
-            reduce this buffer size to equal the size of the
-            contiguous chunks within the aggregate request.
-
-* ``noncoll_write_bufsize``: Maximum size of the buffer used by MPI
-  I/O to satisfy write requests in the noncollective data-access
-  routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_read_bufsize``: Maximum size of the buffer used by MPI I/O to
-  satisfy read requests in the collective data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_write_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy write requests in the collective data-access
-  routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``mpiio_concurrency``: (boolean) controls whether nonblocking
-  I/O routines can bind an extra thread to an LWP.
-
-* ``mpiio_coll_contiguous``: (boolean) controls whether subsequent
-  collective data accesses will request collectively contiguous
-  regions of the file.
-
-**NON-SETTABLE HINTS**
-
-* ``filename``: Access this hint to get the name of the file.
+.. include:: /tuning-apps/_include/ompio-mpi-info-hints.rst
 
 
 

--- a/docs/man-openmpi/man3/MPI_File_open.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_open.3.rst
@@ -83,65 +83,7 @@ hints that can be set.
 HINTS
 -----
 
-The following hints can be used as values for the *info* argument.
-
-**SETTABLE HINTS**
-
-* ``MPI_INFO_NULL``
-
-* ``shared_file_timeout``: Amount of time (in seconds) to wait for
-  access to the shared file pointer before exiting with
-  ``MPI_ERR_TIMEDOUT``.
-
-* ``rwlock_timeout``: Amount of time (in seconds) to wait for
-  obtaining a read or write lock on a contiguous chunk of a UNIX file
-  before exiting with ``MPI_ERR_TIMEDOUT``.
-
-* ``noncoll_read_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy multiple noncontiguous read requests in the noncollective
-  data-access routines.
-
-  .. note:: A buffer size smaller than the distance (in bytes) in a
-            UNIX file between the first byte and the last byte of the
-            access request causes MPI I/O to iterate and perform
-            multiple UNIX `read()` or `write()` calls. If the request
-            includes multiple noncontiguous chunks of data, and the
-            buffer size is greater than the size of those chunks, then
-            the UNIX `read()` or `write()` (made at the MPI I/O level)
-            will access data not requested by this process in order to
-            reduce the total number of `write()` calls made. If this
-            is not desirable behavior, you should reduce this buffer
-            size to equal the size of the contiguous chunks within the
-            aggregate request.
-
-* ``noncoll_write_bufsize``: Maximum size of the buffer used by MPI
-  I/O to satisfy multiple noncontiguous write requests in the
-  noncollective data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_read_bufsize``: Maximum size of the buffer used by MPI I/O to
-  satisfy multiple noncontiguous read requests in the collective
-  data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_write_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy multiple noncontiguous write requests in the collective
-  data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``mpiio_concurrency``: (boolean) controls whether nonblocking I/O
-  routines can bind an extra thread to an LWP.  .sp
-
-* ``mpiio_coll_contiguous``: (boolean) controls whether subsequent
-  collective data accesses will request collectively contiguous
-  regions of the file.
-
-**NON-SETTABLE HINTS**
-
-* ``filename``: Access this hint to get the name of the file.
+.. include:: /tuning-apps/_include/ompio-mpi-info-hints.rst
 
 
 ERRORS

--- a/docs/man-openmpi/man3/MPI_File_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_info.3.rst
@@ -42,63 +42,7 @@ for a list of hints that can be set.
 HINTS
 -----
 
-The following hints can be used as values for the *info* argument.
-
-**SETTABLE HINTS**
-
-* ``shared_file_timeout``: Amount of time (in seconds) to wait for
-  access to the shared file pointer before exiting with
-  ``MPI_ERR_TIMEDOUT``.
-
-* ``rwlock_timeout``: Amount of time (in seconds) to wait for
-  obtaining a read or write lock on a contiguous chunk of a UNIX file
-  before exiting with ``MPI_ERR_TIMEDOUT``.
-
-* ``noncoll_read_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy read requests in the noncollective data-access
-  routines.
-
-  .. note:: A buffer size smaller than the distance (in bytes) in a
-	    UNIX file between the first byte and the last byte of the
-	    access request causes MPI I/O to iterate and perform
-	    multiple UNIX ``read()`` or ``write()`` calls. If the request
-	    includes multiple noncontiguous chunks of data, and the
-	    buffer size is greater than the size of those chunks, then
-	    the UNIX ``read()`` or ``write()`` (made at the MPI I/O level)
-	    will access data not requested by this process in order to
-	    reduce the total number of ``write()`` calls made. If this is
-	    not desirable behavior, you should reduce this buffer size
-	    to equal the size of the contiguous chunks within the
-	    aggregate request.
-
-* ``noncoll_write_bufsize``: Maximum size of the buffer used by MPI
-  I/O to satisfy write requests in the noncollective data-access
-  routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_read_bufsize``: Maximum size of the buffer used by MPI I/O to
-  satisfy read requests in the collective data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_write_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy write requests in the collective data-access
-  routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``mpiio_concurrency``: (boolean) controls whether nonblocking I/O
-  routines can bind an extra thread to an LWP.
-
-* ``mpiio_coll_contiguous``: (boolean) controls whether subsequent
-  collective data accesses will request collectively contiguous
-  regions of the file.
-
-
-  **NON-SETTABLE HINTS**
-
-* ``filename``: Access this hint to get the name of the file.
+.. include:: /tuning-apps/_include/ompio-mpi-info-hints.rst
 
 
 ERRORS

--- a/docs/man-openmpi/man3/MPI_File_set_view.3.rst
+++ b/docs/man-openmpi/man3/MPI_File_set_view.3.rst
@@ -59,62 +59,7 @@ set.
 HINTS
 -----
 
-The following hints can be used as values for the *info* argument.
-
-**SETTABLE HINTS**
-
-* ``MPI_INFO_NULL``
-
-* ``shared_file_timeout``: Amount of time (in seconds) to wait for
-  access to the shared file pointer before exiting with
-  ``MPI_ERR_TIMEDOUT``.
-
-* ``rwlock_timeout``: Amount of time (in seconds) to wait for
-  obtaining a read or write lock on a contiguous chunk of a UNIX file
-  before exiting with ``MPI_ERR_TIMEDOUT``.
-
-* ``noncoll_read_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy read requests in the noncollective data-access routines.
-
-  .. note:: A buffer size smaller than the distance (in bytes) in a
-            UNIX file between the first byte and the last byte of the
-            access request causes MPI I/O to iterate and perform
-            multiple UNIX ``read()`` or ``write()`` calls. If the
-            request includes multiple noncontiguous chunks of data,
-            and the buffer size is greater than the size of those
-            chunks, then the UNIX ``read()`` or ``write()`` (made at
-            the MPI I/O level) will access data not requested by this
-            process in order to reduce the total number of ``write()``
-            calls made. If this is not desirable behavior, you should
-            reduce this buffer size to equal the size of the
-            contiguous chunks within the aggregate request.
-
-* ``noncoll_write_bufsize``: Maximum size of the buffer used by MPI
-  I/O to satisfy write requests in the noncollective data-access
-  routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_read_bufsize``: Maximum size of the buffer used by MPI I/O to
-  satisfy read requests in the collective data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``coll_write_bufsize``: Maximum size of the buffer used by MPI I/O
-  to satisfy write requests in the collective data-access routines.
-
-  See the above note in ``noncoll_read_bufsize``.
-
-* ``mpiio_concurrency``: (boolean) controls whether nonblocking I/O
-  routines can bind an extra thread to an LWP.
-
-* ``mpiio_coll_contiguous``: (boolean) controls whether subsequent
-  collective data accesses will request collectively contiguous
-  regions of the file.
-
-**NON-SETTABLE HINTS**
-
-* ``filename``: Access this hint to get the name of the file.
+.. include:: /tuning-apps/_include/ompio-mpi-info-hints.rst
 
 
 ERRORS

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -33,6 +33,10 @@ Open MPI version v6.0.0
   configure option.  These bindings were experimental, were never part
   of the MPI standard, and are no longer supported.
 
+- Improved OMPIO ``MPI_File_get_info()`` reporting so it returns
+  supported file hints that OMPIO is actually using, including
+  component-owned hints for selected OMPIO subcomponents.
+
 - Added support for MPI-4.1 functions to access and update ``MPI_Status``
   fields.
 

--- a/docs/tuning-apps/_include/ompio-mpi-info-hints.rst
+++ b/docs/tuning-apps/_include/ompio-mpi-info-hints.rst
@@ -1,0 +1,152 @@
+MPI allows applications to pass ``MPI_Info`` hints to
+:ref:`MPI_File_open`, :ref:`MPI_File_set_view`, and
+:ref:`MPI_File_set_info`.  Hints are advisory: OMPIO may ignore hints
+that are not supported in the selected component stack.  The
+:ref:`MPI_File_get_info` routine returns a new ``MPI_Info`` object
+containing the public hints that OMPIO currently associates with the
+file.  The caller is responsible for freeing that returned object with
+:ref:`MPI_Info_free`.
+
+OMPIO preserves the spelling of a supported hint that was accepted
+from the user's ``MPI_Info`` object.  When OMPIO reports an internal
+default that did not come from a user-supplied hint, it uses the
+canonical public spelling shown below.
+
+OMPIO common hints
+^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Hint
+     - Accepted by
+     - Default / MCA parameter
+     - Notes
+   * - ``cb_buffer_size``
+     - ``MPI_File_open``, ``MPI_File_set_info``,
+       ``MPI_File_set_view``
+     - ``io_ompio_bytes_per_agg``
+     - Size, in bytes, of the temporary collective I/O buffer on each
+       aggregator.
+   * - ``cb_nodes``
+     - ``MPI_File_open``, ``MPI_File_set_info``,
+       ``MPI_File_set_view``
+     - ``io_ompio_num_aggregators`` when that MCA parameter is set to
+       a non-negative value.
+     - Number of collective I/O aggregators.  When OMPIO is using its
+       automatic aggregator selection, this hint is not returned as
+       ``-1``.
+   * - ``collective_buffering``
+     - ``MPI_File_open``, ``MPI_File_set_info``,
+       ``MPI_File_set_view``
+     - ``true``
+     - Controls whether collective buffering is enabled for collective
+       I/O decisions.
+
+``sharedfp`` component hints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Hint
+     - Accepted by
+     - Default / MCA parameter
+     - Notes
+   * - ``sharedfp/individual``
+     - ``OMPIO_SHAREDFP_RELAXED_ORDERING``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - If present on a write-capable file open, this hint raises the
+       priority of the ``individual`` shared file pointer component.
+       OMPIO reports it only when that component is selected for the
+       file.
+
+Lustre ``fs`` component hints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Lustre layout hints affect file layout creation.  Lustre applies
+these settings only when a file is created in a mode where layout can
+be set safely; changing them after a file has been opened does not
+change the already-created file layout.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Canonical hint
+     - Accepted alias
+     - Accepted by
+     - Default / MCA parameter
+     - Notes
+   * - ``striping_unit``
+     - ``stripe_size``
+     - ``MPI_File_open``
+     - ``fs_lustre_stripe_size`` when greater than zero.
+     - Stripe size in bytes.
+   * - ``striping_factor``
+     - ``stripe_width``
+     - ``MPI_File_open``
+     - ``fs_lustre_stripe_width`` when greater than zero.
+     - Number of Lustre object storage targets to stripe across.
+
+If an application supplies an alias, :ref:`MPI_File_get_info` returns
+the alias spelling.  If both a canonical hint and its alias are
+supplied, OMPIO prefers the canonical spelling.  If only an MCA
+parameter supplies the value, OMPIO reports the canonical spelling.
+
+GPFS ``fs`` component hints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The GPFS component accepts the hints listed below when the GPFS
+component is built and selected.  These hints are consumed when the
+file is opened.  Later ``MPI_File_set_info`` or ``MPI_File_set_view``
+calls do not reapply them to GPFS, and :ref:`MPI_File_get_info`
+continues to report the open-time accepted values.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Hint
+     - Accepted by
+     - Default / MCA parameter
+     - Notes
+   * - ``useSIOXLib``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Enables optional SIOX-assisted GPFS I/O selection when SIOX
+       support is compiled in.
+   * - ``gpfsAccessRange``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Passed to GPFS as an access range hint.
+   * - ``gpfsFreeRange``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Passed to GPFS as a free range hint.
+   * - ``gpfsClearFileCache``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Requests GPFS file-cache clearing.
+   * - ``gpfsCancelHints``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Requests cancellation of GPFS hints.
+   * - ``gpfsSetReplication``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Passed to GPFS as a replication hint.
+   * - ``gpfsByteRange``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Passed to GPFS as a byte range hint.
+   * - ``gpfsRestripeData``
+     - ``MPI_File_open``
+     - No default; no corresponding MCA parameter.
+     - Requests GPFS data restriping.
+
+When SIOX support is compiled in, the GPFS component also accepts:
+``sioxAccessRange``, ``sioxFreeRange``, ``sioxClearFileCache``,
+``sioxCancelHints``, ``sioxDataShipStart``, ``sioxDataShipStop``,
+``sioxSetReplication``, ``sioxByteRange``, and
+``sioxRestripeData``.

--- a/docs/tuning-apps/mpi-io.rst
+++ b/docs/tuning-apps/mpi-io.rst
@@ -46,6 +46,13 @@ parameters available for the OMPIO ``io``, ``fcoll``, ``fs``,
    shell$ ompi_info --param fbtl     all --level 9
    shell$ ompi_info --param sharedfp all --level 9
 
+.. _label-ompio-mpi-info-hints:
+
+OMPIO MPI_Info hints
+--------------------
+
+.. include:: /tuning-apps/_include/ompio-mpi-info-hints.rst
+
 OMPIO sub-framework components
 ------------------------------
 
@@ -158,15 +165,15 @@ file on a parallel file system.  Note, that many file systems only
 allow changing these setting upon file creation, i.e. modifying these
 values for an already existing file might not be possible.
 
-#. ``fs_lustre_stripe_size``: Sets the number of storage servers for a
+#. ``fs_lustre_stripe_size``: Sets the stripe size, in bytes, for a
    new file on a Lustre file system. If not set, system default will
    be used. Note that this parameter can also be set through the
-   ``stripe_size`` MPI Info value.
+   ``striping_unit`` or ``stripe_size`` MPI Info value.
 
-#. ``fs_lustre_stripe_width``: Sets the size of an individual block
-   for a new file on a Lustre file system. If not set, system default
-   will be used. Note that this parameter can also be set through the
-   ``stripe_width`` MPI Info value.
+#. ``fs_lustre_stripe_width``: Sets the number of storage servers for
+   a new file on a Lustre file system. If not set, system default will
+   be used. Note that this parameter can also be set through the
+   ``striping_factor`` or ``stripe_width`` MPI Info value.
 
 Using GPU device buffers in MPI File I/O operations
 ----------------------------------------------------

--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -17,6 +17,7 @@
  * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,6 +116,14 @@ enum ompio_fs_type
     GPFS = 6
 };
 
+enum mca_common_ompio_info_phase_t
+{
+    MCA_COMMON_OMPIO_INFO_PHASE_OPEN,
+    MCA_COMMON_OMPIO_INFO_PHASE_SET_INFO,
+    MCA_COMMON_OMPIO_INFO_PHASE_SET_VIEW
+};
+typedef enum mca_common_ompio_info_phase_t mca_common_ompio_info_phase_t;
+
 typedef struct mca_common_ompio_io_array_t {
     void                 *memory_address;
     /* we need that of type OMPI_MPI_OFFSET_TYPE */
@@ -180,6 +189,7 @@ struct ompio_file_t {
     opal_convertor_t      *f_mem_convertor;
     opal_convertor_t      *f_file_convertor;
     opal_info_t           *f_info;
+    mca_common_ompio_info_phase_t f_info_phase;
     void                  *f_fs_ptr;
     int                    f_fs_block_size;
     int                    f_atomicity;
@@ -327,6 +337,18 @@ OMPI_DECLSPEC int mca_common_ompio_file_delete (const char *filename,
                                                 struct opal_info_t *info);
 OMPI_DECLSPEC int mca_common_ompio_create_incomplete_file_handle (const char *filename,
                                                                   ompio_file_t **fh);
+OMPI_DECLSPEC int mca_common_ompio_info_subscribe (ompio_file_t *fh,
+                                                   const char *key,
+                                                   const char *value,
+                                                   opal_key_interest_callback_t *callback);
+OMPI_DECLSPEC int mca_common_ompio_info_apply (ompio_file_t *fh,
+                                               opal_info_t *info);
+OMPI_DECLSPEC int mca_common_ompio_info_set (ompio_file_t *fh,
+                                             const char *key,
+                                             const char *value);
+OMPI_DECLSPEC int mca_common_ompio_info_dup (ompio_file_t *fh,
+                                             ompi_info_t **info_used);
+OMPI_DECLSPEC int mca_common_ompio_info_register (ompio_file_t *fh);
 
 OMPI_DECLSPEC int mca_common_ompio_file_close (ompio_file_t *ompio_fh);
 OMPI_DECLSPEC int mca_common_ompio_file_get_size (ompio_file_t *ompio_fh, OMPI_MPI_OFFSET_TYPE *size);

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2026      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -40,6 +41,8 @@
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
 
+#include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <math.h>
 #include "common_ompio.h"
@@ -50,6 +53,238 @@
 
 static mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view_fn;
 static mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value_fn;
+
+/*
+ * The info subscriber callback both decides whether a key is public in
+ * MPI_File_get_info and updates the internal field that older OMPIO code
+ * reads.  Keeping that side effect here prevents a second parser from
+ * drifting away from the value returned to the application.
+ */
+static const char *mca_common_ompio_cb_buffer_size_cb (opal_infosubscriber_t *object,
+                                                      const char *key,
+                                                      const char *value)
+{
+    ompi_file_t *file;
+    mca_common_ompio_data_t *data;
+    ompio_file_t *fh;
+    int bytes_per_agg;
+
+    if (NULL == object || NULL == value) {
+        return NULL;
+    }
+
+    file = (ompi_file_t *) object;
+    data = (mca_common_ompio_data_t *) file->f_io_selected_data;
+    if (NULL == data) {
+        return NULL;
+    }
+    fh = &data->ompio_fh;
+
+    if (1 == sscanf(value, "%d", &bytes_per_agg)) {
+        fh->f_bytes_per_agg = bytes_per_agg;
+    }
+
+    OMPIO_MCA_PRINT_INFO(fh, key, value, "");
+    return value;
+}
+
+static const char *mca_common_ompio_keep_info_value_cb (opal_infosubscriber_t *object,
+                                                        const char *key,
+                                                        const char *value)
+{
+    if (NULL == object || NULL == key || NULL == value) {
+        return NULL;
+    }
+
+    return value;
+}
+
+static const char *mca_common_ompio_cb_nodes_cb (opal_infosubscriber_t *object,
+                                                 const char *key,
+                                                 const char *value)
+{
+    if (NULL == object || NULL == key || NULL == value) {
+        return NULL;
+    }
+
+    /*
+     * The num_aggregators MCA default is -1, which means "let OMPIO
+     * choose automatically."  That sentinel is useful internally but is
+     * not a meaningful MPI_Info value to report back to users.
+     */
+    if (0 == strcmp(value, "-1")) {
+        return NULL;
+    }
+
+    return value;
+}
+
+int mca_common_ompio_info_subscribe (ompio_file_t *fh,
+                                    const char *key,
+                                    const char *value,
+                                    opal_key_interest_callback_t *callback)
+{
+    int ret;
+
+    if (NULL == fh) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    /*
+     * Some nested OMPIO handles, such as private sharedfp handles, do not
+     * have a backing ompi_file_t.  They cannot participate in the public
+     * MPI_Info subscription mechanism, and treating registration as a
+     * no-op keeps those internal opens on the old behavior path.
+     */
+    if (NULL == fh->f_fh) {
+        return OMPI_SUCCESS;
+    }
+
+    if (NULL == key || NULL == callback) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    ret = opal_infosubscribe_subscribe(&fh->f_fh->super, key, value, callback);
+    if (OPAL_SUCCESS == ret) {
+        /*
+         * f_info is intentionally borrowed.  The actual storage belongs to
+         * ompi_file_t::super.s_info so MPI_File_get_info and
+         * MPI_File_set_info see the same object as the lower OMPIO code.
+         */
+        fh->f_info = fh->f_fh->super.s_info;
+    }
+
+    return ret;
+}
+
+int mca_common_ompio_info_apply (ompio_file_t *fh,
+                                opal_info_t *info)
+{
+    int ret;
+
+    if (NULL == fh || NULL == fh->f_fh) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    ret = opal_infosubscribe_change_info(&fh->f_fh->super, info);
+    if (OPAL_SUCCESS == ret) {
+        fh->f_info = fh->f_fh->super.s_info;
+    }
+
+    return ret;
+}
+
+int mca_common_ompio_info_set (ompio_file_t *fh,
+                              const char *key,
+                              const char *value)
+{
+    if (NULL == fh || NULL == key || NULL == value) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    /*
+     * Internal nested OMPIO handles do not have a backing ompi_file_t and
+     * therefore cannot publish user-visible MPI_Info values.  Treat this
+     * like info_subscribe(): a successful no-op instead of writing into the
+     * borrowed info object passed to the internal open path.
+     */
+    if (NULL == fh->f_fh) {
+        return OMPI_SUCCESS;
+    }
+
+    if (NULL == fh->f_info) {
+        if (NULL == fh->f_fh->super.s_info) {
+            return OMPI_ERR_BAD_PARAM;
+        }
+        fh->f_info = fh->f_fh->super.s_info;
+    }
+
+    return opal_info_set(fh->f_info, key, value);
+}
+
+int mca_common_ompio_info_dup (ompio_file_t *fh,
+                              ompi_info_t **info_used)
+{
+    int ret;
+    opal_info_t *opal_info_used;
+
+    if (NULL == fh || NULL == info_used) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    *info_used = ompi_info_allocate();
+    if (NULL == *info_used) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    if (NULL == fh->f_info) {
+        if (NULL == fh->f_fh || NULL == fh->f_fh->super.s_info) {
+            ompi_info_free(info_used);
+            return OMPI_ERR_BAD_PARAM;
+        }
+        fh->f_info = fh->f_fh->super.s_info;
+    }
+
+    /*
+     * MPI requires MPI_File_get_info to return a new caller-owned
+     * MPI_Info handle.  Duplicate only public entries; rejected user hints
+     * remain internal in s_info so components can ignore them without
+     * exposing them as accepted hints.
+     */
+    opal_info_used = &(*info_used)->super;
+    ret = opal_info_dup_public(fh->f_info, &opal_info_used);
+    if (OPAL_SUCCESS != ret) {
+        ompi_info_free(info_used);
+        return ret;
+    }
+
+    return OMPI_SUCCESS;
+}
+
+int mca_common_ompio_info_register (ompio_file_t *fh)
+{
+    char default_value[32];
+    int num_aggregators;
+    int ret;
+    int size;
+
+    if (NULL == fh) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    if (NULL == fh->f_fh) {
+        return OMPI_SUCCESS;
+    }
+
+    size = snprintf(default_value, sizeof(default_value), "%d", fh->f_bytes_per_agg);
+    if (0 > size || sizeof(default_value) <= (size_t) size) {
+        return OMPI_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    ret = mca_common_ompio_info_subscribe (fh, "cb_buffer_size",
+                                           default_value,
+                                           mca_common_ompio_cb_buffer_size_cb);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    num_aggregators = OMPIO_MCA_GET(fh, num_aggregators);
+    size = snprintf(default_value, sizeof(default_value), "%d", num_aggregators);
+    if (0 > size || sizeof(default_value) <= (size_t) size) {
+        return OMPI_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    ret = mca_common_ompio_info_subscribe (fh, "cb_nodes",
+                                           default_value,
+                                           mca_common_ompio_cb_nodes_cb);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    return mca_common_ompio_info_subscribe (fh, "collective_buffering",
+                                            "true",
+                                            mca_common_ompio_keep_info_value_cb);
+}
 
 int mca_common_ompio_file_open (ompi_communicator_t *comm,
                                 const char *filename,
@@ -100,6 +335,7 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     ompio_fh->f_fstype = NONE;
     ompio_fh->f_amode  = amode;
     ompio_fh->f_info   = info;
+    ompio_fh->f_info_phase = MCA_COMMON_OMPIO_INFO_PHASE_OPEN;
 
     /* set some function pointers required for fcoll, fbtls and sharedfp modules*/
     ompio_fh->f_generate_current_file_view = generate_current_file_view_fn;
@@ -123,6 +359,10 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     }
     
     mca_common_ompio_set_file_defaults (ompio_fh);
+    ret = mca_common_ompio_info_register (ompio_fh);
+    if (OMPI_SUCCESS != ret) {
+        goto fn_fail;
+    }
 
     ompio_fh->f_split_coll_req    = NULL;
     ompio_fh->f_split_coll_in_use = false;
@@ -442,24 +682,16 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
 {
 
    if (NULL != fh) {
-       opal_cstring_t *stripe_str;
        ompi_datatype_t *types[2];
        int blocklen[2] = {1, 1};
        ptrdiff_t d[2], base;
-       int i, flag;
+       int i;
        
        fh->f_flags         = 0;
        fh->f_perm          = OMPIO_PERM_NULL;
        fh->f_io_array      = NULL;
        
        fh->f_bytes_per_agg = OMPIO_MCA_GET(fh, bytes_per_agg);
-       opal_info_get (fh->f_info, "cb_buffer_size", &stripe_str, &flag);
-       if ( flag ) {
-           /* Info object trumps mca parameter value */
-           sscanf ( stripe_str->string, "%d", &fh->f_bytes_per_agg  );
-           OMPIO_MCA_PRINT_INFO(fh, "cb_buffer_size", stripe_str->string, "");
-           OBJ_RELEASE(stripe_str);
-       }
 
        fh->f_fs_block_size = 4096;
        fh->f_atomicity     = 0;

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2026      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -35,6 +36,27 @@
 
 static OMPI_MPI_OFFSET_TYPE get_contiguous_chunk_size (ompio_file_t *, int flag);
 static int datatype_duplicate (ompi_datatype_t *oldtype, ompi_datatype_t **newtype );
+static int get_current_info_value (ompio_file_t *fh, const char *key,
+                                   opal_cstring_t **value, int *flag);
+
+static int get_current_info_value (ompio_file_t *fh, const char *key,
+                                   opal_cstring_t **value, int *flag)
+{
+    int ret;
+
+    *flag = 0;
+    *value = NULL;
+
+    if (NULL != fh->f_info) {
+        ret = opal_info_get(fh->f_info, key, value, flag);
+        if (OPAL_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return OMPI_SUCCESS;
+}
+
 static int datatype_duplicate  (ompi_datatype_t *oldtype, ompi_datatype_t **newtype )
 {
     ompi_datatype_t *type;
@@ -71,7 +93,9 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
                                ompi_datatype_t *etype,
                                ompi_datatype_t *filetype,
                                const char *datarep,
-                               opal_info_t *info)
+                               /* Info hints are applied by the caller through the
+                                * subscription path before this helper runs. */
+                               opal_info_t *info __opal_attribute_unused__)
 {
     int ret=OMPI_SUCCESS;
     size_t max_data = 0;
@@ -221,23 +245,14 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     }
 
     opal_cstring_t *stripe_str;
-    /* Check the info object set during File_open */
-    opal_info_get (info, "cb_nodes", &stripe_str, &flag);
+    ret = get_current_info_value(fh, "cb_nodes", &stripe_str, &flag);
+    if (OMPI_SUCCESS != ret) {
+        goto exit;
+    }
     if ( flag ) {
         sscanf ( stripe_str->string, "%d", &num_cb_nodes );
         OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
-        /* add the key/value to the file's info object */
-        opal_info_set_cstring(fh->f_info, "cb_nodes", stripe_str);
         OBJ_RELEASE(stripe_str);
-    }
-    else {
-        /* Check the info object set during file_set_view */
-        opal_info_get (fh->f_info, "cb_nodes", &stripe_str, &flag);
-        if ( flag ) {
-            sscanf ( stripe_str->string, "%d", &num_cb_nodes );
-            OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", stripe_str->string, "");
-            OBJ_RELEASE(stripe_str);
-        }
     }
         
 
@@ -327,7 +342,10 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
     }
 
     bool info_is_set=false;
-    opal_info_get (info, "collective_buffering", &stripe_str, &flag);
+    ret = get_current_info_value(fh, "collective_buffering", &stripe_str, &flag);
+    if (OMPI_SUCCESS != ret) {
+        goto exit;
+    }
     if ( flag ) {
         if ( 0 == strncasecmp(stripe_str->string, "false", 5) ){
             info_is_set = true;
@@ -335,20 +353,7 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
         } else {
             OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
         }
-        /* add the key/value to the file's info object */
-        opal_info_set_cstring(fh->f_info, "collective_buffering", stripe_str);
         OBJ_RELEASE(stripe_str);
-    } else {
-        opal_info_get (fh->f_info, "collective_buffering", &stripe_str, &flag);
-        if ( flag ) {
-            if ( 0 == strncasecmp(stripe_str->string, "false", 5) ){
-                info_is_set = true;
-                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "enforcing using individual fcoll component");
-            } else {
-                OMPIO_MCA_PRINT_INFO(fh, "collective_buffering", stripe_str->string, "");
-            }
-            OBJ_RELEASE(stripe_str);
-        }
     }
 
     mca_fcoll_base_component_t *preferred =NULL;

--- a/ompi/mca/fs/gpfs/fs_gpfs.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -138,5 +139,6 @@ int mca_fs_gpfs_module_init (ompio_file_t *file)
 
 int mca_fs_gpfs_module_finalize (ompio_file_t *file)
 {
+    mca_fs_gpfs_info_cache_free(file);
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/fs/gpfs/fs_gpfs.h
+++ b/ompi/mca/fs/gpfs/fs_gpfs.h
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2012 University of Houston. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -40,6 +41,7 @@ int mca_fs_gpfs_component_file_unquery(ompio_file_t *file);
 
 int mca_fs_gpfs_module_init(ompio_file_t *file);
 int mca_fs_gpfs_module_finalize(ompio_file_t *file);
+void mca_fs_gpfs_info_cache_free(ompio_file_t *file);
 OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
 
 /*

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
@@ -10,6 +10,7 @@
  *  Copyright (c) 2004-2005 The Regents of the University of California.
  *                          All rights reserved.
  *  Copyright (c) 2008-2012 University of Houston. All rights reserved.
+ *  Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  *  $COPYRIGHT$
  *  
  *  Additional copyrights may follow
@@ -38,6 +39,332 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <gpfs_fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct mca_fs_gpfs_info_cache_t {
+    char *use_siox_lib;
+    char *gpfs_access_range;
+    char *gpfs_free_range;
+    char *gpfs_clear_file_cache;
+    char *gpfs_cancel_hints;
+    char *gpfs_set_replication;
+    char *gpfs_byte_range;
+    char *gpfs_restripe_data;
+#ifdef HAVE_C_SIOX_H
+    char *siox_access_range;
+    char *siox_free_range;
+    char *siox_clear_file_cache;
+    char *siox_cancel_hints;
+    char *siox_data_ship_start;
+    char *siox_data_ship_stop;
+    char *siox_set_replication;
+    char *siox_byte_range;
+    char *siox_restripe_data;
+#endif
+};
+
+static const char *const mca_fs_gpfs_hints[] = {
+    "useSIOXLib",
+    "gpfsAccessRange",
+    "gpfsFreeRange",
+    "gpfsClearFileCache",
+    "gpfsCancelHints",
+    "gpfsSetReplication",
+    "gpfsByteRange",
+    "gpfsRestripeData",
+    NULL
+};
+
+#ifdef HAVE_C_SIOX_H
+static const char *const mca_fs_gpfs_siox_hints[] = {
+    "sioxAccessRange",
+    "sioxFreeRange",
+    "sioxClearFileCache",
+    "sioxCancelHints",
+    "sioxDataShipStart",
+    "sioxDataShipStop",
+    "sioxSetReplication",
+    "sioxByteRange",
+    "sioxRestripeData",
+    NULL
+};
+#endif
+
+/*
+ * GPFS hint names are intentionally registered only in the GPFS component.
+ * Keep the cache keyed by the public hint strings so callback registration,
+ * open-time remember logic, and final cleanup all agree on ownership without
+ * teaching OMPIO common code about GPFS-specific names.
+ */
+static char **mca_fs_gpfs_info_cache_slot(ompio_file_t *fh, const char *key)
+{
+    struct mca_fs_gpfs_info_cache_t *cache;
+
+    if (NULL == fh || NULL == fh->f_fs_ptr || NULL == key) {
+        return NULL;
+    }
+
+    cache = (struct mca_fs_gpfs_info_cache_t *) fh->f_fs_ptr;
+    if (0 == strcmp(key, "useSIOXLib")) {
+        return &cache->use_siox_lib;
+    }
+    if (0 == strcmp(key, "gpfsAccessRange")) {
+        return &cache->gpfs_access_range;
+    }
+    if (0 == strcmp(key, "gpfsFreeRange")) {
+        return &cache->gpfs_free_range;
+    }
+    if (0 == strcmp(key, "gpfsClearFileCache")) {
+        return &cache->gpfs_clear_file_cache;
+    }
+    if (0 == strcmp(key, "gpfsCancelHints")) {
+        return &cache->gpfs_cancel_hints;
+    }
+    if (0 == strcmp(key, "gpfsSetReplication")) {
+        return &cache->gpfs_set_replication;
+    }
+    if (0 == strcmp(key, "gpfsByteRange")) {
+        return &cache->gpfs_byte_range;
+    }
+    if (0 == strcmp(key, "gpfsRestripeData")) {
+        return &cache->gpfs_restripe_data;
+    }
+#ifdef HAVE_C_SIOX_H
+    if (0 == strcmp(key, "sioxAccessRange")) {
+        return &cache->siox_access_range;
+    }
+    if (0 == strcmp(key, "sioxFreeRange")) {
+        return &cache->siox_free_range;
+    }
+    if (0 == strcmp(key, "sioxClearFileCache")) {
+        return &cache->siox_clear_file_cache;
+    }
+    if (0 == strcmp(key, "sioxCancelHints")) {
+        return &cache->siox_cancel_hints;
+    }
+    if (0 == strcmp(key, "sioxDataShipStart")) {
+        return &cache->siox_data_ship_start;
+    }
+    if (0 == strcmp(key, "sioxDataShipStop")) {
+        return &cache->siox_data_ship_stop;
+    }
+    if (0 == strcmp(key, "sioxSetReplication")) {
+        return &cache->siox_set_replication;
+    }
+    if (0 == strcmp(key, "sioxByteRange")) {
+        return &cache->siox_byte_range;
+    }
+    if (0 == strcmp(key, "sioxRestripeData")) {
+        return &cache->siox_restripe_data;
+    }
+#endif
+
+    return NULL;
+}
+
+static const char *mca_fs_gpfs_get_cached_info(ompio_file_t *fh, const char *key)
+{
+    char **slot;
+
+    slot = mca_fs_gpfs_info_cache_slot(fh, key);
+    if (NULL == slot) {
+        return NULL;
+    }
+
+    return *slot;
+}
+
+static int mca_fs_gpfs_info_cache_alloc(ompio_file_t *fh)
+{
+    if (NULL == fh) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    if (NULL != fh->f_fs_ptr) {
+        return OMPI_SUCCESS;
+    }
+
+    fh->f_fs_ptr = calloc(1, sizeof(struct mca_fs_gpfs_info_cache_t));
+    if (NULL == fh->f_fs_ptr) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_gpfs_remember_info(ompio_file_t *fh, const char *key)
+{
+    char **slot;
+    char *copy;
+    int flag;
+    opal_cstring_t *value_str;
+
+    slot = mca_fs_gpfs_info_cache_slot(fh, key);
+    if (NULL == slot) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    opal_info_get(fh->f_info, key, &value_str, &flag);
+    if (!flag) {
+        return OMPI_SUCCESS;
+    }
+
+    /*
+     * The subscriber callback can only return borrowed/static storage.
+     * Store a per-file copy of each accepted open-time value so callbacks
+     * during later phases can return the actual value that was applied.
+     */
+    copy = strdup(value_str->string);
+    OBJ_RELEASE(value_str);
+    if (NULL == copy) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    free(*slot);
+    *slot = copy;
+    return OMPI_SUCCESS;
+}
+
+void mca_fs_gpfs_info_cache_free(ompio_file_t *file)
+{
+    struct mca_fs_gpfs_info_cache_t *cache;
+
+    if (NULL == file || NULL == file->f_fs_ptr) {
+        return;
+    }
+
+    cache = (struct mca_fs_gpfs_info_cache_t *) file->f_fs_ptr;
+    free(cache->use_siox_lib);
+    free(cache->gpfs_access_range);
+    free(cache->gpfs_free_range);
+    free(cache->gpfs_clear_file_cache);
+    free(cache->gpfs_cancel_hints);
+    free(cache->gpfs_set_replication);
+    free(cache->gpfs_byte_range);
+    free(cache->gpfs_restripe_data);
+#ifdef HAVE_C_SIOX_H
+    free(cache->siox_access_range);
+    free(cache->siox_free_range);
+    free(cache->siox_clear_file_cache);
+    free(cache->siox_cancel_hints);
+    free(cache->siox_data_ship_start);
+    free(cache->siox_data_ship_stop);
+    free(cache->siox_set_replication);
+    free(cache->siox_byte_range);
+    free(cache->siox_restripe_data);
+#endif
+    free(cache);
+    file->f_fs_ptr = NULL;
+}
+
+static const char *mca_fs_gpfs_hint_cb(opal_infosubscriber_t *object,
+                                       const char *key,
+                                       const char *value)
+{
+    ompi_file_t *file;
+    mca_common_ompio_data_t *data;
+    ompio_file_t *fh;
+
+    if (NULL == object || NULL == key || NULL == value) {
+        return NULL;
+    }
+
+    file = (ompi_file_t *) object;
+    data = (mca_common_ompio_data_t *) file->f_io_selected_data;
+    if (NULL == data) {
+        return NULL;
+    }
+    fh = &data->ompio_fh;
+
+    /*
+     * The existing GPFS code applies these hints only during file open.
+     * Later MPI_File_set_info or MPI_File_set_view calls should not make a
+     * new value public unless GPFS actually consumed it, so report the
+     * cached open-time value outside the OPEN phase.
+     */
+    if (MCA_COMMON_OMPIO_INFO_PHASE_OPEN != fh->f_info_phase) {
+        return mca_fs_gpfs_get_cached_info(fh, key);
+    }
+
+    if ('\0' == value[0]) {
+        return NULL;
+    }
+
+    return value;
+}
+
+static int mca_fs_gpfs_subscribe_hints(ompio_file_t *fh, const char *const *hints)
+{
+    int ret;
+
+    for (int i = 0; NULL != hints[i]; ++i) {
+        ret = mca_common_ompio_info_subscribe(fh, hints[i], NULL,
+                                              mca_fs_gpfs_hint_cb);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_gpfs_remember_hints(ompio_file_t *fh, const char *const *hints)
+{
+    int ret;
+
+    for (int i = 0; NULL != hints[i]; ++i) {
+        ret = mca_fs_gpfs_remember_info(fh, hints[i]);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_gpfs_register_info(ompio_file_t *fh)
+{
+    int ret;
+
+    ret = mca_fs_gpfs_subscribe_hints(fh, mca_fs_gpfs_hints);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+#ifdef HAVE_C_SIOX_H
+    ret = mca_fs_gpfs_subscribe_hints(fh, mca_fs_gpfs_siox_hints);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+#endif
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_gpfs_cache_info(ompio_file_t *fh)
+{
+    int ret;
+
+    /*
+     * Registration makes supported keys public; this second pass records
+     * only the values that survived registration so get_info remains tied
+     * to what the component accepted.
+     */
+    ret = mca_fs_gpfs_remember_hints(fh, mca_fs_gpfs_hints);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+#ifdef HAVE_C_SIOX_H
+    ret = mca_fs_gpfs_remember_hints(fh, mca_fs_gpfs_siox_hints);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+#endif
+
+    return OMPI_SUCCESS;
+}
 
 int
 mca_fs_gpfs_file_open (struct ompi_communicator_t *comm,
@@ -51,6 +378,21 @@ mca_fs_gpfs_file_open (struct ompi_communicator_t *comm,
 
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
+
+    ret = mca_fs_gpfs_info_cache_alloc(fh);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = mca_fs_gpfs_register_info(fh);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = mca_fs_gpfs_cache_info(fh);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
 
     if(OMPIO_ROOT == fh->f_rank) {
         fh->fd = open (filename, amode, perm);

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      DataDirect Networks. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -125,5 +126,6 @@ int mca_fs_lustre_module_init (ompio_file_t *file)
 
 int mca_fs_lustre_module_finalize (ompio_file_t *file)
 {
+    mca_fs_lustre_info_cache_free(file);
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/fs/lustre/fs_lustre.h
+++ b/ompi/mca/fs/lustre/fs_lustre.h
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2024      Advanced Micro Devices, Inc. All rights reserverd.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,6 +58,7 @@ int mca_fs_lustre_component_file_unquery (ompio_file_t *file);
 
 int mca_fs_lustre_module_init (ompio_file_t *file);
 int mca_fs_lustre_module_finalize (ompio_file_t *file);
+void mca_fs_lustre_info_cache_free (ompio_file_t *file);
 
 OMPI_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_lustre_component;
 /*

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2024      Advanced Micro Devices, Inc. All rights reserverd.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,34 @@
 #include "ompi/info/info.h"
 
 #include <sys/ioctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static void *alloc_lum(void);
+struct mca_fs_lustre_info_cache_t;
+static const char *mca_fs_lustre_layout_hint_cb(opal_infosubscriber_t *object,
+                                                const char *key,
+                                                const char *value);
+static const char *mca_fs_lustre_stripe_size_cb(opal_infosubscriber_t *object,
+                                                const char *key,
+                                                const char *value);
+static const char *mca_fs_lustre_stripe_width_cb(opal_infosubscriber_t *object,
+                                                 const char *key,
+                                                 const char *value);
+static const char *mca_fs_lustre_get_cached_info(ompio_file_t *fh,
+                                                 const char *key);
+static bool mca_fs_lustre_info_has_key(opal_infosubscriber_t *object,
+                                       const char *key);
+static int mca_fs_lustre_info_cache_alloc(ompio_file_t *fh);
+static int mca_fs_lustre_remember_info(ompio_file_t *fh, const char *key);
+static int mca_fs_lustre_remember_info_value(ompio_file_t *fh, const char *key,
+                                             const char *value);
+static int mca_fs_lustre_register_info(ompio_file_t *fh);
+static int mca_fs_lustre_parse_int_hint(opal_info_t *info, const char *key,
+                                        int *value);
+static int mca_fs_lustre_set_default_hint(ompio_file_t *fh, const char *key,
+                                          int value);
 
 static void *alloc_lum(void)
 {
@@ -48,6 +75,290 @@ static void *alloc_lum(void)
     LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
 
   return malloc(MAX(v1, v3));
+}
+
+struct mca_fs_lustre_info_cache_t {
+    char *striping_unit;
+    char *striping_factor;
+    char *stripe_size;
+    char *stripe_width;
+};
+
+/*
+ * Lustre layout hints are consumed while creating/opening the file.  They
+ * cannot be safely applied later to an already-open file, so post-open
+ * callbacks return the open-time cached value instead of the new user value.
+ * Returning NULL tells the subscriber layer that the new value was not
+ * accepted and therefore must not become public in MPI_File_get_info.
+ */
+static const char *mca_fs_lustre_layout_hint_cb(opal_infosubscriber_t *object,
+                                                const char *key,
+                                                const char *value)
+{
+    ompi_file_t *file;
+    mca_common_ompio_data_t *data;
+    ompio_file_t *fh;
+
+    if (NULL == object || NULL == key || NULL == value) {
+        return NULL;
+    }
+
+    file = (ompi_file_t *) object;
+    data = (mca_common_ompio_data_t *) file->f_io_selected_data;
+    if (NULL == data) {
+        return NULL;
+    }
+    fh = &data->ompio_fh;
+
+    if (MCA_COMMON_OMPIO_INFO_PHASE_OPEN != fh->f_info_phase) {
+        return mca_fs_lustre_get_cached_info(fh, key);
+    }
+
+    if ('\0' == value[0]) {
+        return NULL;
+    }
+
+    return value;
+}
+
+static bool mca_fs_lustre_info_has_key(opal_infosubscriber_t *object,
+                                       const char *key)
+{
+    int flag;
+    opal_cstring_t *value;
+
+    if (NULL == object || NULL == object->s_info || NULL == key) {
+        return false;
+    }
+
+    opal_info_get(object->s_info, key, &value, &flag);
+    if (!flag) {
+        return false;
+    }
+
+    OBJ_RELEASE(value);
+    return true;
+}
+
+static const char *mca_fs_lustre_stripe_size_cb(opal_infosubscriber_t *object,
+                                                const char *key,
+                                                const char *value)
+{
+    /*
+     * If both MPI-IO canonical spelling and the older OMPIO alias are
+     * present, keep the canonical key public.  This preserves the existing
+     * parser precedence and gives get_info a single accepted spelling.
+     */
+    if (mca_fs_lustre_info_has_key(object, "striping_unit")) {
+        return NULL;
+    }
+
+    return mca_fs_lustre_layout_hint_cb(object, key, value);
+}
+
+static const char *mca_fs_lustre_stripe_width_cb(opal_infosubscriber_t *object,
+                                                 const char *key,
+                                                 const char *value)
+{
+    /*
+     * Same rule as stripe_size: the MPI spelling wins over the historical
+     * alias when both are supplied.
+     */
+    if (mca_fs_lustre_info_has_key(object, "striping_factor")) {
+        return NULL;
+    }
+
+    return mca_fs_lustre_layout_hint_cb(object, key, value);
+}
+
+static char **mca_fs_lustre_info_cache_slot(ompio_file_t *fh, const char *key)
+{
+    struct mca_fs_lustre_info_cache_t *cache;
+
+    if (NULL == fh || NULL == fh->f_fs_ptr || NULL == key) {
+        return NULL;
+    }
+
+    cache = (struct mca_fs_lustre_info_cache_t *) fh->f_fs_ptr;
+    if (0 == strcmp(key, "striping_unit")) {
+        return &cache->striping_unit;
+    }
+    if (0 == strcmp(key, "striping_factor")) {
+        return &cache->striping_factor;
+    }
+    if (0 == strcmp(key, "stripe_size")) {
+        return &cache->stripe_size;
+    }
+    if (0 == strcmp(key, "stripe_width")) {
+        return &cache->stripe_width;
+    }
+
+    return NULL;
+}
+
+static const char *mca_fs_lustre_get_cached_info(ompio_file_t *fh,
+                                                 const char *key)
+{
+    char **slot;
+
+    slot = mca_fs_lustre_info_cache_slot(fh, key);
+    if (NULL == slot) {
+        return NULL;
+    }
+
+    return *slot;
+}
+
+static int mca_fs_lustre_info_cache_alloc(ompio_file_t *fh)
+{
+    if (NULL == fh) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    if (NULL != fh->f_fs_ptr) {
+        return OMPI_SUCCESS;
+    }
+
+    fh->f_fs_ptr = calloc(1, sizeof(struct mca_fs_lustre_info_cache_t));
+    if (NULL == fh->f_fs_ptr) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_lustre_remember_info_value(ompio_file_t *fh, const char *key,
+                                             const char *value)
+{
+    char **slot;
+    char *copy;
+
+    if (NULL == value) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    slot = mca_fs_lustre_info_cache_slot(fh, key);
+    if (NULL == slot) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    copy = strdup(value);
+    if (NULL == copy) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    free(*slot);
+    *slot = copy;
+    return OMPI_SUCCESS;
+}
+
+static int mca_fs_lustre_remember_info(ompio_file_t *fh, const char *key)
+{
+    int flag;
+    int ret;
+    opal_cstring_t *value_str;
+
+    opal_info_get(fh->f_info, key, &value_str, &flag);
+    if (!flag) {
+        return OMPI_SUCCESS;
+    }
+
+    ret = mca_fs_lustre_remember_info_value(fh, key, value_str->string);
+    OBJ_RELEASE(value_str);
+    return ret;
+}
+
+void mca_fs_lustre_info_cache_free(ompio_file_t *file)
+{
+    struct mca_fs_lustre_info_cache_t *cache;
+
+    if (NULL == file || NULL == file->f_fs_ptr) {
+        return;
+    }
+
+    cache = (struct mca_fs_lustre_info_cache_t *) file->f_fs_ptr;
+    free(cache->striping_unit);
+    free(cache->striping_factor);
+    free(cache->stripe_size);
+    free(cache->stripe_width);
+    free(cache);
+    file->f_fs_ptr = NULL;
+}
+
+static int mca_fs_lustre_register_info(ompio_file_t *fh)
+{
+    int ret;
+
+    ret = mca_common_ompio_info_subscribe(fh, "striping_unit", NULL,
+                                          mca_fs_lustre_layout_hint_cb);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = mca_common_ompio_info_subscribe(fh, "stripe_size", NULL,
+                                          mca_fs_lustre_stripe_size_cb);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = mca_common_ompio_info_subscribe(fh, "striping_factor", NULL,
+                                          mca_fs_lustre_layout_hint_cb);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    return mca_common_ompio_info_subscribe(fh, "stripe_width", NULL,
+                                           mca_fs_lustre_stripe_width_cb);
+}
+
+static int mca_fs_lustre_parse_int_hint(opal_info_t *info, const char *key,
+                                        int *value)
+{
+    int flag;
+    opal_cstring_t *value_str;
+
+    opal_info_get(info, key, &value_str, &flag);
+    if (!flag) {
+        return 0;
+    }
+
+    if (1 == sscanf(value_str->string, "%d", value)) {
+        OBJ_RELEASE(value_str);
+        return 1;
+    }
+
+    OBJ_RELEASE(value_str);
+    return 0;
+}
+
+static int mca_fs_lustre_set_default_hint(ompio_file_t *fh, const char *key,
+                                          int value)
+{
+    char value_string[32];
+    int ret;
+    int size;
+
+    if (0 >= value) {
+        return OMPI_SUCCESS;
+    }
+
+    size = snprintf(value_string, sizeof(value_string), "%d", value);
+    if (0 > size || sizeof(value_string) <= (size_t) size) {
+        return OMPI_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    ret = mca_common_ompio_info_set(fh, key, value_string);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    /*
+     * MCA defaults did not come from the user's MPI_Info, so report them
+     * with the canonical public name.  Cache the same value so later
+     * set_info/set_view attempts cannot overwrite get_info with an
+     * unapplied layout request.
+     */
+    return mca_fs_lustre_remember_info_value(fh, key, value_string);
 }
 
 /*
@@ -62,55 +373,88 @@ int
 mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
                      const char* filename,
                      int access_mode,
-                     struct opal_info_t *info,
+                     /* Info hints are applied through the OMPIO subscription
+                      * path; this component reads the accepted values from
+                      * fh->f_info and its private cache. */
+                     struct opal_info_t *info __opal_attribute_unused__,
                      ompio_file_t *fh)
 {
     int amode, perm;
     int rc, ret=OMPI_SUCCESS;
-    int flag;
     int fs_lustre_stripe_size = -1;
     int fs_lustre_stripe_width = -1;
-    opal_cstring_t *stripe_str;
     char *rfilename = (char *)filename;
     struct lov_user_md *lump=NULL;
 
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "striping_unit", &stripe_str, &flag);
-    if ( flag ) {
-        sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
-        OBJ_RELEASE(stripe_str);
+    ret = mca_fs_lustre_info_cache_alloc(fh);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
     }
-    else {
-        //internal info object name used earlier. Kept for backwards compatibility.
-        opal_info_get (info, "stripe_size", &stripe_str, &flag);
-        if ( flag ) {
-            sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_size );
-            OBJ_RELEASE(stripe_str);
+
+    ret = mca_fs_lustre_register_info(fh);
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    /*
+     * Preserve whichever spelling was actually accepted from MPI_Info.
+     * The parser still prefers canonical spellings over aliases to match
+     * the old behavior, but aliases remain visible when they were the
+     * accepted user spelling.
+     */
+    if (mca_fs_lustre_parse_int_hint(fh->f_info, "striping_unit",
+                                     &fs_lustre_stripe_size)) {
+        ret = mca_fs_lustre_remember_info(fh, "striping_unit");
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+    } else {
+        // internal info object name used earlier. Kept for backwards compatibility.
+        if (mca_fs_lustre_parse_int_hint(fh->f_info, "stripe_size",
+                                         &fs_lustre_stripe_size)) {
+            ret = mca_fs_lustre_remember_info(fh, "stripe_size");
+            if (OMPI_SUCCESS != ret) {
+                return ret;
+            }
         }
     }
-    
-    opal_info_get (info, "striping_factor", &stripe_str, &flag);
-    if ( flag ) {
-        sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
-        OBJ_RELEASE(stripe_str);
-    }
-    else {
-        //internal info object name used earlier. Kept for backwards compatibility.        
-        opal_info_get (info, "stripe_width", &stripe_str, &flag);
-        if ( flag ) {
-            sscanf ( stripe_str->string, "%d", &fs_lustre_stripe_width );
-            OBJ_RELEASE(stripe_str);
+
+    if (mca_fs_lustre_parse_int_hint(fh->f_info, "striping_factor",
+                                     &fs_lustre_stripe_width)) {
+        ret = mca_fs_lustre_remember_info(fh, "striping_factor");
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+    } else {
+        // internal info object name used earlier. Kept for backwards compatibility.
+        if (mca_fs_lustre_parse_int_hint(fh->f_info, "stripe_width",
+                                         &fs_lustre_stripe_width)) {
+            ret = mca_fs_lustre_remember_info(fh, "stripe_width");
+            if (OMPI_SUCCESS != ret) {
+                return ret;
+            }
         }
     }
-    
+
     if (fs_lustre_stripe_size < 0) {
         fs_lustre_stripe_size = mca_fs_lustre_stripe_size;
+        ret = mca_fs_lustre_set_default_hint(fh, "striping_unit",
+                                             fs_lustre_stripe_size);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
     }   
 
     if (fs_lustre_stripe_width < 0) {
         fs_lustre_stripe_width = mca_fs_lustre_stripe_width;
+        ret = mca_fs_lustre_set_default_hint(fh, "striping_factor",
+                                             fs_lustre_stripe_width);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
     }
 
     /* Check for soft links and replace filename by the actual

--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -17,6 +17,7 @@
  * Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -162,6 +163,10 @@ int mca_io_ompio_file_get_size (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE * size);
 int mca_io_ompio_file_get_amode (struct ompi_file_t *fh,
                                  int *amode);
+int mca_io_ompio_file_set_info (struct ompi_file_t *fh,
+                                struct ompi_info_t *info);
+int mca_io_ompio_file_get_info (struct ompi_file_t *fh,
+                                struct ompi_info_t **info_used);
 int mca_io_ompio_file_sync (struct ompi_file_t *fh);
 int mca_io_ompio_file_seek (struct ompi_file_t *fh,
                             OMPI_MPI_OFFSET_TYPE offet,

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,6 +100,56 @@ int mca_io_ompio_file_close (ompi_file_t *fh)
     if ( NULL != data ) {
       free ( data );
     }
+
+    return ret;
+}
+
+int mca_io_ompio_file_set_info (ompi_file_t *fh,
+                               ompi_info_t *info)
+{
+    int ret;
+    mca_common_ompio_data_t *data;
+    mca_common_ompio_info_phase_t previous_phase;
+
+    if (NULL == fh || NULL == info) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
+    if (NULL == data) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    OPAL_THREAD_LOCK(&fh->f_lock);
+    previous_phase = data->ompio_fh.f_info_phase;
+    data->ompio_fh.f_info_phase = MCA_COMMON_OMPIO_INFO_PHASE_SET_INFO;
+
+    ret = mca_common_ompio_info_apply(&data->ompio_fh, &info->super);
+
+    data->ompio_fh.f_info_phase = previous_phase;
+    OPAL_THREAD_UNLOCK(&fh->f_lock);
+
+    return ret;
+}
+
+int mca_io_ompio_file_get_info (ompi_file_t *fh,
+                               ompi_info_t **info_used)
+{
+    int ret;
+    mca_common_ompio_data_t *data;
+
+    if (NULL == fh || NULL == info_used) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
+    if (NULL == data) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    OPAL_THREAD_LOCK(&fh->f_lock);
+    ret = mca_common_ompio_info_dup(&data->ompio_fh, info_used);
+    OPAL_THREAD_UNLOCK(&fh->f_lock);
 
     return ret;
 }
@@ -613,4 +664,3 @@ int mca_io_ompio_file_get_position_shared (ompi_file_t *fp,
 
     return ret;
 }
-

--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  *  Copyright (c) 2026      Stony Brook University.  All rights reserved.
  *  $COPYRIGHT$
  *
@@ -65,7 +66,11 @@ int mca_io_ompio_file_set_view (ompi_file_t *fp,
 {
     int ret=OMPI_SUCCESS;
     mca_common_ompio_data_t *data;
+    mca_common_ompio_info_phase_t previous_phase;
     ompio_file_t *fh;
+    opal_info_t *previous_info;
+    opal_info_t *staged_info;
+    int previous_bytes_per_agg;
 
     if ( (strcmp(datarep, "native") && strcmp(datarep, "NATIVE") &&
           strcmp(datarep, "external32") && strcmp(datarep, "EXTERNAL32"))) {
@@ -87,7 +92,59 @@ int mca_io_ompio_file_set_view (ompi_file_t *fp,
         
     
     OPAL_THREAD_LOCK(&fp->f_lock);
-    ret = mca_common_ompio_set_view(fh, disp, etype, filetype, datarep, info);
+    previous_info = fp->super.s_info;
+    previous_bytes_per_agg = fh->f_bytes_per_agg;
+
+    /*
+     * set_view setup consumes accepted hints while it builds the new file
+     * view.  Apply the user's info to a staged copy first: the setup code
+     * sees the requested values, but get_info will not expose them unless
+     * the whole view change succeeds.
+     */
+    staged_info = OBJ_NEW(opal_info_t);
+    if (NULL == staged_info) {
+        OPAL_THREAD_UNLOCK(&fp->f_lock);
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    if (NULL != previous_info) {
+        ret = opal_info_dup_public(previous_info, &staged_info);
+        if (OPAL_SUCCESS != ret) {
+            OBJ_RELEASE(staged_info);
+            OPAL_THREAD_UNLOCK(&fp->f_lock);
+            return ret;
+        }
+    }
+
+    fp->super.s_info = staged_info;
+    fh->f_info = staged_info;
+
+    previous_phase = fh->f_info_phase;
+    fh->f_info_phase = MCA_COMMON_OMPIO_INFO_PHASE_SET_VIEW;
+
+    ret = mca_common_ompio_info_apply(fh, info);
+    fh->f_info_phase = previous_phase;
+
+    if (OMPI_SUCCESS == ret) {
+        ret = mca_common_ompio_set_view(fh, disp, etype, filetype, datarep, info);
+    }
+
+    if (OMPI_SUCCESS == ret) {
+        if (NULL != previous_info) {
+            OBJ_RELEASE(previous_info);
+        }
+    } else {
+        /*
+         * Restore both the public info object and the internal field updated
+         * by cb_buffer_size.  Without the field rollback, a failed set_view
+         * could leave behavior changed even though get_info was restored.
+         */
+        fp->super.s_info = previous_info;
+        fh->f_info = previous_info;
+        fh->f_bytes_per_agg = previous_bytes_per_agg;
+        OBJ_RELEASE(staged_info);
+    }
+
     OPAL_THREAD_UNLOCK(&fp->f_lock);
     return ret;
 }
@@ -113,4 +170,3 @@ int mca_io_ompio_file_get_view (struct ompi_file_t *fp,
 
     return OMPI_SUCCESS;
 }
-

--- a/ompi/mca/io/ompio/io_ompio_module.c
+++ b/ompi/mca/io/ompio/io_ompio_module.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +39,8 @@ mca_io_base_module_3_0_0_t mca_io_ompio_module = {
     mca_io_ompio_file_preallocate,
     mca_io_ompio_file_get_size,
     mca_io_ompio_file_get_amode,
-    NULL,
-    NULL,
+    mca_io_ompio_file_set_info,
+    mca_io_ompio_file_get_info,
 
     mca_io_ompio_file_set_view,
     mca_io_ompio_file_get_view,

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -15,6 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,7 @@
 
 #include "ompi_config.h"
 #include "mpi.h"
+#include "ompi/file/file.h"
 #include "ompi/mca/sharedfp/sharedfp.h"
 #include "ompi/mca/sharedfp/base/base.h"
 #include "ompi/mca/sharedfp/individual/sharedfp_individual.h"
@@ -64,6 +66,38 @@ static mca_sharedfp_base_module_2_0_0_t individual =  {
  * *******************************************************************
  */
 
+static const char *mca_sharedfp_individual_relaxed_ordering_cb(opal_infosubscriber_t *object,
+                                                               const char *key,
+                                                               const char *value)
+{
+    ompi_file_t *file;
+    mca_common_ompio_data_t *data;
+    ompio_file_t *fh;
+
+    if (NULL == object || NULL == key || NULL == value || '\0' == value[0]) {
+        return NULL;
+    }
+
+    file = (ompi_file_t *) object;
+    data = (mca_common_ompio_data_t *) file->f_io_selected_data;
+    if (NULL == data) {
+        return NULL;
+    }
+    fh = &data->ompio_fh;
+
+    /*
+     * sharedfp selection queries every candidate component.  This callback
+     * must accept the hint while selection is still in progress because the
+     * hint raises individual's priority, but once a sharedfp module is known
+     * the hint is public only if this component actually won selection.
+     */
+    if (NULL != fh->f_sharedfp && &individual != fh->f_sharedfp) {
+        return NULL;
+    }
+
+    return value;
+}
+
 int mca_sharedfp_individual_component_init_query(bool enable_progress_threads,
                                             bool enable_mpi_threads)
 {
@@ -79,6 +113,7 @@ struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_individual_component_file
     bool relaxed_order_flag=false;
     opal_info_t *info;
     int flag;
+    int ret;
     opal_cstring_t *info_str;
     *priority = 0;
 
@@ -104,8 +139,22 @@ struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_individual_component_file
 
     /*---------------------------------------------------------*/
     /* 2. Did the user specify MPI_INFO relaxed ordering flag? */
+    if (wronly_flag) {
+        /*
+         * This hint is meaningful only when this component can be selected.
+         * Registering it conditionally avoids reporting a sharedfp hint as
+         * accepted on read-only opens where individual sharedfp will not run.
+         */
+        ret = mca_common_ompio_info_subscribe(fh, "OMPIO_SHAREDFP_RELAXED_ORDERING",
+                                              NULL,
+                                              mca_sharedfp_individual_relaxed_ordering_cb);
+        if (OMPI_SUCCESS != ret) {
+            return NULL;
+        }
+    }
+
     info = fh->f_info;
-    if ( info != &(MPI_INFO_NULL->super) ){
+    if ( wronly_flag && info != &(MPI_INFO_NULL->super) ){
         opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", &info_str, &flag);
         if ( flag ) {
            if ( mca_sharedfp_individual_verbose ) {
@@ -157,11 +206,18 @@ struct mca_sharedfp_base_module_2_0_0_t * mca_sharedfp_individual_component_file
 
 int mca_sharedfp_individual_component_file_unquery (ompio_file_t *file)
 {
-   /* This function might be needed for some purposes later. for now it
-    * does not have anything to do since there are no steps which need
-    * to be undone if this module is not selected */
+    /*
+     * The query path may have subscribed and accepted the relaxed-ordering
+     * hint so it could participate in priority selection.  If another
+     * sharedfp component wins, remove the public value; otherwise
+     * MPI_File_get_info would claim that a hint owned by the losing
+     * individual component is part of the active file stack.
+     */
+    if (NULL != file && NULL != file->f_info) {
+        (void) opal_info_delete(file->f_info, "OMPIO_SHAREDFP_RELAXED_ORDERING");
+    }
 
-   return OMPI_SUCCESS;
+    return OMPI_SUCCESS;
 }
 
 int mca_sharedfp_individual_module_init (ompio_file_t *file)

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +24,8 @@
 
 #include "ompi_config.h"
 #include "sharedfp_individual.h"
+
+#include <stdlib.h>
 
 #include "mpi.h"
 #include "ompi/constants.h"
@@ -81,7 +84,7 @@ int mca_sharedfp_individual_file_open (struct ompi_communicator_t *comm,
     snprintf(datafilename, len, "%s%s%d",filename,".data.",fh->f_rank);
 
 
-    datafilehandle = (ompio_file_t *)malloc(sizeof(ompio_file_t));
+    datafilehandle = (ompio_file_t *) calloc(1, sizeof(ompio_file_t));
     if ( NULL == datafilehandle ) {
         opal_output(0, "mca_sharedfp_individual_file_open: unable to allocate memory\n");
         free ( sh );
@@ -130,7 +133,7 @@ int mca_sharedfp_individual_file_open (struct ompi_communicator_t *comm,
     }
     snprintf ( metadatafilename, len, "%s%s%d", filename, ".metadata.",fh->f_rank);
 
-    metadatafilehandle = (ompio_file_t *)malloc(sizeof(ompio_file_t));
+    metadatafilehandle = (ompio_file_t *) calloc(1, sizeof(ompio_file_t));
     if ( NULL == metadatafilehandle ) {
         free (sh);
         free (datafilename);

--- a/specs/ompio-mpi-info-support/spec.md
+++ b/specs/ompio-mpi-info-support/spec.md
@@ -1,0 +1,269 @@
+<!--
+  Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# OMPIO MPI_Info Hint Plan
+
+## Goal
+
+Make OMPIO comply with the MPI-5.0 `MPI_File_get_info` and
+`MPI_File_set_info` requirements by using Open MPI's existing
+`opal_infosubscriber_t` infrastructure.
+
+This work addresses Open MPI issue #13367, "`MPI_File_get_info`
+fails to return hints as required by MPI standard":
+https://github.com/open-mpi/ompi/issues/13367
+
+The implementation should:
+
+- Return all supported MPI-IO hints with default values.
+- Return user-supplied hints that OMPIO and its selected subcomponents
+  accepted.
+- Return additional hints set by the implementation.
+- Avoid returning ignored or unknown user hints.
+- Preserve user-supplied alias spelling when an alias is accepted.
+- Support hints at `MPI_File_open`, `MPI_File_set_info`, and
+  `MPI_File_set_view` time as appropriate for each hint.
+- Avoid a parallel OMPIO-private hint cache.
+
+## MPI-5.0 Requirements
+
+The governing text is the MPI-5.0 standard, section 15.2.8 ("File
+Info"), which defines `MPI_FILE_SET_INFO` and `MPI_FILE_GET_INFO`;
+section 15.2.8.1 ("Reserved File Hints") lists the reserved hint keys.
+
+Per section 15.2.8, `MPI_File_get_info` returns a newly created info
+object containing the current setting of all hints associated with the
+file. The standard requires the returned object to include:
+
+- Hints supported by the implementation that have specified default
+  values.
+- User-supplied hints that were not ignored.
+- Additional hints set by the implementation.
+
+The returned info object is caller-owned and must be freed by the
+caller with `MPI_Info_free`.
+
+Section 15.2.8 also requires `MPI_File_set_info` to update file hints
+without disturbing previous/default values for hints not present in
+the new info object. If a supplied hint is ignored, the previous value
+or default remains in effect.
+
+## Existing Infrastructure
+
+Use the existing `opal_infosubscriber_t` mechanism:
+
+- `opal_infosubscribe_subscribe()` registers supported keys, default
+  values, and callbacks.
+- `opal_infosubscribe_change_info()` applies a user info object through
+  registered callbacks.
+- `opal_info_dup_public()` produces a public copy suitable for
+  `MPI_File_get_info`.
+- `opal_info_set()` / `opal_info_set_cstring()` store accepted public
+  hints.
+
+`ompi_file_t::super.s_info` should be the authoritative current hint
+object. `ompio_file_t::f_info` should remain a borrowed pointer to that
+same object.
+
+Do not create a second OMPIO-owned list of hints.
+
+## OMPIO Helper Layer
+
+Add thin OMPIO-local helpers, likely under `ompi/mca/common/ompio/`,
+to keep call sites clean:
+
+- Subscribe a hint on the backing `ompi_file_t`.
+- Apply a user info object for a specific phase.
+- Set public implementation hints.
+- Duplicate public current hints for `MPI_File_get_info`.
+
+These helpers should wrap the existing `opal_infosubscriber_t` and
+`opal_info_t` APIs. They should not implement a new shared info
+framework.
+
+## Hint Context
+
+Add a small OMPIO hint phase/context to `ompio_file_t`, for example:
+
+- Open.
+- Set-info.
+- Set-view.
+
+Callbacks can use the phase to decide whether a hint is valid in the
+current operation. For example, filesystem layout hints may be accepted
+during file creation/open but ignored after the file already exists.
+
+## Component Ownership
+
+Each selected component should register its own hints and defaults.
+The OMPIO core should not hard-code hint names owned by `fs`, `fcoll`,
+`fbtl`, or `sharedfp` components.
+
+Initial hint owners to convert:
+
+- OMPIO common/core:
+  - `cb_buffer_size`
+  - `cb_nodes`
+  - `collective_buffering`
+
+- `fs/lustre`:
+  - `striping_unit`
+  - `striping_factor`
+  - `stripe_size` alias
+  - `stripe_width` alias
+
+- `sharedfp/individual`:
+  - `OMPIO_SHAREDFP_RELAXED_ORDERING`
+
+- `fs/gpfs`, when built:
+  - GPFS and SIOX keys currently consumed in
+    `ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c`
+
+Other components can be added by registering their own hints through
+the same mechanism.
+
+## File Open Flow
+
+During file open:
+
+1. `ompi_file_open()` creates `fh->super.s_info`.
+2. OMPIO sets `ompio_fh->f_info = fh->super.s_info`.
+3. OMPIO selects the relevant subcomponents.
+4. Selected components subscribe their supported hints and defaults.
+5. OMPIO applies the original user info through
+   `opal_infosubscribe_change_info()`.
+6. OMPIO and subcomponents consume accepted/current hints from
+   `fh->super.s_info` / `ompio_fh->f_info`.
+
+Defaults must be registered before user hints are applied so that user
+hints can override defaults, and so that `MPI_File_get_info` can return
+supported defaulted hints even when the user passed `MPI_INFO_NULL`.
+
+## MPI_File_set_info Flow
+
+Add OMPIO module hooks:
+
+- `mca_io_ompio_file_set_info`
+- `mca_io_ompio_file_get_info`
+
+`mca_io_ompio_file_set_info` should:
+
+1. Lock the file handle.
+2. Set the OMPIO info phase to set-info.
+3. Apply the user info through `opal_infosubscribe_change_info()`.
+4. Let subscribed component callbacks accept, ignore, or transform
+   values.
+5. Let callbacks update component state for mutable hints.
+6. Leave omitted hints unchanged.
+7. Leave ignored hints at their previous/default values.
+8. Unlock and return.
+
+Hints that cannot be changed after open should be ignored in this
+phase by their owning component.
+
+## MPI_File_get_info Flow
+
+`mca_io_ompio_file_get_info` should:
+
+1. Allocate a new `ompi_info_t`.
+2. Duplicate public current hints from `fh->super.s_info` with
+   `opal_info_dup_public()`.
+3. Return the new object through `info_used`.
+
+OMPIO must not retain ownership of the returned object.
+
+## MPI_File_set_view Flow
+
+Route the `info` argument to `MPI_File_set_view` through the same
+subscription mechanism:
+
+1. Set the OMPIO info phase to set-view.
+2. Apply the view info through `opal_infosubscribe_change_info()`.
+3. Run view setup using accepted/current hints from `fh->super.s_info`.
+4. Preserve existing hints not mentioned by the set-view info object.
+
+This should replace ad hoc patterns where `mca_common_ompio_set_view`
+reads raw input info and manually copies accepted keys into
+`fh->f_info`.
+
+## Alias Handling
+
+If a user supplies an accepted alias, preserve the supplied spelling in
+`MPI_File_get_info`.
+
+For default values with no user-supplied spelling, use the canonical
+public key for that hint.
+
+## Documentation
+
+Update `docs/tuning-apps/mpi-io.rst` with a dedicated `MPI_Info hints`
+section.
+
+Document hints in tables grouped by owner/component. Each row should
+include:
+
+- Hint name.
+- Owner/component.
+- Whether it is accepted at `MPI_File_open`.
+- Whether it is accepted at `MPI_File_set_info`.
+- Whether it is accepted at `MPI_File_set_view`.
+- Default value, if any.
+- Corresponding MCA parameter, if any.
+- Notes, including alias behavior.
+
+Add short cross-references from the MPI file info man pages to the
+MPI-IO tuning page:
+
+- `docs/man-openmpi/man3/MPI_File_open.3.rst`
+- `docs/man-openmpi/man3/MPI_File_set_info.3.rst`
+- `docs/man-openmpi/man3/MPI_File_get_info.3.rst`
+
+## Test Plan
+
+Add a standalone MPI test under `test/simple`. Do not wire it into
+`make check`; Open MPI's `make check` does not run `mpirun`-launched
+tests.
+
+The test should be manually runnable, for example with:
+
+```sh
+mpirun -n 2 --mca io ompio ./ompio_file_info
+```
+
+Suggested coverage:
+
+- Open with `MPI_INFO_NULL`, call `MPI_File_get_info`, and verify
+  supported OMPIO defaulted hints are returned.
+- Open with a supported hint such as `cb_buffer_size`, and verify the
+  returned value.
+- Open with an unknown key, and verify it is not returned.
+- Verify accepted aliases preserve user spelling where the selected
+  component supports the alias.
+- Call `MPI_File_set_info` with a mutable supported hint, and verify
+  `MPI_File_get_info` reflects the update.
+- Call `MPI_File_set_info` with an unknown key, and verify previous or
+  default hints remain unchanged.
+- Call `MPI_File_set_view` with view-related accepted hints, and verify
+  `MPI_File_get_info` reflects accepted changes.
+
+Filesystem-specific cases should skip gracefully if the relevant
+component or filesystem is not active.
+
+## Risks
+
+The `opal_infosubscribe_subscribe()` callback returns `const char *`,
+which is convenient for static strings but awkward for dynamically
+formatted values. If a component needs to publish a dynamically
+computed implementation hint, it should set that value directly in
+`fh->super.s_info` through an OMPIO helper using `opal_info_set()`.
+
+The main ordering risk is applying user info before all relevant
+subcomponents have registered their subscriptions. OMPIO should ensure
+subscriptions are installed before reapplying open-time user info.

--- a/specs/ompio-mpi-info-support/tasks.md
+++ b/specs/ompio-mpi-info-support/tasks.md
@@ -1,0 +1,282 @@
+<!--
+  Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# OMPIO MPI_Info Support Tasks
+
+This implementation is intentionally split into five waves. Each wave
+should leave the tree buildable, runnable, and reviewable before the
+next wave starts.
+
+When asked to "implement phase N", complete all tasks in that phase,
+run the listed verification for that phase, and stop before starting
+the next phase.
+
+## Phase 1: Core Infrastructure
+
+Goal: establish the OMPIO info plumbing with one simple OMPIO-owned
+hint so the model can be reviewed independently.
+
+Implementation tasks:
+
+- [x] Audit current OMPIO-related info calls and record the initial
+  hint inventory in the implementation notes or commit message:
+  - `ompi/mca/common/ompio/`
+  - `ompi/mca/io/ompio/`
+  - `ompi/mca/fs/`
+  - `ompi/mca/fcoll/`
+  - `ompi/mca/fbtl/`
+  - `ompi/mca/sharedfp/`
+- [x] Add OMPIO-local helper declarations and implementation under the
+  appropriate `ompi/mca/common/ompio/` files.
+- [x] Add helper support for:
+  - subscribing a hint on the backing `ompi_file_t`,
+  - applying a user info object through `opal_infosubscribe_change_info()`,
+  - setting public implementation hints,
+  - duplicating public current hints for `MPI_File_get_info`.
+- [x] Add an OMPIO info phase enum for open, set-info, and set-view.
+- [x] Add the current info phase to `ompio_file_t`.
+- [x] Ensure `ompio_file_t::f_info` is a borrowed pointer to
+  `ompi_file_t::super.s_info`.
+- [x] Add `mca_io_ompio_file_set_info()`.
+- [x] Add `mca_io_ompio_file_get_info()`.
+- [x] Wire both functions into `mca_io_ompio_module`.
+- [x] Register exactly one simple OMPIO-owned hint, preferably
+  `cb_buffer_size`, including its default.
+- [x] Reapply open-time user info after the Phase 1 subscription is
+  installed.
+- [x] Make `MPI_File_get_info` return public current hints from
+  `fh->super.s_info`.
+
+Behavior at the end of Phase 1:
+
+- OMPIO has its own get-info and set-info hooks.
+- `MPI_File_get_info` on an OMPIO file can return at least the one
+  registered defaulted hint.
+- Unknown user hints are not returned.
+- Existing OMPIO behavior for other hints is not intentionally changed.
+
+Verification:
+
+- [x] Build the touched OMPIO/common OMPIO sources.
+- [x] Verify the touched OMPIO files are compiled in the local
+  configuration.
+- [x] Manually run a tiny MPI-IO smoke test with `--mca io ompio`.
+- [x] Verify `MPI_File_get_info` returns the Phase 1 defaulted hint
+  after opening with `MPI_INFO_NULL`.
+- [x] Verify an unknown open-time hint is not returned.
+- [x] Review memory ownership:
+  - `fh->super.s_info` remains owned by `ompi_file_t`,
+  - `ompio_file_t::f_info` is borrowed,
+  - returned `MPI_Info` objects are caller-owned.
+
+## Phase 2: OMPIO Core Hints and Manual Test
+
+Goal: convert OMPIO common/core hints to the new mechanism and add a
+manual `test/simple` regression test for generic OMPIO behavior.
+
+Implementation tasks:
+
+- [x] Register `cb_buffer_size` if not completed in Phase 1.
+- [x] Register `cb_nodes`.
+- [x] Register `collective_buffering`.
+- [x] Move OMPIO common/core hint parsing to callbacks or helper-backed
+  accessors.
+- [x] Preserve existing MCA-parameter override behavior.
+- [x] Preserve current runtime behavior for:
+  - aggregator selection,
+  - collective buffering,
+  - collective I/O buffer sizing.
+- [x] Ensure omitted hints survive `MPI_File_set_info`.
+- [x] Ensure ignored/unknown hints do not become public.
+- [x] Add a standalone test under `test/simple`.
+- [x] Make the test build consistently with existing `test/simple`
+  conventions.
+- [x] Cover these generic OMPIO cases in the test:
+  - open with `MPI_INFO_NULL` and verify defaulted supported hints,
+  - open with `cb_buffer_size` and verify the returned value,
+  - open with an unknown key and verify it is not returned,
+  - call `MPI_File_set_info` with a supported mutable hint and verify
+    the update,
+  - call `MPI_File_set_info` with an unknown key and verify previous or
+    default hints remain unchanged.
+- [x] Document manual invocation in the test source comment or nearby
+  test notes, for example:
+
+  ```sh
+  mpirun -n 2 --mca io ompio ./ompio_file_info
+  ```
+
+Behavior at the end of Phase 2:
+
+- OMPIO common/core hints are handled through the existing
+  `opal_infosubscriber_t` mechanism.
+- Generic `MPI_File_get_info` / `MPI_File_set_info` behavior is
+  covered by a manually runnable test.
+- The tree remains useful even without Lustre or GPFS.
+
+Verification:
+
+- [x] Build OMPIO and the new `test/simple` test.
+- [x] Run the new test with `mpirun -n 2 --mca io ompio`.
+- [x] Run the test with supported and unsupported hints.
+- [x] Verify no generated MPI binding files were hand-edited.
+- [x] Check for warnings in touched code.
+
+## Phase 3: MPI_File_set_view Integration
+
+Goal: route `MPI_File_set_view` info handling through the same
+subscription path while keeping the tree fully runnable.
+
+Implementation tasks:
+
+- [x] Update `mca_io_ompio_file_set_view()` to apply its `info`
+  argument through the OMPIO helper layer.
+- [x] Set phase to set-view while applying view info.
+- [x] Preserve existing hints not mentioned in the view info object.
+- [x] Remove ad hoc copying of accepted view hints into `fh->f_info`.
+- [x] Verify view setup reads accepted/current hints from
+  `ompio_fh->f_info`.
+- [x] Extend the `test/simple` test to cover set-view accepted hint
+  handling.
+- [x] Confirm `cb_nodes` and `collective_buffering` semantics are
+  unchanged for view setup.
+
+Behavior at the end of Phase 3:
+
+- Open, set-info, and set-view all use the same OMPIO info mechanism
+  for OMPIO common/core hints.
+- Existing view setup behavior is preserved.
+- The manual test covers set-view info behavior.
+
+Verification:
+
+- [x] Build touched OMPIO files.
+- [x] Run the manual `test/simple` test with `--mca io ompio`.
+- [x] Run at least one smoke MPI-IO program that sets a non-default
+  file view.
+- [x] Confirm omitted hints survive set-view.
+- [x] Confirm unknown set-view hints are not returned by get-info.
+
+## Phase 4: Component-Owned Hints
+
+Goal: extend the mechanism to selected subcomponents without hard-coding
+their hint names in the OMPIO framework.
+
+Implementation tasks:
+
+- [x] Add `sharedfp/individual` subscription for
+  `OMPIO_SHAREDFP_RELAXED_ORDERING`.
+- [x] Move existing direct `fh->f_info` parsing in
+  `sharedfp/individual` to callback/helper logic.
+- [x] Preserve current sharedfp component priority/selection behavior.
+- [~] Add `fs/lustre` subscriptions for:
+  - `striping_unit`
+  - `striping_factor`
+  - `stripe_size`
+  - `stripe_width`
+- [~] Preserve accepted Lustre alias spelling in returned info.
+- [~] Treat Lustre layout hints as open/create-time hints unless the
+  component can safely apply them later.
+- [~] Add `fs/gpfs` subscriptions for supported GPFS/SIOX hints when
+  GPFS support is built.
+- [x] Keep filesystem-specific hint names inside their owning
+  components.
+- [~] Define how each alias stores its canonical relationship.
+- [~] Use canonical public spelling only when returning defaults with no
+  user-supplied spelling.
+- [x] Extend the manual test for alias spelling and component-owned
+  hints where the relevant component is available.
+- [x] Make filesystem-specific test sections skip gracefully when the
+  relevant component/filesystem is unavailable.
+
+Behavior at the end of Phase 4:
+
+- OMPIO common/core, `sharedfp/individual`, `fs/lustre`, and `fs/gpfs`
+  use component-owned hint registration.
+- OMPIO framework/common code does not hard-code hint names owned by
+  those components.
+- Filesystem-dependent behavior remains conditional and reviewable.
+
+Verification:
+
+- [x] Build touched OMPIO and sharedfp files.  The edited Lustre/GPFS
+  component sources could not be built in this local configuration
+  because the Lustre and GPFS development headers are unavailable.
+- [x] Run the manual `test/simple` test on a generic filesystem.
+- [ ] Run Lustre-specific checks only on Lustre or with a build where
+  the component can be selected safely.
+- [ ] Run GPFS-specific checks only when GPFS support is built and
+  available.
+- [x] Verify ignored component-specific hints are not returned.
+- [x] Verify accepted aliases preserve user spelling where locally
+  testable; Lustre alias runtime verification requires a Lustre-enabled
+  build and filesystem.
+- [x] Review for memory ownership and temporary `opal_cstring_t`
+  releases.
+
+## Phase 5: Documentation, Release Note, and Final Cleanup
+
+Goal: document the user-visible behavior and perform final consistency
+checks once the implementation behavior is settled.
+
+Implementation tasks:
+
+- [x] Add an `MPI_Info hints` section to
+  `docs/tuning-apps/mpi-io.rst`.
+- [x] Document hints in tables grouped by owner/component.
+- [x] Include accepted phases, defaults, MCA parameter mappings, and
+  notes.
+- [x] Document alias-preservation behavior.
+- [x] Add cross-references from:
+  - `docs/man-openmpi/man3/MPI_File_open.3.rst`
+  - `docs/man-openmpi/man3/MPI_File_set_view.3.rst`
+  - `docs/man-openmpi/man3/MPI_File_set_info.3.rst`
+  - `docs/man-openmpi/man3/MPI_File_get_info.3.rst`
+- [x] Add a shared include file so the same hint documentation appears
+  in the tuning guide and in the rendered MPI-IO man pages.
+- [x] Add a release-note/changelog entry under
+  `docs/release-notes/changelog/` if the behavior is deemed
+  user-visible.
+- [x] Add rationale comments to the non-obvious implementation paths,
+  especially where callbacks, cached info values, and staged updates
+  preserve MPI semantics.
+- [x] Review all touched code for Open MPI style:
+  - config header first,
+  - constants on the left in equality checks,
+  - braced blocks,
+  - 4-space indentation,
+  - no new global symbols without appropriate prefixes.
+- [x] Confirm no component-specific hint names are hard-coded in OMPIO
+  framework/common code unless OMPIO common/core owns them.
+- [x] Confirm generated MPI binding files were not hand-edited.
+- [x] Confirm no new memory ownership ambiguity:
+  - `fh->super.s_info` remains owned by `ompi_file_t`,
+  - `ompio_file_t::f_info` is borrowed,
+  - returned `MPI_Info` objects are caller-owned,
+  - temporary `opal_cstring_t` values are released.
+
+Behavior at the end of Phase 5:
+
+- The implementation is documented for users.
+- Manual test coverage exists for the implemented behavior.
+- The work is ready for full review.
+
+Verification:
+
+- [~] Build the touched code that is included in this local
+  configuration.  The edited Lustre/GPFS component sources could not be
+  built locally because the corresponding development headers are not
+  installed, matching the Phase 4 verification caveat.
+- [x] Run the manual `test/simple` test with `--mca io ompio`.
+- [x] Run documentation build checks if Sphinx is enabled.
+- [x] If build-system files were not changed, avoid unnecessary
+  `autogen.pl`; if they were changed, regenerate according to
+  `AGENTS.md`.
+- [x] Prepare a concise final test/verification summary for reviewers.

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -20,5 +20,5 @@
 
 # Note: the "environment" subdirectory is stale (it links against a
 # long-gone src/ library layout) and is not part of the build; only the
-# "t" MPI_T tests are wired in.
-SUBDIRS = t
+# "t" MPI_T tests and the "file" MPI-IO info tests are wired in.
+SUBDIRS = t file

--- a/test/mpi/file/Makefile.am
+++ b/test/mpi/file/Makefile.am
@@ -1,0 +1,50 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# These are single-process OMPIO MPI_File info tests.  Each calls
+# MPI_Init and performs all of its I/O on MPI_COMM_SELF, so they need no
+# launcher and can run as part of 'make check'.  They exercise the OMPIO
+# MPI_Info hint reporting required by MPI-5.0 sec. 15.2.8 (Open MPI issue
+# #13367).
+if PROJECT_OMPI
+    check_PROGRAMS = \
+        file_info_defaults \
+        file_info_hints \
+        file_info_set_view \
+        file_info_memkind
+    TESTS = $(check_PROGRAMS)
+
+    common_headers = ompio_file_info_common.h
+    common_ldflags = $(OMPI_PKG_CONFIG_LDFLAGS)
+    common_ldadd = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+    file_info_defaults_SOURCES = file_info_defaults.c $(common_headers)
+    file_info_defaults_LDFLAGS = $(common_ldflags)
+    file_info_defaults_LDADD = $(common_ldadd)
+
+    file_info_hints_SOURCES = file_info_hints.c $(common_headers)
+    file_info_hints_LDFLAGS = $(common_ldflags)
+    file_info_hints_LDADD = $(common_ldadd)
+
+    file_info_set_view_SOURCES = file_info_set_view.c $(common_headers)
+    file_info_set_view_LDFLAGS = $(common_ldflags)
+    file_info_set_view_LDADD = $(common_ldadd)
+
+    file_info_memkind_SOURCES = file_info_memkind.c $(common_headers)
+    file_info_memkind_LDFLAGS = $(common_ldflags)
+    file_info_memkind_LDADD = $(common_ldadd)
+endif # PROJECT_OMPI
+
+distclean-local:
+	rm -rf *.dSYM .deps .libs *.la *.lo *.log *.o *.trs \
+		file_info_defaults file_info_hints file_info_set_view \
+		file_info_memkind Makefile

--- a/test/mpi/file/file_info_defaults.c
+++ b/test/mpi/file/file_info_defaults.c
@@ -1,0 +1,77 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) regression test for Open MPI
+ * issue #13367: MPI_File_get_info on an OMPIO file opened with
+ * MPI_INFO_NULL must return the implementation's supported, defaulted
+ * file hints rather than an empty info object.
+ *
+ * MPI-5.0 section 15.2.8 requires the info object returned by
+ * MPI_File_get_info to contain the current setting of all hints
+ * associated with the file, including hints the implementation supports
+ * with default values.
+ */
+
+#include "ompio_file_info_common.h"
+
+int main(int argc, char *argv[])
+{
+    const char *name = "file_info_defaults";
+    finfo_result_t res = {0, 0};
+    char filename[256];
+    MPI_File fh;
+    MPI_Info info_used;
+    int rc;
+
+    MPI_Init(&argc, &argv);
+
+    /* Make MPI_File_open report failures instead of aborting. */
+    MPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
+
+    finfo_make_filename(filename, sizeof(filename), "defaults");
+
+    rc = finfo_open(&fh, filename, MPI_INFO_NULL);
+    finfo_check_rc(&res, rc, "MPI_File_open(MPI_INFO_NULL)");
+    if (MPI_SUCCESS != rc) {
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info");
+    if (MPI_SUCCESS == rc) {
+        /*
+         * The headline #13367 symptom: a file opened with MPI_INFO_NULL
+         * reported zero hints.  Require a non-empty, well-formed result.
+         */
+        finfo_expect_nonempty(&res, info_used);
+
+        /*
+         * OMPIO core registers these hints with defaults, so they must
+         * appear even though the user supplied no info.
+         */
+        finfo_expect_key(&res, info_used, "cb_buffer_size");
+        finfo_expect_value(&res, info_used, "collective_buffering", "true");
+
+        /*
+         * cb_nodes defaults to the internal "-1" (auto) sentinel, which
+         * must never be reported to the application: the hint is either
+         * omitted or carries a real aggregator count.
+         */
+        finfo_expect_absent_or_not_value(&res, info_used, "cb_nodes", "-1");
+
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    finfo_check_rc(&res, rc, "MPI_File_close");
+
+    MPI_Finalize();
+    return finfo_finish(name, &res);
+}

--- a/test/mpi/file/file_info_hints.c
+++ b/test/mpi/file/file_info_hints.c
@@ -1,0 +1,110 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) test for OMPIO MPI_Info hint
+ * handling at MPI_File_open and MPI_File_set_info time.
+ *
+ * MPI-5.0 section 15.2.8 requires that an accepted user hint be reflected
+ * by MPI_File_get_info, that an unknown/ignored hint not be reported, and
+ * that MPI_File_set_info update the named hints while leaving previous and
+ * default values for omitted (or ignored) hints in effect.
+ */
+
+#include "ompio_file_info_common.h"
+
+int main(int argc, char *argv[])
+{
+    const char *name = "file_info_hints";
+    finfo_result_t res = {0, 0};
+    char filename[256];
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    int rc;
+
+    MPI_Init(&argc, &argv);
+    MPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
+
+    finfo_make_filename(filename, sizeof(filename), "hints");
+
+    /* Open with a supported hint plus an unknown one. */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create");
+    if (MPI_SUCCESS != rc) {
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+    MPI_Info_set(info, "cb_buffer_size", "12345");
+    MPI_Info_set(info, "unknown_ompio_hint", "ignore-me");
+
+    rc = finfo_open(&fh, filename, info);
+    finfo_check_rc(&res, rc, "MPI_File_open(user hints)");
+    MPI_Info_free(&info);
+    if (MPI_SUCCESS != rc) {
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+
+    /* The accepted hint must be reported; the unknown one must not. */
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info (after open)");
+    if (MPI_SUCCESS == rc) {
+        finfo_expect_value(&res, info_used, "cb_buffer_size", "12345");
+        finfo_expect_value(&res, info_used, "collective_buffering", "true");
+        finfo_expect_no_key(&res, info_used, "unknown_ompio_hint");
+        MPI_Info_free(&info_used);
+    }
+
+    /* MPI_File_set_info updates a mutable hint; unknown keys are ignored. */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create");
+    if (MPI_SUCCESS == rc) {
+        MPI_Info_set(info, "cb_buffer_size", "23456");
+        MPI_Info_set(info, "unknown_ompio_hint", "still-ignore-me");
+        rc = MPI_File_set_info(fh, info);
+        finfo_check_rc(&res, rc, "MPI_File_set_info (update)");
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info (after set_info)");
+    if (MPI_SUCCESS == rc) {
+        finfo_expect_value(&res, info_used, "cb_buffer_size", "23456");
+        /* A hint not named in set_info keeps its previous/default value. */
+        finfo_expect_value(&res, info_used, "collective_buffering", "true");
+        finfo_expect_no_key(&res, info_used, "unknown_ompio_hint");
+        finfo_expect_absent_or_not_value(&res, info_used, "cb_nodes", "-1");
+        MPI_Info_free(&info_used);
+    }
+
+    /* set_info with only an unknown key must leave prior hints untouched. */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create");
+    if (MPI_SUCCESS == rc) {
+        MPI_Info_set(info, "unknown_ompio_hint", "unknown-only");
+        rc = MPI_File_set_info(fh, info);
+        finfo_check_rc(&res, rc, "MPI_File_set_info (unknown only)");
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info (after unknown-only set_info)");
+    if (MPI_SUCCESS == rc) {
+        finfo_expect_value(&res, info_used, "cb_buffer_size", "23456");
+        finfo_expect_value(&res, info_used, "collective_buffering", "true");
+        finfo_expect_no_key(&res, info_used, "unknown_ompio_hint");
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    finfo_check_rc(&res, rc, "MPI_File_close");
+
+    MPI_Finalize();
+    return finfo_finish(name, &res);
+}

--- a/test/mpi/file/file_info_memkind.c
+++ b/test/mpi/file/file_info_memkind.c
@@ -1,0 +1,177 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) test for the MPI-4.1
+ * memory-allocation-kind info keys on MPI_File objects.
+ *
+ * MPI-5.0 section 11.4.3 requires that "mpi_memory_alloc_kinds" be
+ * contained in the info object returned by MPI_FILE_GET_INFO, and that
+ * for a file derived from the World Model its value be identical to the
+ * value reported by MPI_COMM_GET_INFO on MPI_COMM_WORLD/MPI_COMM_SELF.
+ * It further requires (sections 11.4.3 and 14.2.8) that when the user
+ * asserts a supported set of kinds via "mpi_assert_memory_alloc_kinds"
+ * at file-open time, MPI_FILE_GET_INFO return that key with a value
+ * identical to the one the user supplied.
+ *
+ * Open MPI only populates "mpi_memory_alloc_kinds" when the kinds were
+ * requested (via the OMPI_MCA_mpi_memory_alloc_kinds MCA parameter, read
+ * when the World Model instance is built; see
+ * ompi/communicator/comm_init.c).  This test therefore requests "system"
+ * -- a kind that is always supported -- in the environment before
+ * MPI_Init, then verifies that the file layer carries the keys through
+ * open, set_info, and set_view.
+ */
+
+#include "ompio_file_info_common.h"
+
+int main(int argc, char *argv[])
+{
+    const char *name = "file_info_memkind";
+    finfo_result_t res = {0, 0};
+    char filename[256];
+    char world_kinds[MPI_MAX_INFO_VAL + 1];
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    MPI_Info world_info;
+    int rc;
+
+    /*
+     * Request a supported memory allocation kind before MPI is
+     * initialized; Open MPI reads this when it constructs the World Model
+     * instance.  setenv() with overwrite forces a deterministic value
+     * regardless of the caller's environment.
+     */
+    setenv("OMPI_MCA_mpi_memory_alloc_kinds", "system", 1);
+
+    MPI_Init(&argc, &argv);
+    MPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
+
+    /*
+     * Capture the World Model reference value.  MPI is free to report
+     * additional kinds beyond the requested "system", so the file checks
+     * below compare against whatever MPI_COMM_WORLD reports rather than a
+     * hard-coded spelling.
+     */
+    rc = MPI_Comm_get_info(MPI_COMM_WORLD, &world_info);
+    finfo_check_rc(&res, rc, "MPI_Comm_get_info(MPI_COMM_WORLD)");
+    if (MPI_SUCCESS != rc) {
+        /* A failed query is a real error, not a skip. */
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+    if (!finfo_info_get(world_info, "mpi_memory_alloc_kinds", world_kinds)) {
+        /*
+         * The instance did not pick up the requested kinds (for example,
+         * the MCA parameter was pinned to a different value in the
+         * environment).  There is no reference value to compare against,
+         * so mark the whole test skipped.  Automake's exit-status test
+         * driver treats exit code 77 as SKIP; returning it keeps a
+         * lost-coverage environment visible under 'make check' instead of
+         * reporting a false PASS.
+         */
+        printf("SKIP: mpi_memory_alloc_kinds not reported on MPI_COMM_WORLD; "
+               "nothing to test\n");
+        MPI_Info_free(&world_info);
+        MPI_Finalize();
+        return 77;
+    }
+    printf("INFO: MPI_COMM_WORLD mpi_memory_alloc_kinds = '%s'\n", world_kinds);
+    MPI_Info_free(&world_info);
+
+    finfo_make_filename(filename, sizeof(filename), "memkind");
+
+    /*
+     * Case 1: a file opened with MPI_INFO_NULL must still report
+     * mpi_memory_alloc_kinds, and the value must match the World Model
+     * value.  It must also survive set_info (which cannot update or
+     * delete the key) and set_view (which rebuilds the reported hint set
+     * from a staged copy).
+     */
+    rc = finfo_open(&fh, filename, MPI_INFO_NULL);
+    finfo_check_rc(&res, rc, "MPI_File_open(MPI_INFO_NULL)");
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_File_get_info(fh, &info_used);
+        finfo_check_rc(&res, rc, "MPI_File_get_info (after open)");
+        if (MPI_SUCCESS == rc) {
+            finfo_expect_value(&res, info_used, "mpi_memory_alloc_kinds",
+                               world_kinds);
+            MPI_Info_free(&info_used);
+        }
+
+        rc = MPI_Info_create(&info);
+        finfo_check_rc(&res, rc, "MPI_Info_create (set_info)");
+        if (MPI_SUCCESS == rc) {
+            /* Update an unrelated hint; the memkind key must be untouched. */
+            MPI_Info_set(info, "cb_buffer_size", "65536");
+            rc = MPI_File_set_info(fh, info);
+            finfo_check_rc(&res, rc, "MPI_File_set_info");
+            MPI_Info_free(&info);
+        }
+        rc = MPI_File_get_info(fh, &info_used);
+        finfo_check_rc(&res, rc, "MPI_File_get_info (after set_info)");
+        if (MPI_SUCCESS == rc) {
+            finfo_expect_value(&res, info_used, "mpi_memory_alloc_kinds",
+                               world_kinds);
+            MPI_Info_free(&info_used);
+        }
+
+        rc = MPI_File_set_view(fh, 0, MPI_BYTE, MPI_BYTE, "native",
+                               MPI_INFO_NULL);
+        finfo_check_rc(&res, rc, "MPI_File_set_view");
+        rc = MPI_File_get_info(fh, &info_used);
+        finfo_check_rc(&res, rc, "MPI_File_get_info (after set_view)");
+        if (MPI_SUCCESS == rc) {
+            finfo_expect_value(&res, info_used, "mpi_memory_alloc_kinds",
+                               world_kinds);
+            MPI_Info_free(&info_used);
+        }
+
+        rc = MPI_File_close(&fh);
+        finfo_check_rc(&res, rc, "MPI_File_close");
+    }
+
+    /*
+     * Case 2: assert a supported subset of kinds at open time.  Because
+     * "system" is supported, the implementation recognizes the assertion
+     * and MPI_File_get_info must return mpi_assert_memory_alloc_kinds
+     * identical to the supplied value, alongside mpi_memory_alloc_kinds.
+     */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create (assert)");
+    if (MPI_SUCCESS == rc) {
+        MPI_Info_set(info, "mpi_assert_memory_alloc_kinds", "system");
+        rc = finfo_open(&fh, filename, info);
+        finfo_check_rc(&res, rc, "MPI_File_open(mpi_assert_memory_alloc_kinds)");
+        MPI_Info_free(&info);
+        if (MPI_SUCCESS == rc) {
+            rc = MPI_File_get_info(fh, &info_used);
+            finfo_check_rc(&res, rc, "MPI_File_get_info (assert)");
+            if (MPI_SUCCESS == rc) {
+                finfo_expect_value(&res, info_used,
+                                   "mpi_assert_memory_alloc_kinds", "system");
+                /*
+                 * A recognized assertion narrows the reported kinds: the
+                 * file must report exactly the asserted "system", not the
+                 * broader World Model value (which also contains "mpi").
+                 * Checking only presence would let a regression that left
+                 * the parent value in place slip through.
+                 */
+                finfo_expect_value(&res, info_used, "mpi_memory_alloc_kinds",
+                                   "system");
+                MPI_Info_free(&info_used);
+            }
+            rc = MPI_File_close(&fh);
+            finfo_check_rc(&res, rc, "MPI_File_close (assert)");
+        }
+    }
+
+    MPI_Finalize();
+    return finfo_finish(name, &res);
+}

--- a/test/mpi/file/file_info_set_view.c
+++ b/test/mpi/file/file_info_set_view.c
@@ -1,0 +1,107 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) test for OMPIO MPI_Info hint
+ * handling at MPI_File_set_view time.
+ *
+ * The info argument to MPI_File_set_view is routed through the same hint
+ * subscription mechanism as open/set_info: view-related hints that OMPIO
+ * accepts (here cb_nodes and collective_buffering) must be reflected by a
+ * subsequent MPI_File_get_info, unknown keys must not be reported, and
+ * hints that were in effect before the view change must be preserved.
+ */
+
+#include "ompio_file_info_common.h"
+
+int main(int argc, char *argv[])
+{
+    const char *name = "file_info_set_view";
+    finfo_result_t res = {0, 0};
+    char filename[256];
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    MPI_Datatype filetype;
+    int rc;
+
+    MPI_Init(&argc, &argv);
+    MPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
+
+    finfo_make_filename(filename, sizeof(filename), "set-view");
+
+    rc = finfo_open(&fh, filename, MPI_INFO_NULL);
+    finfo_check_rc(&res, rc, "MPI_File_open(MPI_INFO_NULL)");
+    if (MPI_SUCCESS != rc) {
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+
+    /* A simple committed filetype is enough to set a view. */
+    rc = MPI_Type_contiguous(2, MPI_BYTE, &filetype);
+    finfo_check_rc(&res, rc, "MPI_Type_contiguous");
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Type_commit(&filetype);
+        finfo_check_rc(&res, rc, "MPI_Type_commit");
+    }
+    if (MPI_SUCCESS != rc) {
+        MPI_File_close(&fh);
+        MPI_Finalize();
+        return finfo_finish(name, &res);
+    }
+
+    /* Set a view carrying view-related hints plus an unknown one. */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create");
+    if (MPI_SUCCESS == rc) {
+        MPI_Info_set(info, "cb_nodes", "1");
+        MPI_Info_set(info, "collective_buffering", "false");
+        MPI_Info_set(info, "unknown_ompio_hint", "set-view-ignore-me");
+        rc = MPI_File_set_view(fh, 0, MPI_BYTE, filetype, "native", info);
+        finfo_check_rc(&res, rc, "MPI_File_set_view (with hints)");
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info (after set_view)");
+    if (MPI_SUCCESS == rc) {
+        finfo_expect_value(&res, info_used, "cb_nodes", "1");
+        finfo_expect_value(&res, info_used, "collective_buffering", "false");
+        finfo_expect_no_key(&res, info_used, "unknown_ompio_hint");
+        /* Default hints from open survive a view change. */
+        finfo_expect_key(&res, info_used, "cb_buffer_size");
+        MPI_Info_free(&info_used);
+    }
+
+    /* A second view with only an unknown key preserves the prior hints. */
+    rc = MPI_Info_create(&info);
+    finfo_check_rc(&res, rc, "MPI_Info_create");
+    if (MPI_SUCCESS == rc) {
+        MPI_Info_set(info, "unknown_ompio_hint", "unknown-only-set-view");
+        rc = MPI_File_set_view(fh, 0, MPI_BYTE, filetype, "native", info);
+        finfo_check_rc(&res, rc, "MPI_File_set_view (unknown only)");
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    finfo_check_rc(&res, rc, "MPI_File_get_info (after unknown-only set_view)");
+    if (MPI_SUCCESS == rc) {
+        finfo_expect_value(&res, info_used, "cb_nodes", "1");
+        finfo_expect_value(&res, info_used, "collective_buffering", "false");
+        finfo_expect_no_key(&res, info_used, "unknown_ompio_hint");
+        MPI_Info_free(&info_used);
+    }
+
+    MPI_Type_free(&filetype);
+
+    rc = MPI_File_close(&fh);
+    finfo_check_rc(&res, rc, "MPI_File_close");
+
+    MPI_Finalize();
+    return finfo_finish(name, &res);
+}

--- a/test/mpi/file/ompio_file_info_common.h
+++ b/test/mpi/file/ompio_file_info_common.h
@@ -1,0 +1,226 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Shared helpers for the single-process OMPIO MPI_File info tests.
+ *
+ * These tests are singletons: each calls MPI_Init and performs all of
+ * its file I/O on MPI_COMM_SELF, so they need no launcher and can run as
+ * part of 'make check'.  They exercise the OMPIO MPI_Info hint reporting
+ * required by MPI-5.0 section 15.2.8 and added for Open MPI issue #13367
+ * ("MPI_File_get_info fails to return hints as required by MPI
+ * standard"): MPI_File_get_info must return every supported hint (its
+ * implementation default, any accepted user value, and any value set by
+ * the implementation), and must not return unknown or ignored user
+ * hints.
+ *
+ * The helpers below are 'static inline' so that an unused helper in any
+ * one test does not trigger -Wunused-function.
+ */
+
+#ifndef OMPIO_FILE_INFO_COMMON_H
+#define OMPIO_FILE_INFO_COMMON_H
+
+#include "mpi.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Running tally of assertions for a single test program. */
+typedef struct {
+    int checks;     /* total assertions made */
+    int failures;   /* assertions that failed */
+} finfo_result_t;
+
+/*
+ * Look up a key in an info object.  Returns 1 and copies the value into
+ * 'value' (a buffer of at least MPI_MAX_INFO_VAL + 1 bytes) if present,
+ * otherwise returns 0.
+ */
+static inline int finfo_info_get(MPI_Info info, const char *key, char *value)
+{
+    int flag = 0;
+    int buflen = MPI_MAX_INFO_VAL;
+
+    value[0] = '\0';
+    MPI_Info_get_string(info, key, &buflen, value, &flag);
+    return flag;
+}
+
+/* Check that an MPI call returned MPI_SUCCESS. */
+static inline void finfo_check_rc(finfo_result_t *res, int rc, const char *call)
+{
+    char errstr[MPI_MAX_ERROR_STRING];
+    int len = 0;
+
+    ++res->checks;
+    if (MPI_SUCCESS != rc) {
+        ++res->failures;
+        MPI_Error_string(rc, errstr, &len);
+        printf("FAIL: %s returned MPI error %d (%.*s)\n", call, rc, len, errstr);
+    }
+}
+
+/* Assert that 'key' is present (with any value). */
+static inline void finfo_expect_key(finfo_result_t *res, MPI_Info info,
+                                  const char *key)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    ++res->checks;
+    if (!finfo_info_get(info, key, value)) {
+        ++res->failures;
+        printf("FAIL: expected hint '%s' to be present\n", key);
+    } else {
+        printf("PASS: hint '%s' present (= '%s')\n", key, value);
+    }
+}
+
+/* Assert that 'key' is present and equal to 'expected'. */
+static inline void finfo_expect_value(finfo_result_t *res, MPI_Info info,
+                                    const char *key, const char *expected)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    ++res->checks;
+    if (!finfo_info_get(info, key, value)) {
+        ++res->failures;
+        printf("FAIL: expected hint '%s' = '%s', but it was absent\n",
+               key, expected);
+    } else if (0 != strcmp(value, expected)) {
+        ++res->failures;
+        printf("FAIL: expected hint '%s' = '%s', got '%s'\n",
+               key, expected, value);
+    } else {
+        printf("PASS: hint '%s' = '%s'\n", key, value);
+    }
+}
+
+/* Assert that 'key' is not reported at all. */
+static inline void finfo_expect_no_key(finfo_result_t *res, MPI_Info info,
+                                     const char *key)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    ++res->checks;
+    if (finfo_info_get(info, key, value)) {
+        ++res->failures;
+        printf("FAIL: hint '%s' should not be reported, but got '%s'\n",
+               key, value);
+    } else {
+        printf("PASS: hint '%s' correctly not reported\n", key);
+    }
+}
+
+/*
+ * Assert that 'key' is either absent or, if present, not equal to the
+ * 'rejected' value.  Used for hints (such as cb_nodes) whose internal
+ * sentinel value must never be reported to the application.
+ */
+static inline void finfo_expect_absent_or_not_value(finfo_result_t *res,
+                                                  MPI_Info info,
+                                                  const char *key,
+                                                  const char *rejected)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    ++res->checks;
+    if (finfo_info_get(info, key, value) && 0 == strcmp(value, rejected)) {
+        ++res->failures;
+        printf("FAIL: hint '%s' must never be reported as '%s'\n",
+               key, rejected);
+    } else {
+        printf("PASS: hint '%s' not reported as '%s'\n", key, rejected);
+    }
+}
+
+/*
+ * Assert that the info object reports at least one hint, and that every
+ * reported hint has a non-empty value.  Issue #13367 was that
+ * MPI_File_get_info returned zero hints.
+ */
+static inline void finfo_expect_nonempty(finfo_result_t *res, MPI_Info info)
+{
+    int nkeys = 0;
+    int i;
+
+    ++res->checks;
+    if (MPI_SUCCESS != MPI_Info_get_nkeys(info, &nkeys) || nkeys <= 0) {
+        ++res->failures;
+        printf("FAIL: MPI_File_get_info returned %d hints, expected at least 1\n",
+               nkeys);
+        return;
+    }
+    printf("PASS: MPI_File_get_info returned %d hint(s)\n", nkeys);
+
+    for (i = 0; i < nkeys; ++i) {
+        char key[MPI_MAX_INFO_KEY + 1];
+        char value[MPI_MAX_INFO_VAL + 1];
+
+        ++res->checks;
+        if (MPI_SUCCESS != MPI_Info_get_nthkey(info, i, key)) {
+            ++res->failures;
+            printf("FAIL: MPI_Info_get_nthkey(%d) failed\n", i);
+            continue;
+        }
+        if (!finfo_info_get(info, key, value) || '\0' == value[0]) {
+            ++res->failures;
+            printf("FAIL: reported hint '%s' has an empty value\n", key);
+        } else {
+            printf("PASS: reported hint '%s' = '%s'\n", key, value);
+        }
+    }
+}
+
+/*
+ * Build a unique, single-process scratch filename.  The pid keeps
+ * concurrent test programs (and any accidental multi-rank launch) from
+ * colliding.  The file itself is always opened MPI_MODE_DELETE_ON_CLOSE.
+ */
+static inline void finfo_make_filename(char *buf, size_t buflen, const char *tag)
+{
+    const char *dir = getenv("TMPDIR");
+
+    if (NULL == dir || '\0' == dir[0]) {
+        dir = "/tmp";
+    }
+    snprintf(buf, buflen, "%s/ompio-file-info-%s-%ld.dat",
+             dir, tag, (long) getpid());
+}
+
+/*
+ * Open a scratch file on MPI_COMM_SELF for read/write, creating it and
+ * arranging for it to be removed on close.  Returns the MPI_File_open
+ * return code; on success the file uses MPI_ERRORS_RETURN.
+ */
+static inline int finfo_open(MPI_File *fh, const char *filename, MPI_Info info)
+{
+    int rc = MPI_File_open(MPI_COMM_SELF, filename,
+                           MPI_MODE_CREATE | MPI_MODE_RDWR
+                           | MPI_MODE_DELETE_ON_CLOSE,
+                           info, fh);
+    if (MPI_SUCCESS == rc) {
+        MPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+    }
+    return rc;
+}
+
+/* Print the final result line and return the process exit status. */
+static inline int finfo_finish(const char *name, const finfo_result_t *res)
+{
+    if (0 == res->failures) {
+        printf("%s: all %d check(s) passed\n", name, res->checks);
+        return EXIT_SUCCESS;
+    }
+    printf("%s: %d of %d check(s) failed\n", name, res->failures, res->checks);
+    return EXIT_FAILURE;
+}
+
+#endif /* OMPIO_FILE_INFO_COMMON_H */

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -4,7 +4,7 @@ PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort 
 		crisscross read_write ziatest slave reduce-hang ziaprobe ziatest bcast_loop \
 		parallel_w8 parallel_w64 parallel_r8 parallel_r64 sio sendrecv_blaster early_abort \
 		debugger singleton_client_server intercomm_create spawn_tree init-exit77 mpi_info \
-		info_spawn server client ring binding badcoll attach xlib \
+		info_spawn server client ring binding badcoll attach xlib ompio_file_info \
 		no-disconnect nonzero interlib pinterlib add_host \
 		buffer_attach_detach_f08
 

--- a/test/simple/ompio_file_info.c
+++ b/test/simple/ompio_file_info.c
@@ -1,0 +1,798 @@
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Manual invocation:
+ *
+ *   mpirun -n 2 --mca io ompio ./ompio_file_info
+ *
+ * The memory-allocation-kind checks request a supported kind in-process
+ * (see main()), so they run without the launcher having to forward the
+ * MCA parameter.
+ *
+ * Optional filesystem-specific checks:
+ *
+ *   OMPIO_FILE_INFO_LUSTRE_DIR=/mnt/lustre \
+ *       mpirun -n 2 --mca io ompio ./ompio_file_info
+ *   OMPIO_FILE_INFO_GPFS_DIR=/gpfs \
+ *       mpirun -n 2 --mca io ompio ./ompio_file_info
+ */
+
+#include "mpi.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int errors = 0;
+
+enum {
+    SECTION_SKIPPED = 0,
+    SECTION_RAN = 1
+};
+
+static void section_start(const char *name, int rank)
+{
+    if (0 == rank) {
+        printf("ompio_file_info: %s: start\n", name);
+        fflush(stdout);
+    }
+}
+
+static void section_finish(const char *name, int errors_before, int ran, int rank)
+{
+    int local_failed = (errors_before != errors) ? 1 : 0;
+    int failed = 0;
+
+    MPI_Allreduce(&local_failed, &failed, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+
+    if (0 == rank) {
+        if (SECTION_SKIPPED == ran) {
+            printf("ompio_file_info: %s: SKIP\n", name);
+        } else if (failed) {
+            printf("ompio_file_info: %s: FAIL\n", name);
+        } else {
+            printf("ompio_file_info: %s: PASS\n", name);
+        }
+        fflush(stdout);
+    }
+}
+
+static void check_rc(int rc, const char *call, int rank)
+{
+    if (MPI_SUCCESS != rc) {
+        fprintf(stderr, "[%d] %s failed with MPI error %d\n", rank, call, rc);
+        ++errors;
+    }
+}
+
+static int info_has_key(MPI_Info info, const char *key, char *value, int value_len)
+{
+    int flag = 0;
+    int buflen = value_len;
+
+    value[0] = '\0';
+    MPI_Info_get_string(info, key, &buflen, value, &flag);
+    return flag;
+}
+
+static void expect_key(MPI_Info info, const char *key, int rank)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    if (!info_has_key(info, key, value, MPI_MAX_INFO_VAL)) {
+        fprintf(stderr, "[%d] expected key %s was not returned\n", rank, key);
+        ++errors;
+    }
+}
+
+static void expect_value(MPI_Info info, const char *key, const char *expected, int rank)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    if (!info_has_key(info, key, value, MPI_MAX_INFO_VAL)) {
+        fprintf(stderr, "[%d] expected key %s was not returned\n", rank, key);
+        ++errors;
+        return;
+    }
+
+    if (0 != strcmp(value, expected)) {
+        fprintf(stderr, "[%d] expected %s=%s, got %s\n", rank, key, expected, value);
+        ++errors;
+    }
+}
+
+static void expect_no_key(MPI_Info info, const char *key, int rank)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    if (info_has_key(info, key, value, MPI_MAX_INFO_VAL)) {
+        fprintf(stderr, "[%d] unexpected key %s=%s was returned\n", rank, key, value);
+        ++errors;
+    }
+}
+
+static void expect_absent_or_not_value(MPI_Info info, const char *key,
+                                       const char *rejected, int rank)
+{
+    char value[MPI_MAX_INFO_VAL + 1];
+
+    if (info_has_key(info, key, value, MPI_MAX_INFO_VAL)
+        && 0 == strcmp(value, rejected)) {
+        fprintf(stderr, "[%d] unexpected %s=%s was returned\n", rank, key, value);
+        ++errors;
+    }
+}
+
+static void expect_same_optional_value(MPI_Info info, const char *key,
+                                       int expected_flag, const char *expected,
+                                       int rank)
+{
+    if (expected_flag) {
+        expect_value(info, key, expected, rank);
+    } else {
+        expect_no_key(info, key, rank);
+    }
+}
+
+static void make_filename_in_dir(char *filename, size_t filename_len,
+                                 const char *dir, const char *tag, int rank)
+{
+    const char *jobid;
+    char jobid_buf[32];
+
+    if (0 == rank) {
+        jobid = getenv("PMIX_NAMESPACE");
+        if (NULL == jobid) {
+            snprintf(jobid_buf, sizeof(jobid_buf), "%ld", (long) getpid());
+            jobid = jobid_buf;
+        }
+
+        snprintf(filename, filename_len, "%s/ompio-file-info-%s-%s.dat",
+                 dir, tag, jobid);
+    }
+
+    MPI_Bcast(filename, (int) filename_len, MPI_CHAR, 0, MPI_COMM_WORLD);
+}
+
+static void make_filename(char *filename, size_t filename_len, int rank)
+{
+    const char *tmpdir;
+
+    tmpdir = getenv("TMPDIR");
+    if (NULL == tmpdir) {
+        tmpdir = "/tmp";
+    }
+
+    make_filename_in_dir(filename, filename_len, tmpdir, "generic", rank);
+}
+
+static void check_default_info(const char *filename, int rank)
+{
+    MPI_File fh;
+    MPI_Info info_used;
+    int rc;
+
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       MPI_INFO_NULL, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_key(info_used, "cb_buffer_size", rank);
+        expect_absent_or_not_value(info_used, "cb_nodes", "-1", rank);
+        expect_key(info_used, "collective_buffering", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+}
+
+static void check_user_info(const char *filename, int rank)
+{
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    MPI_Datatype filetype = MPI_DATATYPE_NULL;
+    char cb_nodes_value[MPI_MAX_INFO_VAL + 1];
+    char collective_buffering_value[MPI_MAX_INFO_VAL + 1];
+    int cb_nodes_flag = 0;
+    int collective_buffering_flag = 0;
+    int filetype_ready = 0;
+    int rc;
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_Info_set(info, "cb_buffer_size", "12345");
+    check_rc(rc, "MPI_Info_set", rank);
+    rc = MPI_Info_set(info, "unknown_ompio_hint", "ignore-me");
+    check_rc(rc, "MPI_Info_set", rank);
+
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       info, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    MPI_Info_free(&info);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+    rc = MPI_File_set_errhandler(fh, MPI_ERRORS_RETURN);
+    check_rc(rc, "MPI_File_set_errhandler", rank);
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "12345", rank);
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(info, "cb_buffer_size", "23456");
+        check_rc(rc, "MPI_Info_set", rank);
+        rc = MPI_Info_set(info, "unknown_ompio_hint", "still-ignore-me");
+        check_rc(rc, "MPI_Info_set", rank);
+
+        rc = MPI_File_set_info(fh, info);
+        check_rc(rc, "MPI_File_set_info", rank);
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "23456", rank);
+        cb_nodes_flag = info_has_key(info_used, "cb_nodes", cb_nodes_value,
+                                     MPI_MAX_INFO_VAL);
+        if (cb_nodes_flag && 0 == strcmp(cb_nodes_value, "-1")) {
+            fprintf(stderr, "[%d] unexpected cb_nodes=-1 was returned\n", rank);
+            ++errors;
+        }
+        collective_buffering_flag = info_has_key(info_used, "collective_buffering",
+                                                 collective_buffering_value,
+                                                 MPI_MAX_INFO_VAL);
+        if (!collective_buffering_flag) {
+            fprintf(stderr, "[%d] expected key collective_buffering was not returned\n", rank);
+            ++errors;
+        }
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(info, "unknown_ompio_hint", "unknown-only");
+        check_rc(rc, "MPI_Info_set", rank);
+
+        rc = MPI_File_set_info(fh, info);
+        check_rc(rc, "MPI_File_set_info", rank);
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "23456", rank);
+        expect_same_optional_value(info_used, "cb_nodes", cb_nodes_flag,
+                                   cb_nodes_value, rank);
+        expect_same_optional_value(info_used, "collective_buffering",
+                                   collective_buffering_flag,
+                                   collective_buffering_value, rank);
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Type_contiguous(2, MPI_BYTE, &filetype);
+    check_rc(rc, "MPI_Type_contiguous", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Type_commit(&filetype);
+        check_rc(rc, "MPI_Type_commit", rank);
+        if (MPI_SUCCESS == rc) {
+            filetype_ready = 1;
+        }
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        if (filetype_ready) {
+            rc = MPI_Info_set(info, "cb_nodes", "1");
+            check_rc(rc, "MPI_Info_set", rank);
+            rc = MPI_Info_set(info, "collective_buffering", "false");
+            check_rc(rc, "MPI_Info_set", rank);
+            rc = MPI_Info_set(info, "unknown_ompio_hint", "set-view-ignore-me");
+            check_rc(rc, "MPI_Info_set", rank);
+
+            rc = MPI_File_set_view(fh, 0, MPI_BYTE, filetype, "native", info);
+            check_rc(rc, "MPI_File_set_view", rank);
+        }
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "23456", rank);
+        expect_value(info_used, "cb_nodes", "1", rank);
+        expect_value(info_used, "collective_buffering", "false", rank);
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        if (filetype_ready) {
+            rc = MPI_Info_set(info, "unknown_ompio_hint", "unknown-only-set-view");
+            check_rc(rc, "MPI_Info_set", rank);
+
+            rc = MPI_File_set_view(fh, 0, MPI_BYTE, filetype, "native", info);
+            check_rc(rc, "MPI_File_set_view", rank);
+        }
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "23456", rank);
+        expect_value(info_used, "cb_nodes", "1", rank);
+        expect_value(info_used, "collective_buffering", "false", rank);
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(info, "cb_buffer_size", "34567");
+        check_rc(rc, "MPI_Info_set", rank);
+        rc = MPI_Info_set(info, "cb_nodes", "2");
+        check_rc(rc, "MPI_Info_set", rank);
+        rc = MPI_Info_set(info, "collective_buffering", "true");
+        check_rc(rc, "MPI_Info_set", rank);
+
+        rc = MPI_File_set_view(fh, 0, MPI_INT, MPI_BYTE, "native", info);
+        if (MPI_SUCCESS == rc) {
+            fprintf(stderr, "[%d] MPI_File_set_view unexpectedly succeeded\n", rank);
+            ++errors;
+        }
+        MPI_Info_free(&info);
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "cb_buffer_size", "23456", rank);
+        expect_value(info_used, "cb_nodes", "1", rank);
+        expect_value(info_used, "collective_buffering", "false", rank);
+        expect_no_key(info_used, "unknown_ompio_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    if (MPI_DATATYPE_NULL != filetype) {
+        rc = MPI_Type_free(&filetype);
+        check_rc(rc, "MPI_Type_free", rank);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+}
+
+static void check_sharedfp_info(const char *filename, int rank)
+{
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    char value[MPI_MAX_INFO_VAL + 1];
+    int rc;
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_Info_set(info, "OMPIO_SHAREDFP_RELAXED_ORDERING", "true");
+    check_rc(rc, "MPI_Info_set", rank);
+    rc = MPI_Info_set(info, "unknown_sharedfp_hint", "ignore-me");
+    check_rc(rc, "MPI_Info_set", rank);
+
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       info, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    MPI_Info_free(&info);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        /*
+         * This hint is public only if sharedfp/individual wins selection.
+         * Some builds prefer another sharedfp component even with the hint,
+         * so absence is a valid result; presence must still preserve the
+         * accepted user value.
+         */
+        if (info_has_key(info_used, "OMPIO_SHAREDFP_RELAXED_ORDERING",
+                         value, MPI_MAX_INFO_VAL)
+            && 0 != strcmp(value, "true")) {
+            fprintf(stderr, "[%d] expected OMPIO_SHAREDFP_RELAXED_ORDERING=true, got %s\n",
+                    rank, value);
+            ++errors;
+        }
+        expect_no_key(info_used, "unknown_sharedfp_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+}
+
+/*
+ * MPI-5.0 sections 11.4.3 and 14.2.8: MPI_File_get_info must report
+ * "mpi_memory_alloc_kinds", and for a file derived from the World Model
+ * its value must be identical to the value reported by MPI_COMM_GET_INFO
+ * on MPI_COMM_WORLD.  When the user asserts a supported set of kinds via
+ * "mpi_assert_memory_alloc_kinds" at open time, that key must round-trip
+ * identically alongside "mpi_memory_alloc_kinds".
+ *
+ * Open MPI only populates "mpi_memory_alloc_kinds" when the kinds were
+ * requested, so main() requests "system" (always supported) before
+ * MPI_Init.  If the key is still not reported (for example, the MCA
+ * parameter was pinned to a different value in the launch environment),
+ * there is no reference value to check against and the section is
+ * treated as skipped.  The value is compared against whatever
+ * MPI_COMM_WORLD reports rather than a hard-coded spelling, since the
+ * library may return additional supported kinds.
+ */
+static int check_memkind_info(const char *filename, int rank)
+{
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    char world_kinds[MPI_MAX_INFO_VAL + 1];
+    int rc;
+
+    rc = MPI_Comm_get_info(MPI_COMM_WORLD, &info_used);
+    check_rc(rc, "MPI_Comm_get_info", rank);
+    if (MPI_SUCCESS != rc) {
+        return SECTION_RAN;
+    }
+    if (!info_has_key(info_used, "mpi_memory_alloc_kinds", world_kinds,
+                      MPI_MAX_INFO_VAL)) {
+        MPI_Info_free(&info_used);
+        return SECTION_SKIPPED;
+    }
+    MPI_Info_free(&info_used);
+
+    /*
+     * A file opened with MPI_INFO_NULL must still report
+     * mpi_memory_alloc_kinds, identical to the World Model value, and the
+     * key must survive both set_info (which cannot update or delete it)
+     * and set_view (which rebuilds the reported hints from a staged copy).
+     */
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       MPI_INFO_NULL, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    if (MPI_SUCCESS != rc) {
+        return SECTION_RAN;
+    }
+    rc = MPI_File_set_errhandler(fh, MPI_ERRORS_RETURN);
+    check_rc(rc, "MPI_File_set_errhandler", rank);
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "mpi_memory_alloc_kinds", world_kinds, rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(info, "cb_buffer_size", "65536");
+        check_rc(rc, "MPI_Info_set", rank);
+        rc = MPI_File_set_info(fh, info);
+        check_rc(rc, "MPI_File_set_info", rank);
+        MPI_Info_free(&info);
+    }
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "mpi_memory_alloc_kinds", world_kinds, rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_set_view(fh, 0, MPI_BYTE, MPI_BYTE, "native", MPI_INFO_NULL);
+    check_rc(rc, "MPI_File_set_view", rank);
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "mpi_memory_alloc_kinds", world_kinds, rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+
+    /*
+     * Assert a supported subset of kinds at open time.  Because "system"
+     * is supported, the implementation recognizes the assertion and
+     * MPI_File_get_info must return mpi_assert_memory_alloc_kinds
+     * identical to the supplied value, with mpi_memory_alloc_kinds still
+     * reported.
+     */
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(info, "mpi_assert_memory_alloc_kinds", "system");
+        check_rc(rc, "MPI_Info_set", rank);
+        rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                           MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                           info, &fh);
+        check_rc(rc, "MPI_File_open", rank);
+        MPI_Info_free(&info);
+        if (MPI_SUCCESS == rc) {
+            rc = MPI_File_set_errhandler(fh, MPI_ERRORS_RETURN);
+            check_rc(rc, "MPI_File_set_errhandler", rank);
+
+            rc = MPI_File_get_info(fh, &info_used);
+            check_rc(rc, "MPI_File_get_info", rank);
+            if (MPI_SUCCESS == rc) {
+                expect_value(info_used, "mpi_assert_memory_alloc_kinds",
+                             "system", rank);
+                /*
+                 * A recognized assertion narrows the reported kinds to the
+                 * asserted "system"; verifying only presence would miss a
+                 * regression that left the broader World Model value
+                 * (which also contains "mpi") in place.
+                 */
+                expect_value(info_used, "mpi_memory_alloc_kinds", "system",
+                             rank);
+                MPI_Info_free(&info_used);
+            }
+
+            rc = MPI_File_close(&fh);
+            check_rc(rc, "MPI_File_close", rank);
+        }
+    }
+
+    return SECTION_RAN;
+}
+
+static int get_optional_dir(const char *env_name, char *dir, size_t dir_len, int rank)
+{
+    const char *value = NULL;
+    int enabled = 0;
+
+    if (0 == rank) {
+        value = getenv(env_name);
+        if (NULL != value && '\0' != value[0]) {
+            enabled = 1;
+            snprintf(dir, dir_len, "%s", value);
+        }
+    }
+
+    MPI_Bcast(&enabled, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (!enabled) {
+        return 0;
+    }
+
+    MPI_Bcast(dir, (int) dir_len, MPI_CHAR, 0, MPI_COMM_WORLD);
+    return 1;
+}
+
+/*
+ * Lustre and GPFS components require matching filesystems and, in many
+ * builds, external development headers.  Keep their coverage in this manual
+ * test, but gate it on an explicit directory so the generic OMPIO test still
+ * runs everywhere.
+ */
+static void check_lustre_open_info(const char *filename, const char *size_key,
+                                   const char *factor_key, int rank)
+{
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    int rc;
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_Info_set(info, size_key, "1048576");
+    check_rc(rc, "MPI_Info_set", rank);
+    rc = MPI_Info_set(info, factor_key, "2");
+    check_rc(rc, "MPI_Info_set", rank);
+    rc = MPI_Info_set(info, "unknown_lustre_hint", "ignore-me");
+    check_rc(rc, "MPI_Info_set", rank);
+
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       info, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    MPI_Info_free(&info);
+    if (MPI_SUCCESS != rc) {
+        return;
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, size_key, "1048576", rank);
+        expect_value(info_used, factor_key, "2", rank);
+        if (0 == strcmp(size_key, "stripe_size")) {
+            expect_no_key(info_used, "striping_unit", rank);
+        } else {
+            expect_no_key(info_used, "stripe_size", rank);
+        }
+        if (0 == strcmp(factor_key, "stripe_width")) {
+            expect_no_key(info_used, "striping_factor", rank);
+        } else {
+            expect_no_key(info_used, "stripe_width", rank);
+        }
+        expect_no_key(info_used, "unknown_lustre_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+}
+
+static int check_lustre_info(int rank)
+{
+    char dir[MPI_MAX_INFO_VAL + 1];
+    char filename[MPI_MAX_INFO_VAL + 128];
+
+    if (!get_optional_dir("OMPIO_FILE_INFO_LUSTRE_DIR", dir, sizeof(dir), rank)) {
+        return SECTION_SKIPPED;
+    }
+
+    make_filename_in_dir(filename, sizeof(filename), dir, "lustre-alias", rank);
+    check_lustre_open_info(filename, "stripe_size", "stripe_width", rank);
+
+    make_filename_in_dir(filename, sizeof(filename), dir, "lustre-canonical", rank);
+    check_lustre_open_info(filename, "striping_unit", "striping_factor", rank);
+
+    return SECTION_RAN;
+}
+
+static int check_gpfs_info(int rank)
+{
+    char dir[MPI_MAX_INFO_VAL + 1];
+    char filename[MPI_MAX_INFO_VAL + 128];
+    MPI_File fh;
+    MPI_Info info;
+    MPI_Info info_used;
+    int rc;
+
+    if (!get_optional_dir("OMPIO_FILE_INFO_GPFS_DIR", dir, sizeof(dir), rank)) {
+        return SECTION_SKIPPED;
+    }
+
+    make_filename_in_dir(filename, sizeof(filename), dir, "gpfs", rank);
+
+    rc = MPI_Info_create(&info);
+    check_rc(rc, "MPI_Info_create", rank);
+    if (MPI_SUCCESS != rc) {
+        return SECTION_RAN;
+    }
+
+    rc = MPI_Info_set(info, "useSIOXLib", "false");
+    check_rc(rc, "MPI_Info_set", rank);
+    rc = MPI_Info_set(info, "unknown_gpfs_hint", "ignore-me");
+    check_rc(rc, "MPI_Info_set", rank);
+
+    rc = MPI_File_open(MPI_COMM_WORLD, filename,
+                       MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_DELETE_ON_CLOSE,
+                       info, &fh);
+    check_rc(rc, "MPI_File_open", rank);
+    MPI_Info_free(&info);
+    if (MPI_SUCCESS != rc) {
+        return SECTION_RAN;
+    }
+
+    rc = MPI_File_get_info(fh, &info_used);
+    check_rc(rc, "MPI_File_get_info", rank);
+    if (MPI_SUCCESS == rc) {
+        expect_value(info_used, "useSIOXLib", "false", rank);
+        expect_no_key(info_used, "unknown_gpfs_hint", rank);
+        MPI_Info_free(&info_used);
+    }
+
+    rc = MPI_File_close(&fh);
+    check_rc(rc, "MPI_File_close", rank);
+
+    return SECTION_RAN;
+}
+
+int main(int argc, char *argv[])
+{
+    char filename[MPI_MAX_INFO_VAL + 128];
+    int global_errors;
+    int errors_before;
+    int rank;
+    int ran;
+
+    /*
+     * Request a supported memory allocation kind before MPI is
+     * initialized; Open MPI reads this when it builds the World Model
+     * instance, and each rank sets it for its own instance.  This lets
+     * the memkind section run without requiring the launcher to forward
+     * the MCA parameter (e.g. mpirun -x).
+     */
+    setenv("OMPI_MCA_mpi_memory_alloc_kinds", "system", 1);
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    make_filename(filename, sizeof(filename), rank);
+
+    errors_before = errors;
+    section_start("default info", rank);
+    check_default_info(filename, rank);
+    section_finish("default info", errors_before, SECTION_RAN, rank);
+
+    errors_before = errors;
+    section_start("open, set_info, and set_view info", rank);
+    check_user_info(filename, rank);
+    section_finish("open, set_info, and set_view info", errors_before,
+                   SECTION_RAN, rank);
+
+    errors_before = errors;
+    section_start("sharedfp info", rank);
+    check_sharedfp_info(filename, rank);
+    section_finish("sharedfp info", errors_before, SECTION_RAN, rank);
+
+    errors_before = errors;
+    section_start("memory allocation kinds info", rank);
+    ran = check_memkind_info(filename, rank);
+    section_finish("memory allocation kinds info", errors_before, ran, rank);
+
+    errors_before = errors;
+    section_start("Lustre info", rank);
+    ran = check_lustre_info(rank);
+    section_finish("Lustre info", errors_before, ran, rank);
+
+    errors_before = errors;
+    section_start("GPFS info", rank);
+    ran = check_gpfs_info(rank);
+    section_finish("GPFS info", errors_before, ran, rank);
+
+    MPI_Allreduce(&errors, &global_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (0 == rank) {
+        printf("ompio_file_info: overall: %s\n",
+               (0 == global_errors) ? "PASS" : "FAIL");
+        fflush(stdout);
+    }
+    MPI_Finalize();
+
+    return (0 == global_errors) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Make OMPIO comply with the MPI-5.0 MPI_File_get_info and MPI_File_set_info requirements by routing all file hints through Open MPI's existing opal_infosubscriber_t infrastructure instead of an OMPIO-private hint cache.  The governing text is the MPI-5.0 standard section 15.2.8 ("File Info"), which defines MPI_FILE_SET_INFO and MPI_FILE_GET_INFO, and section 15.2.8.1 ("Reserved File Hints"). MPI_File_get_info now returns the current value of every supported hint: implementation defaults, user-supplied hints that were accepted, and hints set by the implementation.  Unknown or ignored user hints are not reported.

This fixes Open MPI issue #13367, "MPI_File_get_info fails to return hints as required by MPI standard," in which MPI_File_get_info on an OMPIO file opened with MPI_INFO_NULL returned zero hints: https://github.com/open-mpi/ompi/issues/13367

The authoritative hint storage is ompi_file_t::super.s_info. ompio_file_t::f_info is a borrowed pointer to that same object, so the lower OMPIO layers, MPI_File_get_info, and MPI_File_set_info all see one info object.  A small set of helpers in ompi/mca/common/ompio wraps the opal subscription API: subscribe a hint with its default, apply a user info object through opal_infosubscribe_change_info(), set public implementation hints, and duplicate the public hints for get_info.  An info-phase value on ompio_file_t (open, set-info, set-view) lets callbacks decide whether a hint is valid in the current operation.

Add mca_io_ompio_file_set_info() and mca_io_ompio_file_get_info() and wire them into mca_io_ompio_module.  OMPIO core registers cb_buffer_size, cb_nodes, and collective_buffering with their defaults and moves the existing hint parsing into the subscription callbacks, preserving the MCA-parameter override behavior and the prior aggregator, collective-buffering, and buffer-sizing semantics.  The cb_nodes "-1" sentinel is kept internal rather than reported as a public hint.

Route MPI_File_set_view info through the same path under the set-view phase.  The update is staged into a fresh info object and committed only when both the info application and the view setup succeed, so a failed set_view leaves the previously reported hints untouched.

Let each component own its hints so the framework and common code hard-code no component hint names:

  - sharedfp/individual registers OMPIO_SHAREDFP_RELAXED_ORDERING during selection; if it loses selection, both unquery and the callback drop the hint so get_info does not report a hint owned by an inactive component.

  - fs/lustre registers striping_unit and striping_factor plus the stripe_size and stripe_width aliases.  The accepted user spelling is preserved; open-time layout values are cached so later set_info and set_view calls report the applied value; the canonical name is used only for MCA defaults with no user-supplied spelling.

  - fs/gpfs registers the supported GPFS and SIOX hints when built and reports the open-time accepted value for later phases.

Keep the borrowed-pointer invariant intact for nested opens.  Private sharedfp handles have no backing ompi_file_t, so hint subscription and mca_common_ompio_info_set() are successful no-ops for them; this prevents an internal open from writing hints into a borrowed MPI_Info object such as MPI_INFO_NULL.

Document the user-visible behavior: add an MPI_Info hints section to the MPI-IO tuning guide from a shared RST include, with per-component hint tables listing accepted phases, defaults, MCA-parameter mappings, and alias behavior; cross-reference it from the MPI_File_open, MPI_File_set_info, MPI_File_get_info, and MPI_File_set_view man pages; and add a changelog entry.

Add a standalone test under test/simple that exercises defaulted hints, accepted and unknown hints, set_info and set_view updates, omitted-hint preservation, and Lustre alias spelling, skipping filesystem-specific checks when the component or filesystem is unavailable.  It is run manually and is not wired into make check, which does not launch mpirun.

The test lives in test/simple mainly because that is where other MPI-level test programs already reside, even though many of them are now stale and no longer compile.  Cleaning up the test/simple directory is out of scope for this commit.

---

Also note that there is a trivial / drive-by 2nd commit on this PR that adds 2 more simple/test/* executables to `.gitignore`.  This was included here simply because it noticed during the work on this branch.