### PR TITLE
docs: add man pages for four implemented MPI API functions

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2022 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2023-2025 Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
 # Copyright (c) 2025      Triad National Security, LLC.  All rights reserved.
 #
 # $COPYRIGHT$
@@ -194,6 +194,7 @@ OMPI_MAN3 = \
         MPI_Errors.3 \
         MPI_Exscan.3 \
         MPI_Exscan_init.3 \
+        MPI_F_sync_reg.3 \
         MPI_Fetch_and_op.3 \
         MPI_File_c2f.3 \
         MPI_File_call_errhandler.3 \
@@ -459,10 +460,12 @@ OMPI_MAN3 = \
         MPI_T_category_get_categories.3 \
         MPI_T_category_get_cvars.3 \
         MPI_T_category_get_events.3 \
+        MPI_T_category_get_index.3 \
         MPI_T_category_get_info.3 \
         MPI_T_category_get_num.3 \
         MPI_T_category_get_num_events.3 \
         MPI_T_category_get_pvars.3 \
+        MPI_T_cvar_get_index.3 \
         MPI_T_cvar_get_info.3 \
         MPI_T_cvar_get_num.3 \
         MPI_T_cvar_handle_alloc.3 \
@@ -494,6 +497,7 @@ OMPI_MAN3 = \
         MPI_T_finalize.3 \
         MPI_T_init_thread.3 \
         MPI_Topo_test.3 \
+        MPI_T_pvar_get_index.3 \
         MPI_T_pvar_get_info.3 \
         MPI_T_pvar_get_num.3 \
         MPI_T_pvar_handle_alloc.3 \

--- a/docs/man-openmpi/man3/MPI_F_sync_reg.3.rst
+++ b/docs/man-openmpi/man3/MPI_F_sync_reg.3.rst
@@ -1,0 +1,48 @@
+.. _mpi_f_sync_reg:
+
+
+MPI_F_sync_reg
+==============
+
+.. include_body
+
+:ref:`MPI_F_sync_reg` |mdash| Prevent invalid register optimization of a Fortran buffer
+
+.. The following file was automatically generated
+.. include:: ./bindings/mpi_f_sync_reg.rst
+
+INPUT/OUTPUT PARAMETERS
+-----------------------
+* ``buf``: Initial address of the buffer (choice).
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_F_sync_reg` has no executable statements; it exists only to prevent
+a Fortran compiler from making invalid assumptions about the contents of a
+buffer across an operation that the compiler cannot see. Passing *buf* to this
+routine forces the compiler, when necessary, to flush a cached register copy
+of the buffer back to memory, or to invalidate a cached register copy so that
+the buffer is reloaded from memory on its next use.
+
+This is needed in Fortran code that aggressively optimizes register usage
+around nonblocking or one-sided operations, whose completion |mdash| and
+therefore whose effect on the buffer |mdash| is not visible to the compiler
+from the surrounding code.
+
+
+NOTES
+-----
+
+This routine is provided only in the Fortran bindings; it has no C binding
+because it would serve no purpose in C. It also has no *ierror* argument
+because there is no operation that can fail.
+
+For example, after an :ref:`MPI_Wait` that completes a nonblocking receive
+into *buf*, a call to ``MPI_F_sync_reg(buf)`` ensures that the compiler
+reloads *buf* from memory rather than reusing a stale register copy that
+predates the receive.
+
+
+.. seealso::
+   * :ref:`MPI_Wait`

--- a/docs/man-openmpi/man3/MPI_T_category_get_index.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_category_get_index.3.rst
@@ -1,0 +1,61 @@
+.. _mpi_t_category_get_index:
+
+
+MPI_T_category_get_index
+========================
+
+.. include_body
+
+:ref:`MPI_T_category_get_index` |mdash| Query the index of a category from its name
+
+.. The following file was automatically generated
+.. include:: ./bindings/mpi_t_category_get_index.rst
+
+INPUT PARAMETERS
+----------------
+* ``name``: Name of the category to query.
+
+OUTPUT PARAMETERS
+-----------------
+* ``cat_index``: Index of the category.
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_T_category_get_index` can be used to retrieve the index of a
+category given its name. The *name* argument is provided by the caller as a
+null-terminated string, and the matching index is returned in *cat_index*.
+The returned index can then be passed to other MPI tool information interface
+routines, such as :ref:`MPI_T_category_get_info`.
+
+This routine allows a tool to look up a category by name without iterating
+over the entire set of categories. Because the number of categories exposed
+by the implementation can change over time, this is both more convenient and
+lower overhead than enumerating all of the categories to find a particular
+one.
+
+
+NOTES
+-----
+
+Category names are implementation-specific. Looking a category up by name is
+therefore not portable across MPI implementations, but may be the preferred
+approach for a tool that targets Open MPI specifically.
+
+
+ERRORS
+------
+
+:ref:`MPI_T_category_get_index` will fail if:
+
+* ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface is not initialized.
+
+* ``MPI_T_ERR_INVALID``: ``name`` or ``cat_index`` is ``NULL``.
+
+* ``MPI_T_ERR_INVALID_NAME``: ``name`` does not match the name of any category
+  provided by the implementation at the time of the call.
+
+
+.. seealso::
+   * :ref:`MPI_T_category_get_info`
+   * :ref:`MPI_T_category_get_num`

