### PR TITLE
docs: add a limited llms.txt for the v5.0.x series

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2022 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2023-2024 Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -57,8 +57,18 @@ RST_SOURCE_FILES   = \
         $(srcdir)/man-openshmem/*.rst \
         $(srcdir)/man-openshmem/man*/*.rst
 
+# Files copied verbatim into the root of the rendered HTML via Sphinx's
+# html_extra_path (see conf.py) -- currently just the static llms.txt for
+# this release series.  Sphinx resolves html_extra_path relative to the
+# directory containing conf.py, so for VPATH builds these files must be
+# copied from $(srcdir) into the build tree alongside conf.py (see the
+# copy loops below), exactly like the RST sources.
+EXTRA_HTML_FILES   = \
+        $(srcdir)/llms.txt
+
 EXTRA_DIST         = \
         requirements.txt \
+        $(EXTRA_HTML_FILES) \
         no-prrte-content.rst.txt \
         html \
         man \
@@ -977,7 +987,7 @@ endif
 $(ALL_MAN_BUILT): $(builddir)/prrte-rst-content
 $(ALL_MAN_BUILT): $(builddir)/schizo-ompi-rst-content/schizo-ompi-cli.rstxt
 $(ALL_MAN_BUILT): $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES)
-$(ALL_MAN_BUILT): $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG)
+$(ALL_MAN_BUILT): $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG) $(EXTRA_HTML_FILES)
 
 # Render the RST source into both 1) full HTML docs and 2) nroff man
 # pages.
@@ -1018,7 +1028,7 @@ $(ALL_MAN_BUILT): $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG)
 $(ALL_MAN_BUILT):
 	$(OMPI_V_SPHINX_COPYRST) if test "$(srcdir)" != "$(builddir)"; then \
 	    len=`echo "$(srcdir)/" | wc -c`; \
-	    for file in $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES) $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG); do \
+	    for file in $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES) $(TEXT_SOURCE_FILES) $(EXTRA_HTML_FILES) $(SPHINX_CONFIG); do \
 	        dir=`dirname $$file | cut -c$$len-`; \
 	        if test -z "$$dir"; then \
 	            dir=.; \
@@ -1056,7 +1066,7 @@ clean-local:
 	rm -rf prrte-rst-content schizo-ompi-rst-content
 	if test "$(srcdir)" != "$(builddir)"; then \
 	    len=`echo "$(srcdir)/" | wc -c`; \
-	    for file in $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES) $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG); do \
+	    for file in $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES) $(TEXT_SOURCE_FILES) $(EXTRA_HTML_FILES) $(SPHINX_CONFIG); do \
 	        dir=`dirname $$file | cut -c$$len-`; \
 	        if test -z "$$dir"; then \
 	            rm -rf `basename $$file`; \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,6 +233,13 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
 
+# Paths that contain files copied verbatim into the root of the HTML
+# output.  Used here to publish a static, limited llms.txt for the v5.0.x
+# series (see https://llmstxt.org/).  Unlike Open MPI v6.0.0 and later,
+# v5.0.x does not generate the full machine-readable API catalog, so this
+# file is committed directly rather than generated at build time.
+html_extra_path = ['llms.txt']
+
 # Put a "Last updated on:" timestamp at the bottom of each page.
 html_last_updated_fmt = '%Y-%m-%d %H:%M:%S %Z'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,15 +26,18 @@ Documentation for Open MPI can be found in the following locations:
      - Documentation location
 
    * - v5.0.0 and later
-     - Web: https://docs.open-mpi.org/
+     - * Web: https://docs.open-mpi.org/
 
-       Included in tarball: ``docs/html/index.html``
+       * Included in tarball: ``docs/html/index.html``
 
-       Built in source tree (if Sphinx available): ``docs/_build/html/index.html``
+       * Built in source tree (if Sphinx available): ``docs/_build/html/index.html``
 
-       Installed: ``$docdir/html/index.html``
+       * Installed: ``$docdir/html/index.html``
+         (which defaults to: ``$prefix/share/doc/openmpi/html/index.html``)
 
