### PR TITLE
opal/lifo: fix missing acquire barriers in pop on weak-memory architectures

### DIFF
--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -147,7 +147,8 @@ static inline opal_list_item_t *opal_fifo_pop_atomic(opal_fifo_t *fifo)
         }
     } while (1);
 
-    opal_atomic_wmb();
+    // synchronize with the wmb in push
+    opal_atomic_rmb();
 
     /* check for tail and head consistency */
     if (ghost == next) {

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -163,10 +163,10 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
         if (item == &lifo->opal_lifo_ghost) {
             return NULL;
         }
-
+        // synchronize with the wmb in push
+        opal_atomic_rmb();
         if (opal_update_counted_pointer(&lifo->opal_lifo_head, &old_head,
                                         (opal_list_item_t *) item->opal_list_next)) {
-            opal_atomic_wmb();
             item->opal_list_next = NULL;
             return item;
         }
@@ -227,8 +227,6 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
         opal_atomic_sc_ptr(&lifo->opal_lifo_head.data.item, next, ret);
     } while (!ret);
 
-    opal_atomic_wmb();
-
     item->opal_list_next = NULL;
     return item;
 }
@@ -248,7 +246,8 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
             continue;
         }
 
-        opal_atomic_wmb();
+        // synchronize with the wmb in push
+        opal_atomic_rmb();
 
         head = item;
         /* try to swap out the head pointer */
@@ -268,8 +267,6 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
     if (item == &lifo->opal_lifo_ghost) {
         return NULL;
     }
-
-    opal_atomic_wmb();
 
     item->opal_list_next = NULL;
     return item;

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -163,10 +163,10 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
         if (item == &lifo->opal_lifo_ghost) {
             return NULL;
         }
-
+        // synchronize with the wmb in push
+        opal_atomic_rmb();
         if (opal_update_counted_pointer(&lifo->opal_lifo_head, &old_head,
                                         (opal_list_item_t *) item->opal_list_next)) {
-            opal_atomic_wmb();
             item->opal_list_next = NULL;
             return item;
         }
@@ -222,12 +222,12 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
         if (&lifo->opal_lifo_ghost == item) {
             return NULL;
         }
+        // synchronize with the wmb in push
+        opal_atomic_rmb();
 
         next = (opal_list_item_t *) item->opal_list_next;
         opal_atomic_sc_ptr(&lifo->opal_lifo_head.data.item, next, ret);
     } while (!ret);
-
-    opal_atomic_wmb();
 
     item->opal_list_next = NULL;
     return item;
@@ -248,7 +248,8 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
             continue;
         }
 
-        opal_atomic_wmb();
+        // synchronize with the wmb in push
+        opal_atomic_rmb();
 
         head = item;
         /* try to swap out the head pointer */
@@ -268,8 +269,6 @@ static inline opal_list_item_t *opal_lifo_pop_atomic(opal_lifo_t *lifo)
     if (item == &lifo->opal_lifo_ghost) {
         return NULL;
     }
-
-    opal_atomic_wmb();
 
     item->opal_list_next = NULL;
     return item;

--- a/opal/include/opal/sys/powerpc/atomic_llsc.h
+++ b/opal/include/opal/sys/powerpc/atomic_llsc.h
@@ -42,10 +42,24 @@
  * is that even with an always_inline attribute the compiler may still emit instructions to store
  * then load the arguments to/from the stack. This sequence may cause the ll reservation to be
  * cancelled. */
