### PR TITLE
request: fix MPI_Testall spuriously returning MPI_ERR_IN_STATUS

### DIFF
--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -249,7 +250,7 @@ int ompi_request_default_test_all(
                 ompi_grequest_invoke_query(request, &request->req_status);
             }
             OMPI_COPY_STATUS(&statuses[i], request->req_status, true);
-            if (MPI_SUCCESS == request->req_status.MPI_ERROR) {
+            if (MPI_SUCCESS != request->req_status.MPI_ERROR) {
                 rc = MPI_ERR_IN_STATUS;
 #if OPAL_ENABLE_FT_MPI
                 if (MPI_ERR_PROC_FAILED == request->req_status.MPI_ERROR


### PR DESCRIPTION
## Summary

`MPI_Testall` returns `MPI_ERR_IN_STATUS` on full success — and, symmetrically, **masks** genuine per-request errors — when it is called with a real `array_of_statuses` (i.e. not `MPI_STATUSES_IGNORE`). The success/error comparison in the real-status branch of `ompi_request_default_test_all()` was inverted (`==` where it should be `!=`).

This one-line fix restores the correct `!=` test, making the branch consistent with the three sibling paths that were already correct: the `MPI_STATUSES_IGNORE` branch of the same function, `MPI_Waitall` (`ompi_request_default_wait_all`), and `MPI_Testsome` (`ompi_request_default_test_some`). The adjacent persistent/free logic (which legitimately frees a request only on success) is unchanged.

Closes #13967.

## Provenance

The inverted condition was introduced by #13437 (commit 38a7fbb837, "MPI_ERR_IN_STATUS for persistent requests"), which was addressing #13432. That PR refactored both `req_test.c` and `req_wait.c`; the `req_wait.c` change is correct, but the `req_test.c` rewrite landed with the comparison reversed.

It was discovered during a systematic MPI-5.0 conformance review of `main` (#13954).

## Impact / scope

* **Only `MPI_Testall` is affected.** `MPI_Waitall`, `MPI_Wait`, `MPI_Test`, `MPI_Testany`, `MPI_Testsome`, and the `MPI_STATUSES_IGNORE` path of `MPI_Testall` all use the correct test.
* It is **deterministic, not a race**: any `MPI_Testall` call that completes one or more active requests while a real status array is supplied reproduces it every time. Under the default `MPI_ERRORS_ARE_FATAL` handler the spurious `MPI_ERR_IN_STATUS` aborts the application; under `MPI_ERRORS_RETURN` it surfaces as a bogus error return. The symmetric failure (a real per-request error silently not reported) is just as bad.
* A complete, self-contained reproducer is attached to #13967.

## Affected branches

The regression is present on **`main`, `v5.0.x`, and `v6.0.x`** (#13437 was backported to the release branches). `ompi/request/req_test.c` is identical across all three for this function, so the same one-line change (`==` → `!=`) applies on each. This PR targets `main`; it should be backported to `v5.0.x` and `v6.0.x`.

## Test

Build, then run the reproducer from #13967 with `mpirun -np 2`: before the fix, the `MPI_Testall` + real-status case returns `MPI_ERR_IN_STATUS` on success; after the fix, all three cases (Testall+status, Testall+`STATUSES_IGNORE`, Waitall+status) return `MPI_SUCCESS`.