--- a/docs/man-openmpi/man3/MPI_T_cvar_get_index.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_cvar_get_index.3.rst
@@ -1,0 +1,62 @@
+.. _mpi_t_cvar_get_index:
+
+
+MPI_T_cvar_get_index
+====================
+
+.. include_body
+
+:ref:`MPI_T_cvar_get_index` |mdash| Query the index of a control variable from its name
+
+.. The following file was automatically generated
+.. include:: ./bindings/mpi_t_cvar_get_index.rst
+
+INPUT PARAMETERS
+----------------
+* ``name``: Name of the control variable to query.
+
+OUTPUT PARAMETERS
+-----------------
+* ``cvar_index``: Index of the control variable.
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_T_cvar_get_index` can be used to retrieve the index of a control
+variable given its name. The *name* argument is provided by the caller as a
+null-terminated string, and the matching index is returned in *cvar_index*.
+The returned index can then be passed to other MPI tool information
+interface routines, such as :ref:`MPI_T_cvar_get_info`. Control variables in
+Open MPI are the same as MCA parameters.
+
+This routine allows a tool to look up a control variable by name without
+iterating over the entire set of control variables. Because the number of
+control variables exposed by the implementation can change over time, this is
+both more convenient and lower overhead than enumerating all of the variables
+to find a particular one.
+
+
+NOTES
+-----
+
+Control variable names are implementation-specific. Looking a variable up by
+name is therefore not portable across MPI implementations, but may be the
+preferred approach for a tool that targets Open MPI specifically.
+
+
+ERRORS
+------
+
+:ref:`MPI_T_cvar_get_index` will fail if:
+
+* ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface is not initialized.
+
+* ``MPI_T_ERR_INVALID``: ``name`` or ``cvar_index`` is ``NULL``.
+
+* ``MPI_T_ERR_INVALID_NAME``: ``name`` does not match the name of any control
+  variable provided by the implementation at the time of the call.
+
+
+.. seealso::
+   * :ref:`MPI_T_cvar_get_info`
+   * :ref:`MPI_T_cvar_get_num`

--- a/docs/man-openmpi/man3/MPI_T_pvar_get_index.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_pvar_get_index.3.rst
@@ -1,0 +1,65 @@
+.. _mpi_t_pvar_get_index:
+
+
+MPI_T_pvar_get_index
+====================
+
+.. include_body
+
+:ref:`MPI_T_pvar_get_index` |mdash| Query the index of a performance variable from its name
+
+.. The following file was automatically generated
+.. include:: ./bindings/mpi_t_pvar_get_index.rst
+
+INPUT PARAMETERS
+----------------
+* ``name``: Name of the performance variable to query.
+* ``var_class``: Class of the performance variable to query.
+
+OUTPUT PARAMETERS
+-----------------
+* ``pvar_index``: Index of the performance variable.
+
+DESCRIPTION
+-----------
+
+:ref:`MPI_T_pvar_get_index` can be used to retrieve the index of a
+performance variable given its name and class. The *name* and *var_class*
+arguments are provided by the caller |mdash| *name* as a null-terminated
+string |mdash| and the matching index is returned in *pvar_index*. A
+performance variable is identified by the pair (*name*, *var_class*), so both
+must be supplied. The returned index can then be passed to other MPI tool
+information interface routines, such as :ref:`MPI_T_pvar_get_info`.
+
+This routine allows a tool to look up a performance variable by name without
+iterating over the entire set of performance variables. Because the number of
+performance variables exposed by the implementation can change over time, this
+is both more convenient and lower overhead than enumerating all of the
+variables to find a particular one.
+
+
+NOTES
+-----
+
+Performance variable names are implementation-specific. Looking a variable up
+by name is therefore not portable across MPI implementations, but may be the
+preferred approach for a tool that targets Open MPI specifically.
+
+
+ERRORS
+------
+
+:ref:`MPI_T_pvar_get_index` will fail if:
+
+* ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface is not initialized.
+
+* ``MPI_T_ERR_INVALID``: ``name`` or ``pvar_index`` is ``NULL``.
+
+* ``MPI_T_ERR_INVALID_NAME``: ``name`` does not match the name of any
+  performance variable of the specified *var_class* provided by the
+  implementation at the time of the call.
+
+
+.. seealso::
+   * :ref:`MPI_T_pvar_get_info`
+   * :ref:`MPI_T_pvar_get_num`

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -108,6 +108,7 @@ MPI API manual pages (section 3)
    MPI_Error_string.3.rst
    MPI_Exscan.3.rst
    MPI_Exscan_init.3.rst
+   MPI_F_sync_reg.3.rst
    MPI_Fetch_and_op.3.rst
    MPI_File_c2f.3.rst
    MPI_File_call_errhandler.3.rst
@@ -378,10 +379,12 @@ MPI API manual pages (section 3)
    MPI_T_category_get_categories.3.rst
    MPI_T_category_get_cvars.3.rst
    MPI_T_category_get_events.3.rst
+   MPI_T_category_get_index.3.rst
    MPI_T_category_get_info.3.rst
    MPI_T_category_get_num.3.rst
    MPI_T_category_get_num_events.3.rst
    MPI_T_category_get_pvars.3.rst
+   MPI_T_cvar_get_index.3.rst
    MPI_T_cvar_get_info.3.rst
    MPI_T_cvar_get_num.3.rst
    MPI_T_cvar_handle_alloc.3.rst
@@ -407,6 +410,7 @@ MPI API manual pages (section 3)
    MPI_T_event_set_dropped_handler.3.rst
    MPI_T_finalize.3.rst
    MPI_T_init_thread.3.rst
+   MPI_T_pvar_get_index.3.rst
    MPI_T_pvar_get_info.3.rst
    MPI_T_pvar_get_num.3.rst
    MPI_T_pvar_handle_alloc.3.rst


### PR DESCRIPTION
Add man pages for four implemented MPI API functions that previously had none, so they were absent from the rendered HTML documentation (docs.open-mpi.org) and from the installed Unix man pages:

- `MPI_T_cvar_get_index`
- `MPI_T_pvar_get_index`
- `MPI_T_category_get_index`
- `MPI_F_sync_reg`

All four are implemented and public on **main**, **v5.0.x**, and **v6.0.x**:

- The three `MPI_T_*_get_index` functions are declared in `ompi/include/mpi.h.in` and implemented in `ompi/mpi/tool/{cvar,pvar,category}_get_index.c`.
- `MPI_F_sync_reg` is Fortran-only (no C binding) in `ompi/mpi/fortran/mpif-h/f_sync_reg_f.c` and `ompi/mpi/fortran/use-mpi-f08/f_sync_reg_f08.F90`.

Descriptions follow the MPI standard; the per-language bindings are auto-generated from the MPI Forum metadata (so `MPI_F_sync_reg` is correctly rendered Fortran-only). Each new page is added to the `OMPI_MAN3` install list.

These are back-port candidates to v5.0.x and v6.0.x.

Fixes #13970.