-#define opal_atomic_ll_32(addr, ret)                                                \
-    do {                                                                            \
-        opal_atomic_int32_t *_addr = (addr);                                        \
-        __asm__ __volatile__("lwarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
+
+/* isync is placed immediately after lwarx/ldarx rather than after the paired stwcx./stdcx.
+ * (the canonical Linux PPC_ACQUIRE_BARRIER placement).  In OPAL the LL and SC are separate
+ * macro invocations separated by arbitrary C code inside a caller-written do-while retry loop.
+ * The acquire barrier must therefore live in the LL macro so that the C loads that occur
+ * between the LL and the SC (e.g. reading item->opal_list_next in the lifo pop) are ordered
+ * after the LL's observed value.  Placing isync in the SC macro instead would fire it on
+ * every failed attempt and would still not order those intermediate loads.
+ * isync does not cancel the exclusive reservation set by lwarx/ldarx on current Power
+ * implementations; the reservation is dropped only by intervening stores to the same
+ * address or by the SC instruction itself.
+ * The SC macros use lwsync before stwcx./stdcx. to provide release semantics, matching
+ * the store-release exclusive (stlxr) used by the ARM64 backend. */
+#define opal_atomic_ll_32(addr, ret)                                                        \
+    do {                                                                                    \
+        opal_atomic_int32_t *_addr = (addr);                                                \
+        __asm__ __volatile__("lwarx   %0, 0, %1  \n\t"                                     \
+                             "isync               \n\t" : "=&r"(ret) : "r"(_addr) : "memory"); \
     } while (0)
 
 #define opal_atomic_sc_32(addr, value, ret)                         \
@@ -53,7 +67,8 @@
         opal_atomic_int32_t *_addr = (addr);                        \
         int32_t _ret, _foo, _newval = (int32_t) value;              \
                                                                     \
-        __asm__ __volatile__("   stwcx.  %4, 0, %3  \n\t"           \
+        __asm__ __volatile__("   lwsync              \n\t"           \
+                             "   stwcx.  %4, 0, %3  \n\t"           \
                              "   li      %0,0       \n\t"           \
                              "   bne-    1f         \n\t"           \
                              "   ori     %0,%0,1    \n\t"           \
@@ -62,12 +77,13 @@
                              : "r"(_addr), "r"(_newval)             \
                              : "cc", "memory");                     \
         ret = _ret;                                                 \
-   } while (0)
+    } while (0)
 
-#define opal_atomic_ll_64(addr, ret)                                                \
-    do {                                                                            \
-        opal_atomic_int64_t *_addr = (addr);                                        \
-        __asm__ __volatile__("ldarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
+#define opal_atomic_ll_64(addr, ret)                                                        \
+    do {                                                                                    \
+        opal_atomic_int64_t *_addr = (addr);                                                \
+        __asm__ __volatile__("ldarx   %0, 0, %1  \n\t"                                     \
+                             "isync               \n\t" : "=&r"(ret) : "r"(_addr) : "memory"); \
     } while (0)
 
 #define opal_atomic_sc_64(addr, value, ret)                               \
@@ -76,7 +92,8 @@
         int64_t _newval = (int64_t) value;                                \
         int32_t _ret;                                                     \
                                                                           \
-        __asm__ __volatile__("   stdcx.  %2, 0, %1  \n\t"                 \
+        __asm__ __volatile__("   lwsync              \n\t"                \
+                             "   stdcx.  %2, 0, %1  \n\t"                 \
                              "   li      %0,0       \n\t"                 \
                              "   bne-    1f         \n\t"                 \
                              "   ori     %0,%0,1    \n\t"                 \

--- a/opal/include/opal/sys/powerpc/atomic_llsc.h
+++ b/opal/include/opal/sys/powerpc/atomic_llsc.h
@@ -42,10 +42,27 @@
  * is that even with an always_inline attribute the compiler may still emit instructions to store
  * then load the arguments to/from the stack. This sequence may cause the ll reservation to be
  * cancelled. */
-#define opal_atomic_ll_32(addr, ret)                                                \
-    do {                                                                            \
-        opal_atomic_int32_t *_addr = (addr);                                        \
-        __asm__ __volatile__("lwarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
+
+/* The LL macros (lwarx/ldarx) carry no explicit acquire barrier.  The Power ISA
+ * acquire idiom requires a conditional branch whose outcome depends on the loaded
+ * value followed by isync; because OPAL splits LL and SC into separate macros that
+ * are placed inside a caller-written retry loop, that branch occurs in C code outside
+ * the asm block, making isync inside the LL asm architecturally incorrect as an acquire.
+ * Using lwsync unconditionally after lwarx would be correct but imposes ~30-50 cycles
+ * on every iteration -- including failed SC retries -- without benefit, because all
+ * current callers (opal_lifo_pop_atomic, opal_fifo_pop_atomic) already issue an
+ * explicit opal_atomic_rmb() between the LL and their first pointer dereference.
+ * The SC macros (stwcx./stdcx.) likewise carry no lwsync.  The LL/SC pop paths do
+ * no stores between LL and SC that need to be made visible before the SC; a release
+ * fence is therefore unnecessary, and placing lwsync inside the LL-SC reservation
+ * window (between lwarx and stwcx.) would also increase the probability of spurious
+ * reservation loss under contention.
+ * Both macros retain a "memory" clobber so the compiler treats them as full compiler
+ * barriers even without a hardware fence instruction. */
+#define opal_atomic_ll_32(addr, ret)                                                        \
+    do {                                                                                    \
+        opal_atomic_int32_t *_addr = (addr);                                                \
+        __asm__ __volatile__("lwarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr) : "memory"); \
     } while (0)
 
 #define opal_atomic_sc_32(addr, value, ret)                         \
@@ -62,12 +79,12 @@
                              : "r"(_addr), "r"(_newval)             \
                              : "cc", "memory");                     \
         ret = _ret;                                                 \
-   } while (0)
+    } while (0)
 
-#define opal_atomic_ll_64(addr, ret)                                                \
-    do {                                                                            \
-        opal_atomic_int64_t *_addr = (addr);                                        \
-        __asm__ __volatile__("ldarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr));  \
+#define opal_atomic_ll_64(addr, ret)                                                        \
+    do {                                                                                    \
+        opal_atomic_int64_t *_addr = (addr);                                                \
+        __asm__ __volatile__("ldarx   %0, 0, %1  \n\t" : "=&r"(ret) : "r"(_addr) : "memory"); \
     } while (0)
 
 #define opal_atomic_sc_64(addr, value, ret)                               \


### PR DESCRIPTION
opal/lifo: fix missing acquire barriers in pop on weak-memory architectures

  Three release/acquire pairs were broken in opal_lifo_pop_atomic across
  the three compiled variants of the function.  All atomics in OPAL are
  relaxed; ordering is enforced exclusively through explicit opal_atomic_rmb()
  / opal_atomic_wmb() calls.  The push side is correct in all paths: a wmb
  before the CAS that publishes the item to the head ensures opal_list_next
  (and any caller-written payload) is visible before the pointer becomes
  reachable.  The pop side was missing the corresponding acquire fences.

  1. 128-bit CAS path: after opal_read_counted_pointer() returns the item
     pointer, opal_list_next is read without an intervening rmb.  The rmb
     inside opal_read_counted_pointer() only orders the two fields of the
     counted pointer struct relative to each other; it does not fence the
     subsequent dereference of the item pointer.  Fix: add opal_atomic_rmb()
     inside the retry loop, after the ghost check and before the call to
     opal_update_counted_pointer() which passes item->opal_list_next.

  2. LLSC path: after opal_atomic_ll_ptr() loads the head pointer, the code
     immediately dereferences that pointer to read item->opal_list_next.  On
     ARM64 the ldaxr instruction provides acquire ordering, but on PowerPC
     lwarx/ldarx are plain loads (no ordering), and on RISC-V the address
     dependency between the pointer load and the subsequent dereference is
     not sufficient: RVWMO explicitly does not guarantee ordering through
     address dependencies, unlike the Alpha or ARM memory models.  Fix: add
     opal_atomic_rmb() after opal_atomic_ll_ptr(), consistent with the other
     two pop variants.
     The PowerPC LL macros (lwarx/ldarx) previously had no "memory" clobber,
     meaning the compiler was free to reorder surrounding memory accesses
     across the asm block.  A "memory" clobber is added so the compiler
     treats the LL as a full compiler barrier (matching the SC macros which
     already had one).  No hardware fence instruction (isync or lwsync) is
     added to the LL or SC macros: the Power ISA acquire idiom requires a
     conditional branch whose outcome depends on the loaded value before
     isync, and because OPAL splits LL and SC into separate macro invocations
     around arbitrary C code that branch occurs outside the asm block, making
     isync inside the LL asm architecturally incorrect.  Using lwsync
     unconditionally would be correct but adds ~30-50 cycles per retry with
     no benefit because all callers (opal_lifo_pop_atomic, opal_fifo_pop_atomic)
     already issue an explicit opal_atomic_rmb() between LL and their first
     pointer dereference.  Similarly, no lwsync is added before stwcx./stdcx.:
     the LL/SC pop paths perform no stores between LL and SC that need to be
     made visible before the SC succeeds, and placing lwsync inside the
     reservation window increases the probability of spurious reservation loss
     under contention.

  3. CAS + item_free path: the push uses item_free=0 (written after a second
     wmb following the head CAS) as the "fully published" signal.  The pop
     observes item_free=0 via an atomic swap -- this is the acquire side of
     the release/acquire pair.  The original opal_atomic_wmb() after the
     swap only orders writes; it provides no ordering guarantee for the
     subsequent reads of item->opal_list_next and item payload.  Fix: replace
     opal_atomic_wmb() with opal_atomic_rmb().  A full fence is not needed:
     the CAS on the head pointer is the real serialization point between
     concurrent poppers, so ordering the swap's item_free=1 write before the
     CAS is not a correctness requirement.  Using rmb is consistent with the
     other two pop paths.

In all three pop paths the trailing opal_atomic_wmb() before
item->opal_list_next = NULL is removed.  After a successful CAS or SC the
item is exclusively owned by the caller: no other thread can reach it
through the list, so setting opal_list_next to NULL requires no cross-thread
visibility fence.  The preceding atomic's "memory" clobber prevents the
compiler from hoisting the write across the atomic operation.