-       (which defaults to: ``$prefix/share/doc/openmpi/html/index.html``)
+       * An ``llms.txt`` index of LLM-friendly documentation (links to the
+         human-facing HTML documentation and man pages) for this
+         documentation version: `llms.txt <llms.txt>`_
 
    * - v4.1.x and earlier
      - See the `legacy Open MPI FAQ <https://www.open-mpi.org/faq/>`_

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,111 @@
+# Open MPI v5.0.x
+
+Open MPI is an open source implementation of the Message Passing
+Interface (MPI) specification. This file indexes the LLM-friendly
+documentation available for this Open MPI documentation version.
+
+## About this file
+
+This is a limited llms.txt for the Open MPI v5.0.x release series. It
+indexes the human-facing HTML documentation and the rendered man pages.
+
+Open MPI publishes one llms.txt per documentation version, all under the
+same URL scheme:
+
+    https://docs.open-mpi.org/en/VERSION_SLUG/llms.txt
+
+where VERSION_SLUG is either `main` (Open MPI's development tip) or
+`vA.B.C` (A and B are the major and minor version numbers; use `vA.B.x`
+for a release branch, e.g. `v5.0.x`, or an exact `vA.B.C` for a
+git-tagged release).
+
+Open MPI v5.0.x publishes this limited index only. The full set of
+machine-readable artifacts --- a structured JSONL API catalog, aggregate
+and per-interface Markdown corpora, per-procedure Markdown pages, curated
+examples and an interface guide, and a manifest --- is published for Open
+MPI v6.0.0 and later. If you need that structured API data, use a v6.0.0
+or later version, for example
+https://docs.open-mpi.org/en/v6.0.x/llms.txt or
+https://docs.open-mpi.org/en/main/llms.txt .
+
+Documentation for Open MPI versions older than v5.0.x is not published in
+this format; for those, see
+https://github.com/open-mpi/ompi/blob/v4.1.x/README ,
+https://www.open-mpi.org/faq/ , and https://www.open-mpi.org/doc/ .
+
+- The MPI Standard (https://www.mpi-forum.org/docs/) is authoritative for
+  portable MPI semantics.
+- `MPIX_*` and `OMPI_*` APIs are Open MPI extensions, not portable MPI
+  Standard APIs.
+
+## API and command reference (man pages)
+
+- [MPI API man pages (man3 index)](man-openmpi/man3/index.html)
+- [Open MPI command man pages (man1 index)](man-openmpi/man1/index.html)
+
+## Human-facing documentation
+
+- [Building MPI applications](building-apps/index.html)
+- [Launching MPI applications](launching-apps/index.html)
+- [Tuning MPI applications](tuning-apps/index.html)
+
+## Runtime introspection (installed Open MPI)
+
+The links above are static documentation for this version. To inspect a
+*specific* installation --- its exact Open MPI version, build
+configuration, the MCA components that were compiled in, and the
+run-time tunables (MCA parameters) those components expose --- query the
+installation directly with the `ompi_info` command (listed in the man1
+index above). That information is installation-specific, so it is not
+captured here.
+
+Version and configuration:
+
+- `ompi_info --version` prints the Open MPI version.
+- `ompi_info` with no arguments prints a human-readable summary: the
+  version, the `./configure` command line, the compilers used, the
+  enabled MPI language bindings, and the MCA components that were built.
+- `ompi_info --parsable` prints the same information in a stable,
+  machine-readable `key:value` format (for example, an
+  `ompi:version:full:...` line carries the exact version).
+
+Discovering MCA parameters: the available set depends on which
+components were built, so list them from the installation with
+
+    ompi_info --all --parsable
+
+`--all` shows all configuration options and raises the MCA-parameter
+detail to the maximum (every "level", 1--9); by default only level-1
+parameters are shown. The output is self-describing: each parameter
+emits one line per field, keyed
+`mca:<framework>:<component>:param:<name>:<field>:<value>`, for example:
+
+    mca:btl:tcp:param:btl_tcp_if_include:value:
+    mca:btl:tcp:param:btl_tcp_if_include:level:1
+    mca:btl:tcp:param:btl_tcp_if_include:help:Comma-delimited list ...
+    mca:btl:tcp:param:btl_tcp_if_include:type:string
+
+Read the field names directly from the output: typical fields are the
+current `value`, its `source`, whether it is read-only (`status`), the
+verbosity `level`, the `help` text, the value `type`, whether it is
+`deprecated`, any `enumerator` values, and any `synonym_of` (an older
+name that still works).
+
+Setting MCA parameters: once you know a parameter's name, set it
+(highest precedence first) on the `mpirun` / `mpiexec` command line, in
+the environment, or in a parameter file:
+
+    # command line (highest precedence):
+    mpirun --mca btl tcp,self,sm -np 4 ./my_app
+
+    # environment variable (prefix the parameter name with OMPI_MCA_):
+    export OMPI_MCA_btl=tcp,self,sm
+
+    # parameter file: one "name = value" per line in
+    #   $HOME/.openmpi/mca-params.conf       (per user) or
+    #   $prefix/etc/openmpi-mca-params.conf  (system-wide)
+
+PMIx and PRRTE (Open MPI's run-time dependencies) have their own MCA
+systems, set with the `--pmixmca` / `--prtemca` options and the
+`PMIX_MCA_` / `PRTE_MCA_` environment-variable prefixes (note the single
+"R" in `PRTE_MCA_`).


### PR DESCRIPTION
This PR adds a **limited `llms.txt`** to the Open MPI v5.0.x release series.

/bot:notacherrypick

### Why this is intentionally *not* a cherry-pick from main

This PR is being made explicitly because it is **quite different** from the
main-targeted LLM-friendly documentation work (#13972, which will also be
brought to v6.0.x).  It is deliberately different because the machinery that
#13972 relies on does not exist on the v5.0.x branch:

- the embedded `pympistandard` library (a git submodule under `3rd-party/`),
- `docs/mpi-standard-apis.json` (the MPI Forum binding metadata), and
- the metadata-driven man3 bindings generator (`docs/generate-mpi-man3-bindings.py`).

Backporting that entire toolchain to a stable release branch is not
warranted.  Instead, this PR ships a small, static, hand-maintained
`llms.txt` (https://llmstxt.org/) that:

- links to the human-facing HTML documentation (building / launching / tuning
  applications), and
- links to the rendered man page **indexes** (the man3 MPI API pages and the
  man1 command pages) -- rather than one-time-generating a full enumeration
  that would drift as APIs change.

It is copied verbatim into the HTML output root via Sphinx `html_extra_path`,
so it is served at `https://docs.open-mpi.org/en/v5.0.x/llms.txt` and inherits
the existing tarball, install, and Read the Docs publishing machinery.

### The overall scheme / plan / intent

Taken together with #13972, this PR illustrates the desired end state across
versions:

- **v5.0.x** -- a *limited* `llms.txt` (this PR): an index of the human-facing
  docs and the man page indexes.
- **v6.0.0 and later** -- the *complete* `llms.txt`: the full machine-readable
  API catalog (JSONL), aggregate and per-interface Markdown corpora,
  per-procedure Markdown pages, curated examples and an interface guide, and a
  manifest.

The full-edition `llms.txt` on main/v6.0.x advertises this tiering, so a
consumer who finds the limited v5.0.x file is pointed at the v6.0.0+ versions
for the structured API data.
