### PR TITLE
Add OPAL class/util/datatype unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,6 +447,10 @@ test/class/opal_pointer_array
 test/class/opal_proc_table
 test/class/opal_tree
 test/class/opal_value_array
+test/class/opal_graph
+test/class/opal_hotel
+test/class/opal_interval_tree
+test/class/opal_ring_buffer
 
 test/datatype/ddt_test
 test/datatype/ddt_pack
@@ -466,6 +470,7 @@ test/datatype/unpack_hetero
 test/datatype/opal_datatype_bigcount
 test/datatype/ompi_datatype_bigcount
 test/datatype/mpi_datatype_bigcount
+test/datatype/opal_ddt_api
 
 test/event/signal-test
 test/event/event-test
@@ -521,6 +526,28 @@ test/util/opal_bit_ops
 test/util/bipartite_graph
 test/util/opal_sha256
 test/util/opal_json
+test/util/opal_alfg
+test/util/opal_arch
+test/util/opal_cmd_line
+test/util/opal_crc
+test/util/opal_environ
+test/util/opal_fd
+test/util/opal_few
+test/util/opal_getcwd
+test/util/opal_info
+test/util/opal_info_subscriber
+test/util/opal_keyval_parse
+test/util/opal_malloc
+test/util/opal_net
+test/util/opal_os_dirpath
+test/util/opal_output
+test/util/opal_path
+test/util/opal_printf
+test/util/opal_proc
+test/util/opal_qsort
+test/util/opal_string_copy
+test/util/opal_sys_limits
+test/util/opal_uri
 
 opal/test/reachable/reachable_netlink
 opal/test/reachable/reachable_weighted

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,6 +23,9 @@
 #
 
 AM_CPPFLAGS="-I$(top_srcdir)/test/support"
+
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/test/Makefile.mca-dso-check
 
 if PROJECT_OMPI
   REQUIRES_OMPI = ompi_rb_tree
@@ -36,70 +40,76 @@ check_PROGRAMS = \
 	opal_pointer_array \
 	opal_lifo \
 	opal_fifo \
-	opal_cstring
+	opal_cstring \
+	opal_interval_tree \
+	opal_ring_buffer \
+	opal_hotel \
+	opal_graph
 
 TESTS = $(check_PROGRAMS)
 
+# Common link line for the OPAL unit tests
+opal_test_ldadd = \
+	$(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+	$(top_builddir)/test/support/libsupport.a
+
 opal_bitmap_SOURCES = opal_bitmap.c
-opal_bitmap_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_bitmap_DEPENDENCIES = $(opal_bitmap_LDADD)
+opal_bitmap_LDADD = $(opal_test_ldadd)
+opal_bitmap_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_list_SOURCES = opal_list.c
-opal_list_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_list_DEPENDENCIES = $(opal_list_LDADD)
+opal_list_LDADD = $(opal_test_ldadd)
+opal_list_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_hash_table_SOURCES = opal_hash_table.c
-opal_hash_table_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_hash_table_DEPENDENCIES = $(opal_hash_table_LDADD)
+opal_hash_table_LDADD = $(opal_test_ldadd)
+opal_hash_table_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_proc_table_SOURCES = opal_proc_table.c
-opal_proc_table_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_proc_table_DEPENDENCIES = $(opal_proc_table_LDADD)
+opal_proc_table_LDADD = $(opal_test_ldadd)
+opal_proc_table_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_pointer_array_SOURCES = opal_pointer_array.c
-opal_pointer_array_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_pointer_array_DEPENDENCIES = $(opal_pointer_array_LDADD)
+opal_pointer_array_LDADD = $(opal_test_ldadd)
+opal_pointer_array_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_value_array_SOURCES = opal_value_array.c
-opal_value_array_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-        $(top_builddir)/test/support/libsupport.a
-opal_value_array_DEPENDENCIES = $(opal_value_array_LDADD)
+opal_value_array_LDADD = $(opal_test_ldadd)
+opal_value_array_DEPENDENCIES = $(opal_test_ldadd)
 
 ompi_rb_tree_SOURCES = ompi_rb_tree.c
 ompi_rb_tree_LDADD = \
-        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-	$(top_builddir)/test/support/libsupport.a
+	$(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(opal_test_ldadd)
 ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)
 
 opal_lifo_SOURCES = opal_lifo.c
-opal_lifo_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-	$(top_builddir)/test/support/libsupport.a
-opal_lifo_DEPENDENCIES = $(opal_lifo_LDADD)
+opal_lifo_LDADD = $(opal_test_ldadd)
+opal_lifo_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_fifo_SOURCES = opal_fifo.c
-opal_fifo_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-	$(top_builddir)/test/support/libsupport.a
-opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
+opal_fifo_LDADD = $(opal_test_ldadd)
+opal_fifo_DEPENDENCIES = $(opal_test_ldadd)
 
 opal_cstring_SOURCES = opal_cstring.c
-opal_cstring_LDADD = \
-        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
-	$(top_builddir)/test/support/libsupport.a
-opal_cstring_DEPENDENCIES = $(opal_cstring_LDADD)
+opal_cstring_LDADD = $(opal_test_ldadd)
+opal_cstring_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_interval_tree_SOURCES = opal_interval_tree.c
+opal_interval_tree_LDADD = $(opal_test_ldadd)
+opal_interval_tree_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_ring_buffer_SOURCES = opal_ring_buffer.c
+opal_ring_buffer_LDADD = $(opal_test_ldadd)
+opal_ring_buffer_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_hotel_SOURCES = opal_hotel.c
+opal_hotel_LDADD = $(opal_test_ldadd)
+opal_hotel_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_graph_SOURCES = opal_graph.c
+opal_graph_LDADD = $(opal_test_ldadd)
+opal_graph_DEPENDENCIES = $(opal_test_ldadd)
 
 clean-local:
 	rm -f opal_bitmap_test_out.txt opal_hash_table_test_out.txt opal_proc_table_test_out.txt

--- a/test/class/opal_bitmap.c
+++ b/test/class/opal_bitmap.c
@@ -1,419 +1,443 @@
 /*
- * Testcase for bitmap
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_bitmap_t.  Exercises the full public API with
+ * self-checking assertions (via the support harness).  Note: the
+ * library is compiled with -DNDEBUG, so assert() is a no-op here --
+ * all verification must go through test_verify()/test_failure().
  */
 
 #include "opal_config.h"
 
-#include "support.h"
 #include <stdio.h>
+
+#include "support.h"
 
 #include "opal/class/opal_bitmap.h"
 #include "opal/constants.h"
 
-#define BSIZE            26
-#define OPAL_INVALID_BIT -1
-#define ERR_CODE         -2
+#define BSIZE 26
 
-#define PRINT_VALID_ERR                                        \
-    fprintf(error_out, "================================ \n"); \
-    fprintf(error_out, "This is supposed to throw error  \n"); \
-    fprintf(error_out, "================================ \n")
+/* Number of bits per underlying array element (mirrors the value used
+   internally by opal_bitmap.c). */
+#define BITS_PER_ELEMENT 64
 
-static void test_bitmap_set(opal_bitmap_t *bm);
-static void test_bitmap_clear(opal_bitmap_t *bm);
-static void test_bitmap_is_set(opal_bitmap_t *bm);
-static void test_bitmap_clear_all(opal_bitmap_t *bm);
-static void test_bitmap_set_all(opal_bitmap_t *bm);
-static void test_bitmap_find_and_set(opal_bitmap_t *bm);
-static void test_bitmap_num_set_bits(opal_bitmap_t *bm);
-
-static int set_bit(opal_bitmap_t *bm, int bit);
-static int clear_bit(opal_bitmap_t *bm, int bit);
-static int is_set_bit(opal_bitmap_t *bm, int bit);
-static int clear_all(opal_bitmap_t *bm);
-static int set_all(opal_bitmap_t *bm);
-static int find_and_set(opal_bitmap_t *bm, int bit);
-
-#define WANT_PRINT_BITMAP 0
-#if WANT_PRINT_BITMAP
-static void print_bitmap(opal_bitmap_t *bm);
-#endif
-
-static FILE *error_out = NULL;
+static void test_init_errors(void);
+static void test_set_and_is_set(void);
+static void test_clear(void);
+static void test_clear_and_set_all(void);
+static void test_find_and_set(void);
+static void test_num_bits(void);
+static void test_bitwise_ops(void);
+static void test_are_different(void);
+static void test_get_string(void);
+static void test_copy(void);
+static void test_max_size(void);
+static void test_size_accessor(void);
 
 int main(int argc, char *argv[])
 {
-    /* Local variables */
-    opal_bitmap_t bm;
-    int err;
-
-    /* Perform overall test initialization */
     test_init("opal_bitmap_t");
 
-#ifdef STANDALONE
-    error_out = stderr;
-#else
-    error_out = fopen("./opal_bitmap_test_out.txt", "w");
-    if (error_out == NULL)
-        error_out = stderr;
-#endif
+    test_init_errors();
+    test_set_and_is_set();
+    test_clear();
+    test_clear_and_set_all();
+    test_find_and_set();
+    test_num_bits();
+    test_bitwise_ops();
+    test_are_different();
+    test_get_string();
+    test_copy();
+    test_max_size();
+    test_size_accessor();
 
-    /* Initialize bitmap  */
+    /* test_finalize() returns non-zero if any check failed, which
+       becomes this program's exit status for "make check". */
+    return test_finalize();
+}
+
+static void test_init_errors(void)
+{
+    opal_bitmap_t bm;
     OBJ_CONSTRUCT(&bm, opal_bitmap_t);
-    PRINT_VALID_ERR;
-    err = opal_bitmap_init(NULL, 2);
-    if (err == OPAL_ERR_BAD_PARAM)
-        fprintf(error_out, "ERROR: Initialization of bitmap failed\n\n");
 
-    PRINT_VALID_ERR;
-    err = opal_bitmap_init(&bm, -1);
-    if (err == OPAL_ERR_BAD_PARAM)
-        fprintf(error_out, "ERROR: Initialization of bitmap failed \n\n");
+    /* NULL bitmap is rejected */
+    test_verify("init(NULL) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_init(NULL, 2));
+    /* non-positive sizes are rejected */
+    test_verify("init(size=-1) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_init(&bm, -1));
+    test_verify("init(size=0) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_init(&bm, 0));
+    /* valid size succeeds and rounds up to a whole element */
+    test_verify("init(BSIZE) ok", OPAL_SUCCESS == opal_bitmap_init(&bm, BSIZE));
+    test_verify("init rounds up to one element", BITS_PER_ELEMENT == opal_bitmap_size(&bm));
+    /* a freshly initialized bitmap is entirely clear */
+    test_verify("fresh bitmap is clear", opal_bitmap_is_clear(&bm));
 
-    err = opal_bitmap_init(&bm, BSIZE);
-    if (0 > err) {
-        fprintf(error_out, "Error in bitmap create -- aborting \n");
-        exit(-1);
+    OBJ_DESTRUCT(&bm);
+}
+
+static void test_set_and_is_set(void)
+{
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, BSIZE);
+
+    /* Set bits at element boundaries and beyond the initial size (which
+       must auto-expand the bitmap). */
+    int bits[] = {0, 1, 7, 8, 24, 31, 32, 44, 63, 64, 82};
+    int nbits = (int) (sizeof(bits) / sizeof(bits[0]));
+    for (int i = 0; i < nbits; ++i) {
+        test_verify("set_bit ok", OPAL_SUCCESS == opal_bitmap_set_bit(&bm, bits[i]));
+    }
+    for (int i = 0; i < nbits; ++i) {
+        test_verify("set bit reads back set", opal_bitmap_is_set_bit(&bm, bits[i]));
     }
 
-    fprintf(error_out, "\nTesting bitmap set... \n");
-    test_bitmap_set(&bm);
+    /* Setting bit 82 must have grown the bitmap past 82 bits. */
+    test_verify("set_bit auto-expanded", opal_bitmap_size(&bm) > 82);
 
-    fprintf(error_out, "\nTesting bitmap clear ... \n");
-    test_bitmap_clear(&bm);
+    /* Bits we never set must read as unset. */
+    test_verify("unset bit 2 reads clear", !opal_bitmap_is_set_bit(&bm, 2));
+    test_verify("unset bit 30 reads clear", !opal_bitmap_is_set_bit(&bm, 30));
 
-    fprintf(error_out, "\nTesting bitmap is_set ... \n");
-    test_bitmap_is_set(&bm);
+    /* Out-of-range / negative indices: set is rejected, is_set is false. */
+    test_verify("set_bit(-1) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_set_bit(&bm, -1));
+    test_verify("is_set_bit(-1) false", !opal_bitmap_is_set_bit(&bm, -1));
+    test_verify("is_set_bit(huge) false", !opal_bitmap_is_set_bit(&bm, 1000000));
 
-    fprintf(error_out, "\nTesting bitmap clear_all... \n");
-    test_bitmap_clear_all(&bm);
-
-    fprintf(error_out, "\nTesting bitmap set_all... \n");
-    test_bitmap_set_all(&bm);
-
-    fprintf(error_out, "\nTesting bitmap find_and_set... \n");
-    test_bitmap_find_and_set(&bm);
-
-    fprintf(error_out, "\nTesting bitmap num_set_bits... \n");
-    test_bitmap_num_set_bits(&bm);
-
-    fprintf(error_out, "\n~~~~~~     Testing complete     ~~~~~~ \n\n");
-
-    test_finalize();
-#ifndef STANDALONE
-    fclose(error_out);
-#endif
-
-    return 0;
+    OBJ_DESTRUCT(&bm);
 }
 
-void test_bitmap_set(opal_bitmap_t *bm)
+static void test_clear(void)
 {
-    int result = 0;
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, BSIZE);
 
-    /* start of bitmap and boundaries */
-    set_bit(bm, 0);
-    set_bit(bm, 1);
-    set_bit(bm, 7);
-    set_bit(bm, 8);
-    /* middle of bitmap  */
-    set_bit(bm, 24);
+    opal_bitmap_set_bit(&bm, 5);
+    test_verify("bit 5 set", opal_bitmap_is_set_bit(&bm, 5));
+    test_verify("clear_bit ok", OPAL_SUCCESS == opal_bitmap_clear_bit(&bm, 5));
+    test_verify("bit 5 now clear", !opal_bitmap_is_set_bit(&bm, 5));
 
-    /* end of bitmap initial size */
-    set_bit(bm, 31);
-    set_bit(bm, 32);
+    /* Negative and out-of-range bits are rejected (clear does not grow). */
+    test_verify("clear_bit(-1) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_clear_bit(&bm, -1));
+    test_verify("clear_bit(out of range) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_clear_bit(&bm, opal_bitmap_size(&bm)));
 
-    /* beyond bitmap -- this is valid */
-    set_bit(bm, 44);
-    set_bit(bm, 82);
-
-    /* invalid bit */
-    PRINT_VALID_ERR;
-    result = set_bit(bm, -1);
-    TEST_AND_REPORT(result, ERR_CODE, "opal_bitmap_set_bit");
+    OBJ_DESTRUCT(&bm);
 }
 
-void test_bitmap_clear(opal_bitmap_t *bm)
+static void test_clear_and_set_all(void)
 {
-    int result = 0;
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, 128);
+    int size = opal_bitmap_size(&bm);
 
-    /* Valid set bits  */
-    clear_bit(bm, 29);
-    clear_bit(bm, 31);
-    clear_bit(bm, 33);
-    clear_bit(bm, 32);
-    clear_bit(bm, 0);
+    test_verify("set_all ok", OPAL_SUCCESS == opal_bitmap_set_all_bits(&bm));
+    test_verify("set_all -> not clear", !opal_bitmap_is_clear(&bm));
+    test_verify("set_all -> all bits set", size == opal_bitmap_num_set_bits(&bm, size));
+    test_verify("set_all -> no unset bits", 0 == opal_bitmap_num_unset_bits(&bm, size));
+    test_verify("set_all -> first bit set", opal_bitmap_is_set_bit(&bm, 0));
+    test_verify("set_all -> last bit set", opal_bitmap_is_set_bit(&bm, size - 1));
 
-    /* invalid bit */
-    PRINT_VALID_ERR;
-    result = clear_bit(bm, -1);
-    TEST_AND_REPORT(result, ERR_CODE, "opal_bitmap_clear_bit");
-    PRINT_VALID_ERR;
-    result = clear_bit(bm, 142);
-    TEST_AND_REPORT(result, ERR_CODE, "opal_bitmap_clear_bit");
+    test_verify("clear_all ok", OPAL_SUCCESS == opal_bitmap_clear_all_bits(&bm));
+    test_verify("clear_all -> is_clear", opal_bitmap_is_clear(&bm));
+    test_verify("clear_all -> zero set bits", 0 == opal_bitmap_num_set_bits(&bm, size));
+
+    /* NULL handling */
+    test_verify("set_all(NULL) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_set_all_bits(NULL));
+    test_verify("clear_all(NULL) rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_clear_all_bits(NULL));
+
+    OBJ_DESTRUCT(&bm);
 }
 
-void test_bitmap_is_set(opal_bitmap_t *bm)
+static void test_find_and_set(void)
 {
-    int result = 0;
+    opal_bitmap_t bm;
+    int pos;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, BSIZE);
+    opal_bitmap_clear_all_bits(&bm);
 
-    /* First set some bits */
-    test_bitmap_set(bm);
-    is_set_bit(bm, 0);
-    is_set_bit(bm, 1);
-    is_set_bit(bm, 31);
-    is_set_bit(bm, 32);
-
-    result = is_set_bit(bm, 1122);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_is_set_bit");
-    is_set_bit(bm, -33);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_is_set_bit");
-    is_set_bit(bm, -1);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_is_set_bit");
-}
-
-void test_bitmap_find_and_set(opal_bitmap_t *bm)
-{
-    int bsize;
-    int result = 0;
-
-    opal_bitmap_clear_all_bits(bm);
-    result = find_and_set(bm, 0);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-    result = find_and_set(bm, 1);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-    result = find_and_set(bm, 2);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-    result = find_and_set(bm, 3);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-
-    result = opal_bitmap_set_bit(bm, 5);
-    result = find_and_set(bm, 4);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-
-    result = opal_bitmap_set_bit(bm, 6);
-    result = opal_bitmap_set_bit(bm, 7);
-
-    /* Setting beyond a char boundary */
-    result = find_and_set(bm, 8);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-    opal_bitmap_set_bit(bm, 9);
-    result = find_and_set(bm, 10);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-
-    /* Setting beyond the current size of bitmap  */
-    opal_bitmap_set_all_bits(bm);
-    bsize = opal_bitmap_size(bm);
-    result = find_and_set(bm, bsize);
-    TEST_AND_REPORT(result, 0, "opal_bitmap_find_and_set_first_unset_bit");
-}
-
-void test_bitmap_clear_all(opal_bitmap_t *bm)
-{
-    int result = clear_all(bm);
-    TEST_AND_REPORT(result, 0, " error in opal_bitmap_clear_all_bits");
-}
-
-void test_bitmap_set_all(opal_bitmap_t *bm)
-{
-    int result = set_all(bm);
-    TEST_AND_REPORT(result, 0, " error in opal_bitmap_set_ala_bitsl");
-}
-
-void test_bitmap_num_set_bits(opal_bitmap_t *bm)
-{
-    int result, expected;
-
-    /* Test 1: Clear all bits and count - should be 0 */
-    opal_bitmap_clear_all_bits(bm);
-    result = opal_bitmap_num_set_bits(bm, 64);
-    expected = 0;
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: cleared bitmap");
-
-    /* Test 2: Set specific bits and count within first 64 bits */
-    opal_bitmap_set_bit(bm, 0);
-    opal_bitmap_set_bit(bm, 1);
-    opal_bitmap_set_bit(bm, 5);
-    opal_bitmap_set_bit(bm, 63);
-    result = opal_bitmap_num_set_bits(bm, 64);
-    expected = 4;
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: 4 bits in first 64");
-
-    /* Test 3: Count partial element (len not a multiple of 64) */
-    /* Count only first 10 bits - should be 3 (bits 0, 1, 5) */
-    result = opal_bitmap_num_set_bits(bm, 10);
-    expected = 3;
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: partial element (10 bits)");
-
-    /* Test 4: Count up to bit 63 - should include bit 63 */
-    result = opal_bitmap_num_set_bits(bm, 64);
-    expected = 4;
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: up to bit 63");
-
-    /* Test 5: Set bits across multiple array elements */
-    opal_bitmap_set_bit(bm, 64);
-    opal_bitmap_set_bit(bm, 65);
-    opal_bitmap_set_bit(bm, 100);
-    opal_bitmap_set_bit(bm, 127);
-
-    /* Count across 128 bits (2 full elements) */
-    result = opal_bitmap_num_set_bits(bm, 128);
-    expected = 8; /* 4 from first element + 4 from second element */
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: across 2 elements (128 bits)");
-
-    /* Test 6: Count partial second element (130 bits = 2 elements + 2 bits) */
-    result = opal_bitmap_num_set_bits(bm, 130);
-    expected = 8; /* Should still be 8, as bits 128-129 are not set */
-    TEST_AND_REPORT(result, expected,
-                    "opal_bitmap_num_set_bits: partial second element (130 bits)");
-
-    /* Test 7: Verify len is treated as bits, not array indices
-     * Set bit 200 and count up to 201 bits (not 201 array elements) */
-    opal_bitmap_clear_all_bits(bm);
-    opal_bitmap_set_bit(bm, 200);
-    result = opal_bitmap_num_set_bits(bm, 201);
-    expected = 1;
-    TEST_AND_REPORT(result, expected,
-                    "opal_bitmap_num_set_bits: len treated as bits (201 bits)");
-
-    /* Test 8: Count up to 200 should not include bit 200 */
-    result = opal_bitmap_num_set_bits(bm, 200);
-    expected = 0;
-    TEST_AND_REPORT(result, expected,
-                    "opal_bitmap_num_set_bits: len boundary not included (200 bits)");
-
-    /* Test 9: Set all bits in first element and count partial */
-    opal_bitmap_clear_all_bits(bm);
-    for (int i = 0; i < 64; ++i) {
-        opal_bitmap_set_bit(bm, i);
-    }
-    /* Count only first 50 bits - should be 50 */
-    result = opal_bitmap_num_set_bits(bm, 50);
-    expected = 50;
-    TEST_AND_REPORT(result, expected,
-                    "opal_bitmap_num_set_bits: partial full element (50 of 64 bits)");
-
-    /* Test 10: Edge case - count exactly one full element */
-    result = opal_bitmap_num_set_bits(bm, 64);
-    expected = 64;
-    TEST_AND_REPORT(result, expected,
-                    "opal_bitmap_num_set_bits: exactly one element (64 bits)");
-
-    /* Test 11: Test opal_bitmap_num_unset_bits consistency */
-    opal_bitmap_clear_all_bits(bm);
-    opal_bitmap_set_bit(bm, 5);
-    opal_bitmap_set_bit(bm, 10);
-    opal_bitmap_set_bit(bm, 15);
-    result = opal_bitmap_num_set_bits(bm, 64);
-    expected = 3;
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_set_bits: 3 set bits in 64");
-
-    result = opal_bitmap_num_unset_bits(bm, 64);
-    expected = 61; /* 64 - 3 = 61 */
-    TEST_AND_REPORT(result, expected, "opal_bitmap_num_unset_bits: 61 unset bits in 64");
-}
-
-int set_bit(opal_bitmap_t *bm, int bit)
-{
-    int err = opal_bitmap_set_bit(bm, bit);
-    if (err != 0 || !opal_bitmap_is_set_bit(bm, bit)) {
-        fprintf(error_out, "ERROR: set_bit for bit = %d\n\n", bit);
-        return ERR_CODE;
-    }
-    return 0;
-}
-
-int clear_bit(opal_bitmap_t *bm, int bit)
-{
-    int err = opal_bitmap_clear_bit(bm, bit);
-    if ((err != 0) || opal_bitmap_is_set_bit(bm, bit)) {
-        fprintf(error_out, "ERROR: clear_bit for bit = %d \n\n", bit);
-        return ERR_CODE;
+    /* Repeatedly find-and-set the first unset bit: should yield 0,1,2,3 */
+    for (int expected = 0; expected < 4; ++expected) {
+        test_verify("find_and_set ok",
+                    OPAL_SUCCESS == opal_bitmap_find_and_set_first_unset_bit(&bm, &pos));
+        test_verify("find_and_set returns next free bit", pos == expected);
     }
 
-    return 0;
+    /* Pre-set bit 5; the next find should skip it and return 4, then 6. */
+    opal_bitmap_set_bit(&bm, 5);
+    opal_bitmap_find_and_set_first_unset_bit(&bm, &pos);
+    test_verify("find_and_set returns 4", 4 == pos);
+    opal_bitmap_find_and_set_first_unset_bit(&bm, &pos);
+    test_verify("find_and_set skips pre-set bit 5", 6 == pos);
+
+    /* When an element is completely full, find_and_set must expand and
+       return the first bit of the new element. */
+    opal_bitmap_set_all_bits(&bm);
+    int old_size = opal_bitmap_size(&bm);
+    test_verify("find_and_set on full bitmap ok",
+                OPAL_SUCCESS == opal_bitmap_find_and_set_first_unset_bit(&bm, &pos));
+    test_verify("find_and_set expands at boundary", pos == old_size);
+
+    test_verify("find_and_set(NULL) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_find_and_set_first_unset_bit(NULL, &pos));
+
+    OBJ_DESTRUCT(&bm);
 }
 
-int is_set_bit(opal_bitmap_t *bm, int bit)
+static void test_num_bits(void)
 {
-    bool result = opal_bitmap_is_set_bit(bm, bit);
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, 256);
 
-    if (result) {
-        if (bit < 0) {
-            fprintf(error_out, "ERROR: is_set_bit for bit = %d \n\n", bit);
-            return ERR_CODE;
+    opal_bitmap_clear_all_bits(&bm);
+    test_verify("num_set on cleared == 0", 0 == opal_bitmap_num_set_bits(&bm, 64));
+
+    opal_bitmap_set_bit(&bm, 0);
+    opal_bitmap_set_bit(&bm, 1);
+    opal_bitmap_set_bit(&bm, 5);
+    opal_bitmap_set_bit(&bm, 63);
+    test_verify("num_set in first 64 == 4", 4 == opal_bitmap_num_set_bits(&bm, 64));
+    /* Partial element: only the first 10 bits -> bits 0,1,5 -> 3 */
+    test_verify("num_set partial element == 3", 3 == opal_bitmap_num_set_bits(&bm, 10));
+
+    /* Spread bits across multiple elements. */
+    opal_bitmap_set_bit(&bm, 64);
+    opal_bitmap_set_bit(&bm, 100);
+    opal_bitmap_set_bit(&bm, 200);
+    test_verify("num_set across 256 == 7", 7 == opal_bitmap_num_set_bits(&bm, 256));
+    test_verify("num_unset across 256 == 249", 249 == opal_bitmap_num_unset_bits(&bm, 256));
+
+    /* len is measured in bits, not elements: counting up to 200 excludes
+       bit 200 itself. */
+    test_verify("num_set up to 200 excludes bit 200", 6 == opal_bitmap_num_set_bits(&bm, 200));
+    test_verify("num_set up to 201 includes bit 200", 7 == opal_bitmap_num_set_bits(&bm, 201));
+
+    OBJ_DESTRUCT(&bm);
+}
+
+/* Initialize a bitmap to a given size with a caller-supplied 64-bit
+   pattern in its first element. */
+static void fill_pattern(opal_bitmap_t *bm, int size, uint64_t pattern)
+{
+    opal_bitmap_init(bm, size);
+    opal_bitmap_clear_all_bits(bm);
+    for (int b = 0; b < 64; ++b) {
+        if (pattern & (1UL << b)) {
+            opal_bitmap_set_bit(bm, b);
         }
-        return 0;
     }
+}
 
-    if (!result) {
-        if (0 <= bit && bit <= bm->array_size && !opal_bitmap_is_set_bit(bm, bit)) {
-            fprintf(error_out, "ERROR: is_set_bit for bit = %d \n\n", bit);
-            return ERR_CODE;
+static void test_bitwise_ops(void)
+{
+    opal_bitmap_t a, b;
+    OBJ_CONSTRUCT(&a, opal_bitmap_t);
+    OBJ_CONSTRUCT(&b, opal_bitmap_t);
+
+    /* AND */
+    fill_pattern(&a, 64, 0xF0F0UL);
+    fill_pattern(&b, 64, 0xFF00UL);
+    test_verify("and ok", OPAL_SUCCESS == opal_bitmap_bitwise_and_inplace(&a, &b));
+    test_verify("and result bit 12 set", opal_bitmap_is_set_bit(&a, 12)); /* 0xF000 */
+    test_verify("and result bit 4 clear", !opal_bitmap_is_set_bit(&a, 4));
+
+    /* OR */
+    fill_pattern(&a, 64, 0x0F0FUL);
+    fill_pattern(&b, 64, 0xF0F0UL);
+    test_verify("or ok", OPAL_SUCCESS == opal_bitmap_bitwise_or_inplace(&a, &b));
+    test_verify("or result == 0xFFFF (16 bits)", 16 == opal_bitmap_num_set_bits(&a, 16));
+
+    /* XOR */
+    fill_pattern(&a, 64, 0xFF00UL);
+    fill_pattern(&b, 64, 0x0FF0UL);
+    test_verify("xor ok", OPAL_SUCCESS == opal_bitmap_bitwise_xor_inplace(&a, &b));
+    test_verify("xor result bit 4 set", opal_bitmap_is_set_bit(&a, 4));   /* 0xF0F0 */
+    test_verify("xor result bit 8 clear", !opal_bitmap_is_set_bit(&a, 8));
+
+    /* Error paths: NULL operands and mismatched sizes. */
+    test_verify("and(NULL) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_bitwise_and_inplace(&a, NULL));
+    test_verify("or(NULL) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_bitwise_or_inplace(NULL, &b));
+    test_verify("xor(NULL) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_bitwise_xor_inplace(&a, NULL));
+
+    opal_bitmap_t big;
+    OBJ_CONSTRUCT(&big, opal_bitmap_t);
+    opal_bitmap_init(&big, 256);
+    test_verify("and size mismatch rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_bitwise_and_inplace(&a, &big));
+    OBJ_DESTRUCT(&big);
+
+    OBJ_DESTRUCT(&a);
+    OBJ_DESTRUCT(&b);
+}
+
+static void test_are_different(void)
+{
+    opal_bitmap_t a, b;
+    OBJ_CONSTRUCT(&a, opal_bitmap_t);
+    OBJ_CONSTRUCT(&b, opal_bitmap_t);
+
+    fill_pattern(&a, 64, 0xABCDUL);
+    fill_pattern(&b, 64, 0xABCDUL);
+    test_verify("equal bitmaps not different", !opal_bitmap_are_different(&a, &b));
+
+    opal_bitmap_set_bit(&b, 40);
+    test_verify("differing content is different", opal_bitmap_are_different(&a, &b));
+
+    opal_bitmap_t big;
+    OBJ_CONSTRUCT(&big, opal_bitmap_t);
+    opal_bitmap_init(&big, 256);
+    test_verify("differing size is different", opal_bitmap_are_different(&a, &big));
+    OBJ_DESTRUCT(&big);
+
+    OBJ_DESTRUCT(&a);
+    OBJ_DESTRUCT(&b);
+}
+
+static void test_get_string(void)
+{
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+    opal_bitmap_init(&bm, 64);
+    opal_bitmap_clear_all_bits(&bm);
+    opal_bitmap_set_bit(&bm, 0);
+    opal_bitmap_set_bit(&bm, 3);
+
+    char *s = opal_bitmap_get_string(&bm);
+    test_verify("get_string non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("get_string length == size", (int) strlen(s) == opal_bitmap_size(&bm));
+        test_verify("get_string marks set bit 0", 'X' == s[0]);
+        test_verify("get_string marks unset bit 1", '_' == s[1]);
+        test_verify("get_string marks set bit 3", 'X' == s[3]);
+        free(s);
+    }
+    test_verify("get_string(NULL) == NULL", NULL == opal_bitmap_get_string(NULL));
+
+    OBJ_DESTRUCT(&bm);
+}
+
+static void test_copy(void)
+{
+    opal_bitmap_t src, dst;
+    OBJ_CONSTRUCT(&src, opal_bitmap_t);
+    OBJ_CONSTRUCT(&dst, opal_bitmap_t);
+
+    opal_bitmap_init(&src, 128);
+    opal_bitmap_clear_all_bits(&src);
+    opal_bitmap_set_bit(&src, 1);
+    opal_bitmap_set_bit(&src, 70);
+
+    /* Copy into a fresh (smaller/empty) destination -- exercises the
+       (re)allocation path. */
+    opal_bitmap_copy(&dst, &src);
+    test_verify("copy into empty dst matches src", !opal_bitmap_are_different(&dst, &src));
+    test_verify("copy preserved bit 1", opal_bitmap_is_set_bit(&dst, 1));
+    test_verify("copy preserved bit 70", opal_bitmap_is_set_bit(&dst, 70));
+
+    /* Copy again into an already-large-enough destination -- exercises the
+       no-realloc path. */
+    opal_bitmap_clear_all_bits(&src);
+    opal_bitmap_set_bit(&src, 5);
+    opal_bitmap_copy(&dst, &src);
+    test_verify("second copy matches src", !opal_bitmap_are_different(&dst, &src));
+    test_verify("second copy preserved bit 5", opal_bitmap_is_set_bit(&dst, 5));
+    test_verify("second copy cleared old bit 70", !opal_bitmap_is_set_bit(&dst, 70));
+
+    OBJ_DESTRUCT(&src);
+    OBJ_DESTRUCT(&dst);
+}
+
+static void test_max_size(void)
+{
+    opal_bitmap_t bm;
+    opal_bitmap_t cap65;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
+
+    test_verify("set_max_size(NULL) rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_set_max_size(NULL, 64));
+
+    /* Cap the bitmap at 64 bits, then ask for more -> rejected. */
+    test_verify("set_max_size ok", OPAL_SUCCESS == opal_bitmap_set_max_size(&bm, 64));
+    test_verify("init beyond max rejected", OPAL_ERR_BAD_PARAM == opal_bitmap_init(&bm, 65));
+    test_verify("init within max ok", OPAL_SUCCESS == opal_bitmap_init(&bm, 64));
+
+    OBJ_DESTRUCT(&bm);
+
+    /*
+     * The cap is enforced in bits, not rounded up to a 64-bit word.  With
+     * a non-word-aligned cap of 65 bits, a request for 128 bits -- which
+     * rounds to the same 2-word allocation -- must still be rejected, and
+     * bit indices at or beyond the cap must be refused.
+     */
+    OBJ_CONSTRUCT(&cap65, opal_bitmap_t);
+    test_verify("set_max_size(65) ok", OPAL_SUCCESS == opal_bitmap_set_max_size(&cap65, 65));
+    test_verify("init(128) beyond 65-bit cap rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_init(&cap65, 128));
+    test_verify("init(66) beyond 65-bit cap rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_init(&cap65, 66));
+    test_verify("init(65) at cap ok", OPAL_SUCCESS == opal_bitmap_init(&cap65, 65));
+    test_verify("set_bit(64) within 65-bit cap ok",
+                OPAL_SUCCESS == opal_bitmap_set_bit(&cap65, 64));
+    test_verify("set_bit(65) at cap rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_set_bit(&cap65, 65));
+    test_verify("set_bit(100) beyond cap rejected",
+                OPAL_ERR_BAD_PARAM == opal_bitmap_set_bit(&cap65, 100));
+
+    /*
+     * find_and_set must honor the bit cap as well.  Fill every valid bit
+     * [0, 65); a further find_and_set then has no room and must refuse,
+     * rather than handing back an out-of-cap bit (e.g. bit 65) from the
+     * unused tail of the last allocated word.  (Regression: the within-word
+     * fast path used to set the bit without checking max_size.)
+     */
+    {
+        int pos = -1;
+        for (int b = 0; b < 65; b++) {
+            (void) opal_bitmap_set_bit(&cap65, b);
         }
-        return 0;
+        test_verify("find_and_set on a full 65-bit bitmap is refused",
+                    OPAL_SUCCESS != opal_bitmap_find_and_set_first_unset_bit(&cap65, &pos));
+        test_verify("find_and_set did not set an out-of-cap bit",
+                    !opal_bitmap_is_set_bit(&cap65, 65));
     }
 
-    return 0;
+    OBJ_DESTRUCT(&cap65);
 }
 
-int find_and_set(opal_bitmap_t *bm, int bit)
+static void test_size_accessor(void)
 {
-    int ret, pos;
-    /* bit here is the bit that should be found and set, in the top
-       level stub, this function will be called in sequence to test */
+    opal_bitmap_t bm;
+    OBJ_CONSTRUCT(&bm, opal_bitmap_t);
 
-    ret = opal_bitmap_find_and_set_first_unset_bit(bm, &pos);
-    if (ret != OPAL_SUCCESS)
-        return ret;
+    test_verify("size(NULL) == 0", 0 == opal_bitmap_size(NULL));
+    opal_bitmap_init(&bm, 100);
+    /* 100 bits rounds up to 2 elements -> 128 bits. */
+    test_verify("size rounds up to element multiple", 128 == opal_bitmap_size(&bm));
 
-    if (pos != bit) {
-        fprintf(error_out, "ERROR: find_and_set: expected to find_and_set %d\n\n", bit);
-        return ERR_CODE;
-    }
-
-    return 0;
+    OBJ_DESTRUCT(&bm);
 }
-
-int clear_all(opal_bitmap_t *bm)
-{
-    int i;
-    if (OPAL_SUCCESS != opal_bitmap_clear_all_bits(bm)) {
-        return ERR_CODE;
-    }
-    for (i = 0; i < bm->array_size; ++i)
-        if (bm->bitmap[i] != 0) {
-            fprintf(error_out, "ERROR: clear_all for bitmap array entry %d\n\n", i);
-            return ERR_CODE;
-        }
-    return 0;
-}
-
-int set_all(opal_bitmap_t *bm)
-{
-    int i;
-    if (OPAL_SUCCESS != opal_bitmap_set_all_bits(bm)) {
-        return ERR_CODE;
-    }
-    for (i = 0; i < bm->array_size; ++i)
-        if (bm->bitmap[i] != 0xffffffffffffffffUL) {
-            fprintf(error_out, "ERROR: set_all for bitmap array entry %d\n\n", i);
-            return ERR_CODE;
-        }
-    return 0;
-}
-
-#if WANT_PRINT_BITMAP
-void print_bitmap(opal_bitmap_t *bm)
-{
-    /* Accessing the fields within the structure, since its not an
-       opaque structure  */
-
-    int i;
-    for (i = 0; i < bm->array_size; ++i) {
-        fprintf(error_out, "---\n bitmap[%d] = %x \n---\n\n", i, (bm->bitmap[i] & 0xff));
-    }
-    fprintf(error_out, "========================= \n");
-    return;
-}
-#endif

--- a/test/class/opal_graph.c
+++ b/test/class/opal_graph.c
@@ -1,0 +1,704 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_graph_t and its full public API.
+ *
+ * Graph under test (directed, weighted):
+ *
+ *   A --(1)--> B --(2)--> C --(1)--> D --(3)--> E
+ *   A --(4)--> C          B --(5)--> D
+ *
+ * order (vertices) = 5, size (edges) = 6
+ *
+ * Hand-computed Dijkstra shortest paths FROM A:
+ *   dist(A,B) = 1  (direct)
+ *   dist(A,C) = 3  (A->B->C; direct A->C costs 4)
+ *   dist(A,D) = 4  (A->B->C->D)
+ *   dist(A,E) = 7  (A->B->C->D->E)
+ *   dist(E,A) = INFINITY  (E has no out-edges)
+ *   adjacent(A,C) = 4  (direct edge weight, != spf 3)
+ *
+ * NOTE: -DNDEBUG is set; assert() is a no-op. All verification uses
+ * test_verify().  Do NOT use assert().
+ */
+
+#include "opal_config.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "support.h"
+
+#include "opal/class/opal_graph.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/class/opal_value_array.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+/* --------------------------------------------------------------------------
+ * Vertex data: each vertex carries a heap-allocated int label (A=0..E=4).
+ * The hooks let duplicate() / find_vertex() / print work.
+ * -------------------------------------------------------------------------- */
+
+static void my_copy_vertex_data(void **dst, void *src)
+{
+    if (NULL == *dst) {
+        *dst = malloc(sizeof(int));
+    }
+    *((int *) (*dst)) = *((int *) src);
+}
+
+static void my_free_vertex_data(void *data)
+{
+    free(data);
+}
+
+static void *my_alloc_vertex_data(void)
+{
+    return malloc(sizeof(int));
+}
+
+static int my_compare_vertex_data(void *data1, void *data2)
+{
+    int v1 = *((int *) data1);
+    int v2 = *((int *) data2);
+    if (v1 > v2) {
+        return 1;
+    }
+    if (v1 < v2) {
+        return -1;
+    }
+    return 0;
+}
+
+/* print_vertex MUST return malloc'd memory; opal_graph_print calls free(). */
+static char *my_print_vertex(void *data)
+{
+    char *buf = malloc(8);
+    if (NULL != buf) {
+        snprintf(buf, 8, "%c", 'A' + *((int *) data));
+    }
+    return buf;
+}
+
+/* Helper: allocate and populate a vertex with label idx (0=A..4=E). */
+static opal_graph_vertex_t *make_vertex(int idx)
+{
+    opal_graph_vertex_t *v = OBJ_NEW(opal_graph_vertex_t);
+    int *data = (int *) my_alloc_vertex_data();
+    *data = idx;
+    v->vertex_data = data;
+    v->alloc_vertex_data = my_alloc_vertex_data;
+    v->copy_vertex_data = my_copy_vertex_data;
+    v->free_vertex_data = my_free_vertex_data;
+    v->compare_vertex = my_compare_vertex_data;
+    v->print_vertex = my_print_vertex;
+    return v;
+}
+
+/* Helper: build an edge on the heap (weight w, start -> end). */
+static opal_graph_edge_t *make_edge(opal_graph_vertex_t *start,
+                                    opal_graph_vertex_t *end,
+                                    uint32_t w)
+{
+    opal_graph_edge_t *e = OBJ_NEW(opal_graph_edge_t);
+    e->start = start;
+    e->end = end;
+    e->weight = w;
+    return e;
+}
+
+/*
+ * Build the canonical test graph into *g.
+ * Vertices stored in vA..vE (all OBJ_NEW, owned by the graph).
+ * Edges: A->B:1, A->C:4, B->C:2, B->D:5, C->D:1, D->E:3
+ *        (all OBJ_NEW, owned by the graph after successful add_edge).
+ */
+static void build_graph(opal_graph_t **g,
+                        opal_graph_vertex_t **vA, opal_graph_vertex_t **vB,
+                        opal_graph_vertex_t **vC, opal_graph_vertex_t **vD,
+                        opal_graph_vertex_t **vE)
+{
+    *g = OBJ_NEW(opal_graph_t);
+    *vA = make_vertex(0);  /* A */
+    *vB = make_vertex(1);  /* B */
+    *vC = make_vertex(2);  /* C */
+    *vD = make_vertex(3);  /* D */
+    *vE = make_vertex(4);  /* E */
+
+    opal_graph_add_vertex(*g, *vA);
+    opal_graph_add_vertex(*g, *vB);
+    opal_graph_add_vertex(*g, *vC);
+    opal_graph_add_vertex(*g, *vD);
+    opal_graph_add_vertex(*g, *vE);
+
+    opal_graph_add_edge(*g, make_edge(*vA, *vB, 1));
+    opal_graph_add_edge(*g, make_edge(*vA, *vC, 4));
+    opal_graph_add_edge(*g, make_edge(*vB, *vC, 2));
+    opal_graph_add_edge(*g, make_edge(*vB, *vD, 5));
+    opal_graph_add_edge(*g, make_edge(*vC, *vD, 1));
+    opal_graph_add_edge(*g, make_edge(*vD, *vE, 3));
+}
+
+/*
+ * Destroy a graph and release the vertices that were OBJ_NEW'd.
+ * After OBJ_RELEASE(graph) the adjacency structure and edges are gone,
+ * but the vertices themselves are NOT freed by the graph — release them.
+ */
+static void destroy_graph(opal_graph_t *g,
+                           opal_graph_vertex_t *vA, opal_graph_vertex_t *vB,
+                           opal_graph_vertex_t *vC, opal_graph_vertex_t *vD,
+                           opal_graph_vertex_t *vE)
+{
+    OBJ_RELEASE(g);
+    OBJ_RELEASE(vA);
+    OBJ_RELEASE(vB);
+    OBJ_RELEASE(vC);
+    OBJ_RELEASE(vD);
+    OBJ_RELEASE(vE);
+}
+
+/* --------------------------------------------------------------------------
+ * Test sections
+ * -------------------------------------------------------------------------- */
+
+static void test_order_and_size(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    test_verify("order == 5", 5 == opal_graph_get_order(g));
+    test_verify("size == 6",  6 == opal_graph_get_size(g));
+
+    /* Adding the same vertex twice must be a no-op */
+    opal_graph_add_vertex(g, vA);
+    test_verify("add duplicate vertex -> order still 5", 5 == opal_graph_get_order(g));
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_add_edge_error(void)
+{
+    /* add_edge returns OPAL_ERROR when a vertex is not in the graph */
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_graph_vertex_t *orphan;
+    opal_graph_edge_t *bad_edge;
+    int rc;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    orphan = make_vertex(9); /* not added to any graph */
+    bad_edge = make_edge(vA, orphan, 99);
+    rc = opal_graph_add_edge(g, bad_edge);
+    test_verify("add_edge with unknown end vertex returns OPAL_ERROR",
+                OPAL_ERROR == rc);
+    /* bad_edge was not adopted by the graph; release it ourselves. */
+    OBJ_RELEASE(bad_edge);
+    OBJ_RELEASE(orphan);
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_adjacent(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    uint32_t w;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    /* Direct edges */
+    w = opal_graph_adjacent(g, vA, vB);
+    test_verify("adjacent(A,B) == 1", 1 == w);
+
+    w = opal_graph_adjacent(g, vA, vC);
+    test_verify("adjacent(A,C) == 4 (direct edge, not shortest path)", 4 == w);
+
+    w = opal_graph_adjacent(g, vC, vD);
+    test_verify("adjacent(C,D) == 1", 1 == w);
+
+    w = opal_graph_adjacent(g, vD, vE);
+    test_verify("adjacent(D,E) == 3", 3 == w);
+
+    /* No direct edge from A to D */
+    w = opal_graph_adjacent(g, vA, vD);
+    test_verify("adjacent(A,D) == INFINITY (no direct edge)",
+                DISTANCE_INFINITY == w);
+
+    /* No out-edges from E */
+    w = opal_graph_adjacent(g, vE, vA);
+    test_verify("adjacent(E,A) == INFINITY", DISTANCE_INFINITY == w);
+
+    /* Self-loop: adjacent(v,v) == 0 per the source */
+    w = opal_graph_adjacent(g, vA, vA);
+    test_verify("adjacent(A,A) == 0", 0 == w);
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_find_vertex(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_graph_vertex_t *found;
+    int key;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    key = 0; /* A */
+    found = opal_graph_find_vertex(g, &key);
+    test_verify("find_vertex A by data returns vA", vA == found);
+
+    key = 4; /* E */
+    found = opal_graph_find_vertex(g, &key);
+    test_verify("find_vertex E by data returns vE", vE == found);
+
+    key = 99; /* not in graph */
+    found = opal_graph_find_vertex(g, &key);
+    test_verify("find_vertex unknown returns NULL", NULL == found);
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_get_graph_vertices(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_pointer_array_t *arr;
+    int n;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    arr = OBJ_NEW(opal_pointer_array_t);
+    opal_pointer_array_init(arr, 8, INT_MAX, 8);
+    n = opal_graph_get_graph_vertices(g, arr);
+    test_verify("get_graph_vertices returns order", 5 == n);
+
+    /* Every vertex pointer should appear exactly once somewhere in arr. */
+    {
+        int i;
+        int found_A = 0, found_E = 0;
+        for (i = 0; i < n; i++) {
+            void *p = opal_pointer_array_get_item(arr, i);
+            if (p == (void *) vA) {
+                found_A = 1;
+            }
+            if (p == (void *) vE) {
+                found_E = 1;
+            }
+        }
+        test_verify("get_graph_vertices contains vA", 1 == found_A);
+        test_verify("get_graph_vertices contains vE", 1 == found_E);
+    }
+    OBJ_RELEASE(arr);
+
+    /* Empty graph returns 0 */
+    {
+        opal_graph_t *empty = OBJ_NEW(opal_graph_t);
+        opal_pointer_array_t *arr2 = OBJ_NEW(opal_pointer_array_t);
+        opal_pointer_array_init(arr2, 4, INT_MAX, 4);
+        n = opal_graph_get_graph_vertices(empty, arr2);
+        test_verify("get_graph_vertices on empty graph == 0", 0 == n);
+        OBJ_RELEASE(arr2);
+        OBJ_RELEASE(empty);
+    }
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_get_adjacent_vertices(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_value_array_t adj;
+    int n;
+    size_t i;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    OBJ_CONSTRUCT(&adj, opal_value_array_t);
+    opal_value_array_init(&adj, sizeof(vertex_distance_from_t));
+
+    /* A has out-edges to B(1) and C(4) */
+    n = opal_graph_get_adjacent_vertices(g, vA, &adj);
+    test_verify("get_adjacent_vertices(A) == 2", 2 == n);
+    {
+        int found_B = 0, found_C = 0;
+        for (i = 0; i < opal_value_array_get_size(&adj); i++) {
+            vertex_distance_from_t *vd = (vertex_distance_from_t *)
+                opal_value_array_get_item(&adj, i);
+            if (NULL == vd) {
+                continue;
+            }
+            if (vd->vertex == vB && 1 == vd->weight) {
+                found_B = 1;
+            }
+            if (vd->vertex == vC && 4 == vd->weight) {
+                found_C = 1;
+            }
+        }
+        test_verify("adjacent_vertices(A) contains B with weight 1", 1 == found_B);
+        test_verify("adjacent_vertices(A) contains C with weight 4", 1 == found_C);
+    }
+
+    /* E has no out-edges */
+    opal_value_array_set_size(&adj, 0);
+    n = opal_graph_get_adjacent_vertices(g, vE, &adj);
+    test_verify("get_adjacent_vertices(E) == 0 (no out-edges)", 0 == n);
+
+    OBJ_DESTRUCT(&adj);
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_dijkstra(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_value_array_t dist;
+    uint32_t n;
+    size_t i;
+    int found_B = 0, found_C = 0, found_D = 0, found_E = 0;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    OBJ_CONSTRUCT(&dist, opal_value_array_t);
+    opal_value_array_init(&dist, sizeof(vertex_distance_from_t));
+    opal_value_array_reserve(&dist, 10);
+
+    /* Dijkstra from A: output has order-1 == 4 entries (source excluded). */
+    n = opal_graph_dijkstra(g, vA, &dist);
+    test_verify("dijkstra from A returns order-1 == 4 entries", 4 == n);
+
+    /*
+     * Hand-computed shortest distances from A:
+     *   B=1, C=3 (via A->B->C), D=4 (via A->B->C->D), E=7 (via A->B->C->D->E)
+     * Note: adjacent(A,C)=4 but shortest path is 3.
+     */
+    for (i = 0; i < opal_value_array_get_size(&dist); i++) {
+        vertex_distance_from_t *vd = (vertex_distance_from_t *)
+            opal_value_array_get_item(&dist, i);
+        if (NULL == vd) {
+            continue;
+        }
+        if (vd->vertex == vB) {
+            found_B = 1;
+            test_verify("dijkstra dist(A,B) == 1", 1 == vd->weight);
+        }
+        if (vd->vertex == vC) {
+            found_C = 1;
+            /* Shortest via B->C (1+2=3), not direct A->C (4). */
+            test_verify("dijkstra dist(A,C) == 3 (via B, not direct)", 3 == vd->weight);
+        }
+        if (vd->vertex == vD) {
+            found_D = 1;
+            test_verify("dijkstra dist(A,D) == 4", 4 == vd->weight);
+        }
+        if (vd->vertex == vE) {
+            found_E = 1;
+            test_verify("dijkstra dist(A,E) == 7", 7 == vd->weight);
+        }
+    }
+    test_verify("dijkstra output contained B", 1 == found_B);
+    test_verify("dijkstra output contained C", 1 == found_C);
+    test_verify("dijkstra output contained D", 1 == found_D);
+    test_verify("dijkstra output contained E", 1 == found_E);
+
+    OBJ_DESTRUCT(&dist);
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_spf(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    uint32_t d;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    d = opal_graph_spf(g, vA, vB);
+    test_verify("spf(A,B) == 1", 1 == d);
+
+    d = opal_graph_spf(g, vA, vC);
+    test_verify("spf(A,C) == 3 (NOT 4; shortest is via B)", 3 == d);
+
+    d = opal_graph_spf(g, vA, vD);
+    test_verify("spf(A,D) == 4", 4 == d);
+
+    d = opal_graph_spf(g, vA, vE);
+    test_verify("spf(A,E) == 7", 7 == d);
+
+    /* No path from E back to A */
+    d = opal_graph_spf(g, vE, vA);
+    test_verify("spf(E,A) == INFINITY (no out-edges from E)",
+                DISTANCE_INFINITY == d);
+
+    /*
+     * Note: opal_graph_spf(v, v) (the trivial self path) currently returns
+     * DISTANCE_INFINITY rather than 0, because opal_graph_dijkstra()
+     * excludes the source vertex (Q[0]) from its output array, so spf()
+     * never finds vertex2 == vertex1.  Whether that ought to be 0 is
+     * arguably a defect, but "fixing" it would change dijkstra()'s
+     * published output for every caller, so we only exercise the path here
+     * (for coverage) without asserting a specific self-distance value.
+     */
+    d = opal_graph_spf(g, vA, vA);
+    (void) d;
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_remove_edge(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_graph_edge_t *e_extra;
+    uint32_t w;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    /* Add a second edge A->B with weight 10, then remove it. */
+    e_extra = make_edge(vA, vB, 10);
+    opal_graph_add_edge(g, e_extra);
+    test_verify("size after add extra edge == 7", 7 == opal_graph_get_size(g));
+
+    /* remove_edge un-lists the edge but does NOT free it. */
+    opal_graph_remove_edge(g, e_extra);
+    test_verify("size after remove_edge == 6", 6 == opal_graph_get_size(g));
+
+    /* The removed edge is no longer found via adjacent -- only the 1-weight
+       edge should remain, so adjacent(A,B) is back to 1. */
+    w = opal_graph_adjacent(g, vA, vB);
+    test_verify("adjacent(A,B) == 1 after removing weight-10 edge", 1 == w);
+
+    /* Must free the removed edge ourselves (per API comment). */
+    OBJ_RELEASE(e_extra);
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+static void test_remove_vertex(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    /*
+     * Remove C.  Edges removed: A->C(4), B->C(2), C->D(1) — three edges.
+     * remove_vertex() also frees vC via OBJ_RELEASE, so we must NOT
+     * release vC ourselves after this point.
+     */
+    opal_graph_remove_vertex(g, vC);
+    vC = NULL; /* freed inside remove_vertex */
+
+    test_verify("order after removing C == 4", 4 == opal_graph_get_order(g));
+
+    /*
+     * remove_vertex() frees the three edges touching C (A->C, B->C, C->D)
+     * and keeps the graph's edge count in sync, so get_size() drops from
+     * 6 to 3.
+     */
+    test_verify("size after removing C == 3", 3 == opal_graph_get_size(g));
+
+    /* Remaining edges: A->B:1, B->D:5, D->E:3 */
+    test_verify("adjacent(A,B) still 1 after removing C", 1 ==
+                opal_graph_adjacent(g, vA, vB));
+    test_verify("adjacent(B,D) still 5 after removing C", 5 ==
+                opal_graph_adjacent(g, vB, vD));
+    test_verify("adjacent(D,E) still 3 after removing C", 3 ==
+                opal_graph_adjacent(g, vD, vE));
+
+    /* A->C no longer valid (C is gone) -- release graph then remaining vertices. */
+    OBJ_RELEASE(g);
+    OBJ_RELEASE(vA);
+    OBJ_RELEASE(vB);
+    /* vC already freed */
+    OBJ_RELEASE(vD);
+    OBJ_RELEASE(vE);
+}
+
+static void test_duplicate(void)
+{
+    opal_graph_t *src, *dst;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+    opal_pointer_array_t *arr;
+    int n;
+
+    build_graph(&src, &vA, &vB, &vC, &vD, &vE);
+
+    opal_graph_duplicate(&dst, src);
+
+    test_verify("duplicate order matches source", opal_graph_get_order(src) ==
+                opal_graph_get_order(dst));
+    test_verify("duplicate size matches source", opal_graph_get_size(src) ==
+                opal_graph_get_size(dst));
+    test_verify("duplicate order == 5", 5 == opal_graph_get_order(dst));
+    test_verify("duplicate size == 6",  6 == opal_graph_get_size(dst));
+
+    /* Verify the duplicate's vertices are distinct objects from the source's. */
+    arr = OBJ_NEW(opal_pointer_array_t);
+    opal_pointer_array_init(arr, 8, INT_MAX, 8);
+    n = opal_graph_get_graph_vertices(dst, arr);
+    test_verify("duplicate get_graph_vertices == 5", 5 == n);
+    {
+        int i;
+        int distinct = 1;
+        for (i = 0; i < n; i++) {
+            void *p = opal_pointer_array_get_item(arr, i);
+            if (p == (void *) vA || p == (void *) vB ||
+                p == (void *) vC || p == (void *) vD ||
+                p == (void *) vE) {
+                distinct = 0;
+                break;
+            }
+        }
+        test_verify("duplicate vertices are new objects (not the originals)", 1 == distinct);
+    }
+    OBJ_RELEASE(arr);
+
+    /*
+     * Verify adjacency is preserved in the duplicate.
+     * We can't use the original vertex pointers against dst; use find_vertex
+     * (which relies on compare_vertex being set, which duplicate copies).
+     */
+    {
+        int key_a = 0, key_b = 1, key_c = 2;
+        opal_graph_vertex_t *da, *db, *dc;
+        uint32_t w;
+
+        da = opal_graph_find_vertex(dst, &key_a);
+        db = opal_graph_find_vertex(dst, &key_b);
+        dc = opal_graph_find_vertex(dst, &key_c);
+
+        test_verify("find_vertex A in duplicate non-NULL", NULL != da);
+        test_verify("find_vertex B in duplicate non-NULL", NULL != db);
+        test_verify("find_vertex C in duplicate non-NULL", NULL != dc);
+
+        if (NULL != da && NULL != db) {
+            w = opal_graph_adjacent(dst, da, db);
+            test_verify("duplicate adjacent(A,B) == 1", 1 == w);
+        }
+        if (NULL != da && NULL != dc) {
+            w = opal_graph_adjacent(dst, da, dc);
+            test_verify("duplicate adjacent(A,C) == 4", 4 == w);
+        }
+    }
+
+    /*
+     * Release the duplicate.  opal_graph_duplicate creates its own vertices
+     * via OBJ_NEW, adds them, and the duplicate graph owns them via the
+     * adjacency list.  However, the graph destructor does NOT free vertices.
+     * Collect them first, then release the graph, then release each vertex.
+     */
+    {
+        opal_pointer_array_t *dst_verts = OBJ_NEW(opal_pointer_array_t);
+        int i, cnt;
+        opal_pointer_array_init(dst_verts, 8, INT_MAX, 8);
+        cnt = opal_graph_get_graph_vertices(dst, dst_verts);
+        OBJ_RELEASE(dst);
+        for (i = 0; i < cnt; i++) {
+            opal_graph_vertex_t *v = (opal_graph_vertex_t *)
+                opal_pointer_array_get_item(dst_verts, i);
+            if (NULL != v) {
+                OBJ_RELEASE(v);
+            }
+        }
+        OBJ_RELEASE(dst_verts);
+    }
+
+    destroy_graph(src, vA, vB, vC, vD, vE);
+}
+
+static void test_print(void)
+{
+    opal_graph_t *g;
+    opal_graph_vertex_t *vA, *vB, *vC, *vD, *vE;
+
+    build_graph(&g, &vA, &vB, &vC, &vD, &vE);
+
+    /*
+     * opal_graph_print() calls opal_output() to print the graph to
+     * stream 0. There is no return value; we just verify it does not
+     * crash, which is covered by reaching this point.
+     */
+    opal_graph_print(g);
+    test_verify("opal_graph_print completes without crash", 1);
+
+    /* Also exercise with NULL print_vertex hooks (should print empty strings). */
+    {
+        opal_graph_t *g2 = OBJ_NEW(opal_graph_t);
+        opal_graph_vertex_t *v1 = OBJ_NEW(opal_graph_vertex_t);
+        opal_graph_vertex_t *v2 = OBJ_NEW(opal_graph_vertex_t);
+        opal_graph_edge_t *e = make_edge(v1, v2, 7);
+
+        /* No print_vertex hook; print_vertex == NULL on construct. */
+        opal_graph_add_vertex(g2, v1);
+        opal_graph_add_vertex(g2, v2);
+        opal_graph_add_edge(g2, e);
+
+        opal_graph_print(g2);
+        test_verify("opal_graph_print with NULL hooks completes", 1);
+
+        OBJ_RELEASE(g2);
+        OBJ_RELEASE(v1);
+        OBJ_RELEASE(v2);
+    }
+
+    destroy_graph(g, vA, vB, vC, vD, vE);
+}
+
+/* --------------------------------------------------------------------------
+ * main
+ * -------------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    int rc;
+
+    test_init("opal_graph_t");
+
+    rc = opal_init_util(&argc, &argv);
+    test_verify("opal_init_util succeeds", OPAL_SUCCESS == rc);
+    if (OPAL_SUCCESS != rc) {
+        return test_finalize();
+    }
+
+    test_order_and_size();
+    test_add_edge_error();
+    test_adjacent();
+    test_find_vertex();
+    test_get_graph_vertices();
+    test_get_adjacent_vertices();
+    test_dijkstra();
+    test_spf();
+    test_remove_edge();
+    test_remove_vertex();
+    test_duplicate();
+    test_print();
+
+    opal_finalize_util();
+
+    return test_finalize();
+}

--- a/test/class/opal_hash_table.c
+++ b/test/class/opal_hash_table.c
@@ -14,6 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -242,6 +243,212 @@ static void test_static(void)
     OBJ_DESTRUCT(&table);
 }
 
+/* Values used by uint64 and ptr key family tests.  These are mutable
+ * char arrays (rather than char * to string literals) so the build stays
+ * warning-free under -Wwrite-strings; the tests only use them as opaque
+ * pointers. */
+static char val_a[] = "alpha";
+static char val_b[] = "beta";
+static char val_c[] = "gamma";
+
+static void test_uint64_keys(void)
+{
+    opal_hash_table_t table;
+    uint64_t key;
+    void *value;
+    void *node;
+    int rc;
+    size_t count;
+
+    fprintf(error_out, "\nTesting uint64 key family...\n");
+
+    OBJ_CONSTRUCT(&table, opal_hash_table_t);
+    opal_hash_table_init(&table, 8);
+
+    /* basic set / get */
+    rc = opal_hash_table_set_value_uint64(&table, UINT64_C(0xDEADBEEF00000001), val_a);
+    test_verify("set uint64 key 1 succeeds", OPAL_SUCCESS == rc);
+
+    rc = opal_hash_table_set_value_uint64(&table, UINT64_C(0xDEADBEEF00000002), val_b);
+    test_verify("set uint64 key 2 succeeds", OPAL_SUCCESS == rc);
+
+    rc = opal_hash_table_set_value_uint64(&table, UINT64_C(0xDEADBEEF00000003), val_c);
+    test_verify("set uint64 key 3 succeeds", OPAL_SUCCESS == rc);
+
+    test_verify("get_size after 3 inserts", 3 == opal_hash_table_get_size(&table));
+
+    rc = opal_hash_table_get_value_uint64(&table, UINT64_C(0xDEADBEEF00000001), &value);
+    test_verify("get uint64 key 1 found", OPAL_SUCCESS == rc);
+    test_verify("get uint64 key 1 value correct", value == val_a);
+
+    rc = opal_hash_table_get_value_uint64(&table, UINT64_C(0xDEADBEEF00000002), &value);
+    test_verify("get uint64 key 2 found", OPAL_SUCCESS == rc);
+    test_verify("get uint64 key 2 value correct", value == val_b);
+
+    /* get non-existent key */
+    rc = opal_hash_table_get_value_uint64(&table, UINT64_C(0xFFFFFFFFFFFFFFFF), &value);
+    test_verify("get uint64 missing key returns not-found", OPAL_ERR_NOT_FOUND == rc);
+
+    /* overwrite existing key */
+    rc = opal_hash_table_set_value_uint64(&table, UINT64_C(0xDEADBEEF00000001), val_c);
+    test_verify("overwrite uint64 key 1 succeeds", OPAL_SUCCESS == rc);
+    rc = opal_hash_table_get_value_uint64(&table, UINT64_C(0xDEADBEEF00000001), &value);
+    test_verify("get uint64 key 1 after overwrite", OPAL_SUCCESS == rc);
+    test_verify("value after overwrite is new value", value == val_c);
+    /* size stays the same after overwrite */
+    test_verify("get_size unchanged after overwrite", 3 == opal_hash_table_get_size(&table));
+
+    /* remove one key and verify */
+    rc = opal_hash_table_remove_value_uint64(&table, UINT64_C(0xDEADBEEF00000002));
+    test_verify("remove uint64 key 2 succeeds", OPAL_SUCCESS == rc);
+    test_verify("get_size after remove", 2 == opal_hash_table_get_size(&table));
+    rc = opal_hash_table_get_value_uint64(&table, UINT64_C(0xDEADBEEF00000002), &value);
+    test_verify("removed uint64 key 2 not found", OPAL_ERR_NOT_FOUND == rc);
+
+    /* remove non-existent key */
+    rc = opal_hash_table_remove_value_uint64(&table, UINT64_C(0xDEADBEEF00000002));
+    test_verify("remove non-existent uint64 key returns error", OPAL_SUCCESS != rc);
+
+    /* traversal: get_first / get_next */
+    count = 0;
+    for (rc = opal_hash_table_get_first_key_uint64(&table, &key, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_uint64(&table, &key, &value, node, &node)) {
+        count++;
+    }
+    test_verify("uint64 traversal ends in OPAL_ERROR", OPAL_ERROR == rc);
+    test_verify("uint64 traversal visits all remaining keys", count == opal_hash_table_get_size(&table));
+
+    OBJ_DESTRUCT(&table);
+}
+
+/* Key buffers for ptr-key tests -- must outlive the table */
+static const char ptr_key1[] = "ptr-key-one";
+static const char ptr_key2[] = "ptr-key-two";
+static const char ptr_key3[] = "ptr-key-three";
+
+static void test_ptr_keys(void)
+{
+    opal_hash_table_t table;
+    void *key;
+    size_t key_size;
+    void *value;
+    void *node;
+    int rc;
+    size_t count;
+
+    fprintf(error_out, "\nTesting ptr key family (full)...\n");
+
+    OBJ_CONSTRUCT(&table, opal_hash_table_t);
+    opal_hash_table_init(&table, 8);
+
+    /* set */
+    rc = opal_hash_table_set_value_ptr(&table, ptr_key1, strlen(ptr_key1), val_a);
+    test_verify("set ptr key1 succeeds", OPAL_SUCCESS == rc);
+    rc = opal_hash_table_set_value_ptr(&table, ptr_key2, strlen(ptr_key2), val_b);
+    test_verify("set ptr key2 succeeds", OPAL_SUCCESS == rc);
+    rc = opal_hash_table_set_value_ptr(&table, ptr_key3, strlen(ptr_key3), val_c);
+    test_verify("set ptr key3 succeeds", OPAL_SUCCESS == rc);
+    test_verify("get_size after 3 ptr inserts", 3 == opal_hash_table_get_size(&table));
+
+    /* get */
+    rc = opal_hash_table_get_value_ptr(&table, ptr_key1, strlen(ptr_key1), &value);
+    test_verify("get ptr key1 found", OPAL_SUCCESS == rc);
+    test_verify("get ptr key1 value correct", value == val_a);
+
+    rc = opal_hash_table_get_value_ptr(&table, ptr_key2, strlen(ptr_key2), &value);
+    test_verify("get ptr key2 found", OPAL_SUCCESS == rc);
+    test_verify("get ptr key2 value correct", value == val_b);
+
+    /* get missing key */
+    rc = opal_hash_table_get_value_ptr(&table, "no-such-key", 11, &value);
+    test_verify("get missing ptr key returns not-found", OPAL_ERR_NOT_FOUND == rc);
+
+    /* overwrite */
+    rc = opal_hash_table_set_value_ptr(&table, ptr_key1, strlen(ptr_key1), val_b);
+    test_verify("overwrite ptr key1 succeeds", OPAL_SUCCESS == rc);
+    rc = opal_hash_table_get_value_ptr(&table, ptr_key1, strlen(ptr_key1), &value);
+    test_verify("get ptr key1 after overwrite", OPAL_SUCCESS == rc);
+    test_verify("ptr key1 value after overwrite is correct", value == val_b);
+    test_verify("size unchanged after ptr overwrite", 3 == opal_hash_table_get_size(&table));
+
+    /* remove */
+    rc = opal_hash_table_remove_value_ptr(&table, ptr_key2, strlen(ptr_key2));
+    test_verify("remove ptr key2 succeeds", OPAL_SUCCESS == rc);
+    test_verify("get_size after ptr remove", 2 == opal_hash_table_get_size(&table));
+    rc = opal_hash_table_get_value_ptr(&table, ptr_key2, strlen(ptr_key2), &value);
+    test_verify("removed ptr key2 not found", OPAL_ERR_NOT_FOUND == rc);
+
+    /* remove non-existent */
+    rc = opal_hash_table_remove_value_ptr(&table, ptr_key2, strlen(ptr_key2));
+    test_verify("remove non-existent ptr key returns error", OPAL_SUCCESS != rc);
+
+    /* traversal: get_first_key_ptr / get_next_key_ptr */
+    count = 0;
+    for (rc = opal_hash_table_get_first_key_ptr(&table, &key, &key_size, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_ptr(&table, &key, &key_size, &value, node, &node)) {
+        count++;
+    }
+    test_verify("ptr traversal ends in OPAL_ERROR", OPAL_ERROR == rc);
+    test_verify("ptr traversal visits all remaining keys",
+                count == opal_hash_table_get_size(&table));
+
+    /* remove_all then verify size */
+    opal_hash_table_remove_all(&table);
+    test_verify("get_size 0 after remove_all on ptr table", 0 == opal_hash_table_get_size(&table));
+
+    OBJ_DESTRUCT(&table);
+}
+
+static void test_init2_and_growth(void)
+{
+    opal_hash_table_t table;
+    size_t old_cap;
+    int i, rc;
+    char key_buf[64];
+    void *value;
+    int num_inserts = 200; /* enough to trigger at least one growth */
+
+    fprintf(error_out, "\nTesting opal_hash_table_init2 and table growth...\n");
+
+    OBJ_CONSTRUCT(&table, opal_hash_table_t);
+    /* non-default density: 3/4, growth factor: 2/1 */
+    rc = opal_hash_table_init2(&table, 8, 3, 4, 2, 1);
+    test_verify("opal_hash_table_init2 succeeds", OPAL_SUCCESS == rc);
+    test_verify("get_size after init2 is 0", 0 == opal_hash_table_get_size(&table));
+
+    old_cap = table.ht_capacity;
+
+    /* Insert enough uint64 keys to force growth */
+    for (i = 0; i < num_inserts; i++) {
+        rc = opal_hash_table_set_value_uint64(&table, (uint64_t) i, val_a);
+        test_verify("insert uint64 key during growth test", OPAL_SUCCESS == rc);
+    }
+    test_verify("get_size correct after many inserts",
+                (size_t) num_inserts == opal_hash_table_get_size(&table));
+    test_verify("capacity grew at least once", table.ht_capacity > old_cap);
+
+    /* verify all keys still retrievable */
+    for (i = 0; i < num_inserts; i++) {
+        rc = opal_hash_table_get_value_uint64(&table, (uint64_t) i, &value);
+        if (OPAL_SUCCESS != rc) {
+            snprintf(key_buf, sizeof(key_buf), "key %d not found after growth", i);
+            test_failure(key_buf);
+            break;
+        }
+    }
+    if (i == num_inserts) {
+        test_success();
+    }
+
+    /* remove_all */
+    opal_hash_table_remove_all(&table);
+    test_verify("get_size 0 after remove_all", 0 == opal_hash_table_get_size(&table));
+
+    OBJ_DESTRUCT(&table);
+}
+
 int main(int argc, char **argv)
 {
     int rc;
@@ -265,6 +472,9 @@ int main(int argc, char **argv)
 
     test_dynamic();
     test_static();
+    test_uint64_keys();
+    test_ptr_keys();
+    test_init2_and_growth();
 #ifndef STANDALONE
     fclose(error_out);
 #endif

--- a/test/class/opal_hotel.c
+++ b/test/class/opal_hotel.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_hotel_t.  Exercises the full public API with
+ * self-checking assertions (via the support harness).  Note: the
+ * library is compiled with -DNDEBUG, so assert() is a no-op here --
+ * all verification must go through test_verify()/test_failure().
+ *
+ * We pass evbase=NULL throughout so that no libevent timers are armed.
+ * With evbase=NULL, checkin/checkout work entirely synchronously.
+ * A non-NULL evict_callback_fn is still required by opal_hotel_init().
+ */
+
+#include "opal_config.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "support.h"
+
+#include "opal/class/opal_hotel.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+/* Trivial eviction callback -- never actually called in these tests
+   because evbase==NULL means no timer fires.  It must be non-NULL to
+   satisfy the bozo check inside opal_hotel_init(). */
+static void evict_cb(struct opal_hotel_t *hotel, int room_num, void *occupant)
+{
+    (void) hotel;
+    (void) room_num;
+    (void) occupant;
+    /* Should never be reached in these tests (evbase==NULL). */
+    test_failure("evict_cb: unexpected eviction callback invoked");
+}
+
+/* Opaque occupant payloads -- pointer identity only. */
+static int guests[16];
+#define GUEST(n) ((void *)&guests[(n)])
+
+static void test_init_errors(void);
+static void test_basic_checkin_checkout(void);
+static void test_checkout_and_return(void);
+static void test_is_empty(void);
+static void test_full_hotel(void);
+static void test_checkin_with_res(void);
+static void test_knock(void);
+static void test_checkout_empty_room(void);
+
+int main(int argc, char *argv[])
+{
+    /* Some opal_hotel error paths call opal_output(), which needs the
+       opal output/finalize infrastructure initialized. */
+    opal_init_util(&argc, &argv);
+
+    test_init("opal_hotel_t");
+
+    test_init_errors();
+    test_basic_checkin_checkout();
+    test_checkout_and_return();
+    test_is_empty();
+    test_full_hotel();
+    test_checkin_with_res();
+    test_knock();
+    test_checkout_empty_room();
+
+    int ret = test_finalize();
+    opal_finalize_util();
+    return ret;
+}
+
+/* --------------------------------------------------------------------------
+ * opal_hotel_init() error paths
+ * -------------------------------------------------------------------------- */
+static void test_init_errors(void)
+{
+    opal_hotel_t h;
+    int rc;
+
+    /* num_rooms == 0 is rejected */
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    rc = opal_hotel_init(&h, 0, NULL, 0, 0, evict_cb);
+    test_verify("init(num_rooms=0) -> BAD_PARAM", OPAL_ERR_BAD_PARAM == rc);
+    OBJ_DESTRUCT(&h);
+
+    /* num_rooms < 0 is rejected */
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    rc = opal_hotel_init(&h, -1, NULL, 0, 0, evict_cb);
+    test_verify("init(num_rooms=-1) -> BAD_PARAM", OPAL_ERR_BAD_PARAM == rc);
+    OBJ_DESTRUCT(&h);
+
+    /* NULL evict_callback_fn is rejected */
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    rc = opal_hotel_init(&h, 3, NULL, 0, 0, NULL);
+    test_verify("init(evict_fn=NULL) -> BAD_PARAM", OPAL_ERR_BAD_PARAM == rc);
+    OBJ_DESTRUCT(&h);
+
+    /* Valid parameters succeed */
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    rc = opal_hotel_init(&h, 3, NULL, 0, 0, evict_cb);
+    test_verify("init(3, NULL, 0, 0, cb) -> SUCCESS", OPAL_SUCCESS == rc);
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * Basic checkin / checkout sequence
+ * -------------------------------------------------------------------------- */
+static void test_basic_checkin_checkout(void)
+{
+    opal_hotel_t h;
+    int room[3];
+    int i, rc;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(3) ok", OPAL_SUCCESS == opal_hotel_init(&h, 3, NULL, 0, 0, evict_cb));
+
+    /* Check in three occupants; each must get a distinct, in-range room. */
+    for (i = 0; i < 3; ++i) {
+        room[i] = -1;
+        rc = opal_hotel_checkin(&h, GUEST(i), &room[i]);
+        test_verify("checkin -> SUCCESS", OPAL_SUCCESS == rc);
+        test_verify("room num in range [0, num_rooms)",
+                    room[i] >= 0 && room[i] < 3);
+    }
+
+    /* All three room numbers must be distinct. */
+    test_verify("room 0 != room 1", room[0] != room[1]);
+    test_verify("room 0 != room 2", room[0] != room[2]);
+    test_verify("room 1 != room 2", room[1] != room[2]);
+
+    /* Check out each room; afterwards a fresh checkin must succeed
+       (verifying the room was returned to the free pool). */
+    for (i = 0; i < 3; ++i) {
+        opal_hotel_checkout(&h, room[i]);
+    }
+
+    int new_room = -1;
+    rc = opal_hotel_checkin(&h, GUEST(5), &new_room);
+    test_verify("checkin after all checkouts -> SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("room from fresh checkin in range", new_room >= 0 && new_room < 3);
+    opal_hotel_checkout(&h, new_room);
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * checkout_and_return_occupant: verify occupant pointer is returned
+ * -------------------------------------------------------------------------- */
+static void test_checkout_and_return(void)
+{
+    opal_hotel_t h;
+    int room = -1;
+    void *out = NULL;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(2) ok", OPAL_SUCCESS == opal_hotel_init(&h, 2, NULL, 0, 0, evict_cb));
+
+    opal_hotel_checkin(&h, GUEST(7), &room);
+    test_verify("room is valid", room >= 0 && room < 2);
+
+    opal_hotel_checkout_and_return_occupant(&h, room, &out);
+    test_verify("returned occupant matches checked-in guest", GUEST(7) == out);
+
+    /* A second checkout from the same (now-empty) room must return NULL. */
+    out = GUEST(15); /* non-NULL sentinel distinct from GUEST(7) */
+    opal_hotel_checkout_and_return_occupant(&h, room, &out);
+    test_verify("checkout_and_return on empty room -> NULL occupant", NULL == out);
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * is_empty transitions
+ * -------------------------------------------------------------------------- */
+static void test_is_empty(void)
+{
+    opal_hotel_t h;
+    int r0 = -1, r1 = -1;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(2) ok", OPAL_SUCCESS == opal_hotel_init(&h, 2, NULL, 0, 0, evict_cb));
+
+    /* Fresh hotel is empty */
+    test_verify("fresh hotel is_empty == true", opal_hotel_is_empty(&h));
+
+    /* After first checkin, hotel is no longer empty */
+    opal_hotel_checkin(&h, GUEST(0), &r0);
+    test_verify("after first checkin is_empty == false", !opal_hotel_is_empty(&h));
+
+    /* After second checkin (all rooms occupied) still not empty */
+    opal_hotel_checkin(&h, GUEST(1), &r1);
+    test_verify("after both checkins is_empty == false", !opal_hotel_is_empty(&h));
+
+    /* Checkout one; not yet empty */
+    opal_hotel_checkout(&h, r0);
+    test_verify("after one checkout is_empty == false", !opal_hotel_is_empty(&h));
+
+    /* Checkout the other; now empty */
+    opal_hotel_checkout(&h, r1);
+    test_verify("after all checkouts is_empty == true", opal_hotel_is_empty(&h));
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * Checkin beyond capacity returns OPAL_ERR_TEMP_OUT_OF_RESOURCE
+ * -------------------------------------------------------------------------- */
+static void test_full_hotel(void)
+{
+    opal_hotel_t h;
+    int rooms[3];
+    int i, rc;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(3) ok", OPAL_SUCCESS == opal_hotel_init(&h, 3, NULL, 0, 0, evict_cb));
+
+    for (i = 0; i < 3; ++i) {
+        rooms[i] = -1;
+        rc = opal_hotel_checkin(&h, GUEST(i), &rooms[i]);
+        test_verify("fill: checkin -> SUCCESS", OPAL_SUCCESS == rc);
+    }
+
+    /* Hotel is full; one more checkin must fail. */
+    int overflow_room = -1;
+    rc = opal_hotel_checkin(&h, GUEST(9), &overflow_room);
+    test_verify("checkin when full -> TEMP_OUT_OF_RESOURCE",
+                OPAL_ERR_TEMP_OUT_OF_RESOURCE == rc);
+
+    /* Room variable must be untouched on failure (remains -1) */
+    test_verify("overflow room_num unchanged on failure", -1 == overflow_room);
+
+    /* Free one room; the next checkin must succeed. */
+    opal_hotel_checkout(&h, rooms[0]);
+    rc = opal_hotel_checkin(&h, GUEST(10), &rooms[0]);
+    test_verify("checkin after partial checkout -> SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("new room in range after partial checkout",
+                rooms[0] >= 0 && rooms[0] < 3);
+
+    /* Clean up remaining occupants */
+    for (i = 0; i < 3; ++i) {
+        opal_hotel_checkout(&h, rooms[i]);
+    }
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * checkin_with_res: optimized path for a caller that knows a room is free
+ * -------------------------------------------------------------------------- */
+static void test_checkin_with_res(void)
+{
+    opal_hotel_t h;
+    int room = -1;
+    void *out = NULL;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(2) ok", OPAL_SUCCESS == opal_hotel_init(&h, 2, NULL, 0, 0, evict_cb));
+
+    /* Use the with_res variant (caller asserts a room is available). */
+    opal_hotel_checkin_with_res(&h, GUEST(3), &room);
+    test_verify("checkin_with_res: room in range", room >= 0 && room < 2);
+
+    /* Verify occupant is actually present via checkout_and_return */
+    opal_hotel_checkout_and_return_occupant(&h, room, &out);
+    test_verify("checkin_with_res: occupant correct", GUEST(3) == out);
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * knock(): peek at a room without checking the occupant out
+ * -------------------------------------------------------------------------- */
+static void test_knock(void)
+{
+    opal_hotel_t h;
+    int room = -1;
+    void *out = NULL;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(2) ok", OPAL_SUCCESS == opal_hotel_init(&h, 2, NULL, 0, 0, evict_cb));
+
+    opal_hotel_checkin(&h, GUEST(6), &room);
+    test_verify("knock: room in range", room >= 0 && room < 2);
+
+    /* knock peeks at occupant but does NOT check them out */
+    opal_hotel_knock(&h, room, &out);
+    test_verify("knock returns correct occupant", GUEST(6) == out);
+
+    /* Occupant is still there -- a second knock sees the same value */
+    out = NULL;
+    opal_hotel_knock(&h, room, &out);
+    test_verify("knock is non-destructive (second knock)", GUEST(6) == out);
+
+    /* And checkout_and_return still works after two knocks */
+    out = NULL;
+    opal_hotel_checkout_and_return_occupant(&h, room, &out);
+    test_verify("occupant still present after knocks", GUEST(6) == out);
+
+    OBJ_DESTRUCT(&h);
+}
+
+/* --------------------------------------------------------------------------
+ * Checkout an already-empty room: must be a no-op (not crash or corrupt state)
+ * -------------------------------------------------------------------------- */
+static void test_checkout_empty_room(void)
+{
+    opal_hotel_t h;
+    int room = -1;
+    int rc;
+
+    OBJ_CONSTRUCT(&h, opal_hotel_t);
+    test_verify("init(2) ok", OPAL_SUCCESS == opal_hotel_init(&h, 2, NULL, 0, 0, evict_cb));
+
+    /* Checkin then checkout to get a valid room number in range */
+    rc = opal_hotel_checkin(&h, GUEST(0), &room);
+    test_verify("setup checkin ok", OPAL_SUCCESS == rc);
+    opal_hotel_checkout(&h, room);
+
+    /* Checkout same room again (already empty) -- the inline code has an
+       OPAL_LIKELY(room->occupant != NULL) guard, so it simply does nothing.
+       Verify the hotel state remains consistent: we can still checkin. */
+    opal_hotel_checkout(&h, room); /* no-op */
+
+    int new_room = -1;
+    rc = opal_hotel_checkin(&h, GUEST(1), &new_room);
+    test_verify("checkin after double-checkout still works", OPAL_SUCCESS == rc);
+    test_verify("room from checkin after double-checkout in range",
+                new_room >= 0 && new_room < 2);
+    opal_hotel_checkout(&h, new_room);
+
+    OBJ_DESTRUCT(&h);
+}

--- a/test/class/opal_interval_tree.c
+++ b/test/class/opal_interval_tree.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_interval_tree_t.  Exercises insert/find/delete,
+ * traversal, size/depth, structural verification and DOT dump.  The
+ * library is built with -DNDEBUG, so verification must use test_verify(),
+ * never assert().
+ */
+
+#include "opal_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "support.h"
+
+#include "opal/class/opal_interval_tree.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#define N 60
+
+/* Traverse action: count how many nodes the traversal visited. */
+static int count_action(uint64_t low, uint64_t high, void *data, void *ctx)
+{
+    (void) low;
+    (void) high;
+    (void) data;
+    int *counter = (int *) ctx;
+    (*counter)++;
+    return OPAL_SUCCESS;
+}
+
+/* Traverse action that aborts the traversal by returning an error. */
+static int abort_action(uint64_t low, uint64_t high, void *data, void *ctx)
+{
+    (void) low;
+    (void) high;
+    (void) data;
+    (void) ctx;
+    return OPAL_ERROR;
+}
+
+static void test_empty(void)
+{
+    opal_interval_tree_t tree;
+    OBJ_CONSTRUCT(&tree, opal_interval_tree_t);
+    test_verify("init empty tree", OPAL_SUCCESS == opal_interval_tree_init(&tree));
+
+    test_verify("empty size is 0", 0 == opal_interval_tree_size(&tree));
+    test_verify("empty find returns NULL", NULL == opal_interval_tree_find_overlapping(&tree, 5, 9));
+    test_verify("empty tree verifies", opal_interval_tree_verify(&tree));
+    test_verify("empty tree depth >= 1", opal_interval_tree_depth(&tree) >= 1);
+
+    OBJ_DESTRUCT(&tree);
+}
+
+static void test_insert_find(void)
+{
+    opal_interval_tree_t tree;
+    OBJ_CONSTRUCT(&tree, opal_interval_tree_t);
+    opal_interval_tree_init(&tree);
+
+    /* Insert N disjoint intervals [10*i, 10*i+5] with data = i+1. */
+    for (int i = 0; i < N; ++i) {
+        void *data = (void *) (intptr_t) (i + 1);
+        test_verify("insert ok",
+                    OPAL_SUCCESS == opal_interval_tree_insert(&tree, data, 10 * i, 10 * i + 5));
+    }
+    test_verify("size after inserts", N == (int) opal_interval_tree_size(&tree));
+    test_verify("tree verifies after inserts", opal_interval_tree_verify(&tree));
+
+    /* Exact-interval queries reliably locate their node. */
+    int found_all = 1;
+    for (int i = 0; i < N; ++i) {
+        void *expect = (void *) (intptr_t) (i + 1);
+        if (expect != opal_interval_tree_find_overlapping(&tree, 10 * i, 10 * i + 5)) {
+            found_all = 0;
+        }
+    }
+    test_verify("exact find returns inserted data", found_all);
+
+    /* A range that falls in a gap (not contained by any interval) is not
+       found. */
+    test_verify("gap range not found", NULL == opal_interval_tree_find_overlapping(&tree, 7, 8));
+
+    /* low > high is rejected. */
+    test_verify("insert low>high rejected",
+                OPAL_ERR_BAD_PARAM == opal_interval_tree_insert(&tree, (void *) 0x1, 50, 40));
+
+    OBJ_DESTRUCT(&tree);
+}
+
+static void test_traverse(void)
+{
+    opal_interval_tree_t tree;
+    int counter;
+    OBJ_CONSTRUCT(&tree, opal_interval_tree_t);
+    opal_interval_tree_init(&tree);
+
+    for (int i = 0; i < 10; ++i) {
+        opal_interval_tree_insert(&tree, (void *) (intptr_t) (i + 1), 10 * i, 10 * i + 5);
+    }
+
+    /* A traversal over the full range with partial_ok visits every node. */
+    counter = 0;
+    test_verify("traverse full range ok",
+                OPAL_SUCCESS
+                    == opal_interval_tree_traverse(&tree, 0, (uint64_t) -1, true, count_action,
+                                                   &counter));
+    test_verify("traverse visited all nodes", 10 == counter);
+
+    /* NULL action is rejected. */
+    test_verify("traverse NULL action rejected",
+                OPAL_ERR_BAD_PARAM
+                    == opal_interval_tree_traverse(&tree, 0, 100, true, NULL, NULL));
+
+    /* An action that returns an error aborts the traversal and propagates
+       the error code. */
+    test_verify("traverse propagates action error",
+                OPAL_ERROR
+                    == opal_interval_tree_traverse(&tree, 0, (uint64_t) -1, true, abort_action,
+                                                   NULL));
+
+    OBJ_DESTRUCT(&tree);
+}
+
+static void test_delete(void)
+{
+    opal_interval_tree_t tree;
+    OBJ_CONSTRUCT(&tree, opal_interval_tree_t);
+    opal_interval_tree_init(&tree);
+
+    for (int i = 0; i < N; ++i) {
+        opal_interval_tree_insert(&tree, (void *) (intptr_t) (i + 1), 10 * i, 10 * i + 5);
+    }
+
+    /* Deleting a non-existent interval reports NOT_FOUND. */
+    test_verify("delete missing -> NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == opal_interval_tree_delete(&tree, 9999, 10000, NULL));
+
+    /* Delete every other interval by exact (low, high, data) match; this
+       forces both leaf and interior deletions plus rebalancing. */
+    int deleted = 0;
+    for (int i = 0; i < N; i += 2) {
+        void *data = (void *) (intptr_t) (i + 1);
+        if (OPAL_SUCCESS == opal_interval_tree_delete(&tree, 10 * i, 10 * i + 5, data)) {
+            deleted++;
+        }
+    }
+    test_verify("deleted expected count", deleted == (N + 1) / 2);
+    test_verify("size after deletes", (N - deleted) == (int) opal_interval_tree_size(&tree));
+    test_verify("tree verifies after deletes", opal_interval_tree_verify(&tree));
+
+    /* The remaining (odd-index) intervals are still findable; the deleted
+       ones are gone. */
+    int ok = 1;
+    for (int i = 1; i < N; i += 2) {
+        if ((void *) (intptr_t) (i + 1)
+            != opal_interval_tree_find_overlapping(&tree, 10 * i, 10 * i + 5)) {
+            ok = 0;
+        }
+    }
+    test_verify("remaining intervals still found", ok);
+
+    OBJ_DESTRUCT(&tree);
+}
+
+static void test_depth_and_dump(void)
+{
+    opal_interval_tree_t tree;
+    OBJ_CONSTRUCT(&tree, opal_interval_tree_t);
+    opal_interval_tree_init(&tree);
+
+    /* Insert in ascending order to force a long run of rotations. */
+    for (int i = 0; i < 63; ++i) {
+        opal_interval_tree_insert(&tree, (void *) (intptr_t) (i + 1), 10 * i, 10 * i + 5);
+    }
+
+    /* A red-black tree of 63 nodes must stay O(log n) deep; allow a
+       generous bound (2*log2(64) = 12, plus the root sentinel and slack). */
+    size_t depth = opal_interval_tree_depth(&tree);
+    test_verify("depth is O(log n)", depth >= 1 && depth <= 16);
+    test_verify("tree of 63 verifies", opal_interval_tree_verify(&tree));
+
+    /* DOT dump to a writable path succeeds; an unwritable path fails. */
+    char path[] = "/tmp/opal_itree_dumpXXXXXX";
+    int fd = mkstemp(path);
+    if (fd >= 0) {
+        close(fd);
+        test_verify("dump to file ok", OPAL_SUCCESS == opal_interval_tree_dump(&tree, path));
+        unlink(path);
+    }
+    test_verify("dump to bad path rejected",
+                OPAL_ERR_BAD_PARAM
+                    == opal_interval_tree_dump(&tree, "/nonexistent_dir_xyz/itree.dot"));
+
+    OBJ_DESTRUCT(&tree);
+}
+
+int main(int argc, char *argv[])
+{
+    /* opal_interval_tree uses an opal_free_list, which relies on
+       opal_cache_line_size and the MCA infrastructure being set up. */
+    opal_init_util(&argc, &argv);
+
+    test_init("opal_interval_tree_t");
+
+    test_empty();
+    test_insert_find();
+    test_traverse();
+    test_delete();
+    test_depth_and_dump();
+
+    int ret = test_finalize();
+    opal_finalize_util();
+    return ret;
+}

--- a/test/class/opal_list.c
+++ b/test/class/opal_list.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,6 +20,7 @@
 
 #include "opal_config.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #include "opal/class/opal_list.h"
 #include "opal/constants.h"
@@ -36,6 +38,176 @@ typedef struct test_data {
 } test_data_t;
 
 OBJ_CLASS_INSTANCE(test_data_t, opal_list_item_t, NULL, NULL);
+
+/* Comparator for opal_list_sort(): ascending order on test_data_t.data */
+static int compare_test_data(opal_list_item_t **a, opal_list_item_t **b)
+{
+    const test_data_t *da = (const test_data_t *) *a;
+    const test_data_t *db = (const test_data_t *) *b;
+    if (da->data < db->data) {
+        return -1;
+    } else if (da->data > db->data) {
+        return 1;
+    }
+    return 0;
+}
+
+static void test_sort(void)
+{
+    opal_list_t slist;
+    test_data_t items[5];
+    test_data_t *ele;
+    size_t expected_order[] = {0, 1, 2, 3, 4};
+    /* Insert in reverse order so sort is non-trivial */
+    size_t insert_order[] = {4, 2, 0, 3, 1};
+    size_t n = 5;
+    size_t i;
+    int rc;
+    size_t idx;
+
+    OBJ_CONSTRUCT(&slist, opal_list_t);
+    for (i = 0; i < n; i++) {
+        OBJ_CONSTRUCT(&items[i], test_data_t);
+        items[i].data = insert_order[i];
+        opal_list_append(&slist, (opal_list_item_t *) &items[i]);
+    }
+    test_verify("sort: list has correct size before sort",
+                n == opal_list_get_size(&slist));
+
+    rc = opal_list_sort(&slist, compare_test_data);
+    test_verify("opal_list_sort returns success", OPAL_SUCCESS == rc);
+    test_verify("sort: list size unchanged after sort",
+                n == opal_list_get_size(&slist));
+
+    /* Verify order is ascending */
+    idx = 0;
+    OPAL_LIST_FOREACH(ele, &slist, test_data_t) {
+        test_verify("sort: element in correct ascending position",
+                    ele->data == expected_order[idx]);
+        idx++;
+    }
+    test_verify("sort: iterated correct number of elements", idx == n);
+
+    /* Remove all items before destructing (items are stack-allocated) */
+    while (!opal_list_is_empty(&slist)) {
+        opal_list_remove_first(&slist);
+    }
+    OBJ_DESTRUCT(&slist);
+    for (i = 0; i < n; i++) {
+        OBJ_DESTRUCT(&items[i]);
+    }
+}
+
+static void test_insert_pos(void)
+{
+    opal_list_t ilist;
+    test_data_t items[4];
+    test_data_t *ele;
+    opal_list_item_t *pos;
+    size_t i;
+    size_t idx;
+
+    /* Build list: 0 -> 1 -> 2, then insert 99 before item[1] */
+    OBJ_CONSTRUCT(&ilist, opal_list_t);
+    for (i = 0; i < 3; i++) {
+        OBJ_CONSTRUCT(&items[i], test_data_t);
+        items[i].data = i;
+        opal_list_append(&ilist, (opal_list_item_t *) &items[i]);
+    }
+    OBJ_CONSTRUCT(&items[3], test_data_t);
+    items[3].data = 99;
+
+    /* pos = item at index 1 (data==1) */
+    pos = opal_list_get_next(opal_list_get_first(&ilist));
+    opal_list_insert_pos(&ilist, pos, (opal_list_item_t *) &items[3]);
+
+    test_verify("insert_pos: list size after insert", 4 == opal_list_get_size(&ilist));
+
+    /* Expected order: 0, 99, 1, 2 */
+    {
+        size_t expected[] = {0, 99, 1, 2};
+        idx = 0;
+        OPAL_LIST_FOREACH(ele, &ilist, test_data_t) {
+            test_verify("insert_pos: element order correct",
+                        ele->data == expected[idx]);
+            idx++;
+        }
+        test_verify("insert_pos: iterated correct count", idx == 4);
+    }
+
+    while (!opal_list_is_empty(&ilist)) {
+        opal_list_remove_first(&ilist);
+    }
+    OBJ_DESTRUCT(&ilist);
+    for (i = 0; i < 4; i++) {
+        OBJ_DESTRUCT(&items[i]);
+    }
+}
+
+static void test_foreach_macros(void)
+{
+    opal_list_t flist;
+    test_data_t items[4];
+    test_data_t *ele, *next;
+    size_t n = 4;
+    size_t i;
+    size_t fwd_count, rev_count;
+
+    OBJ_CONSTRUCT(&flist, opal_list_t);
+    for (i = 0; i < n; i++) {
+        OBJ_CONSTRUCT(&items[i], test_data_t);
+        items[i].data = i;
+        opal_list_append(&flist, (opal_list_item_t *) &items[i]);
+    }
+
+    /* OPAL_LIST_FOREACH forward */
+    fwd_count = 0;
+    i = 0;
+    OPAL_LIST_FOREACH(ele, &flist, test_data_t) {
+        test_verify("FOREACH: element data matches forward order", ele->data == i);
+        fwd_count++;
+        i++;
+    }
+    test_verify("FOREACH: visited all elements", fwd_count == n);
+
+    /* OPAL_LIST_FOREACH_REV */
+    rev_count = 0;
+    i = n;
+    OPAL_LIST_FOREACH_REV(ele, &flist, test_data_t) {
+        i--;
+        test_verify("FOREACH_REV: element data matches reverse order", ele->data == i);
+        rev_count++;
+    }
+    test_verify("FOREACH_REV: visited all elements", rev_count == n);
+
+    /* OPAL_LIST_FOREACH_SAFE: remove even-data items while iterating */
+    OPAL_LIST_FOREACH_SAFE(ele, next, &flist, test_data_t) {
+        if (0 == ele->data % 2) {
+            opal_list_remove_item(&flist, (opal_list_item_t *) ele);
+        }
+    }
+    /* For n=4 we removed items with data 0 and 2; remaining: 1, 3 */
+    test_verify("FOREACH_SAFE: list size after safe removal",
+                2 == opal_list_get_size(&flist));
+    {
+        size_t expected[] = {1, 3};
+        size_t idx = 0;
+        OPAL_LIST_FOREACH(ele, &flist, test_data_t) {
+            test_verify("FOREACH_SAFE: remaining elements correct",
+                        ele->data == expected[idx]);
+            idx++;
+        }
+        test_verify("FOREACH_SAFE: iterated remaining count", idx == 2);
+    }
+
+    while (!opal_list_is_empty(&flist)) {
+        opal_list_remove_first(&flist);
+    }
+    OBJ_DESTRUCT(&flist);
+    for (i = 0; i < n; i++) {
+        OBJ_DESTRUCT(&items[i]);
+    }
+}
 
 int main(int argc, char **argv)
 {
@@ -305,6 +477,11 @@ int main(int argc, char **argv)
 
     if (NULL != elements)
         free(elements);
+
+    /* Additional coverage tests */
+    test_sort();
+    test_insert_pos();
+    test_foreach_macros();
 
     opal_finalize_util();
 

--- a/test/class/opal_pointer_array.c
+++ b/test/class/opal_pointer_array.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -155,9 +156,25 @@ static void test(bool thread_usage)
             if (0 != opal_pointer_array_set_item(array, i, NULL))
                 test_failure("Add/Remove: failure during item removal ");
     }
+    /*
+     * Re-add up to 4 items.  The array was init'd with max_size=4;
+     * after the removals above (indices 1 and 3 freed), exactly 2 slots
+     * are available.  So the first 2 adds succeed (returning >= 0) and
+     * the last 2 fail because the array is at max capacity (returning -1).
+     *
+     * PRE-EXISTING BUG FIXED:
+     *   Original code used `if (!opal_pointer_array_add(...))` which
+     *   treats the return value as a boolean -- this incorrectly reports
+     *   a failure when index 0 is returned (because !0 == true).
+     *   Changed to `< 0` to check for the documented error sentinel.
+     *
+     *   The guard was also wrong: `if (i != 2)` only excuses the i==2
+     *   failure; the i==3 failure (same root cause: at max capacity)
+     *   was incorrectly reported as a test failure.  Changed to `i >= 2`.
+     */
     for (i = 0; i < 4; i++) {
-        if (!opal_pointer_array_add(array, (void *) (uintptr_t)(i + 1))) {
-            if (i != 2) {
+        if (0 > opal_pointer_array_add(array, (void *) (uintptr_t)(i + 1))) {
+            if (i < 2) {
                 test_failure("Add/Remove: failure during the readd ");
                 break;
             }
@@ -170,6 +187,73 @@ static void test(bool thread_usage)
     free(test_data);
 }
 
+static void test_set_size_and_get_size(void)
+{
+    opal_pointer_array_t *array;
+    int rc;
+    int initial_size;
+
+    array = OBJ_NEW(opal_pointer_array_t);
+    opal_pointer_array_init(array, 4, 64, 4);
+
+    initial_size = opal_pointer_array_get_size(array);
+    test_verify("get_size returns initial allocation size", initial_size == 4);
+
+    /* Grow the array via set_size */
+    rc = opal_pointer_array_set_size(array, 16);
+    test_verify("set_size to larger value succeeds", OPAL_SUCCESS == rc);
+    test_verify("get_size reflects new size", opal_pointer_array_get_size(array) >= 16);
+
+    /* set_size to the same value should be a no-op (no error) */
+    rc = opal_pointer_array_set_size(array, 16);
+    test_verify("set_size to same value succeeds", OPAL_SUCCESS == rc);
+
+    /* set_size to a smaller value: documented to succeed without shrinking */
+    rc = opal_pointer_array_set_size(array, 2);
+    test_verify("set_size to smaller value succeeds", OPAL_SUCCESS == rc);
+
+    OBJ_RELEASE(array);
+}
+
+static void test_test_and_set_item(void)
+{
+    opal_pointer_array_t *array;
+    bool ok;
+    void *sentinel_a = (void *) (uintptr_t) 0xABCD;
+    void *sentinel_b = (void *) (uintptr_t) 0xEF01;
+
+    array = OBJ_NEW(opal_pointer_array_t);
+    opal_pointer_array_init(array, 4, 64, 4);
+
+    /* Slot 2 is free: test_and_set should succeed */
+    ok = opal_pointer_array_test_and_set_item(array, 2, sentinel_a);
+    test_verify("test_and_set on free slot returns true", ok == true);
+    test_verify("test_and_set stored correct value",
+                opal_pointer_array_get_item(array, 2) == sentinel_a);
+
+    /* Slot 2 is now occupied: test_and_set should fail */
+    ok = opal_pointer_array_test_and_set_item(array, 2, sentinel_b);
+    test_verify("test_and_set on occupied slot returns false", ok == false);
+    /* value should be unchanged */
+    test_verify("test_and_set did not overwrite occupied slot",
+                opal_pointer_array_get_item(array, 2) == sentinel_a);
+
+    /* test_and_set at an index beyond current size (auto-grow) */
+    ok = opal_pointer_array_test_and_set_item(array, 10, sentinel_b);
+    test_verify("test_and_set beyond current size grows array", ok == true);
+    test_verify("test_and_set at grown index has correct value",
+                opal_pointer_array_get_item(array, 10) == sentinel_b);
+
+    /* After freeing slot 2 (set to NULL), test_and_set should succeed again */
+    opal_pointer_array_set_item(array, 2, NULL);
+    ok = opal_pointer_array_test_and_set_item(array, 2, sentinel_b);
+    test_verify("test_and_set on newly-freed slot returns true", ok == true);
+    test_verify("test_and_set after free has new value",
+                opal_pointer_array_get_item(array, 2) == sentinel_b);
+
+    OBJ_RELEASE(array);
+}
+
 int main(int argc, char **argv)
 {
     test_init("opal_pointer_array");
@@ -179,6 +263,10 @@ int main(int argc, char **argv)
 
     /* run through tests with thread usage set to true */
     test(true);
+
+    /* Additional API coverage */
+    test_set_size_and_get_size();
+    test_test_and_set_item();
 
     return test_finalize();
 }

--- a/test/class/opal_ring_buffer.c
+++ b/test/class/opal_ring_buffer.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_ring_buffer_t.  Exercises the full public API with
+ * self-checking assertions (via the support harness).  Note: the
+ * library is compiled with -DNDEBUG, so assert() is a no-op here --
+ * all verification must go through test_verify()/test_failure().
+ */
+
+#include "opal_config.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "support.h"
+
+#include "opal/class/opal_ring_buffer.h"
+#include "opal/constants.h"
+
+/* Use addresses of static ints as opaque void* payloads -- pointer
+   identity only, no heap allocation needed.  A large pool covers all
+   tests without reuse confusion. */
+static int items[32];
+
+/* Shorthand: item pointer */
+#define ITEM(n) ((void *)&items[(n)])
+
+static void test_init_error(void);
+static void test_push_and_pop_basic(void);
+static void test_push_eviction_wraparound(void);
+static void test_poke(void);
+static void test_pop_empty(void);
+
+int main(int argc, char *argv[])
+{
+    test_init("opal_ring_buffer_t");
+
+    test_init_error();
+    test_push_and_pop_basic();
+    test_push_eviction_wraparound();
+    test_poke();
+    test_pop_empty();
+
+    return test_finalize();
+}
+
+/* --------------------------------------------------------------------------
+ * init error paths
+ * -------------------------------------------------------------------------- */
+static void test_init_error(void)
+{
+    /* NULL ring pointer must return OPAL_ERR_BAD_PARAM */
+    test_verify("init(NULL) returns BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_ring_buffer_init(NULL, 4));
+}
+
+/* --------------------------------------------------------------------------
+ * Basic push-pop FIFO ordering (no wraparound / eviction)
+ * -------------------------------------------------------------------------- */
+static void test_push_and_pop_basic(void)
+{
+    opal_ring_buffer_t rb;
+    void *ret;
+
+    OBJ_CONSTRUCT(&rb, opal_ring_buffer_t);
+    test_verify("init(3) ok", OPAL_SUCCESS == opal_ring_buffer_init(&rb, 3));
+
+    /* Push three items into a 3-slot ring -- no slot is overwritten yet,
+       so push must return NULL (no evicted occupant). */
+    ret = opal_ring_buffer_push(&rb, ITEM(0));
+    test_verify("push A into empty slot -> NULL", NULL == ret);
+
+    ret = opal_ring_buffer_push(&rb, ITEM(1));
+    test_verify("push B into empty slot -> NULL", NULL == ret);
+
+    ret = opal_ring_buffer_push(&rb, ITEM(2));
+    test_verify("push C into empty slot -> NULL", NULL == ret);
+
+    /* Pop should return items FIFO -- oldest first: A, B, C */
+    test_verify("pop returns oldest (A)", ITEM(0) == opal_ring_buffer_pop(&rb));
+    test_verify("pop returns next   (B)", ITEM(1) == opal_ring_buffer_pop(&rb));
+    test_verify("pop returns newest (C)", ITEM(2) == opal_ring_buffer_pop(&rb));
+
+    /* Ring is now empty */
+    test_verify("pop on empty -> NULL", NULL == opal_ring_buffer_pop(&rb));
+
+    OBJ_DESTRUCT(&rb);
+}
+
+/* --------------------------------------------------------------------------
+ * Push-when-full: eviction and FIFO ordering after wrap-around
+ *
+ * After filling a 3-slot ring (A, B, C), pushing D must evict A (the
+ * oldest / tail element) and return it.  The ring then contains B, C, D
+ * oldest-to-newest.
+ *
+ * NOTE: The function header comment says push "returns error if ring cannot
+ * take another entry", yet the C signature is void* and the implementation
+ * returns the evicted pointer (not an error code).  The void* return is the
+ * authoritative contract; the header @return text is misleading.
+ *
+ * SUSPECTED BUG: header @return text says "returns error if ring cannot
+ * take another entry" but the function signature is void* and the
+ * implementation returns the evicted occupant (or NULL for a free slot).
+ * The text contradicts the actual void* contract.
+ * -------------------------------------------------------------------------- */
+static void test_push_eviction_wraparound(void)
+{
+    opal_ring_buffer_t rb;
+    void *evicted;
+
+    OBJ_CONSTRUCT(&rb, opal_ring_buffer_t);
+    test_verify("init(3) ok", OPAL_SUCCESS == opal_ring_buffer_init(&rb, 3));
+
+    /* Fill the ring: A at slot0, B at slot1, C at slot2. */
+    opal_ring_buffer_push(&rb, ITEM(10)); /* A */
+    opal_ring_buffer_push(&rb, ITEM(11)); /* B */
+    opal_ring_buffer_push(&rb, ITEM(12)); /* C */
+
+    /* Pushing D into a full ring must evict and return A (oldest). */
+    evicted = opal_ring_buffer_push(&rb, ITEM(13)); /* D evicts A */
+    test_verify("push into full -> evicts oldest (A)", ITEM(10) == evicted);
+
+    /* Ring now: B, C, D (oldest to newest). */
+    test_verify("pop after eviction -> B", ITEM(11) == opal_ring_buffer_pop(&rb));
+    test_verify("pop after eviction -> C", ITEM(12) == opal_ring_buffer_pop(&rb));
+    test_verify("pop after eviction -> D", ITEM(13) == opal_ring_buffer_pop(&rb));
+    test_verify("pop on empty after eviction -> NULL", NULL == opal_ring_buffer_pop(&rb));
+
+    /* Verify multiple wrap-arounds: push 6 items into an empty size-3 ring.
+       After 6 pushes the ring should hold items 23,24,25 (newest three). */
+    opal_ring_buffer_push(&rb, ITEM(20)); /* evicts nothing (empty) */
+    opal_ring_buffer_push(&rb, ITEM(21));
+    opal_ring_buffer_push(&rb, ITEM(22));
+    opal_ring_buffer_push(&rb, ITEM(23)); /* evicts ITEM(20) */
+    opal_ring_buffer_push(&rb, ITEM(24)); /* evicts ITEM(21) */
+    opal_ring_buffer_push(&rb, ITEM(25)); /* evicts ITEM(22) */
+
+    test_verify("wrap: pop -> item 23", ITEM(23) == opal_ring_buffer_pop(&rb));
+    test_verify("wrap: pop -> item 24", ITEM(24) == opal_ring_buffer_pop(&rb));
+    test_verify("wrap: pop -> item 25", ITEM(25) == opal_ring_buffer_pop(&rb));
+    test_verify("wrap: pop on empty -> NULL", NULL == opal_ring_buffer_pop(&rb));
+
+    OBJ_DESTRUCT(&rb);
+}
+
+/* --------------------------------------------------------------------------
+ * poke(): non-destructive index into the ring
+ *
+ * poke(i>=0): return element i positions forward from the tail (oldest).
+ * poke(i<0):  return the element at the head - 1, i.e., the newest item.
+ * poke(i>=size): return NULL.
+ * poke on empty ring: return NULL regardless of index.
+ * -------------------------------------------------------------------------- */
+static void test_poke(void)
+{
+    opal_ring_buffer_t rb;
+
+    OBJ_CONSTRUCT(&rb, opal_ring_buffer_t);
+    test_verify("init(4) ok", OPAL_SUCCESS == opal_ring_buffer_init(&rb, 4));
+
+    /* poke on an empty ring must return NULL for any index */
+    test_verify("poke(0) on empty -> NULL", NULL == opal_ring_buffer_poke(&rb, 0));
+    test_verify("poke(-1) on empty -> NULL", NULL == opal_ring_buffer_poke(&rb, -1));
+    test_verify("poke(3) on empty -> NULL", NULL == opal_ring_buffer_poke(&rb, 3));
+
+    /* Push 4 items: A=ITEM(0), B=ITEM(1), C=ITEM(2), D=ITEM(3) */
+    opal_ring_buffer_push(&rb, ITEM(0)); /* A, oldest */
+    opal_ring_buffer_push(&rb, ITEM(1)); /* B */
+    opal_ring_buffer_push(&rb, ITEM(2)); /* C */
+    opal_ring_buffer_push(&rb, ITEM(3)); /* D, newest */
+
+    /* poke by non-negative offset from tail (oldest) */
+    test_verify("poke(0) -> oldest (A)", ITEM(0) == opal_ring_buffer_poke(&rb, 0));
+    test_verify("poke(1) -> B",          ITEM(1) == opal_ring_buffer_poke(&rb, 1));
+    test_verify("poke(2) -> C",          ITEM(2) == opal_ring_buffer_poke(&rb, 2));
+    test_verify("poke(3) -> newest (D)", ITEM(3) == opal_ring_buffer_poke(&rb, 3));
+
+    /* poke(-1) returns the element at head-1 = newest */
+    test_verify("poke(-1) -> newest (D)", ITEM(3) == opal_ring_buffer_poke(&rb, -1));
+
+    /* poke with index >= size returns NULL */
+    test_verify("poke(4) -> NULL (i >= size)", NULL == opal_ring_buffer_poke(&rb, 4));
+    test_verify("poke(99) -> NULL (i >> size)", NULL == opal_ring_buffer_poke(&rb, 99));
+
+    /* After push-eviction the ring wraps; poke must still work correctly.
+       Push E (evicts A): ring is B,C,D,E oldest-to-newest. */
+    opal_ring_buffer_push(&rb, ITEM(4)); /* E evicts A */
+
+    test_verify("poke(0) after wrap -> B", ITEM(1) == opal_ring_buffer_poke(&rb, 0));
+    test_verify("poke(3) after wrap -> E", ITEM(4) == opal_ring_buffer_poke(&rb, 3));
+    test_verify("poke(-1) after wrap -> E (newest)", ITEM(4) == opal_ring_buffer_poke(&rb, -1));
+
+    /* poke does NOT remove; pop should still deliver items in FIFO order */
+    test_verify("poke does not remove: pop -> B", ITEM(1) == opal_ring_buffer_pop(&rb));
+    test_verify("poke does not remove: pop -> C", ITEM(2) == opal_ring_buffer_pop(&rb));
+    test_verify("poke does not remove: pop -> D", ITEM(3) == opal_ring_buffer_pop(&rb));
+    test_verify("poke does not remove: pop -> E", ITEM(4) == opal_ring_buffer_pop(&rb));
+
+    OBJ_DESTRUCT(&rb);
+}
+
+/* --------------------------------------------------------------------------
+ * pop from empty ring always returns NULL
+ * -------------------------------------------------------------------------- */
+static void test_pop_empty(void)
+{
+    opal_ring_buffer_t rb;
+
+    OBJ_CONSTRUCT(&rb, opal_ring_buffer_t);
+    test_verify("init(1) ok", OPAL_SUCCESS == opal_ring_buffer_init(&rb, 1));
+
+    /* Freshly initialised, tail == -1 -> empty */
+    test_verify("pop from fresh empty ring -> NULL", NULL == opal_ring_buffer_pop(&rb));
+
+    /* Push one item, pop it, then pop again -- ring is empty */
+    opal_ring_buffer_push(&rb, ITEM(5));
+    opal_ring_buffer_pop(&rb);
+    test_verify("pop from drained ring -> NULL", NULL == opal_ring_buffer_pop(&rb));
+
+    OBJ_DESTRUCT(&rb);
+}

--- a/test/class/opal_value_array.c
+++ b/test/class/opal_value_array.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -112,6 +113,112 @@ int main(int argc, char **argv)
     }
 
     OBJ_DESTRUCT(&array);
+
+    /* ------- Additional coverage tests ------- */
+
+    /* opal_value_array_reserve: reserve should grow alloc without changing size */
+    {
+        opal_value_array_t ra;
+        int rc;
+
+        OBJ_CONSTRUCT(&ra, opal_value_array_t);
+        opal_value_array_init(&ra, sizeof(uint64_t));
+
+        rc = opal_value_array_reserve(&ra, 50);
+        test_verify("opal_value_array_reserve succeeds", OPAL_SUCCESS == rc);
+        test_verify("reserve grows allocated capacity", ra.array_alloc_size >= 50);
+        test_verify("reserve does not change logical size", 0 == opal_value_array_get_size(&ra));
+
+        /* reserving a smaller size is a no-op */
+        rc = opal_value_array_reserve(&ra, 1);
+        test_verify("reserve smaller is a no-op (succeeds)", OPAL_SUCCESS == rc);
+        test_verify("reserve smaller does not shrink alloc", ra.array_alloc_size >= 50);
+
+        OBJ_DESTRUCT(&ra);
+    }
+
+    /* opal_value_array_get_item auto-grow path */
+    {
+        opal_value_array_t ga;
+        void *ptr;
+        uint64_t *uptr;
+
+        OBJ_CONSTRUCT(&ga, opal_value_array_t);
+        opal_value_array_init(&ga, sizeof(uint64_t));
+
+        /* index 9 is beyond current size (0); get_item should auto-grow */
+        ptr = opal_value_array_get_item(&ga, 9);
+        test_verify("get_item auto-grows array when index beyond size",
+                    NULL != ptr);
+        test_verify("get_item auto-grow updates logical size",
+                    opal_value_array_get_size(&ga) >= 10);
+
+        /* write to the returned pointer and read it back via GET_ITEM */
+        uptr = (uint64_t *) ptr;
+        *uptr = UINT64_C(0xCAFEBABE);
+        test_verify("get_item auto-grow: stored value readable via GET_ITEM",
+                    UINT64_C(0xCAFEBABE) == OPAL_VALUE_ARRAY_GET_ITEM(&ga, uint64_t, 9));
+
+        OBJ_DESTRUCT(&ga);
+    }
+
+    /* opal_value_array_set_item (function, not macro) with auto-grow */
+    {
+        opal_value_array_t si;
+        uint64_t wval, rval;
+        int rc;
+
+        OBJ_CONSTRUCT(&si, opal_value_array_t);
+        opal_value_array_init(&si, sizeof(uint64_t));
+
+        wval = UINT64_C(0x1234567890ABCDEF);
+        rc = opal_value_array_set_item(&si, 5, &wval);
+        test_verify("set_item auto-grows and succeeds", OPAL_SUCCESS == rc);
+        test_verify("set_item auto-grow updates logical size",
+                    opal_value_array_get_size(&si) >= 6);
+
+        rval = OPAL_VALUE_ARRAY_GET_ITEM(&si, uint64_t, 5);
+        test_verify("set_item stored correct value", rval == wval);
+
+        /* overwrite an existing index */
+        wval = UINT64_C(0xDEADBEEF);
+        rc = opal_value_array_set_item(&si, 5, &wval);
+        test_verify("set_item overwrite succeeds", OPAL_SUCCESS == rc);
+        rval = OPAL_VALUE_ARRAY_GET_ITEM(&si, uint64_t, 5);
+        test_verify("set_item overwrite stored new value", rval == wval);
+
+        OBJ_DESTRUCT(&si);
+    }
+
+    /* OPAL_VALUE_ARRAY_GET_BASE */
+    {
+        opal_value_array_t ba;
+        uint64_t *base;
+        size_t j;
+
+        OBJ_CONSTRUCT(&ba, opal_value_array_t);
+        opal_value_array_init(&ba, sizeof(uint64_t));
+        opal_value_array_set_size(&ba, 8);
+        for (j = 0; j < 8; j++) {
+            OPAL_VALUE_ARRAY_SET_ITEM(&ba, uint64_t, j, (uint64_t) (j * 10));
+        }
+
+        base = OPAL_VALUE_ARRAY_GET_BASE(&ba, uint64_t);
+        test_verify("OPAL_VALUE_ARRAY_GET_BASE returns non-NULL pointer",
+                    NULL != base);
+        {
+            int all_ok = 1;
+            for (j = 0; j < 8; j++) {
+                if (base[j] != (uint64_t) (j * 10)) {
+                    all_ok = 0;
+                }
+            }
+            test_verify("OPAL_VALUE_ARRAY_GET_BASE elements match SET_ITEM values",
+                        1 == all_ok);
+        }
+
+        OBJ_DESTRUCT(&ba);
+    }
 
     opal_finalize_util();
 

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -7,12 +7,15 @@
 # Copyright (c) 2014-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+AM_CPPFLAGS = -I$(top_srcdir)/test/support
 
 # Make "make check" work in an uninstalled --enable-mca-dso build tree
 include $(top_srcdir)/test/Makefile.mca-dso-check
@@ -21,7 +24,7 @@ if PROJECT_OMPI
     MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial ompi_datatype_bigcount mpi_datatype_bigcount
     MPI_CHECKS = to_self reduce_local
 endif
-TESTS = opal_datatype_test opal_datatype_bigcount unpack_hetero $(MPI_TESTS)
+TESTS = opal_datatype_test opal_datatype_bigcount unpack_hetero opal_ddt_api $(MPI_TESTS)
 
 check_PROGRAMS = $(TESTS) $(MPI_CHECKS)
 
@@ -115,6 +118,12 @@ unpack_hetero_SOURCES = unpack_hetero.c
 unpack_hetero_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 unpack_hetero_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+opal_ddt_api_SOURCES = opal_ddt_api.c
+opal_ddt_api_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+opal_ddt_api_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+        $(top_builddir)/test/support/libsupport.a
 
 reduce_local_SOURCES = reduce_local.c
 reduce_local_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)

--- a/test/datatype/opal_ddt_api.c
+++ b/test/datatype/opal_ddt_api.c
@@ -1,0 +1,668 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for OPAL datatype API functions with little or no existing
+ * coverage:
+ *
+ *   opal_datatype_is_monotonic          (opal_datatype_monotonic.c)
+ *   opal_datatype_get_element_count     (opal_datatype_get_count.c)
+ *   opal_datatype_set_element_count     (opal_datatype_get_count.c)
+ *   opal_datatype_compute_ptypes        (opal_datatype_get_count.c)
+ *   opal_datatype_copy_content_same_ddt (opal_datatype_copy.c)
+ *   opal_datatype_clone                 (opal_datatype_clone.c)
+ *   opal_datatype_resize                (opal_datatype_resize.c)
+ *
+ * Plus helpers exercising opal_datatype_create / opal_datatype_add /
+ * opal_datatype_commit used to build the non-trivial types above.
+ *
+ * NOTE: The library is built with -DNDEBUG, so assert() is a no-op.
+ * All verification MUST go through test_verify() / test_failure().
+ *
+ * NOTE ON INIT: The task specification suggests opal_init_util(), but
+ * opal_datatype_init() (and the convertor / accelerator framework that
+ * opal_datatype_is_monotonic() requires) is only bootstrapped by the
+ * full opal_init() path.  Every sibling datatype test (ddt_pack.c,
+ * checksum.c, opal_datatype_test.c, …) confirms this.  We therefore
+ * call opal_init(&argc, &argv) / opal_finalize() following the
+ * established codebase pattern.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/datatype/opal_datatype.h"
+#include "opal/datatype/opal_datatype_internal.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Helper: build a vector of (count) blocks of (blocklen) elements of
+ * base_type, with inter-block stride (stride * sizeof(base_type)).
+ * The caller is responsible for OBJ_RELEASE on the returned pointer.
+ */
+static opal_datatype_t *make_vector(const opal_datatype_t *base_type,
+                                    int count, int blocklen, int stride)
+{
+    opal_datatype_t *pdt;
+    ptrdiff_t extent;
+
+    opal_datatype_type_extent(base_type, &extent);
+    pdt = opal_datatype_create(base_type->desc.used + 2);
+    if (NULL == pdt) {
+        return NULL;
+    }
+
+    if ((blocklen == stride) || (1 == count)) {
+        /* contiguous */
+        opal_datatype_add(pdt, base_type, (size_t)(count * blocklen), 0, extent);
+    } else if (1 == blocklen) {
+        opal_datatype_add(pdt, base_type, (size_t) count, 0, extent * stride);
+    } else {
+        opal_datatype_t *inner;
+        inner = opal_datatype_create(base_type->desc.used + 2);
+        if (NULL == inner) {
+            OBJ_RELEASE(pdt);
+            return NULL;
+        }
+        opal_datatype_add(inner, base_type, (size_t) blocklen, 0, extent);
+        opal_datatype_add(pdt, inner, (size_t) count, 0, extent * stride);
+        OBJ_RELEASE(inner);
+    }
+
+    opal_datatype_commit(pdt);
+    return pdt;
+}
+
+/* ------------------------------------------------------------------ */
+/* test_is_monotonic
+ *
+ * Definitions:
+ *   A contiguous array of int4 is trivially monotonic.
+ *   A vector with positive stride (stride > blocklen) is monotonic:
+ *     consecutive iov bases advance forward in memory.
+ *   A type whose iov stream walks backward (decreasing base addresses)
+ *   is NOT monotonic.
+ *
+ * Primary non-monotonic construction — negative-stride vector:
+ *   3 single int4 elements, stride = -2 (i.e. each element is placed
+ *   2*sizeof(int4) = 8 bytes BEFORE the previous one).
+ *   opal_datatype_add(pdt, &int4, count=3, disp=0, extent=-8)
+ *   Layout:  elem[0] @ 0, elem[1] @ -8, elem[2] @ -16
+ *   The convertor produces iov_base = 0, then -8, then -16 — strictly
+ *   decreasing → not monotonic.
+ *   This uses the blocklen==1 path in make_vector, which issues a
+ *   single opal_datatype_add with extent*stride.  A single loop cannot
+ *   be reordered by the commit-time optimizer, so the backward traversal
+ *   order is guaranteed by construction.
+ *
+ * Secondary non-monotonic construction (redundant cross-check) —
+ * reversed-displacement struct:
+ *   add int4 @ disp=4 first, then add int4 @ disp=0.
+ *   MPI struct semantics require descriptors to be traversed in the
+ *   order they were added, so the convertor visits offset 4 before
+ *   offset 0 — backward.  We verify true_ub==8 before trusting the
+ *   monotonicity result to confirm commit did not reorder descriptors.
+ */
+static void test_is_monotonic(void)
+{
+    opal_datatype_t *pdt_contig;
+    opal_datatype_t *pdt_pos_vector;
+    opal_datatype_t *pdt_neg_stride;
+    opal_datatype_t *pdt_backward_struct;
+    int32_t result;
+
+    /* --- contiguous int4 array: monotonic --- */
+    pdt_contig = opal_datatype_create(opal_datatype_int4.desc.used + 2);
+    test_verify("create contiguous type", NULL != pdt_contig);
+    if (NULL != pdt_contig) {
+        opal_datatype_add(pdt_contig, &opal_datatype_int4,
+                          4, 0, (ptrdiff_t) sizeof(int32_t));
+        opal_datatype_commit(pdt_contig);
+
+        result = opal_datatype_is_monotonic(pdt_contig);
+        test_verify("contiguous int4 array is monotonic (result == 1)",
+                    1 == result);
+        OBJ_RELEASE(pdt_contig);
+    }
+
+    /* --- vector with positive stride: monotonic --- */
+    /* 3 blocks of 2 int4, stride 5 (gap between blocks). */
+    pdt_pos_vector = make_vector(&opal_datatype_int4, 3, 2, 5);
+    test_verify("create positive-stride vector", NULL != pdt_pos_vector);
+    if (NULL != pdt_pos_vector) {
+        result = opal_datatype_is_monotonic(pdt_pos_vector);
+        test_verify("positive-stride vector is monotonic (result == 1)",
+                    1 == result);
+        OBJ_RELEASE(pdt_pos_vector);
+    }
+
+    /* --- Primary non-monotonic: negative-stride vector --- */
+    /* 3 single int4 elements, extent per step = -2 * sizeof(int4) = -8.
+     * Layout: elem[0] @ 0, elem[1] @ -8, elem[2] @ -16.
+     * A single opal_datatype_add loop cannot be reordered by commit,
+     * so the backward traversal is guaranteed.
+     * Sanity: true_lb == -16, true_ub == 4 (first element's ub).
+     */
+    {
+        ptrdiff_t e = (ptrdiff_t) sizeof(int32_t); /* 4 */
+        pdt_neg_stride = opal_datatype_create(opal_datatype_int4.desc.used + 2);
+        test_verify("create negative-stride vector", NULL != pdt_neg_stride);
+        if (NULL != pdt_neg_stride) {
+            /* blocklen=1, stride=-2: extent_per_step = e * -2 = -8 */
+            opal_datatype_add(pdt_neg_stride, &opal_datatype_int4,
+                              3, 0, e * (-2));
+            opal_datatype_commit(pdt_neg_stride);
+
+            /* Confirm construction: true_lb=-16, true_ub=4 */
+            test_verify("neg-stride: true_lb == -16",
+                        -16 == (int) pdt_neg_stride->true_lb);
+            test_verify("neg-stride: true_ub == 4",
+                        4   == (int) pdt_neg_stride->true_ub);
+
+            result = opal_datatype_is_monotonic(pdt_neg_stride);
+            test_verify("negative-stride vector is NOT monotonic (result == 0)",
+                        0 == result);
+            OBJ_RELEASE(pdt_neg_stride);
+        }
+    }
+
+    /* --- Secondary non-monotonic: reversed-displacement struct --- */
+    /* add int4 @ disp=4 first, then add int4 @ disp=0.
+     * Verify construction (true_ub==8) before trusting the result.
+     */
+    {
+        ptrdiff_t e = (ptrdiff_t) sizeof(int32_t);
+        pdt_backward_struct = opal_datatype_create(4);
+        test_verify("create backward struct", NULL != pdt_backward_struct);
+        if (NULL != pdt_backward_struct) {
+            /* first descriptor: int4 at byte 4 */
+            opal_datatype_add(pdt_backward_struct, &opal_datatype_int4, 1, e, e);
+            /* second descriptor: int4 at byte 0  (lower address) */
+            opal_datatype_add(pdt_backward_struct, &opal_datatype_int4, 1, 0, e);
+            opal_datatype_commit(pdt_backward_struct);
+
+            /* Sanity: true extent covers bytes 0..7 */
+            test_verify("backward struct: true_lb == 0",
+                        0 == (int) pdt_backward_struct->true_lb);
+            test_verify("backward struct: true_ub == 8",
+                        8 == (int) pdt_backward_struct->true_ub);
+
+            result = opal_datatype_is_monotonic(pdt_backward_struct);
+            test_verify("backward struct is NOT monotonic (result == 0)",
+                        0 == result);
+            OBJ_RELEASE(pdt_backward_struct);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* test_get_element_count
+ *
+ * Type: vector of 3 blocks x 4 elements of int4, stride = 6.
+ *   Basic element size = 4 bytes.
+ *   Total basic elements = 3 * 4 = 12.
+ *   type->size = 12 * 4 = 48 bytes.
+ *
+ * opal_datatype_get_element_count(t, t->size) must return 12.
+ * opal_datatype_get_element_count(t, 4)       must return 1.
+ * opal_datatype_get_element_count(t, 16)      must return 4.
+ */
+static void test_get_element_count(void)
+{
+    opal_datatype_t *pdt;
+    ssize_t count;
+    size_t sz;
+
+    /* 3 blocks * 4 int4 elements, stride 6 */
+    pdt = make_vector(&opal_datatype_int4, 3, 4, 6);
+    test_verify("create vector for get_element_count", NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    /* Hand-computed: 3*4 = 12 elements, size = 12*4 = 48 */
+    opal_datatype_type_size(pdt, &sz);
+    test_verify("vector size == 48", 48 == (int) sz);
+
+    count = opal_datatype_get_element_count(pdt, sz);
+    test_verify("get_element_count(full size) == 12", 12 == (int) count);
+
+    count = opal_datatype_get_element_count(pdt, 4);
+    test_verify("get_element_count(4 bytes) == 1", 1 == (int) count);
+
+    count = opal_datatype_get_element_count(pdt, 16);
+    test_verify("get_element_count(16 bytes) == 4", 4 == (int) count);
+
+    OBJ_RELEASE(pdt);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_set_element_count
+ *
+ * Using the same vector (3 blocks x 4 int4, stride 6):
+ *   set_element_count(0, &len)  => len = 0
+ *   set_element_count(1, &len)  => len = 4   (1 * 4 bytes)
+ *   set_element_count(4, &len)  => len = 16  (4 * 4 bytes)
+ *   set_element_count(12, &len) => len = 48  (12 * 4 bytes = full type)
+ */
+static void test_set_element_count(void)
+{
+    opal_datatype_t *pdt;
+    size_t len;
+    int32_t rc;
+
+    pdt = make_vector(&opal_datatype_int4, 3, 4, 6);
+    test_verify("create vector for set_element_count", NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    len = (size_t) -1;
+    rc = opal_datatype_set_element_count(pdt, 0, &len);
+    test_verify("set_element_count(0) returns 0", 0 == rc);
+    test_verify("set_element_count(0) => len == 0", 0 == (int) len);
+
+    len = (size_t) -1;
+    rc = opal_datatype_set_element_count(pdt, 1, &len);
+    test_verify("set_element_count(1) returns 0", 0 == rc);
+    test_verify("set_element_count(1) => len == 4", 4 == (int) len);
+
+    len = (size_t) -1;
+    rc = opal_datatype_set_element_count(pdt, 4, &len);
+    test_verify("set_element_count(4) returns 0", 0 == rc);
+    test_verify("set_element_count(4) => len == 16", 16 == (int) len);
+
+    len = (size_t) -1;
+    rc = opal_datatype_set_element_count(pdt, 12, &len);
+    test_verify("set_element_count(12) returns 0", 0 == rc);
+    test_verify("set_element_count(12) => len == 48", 48 == (int) len);
+
+    OBJ_RELEASE(pdt);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_compute_ptypes
+ *
+ * Type: struct of 1 int1 + 1 float8.
+ *   After commit and opal_datatype_compute_ptypes():
+ *     ptypes[OPAL_DATATYPE_INT1]   == 1
+ *     ptypes[OPAL_DATATYPE_FLOAT8] == 1
+ *   All other ptypes entries == 0.
+ *   type->size == sizeof(int8) + sizeof(float8) == 1 + 8 == 9 bytes.
+ *   type->nbElems == 2 (one int1 + one float8 == 2 basic elements).
+ */
+static void test_compute_ptypes(void)
+{
+    opal_datatype_t *pdt;
+    size_t sz;
+    int rc;
+
+    /* Build { int1 @ disp=0, float8 @ disp=1 } */
+    pdt = opal_datatype_create((ssize_t)(opal_datatype_int1.desc.used
+                                        + opal_datatype_float8.desc.used + 4));
+    test_verify("create struct type for compute_ptypes", NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    opal_datatype_add(pdt, &opal_datatype_int1, 1, 0,
+                      (ptrdiff_t) sizeof(int8_t));
+    opal_datatype_add(pdt, &opal_datatype_float8, 1, 1,
+                      (ptrdiff_t) sizeof(double));
+    opal_datatype_commit(pdt);
+
+    opal_datatype_type_size(pdt, &sz);
+    /* size = 1 (int1) + 8 (float8) = 9 */
+    test_verify("struct int1+float8 size == 9", 9 == (int) sz);
+    test_verify("struct int1+float8 nbElems == 2", 2 == (int) pdt->nbElems);
+
+    rc = opal_datatype_compute_ptypes(pdt);
+    test_verify("compute_ptypes returns 0", 0 == rc);
+    test_verify("ptypes array allocated", NULL != pdt->ptypes);
+
+    if (NULL != pdt->ptypes) {
+        test_verify("ptypes[OPAL_DATATYPE_INT1] == 1",
+                    1 == (int) pdt->ptypes[OPAL_DATATYPE_INT1]);
+        test_verify("ptypes[OPAL_DATATYPE_FLOAT8] == 1",
+                    1 == (int) pdt->ptypes[OPAL_DATATYPE_FLOAT8]);
+        /* A type containing only int1+float8 must NOT count int4 */
+        test_verify("ptypes[OPAL_DATATYPE_INT4] == 0",
+                    0 == (int) pdt->ptypes[OPAL_DATATYPE_INT4]);
+        /* second call must be a no-op (array already allocated) */
+        rc = opal_datatype_compute_ptypes(pdt);
+        test_verify("second compute_ptypes call returns 0 (no-op)", 0 == rc);
+    }
+
+    OBJ_RELEASE(pdt);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_copy_content_same_ddt
+ *
+ * Type: vector of 3 blocks x 2 int4 elements, stride = 4.
+ *   extent    = stride * sizeof(int4) = 4 * 4 = 16 bytes
+ *   size      = 3 * 2 * 4 = 24 bytes (only data bytes, no gaps)
+ *   true_ub   = 3*stride*4 - gap_at_end = (3-1)*16 + 2*4 = 40 bytes
+ *   Memory span for 1 repetition = 40 bytes (true_extent).
+ *
+ * Layout (byte offsets, stride=4 int4 = 16 bytes per block):
+ *   block 0: bytes  0.. 7  (2 x int4)
+ *   block 1: bytes 16..23
+ *   block 2: bytes 32..39
+ *   gap bytes: 8..15, 24..31  (each 8 bytes)
+ *
+ * We allocate two 40-byte buffers, fill src with ascending bytes,
+ * fill dst with sentinel (0xCC), then call copy_content_same_ddt.
+ * Verify:
+ *   (a) data bytes (blocks) in dst match src.
+ *   (b) gap bytes in dst still hold the sentinel (gaps not touched).
+ */
+static void test_copy_content_same_ddt(void)
+{
+    opal_datatype_t *pdt;
+    ptrdiff_t lb, extent;
+    size_t sz;
+    int rc;
+
+    /* 3 blocks x 2 int4, stride 4 int4 = 4 * sizeof(int4) */
+    pdt = make_vector(&opal_datatype_int4, 3, 2, 4);
+    test_verify("create vector for copy_content", NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    opal_datatype_get_extent(pdt, &lb, &extent);
+    opal_datatype_type_size(pdt, &sz);
+
+    /* extent = 3 blocks * 4 stride * 4 bytes = wait, let's think again.
+     *
+     * stride = 4 elements of int4 = stride in units of basic type.
+     * make_vector uses: opal_datatype_add(inner, base, count=2, 0, e)
+     *                   opal_datatype_add(outer, inner, count=3, 0, e*stride=4*4=16)
+     * So outer extent = 3 * 16 = 48 bytes.  But wait: outer ub = 0 + 2*16 + 2*4 = 40.
+     * Actually: extent = ub - lb.
+     *
+     * After commit:
+     *   lb = 0
+     *   ub = (count-1)*stride*e + blocklen*e = 2*16 + 2*4 = 40
+     *   extent = 40
+     *   size = 3*2*4 = 24
+     *
+     * Buffer size needed for 1 repetition = true_extent = ub - lb = 40.
+     */
+    {
+        ptrdiff_t true_lb, true_extent;
+        size_t buf_size;
+        unsigned char *src_buf, *dst_buf;
+        unsigned int i;
+
+        opal_datatype_get_true_extent(pdt, &true_lb, &true_extent);
+        buf_size = (size_t)(true_lb + true_extent);
+        if (0 == buf_size) {
+            test_failure("copy_content: unexpected zero buffer size");
+            OBJ_RELEASE(pdt);
+            return;
+        }
+
+        src_buf = (unsigned char *) malloc(buf_size);
+        dst_buf = (unsigned char *) malloc(buf_size);
+        test_verify("alloc src_buf for copy_content", NULL != src_buf);
+        test_verify("alloc dst_buf for copy_content", NULL != dst_buf);
+        if (NULL == src_buf || NULL == dst_buf) {
+            free(src_buf);
+            free(dst_buf);
+            OBJ_RELEASE(pdt);
+            return;
+        }
+
+        /* Fill src with ascending pattern, dst with sentinel */
+        for (i = 0; i < (unsigned int) buf_size; i++) {
+            src_buf[i] = (unsigned char)(i & 0xFF);
+        }
+        memset(dst_buf, 0xCC, buf_size);
+
+        /* pdst / psrc adjusted by lb (== 0 here, so same as buf ptr) */
+        rc = opal_datatype_copy_content_same_ddt(pdt, 1,
+                                                 (char *)(dst_buf - lb),
+                                                 (char *)(src_buf - lb));
+        test_verify("copy_content_same_ddt returns OPAL_SUCCESS",
+                    OPAL_SUCCESS == rc);
+
+        /*
+         * Verify data blocks were copied correctly.
+         * Block layout (stride=4 int4=16, blocklen=2 int4=8):
+         *   block 0: bytes  0.. 7
+         *   block 1: bytes 16..23
+         *   block 2: bytes 32..39
+         */
+        {
+            int all_data_ok = 1;
+            int all_gaps_ok = 1;
+            int b, byte_off;
+            int block_size_bytes = 2 * (int) sizeof(int32_t);  /* 8 */
+            int stride_bytes     = 4 * (int) sizeof(int32_t);  /* 16 */
+
+            for (b = 0; b < 3; b++) {
+                int block_start = b * stride_bytes;
+
+                /* data bytes inside the block */
+                for (i = (unsigned int) block_start;
+                     i < (unsigned int)(block_start + block_size_bytes);
+                     i++) {
+                    if (dst_buf[i] != src_buf[i]) {
+                        all_data_ok = 0;
+                    }
+                }
+                /* gap bytes after this block (skip for last block) */
+                if (b < 2) {
+                    int gap_start = block_start + block_size_bytes;
+                    int gap_end   = block_start + stride_bytes;
+                    for (byte_off = gap_start; byte_off < gap_end; byte_off++) {
+                        if (0xCC != dst_buf[byte_off]) {
+                            all_gaps_ok = 0;
+                        }
+                    }
+                }
+            }
+
+            test_verify("copy_content: data bytes match src", all_data_ok);
+            test_verify("copy_content: gap bytes retain sentinel (0xCC)",
+                        all_gaps_ok);
+        }
+
+        free(src_buf);
+        free(dst_buf);
+    }
+
+    /* Suppress unused-variable warnings for lb/extent/sz. */
+    (void) lb;
+    (void) extent;
+    (void) sz;
+
+    OBJ_RELEASE(pdt);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_clone
+ *
+ * Build a committed vector, clone it into a freshly created
+ * destination, then verify:
+ *   (a) size matches
+ *   (b) extent matches
+ *   (c) nbElems matches
+ *   (d) flags (committed bit) match
+ *
+ * The destination datatype must be allocated with enough descriptor
+ * space before clone is called -- mirroring ompi_datatype_duplicate().
+ */
+static void test_clone(void)
+{
+    opal_datatype_t *orig;
+    opal_datatype_t *cloned;
+    size_t orig_sz, clone_sz;
+    ptrdiff_t orig_ext, clone_ext;
+
+    /* original: 4 blocks x 3 float8, stride 5 */
+    orig = make_vector(&opal_datatype_float8, 4, 3, 5);
+    test_verify("create vector for clone test", NULL != orig);
+    if (NULL == orig) {
+        return;
+    }
+
+    /* Allocate clone destination with enough descriptor room */
+    cloned = opal_datatype_create((ssize_t)(orig->desc.used + 2));
+    test_verify("create clone destination", NULL != cloned);
+    if (NULL == cloned) {
+        OBJ_RELEASE(orig);
+        return;
+    }
+
+    int32_t rc = opal_datatype_clone(orig, cloned);
+    test_verify("opal_datatype_clone returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    opal_datatype_type_size(orig,   &orig_sz);
+    opal_datatype_type_size(cloned, &clone_sz);
+    test_verify("clone size == original size", orig_sz == clone_sz);
+
+    opal_datatype_type_extent(orig,   &orig_ext);
+    opal_datatype_type_extent(cloned, &clone_ext);
+    test_verify("clone extent == original extent", orig_ext == clone_ext);
+
+    test_verify("clone nbElems == original nbElems",
+                orig->nbElems == cloned->nbElems);
+    test_verify("clone has COMMITTED flag",
+                opal_datatype_is_committed(cloned));
+
+    /* Hand-computed values for 4 blocks x 3 float8, stride 5:
+     *   size    = 4 * 3 * 8 = 96 bytes
+     *   extent  = (4-1)*5*8 + 3*8 = 120 + 24 = 144 bytes
+     *   nbElems = 4 * 3 = 12
+     */
+    test_verify("clone size == 96",    96  == (int) clone_sz);
+    test_verify("clone extent == 144", 144 == (int) clone_ext);
+    test_verify("clone nbElems == 12", 12  == (int) cloned->nbElems);
+
+    OBJ_RELEASE(cloned);
+    OBJ_RELEASE(orig);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_resize
+ *
+ * Build a committed vector of 2 blocks x 2 int4, stride 3.
+ *   natural size   = 2 * 2 * 4 = 16 bytes
+ *   natural extent = (2-1)*3*4 + 2*4 = 12 + 8 = 20 bytes
+ *   natural lb     = 0
+ *
+ * After resize(lb=0, extent=100):
+ *   lb     == 0
+ *   ub     == 100
+ *   extent == 100
+ *   size unchanged (resize only changes lb/ub, not actual data size)
+ *
+ * After resize(lb=-4, extent=100):
+ *   lb     == -4
+ *   ub     == -4 + 100 == 96
+ *   extent == 100
+ */
+static void test_resize(void)
+{
+    opal_datatype_t *pdt;
+    ptrdiff_t lb, ext;
+    size_t sz;
+    int32_t rc;
+
+    /* 2 blocks x 2 int4, stride 3 */
+    pdt = make_vector(&opal_datatype_int4, 2, 2, 3);
+    test_verify("create vector for resize test", NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    /* Verify natural state before resize */
+    opal_datatype_type_size(pdt, &sz);
+    test_verify("resize: natural size == 16", 16 == (int) sz);
+
+    opal_datatype_get_extent(pdt, &lb, &ext);
+    test_verify("resize: natural lb == 0", 0 == (int) lb);
+    test_verify("resize: natural extent == 20", 20 == (int) ext);
+
+    /* resize to extent=100, lb=0 */
+    rc = opal_datatype_resize(pdt, 0, 100);
+    test_verify("opal_datatype_resize(lb=0, ext=100) returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    opal_datatype_get_extent(pdt, &lb, &ext);
+    test_verify("after resize(0,100): lb == 0",   0   == (int) lb);
+    test_verify("after resize(0,100): ext == 100", 100 == (int) ext);
+
+    /* size must be unchanged by resize */
+    opal_datatype_type_size(pdt, &sz);
+    test_verify("resize does not change size (still 16)", 16 == (int) sz);
+
+    /* resize with negative lb */
+    rc = opal_datatype_resize(pdt, -4, 100);
+    test_verify("opal_datatype_resize(lb=-4, ext=100) returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    opal_datatype_get_extent(pdt, &lb, &ext);
+    test_verify("after resize(-4,100): lb == -4",  -4  == (int) lb);
+    test_verify("after resize(-4,100): ext == 100", 100 == (int) ext);
+
+    opal_datatype_type_lb(pdt, &lb);
+    test_verify("type_lb after resize(-4,100) == -4", -4 == (int) lb);
+
+    opal_datatype_type_ub(pdt, &ext);
+    test_verify("type_ub after resize(-4,100) == 96", 96 == (int) ext);
+
+    OBJ_RELEASE(pdt);
+}
+
+/* ------------------------------------------------------------------ */
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_ddt_api");
+
+    /* Full opal_init required: opal_datatype_init() and the accelerator
+     * framework (needed by opal_datatype_is_monotonic()) are bootstrapped
+     * only by opal_init(), not by the lighter opal_init_util().  All
+     * sibling tests in test/datatype/ follow the same pattern.        */
+    opal_init(&argc, &argv);
+
+    test_is_monotonic();
+    test_get_element_count();
+    test_set_element_count();
+    test_compute_ptypes();
+    test_copy_content_same_ddt();
+    test_clone();
+    test_resize();
+
+    r = test_finalize();
+    opal_finalize();
+    return r;
+}

--- a/test/datatype/opal_ddt_hetero.c
+++ b/test/datatype/opal_ddt_hetero.c
@@ -1,0 +1,840 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Self-checking unit tests for OPAL heterogeneous datatype conversion.
+ *
+ * Covered source files:
+ *   opal/datatype/opal_copy_functions_heterogeneous.c  -- byte-swap copy functions
+ *   opal/datatype/opal_datatype_fake_stack.c           -- position-restore stack
+ *   opal/datatype/opal_datatype_get_count.c            -- compute_remote_size / compute_ptypes
+ *
+ * Strategy: construct a "remote" architecture whose endianness is the
+ * opposite of the local one (remote_arch = opal_local_arch ^ OPAL_ARCH_ISBIGENDIAN).
+ * Build wire buffers by byte-reversing known host values independently of
+ * the implementation, then unpack via a heterogeneous convertor and assert
+ * that the recovered host values match.
+ *
+ * NOTE: The library is compiled with -DNDEBUG so assert() is a no-op.
+ * All verification MUST go through test_verify() so that failures are real.
+ *
+ * Initialization note: this file uses opal_init()/opal_finalize() rather
+ * than the opal_init_util()+opal_datatype_init() pattern used by some OPAL
+ * class tests.  The reason is that opal_convertor_prepare_for_recv()
+ * unconditionally invokes opal_convertor_accelerator_init(), which calls into
+ * the accelerator framework.  That framework is only initialized by the full
+ * opal_init() path (see the explicit ordering note in opal_init.c: "datatype
+ * convertor code has a dependency on the accelerator framework being
+ * initialized").  This matches unpack_hetero.c and every other in-tree
+ * datatype test that links against only libopal.la.
+ */
+
+/*
+ * STATUS: this test is intentionally NOT wired into test/datatype/Makefile.am
+ * (not built or run by "make check") because two of its assertions currently
+ * fail and document open items awaiting a maintainer's decision:
+ *
+ *   1. test_fake_stack_direct() (the "fake_stack: bConverted advanced to
+ *      seek_to" assertion) exercises an internal helper
+ *      (opal_convertor_create_stack_with_pos_general) that has zero production
+ *      callers; the asserted postcondition is undocumented and does not hold
+ *      for the predefined-contiguous input used here.  Likely a test bug.
+ *
+ *   2. test_set_position_and_resume() (the "set_pos: elem[2] correct after
+ *      resume" assertion) reveals a real disp-composition asymmetry between the
+ *      homogeneous and heterogeneous unpack paths after a mid-stream
+ *      opal_convertor_set_position() on a FLAG_CONTIGUOUS recv convertor.
+ *      Whether that is a live bug depends on whether production ever drives
+ *      that exact combination -- a question for a datatype maintainer.
+ *
+ * The remaining ~60 assertions pass on both Linux and macOS.  See the inline
+ * NOTE/OPEN QUESTION comments at each failing assertion for the full analysis.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/datatype/opal_convertor.h"
+#include "opal/datatype/opal_datatype.h"
+#include "opal/datatype/opal_datatype_internal.h"
+#include "opal/datatype/opal_datatype_prototypes.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+#include "opal/util/arch.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/* -----------------------------------------------------------------------
+ * Helper: portable byte-reversal.
+ * Produces the byte-swapped representation of 'in' in 'out'.
+ * 'size' is the width in bytes (1, 2, 4, 8, ...).
+ * This is derived from first principles (mirror the byte array), NOT from
+ * opal_dt_swap_bytes, so that the test is independent of the implementation.
+ * ----------------------------------------------------------------------- */
+static void swap_bytes(void *out, const void *in, size_t size)
+{
+    const unsigned char *src = (const unsigned char *) in;
+    unsigned char *dst = (unsigned char *) out;
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        dst[i] = src[size - 1 - i];
+    }
+}
+
+/* -----------------------------------------------------------------------
+ * Helper: unpack one or more elements of a predefined type from a
+ * wire buffer via a heterogeneous convertor and return the convertor.
+ * The caller must OBJ_RELEASE the returned convertor.
+ * Returns OPAL_SUCCESS on success, otherwise the error code.
+ * ----------------------------------------------------------------------- */
+static int hetero_unpack(uint32_t remote_arch,
+                         const opal_datatype_t *dtype,
+                         size_t count,
+                         void *recv_buf,
+                         void *wire_buf,
+                         size_t wire_len)
+{
+    opal_convertor_t *conv;
+    struct iovec iov;
+    uint32_t iov_count;
+    size_t max_data;
+    int rc;
+
+    conv = opal_convertor_create(remote_arch, 0);
+    if (NULL == conv) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    rc = opal_convertor_prepare_for_recv(conv, dtype, count, recv_buf);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(conv);
+        return rc;
+    }
+
+    iov.iov_base = wire_buf;
+    iov.iov_len  = wire_len;
+    iov_count    = 1;
+    max_data     = wire_len;
+    opal_convertor_unpack(conv, &iov, &iov_count, &max_data);
+
+    OBJ_RELEASE(conv);
+    return OPAL_SUCCESS;
+}
+
+/* -----------------------------------------------------------------------
+ * Test sections
+ * ----------------------------------------------------------------------- */
+
+/*
+ * test_int2: copy_int2_heterogeneous
+ *
+ * Single int16_t value.  The wire buffer contains the byte-swapped
+ * representation; unpacking through a hetero convertor must restore
+ * the original host value.
+ */
+static void test_int2(uint32_t remote_arch)
+{
+    int16_t host_val = 0x1234;
+    int16_t wire_val;
+    int16_t recv_val = 0;
+    int rc;
+
+    /* Build wire buffer: byte-reversed host value */
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_int2, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("int2: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("int2: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_int4: copy_int4_heterogeneous
+ *
+ * Single int32_t.  This is the same path exercised by unpack_hetero.c
+ * but with a known value and a real assertion.
+ */
+static void test_int4(uint32_t remote_arch)
+{
+    int32_t host_val = 0x01020304;
+    int32_t wire_val;
+    int32_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_int4, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("int4: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("int4: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_int8: copy_int8_heterogeneous
+ */
+static void test_int8(uint32_t remote_arch)
+{
+    int64_t host_val = (int64_t) 0x0102030405060708LL;
+    int64_t wire_val;
+    int64_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_int8, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("int8: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("int8: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_uint2: copy_int2_heterogeneous (reused for UINT2)
+ */
+static void test_uint2(uint32_t remote_arch)
+{
+    uint16_t host_val = 0xABCD;
+    uint16_t wire_val;
+    uint16_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_uint2, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("uint2: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("uint2: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_uint4: copy_int4_heterogeneous (reused for UINT4)
+ */
+static void test_uint4(uint32_t remote_arch)
+{
+    uint32_t host_val = 0xDEADBEEFU;
+    uint32_t wire_val;
+    uint32_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_uint4, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("uint4: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("uint4: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_uint8: copy_int8_heterogeneous (reused for UINT8)
+ */
+static void test_uint8(uint32_t remote_arch)
+{
+    uint64_t host_val = 0xCAFEBABEDEADF00DULL;
+    uint64_t wire_val;
+    uint64_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_uint8, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("uint8: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("uint8: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_float4: copy_float4_heterogeneous
+ *
+ * IEEE-754 single precision.  Use the bit-pattern of a known float.
+ * 1.0f in IEEE-754 LE = 0x3F800000.
+ * Byte-reversed: 0x0000803F.
+ * After unpacking via hetero convertor we should recover 1.0f.
+ */
+static void test_float4(uint32_t remote_arch)
+{
+    float host_val = 1.0f;
+    float wire_val_f;
+    float recv_val = 0.0f;
+    int rc;
+
+    swap_bytes(&wire_val_f, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_float4, 1, &recv_val,
+                       &wire_val_f, sizeof(wire_val_f));
+    test_verify("float4: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("float4: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_float8: copy_float8_heterogeneous
+ *
+ * IEEE-754 double precision.  Use 1.0 = 0x3FF0000000000000 in LE.
+ */
+static void test_float8(uint32_t remote_arch)
+{
+    double host_val = 1.0;
+    double wire_val_d;
+    double recv_val = 0.0;
+    int rc;
+
+    swap_bytes(&wire_val_d, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_float8, 1, &recv_val,
+                       &wire_val_d, sizeof(wire_val_d));
+    test_verify("float8: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("float8: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_int4_contiguous_array
+ *
+ * Unpack 4 contiguous int32_t values.  This exercises the
+ * multi-element contiguous path in copy_int4_heterogeneous (the
+ * "countperblock = count, nblocksleft = 1" branch).
+ */
+static void test_int4_contiguous_array(uint32_t remote_arch)
+{
+    static const int32_t host_vals[4] = {0x10203040, 0x50607080,
+                                         (int32_t) 0x90A0B0C0, (int32_t) 0xD0E0F001};
+    int32_t wire_buf[4];
+    int32_t recv_buf[4];
+    size_t i;
+    int rc;
+
+    memset(recv_buf, 0, sizeof(recv_buf));
+
+    for (i = 0; i < 4; i++) {
+        swap_bytes(&wire_buf[i], &host_vals[i], sizeof(int32_t));
+    }
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_int4, 4, recv_buf,
+                       wire_buf, sizeof(wire_buf));
+    test_verify("int4[4]: unpack succeeds", OPAL_SUCCESS == rc);
+    for (i = 0; i < 4; i++) {
+        test_verify("int4[4]: each element byte-swapped correctly",
+                    host_vals[i] == recv_buf[i]);
+    }
+}
+
+/*
+ * test_int4_negative: single negative int32_t
+ *
+ * Verify sign extension is preserved across the byte swap.
+ */
+static void test_int4_negative(uint32_t remote_arch)
+{
+    int32_t host_val = -1;          /* 0xFFFFFFFF */
+    int32_t wire_val;
+    int32_t recv_val = 0;
+    int rc;
+
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_int4, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("int4 negative: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("int4 negative: -1 round-trips correctly", -1 == recv_val);
+}
+
+/*
+ * test_wchar: copy_wchar_heterogeneous
+ *
+ * wchar_t width is platform-dependent; we only test if sizeof(wchar_t) > 1
+ * so there is something to swap.
+ */
+static void test_wchar(uint32_t remote_arch)
+{
+    wchar_t host_val;
+    wchar_t wire_val;
+    wchar_t recv_val;
+    int rc;
+
+    if (sizeof(wchar_t) <= 1) {
+        /* Nothing interesting to byte-swap; skip but count as a pass. */
+        test_verify("wchar: skip (sizeof == 1)", 1);
+        return;
+    }
+
+    host_val = (wchar_t) 0x0410;       /* some non-ASCII codepoint, fits in 2+ byte wchar_t */
+    swap_bytes(&wire_val, &host_val, sizeof(host_val));
+    recv_val = 0;
+
+    rc = hetero_unpack(remote_arch, &opal_datatype_wchar, 1, &recv_val,
+                       &wire_val, sizeof(wire_val));
+    test_verify("wchar: unpack succeeds", OPAL_SUCCESS == rc);
+    test_verify("wchar: byte-swap round-trip", host_val == recv_val);
+}
+
+/*
+ * test_remote_size_predefined
+ *
+ * opal_convertor_compute_remote_size on a predefined type should return
+ * count * sizeof(type).
+ *
+ * Covers: opal_datatype_compute_remote_size (predefined short-circuit path)
+ */
+static void test_remote_size_predefined(uint32_t remote_arch)
+{
+    opal_convertor_t *conv;
+    size_t rsize;
+    const size_t count = 3;
+    int64_t dummy_buf[3] = {0, 0, 0};
+    int rc;
+
+    conv = opal_convertor_create(remote_arch, 0);
+    test_verify("remote_size pred: convertor created", NULL != conv);
+    if (NULL == conv) {
+        return;
+    }
+
+    rc = opal_convertor_prepare_for_recv(conv, &opal_datatype_int8, count, dummy_buf);
+    test_verify("remote_size pred: prepare ok", OPAL_SUCCESS == rc);
+
+    rsize = opal_convertor_compute_remote_size(conv);
+    test_verify("remote_size pred: returns count * sizeof(int8)",
+                (count * sizeof(int64_t)) == rsize);
+
+    OBJ_RELEASE(conv);
+}
+
+/*
+ * test_remote_size_derived
+ *
+ * opal_convertor_compute_remote_size on a derived type must call
+ * opal_datatype_compute_ptypes (get_count.c).
+ *
+ * We build a struct-like derived type: 3 x int4 followed by 2 x int8.
+ * Local and remote sizes of each predefined type are the same in this
+ * test (we only flip endianness, not type sizes), so remote_size should
+ * equal local_size = count * (3*4 + 2*8) = 1 * 20 = 20 bytes.
+ *
+ * Covers: opal_datatype_compute_ptypes, opal_datatype_compute_remote_size
+ *         (derived type path)
+ */
+static void test_remote_size_derived(uint32_t remote_arch)
+{
+    opal_datatype_t *derived = NULL;
+    opal_convertor_t *conv   = NULL;
+    static char dummy_recv[64];
+    size_t rsize;
+    int rc;
+    /* 3 x int4 (12 bytes) + 2 x int8 (16 bytes) = 28 bytes total */
+    const size_t expected_local = 3 * sizeof(int32_t) + 2 * sizeof(int64_t);
+
+    rc = opal_datatype_create_contiguous(0, &opal_datatype_empty, &derived);
+    test_verify("remote_size derived: create empty ok", OPAL_SUCCESS == rc);
+    if (OPAL_SUCCESS != rc || NULL == derived) {
+        return;
+    }
+
+    rc = opal_datatype_add(derived, &opal_datatype_int4, 3, 0, sizeof(int32_t));
+    test_verify("remote_size derived: add int4 ok", OPAL_SUCCESS == rc);
+
+    rc = opal_datatype_add(derived, &opal_datatype_int8, 2,
+                           3 * (ptrdiff_t) sizeof(int32_t), sizeof(int64_t));
+    test_verify("remote_size derived: add int8 ok", OPAL_SUCCESS == rc);
+
+    rc = opal_datatype_commit(derived);
+    test_verify("remote_size derived: commit ok", OPAL_SUCCESS == rc);
+
+    conv = opal_convertor_create(remote_arch, 0);
+    test_verify("remote_size derived: convertor created", NULL != conv);
+    if (NULL == conv) {
+        opal_datatype_destroy(&derived);
+        return;
+    }
+
+    /* Use the dummy recv buffer (not accessed; we only test size computation). */
+    rc = opal_convertor_prepare_for_recv(conv, derived, 1, dummy_recv);
+    test_verify("remote_size derived: prepare ok", OPAL_SUCCESS == rc);
+
+    rsize = opal_convertor_compute_remote_size(conv);
+    /*
+     * Since we only flip endianness (not type sizes), the remote size equals
+     * the local size for this derived type.
+     */
+    test_verify("remote_size derived: equals expected local size",
+                expected_local == rsize);
+
+    OBJ_RELEASE(conv);
+    opal_datatype_destroy(&derived);
+}
+
+/*
+ * test_strided_int4_unpack
+ *
+ * Build a derived type with two non-contiguous int32_t fields (a "struct"
+ * with a gap).  This exercises copy_int4_heterogeneous on a non-contiguous
+ * layout (the "countperblock=1, nblocksleft=count" branch).
+ *
+ * Layout per instance (bytes):
+ *   [0..3]  = field A (int32_t)
+ *   [4..7]  = gap (unwritten)
+ *   [8..11] = field B (int32_t)
+ *   extent  = 12 bytes
+ *   size    = 8 bytes
+ *
+ * The wire buffer for N instances is N*8 bytes of packed (gapless) data.
+ * The recv buffer must be at least N*12 bytes.
+ */
+static void test_strided_int4_unpack(uint32_t remote_arch)
+{
+    opal_datatype_t *gapped = NULL;
+    opal_convertor_t *conv  = NULL;
+    const int NINSTANCES = 3;
+    /*
+     * Two int32_t fields per instance, separated by a 4-byte gap.
+     * field A at offset 0, field B at offset 8.
+     * extent = 12 bytes.
+     */
+    const ptrdiff_t disp_A  = 0;
+    const ptrdiff_t disp_B  = 8;
+    const ptrdiff_t ext_instance = 12; /* extent of one instance */
+
+    /* Host values: 3 instances, 2 fields each */
+    static const int32_t host_A[3] = {0x11223344, 0x55667788, (int32_t) 0x99AABBCC};
+    static const int32_t host_B[3] = {0x0A0B0C0D, 0x0E0F1011, 0x12131415};
+
+    /* Wire buffer: packed, 2 int32 per instance, no gaps */
+    int32_t wire_buf[6];
+    /* Recv buffer: 3 instances each of extent 12 bytes = 9 int32 slots */
+    int32_t recv_buf[9];
+    struct iovec iov;
+    uint32_t iov_count;
+    size_t max_data;
+    int rc;
+    int i;
+
+    memset(recv_buf, 0xAB, sizeof(recv_buf)); /* fill with sentinel */
+
+    /* Build wire buffer: byte-swapped A then byte-swapped B, per instance */
+    for (i = 0; i < NINSTANCES; i++) {
+        swap_bytes(&wire_buf[i * 2 + 0], &host_A[i], sizeof(int32_t));
+        swap_bytes(&wire_buf[i * 2 + 1], &host_B[i], sizeof(int32_t));
+    }
+
+    /* Create derived type: empty base, then add field A and field B */
+    rc = opal_datatype_create_contiguous(0, &opal_datatype_empty, &gapped);
+    test_verify("gapped int4: create empty ok", OPAL_SUCCESS == rc);
+    if (OPAL_SUCCESS != rc || NULL == gapped) {
+        return;
+    }
+
+    /* field A: 1 int4 at offset 0, extent = disp_B (= 8) */
+    rc = opal_datatype_add(gapped, &opal_datatype_int4, 1, disp_A, disp_B);
+    test_verify("gapped int4: add field A ok", OPAL_SUCCESS == rc);
+
+    /* field B: 1 int4 at offset 8, extent = ext_instance (= 12) */
+    rc = opal_datatype_add(gapped, &opal_datatype_int4, 1, disp_B, ext_instance);
+    test_verify("gapped int4: add field B ok", OPAL_SUCCESS == rc);
+
+    rc = opal_datatype_commit(gapped);
+    test_verify("gapped int4: commit ok", OPAL_SUCCESS == rc);
+
+    test_verify("gapped int4: type size == 8",
+                (size_t) 8 == gapped->size);
+    test_verify("gapped int4: type is non-contiguous",
+                0 == (gapped->flags & OPAL_DATATYPE_FLAG_NO_GAPS));
+
+    conv = opal_convertor_create(remote_arch, 0);
+    test_verify("gapped int4: convertor created", NULL != conv);
+    if (NULL == conv) {
+        opal_datatype_destroy(&gapped);
+        return;
+    }
+
+    rc = opal_convertor_prepare_for_recv(conv, gapped, NINSTANCES, recv_buf);
+    test_verify("gapped int4: prepare ok", OPAL_SUCCESS == rc);
+
+    iov.iov_base = wire_buf;
+    iov.iov_len  = sizeof(wire_buf);    /* 6 * 4 = 24 bytes */
+    iov_count    = 1;
+    max_data     = sizeof(wire_buf);
+    opal_convertor_unpack(conv, &iov, &iov_count, &max_data);
+
+    /*
+     * Each instance of gapped occupies ext_instance=12 bytes in recv_buf
+     * (i.e. 3 int32 slots).  Field A is at offset 0, field B at offset 8
+     * within each instance.
+     *
+     *  instance i recv_buf layout (int32 indices):
+     *    [i*3 + 0] = field A    (offset 0 / ext=12 => byte 0 in instance)
+     *    [i*3 + 1] = gap        (bytes 4-7, never written)
+     *    [i*3 + 2] = field B    (offset 8 / ext=12 => byte 8 in instance)
+     */
+    for (i = 0; i < NINSTANCES; i++) {
+        test_verify("gapped int4: field A round-trips",
+                    host_A[i] == recv_buf[i * 3 + 0]);
+        test_verify("gapped int4: field B round-trips",
+                    host_B[i] == recv_buf[i * 3 + 2]);
+    }
+
+    OBJ_RELEASE(conv);
+    opal_datatype_destroy(&gapped);
+}
+
+/*
+ * test_fake_stack_direct
+ *
+ * Directly call opal_convertor_create_stack_with_pos_general to exercise
+ * the heterogeneous position-restore stack (opal_datatype_fake_stack.c).
+ *
+ * The function signature is:
+ *   int opal_convertor_create_stack_with_pos_general(
+ *           opal_convertor_t *pConvertor,
+ *           size_t starting_point,
+ *           const size_t *sizes);
+ *
+ * Preconditions from the source:
+ *   - starting_point != 0
+ *   - pConvertor->bConverted != starting_point  (i.e. not already there)
+ *   - starting_point <= pConvertor->count * pData->size
+ *   - !(pConvertor->flags & CONVERTOR_SEND)
+ *
+ * We set up a heterogeneous recv convertor over an array of int4 values,
+ * partially unpack the first element (so bConverted = sizeof(int32_t)),
+ * then call the function to seek to the second element.  After the call
+ * we verify that bConverted has advanced to the requested position.
+ *
+ * Note: opal_convertor_create_stack_with_pos_general is declared in
+ * opal_datatype_fake_stack.c with an extern prototype inside the same
+ * file.  We declare it here to be able to call it.
+ */
+extern int opal_convertor_create_stack_with_pos_general(opal_convertor_t *pConvertor,
+                                                        size_t starting_point,
+                                                        const size_t *sizes);
+
+static void test_fake_stack_direct(uint32_t remote_arch)
+{
+    /*
+     * 4 int32_t values; after seeking past 2 elements, bConverted == 8.
+     */
+    static const int32_t host_vals[4] = {10, 20, 30, 40};
+    int32_t wire_buf[4];
+    int32_t recv_buf[4];
+    opal_convertor_t *conv = NULL;
+    struct iovec iov;
+    uint32_t iov_count;
+    size_t max_data;
+    size_t seek_to;
+    int rc;
+    int i;
+
+    memset(recv_buf, 0, sizeof(recv_buf));
+
+    for (i = 0; i < 4; i++) {
+        swap_bytes(&wire_buf[i], &host_vals[i], sizeof(int32_t));
+    }
+
+    conv = opal_convertor_create(remote_arch, 0);
+    test_verify("fake_stack: convertor created", NULL != conv);
+    if (NULL == conv) {
+        return;
+    }
+
+    rc = opal_convertor_prepare_for_recv(conv, &opal_datatype_int4, 4, recv_buf);
+    test_verify("fake_stack: prepare ok", OPAL_SUCCESS == rc);
+
+    /* Unpack the first element so that bConverted = sizeof(int32_t) */
+    iov.iov_base = wire_buf;
+    iov.iov_len  = sizeof(int32_t);
+    iov_count    = 1;
+    max_data     = sizeof(int32_t);
+    opal_convertor_unpack(conv, &iov, &iov_count, &max_data);
+
+    test_verify("fake_stack: first element unpacked",
+                host_vals[0] == recv_buf[0]);
+    test_verify("fake_stack: bConverted == sizeof(int32_t) after first unpack",
+                sizeof(int32_t) == conv->bConverted);
+
+    /*
+     * Now seek to just past the second element: starting_point = 2*4 = 8.
+     * Preconditions satisfied:
+     *   starting_point (8) != 0
+     *   bConverted (4) != starting_point (8)
+     *   starting_point (8) <= count*size (4*4 = 16)
+     *   !(flags & CONVERTOR_SEND)
+     */
+    seek_to = 2 * sizeof(int32_t);
+    rc = opal_convertor_create_stack_with_pos_general(conv, seek_to,
+                                                      opal_datatype_local_sizes);
+    test_verify("fake_stack: create_stack_with_pos_general returns ok",
+                OPAL_SUCCESS == rc);
+    /*
+     * NOTE: this assertion currently FAILS, and the assertion -- not the
+     * library -- is the suspect.  opal_convertor_create_stack_with_pos_general()
+     * is an internal helper with ZERO production callers (grep the tree): for a
+     * predefined CONTIGUOUS datatype like int4, production always routes through
+     * opal_convertor_create_stack_with_pos_contig() instead, so this path is
+     * never exercised in practice.  Called directly here in the heterogeneous +
+     * predefined-contiguous regime, the general walker consumes the single DATA
+     * descriptor element and falls through to bConverted = local_size (16), not
+     * the asserted seek_to (8).  There is no documented postcondition that
+     * bConverted == starting_point for this helper.  Left in place (failing) for
+     * a maintainer to confirm/restrict.  (This test is intentionally NOT wired
+     * into "make check"; see the file-level note.)
+     */
+    test_verify("fake_stack: bConverted advanced to seek_to",
+                seek_to == conv->bConverted);
+
+    OBJ_RELEASE(conv);
+}
+
+/*
+ * test_set_position_and_resume
+ *
+ * Exercises the convertor set-position path (which internally calls
+ * opal_convertor_set_position_nocheck) then resumes unpacking.
+ *
+ * We send 4 int32_t values one at a time, verifying that we can seek
+ * to an arbitrary byte offset mid-array and continue unpacking from
+ * that point.
+ *
+ * This path also exercises the fake_stack indirectly via
+ * opal_convertor_set_position -> set_position_nocheck ->
+ * (for contiguous types) create_stack_with_pos_contig.
+ */
+static void test_set_position_and_resume(uint32_t remote_arch)
+{
+    static const int32_t host_vals[4] = {100, 200, 300, 400};
+    int32_t wire_buf[4];
+    int32_t recv_buf[4];
+    opal_convertor_t *conv = NULL;
+    struct iovec iov;
+    uint32_t iov_count;
+    size_t max_data;
+    size_t pos;
+    int rc;
+    int i;
+
+    memset(recv_buf, 0, sizeof(recv_buf));
+    for (i = 0; i < 4; i++) {
+        swap_bytes(&wire_buf[i], &host_vals[i], sizeof(int32_t));
+    }
+
+    conv = opal_convertor_create(remote_arch, 0);
+    test_verify("set_pos: convertor created", NULL != conv);
+    if (NULL == conv) {
+        return;
+    }
+
+    rc = opal_convertor_prepare_for_recv(conv, &opal_datatype_int4, 4, recv_buf);
+    test_verify("set_pos: prepare ok", OPAL_SUCCESS == rc);
+
+    /* Unpack element 0 only */
+    iov.iov_base = &wire_buf[0];
+    iov.iov_len  = sizeof(int32_t);
+    iov_count    = 1;
+    max_data     = sizeof(int32_t);
+    opal_convertor_unpack(conv, &iov, &iov_count, &max_data);
+    test_verify("set_pos: elem[0] correct", host_vals[0] == recv_buf[0]);
+
+    /* Seek past element 1 (skip it) to byte offset 8 */
+    pos = 2 * sizeof(int32_t);
+    rc = opal_convertor_set_position(conv, &pos);
+    test_verify("set_pos: set_position ok", OPAL_SUCCESS == rc);
+    test_verify("set_pos: position landed at 8", (size_t) 8 == conv->bConverted);
+
+    /* Unpack elements 2 and 3 from their respective wire positions */
+    iov.iov_base = &wire_buf[2];
+    iov.iov_len  = 2 * sizeof(int32_t);
+    iov_count    = 1;
+    max_data     = 2 * sizeof(int32_t);
+    opal_convertor_unpack(conv, &iov, &iov_count, &max_data);
+    /*
+     * OPEN QUESTION (this assertion currently FAILS): after set_position(8) on a
+     * HETEROGENEOUS, FLAG_CONTIGUOUS recv convertor, elem[2] is never written
+     * (stays 0) while elem[3] resumes correctly.  Traced cause: a disp-
+     * composition mismatch -- opal_convertor_create_stack_with_pos_contig()
+     * encodes the element skip in stack[0].disp, but the heterogeneous unpack
+     * path (opal_unpack_general) initializes conv_ptr from stack[1].disp (== 0).
+     * The identical sequence PASSES homogeneous (the contig unpack composes both
+     * disps) and FAILS heterogeneous.  Whether this is a live OPAL bug or merely
+     * an unreachable path depends on whether production ever calls
+     * opal_convertor_set_position() mid-stream on a heterogeneous +
+     * FLAG_CONTIGUOUS recv convertor -- a question for a maintainer.  Left in
+     * place (failing).  (This test is intentionally NOT wired into "make check";
+     * see the file-level note.)
+     */
+    test_verify("set_pos: elem[2] correct after resume", host_vals[2] == recv_buf[2]);
+    test_verify("set_pos: elem[3] correct after resume", host_vals[3] == recv_buf[3]);
+
+    OBJ_RELEASE(conv);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+int main(int argc, char *argv[])
+{
+    uint32_t remote_arch;
+    int ret;
+
+    test_init("opal_ddt_hetero");
+
+    /*
+     * opal_init initialises the arch detection (opal_local_arch) and
+     * the datatype engine.  All existing OPAL-only datatype tests follow
+     * this pattern.
+     */
+    opal_init(NULL, NULL);
+
+    /*
+     * Simulate a peer whose endianness is the opposite of ours.
+     * This forces every conversion function to byte-swap.
+     */
+    remote_arch = opal_local_arch ^ OPAL_ARCH_ISBIGENDIAN;
+
+    /* --- copy_functions_heterogeneous.c --- */
+    test_int2(remote_arch);
+    test_int4(remote_arch);
+    test_int8(remote_arch);
+    test_uint2(remote_arch);
+    test_uint4(remote_arch);
+    test_uint8(remote_arch);
+    test_float4(remote_arch);
+    test_float8(remote_arch);
+    test_wchar(remote_arch);
+
+    /* Contiguous multi-element: exercises "countperblock = count" branch */
+    test_int4_contiguous_array(remote_arch);
+    test_int4_negative(remote_arch);
+
+    /* --- opal_datatype_get_count.c (compute_ptypes, compute_remote_size) --- */
+    test_remote_size_predefined(remote_arch);
+    test_remote_size_derived(remote_arch);
+
+    /* --- non-contiguous strided type --- */
+    test_strided_int4_unpack(remote_arch);
+
+    /* --- opal_datatype_fake_stack.c --- */
+    test_fake_stack_direct(remote_arch);
+
+    /* --- set_position path (also drives fake_stack indirectly) --- */
+    test_set_position_and_resume(remote_arch);
+
+    ret = test_finalize();
+    opal_finalize();
+    return ret;
+}

--- a/test/support/support.h
+++ b/test/support/support.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2024      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,9 +51,10 @@ void test_fail_stop(const char *msg, int status);
 #define test_verify(MESSAGE, EXPR)                                                         \
     do {                                                                                   \
         if (!(EXPR)) {                                                                     \
-            char s[256];                                                                   \
-            snprintf(s, sizeof(s), "%s:%d: %s: %s\n", __FILE__, __LINE__, MESSAGE, #EXPR); \
-            test_failure(s);                                                               \
+            char test_verify_msgbuf_[256];                                                 \
+            snprintf(test_verify_msgbuf_, sizeof(test_verify_msgbuf_),                      \
+                     "%s:%d: %s: %s\n", __FILE__, __LINE__, MESSAGE, #EXPR);               \
+            test_failure(test_verify_msgbuf_);                                             \
         } else {                                                                           \
             test_success();                                                                \
         }                                                                                  \

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -17,6 +17,7 @@
 # Copyright (c) 2018      Intel, Inc.  All rights reserved.
 # Copyright (c) 2024      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,6 +26,9 @@
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)/test/support
+
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/test/Makefile.mca-dso-check
 
 #check_PROGRAMS = \
 #        ompi_numtostr \
@@ -44,10 +48,155 @@ check_PROGRAMS = \
 	opal_path_nfs \
         opal_json \
         opal_sha256 \
-	opal_timer
+	opal_timer \
+	opal_string_copy \
+	ompi_numtostr \
+	opal_basename \
+	opal_os_path \
+	opal_getcwd \
+	opal_argv \
+	opal_environ \
+	opal_printf \
+	opal_uri \
+	opal_qsort \
+	opal_alfg \
+	opal_crc \
+	opal_fd \
+	opal_arch \
+	opal_cmd_line \
+	opal_few \
+	opal_info_subscriber \
+	opal_keyval_parse \
+	opal_malloc \
+	opal_os_dirpath \
+	opal_path \
+	opal_proc \
+	opal_sys_limits \
+	opal_error \
+	opal_if \
+	opal_info \
+	opal_net \
+	opal_output
 
 TESTS = \
 	$(check_PROGRAMS)
+
+# Common link line for the OPAL unit tests
+opal_test_ldadd = \
+	$(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+	$(top_builddir)/test/support/libsupport.a
+
+opal_string_copy_SOURCES = opal_string_copy.c
+opal_string_copy_LDADD = $(opal_test_ldadd)
+opal_string_copy_DEPENDENCIES = $(opal_test_ldadd)
+
+ompi_numtostr_SOURCES = ompi_numtostr.c
+ompi_numtostr_LDADD = $(opal_test_ldadd)
+ompi_numtostr_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_basename_SOURCES = opal_basename.c
+opal_basename_LDADD = $(opal_test_ldadd)
+opal_basename_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_os_path_SOURCES = opal_os_path.c
+opal_os_path_LDADD = $(opal_test_ldadd)
+opal_os_path_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_getcwd_SOURCES = opal_getcwd.c
+opal_getcwd_LDADD = $(opal_test_ldadd)
+opal_getcwd_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_argv_SOURCES = opal_argv.c
+opal_argv_LDADD = $(opal_test_ldadd)
+opal_argv_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_environ_SOURCES = opal_environ.c
+opal_environ_LDADD = $(opal_test_ldadd)
+opal_environ_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_printf_SOURCES = opal_printf.c
+opal_printf_LDADD = $(opal_test_ldadd)
+opal_printf_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_uri_SOURCES = opal_uri.c
+opal_uri_LDADD = $(opal_test_ldadd)
+opal_uri_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_qsort_SOURCES = opal_qsort.c
+opal_qsort_LDADD = $(opal_test_ldadd)
+opal_qsort_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_alfg_SOURCES = opal_alfg.c
+opal_alfg_LDADD = $(opal_test_ldadd)
+opal_alfg_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_crc_SOURCES = opal_crc.c
+opal_crc_LDADD = $(opal_test_ldadd)
+opal_crc_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_fd_SOURCES = opal_fd.c
+opal_fd_LDADD = $(opal_test_ldadd)
+opal_fd_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_arch_SOURCES = opal_arch.c
+opal_arch_LDADD = $(opal_test_ldadd)
+opal_arch_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_cmd_line_SOURCES = opal_cmd_line.c
+opal_cmd_line_LDADD = $(opal_test_ldadd)
+opal_cmd_line_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_few_SOURCES = opal_few.c
+opal_few_LDADD = $(opal_test_ldadd)
+opal_few_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_info_subscriber_SOURCES = opal_info_subscriber.c
+opal_info_subscriber_LDADD = $(opal_test_ldadd)
+opal_info_subscriber_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_keyval_parse_SOURCES = opal_keyval_parse.c
+opal_keyval_parse_LDADD = $(opal_test_ldadd)
+opal_keyval_parse_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_malloc_SOURCES = opal_malloc.c
+opal_malloc_LDADD = $(opal_test_ldadd)
+opal_malloc_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_os_dirpath_SOURCES = opal_os_dirpath.c
+opal_os_dirpath_LDADD = $(opal_test_ldadd)
+opal_os_dirpath_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_path_SOURCES = opal_path.c
+opal_path_LDADD = $(opal_test_ldadd)
+opal_path_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_proc_SOURCES = opal_proc.c
+opal_proc_LDADD = $(opal_test_ldadd)
+opal_proc_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_sys_limits_SOURCES = opal_sys_limits.c
+opal_sys_limits_LDADD = $(opal_test_ldadd)
+opal_sys_limits_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_error_SOURCES = opal_error.c
+opal_error_LDADD = $(opal_test_ldadd)
+opal_error_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_if_SOURCES = opal_if.c
+opal_if_LDADD = $(opal_test_ldadd)
+opal_if_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_info_SOURCES = opal_info.c
+opal_info_LDADD = $(opal_test_ldadd)
+opal_info_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_net_SOURCES = opal_net.c
+opal_net_LDADD = $(opal_test_ldadd)
+opal_net_DEPENDENCIES = $(opal_test_ldadd)
+
+opal_output_SOURCES = opal_output.c
+opal_output_LDADD = $(opal_test_ldadd)
+opal_output_DEPENDENCIES = $(opal_test_ldadd)
 
 #ompi_numtostr_SOURCES = ompi_numtostr.c
 #ompi_numtostr_LDADD = \

--- a/test/util/ompi_numtostr.c
+++ b/test/util/ompi_numtostr.c
@@ -1,40 +1,128 @@
-#include "ompi_config.h"
-#include "opal/util/numtostr.h"
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "support.h"
+#include "opal/util/numtostr.h"
+#include "opal/constants.h"
 
 int main(int argc, char *argv[])
 {
-    char *tst;
-    char *expected;
+    char *result;
 
-    test_init("ompi_numtostr_t");
+    test_init("opal_numtostr");
 
-    tst = opal_ltostr(10);
-    expected = malloc(sizeof(long) * 8);
-    snprintf(expected, sizeof(long) * 8, "%d", 10);
-    if (strcmp(tst, expected) != 0) {
-        test_failure("opal_ltostr test failed");
-    } else {
-        test_success();
+    /* --- opal_ltostr: zero --- */
+    result = opal_ltostr(0L);
+    test_verify("ltostr(0): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(0): equals '0'", 0 == strcmp(result, "0"));
+        free(result);
     }
 
-    free(tst);
-    free(expected);
-
-    tst = opal_dtostr(5.32);
-    expected = malloc(sizeof(long) * 8);
-    snprintf(expected, sizeof(long) * 8, "%f", 5.32);
-    if (strcmp(tst, expected) != 0) {
-        test_failure("opal_dtostr test failed");
-    } else {
-        test_success();
+    /* --- opal_ltostr: positive --- */
+    result = opal_ltostr(42L);
+    test_verify("ltostr(42): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(42): equals '42'", 0 == strcmp(result, "42"));
+        free(result);
     }
 
-    test_finalize();
+    /* --- opal_ltostr: negative --- */
+    result = opal_ltostr(-1L);
+    test_verify("ltostr(-1): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(-1): equals '-1'", 0 == strcmp(result, "-1"));
+        free(result);
+    }
 
-    return 0;
+    /* --- opal_ltostr: negative large --- */
+    result = opal_ltostr(-9999L);
+    test_verify("ltostr(-9999): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(-9999): equals '-9999'", 0 == strcmp(result, "-9999"));
+        free(result);
+    }
+
+    /* --- opal_ltostr: large positive --- */
+    result = opal_ltostr(1000000L);
+    test_verify("ltostr(1000000): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(1000000): equals '1000000'", 0 == strcmp(result, "1000000"));
+        free(result);
+    }
+
+    /* --- opal_ltostr: value 10 (original test case) --- */
+    result = opal_ltostr(10L);
+    test_verify("ltostr(10): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("ltostr(10): equals '10'", 0 == strcmp(result, "10"));
+        free(result);
+    }
+
+    /* --- opal_dtostr: zero ---
+     * %f with no precision specifier always produces 6 decimal digits.
+     */
+    result = opal_dtostr(0.0);
+    test_verify("dtostr(0.0): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("dtostr(0.0): equals '0.000000'", 0 == strcmp(result, "0.000000"));
+        free(result);
+    }
+
+    /* --- opal_dtostr: positive --- */
+    result = opal_dtostr(1.0);
+    test_verify("dtostr(1.0): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("dtostr(1.0): equals '1.000000'", 0 == strcmp(result, "1.000000"));
+        free(result);
+    }
+
+    /* --- opal_dtostr: positive fractional (original test case) --- */
+    result = opal_dtostr(5.32);
+    test_verify("dtostr(5.32): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("dtostr(5.32): equals '5.320000'", 0 == strcmp(result, "5.320000"));
+        free(result);
+    }
+
+    /* --- opal_dtostr: negative --- */
+    result = opal_dtostr(-3.14);
+    test_verify("dtostr(-3.14): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("dtostr(-3.14): equals '-3.140000'", 0 == strcmp(result, "-3.140000"));
+        free(result);
+    }
+
+    /* --- opal_dtostr: large value --- */
+    result = opal_dtostr(1e6);
+    test_verify("dtostr(1e6): not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("dtostr(1e6): equals '1000000.000000'",
+                    0 == strcmp(result, "1000000.000000"));
+        free(result);
+    }
+
+    return test_finalize();
 }

--- a/test/util/opal_alfg.c
+++ b/test/util/opal_alfg.c
@@ -1,0 +1,315 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/util/alfg.h"
+#include "opal/constants.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Number of values to draw per sequence in divergence/determinism tests */
+#define SEQ_LEN 256
+
+/* -----------------------------------------------------------------------
+ * opal_srand return value
+ * ----------------------------------------------------------------------- */
+
+static void test_srand_returns_one(void)
+{
+    opal_rng_buff_t buff;
+    int rc;
+
+    rc = opal_srand(&buff, 12345u);
+    /* NOTE: unlike other OPAL functions, opal_srand returns 1 on success */
+    test_verify("opal_srand returns 1", 1 == rc);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand: a drawn sequence is not a single constant value
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_not_constant(void)
+{
+    opal_rng_buff_t buff;
+    uint32_t first;
+    uint32_t v;
+    int i;
+    int any_differ = 0;
+
+    opal_srand(&buff, 99999u);
+    first = opal_rand(&buff);
+    for (i = 1; i < SEQ_LEN; i++) {
+        v = opal_rand(&buff);
+        if (v != first) {
+            any_differ = 1;
+        }
+    }
+
+    test_verify("opal_rand: sequence is not a single constant value", any_differ);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand determinism: same seed -> same sequence
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_deterministic(void)
+{
+    opal_rng_buff_t buff1, buff2;
+    uint32_t seq1[SEQ_LEN];
+    uint32_t seq2[SEQ_LEN];
+    int i;
+    int deterministic = 1;
+
+    opal_srand(&buff1, 42u);
+    opal_srand(&buff2, 42u);
+
+    for (i = 0; i < SEQ_LEN; i++) {
+        seq1[i] = opal_rand(&buff1);
+        seq2[i] = opal_rand(&buff2);
+        if (seq1[i] != seq2[i]) {
+            deterministic = 0;
+        }
+    }
+
+    test_verify("opal_rand: same seed produces identical sequences", deterministic);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand divergence: different seeds produce different sequences
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_divergence(void)
+{
+    opal_rng_buff_t buffA, buffB;
+    uint32_t seqA[SEQ_LEN];
+    uint32_t seqB[SEQ_LEN];
+    int i;
+    int any_differ = 0;
+
+    opal_srand(&buffA, 1u);
+    opal_srand(&buffB, 2u);
+
+    for (i = 0; i < SEQ_LEN; i++) {
+        seqA[i] = opal_rand(&buffA);
+        seqB[i] = opal_rand(&buffB);
+        if (seqA[i] != seqB[i]) {
+            any_differ = 1;
+        }
+    }
+
+    test_verify("opal_rand: different seeds produce different sequences", any_differ);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand: re-seeding with same seed resets to same sequence
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_reseed(void)
+{
+    opal_rng_buff_t buff;
+    uint32_t first[SEQ_LEN];
+    uint32_t second[SEQ_LEN];
+    int i;
+    int same = 1;
+
+    opal_srand(&buff, 777u);
+    for (i = 0; i < SEQ_LEN; i++) {
+        first[i] = opal_rand(&buff);
+    }
+
+    /* Re-seed with the same value */
+    opal_srand(&buff, 777u);
+    for (i = 0; i < SEQ_LEN; i++) {
+        second[i] = opal_rand(&buff);
+        if (first[i] != second[i]) {
+            same = 0;
+        }
+    }
+
+    test_verify("opal_rand: re-seeding with same seed restores sequence", same);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand: seed=0 does not crash and produces a sequence
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_seed_zero(void)
+{
+    opal_rng_buff_t buff;
+    int rc;
+    uint32_t v;
+
+    rc = opal_srand(&buff, 0u);
+    test_verify("opal_srand with seed=0 returns 1", 1 == rc);
+    v = opal_rand(&buff);
+    (void) v;
+    test_verify("opal_rand after seed=0: no crash", 1);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand: seed=UINT32_MAX does not crash
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_seed_max(void)
+{
+    opal_rng_buff_t buff;
+    int rc;
+    uint32_t v;
+
+    rc = opal_srand(&buff, UINT32_MAX);
+    test_verify("opal_srand with seed=UINT32_MAX returns 1", 1 == rc);
+    v = opal_rand(&buff);
+    (void) v;
+    test_verify("opal_rand after seed=UINT32_MAX: no crash", 1);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_rand: buffer state is independent across two buffers
+ * ----------------------------------------------------------------------- */
+
+static void test_rand_independent_buffers(void)
+{
+    opal_rng_buff_t buffX, buffY;
+    uint32_t x1, x2, y1, y2;
+
+    opal_srand(&buffX, 10u);
+    opal_srand(&buffY, 20u);
+
+    /* Advance each buffer by a different amount */
+    x1 = opal_rand(&buffX);
+    x2 = opal_rand(&buffX);
+    y1 = opal_rand(&buffY);
+    y2 = opal_rand(&buffY);
+
+    /* Confirm they don't interfere by re-seeding X and checking it */
+    opal_rng_buff_t buffX2;
+    opal_srand(&buffX2, 10u);
+    test_verify("opal_rand: buffX is independent of buffY (first value)",
+                x1 == opal_rand(&buffX2));
+    test_verify("opal_rand: buffX is independent of buffY (second value)",
+                x2 == opal_rand(&buffX2));
+
+    (void) y1;
+    (void) y2;
+}
+
+/* -----------------------------------------------------------------------
+ * opal_random (global wrapper)
+ * ----------------------------------------------------------------------- */
+
+static void test_random_range(void)
+{
+    int v;
+    int i;
+    int all_nonneg = 1;
+
+    /* Seed the global buffer first via a buff; the implementation copies
+     * from buff into the global alfg_buffer inside opal_srand. */
+    opal_rng_buff_t buff;
+    opal_srand(&buff, 55555u);
+
+    for (i = 0; i < SEQ_LEN; i++) {
+        v = opal_random();
+        /* opal_random masks with 0x7FFFFFFF -> always non-negative */
+        if (v < 0) {
+            all_nonneg = 0;
+        }
+    }
+
+    test_verify("opal_random: all values are non-negative", all_nonneg);
+}
+
+static void test_random_deterministic_via_global(void)
+{
+    opal_rng_buff_t buff;
+    int seq1[SEQ_LEN];
+    int seq2[SEQ_LEN];
+    int i;
+    int same = 1;
+
+    /* First run */
+    opal_srand(&buff, 12u);
+    for (i = 0; i < SEQ_LEN; i++) {
+        seq1[i] = opal_random();
+    }
+
+    /* Re-seed global to same value and re-draw */
+    opal_srand(&buff, 12u);
+    for (i = 0; i < SEQ_LEN; i++) {
+        seq2[i] = opal_random();
+        if (seq1[i] != seq2[i]) {
+            same = 0;
+        }
+    }
+
+    test_verify("opal_random: same global seed produces same sequence", same);
+}
+
+static void test_random_not_always_zero(void)
+{
+    opal_rng_buff_t buff;
+    int i;
+    int any_nonzero = 0;
+
+    opal_srand(&buff, 1u);
+    for (i = 0; i < SEQ_LEN; i++) {
+        if (0 != opal_random()) {
+            any_nonzero = 1;
+            break;
+        }
+    }
+
+    test_verify("opal_random: produces non-zero values", any_nonzero);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_alfg");
+
+    /* opal_srand */
+    test_srand_returns_one();
+    test_rand_seed_zero();
+    test_rand_seed_max();
+
+    /* opal_rand */
+    test_rand_not_constant();
+    test_rand_deterministic();
+    test_rand_divergence();
+    test_rand_reseed();
+    test_rand_independent_buffers();
+
+    /* opal_random */
+    test_random_range();
+    test_random_deterministic_via_global();
+    test_random_not_always_zero();
+
+    return test_finalize();
+}

--- a/test/util/opal_arch.c
+++ b/test/util/opal_arch.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal_arch_{init,checkmask,set_fortran_logical_size}.
+ *
+ * KEY FACTS derived from arch.h documentation:
+ *
+ * opal_arch_checkmask(var, mask) returns:
+ *    1   -- all bits in mask are set in *var  (match)
+ *    0   -- mask bits are NOT all set in *var (no match)
+ *   -1   -- *var does not have valid header bits (HEADERMASK in byte-1)
+ *           and cannot be corrected by byte-swapping.
+ *
+ * A valid arch id must have OPAL_ARCH_HEADERMASK set in the high byte (byte 1
+ * of the layout: bits 25-26 of the 32-bit word, i.e., 0x03000000).
+ * OPAL_ARCH_HEADERMASK2 (0x00000003) is the "other end" sentinel and must NOT
+ * be set for a straightforwardly valid id (the swap path is for byte-swapped
+ * remote arch ids).
+ *
+ * Zero-valued encoding macros: LONGIS32 (0), BOOLIS8 (0), LOGICALIS8 (0),
+ * LONGDOUBLEIS64 (0), LDEXPSIZEIS11 (0), LDMANTDIGIS53 (0).
+ * Asserting checkmask on a 0-valued mask is always 1 when the header is
+ * valid; we therefore only use non-zero mask values in assertions.
+ *
+ * opal_arch_init() and opal_arch_set_fortran_logical_size() only OR bits
+ * into opal_local_arch; they never clear bits.  Test interactions are noted
+ * in each sub-test.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/arch.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* test_checkmask_valid_header                                         */
+/*                                                                     */
+/* Build a hand-crafted valid arch id (HEADERMASK set, HEADERMASK2    */
+/* clear) and exercise the trichotomy of return values.               */
+/* ------------------------------------------------------------------ */
+static void test_checkmask_valid_header(void)
+{
+    /* A minimal valid id: header bits set and LONGIS64 set. */
+    uint32_t v;
+    int32_t r;
+
+    v = OPAL_ARCH_HEADERMASK | OPAL_ARCH_LONGIS64;
+
+    /* mask matches: expect 1 */
+    r = opal_arch_checkmask(&v, OPAL_ARCH_LONGIS64);
+    test_verify("checkmask: matching non-zero mask returns 1", 1 == r);
+
+    /* mask does not match: BOOLIS16 is not set; expect 0 */
+    v = OPAL_ARCH_HEADERMASK | OPAL_ARCH_LONGIS64;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_BOOLIS16);
+    test_verify("checkmask: non-matching non-zero mask returns 0", 0 == r);
+
+    /* multiple bits in mask: LONGIS64 | BOOLIS16 -- only LONGIS64 is set */
+    v = OPAL_ARCH_HEADERMASK | OPAL_ARCH_LONGIS64;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_LONGIS64 | OPAL_ARCH_BOOLIS16);
+    test_verify("checkmask: partial mask match returns 0", 0 == r);
+
+    /* all bits of compound mask are set: both LONGIS64 and BOOLIS16 */
+    v = OPAL_ARCH_HEADERMASK | OPAL_ARCH_LONGIS64 | OPAL_ARCH_BOOLIS16;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_LONGIS64 | OPAL_ARCH_BOOLIS16);
+    test_verify("checkmask: all bits of compound mask set returns 1", 1 == r);
+
+    /* ISBIGENDIAN mask -- test both states */
+    v = OPAL_ARCH_HEADERMASK | OPAL_ARCH_ISBIGENDIAN;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_ISBIGENDIAN);
+    test_verify("checkmask: ISBIGENDIAN set -> match returns 1", 1 == r);
+
+    v = OPAL_ARCH_HEADERMASK; /* no ISBIGENDIAN */
+    r = opal_arch_checkmask(&v, OPAL_ARCH_ISBIGENDIAN);
+    test_verify("checkmask: ISBIGENDIAN not set -> match returns 0", 0 == r);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_checkmask_invalid_header                                       */
+/*                                                                     */
+/* An id with no header bits and no HEADERMASK2 bits is invalid; the  */
+/* function must return -1.                                            */
+/* ------------------------------------------------------------------ */
+static void test_checkmask_invalid_header(void)
+{
+    /* Neither HEADERMASK (0x03000000) nor HEADERMASK2 (0x00000003) set. */
+    uint32_t v = OPAL_ARCH_LONGIS64; /* no header at all */
+    int32_t r = opal_arch_checkmask(&v, OPAL_ARCH_LONGIS64);
+    test_verify("checkmask: no header bits returns -1", -1 == r);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_arch_init                                                      */
+/*                                                                     */
+/* After opal_arch_init() the global opal_local_arch must have valid  */
+/* header bits and must not have the other-end sentinel HEADERMASK2.  */
+/* ------------------------------------------------------------------ */
+static void test_arch_init(void)
+{
+    int rc;
+    uint32_t v;
+    int32_t r;
+
+    rc = opal_arch_init();
+    test_verify("opal_arch_init returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Verify header is valid by trying a benign checkmask call. */
+    v = opal_local_arch;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_LONGIS64);
+    test_verify("opal_arch_init: resulting opal_local_arch has valid header",
+                -1 != r);
+
+    /* HEADERMASK must be set. */
+    test_verify("opal_arch_init: HEADERMASK bits set",
+                0 != (opal_local_arch & OPAL_ARCH_HEADERMASK));
+}
+
+/* ------------------------------------------------------------------ */
+/* test_set_fortran_logical_size                                       */
+/*                                                                     */
+/* opal_arch_set_fortran_logical_size() ORs the appropriate           */
+/* LOGICALIS* bits into opal_local_arch.  We call it with size=2      */
+/* (LOGICALIS16, a non-zero mask value) and verify via checkmask.     */
+/*                                                                     */
+/* NOTE: Because init already ran, LOGICALIS8 (0x0) bits cannot be    */
+/* tested this way (it is the zero encoding).  We test LOGICALIS16    */
+/* and LOGICALIS32 which have non-zero bit patterns.                  */
+/* ------------------------------------------------------------------ */
+static void test_set_fortran_logical_size(void)
+{
+    int rc;
+    uint32_t v;
+    int32_t r;
+
+    /* Set logical size to 2 bytes -> LOGICALIS16 (0x00000100) */
+    rc = opal_arch_set_fortran_logical_size(2);
+    test_verify("set_fortran_logical_size(2) returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    v = opal_local_arch;
+    r = opal_arch_checkmask(&v, OPAL_ARCH_LOGICALIS16);
+    test_verify("set_fortran_logical_size(2): LOGICALIS16 bit set",
+                1 == r);
+
+    /* The mask field (LOGICALISxx) should now reflect 16-bit encoding. */
+    test_verify("set_fortran_logical_size(2): LOGICALISxx field == LOGICALIS16",
+                OPAL_ARCH_LOGICALIS16 == (opal_local_arch & OPAL_ARCH_LOGICALISxx));
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_arch");
+
+    opal_init_util(&argc, &argv);
+
+    /*
+     * Run checkmask tests on hand-crafted values first (no dependency on
+     * opal_arch_init state).  Then run arch_init, then set_fortran.
+     */
+    test_checkmask_valid_header();
+    test_checkmask_invalid_header();
+    test_arch_init();
+    test_set_fortran_logical_size();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_argv.c
+++ b/test/util/opal_argv.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,602 +18,834 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
-#include <stdio.h>
+#include "opal_config.h"
+#include "support.h"
+#include "opal/util/argv.h"
+#include "opal/constants.h"
 #include <stdlib.h>
 #include <string.h>
 
-#include "opal/constants.h"
-#include "opal/util/argv.h"
-#include "support.h"
+/* ------------------------------------------------------------------ */
+/* opal_argv_append / opal_argv_append_nosize                         */
+/* ------------------------------------------------------------------ */
 
-static bool test1(void);
-static bool test2(void);
-static bool test3(void);
-static bool test4(void);
-static bool test5(void);
-static bool test6(void);
-static bool test7(void);
-static bool test8(void);
-static bool test9(void);
-static bool test10(void);
+static void test_append(void)
+{
+    char **argv = NULL;
+    int argc = 42; /* intentionally bogus -- must be reset on first call */
+
+    /* First append to NULL argv: argc is updated, array has 1 element + NULL */
+    test_verify("append first: returns OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append(&argc, &argv, "alpha"));
+    test_verify("append first: argc == 1", 1 == argc);
+    test_verify("append first: argv non-NULL", NULL != argv);
+    test_verify("append first: argv[0] is 'alpha'",
+                0 == strcmp("alpha", argv[0]));
+    test_verify("append first: argv[1] is NULL", NULL == argv[1]);
+
+    /* Second append */
+    test_verify("append second: returns OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append(&argc, &argv, "beta"));
+    test_verify("append second: argc == 2", 2 == argc);
+    test_verify("append second: argv[0] still 'alpha'",
+                0 == strcmp("alpha", argv[0]));
+    test_verify("append second: argv[1] is 'beta'",
+                0 == strcmp("beta", argv[1]));
+    test_verify("append second: argv[2] is NULL", NULL == argv[2]);
+
+    /* Strings are copied by value -- mutate source and verify argv unchanged */
+    {
+        char buf[] = "gamma";
+        test_verify("append copy-by-value setup",
+                    OPAL_SUCCESS == opal_argv_append(&argc, &argv, buf));
+        buf[0] = 'X';
+        test_verify("append copy-by-value: stored string unchanged",
+                    0 == strcmp("gamma", argv[2]));
+    }
+
+    opal_argv_free(argv);
+}
+
+static void test_append_nosize(void)
+{
+    char **argv = NULL;
+
+    test_verify("append_nosize first: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append_nosize(&argv, "one"));
+    test_verify("append_nosize first: argv non-NULL", NULL != argv);
+    test_verify("append_nosize first: argv[0] == 'one'",
+                0 == strcmp("one", argv[0]));
+    test_verify("append_nosize first: argv[1] == NULL", NULL == argv[1]);
+
+    test_verify("append_nosize second: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append_nosize(&argv, "two"));
+    test_verify("append_nosize second: argv[1] == 'two'",
+                0 == strcmp("two", argv[1]));
+    test_verify("append_nosize second: argv[2] == NULL", NULL == argv[2]);
+
+    opal_argv_free(argv);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_prepend_nosize                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_prepend(void)
+{
+    char **argv = NULL;
+
+    /* prepend to empty array */
+    test_verify("prepend to NULL: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_prepend_nosize(&argv, "first"));
+    test_verify("prepend to NULL: argv[0] == 'first'",
+                0 == strcmp("first", argv[0]));
+    test_verify("prepend to NULL: argv[1] == NULL", NULL == argv[1]);
+
+    /* prepend a second element */
+    test_verify("prepend second: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_prepend_nosize(&argv, "zero"));
+    test_verify("prepend second: argv[0] == 'zero'",
+                0 == strcmp("zero", argv[0]));
+    test_verify("prepend second: argv[1] == 'first'",
+                0 == strcmp("first", argv[1]));
+    test_verify("prepend second: argv[2] == NULL", NULL == argv[2]);
+
+    /* prepend a third */
+    test_verify("prepend third: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_prepend_nosize(&argv, "neg1"));
+    test_verify("prepend third: argv[0] == 'neg1'",
+                0 == strcmp("neg1", argv[0]));
+    test_verify("prepend third: argv[1] == 'zero'",
+                0 == strcmp("zero", argv[1]));
+    test_verify("prepend third: argv[2] == 'first'",
+                0 == strcmp("first", argv[2]));
+    test_verify("prepend third: argv[3] == NULL", NULL == argv[3]);
+
+    opal_argv_free(argv);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_append_unique_nosize                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_append_unique(void)
+{
+    char **argv = NULL;
+
+    /* Fast path: NULL array -- appends unconditionally */
+    test_verify("unique: NULL array appends",
+                OPAL_SUCCESS == opal_argv_append_unique_nosize(&argv, "x", false));
+    test_verify("unique: NULL array: argv[0] == 'x'",
+                0 == strcmp("x", argv[0]));
+
+    /* Adding a fresh element -- should append */
+    test_verify("unique: new element appended",
+                OPAL_SUCCESS == opal_argv_append_unique_nosize(&argv, "y", false));
+    test_verify("unique: new element: count == 2",
+                2 == opal_argv_count(argv));
+
+    /* Duplicate with overwrite=false -- no change, still OPAL_SUCCESS */
+    test_verify("unique: dup overwrite=false returns OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append_unique_nosize(&argv, "x", false));
+    test_verify("unique: dup overwrite=false: count stays 2",
+                2 == opal_argv_count(argv));
+    test_verify("unique: dup overwrite=false: argv[0] still 'x'",
+                0 == strcmp("x", argv[0]));
+
+    /* Duplicate with overwrite=true -- value replaced, count unchanged */
+    test_verify("unique: dup overwrite=true returns OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_append_unique_nosize(&argv, "x", true));
+    test_verify("unique: dup overwrite=true: count stays 2",
+                2 == opal_argv_count(argv));
+    test_verify("unique: dup overwrite=true: argv[0] still 'x'",
+                0 == strcmp("x", argv[0]));
+
+    opal_argv_free(argv);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_free                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_free(void)
+{
+    char **argv = NULL;
+    int argc = 0;
+
+    /* free(NULL) must be a no-op */
+    opal_argv_free(NULL); /* would segfault if broken */
+    test_verify("free(NULL) is harmless", 1);
+
+    /* build and free a real array */
+    opal_argv_append(&argc, &argv, "a");
+    opal_argv_append(&argc, &argv, "b");
+    opal_argv_free(argv); /* would segfault or fail asan/valgrind if broken */
+    test_verify("free real array is harmless", 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_count                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_count(void)
+{
+    char *a[] = {"a", "b", "c", NULL};
+
+    test_verify("count(NULL) == 0", 0 == opal_argv_count(NULL));
+    test_verify("count(3-elem) == 3", 3 == opal_argv_count(a));
+
+    /* empty array (only NULL terminator) */
+    {
+        char **empty = NULL;
+        int argc = 0;
+        opal_argv_append(&argc, &empty, "tmp");
+        /* delete all */
+        opal_argv_delete(&argc, &empty, 0, 99);
+        test_verify("count after delete-all == 0", 0 == opal_argv_count(empty));
+        opal_argv_free(empty);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_split / opal_argv_split_with_empty                       */
+/* ------------------------------------------------------------------ */
+
+static void test_split(void)
+{
+    char **result;
+
+    /* Basic split */
+    result = opal_argv_split("a:b:c", ':');
+    test_verify("split basic: non-NULL", NULL != result);
+    test_verify("split basic: count == 3", 3 == opal_argv_count(result));
+    test_verify("split basic: [0]=='a'", 0 == strcmp("a", result[0]));
+    test_verify("split basic: [1]=='b'", 0 == strcmp("b", result[1]));
+    test_verify("split basic: [2]=='c'", 0 == strcmp("c", result[2]));
+    opal_argv_free(result);
+
+    /* split skips consecutive delimiters (empty tokens) */
+    result = opal_argv_split("a::b", ':');
+    test_verify("split consecutive delimiters: count == 2",
+                2 == opal_argv_count(result));
+    test_verify("split consecutive: [0]=='a'", 0 == strcmp("a", result[0]));
+    test_verify("split consecutive: [1]=='b'", 0 == strcmp("b", result[1]));
+    opal_argv_free(result);
+
+    /* split skips leading delimiter */
+    result = opal_argv_split(":a:b", ':');
+    test_verify("split leading delim: count == 2", 2 == opal_argv_count(result));
+    test_verify("split leading: [0]=='a'", 0 == strcmp("a", result[0]));
+    opal_argv_free(result);
+
+    /* split skips trailing delimiter */
+    result = opal_argv_split("a:b:", ':');
+    test_verify("split trailing delim: count == 2", 2 == opal_argv_count(result));
+    test_verify("split trailing: [0]=='a'", 0 == strcmp("a", result[0]));
+    test_verify("split trailing: [1]=='b'", 0 == strcmp("b", result[1]));
+    opal_argv_free(result);
+
+    /* split empty string returns NULL (nothing to iterate) */
+    result = opal_argv_split("", ':');
+    test_verify("split empty string: returns NULL", NULL == result);
+    /* (no free needed for NULL) */
+
+    /* split NULL src_string returns NULL */
+    result = opal_argv_split(NULL, ':');
+    test_verify("split NULL src: returns NULL", NULL == result);
+}
+
+static void test_split_with_empty(void)
+{
+    char **result;
+
+    /* Basic split_with_empty -- same as split for non-empty tokens */
+    result = opal_argv_split_with_empty("a:b:c", ':');
+    test_verify("split_with_empty basic: count == 3",
+                3 == opal_argv_count(result));
+    test_verify("split_with_empty basic: [0]=='a'",
+                0 == strcmp("a", result[0]));
+    opal_argv_free(result);
+
+    /* Consecutive delimiters produce empty strings */
+    result = opal_argv_split_with_empty("a::b", ':');
+    test_verify("split_with_empty consecutive: count == 3",
+                3 == opal_argv_count(result));
+    test_verify("split_with_empty consecutive: [0]=='a'",
+                0 == strcmp("a", result[0]));
+    test_verify("split_with_empty consecutive: [1]==''",
+                0 == strcmp("", result[1]));
+    test_verify("split_with_empty consecutive: [2]=='b'",
+                0 == strcmp("b", result[2]));
+    opal_argv_free(result);
+
+    /* Leading delimiter produces empty string at index 0 */
+    result = opal_argv_split_with_empty(":a", ':');
+    test_verify("split_with_empty leading: count == 2",
+                2 == opal_argv_count(result));
+    test_verify("split_with_empty leading: [0]==''",
+                0 == strcmp("", result[0]));
+    test_verify("split_with_empty leading: [1]=='a'",
+                0 == strcmp("a", result[1]));
+    opal_argv_free(result);
+
+    /* An interior empty field is included.  (Whether a *trailing*
+     * delimiter should also yield a trailing empty field is left
+     * unspecified by the documentation -- which only says "include empty
+     * strings" -- and the implementation does not produce one, so we do
+     * not assert that ambiguous case here.) */
+    result = opal_argv_split_with_empty("a::b", ':');
+    test_verify("split_with_empty interior: count == 3", 3 == opal_argv_count(result));
+    test_verify("split_with_empty interior: [0]=='a'", 0 == strcmp("a", result[0]));
+    test_verify("split_with_empty interior: [1]==''", 0 == strcmp("", result[1]));
+    test_verify("split_with_empty interior: [2]=='b'", 0 == strcmp("b", result[2]));
+    opal_argv_free(result);
+
+    /* Difference from split: split_with_empty keeps empty, split does not */
+    {
+        char **without_empty = opal_argv_split("a::b", ':');
+        char **with_empty = opal_argv_split_with_empty("a::b", ':');
+        test_verify("split vs split_with_empty differ on empty tokens",
+                    opal_argv_count(without_empty) < opal_argv_count(with_empty));
+        opal_argv_free(without_empty);
+        opal_argv_free(with_empty);
+    }
+
+    /* Empty source string */
+    result = opal_argv_split_with_empty("", ':');
+    test_verify("split_with_empty empty string: NULL", NULL == result);
+
+    /* NULL source string */
+    result = opal_argv_split_with_empty(NULL, ':');
+    test_verify("split_with_empty NULL src: NULL", NULL == result);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_join / opal_argv_join_range                              */
+/* ------------------------------------------------------------------ */
+
+static void test_join(void)
+{
+    char *joined;
+
+    /* bozo cases */
+    joined = opal_argv_join(NULL, ':');
+    test_verify("join(NULL): returns non-NULL (empty string)",
+                NULL != joined);
+    test_verify("join(NULL): returns empty string",
+                0 == strcmp("", joined));
+    free(joined);
+
+    {
+        char *empty_argv[] = {NULL};
+        joined = opal_argv_join(empty_argv, ':');
+        test_verify("join(empty array): non-NULL", NULL != joined);
+        test_verify("join(empty array): empty string",
+                    0 == strcmp("", joined));
+        free(joined);
+    }
+
+    /* basic join */
+    {
+        char *a[] = {"x", "y", "z", NULL};
+        joined = opal_argv_join(a, ':');
+        test_verify("join basic: non-NULL", NULL != joined);
+        test_verify("join basic: 'x:y:z'",
+                    0 == strcmp("x:y:z", joined));
+        free(joined);
+    }
+
+    /* single element: no delimiter in output */
+    {
+        char *a[] = {"solo", NULL};
+        joined = opal_argv_join(a, ',');
+        test_verify("join single: 'solo'",
+                    0 == strcmp("solo", joined));
+        free(joined);
+    }
+
+    /* round-trip: split then join reproduces original */
+    {
+        char *orig = "the quick brown fox";
+        char **parts = opal_argv_split(orig, ' ');
+        joined = opal_argv_join(parts, ' ');
+        test_verify("join round-trip",
+                    0 == strcmp(orig, joined));
+        free(joined);
+        opal_argv_free(parts);
+    }
+}
+
+static void test_join_range(void)
+{
+    char *joined;
+    char *a[] = {"a", "b", "c", "d", NULL};
+
+    /* bozo: NULL array */
+    joined = opal_argv_join_range(NULL, 0, 2, ':');
+    test_verify("join_range NULL array: non-NULL (empty string)",
+                NULL != joined);
+    test_verify("join_range NULL array: empty string",
+                0 == strcmp("", joined));
+    free(joined);
+
+    /* bozo: start >= count */
+    joined = opal_argv_join_range(a, 99, 100, ':');
+    test_verify("join_range start>=count: empty string",
+                0 == strcmp("", joined));
+    free(joined);
+
+    /* range [1,3) => "b:c" */
+    joined = opal_argv_join_range(a, 1, 3, '-');
+    test_verify("join_range [1,3): non-NULL", NULL != joined);
+    test_verify("join_range [1,3): 'b-c'",
+                0 == strcmp("b-c", joined));
+    free(joined);
+
+    /* range [0,4) => full array */
+    joined = opal_argv_join_range(a, 0, 4, ':');
+    test_verify("join_range [0,4): 'a:b:c:d'",
+                0 == strcmp("a:b:c:d", joined));
+    free(joined);
+
+    /* range [2,4) => "c:d" */
+    joined = opal_argv_join_range(a, 2, 4, ':');
+    test_verify("join_range [2,4): 'c:d'",
+                0 == strcmp("c:d", joined));
+    free(joined);
+
+    /* single element range [1,2) => "b" */
+    joined = opal_argv_join_range(a, 1, 2, ':');
+    test_verify("join_range single element: 'b'",
+                0 == strcmp("b", joined));
+    free(joined);
+
+    /* end beyond array: stops at NULL */
+    joined = opal_argv_join_range(a, 2, 999, ':');
+    test_verify("join_range end>count: 'c:d'",
+                0 == strcmp("c:d", joined));
+    free(joined);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_len                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_len(void)
+{
+    /* NULL returns 0 */
+    test_verify("len(NULL) == 0", (size_t) 0 == opal_argv_len(NULL));
+
+    /* ["a","b","c"]: each entry: strlen + 1 (for '\0') + sizeof(char*),
+       plus one trailing sizeof(char*) for the NULL sentinel pointer.
+       = sizeof(char*) + 3*(1+1+sizeof(char*)) */
+    {
+        char *a[] = {"a", "b", "c", NULL};
+        size_t expected = sizeof(char *) + 3 * (1 + 1 + sizeof(char *));
+        test_verify("len(['a','b','c'])", expected == opal_argv_len(a));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_copy                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_copy(void)
+{
+    /* NULL input returns NULL */
+    test_verify("copy(NULL) == NULL", NULL == opal_argv_copy(NULL));
+
+    /* empty array (just NULL sentinel) returns a valid [NULL] array */
+    {
+        char *empty[] = {NULL};
+        char **dup = opal_argv_copy(empty);
+        test_verify("copy([NULL]): non-NULL", NULL != dup);
+        test_verify("copy([NULL]): count == 0", 0 == opal_argv_count(dup));
+        opal_argv_free(dup);
+    }
+
+    /* normal array: deep copy */
+    {
+        char *a[] = {"foo", "bar", "baz", NULL};
+        char **dup = opal_argv_copy(a);
+        test_verify("copy: non-NULL", NULL != dup);
+        test_verify("copy: count matches",
+                    opal_argv_count(a) == opal_argv_count(dup));
+        test_verify("copy: [0] matches", 0 == strcmp(a[0], dup[0]));
+        test_verify("copy: [1] matches", 0 == strcmp(a[1], dup[1]));
+        test_verify("copy: [2] matches", 0 == strcmp(a[2], dup[2]));
+        /* deep copy: different pointers */
+        test_verify("copy: [0] different pointer", a[0] != dup[0]);
+        opal_argv_free(dup);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_delete                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_delete(void)
+{
+    char **a;
+    int argc;
+
+    /* bozo: NULL argv/NULL *argv => OPAL_SUCCESS */
+    test_verify("delete(NULL,NULL): OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(NULL, NULL, 0, 0));
+
+    /* bozo: 0 num_to_delete => no-op */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "alpha");
+    test_verify("delete 0 items: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 0, 0));
+    test_verify("delete 0 items: count unchanged", 1 == opal_argv_count(a));
+    opal_argv_free(a);
+
+    /* bozo: start > count => no-op */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "alpha");
+    test_verify("delete start>count: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 7, 1));
+    test_verify("delete start>count: count unchanged", 1 == opal_argv_count(a));
+    opal_argv_free(a);
+
+    /* bad param: negative start */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "alpha");
+    test_verify("delete negative start: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_argv_delete(&argc, &a, -1, 1));
+    opal_argv_free(a);
+
+    /* delete first element */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    opal_argv_append(&argc, &a, "c");
+    test_verify("delete first: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 0, 1));
+    test_verify("delete first: count == 2", 2 == opal_argv_count(a));
+    test_verify("delete first: [0]=='b'", 0 == strcmp("b", a[0]));
+    test_verify("delete first: [1]=='c'", 0 == strcmp("c", a[1]));
+    opal_argv_free(a);
+
+    /* delete from middle */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    opal_argv_append(&argc, &a, "c");
+    opal_argv_append(&argc, &a, "d");
+    test_verify("delete middle: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 1, 2));
+    test_verify("delete middle: count == 2", 2 == opal_argv_count(a));
+    test_verify("delete middle: [0]=='a'", 0 == strcmp("a", a[0]));
+    test_verify("delete middle: [1]=='d'", 0 == strcmp("d", a[1]));
+    opal_argv_free(a);
+
+    /* delete from end */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    opal_argv_append(&argc, &a, "c");
+    test_verify("delete from end: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 2, 1));
+    test_verify("delete from end: count == 2", 2 == opal_argv_count(a));
+    test_verify("delete from end: [0]=='a'", 0 == strcmp("a", a[0]));
+    test_verify("delete from end: [1]=='b'", 0 == strcmp("b", a[1]));
+    opal_argv_free(a);
+
+    /* over-delete: num_to_delete exceeds remaining elements */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    test_verify("delete over-delete: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 0, 99));
+    test_verify("delete over-delete: count == 0", 0 == opal_argv_count(a));
+    /* Over-deleting (asking to remove more elements than exist) must
+     * still leave argc consistent with the actual array length. */
+    test_verify("delete over-delete: argc == count", argc == opal_argv_count(a));
+    opal_argv_free(a);
+
+    /* delete all starting from middle */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    opal_argv_append(&argc, &a, "c");
+    test_verify("delete from middle to end: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 1, 99));
+    test_verify("delete from middle to end: count == 1", 1 == opal_argv_count(a));
+    test_verify("delete from middle to end: [0]=='a'", 0 == strcmp("a", a[0]));
+    opal_argv_free(a);
+
+    /* delete last of 6 */
+    a = NULL;
+    argc = 0;
+    opal_argv_append(&argc, &a, "a");
+    opal_argv_append(&argc, &a, "b");
+    opal_argv_append(&argc, &a, "c");
+    opal_argv_append(&argc, &a, "d");
+    opal_argv_append(&argc, &a, "e");
+    opal_argv_append(&argc, &a, "f");
+    test_verify("delete last of 6: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_delete(&argc, &a, 5, 1));
+    test_verify("delete last of 6: count == 5", 5 == opal_argv_count(a));
+    test_verify("delete last of 6: [4]=='e'", 0 == strcmp("e", a[4]));
+    opal_argv_free(a);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_insert                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_insert(void)
+{
+    char **target;
+    char **source;
+    int t, s;
+
+    /* bozo: NULL target => OPAL_ERR_BAD_PARAM */
+    test_verify("insert NULL target: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_argv_insert(NULL, 0, NULL));
+
+    /* bozo: *target is NULL => OPAL_ERR_BAD_PARAM */
+    {
+        char **p = NULL;
+        test_verify("insert *target==NULL: OPAL_ERR_BAD_PARAM",
+                    OPAL_ERR_BAD_PARAM == opal_argv_insert(&p, 0, NULL));
+    }
+
+    /* bozo: negative start => OPAL_ERR_BAD_PARAM */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "orig a");
+    test_verify("insert negative start: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_argv_insert(&target, -1, NULL));
+    opal_argv_free(target);
+
+    /* NULL source => no-op, OPAL_SUCCESS */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "orig a");
+    test_verify("insert NULL source: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert(&target, 0, NULL));
+    test_verify("insert NULL source: count unchanged", 1 == opal_argv_count(target));
+    opal_argv_free(target);
+
+    /* append to end (start > count) */
+    target = NULL;
+    t = 0;
+    source = NULL;
+    s = 0;
+    opal_argv_append(&t, &target, "orig a");
+    opal_argv_append(&t, &target, "orig b");
+    opal_argv_append(&s, &source, "ins a");
+    opal_argv_append(&s, &source, "ins b");
+    test_verify("insert beyond end: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert(&target, 99, source));
+    test_verify("insert beyond end: count == 4", 4 == opal_argv_count(target));
+    test_verify("insert beyond end: [0]=='orig a'",
+                0 == strcmp("orig a", target[0]));
+    test_verify("insert beyond end: [2]=='ins a'",
+                0 == strcmp("ins a", target[2]));
+    test_verify("insert beyond end: [3]=='ins b'",
+                0 == strcmp("ins b", target[3]));
+    opal_argv_free(target);
+    opal_argv_free(source);
+
+    /* insert at position 0 (beginning) */
+    target = NULL;
+    t = 0;
+    source = NULL;
+    s = 0;
+    opal_argv_append(&t, &target, "orig a");
+    opal_argv_append(&t, &target, "orig b");
+    opal_argv_append(&t, &target, "orig c");
+    opal_argv_append(&s, &source, "ins a");
+    opal_argv_append(&s, &source, "ins b");
+    opal_argv_append(&s, &source, "ins c");
+    test_verify("insert at 0: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert(&target, 0, source));
+    test_verify("insert at 0: count == 6", 6 == opal_argv_count(target));
+    test_verify("insert at 0: [0]=='ins a'",
+                0 == strcmp("ins a", target[0]));
+    test_verify("insert at 0: [1]=='ins b'",
+                0 == strcmp("ins b", target[1]));
+    test_verify("insert at 0: [2]=='ins c'",
+                0 == strcmp("ins c", target[2]));
+    test_verify("insert at 0: [3]=='orig a'",
+                0 == strcmp("orig a", target[3]));
+    test_verify("insert at 0: [4]=='orig b'",
+                0 == strcmp("orig b", target[4]));
+    test_verify("insert at 0: [5]=='orig c'",
+                0 == strcmp("orig c", target[5]));
+    opal_argv_free(target);
+    opal_argv_free(source);
+
+    /* insert in the middle */
+    target = NULL;
+    t = 0;
+    source = NULL;
+    s = 0;
+    opal_argv_append(&t, &target, "orig a");
+    opal_argv_append(&t, &target, "orig b");
+    opal_argv_append(&t, &target, "orig c");
+    opal_argv_append(&s, &source, "ins a");
+    opal_argv_append(&s, &source, "ins b");
+    test_verify("insert middle: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert(&target, 1, source));
+    test_verify("insert middle: count == 5", 5 == opal_argv_count(target));
+    test_verify("insert middle: [0]=='orig a'",
+                0 == strcmp("orig a", target[0]));
+    test_verify("insert middle: [1]=='ins a'",
+                0 == strcmp("ins a", target[1]));
+    test_verify("insert middle: [2]=='ins b'",
+                0 == strcmp("ins b", target[2]));
+    test_verify("insert middle: [3]=='orig b'",
+                0 == strcmp("orig b", target[3]));
+    test_verify("insert middle: [4]=='orig c'",
+                0 == strcmp("orig c", target[4]));
+    opal_argv_free(target);
+    opal_argv_free(source);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_argv_insert_element                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_insert_element(void)
+{
+    char **target;
+    int t;
+    char elem[] = "NEW";
+
+    /* bozo: NULL target */
+    test_verify("insert_element NULL target: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_argv_insert_element(NULL, 0, elem));
+
+    /* bozo: *target is NULL */
+    {
+        char **p = NULL;
+        test_verify("insert_element *target==NULL: OPAL_ERR_BAD_PARAM",
+                    OPAL_ERR_BAD_PARAM == opal_argv_insert_element(&p, 0, elem));
+    }
+
+    /* bozo: negative location */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    test_verify("insert_element negative loc: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == opal_argv_insert_element(&target, -1, elem));
+    opal_argv_free(target);
+
+    /* NULL source element: no-op */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    test_verify("insert_element NULL source: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert_element(&target, 0, NULL));
+    test_verify("insert_element NULL source: count unchanged",
+                1 == opal_argv_count(target));
+    opal_argv_free(target);
+
+    /* insert at position 0 (front) */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    opal_argv_append(&t, &target, "b");
+    opal_argv_append(&t, &target, "c");
+    test_verify("insert_element at 0: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert_element(&target, 0, elem));
+    test_verify("insert_element at 0: count == 4", 4 == opal_argv_count(target));
+    test_verify("insert_element at 0: [0]=='NEW'",
+                0 == strcmp("NEW", target[0]));
+    test_verify("insert_element at 0: [1]=='a'",
+                0 == strcmp("a", target[1]));
+    test_verify("insert_element at 0: [2]=='b'",
+                0 == strcmp("b", target[2]));
+    test_verify("insert_element at 0: [3]=='c'",
+                0 == strcmp("c", target[3]));
+    opal_argv_free(target);
+
+    /* insert in the middle */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    opal_argv_append(&t, &target, "b");
+    opal_argv_append(&t, &target, "c");
+    test_verify("insert_element middle: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert_element(&target, 1, elem));
+    test_verify("insert_element middle: count == 4", 4 == opal_argv_count(target));
+    test_verify("insert_element middle: [0]=='a'",
+                0 == strcmp("a", target[0]));
+    test_verify("insert_element middle: [1]=='NEW'",
+                0 == strcmp("NEW", target[1]));
+    test_verify("insert_element middle: [2]=='b'",
+                0 == strcmp("b", target[2]));
+    test_verify("insert_element middle: [3]=='c'",
+                0 == strcmp("c", target[3]));
+    opal_argv_free(target);
+
+    /* insert at end (location == count) */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    opal_argv_append(&t, &target, "b");
+    test_verify("insert_element at count (end): OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert_element(&target, 2, elem));
+    test_verify("insert_element at end: count == 3", 3 == opal_argv_count(target));
+    test_verify("insert_element at end: [0]=='a'",
+                0 == strcmp("a", target[0]));
+    test_verify("insert_element at end: [1]=='b'",
+                0 == strcmp("b", target[1]));
+    test_verify("insert_element at end: [2]=='NEW'",
+                0 == strcmp("NEW", target[2]));
+    opal_argv_free(target);
+
+    /* insert beyond end (location > count): appended */
+    target = NULL;
+    t = 0;
+    opal_argv_append(&t, &target, "a");
+    test_verify("insert_element beyond end: OPAL_SUCCESS",
+                OPAL_SUCCESS == opal_argv_insert_element(&target, 99, elem));
+    test_verify("insert_element beyond end: count == 2",
+                2 == opal_argv_count(target));
+    test_verify("insert_element beyond end: [1]=='NEW'",
+                0 == strcmp("NEW", target[1]));
+    opal_argv_free(target);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char *argv[])
 {
+    (void) argc;
+    (void) argv;
 
-    test_init("opal_argv_t");
+    test_init("opal_argv");
 
-    if (test1())
-        test_success();
-    else
-        test_failure("test1 argv test failed");
+    test_append();
+    test_append_nosize();
+    test_prepend();
+    test_append_unique();
+    test_free();
+    test_count();
+    test_split();
+    test_split_with_empty();
+    test_join();
+    test_join_range();
+    test_len();
+    test_copy();
+    test_delete();
+    test_insert();
+    test_insert_element();
 
-    if (test2())
-        test_success();
-    else
-        test_failure("test2 argv test failed");
-
-    if (test3())
-        test_success();
-    else
-        test_failure("test3 argv test failed");
-
-    if (test4())
-        test_success();
-    else
-        test_failure("test4 argv test failed");
-
-    if (test5())
-        test_success();
-    else
-        test_failure("test5 argv test failed");
-
-    if (test6())
-        test_success();
-    else
-        test_failure("test6 argv test failed");
-
-    if (test7())
-        test_success();
-    else
-        test_failure("test7 argv test failed");
-
-    if (test8())
-        test_success();
-    else
-        test_failure("test8 argv test failed");
-
-    if (test9()) {
-        test_success();
-    } else {
-        test_failure("test9 argv test failed");
-    }
-
-    if (test10()) {
-        test_success();
-    } else {
-        test_failure("test10 argv test failed");
-    }
-
-    /* All done */
     return test_finalize();
-}
-
-static bool test1(void)
-{
-    char *a[] = {"argv1", "argv2", "argv3", NULL};
-    char **argv = NULL;
-    int i, j, argc = 28;
-
-    /* Test basic functionality.  Start with a NULL argv and add the
-       contents of the a array.
-
-       Set argc to be an initial bogus number -- opal_argv_add() should
-       reset it back to zero after the first iteration.
-
-       After adding the a[i], ensure that argv[0 - (i-1)] are the same
-       as a[0 - (i-1)].
-
-       Also ensure that a[i + 1] == NULL and that argc is the proper
-       value. */
-
-    for (i = 0; a[i] != NULL; ++i) {
-        if (opal_argv_append(&argc, &argv, a[i]) != OPAL_SUCCESS) {
-            return false;
-        }
-        for (j = 0; j <= i; ++j) {
-            if (strcmp(argv[j], a[j]) != 0) {
-                return false;
-            }
-        }
-        if (NULL != argv[i + 1]) {
-            return false;
-        }
-        if (argc != i + 1) {
-            return false;
-        }
-    }
-    opal_argv_free(argv);
-
-    return true;
-}
-
-static bool test2(void)
-{
-    int i, j;
-    char **argv = NULL;
-    int argc;
-    char *a[] = {"aaa", "bbb", "ccc", NULL};
-    char *b[4];
-
-    /* Similar test to above, but ensure that opal_argv_add is actually
-       *copying* the string by value, not by reference.  So copy the a
-       array into b, and then opal_argv_add() from b.  After that,
-       scribble in the first character of the b[] string that we just
-       added, and compare all entries in a to argv -- they should be
-       identical (even though b is now corrupted). */
-
-    for (i = 0; a[i] != NULL; ++i) {
-        b[i] = strdup(a[i]);
-    }
-    b[i] = NULL;
-
-    for (i = 0; b[i] != NULL; ++i) {
-        if (opal_argv_append(&argc, &argv, b[i]) != OPAL_SUCCESS) {
-            return false;
-        }
-        ++b[i][0];
-        for (j = 0; j <= i; ++j) {
-            if (strcmp(argv[j], a[j]) != 0) {
-                return false;
-            }
-        }
-        if (NULL != argv[i + 1]) {
-            return false;
-        }
-        if (argc != i + 1) {
-            return false;
-        }
-    }
-
-    opal_argv_free(argv);
-    for (i = 0; b[i] != NULL; ++i) {
-        free(b[i]);
-    }
-
-    return true;
-}
-
-static bool test3(void)
-{
-    int i;
-    int argc;
-    char **argv = NULL;
-    char *a[] = {"aaa", "bbb", "ccc", NULL};
-    char *b[4];
-
-    /* Try to free a null argv -- should be harmless (we'll seg fault if
-       it's not!) */
-
-    opal_argv_free(argv);
-
-    /* Now add some stuff and try to free it.  We'll seg fault if
-       anything goes wrong.  a is on the stack, so if it mistakenly
-       tries to free it, we should get a seg fault. */
-
-    for (i = 0; a[i] != NULL; ++i) {
-        if (opal_argv_append(&argc, &argv, a[i]) != OPAL_SUCCESS) {
-            return false;
-        }
-    }
-    opal_argv_free(argv);
-
-    /* Do the same thing but guarantee that the copied array was from
-       the heap and was freed before we call opal_argv_free(). */
-
-    argc = 0;
-    argv = NULL;
-    for (i = 0; a[i] != NULL; ++i) {
-        b[i] = strdup(a[i]);
-    }
-    b[i] = NULL;
-    for (i = 0; b[i] != NULL; ++i) {
-        if (opal_argv_append(&argc, &argv, b[i]) != OPAL_SUCCESS) {
-            return false;
-        }
-    }
-    for (i = 0; b[i] != NULL; ++i) {
-        free(b[i]);
-    }
-    opal_argv_free(argv);
-
-    /* All done */
-
-    return true;
-}
-
-static bool test4(void)
-{
-    size_t i, count;
-    char *a = strdup("the quick  brown fox jumped over  the lazy  dog "
-                     "a_really_long_argument_to_force_a_long_copy_"
-                     "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-                     "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz");
-    char **b;
-    char *start;
-
-    /* split a string into an argv, and compare it against the original
-       string.  Add double spaces into the string; opal_argv_split()
-       should skip them. */
-
-    b = opal_argv_split(a, ' ');
-
-    for (count = i = 1; i < strlen(a); ++i) {
-        if (a[i] != ' ' && a[i - 1] == ' ') {
-            ++count;
-        }
-    }
-    for (i = 0; b[i] != NULL; ++i) {
-        continue;
-    }
-    if (i != count) {
-        return false;
-    }
-
-    /* now do the same thing and compare each token in b */
-
-    for (start = a, count = i = 0; i < strlen(a); ++i) {
-        if (a[i] == ' ' && a[i - 1] != ' ') {
-            a[i] = '\0';
-            if (strcmp(start, b[count]) != 0) {
-                return false;
-            }
-            ++count;
-            a[i] = ' ';
-        }
-        if (a[i] == ' ' && a[i + 1] != ' ') {
-            start = a + i + 1;
-        }
-    }
-    if (strcmp(start, b[count]) != 0) {
-        return false;
-    }
-
-    /* all done */
-
-    opal_argv_free(b);
-    free(a);
-    return true;
-}
-
-static bool test5(void)
-{
-    char *a[] = {"aaa", "bbb", "ccc", NULL};
-
-    return (opal_argv_count(NULL) == 0 && opal_argv_count(a) == 3);
-}
-
-static bool test6(void)
-{
-    char *a = "the quick brown fox jumped over the lazy dog "
-              "a_really_long_argument_to_force_a_long_copy_"
-              "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-              "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-    char **b;
-    char *c;
-
-    /* split the string above and then join it -- the joined version
-       should be just like the original */
-
-    b = opal_argv_split(a, ' ');
-    c = opal_argv_join(b, ' ');
-
-    if (strcmp(a, c) != 0) {
-        return false;
-    }
-
-    /* All done */
-
-    free(c);
-    opal_argv_free(b);
-    return true;
-}
-
-static bool test7(void)
-{
-    char *a[] = {"a", "b", "c", NULL};
-    size_t a_len = (1 + 1 + sizeof(char *)) * 3 + sizeof(char **);
-
-    /* check a NULL pointer first -- should return 0 */
-
-    if (opal_argv_len(NULL) != (size_t) 0) {
-        return false;
-    }
-
-    /* now check a real string */
-    /* size should be (sizeof(char **) + (sizeof(char) + sizeof('\0') +
-       sizeof(char*)) * 3) */
-
-    if (opal_argv_len(a) != a_len) {
-        return false;
-    }
-
-    /* All done */
-
-    return true;
-}
-
-static bool test8(void)
-{
-    char *a[] = {"aaa", "bbbbbbbb", "cccccccccc", NULL};
-    int i;
-    char **b;
-
-    /* bozo case */
-
-    if (NULL != opal_argv_copy(NULL)) {
-        return false;
-    }
-
-    /* dup the a array and compare it (array length, contents, etc.) */
-
-    b = opal_argv_copy(a);
-
-    if (opal_argv_count(a) != opal_argv_count(b)) {
-        return false;
-    }
-    for (i = 0; a[i] != NULL; ++i) {
-        if (0 != strcmp(a[i], b[i])) {
-            return false;
-        }
-    }
-
-    /* All done */
-
-    opal_argv_free(b);
-    return true;
-}
-
-static bool test9(void)
-{
-    char **a = NULL;
-    int argc;
-
-    /* bozo cases */
-
-    if (OPAL_SUCCESS != opal_argv_delete(NULL, NULL, 0, 0)) {
-        return false;
-    }
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "foo");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 7, 1) || 1 != opal_argv_count(a)) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "foo");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 0, 0) || 1 != opal_argv_count(a)) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* now some real tests */
-    /* delete 1 off the top */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    opal_argv_append(&argc, &a, "c");
-    opal_argv_append(&argc, &a, "d");
-    opal_argv_append(&argc, &a, "e");
-    opal_argv_append(&argc, &a, "f");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 0, 1) || 5 != opal_argv_count(a)
-        || 0 != strcmp(a[0], "b") || 0 != strcmp(a[1], "c") || 0 != strcmp(a[2], "d")
-        || 0 != strcmp(a[3], "e") || 0 != strcmp(a[4], "f")) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* delete 2 off the top */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    opal_argv_append(&argc, &a, "c");
-    opal_argv_append(&argc, &a, "d");
-    opal_argv_append(&argc, &a, "e");
-    opal_argv_append(&argc, &a, "f");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 0, 2) || 4 != opal_argv_count(a)
-        || 0 != strcmp(a[0], "c") || 0 != strcmp(a[1], "d") || 0 != strcmp(a[2], "e")
-        || 0 != strcmp(a[3], "f")) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* delete 1 in the middle */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    opal_argv_append(&argc, &a, "c");
-    opal_argv_append(&argc, &a, "d");
-    opal_argv_append(&argc, &a, "e");
-    opal_argv_append(&argc, &a, "f");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 1, 1) || 5 != opal_argv_count(a)
-        || 0 != strcmp(a[0], "a") || 0 != strcmp(a[1], "c") || 0 != strcmp(a[2], "d")
-        || 0 != strcmp(a[3], "e") || 0 != strcmp(a[4], "f")) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* delete 2 in the middle */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    opal_argv_append(&argc, &a, "c");
-    opal_argv_append(&argc, &a, "d");
-    opal_argv_append(&argc, &a, "e");
-    opal_argv_append(&argc, &a, "f");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 1, 2) || 4 != opal_argv_count(a)
-        || 0 != strcmp(a[0], "a") || 0 != strcmp(a[1], "d") || 0 != strcmp(a[2], "e")
-        || 0 != strcmp(a[3], "f")) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* delete everything from the top */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 0, 99) || 0 != opal_argv_count(a)) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* delete everything from the middle */
-
-    a = NULL;
-    argc = 0;
-    opal_argv_append(&argc, &a, "a");
-    opal_argv_append(&argc, &a, "b");
-    if (OPAL_SUCCESS != opal_argv_delete(&argc, &a, 1, 99) || 1 != opal_argv_count(a)
-        || 0 != strcmp(a[0], "a")) {
-        return false;
-    }
-    opal_argv_free(a);
-
-    /* All done */
-
-    return true;
-}
-
-static bool test10(void)
-{
-    char **orig;
-    char **insert;
-    int o, i;
-
-    /* bozo cases */
-
-    orig = NULL;
-    o = 0;
-    insert = NULL;
-    i = 0;
-    opal_argv_append(&i, &insert, "insert a");
-    if (OPAL_SUCCESS == opal_argv_insert(NULL, 0, insert)) {
-        return false;
-    }
-    opal_argv_append(&o, &orig, "orig a");
-    if (OPAL_SUCCESS != opal_argv_insert(&orig, 0, NULL)) {
-        return false;
-    }
-    if (OPAL_SUCCESS == opal_argv_insert(&orig, -1, insert)) {
-        return false;
-    }
-    opal_argv_free(orig);
-    opal_argv_free(insert);
-
-    /* append to the end */
-
-    orig = NULL;
-    o = 0;
-    insert = NULL;
-    i = 0;
-    opal_argv_append(&i, &insert, "insert a");
-    opal_argv_append(&i, &insert, "insert b");
-    opal_argv_append(&i, &insert, "insert c");
-    opal_argv_append(&o, &orig, "orig a");
-    opal_argv_append(&o, &orig, "orig b");
-    opal_argv_append(&o, &orig, "orig c");
-    if (OPAL_SUCCESS != opal_argv_insert(&orig, 99, insert) || 6 != opal_argv_count(orig)
-        || 0 != strcmp(orig[0], "orig a") || 0 != strcmp(orig[1], "orig b")
-        || 0 != strcmp(orig[2], "orig c") || 0 != strcmp(orig[3], "insert a")
-        || 0 != strcmp(orig[4], "insert b") || 0 != strcmp(orig[5], "insert c")) {
-        return false;
-    }
-    opal_argv_free(orig);
-    opal_argv_free(insert);
-
-    /* insert at the beginning */
-
-    orig = NULL;
-    o = 0;
-    insert = NULL;
-    i = 0;
-    opal_argv_append(&i, &insert, "insert a");
-    opal_argv_append(&i, &insert, "insert b");
-    opal_argv_append(&i, &insert, "insert c");
-    opal_argv_append(&o, &orig, "orig a");
-    opal_argv_append(&o, &orig, "orig b");
-    opal_argv_append(&o, &orig, "orig c");
-    if (OPAL_SUCCESS != opal_argv_insert(&orig, 0, insert) || 6 != opal_argv_count(orig)
-        || 0 != strcmp(orig[3], "orig a") || 0 != strcmp(orig[4], "orig b")
-        || 0 != strcmp(orig[5], "orig c") || 0 != strcmp(orig[0], "insert a")
-        || 0 != strcmp(orig[1], "insert b") || 0 != strcmp(orig[2], "insert c")) {
-        return false;
-    }
-    opal_argv_free(orig);
-    opal_argv_free(insert);
-
-    /* insert in the middle */
-
-    orig = NULL;
-    o = 0;
-    insert = NULL;
-    i = 0;
-    opal_argv_append(&i, &insert, "insert a");
-    opal_argv_append(&i, &insert, "insert b");
-    opal_argv_append(&i, &insert, "insert c");
-    opal_argv_append(&o, &orig, "orig a");
-    opal_argv_append(&o, &orig, "orig b");
-    opal_argv_append(&o, &orig, "orig c");
-    if (OPAL_SUCCESS != opal_argv_insert(&orig, 1, insert) || 6 != opal_argv_count(orig)
-        || 0 != strcmp(orig[0], "orig a") || 0 != strcmp(orig[4], "orig b")
-        || 0 != strcmp(orig[5], "orig c") || 0 != strcmp(orig[1], "insert a")
-        || 0 != strcmp(orig[2], "insert b") || 0 != strcmp(orig[3], "insert c")) {
-        return false;
-    }
-    opal_argv_free(orig);
-    opal_argv_free(insert);
-
-    /* insert in the middle */
-
-    orig = NULL;
-    o = 0;
-    insert = NULL;
-    i = 0;
-    opal_argv_append(&i, &insert, "insert a");
-    opal_argv_append(&i, &insert, "insert b");
-    opal_argv_append(&i, &insert, "insert c");
-    opal_argv_append(&o, &orig, "orig a");
-    opal_argv_append(&o, &orig, "orig b");
-    opal_argv_append(&o, &orig, "orig c");
-    opal_argv_append(&o, &orig, "orig d");
-    opal_argv_append(&o, &orig, "orig e");
-    opal_argv_append(&o, &orig, "orig f");
-    if (OPAL_SUCCESS != opal_argv_insert(&orig, 1, insert) || 9 != opal_argv_count(orig)
-        || 0 != strcmp(orig[0], "orig a") || 0 != strcmp(orig[4], "orig b")
-        || 0 != strcmp(orig[5], "orig c") || 0 != strcmp(orig[6], "orig d")
-        || 0 != strcmp(orig[7], "orig e") || 0 != strcmp(orig[8], "orig f")
-        || 0 != strcmp(orig[1], "insert a") || 0 != strcmp(orig[2], "insert b")
-        || 0 != strcmp(orig[3], "insert c")) {
-        return false;
-    }
-    opal_argv_free(orig);
-    opal_argv_free(insert);
-
-    /* All done */
-
-    return true;
 }

--- a/test/util/opal_basename.c
+++ b/test/util/opal_basename.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,49 +18,145 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
+#include "opal_config.h"
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "opal/util/basename.h"
-#include "opal/util/printf.h"
 #include "support.h"
+#include "opal/util/basename.h"
+#include "opal/constants.h"
 
-static void test(const char *in, const char *out);
+/* Helper that tests opal_basename and frees the result. */
+static void check_basename(const char *input, const char *expected)
+{
+    char *result = opal_basename(input);
+    char msg[256];
+
+    if (NULL == expected) {
+        snprintf(msg, sizeof(msg),
+                 "basename(NULL): expected NULL, got '%s'",
+                 result ? result : "(null)");
+        test_verify(msg, NULL == result);
+        /* result should already be NULL here, but free defensively */
+        if (NULL != result) {
+            free(result);
+        }
+        return;
+    }
+
+    snprintf(msg, sizeof(msg),
+             "basename(\"%s\"): expected \"%s\", got \"%s\"",
+             input ? input : "(null)", expected,
+             result ? result : "(null)");
+    test_verify(msg, NULL != result && 0 == strcmp(result, expected));
+    if (NULL != result) {
+        free(result);
+    }
+}
+
+/* Helper that tests opal_dirname and frees the result. */
+static void check_dirname(const char *input, const char *expected)
+{
+    char *result = opal_dirname(input);
+    char msg[256];
+
+    snprintf(msg, sizeof(msg),
+             "dirname(\"%s\"): expected \"%s\", got \"%s\"",
+             input ? input : "(null)", expected,
+             result ? result : "(null)");
+    test_verify(msg, NULL != result && 0 == strcmp(result, expected));
+    if (NULL != result) {
+        free(result);
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    test_init("opal_basename()");
+    test_init("opal_basename_dirname");
 
-    test("foo.txt", "foo.txt");
-    test("/foo/bar/baz", "baz");
-    test("/yow.c", "yow.c");
-    test("/", "/");
+    /* ================================================================
+     * opal_basename() tests
+     * ================================================================ */
 
-    test("foo.txt/", "foo.txt");
-    test("/foo/bar/baz/", "baz");
-    test("/yow.c/", "yow.c");
-    test("//", "/");
+    /* NULL input -> NULL return */
+    check_basename(NULL, NULL);
 
-    /* All done */
+    /* Empty string -> empty string */
+    check_basename("", "");
+
+    /* No slash -> entire string */
+    check_basename("foo.txt", "foo.txt");
+    check_basename("foo", "foo");
+
+    /* Absolute paths */
+    check_basename("/foo/bar/baz", "baz");
+    check_basename("/yow.c", "yow.c");
+
+    /* Root: "/" -> "/" */
+    check_basename("/", "/");
+
+    /* Trailing slash is stripped */
+    check_basename("foo.txt/", "foo.txt");
+    check_basename("/foo/bar/baz/", "baz");
+    check_basename("/yow.c/", "yow.c");
+
+    /* Double trailing slash */
+    check_basename("//", "/");
+
+    /* Multiple trailing slashes on a path */
+    check_basename("/foo/bar///", "bar");
+
+    /* Single component with trailing slash */
+    check_basename("onlyone/", "onlyone");
+
+    /* Dot and dot-dot */
+    check_basename(".", ".");
+    check_basename("..", "..");
+
+    /* ================================================================
+     * opal_dirname() tests
+     *
+     * NOTE: The header's documentation examples for opal_dirname() are
+     * incorrect -- they list "foo.txt" -> "foo.txt" and "/" -> "", which
+     * are basename examples, not dirname. We assert POSIX dirname(3)
+     * behavior, which is the authoritative reference and matches the
+     * libc-delegating implementation used on systems that have dirname().
+     * ================================================================ */
+
+    /* No slash -> "." (POSIX dirname of a bare filename) */
+    check_dirname("foo.txt", ".");
+    check_dirname("foo", ".");
+
+    /* Absolute paths */
+    check_dirname("/foo/bar/baz", "/foo/bar");
+    check_dirname("/yow.c", "/");
+
+    /* Root: "/" -> "/" (POSIX) */
+    check_dirname("/", "/");
+
+    /* Trailing slash: POSIX dirname treats trailing slashes as if stripped */
+    check_dirname("/foo/bar/baz/", "/foo/bar");
+    check_dirname("/usr/", "/");
+
+    /* Two-level */
+    check_dirname("/a/b", "/a");
+
+    /* Single component absolute */
+    check_dirname("/single", "/");
+
+    /* Dot */
+    check_dirname(".", ".");
+
+    /* opal_dirname(NULL) is guarded (mirroring opal_basename) and
+       returns NULL rather than dereferencing the NULL pointer. */
+    {
+        char *d = opal_dirname(NULL);
+        test_verify("dirname(NULL) returns NULL", NULL == d);
+        if (NULL != d) {
+            free(d);
+        }
+    }
+
     return test_finalize();
-}
-
-void test(const char *in, const char *out)
-{
-    char *msg;
-    char *ret = opal_basename(in);
-
-    if (0 == strcmp(ret, out)) {
-        test_success();
-    } else {
-        opal_asprintf(&msg, "Mismatch: input \"%s\", expected \"%s\", got \"%s\"\n", in, out, ret);
-        test_failure(msg);
-        free(msg);
-    }
-    if (NULL != ret) {
-        free(ret);
-    }
 }

--- a/test/util/opal_cmd_line.c
+++ b/test/util/opal_cmd_line.c
@@ -1,0 +1,937 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit test for opal_cmd_line_t and its full public API.
+ *
+ * Coverage targets (opal/util/cmd_line.c, 539 lines, 0% prior coverage):
+ *   opal_cmd_line_create, opal_cmd_line_add, opal_cmd_line_make_opt_mca,
+ *   opal_cmd_line_make_opt3, opal_cmd_line_parse, opal_cmd_line_get_usage_msg,
+ *   opal_cmd_line_is_taken, opal_cmd_line_get_ninsts, opal_cmd_line_get_param,
+ *   opal_cmd_line_get_argc, opal_cmd_line_get_argv, opal_cmd_line_get_tail.
+ *   Also exercises internally: make_opt, find_option, split_shorts, set_dest,
+ *   free_parse_results, fill, qsort_callback, get_help_otype, build_parsable.
+ *
+ * NOTE: -DNDEBUG is set; assert() is a no-op. All verification uses
+ * test_verify().  Do NOT use assert().
+ *
+ * NOTE: The cmd_line module uses opal_output / MCA / opal classes, so
+ * opal_init_util() is required before any cmd_line calls.
+ */
+
+#include "opal_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "support.h"
+
+#include "opal/util/cmd_line.h"
+#include "opal/util/argv.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+/* -----------------------------------------------------------------------
+ * Forward declarations
+ * ----------------------------------------------------------------------- */
+static void test_make_opt3_errors(void);
+static void test_create_and_add(void);
+static void test_make_opt_mca(void);
+static void test_parse_flags(void);
+static void test_parse_option_with_params(void);
+static void test_get_param_documented_example(void);
+static void test_parse_multiple_instances(void);
+static void test_parse_single_dash_name(void);
+static void test_combined_shorts(void);
+static void test_parse_double_dash_separator(void);
+static void test_parse_unknown_option_error(void);
+static void test_parse_missing_param_error(void);
+static void test_parse_ignore_unknown(void);
+static void test_get_argc_and_argv(void);
+static void test_get_tail(void);
+static void test_get_ninsts_unregistered(void);
+static void test_get_usage_msg(void);
+static void test_set_dest_variable(void);
+static void test_reparse(void);
+static void test_set_dest_int_invalid(void);
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    int rc;
+
+    test_init("opal_cmd_line");
+
+    rc = opal_init_util(&argc, &argv);
+    test_verify("opal_init_util succeeds", OPAL_SUCCESS == rc);
+    if (OPAL_SUCCESS != rc) {
+        return test_finalize();
+    }
+
+    test_make_opt3_errors();
+    test_create_and_add();
+    test_make_opt_mca();
+    test_parse_flags();
+    test_parse_option_with_params();
+    test_get_param_documented_example();
+    test_parse_multiple_instances();
+    test_parse_single_dash_name();
+    test_combined_shorts();
+    test_parse_double_dash_separator();
+    test_parse_unknown_option_error();
+    test_parse_missing_param_error();
+    test_parse_ignore_unknown();
+    test_get_argc_and_argv();
+    test_get_tail();
+    test_get_ninsts_unregistered();
+    test_get_usage_msg();
+    test_set_dest_variable();
+    test_set_dest_int_invalid();
+    test_reparse();
+
+    opal_finalize_util();
+
+    return test_finalize();
+}
+
+/* -----------------------------------------------------------------------
+ * test_make_opt3_errors -- error paths in make_opt / make_opt3
+ * ----------------------------------------------------------------------- */
+static void test_make_opt3_errors(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+
+    /* All three name arguments NULL/'\0' must fail */
+    rc = opal_cmd_line_make_opt3(&cmd, '\0', NULL, NULL, 0, "no names");
+    test_verify("make_opt3 all-empty names returns ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+
+    /* num_params < 0 must fail */
+    rc = opal_cmd_line_make_opt3(&cmd, 'x', NULL, NULL, -1, "neg params");
+    test_verify("make_opt3 num_params<0 returns ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+
+    /* Valid option must succeed */
+    rc = opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose mode");
+    test_verify("make_opt3 valid short+long succeeds",
+                OPAL_SUCCESS == rc);
+
+    /* Duplicate long name must fail */
+    rc = opal_cmd_line_make_opt3(&cmd, '\0', NULL, "verbose", 0, "Dup");
+    test_verify("make_opt3 duplicate long name returns ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_create_and_add -- opal_cmd_line_create + opal_cmd_line_add
+ * ----------------------------------------------------------------------- */
+static void test_create_and_add(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    /* Table-driven create */
+    opal_cmd_line_init_t table[] = {
+        { NULL, 'h', NULL, "help", 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL,
+          "This help message", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+        { NULL, 'n', NULL, "numprocs", 1,
+          NULL, OPAL_CMD_LINE_TYPE_NULL,
+          "Number of processes", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+        /* Sentinel */
+        { NULL, '\0', NULL, NULL, 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL, NULL, OPAL_CMD_LINE_OTYPE_NULL }
+    };
+
+    rc = opal_cmd_line_create(&cmd, table);
+    test_verify("opal_cmd_line_create returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Extend with an additional option via opal_cmd_line_add */
+    opal_cmd_line_init_t extra[] = {
+        { NULL, 'd', NULL, "debug", 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL,
+          "Enable debug", OPAL_CMD_LINE_OTYPE_DEBUG },
+
+        { NULL, '\0', NULL, NULL, 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL, NULL, OPAL_CMD_LINE_OTYPE_NULL }
+    };
+    rc = opal_cmd_line_add(&cmd, extra);
+    test_verify("opal_cmd_line_add returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* NULL table is legal (no-op) */
+    rc = opal_cmd_line_add(&cmd, NULL);
+    test_verify("opal_cmd_line_add(NULL table) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Before parsing: nothing is taken */
+    test_verify("is_taken('help') before parse == false",
+                !opal_cmd_line_is_taken(&cmd, "help"));
+    test_verify("get_ninsts('numprocs') before parse == 0",
+                0 == opal_cmd_line_get_ninsts(&cmd, "numprocs"));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_make_opt_mca -- opal_cmd_line_make_opt_mca
+ * ----------------------------------------------------------------------- */
+static void test_make_opt_mca(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+
+    opal_cmd_line_init_t entry = {
+        NULL,           /* ocl_mca_param_name */
+        'q',            /* ocl_cmd_short_name */
+        NULL,           /* ocl_cmd_single_dash_name */
+        "quiet",        /* ocl_cmd_long_name */
+        0,              /* ocl_num_params */
+        NULL,           /* ocl_variable_dest */
+        OPAL_CMD_LINE_TYPE_NULL,
+        "Quiet mode",   /* ocl_description */
+        OPAL_CMD_LINE_OTYPE_GENERAL
+    };
+    rc = opal_cmd_line_make_opt_mca(&cmd, entry);
+    test_verify("make_opt_mca valid entry returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* All-empty sentinel is a no-op, not an error */
+    opal_cmd_line_init_t sentinel = {
+        NULL, '\0', NULL, NULL, 0,
+        NULL, OPAL_CMD_LINE_TYPE_NULL, NULL, OPAL_CMD_LINE_OTYPE_NULL
+    };
+    rc = opal_cmd_line_make_opt_mca(&cmd, sentinel);
+    test_verify("make_opt_mca sentinel returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_flags -- zero-param options (flags)
+ * ----------------------------------------------------------------------- */
+static void test_parse_flags(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+    opal_cmd_line_make_opt3(&cmd, 'd', NULL, "debug",   0, "Debug");
+    opal_cmd_line_make_opt3(&cmd, 'q', NULL, "quiet",   0, "Quiet");
+
+    /* Parse: program verbose debug; quiet absent */
+    char *args[] = { "prog", "--verbose", "--debug", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 3, args);
+    test_verify("parse flags returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('verbose') == true",
+                opal_cmd_line_is_taken(&cmd, "verbose"));
+    test_verify("is_taken('v') == true (short alias)",
+                opal_cmd_line_is_taken(&cmd, "v"));
+    test_verify("is_taken('debug') == true",
+                opal_cmd_line_is_taken(&cmd, "debug"));
+    test_verify("is_taken('quiet') == false (not passed)",
+                !opal_cmd_line_is_taken(&cmd, "quiet"));
+
+    test_verify("get_ninsts('verbose') == 1", 1 == opal_cmd_line_get_ninsts(&cmd, "verbose"));
+    test_verify("get_ninsts('debug') == 1",   1 == opal_cmd_line_get_ninsts(&cmd, "debug"));
+    test_verify("get_ninsts('quiet') == 0",   0 == opal_cmd_line_get_ninsts(&cmd, "quiet"));
+
+    /* Zero-param option: get_param returns NULL (no parameter tokens recorded) */
+    test_verify("get_param(verbose,0,0) == NULL for zero-param option",
+                NULL == opal_cmd_line_get_param(&cmd, "verbose", 0, 0));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_option_with_params -- options that take string parameters
+ * ----------------------------------------------------------------------- */
+static void test_parse_option_with_params(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    char *p;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'o', NULL, "output",  1, "Output file");
+    opal_cmd_line_make_opt3(&cmd, 'n', NULL, "numprocs",1, "Num procs");
+
+    char *args[] = { "prog", "--output", "results.txt", "-n", "8", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 5, args);
+    test_verify("parse with params returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('output') == true",
+                opal_cmd_line_is_taken(&cmd, "output"));
+    test_verify("is_taken('o') == true (short)",
+                opal_cmd_line_is_taken(&cmd, "o"));
+    test_verify("is_taken('numprocs') == true",
+                opal_cmd_line_is_taken(&cmd, "numprocs"));
+
+    p = opal_cmd_line_get_param(&cmd, "output", 0, 0);
+    test_verify("get_param(output,0,0) non-NULL", NULL != p);
+    test_verify("get_param(output,0,0) == 'results.txt'",
+                NULL != p && 0 == strcmp("results.txt", p));
+
+    p = opal_cmd_line_get_param(&cmd, "numprocs", 0, 0);
+    test_verify("get_param(numprocs,0,0) non-NULL", NULL != p);
+    test_verify("get_param(numprocs,0,0) == '8'",
+                NULL != p && 0 == strcmp("8", p));
+
+    /* Out-of-range instance and param index both return NULL */
+    test_verify("get_param(output,1,0) == NULL (instance out of range)",
+                NULL == opal_cmd_line_get_param(&cmd, "output", 1, 0));
+    test_verify("get_param(output,0,1) == NULL (param index out of range)",
+                NULL == opal_cmd_line_get_param(&cmd, "output", 0, 1));
+
+    /* Unknown option name returns NULL */
+    test_verify("get_param on unknown opt == NULL",
+                NULL == opal_cmd_line_get_param(&cmd, "nonexistent", 0, 0));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_get_param_documented_example -- exact example from cmd_line.h
+ *
+ * From header: executable --foo bar1 bar2 --foo bar3 bar4
+ *   get_param(cmd, "foo", 1, 1) == "bar4"
+ *   get_param(cmd, "bar", 0, 0) == NULL   (unregistered)
+ *   get_param(cmd, "foo", 2, 2) == NULL   (inst 2 doesn't exist)
+ * ----------------------------------------------------------------------- */
+static void test_get_param_documented_example(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    char *p;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    /* "foo" takes 2 parameters */
+    opal_cmd_line_make_opt3(&cmd, '\0', NULL, "foo", 2, "Foo option");
+
+    char *args[] = {
+        "executable",
+        "--foo", "bar1", "bar2",
+        "--foo", "bar3", "bar4",
+        NULL
+    };
+    rc = opal_cmd_line_parse(&cmd, false, false, 7, args);
+    test_verify("documented example parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("get_ninsts('foo') == 2",
+                2 == opal_cmd_line_get_ninsts(&cmd, "foo"));
+
+    /* Instance 0, param 0 -> "bar1" */
+    p = opal_cmd_line_get_param(&cmd, "foo", 0, 0);
+    test_verify("get_param(foo,0,0) == 'bar1'",
+                NULL != p && 0 == strcmp("bar1", p));
+
+    /* Instance 0, param 1 -> "bar2" */
+    p = opal_cmd_line_get_param(&cmd, "foo", 0, 1);
+    test_verify("get_param(foo,0,1) == 'bar2'",
+                NULL != p && 0 == strcmp("bar2", p));
+
+    /* Instance 1, param 0 -> "bar3" */
+    p = opal_cmd_line_get_param(&cmd, "foo", 1, 0);
+    test_verify("get_param(foo,1,0) == 'bar3'",
+                NULL != p && 0 == strcmp("bar3", p));
+
+    /* Header documented example: instance 1, param 1 -> "bar4" */
+    p = opal_cmd_line_get_param(&cmd, "foo", 1, 1);
+    test_verify("get_param(foo,1,1) == 'bar4' [documented example]",
+                NULL != p && 0 == strcmp("bar4", p));
+
+    /* Header documented example: unregistered option -> NULL */
+    p = opal_cmd_line_get_param(&cmd, "bar", 0, 0);
+    test_verify("get_param(bar,0,0) == NULL [documented: unregistered]",
+                NULL == p);
+
+    /* Header documented example: instance 2 doesn't exist -> NULL */
+    p = opal_cmd_line_get_param(&cmd, "foo", 2, 2);
+    test_verify("get_param(foo,2,2) == NULL [documented: no third instance]",
+                NULL == p);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_multiple_instances -- same option repeated on command line
+ * ----------------------------------------------------------------------- */
+static void test_parse_multiple_instances(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    char *p;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'I', NULL, "include", 1, "Include path");
+
+    char *args[] = {
+        "prog",
+        "--include", "/usr/include",
+        "--include", "/opt/include",
+        "--include", "/home/user/include",
+        NULL
+    };
+    rc = opal_cmd_line_parse(&cmd, false, false, 7, args);
+    test_verify("multiple instances parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('include') == true",
+                opal_cmd_line_is_taken(&cmd, "include"));
+    test_verify("get_ninsts('include') == 3",
+                3 == opal_cmd_line_get_ninsts(&cmd, "include"));
+
+    p = opal_cmd_line_get_param(&cmd, "include", 0, 0);
+    test_verify("include instance 0 == '/usr/include'",
+                NULL != p && 0 == strcmp("/usr/include", p));
+
+    p = opal_cmd_line_get_param(&cmd, "include", 1, 0);
+    test_verify("include instance 1 == '/opt/include'",
+                NULL != p && 0 == strcmp("/opt/include", p));
+
+    p = opal_cmd_line_get_param(&cmd, "include", 2, 0);
+    test_verify("include instance 2 == '/home/user/include'",
+                NULL != p && 0 == strcmp("/home/user/include", p));
+
+    /* Instance 3 (zero-indexed 4th) does not exist */
+    p = opal_cmd_line_get_param(&cmd, "include", 3, 0);
+    test_verify("include instance 3 == NULL (doesn't exist)",
+                NULL == p);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_single_dash_name -- single-dash multi-char name (e.g., -np)
+ * ----------------------------------------------------------------------- */
+static void test_parse_single_dash_name(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    char *p;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+
+    /* Register a single-dash name "np" (no short, no long) */
+    opal_cmd_line_make_opt3(&cmd, '\0', "np", NULL, 1, "Num procs (compat)");
+    /* Also register a normal long option to keep things interesting */
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    char *args[] = { "mpirun", "-np", "4", "--verbose", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 4, args);
+    test_verify("single-dash name parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('np') == true",
+                opal_cmd_line_is_taken(&cmd, "np"));
+    test_verify("is_taken('verbose') == true",
+                opal_cmd_line_is_taken(&cmd, "verbose"));
+
+    p = opal_cmd_line_get_param(&cmd, "np", 0, 0);
+    test_verify("get_param('np',0,0) == '4'",
+                NULL != p && 0 == strcmp("4", p));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_combined_shorts -- "-abc" expands to "-a -b -c" via split_shorts
+ * ----------------------------------------------------------------------- */
+static void test_combined_shorts(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'a', NULL, "all",     0, "Option A");
+    opal_cmd_line_make_opt3(&cmd, 'b', NULL, "batch",   0, "Option B");
+    opal_cmd_line_make_opt3(&cmd, 'c', NULL, "check",   0, "Option C");
+    opal_cmd_line_make_opt3(&cmd, 'd', NULL, "debug",   0, "Debug");
+
+    /* "-abc" should expand to "-a", "-b", "-c" */
+    char *args[] = { "prog", "-abc", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 2, args);
+    test_verify("combined shorts parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('a') == true after -abc",
+                opal_cmd_line_is_taken(&cmd, "a"));
+    test_verify("is_taken('b') == true after -abc",
+                opal_cmd_line_is_taken(&cmd, "b"));
+    test_verify("is_taken('c') == true after -abc",
+                opal_cmd_line_is_taken(&cmd, "c"));
+    test_verify("is_taken('d') == false (not in -abc)",
+                !opal_cmd_line_is_taken(&cmd, "d"));
+
+    /* Each flag appears once */
+    test_verify("get_ninsts('a') == 1", 1 == opal_cmd_line_get_ninsts(&cmd, "a"));
+    test_verify("get_ninsts('b') == 1", 1 == opal_cmd_line_get_ninsts(&cmd, "b"));
+    test_verify("get_ninsts('c') == 1", 1 == opal_cmd_line_get_ninsts(&cmd, "c"));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_double_dash_separator -- "--" stops parsing, rest goes to tail
+ * ----------------------------------------------------------------------- */
+static void test_parse_double_dash_separator(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    int tailc;
+    char **tailv;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+    opal_cmd_line_make_opt3(&cmd, 'n', NULL, "numprocs",1, "Num procs");
+
+    /* "--" separates known options from the "tail" arguments */
+    char *args[] = {
+        "prog", "--verbose", "--", "tail1", "tail2", "tail3", NULL
+    };
+    rc = opal_cmd_line_parse(&cmd, false, false, 6, args);
+    test_verify("double-dash parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('verbose') == true (before --)",
+                opal_cmd_line_is_taken(&cmd, "verbose"));
+    test_verify("is_taken('numprocs') == false (not in argv)",
+                !opal_cmd_line_is_taken(&cmd, "numprocs"));
+
+    tailc = 0;
+    tailv = NULL;
+    rc = opal_cmd_line_get_tail(&cmd, &tailc, &tailv);
+    test_verify("get_tail returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* tailc = number of real tail tokens (NOT including the NULL sentinel,
+     * despite what the header says about "length including the final NULL
+     * entry" -- the code uses opal_argv_append which counts real tokens
+     * only, so tailc == 3 here.
+     * SUSPECTED BUG: header documents tailc as "length including the final
+     * NULL entry", but the implementation sets tailc = opal_argv_append
+     * count, which excludes the NULL terminator.  We assert the code's
+     * actual behavior (tailc == 3) and verify tailv[tailc] == NULL. */
+    test_verify("tailc == 3 (code counts real tokens, not the NULL sentinel)",
+                3 == tailc);
+    test_verify("tailv is non-NULL", NULL != tailv);
+    if (NULL != tailv) {
+        test_verify("tailv[0] == 'tail1'",
+                    0 == strcmp("tail1", tailv[0]));
+        test_verify("tailv[1] == 'tail2'",
+                    0 == strcmp("tail2", tailv[1]));
+        test_verify("tailv[2] == 'tail3'",
+                    0 == strcmp("tail3", tailv[2]));
+        test_verify("tailv[tailc] == NULL (null-terminated)",
+                    NULL == tailv[tailc]);
+        opal_argv_free(tailv);
+    }
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_unknown_option_error -- unrecognized "-foo" triggers error
+ * ----------------------------------------------------------------------- */
+static void test_parse_unknown_option_error(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    int tailc;
+    char **tailv;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    /* "--unknown" is not registered; parse should fail with OPAL_ERR_SILENT */
+    char *args[] = { "prog", "--verbose", "--unknown", "after", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 4, args);
+    test_verify("unknown option returns OPAL_ERR_SILENT",
+                OPAL_ERR_SILENT == rc);
+
+    /* verbose was seen before the unknown; it should still be recorded */
+    test_verify("is_taken('verbose') == true (seen before unknown)",
+                opal_cmd_line_is_taken(&cmd, "verbose"));
+
+    /* Everything from the unknown token onward goes to the tail */
+    tailc = 0;
+    tailv = NULL;
+    opal_cmd_line_get_tail(&cmd, &tailc, &tailv);
+    test_verify("tail has items after unknown option", tailc >= 1);
+    if (NULL != tailv) {
+        test_verify("first tail token is the unknown option",
+                    0 == strcmp("--unknown", tailv[0]));
+        opal_argv_free(tailv);
+    }
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_missing_param_error -- option that needs N params but gets <N
+ * ----------------------------------------------------------------------- */
+static void test_parse_missing_param_error(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, '\0', NULL, "pair", 2, "Needs two args");
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    /* "--pair" needs 2 args but only 1 follows */
+    char *args[] = { "prog", "--pair", "only_one", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 3, args);
+    test_verify("missing param always returns OPAL_ERR_SILENT",
+                OPAL_ERR_SILENT == rc);
+
+    /* The incomplete option should NOT be recorded as taken */
+    test_verify("is_taken('pair') == false (incomplete, error path)",
+                !opal_cmd_line_is_taken(&cmd, "pair"));
+    test_verify("get_ninsts('pair') == 0", 0 == opal_cmd_line_get_ninsts(&cmd, "pair"));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_parse_ignore_unknown -- ignore_unknown=true, unknown becomes tail
+ * ----------------------------------------------------------------------- */
+static void test_parse_ignore_unknown(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    int tailc;
+    char **tailv;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    /* Unknown plain token (no leading dash) stops parsing when
+     * ignore_unknown=false.  With ignore_unknown=true, it becomes tail. */
+    char *args[] = { "prog", "--verbose", "plain_arg", NULL };
+    rc = opal_cmd_line_parse(&cmd, true, true, 3, args);
+    test_verify("ignore_unknown=true returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    test_verify("is_taken('verbose') == true", opal_cmd_line_is_taken(&cmd, "verbose"));
+
+    tailc = 0;
+    tailv = NULL;
+    opal_cmd_line_get_tail(&cmd, &tailc, &tailv);
+    /* "plain_arg" has no leading dash, so it's an unknown token; it goes to tail */
+    test_verify("plain token is captured in tail", tailc >= 1);
+    if (NULL != tailv) {
+        test_verify("tailv[0] == 'plain_arg'",
+                    0 == strcmp("plain_arg", tailv[0]));
+        opal_argv_free(tailv);
+    }
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_get_argc_and_argv -- opal_cmd_line_get_argc / get_argv
+ * ----------------------------------------------------------------------- */
+static void test_get_argc_and_argv(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    /* Before any parse, argc should be 0 (no argv stored yet) */
+    test_verify("get_argc before parse == 0", 0 == opal_cmd_line_get_argc(&cmd));
+    test_verify("get_argv before parse == NULL", NULL == opal_cmd_line_get_argv(&cmd, 0));
+
+    char *args[] = { "prog", "--verbose", "extra", NULL };
+    rc = opal_cmd_line_parse(&cmd, true, true, 3, args);
+    test_verify("argc/argv parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* After parsing, argc == original argc passed to parse */
+    test_verify("get_argc after parse == 3", 3 == opal_cmd_line_get_argc(&cmd));
+
+    /* get_argv returns the stored copy of the original tokens */
+    test_verify("get_argv(0) == 'prog'",
+                0 == strcmp("prog", opal_cmd_line_get_argv(&cmd, 0)));
+    test_verify("get_argv(1) == '--verbose'",
+                0 == strcmp("--verbose", opal_cmd_line_get_argv(&cmd, 1)));
+    test_verify("get_argv(2) == 'extra'",
+                0 == strcmp("extra", opal_cmd_line_get_argv(&cmd, 2)));
+
+    /* Out-of-range index */
+    test_verify("get_argv(-1) == NULL", NULL == opal_cmd_line_get_argv(&cmd, -1));
+    test_verify("get_argv(3) == NULL (one past end)", NULL == opal_cmd_line_get_argv(&cmd, 3));
+    test_verify("get_argv(999) == NULL", NULL == opal_cmd_line_get_argv(&cmd, 999));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_get_tail -- detailed tail coverage
+ * ----------------------------------------------------------------------- */
+static void test_get_tail(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    int tailc;
+    char **tailv;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    /* No tail expected on a clean parse */
+    char *args1[] = { "prog", "--verbose", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 2, args1);
+    test_verify("clean parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    tailc = 99;
+    tailv = NULL;
+    rc = opal_cmd_line_get_tail(&cmd, &tailc, &tailv);
+    test_verify("get_tail returns OPAL_SUCCESS on clean parse", OPAL_SUCCESS == rc);
+    test_verify("tailc == 0 on clean parse", 0 == tailc);
+    /* opal_argv_copy(NULL) may return NULL; either way free is safe */
+    if (NULL != tailv) {
+        opal_argv_free(tailv);
+    }
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_get_ninsts_unregistered -- get_ninsts on an option not in the handle
+ *
+ * Header prose says: "OPAL_ERR if the command line option was not found
+ * during opal_cmd_line_parse(), or opal_cmd_line_parse() was not invoked
+ * on this handle."
+ *
+ * Code reality: get_ninsts initializes ret=0 and returns 0 when
+ * find_option returns NULL for an unregistered name.  Returning 0 is
+ * internally consistent with the "count including 0" semantics documented
+ * elsewhere in the same function, and is_taken (which calls get_ninsts)
+ * produces the correct false result.  We therefore treat the header prose
+ * as a documentation inaccuracy rather than a code bug, and assert 0.
+ *
+ * DOCUMENTATION DEFECT: header says OPAL_ERR(-1) for an unregistered
+ * option; the implementation returns 0.  Asserting 0 (the sensible value
+ * matching "zero instances found") is correct; the prose should be
+ * updated to match.
+ * ----------------------------------------------------------------------- */
+static void test_get_ninsts_unregistered(void)
+{
+    opal_cmd_line_t cmd;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+
+    char *args[] = { "prog", "--verbose", NULL };
+    opal_cmd_line_parse(&cmd, false, false, 2, args);
+
+    /* Returns 0 (not OPAL_ERROR/-1 as the header prose implies).
+     * DOCUMENTATION DEFECT: see block comment above. */
+    test_verify("get_ninsts on unregistered option returns 0 "
+                "[header prose says OPAL_ERR -- documentation defect, "
+                "0 is the sensible value]",
+                0 == opal_cmd_line_get_ninsts(&cmd, "notregistered"));
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_get_usage_msg -- opal_cmd_line_get_usage_msg returns non-NULL string
+ * ----------------------------------------------------------------------- */
+static void test_get_usage_msg(void)
+{
+    opal_cmd_line_t cmd;
+    char *msg;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose",  0, "Enable verbose output");
+    opal_cmd_line_make_opt3(&cmd, 'n', NULL, "numprocs", 1, "Number of processes");
+    opal_cmd_line_make_opt3(&cmd, '\0', NULL, "hidden", 0, NULL); /* no description */
+
+    msg = opal_cmd_line_get_usage_msg(&cmd);
+    test_verify("get_usage_msg returns non-NULL", NULL != msg);
+    if (NULL != msg) {
+        /* The message should mention at least one of the documented options */
+        test_verify("usage msg contains 'verbose'",
+                    NULL != strstr(msg, "verbose"));
+        test_verify("usage msg contains 'numprocs'",
+                    NULL != strstr(msg, "numprocs"));
+        free(msg);
+    }
+
+    /* Empty handle (no options) should return a non-NULL (possibly empty) string */
+    opal_cmd_line_t empty;
+    OBJ_CONSTRUCT(&empty, opal_cmd_line_t);
+    msg = opal_cmd_line_get_usage_msg(&empty);
+    test_verify("get_usage_msg on empty handle returns non-NULL", NULL != msg);
+    if (NULL != msg) {
+        free(msg);
+    }
+    OBJ_DESTRUCT(&empty);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_set_dest_variable -- ocl_variable_dest auto-fill via create table
+ * ----------------------------------------------------------------------- */
+static void test_set_dest_variable(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    /* Destinations that get filled by the parser */
+    bool    flag_val  = false;
+    char   *str_val   = NULL;
+    int     int_val   = 0;
+
+    opal_cmd_line_init_t table[] = {
+        /* Boolean flag */
+        { NULL, 'f', NULL, "flag", 0,
+          &flag_val, OPAL_CMD_LINE_TYPE_BOOL,
+          "A boolean flag", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+        /* String option */
+        { NULL, 's', NULL, "str", 1,
+          &str_val, OPAL_CMD_LINE_TYPE_STRING,
+          "A string option", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+        /* Int option */
+        { NULL, 'i', NULL, "ival", 1,
+          &int_val, OPAL_CMD_LINE_TYPE_INT,
+          "An int option", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+        /* Sentinel */
+        { NULL, '\0', NULL, NULL, 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL, NULL, OPAL_CMD_LINE_OTYPE_NULL }
+    };
+
+    rc = opal_cmd_line_create(&cmd, table);
+    test_verify("create with dest table succeeds", OPAL_SUCCESS == rc);
+
+    char *args[] = { "prog", "--flag", "--str", "hello", "--ival", "42", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 6, args);
+    test_verify("parse with dest variables returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Bool flag dest set to true (1) */
+    test_verify("bool dest set to true after --flag", flag_val);
+
+    /* String dest set to a copy of the argument */
+    test_verify("str dest non-NULL after --str hello", NULL != str_val);
+    if (NULL != str_val) {
+        test_verify("str dest == 'hello'", 0 == strcmp("hello", str_val));
+        /* set_dest strdup's the value; we free it to avoid a leak */
+        free(str_val);
+        str_val = NULL;
+    }
+
+    /* Int dest set to 42 */
+    test_verify("int dest == 42 after --ival 42", 42 == int_val);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_set_dest_int_invalid -- set_dest with non-numeric value for INT type
+ *
+ * When an option is registered with OPAL_CMD_LINE_TYPE_INT and the value
+ * supplied on the command line is not a valid integer (e.g. "abc"), set_dest
+ * prints an error message to stderr and returns OPAL_ERR_SILENT, which
+ * propagates out of opal_cmd_line_parse.
+ *
+ * SUSPECTED BUG: In the OPAL_CMD_LINE_TYPE_INT validation error path
+ * (cmd_line.c set_dest), the function prints to stderr and returns
+ * OPAL_ERR_SILENT but does NOT call OBJ_RELEASE(param) before returning —
+ * the param_t allocated during parsing is leaked.  This is an early-return
+ * path that bypasses the normal cleanup.  We cannot assert the leak here
+ * (no portable way to observe it), but we note it for future investigation.
+ * ----------------------------------------------------------------------- */
+static void test_set_dest_int_invalid(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+    int int_val = 0;
+
+    opal_cmd_line_init_t table[] = {
+        { NULL, 'i', NULL, "ival", 1,
+          &int_val, OPAL_CMD_LINE_TYPE_INT,
+          "An int option", OPAL_CMD_LINE_OTYPE_GENERAL },
+        { NULL, '\0', NULL, NULL, 0,
+          NULL, OPAL_CMD_LINE_TYPE_NULL, NULL, OPAL_CMD_LINE_OTYPE_NULL }
+    };
+
+    rc = opal_cmd_line_create(&cmd, table);
+    test_verify("create for int-invalid test succeeds", OPAL_SUCCESS == rc);
+
+    /* "abc" is not a valid integer; set_dest returns OPAL_ERR_SILENT */
+    char *args[] = { "prog", "--ival", "abc", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 3, args);
+    test_verify("parse with non-numeric INT value returns OPAL_ERR_SILENT",
+                OPAL_ERR_SILENT == rc);
+
+    /* int_val must remain at its pre-parse sentinel (0) since set_dest errored */
+    test_verify("int dest unchanged after invalid parse", 0 == int_val);
+
+    OBJ_DESTRUCT(&cmd);
+}
+
+/* -----------------------------------------------------------------------
+ * test_reparse -- calling opal_cmd_line_parse twice on the same handle
+ *                 must erase previous results
+ * ----------------------------------------------------------------------- */
+static void test_reparse(void)
+{
+    opal_cmd_line_t cmd;
+    int rc;
+
+    OBJ_CONSTRUCT(&cmd, opal_cmd_line_t);
+    opal_cmd_line_make_opt3(&cmd, 'v', NULL, "verbose", 0, "Verbose");
+    opal_cmd_line_make_opt3(&cmd, 'd', NULL, "debug",   0, "Debug");
+
+    /* First parse: only verbose */
+    char *args1[] = { "prog", "--verbose", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 2, args1);
+    test_verify("first parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("verbose taken after first parse",
+                opal_cmd_line_is_taken(&cmd, "verbose"));
+    test_verify("debug not taken after first parse",
+                !opal_cmd_line_is_taken(&cmd, "debug"));
+
+    /* Second parse: only debug — previous results must be cleared */
+    char *args2[] = { "prog", "--debug", NULL };
+    rc = opal_cmd_line_parse(&cmd, false, false, 2, args2);
+    test_verify("second parse returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("debug taken after second parse",
+                opal_cmd_line_is_taken(&cmd, "debug"));
+    test_verify("verbose NOT taken after second parse (results erased)",
+                !opal_cmd_line_is_taken(&cmd, "verbose"));
+    test_verify("get_ninsts('verbose') == 0 after second parse",
+                0 == opal_cmd_line_get_ninsts(&cmd, "verbose"));
+
+    OBJ_DESTRUCT(&cmd);
+}

--- a/test/util/opal_crc.c
+++ b/test/util/opal_crc.c
@@ -1,0 +1,687 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/util/crc.h"
+
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_csum_partial / opal_csum (unsigned long variant)
+ * ---------------------------------------------------------------------- */
+
+static void test_csum_partial_determinism(void)
+{
+    /* Same input must produce the same output */
+    static const unsigned char buf[16] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10
+    };
+    unsigned long plong1 = 0, plong2 = 0;
+    size_t plen1 = 0, plen2 = 0;
+
+    unsigned long c1 = opal_csum_partial(buf, sizeof(buf), &plong1, &plen1);
+    unsigned long c2 = opal_csum_partial(buf, sizeof(buf), &plong2, &plen2);
+
+    test_verify("csum_partial: same input -> same result (c1==c2)", c1 == c2);
+    test_verify("csum_partial: inline helper opal_csum matches",
+                opal_csum(buf, sizeof(buf)) == c1);
+}
+
+static void test_csum_partial_different_inputs(void)
+{
+    static const unsigned char buf_a[8] = {0x01, 0x02, 0x03, 0x04,
+                                           0x05, 0x06, 0x07, 0x08};
+    static const unsigned char buf_b[8] = {0xff, 0xfe, 0xfd, 0xfc,
+                                           0xfb, 0xfa, 0xf9, 0xf8};
+    unsigned long plong = 0;
+    size_t plen = 0;
+
+    unsigned long ca = opal_csum_partial(buf_a, sizeof(buf_a), &plong, &plen);
+    plong = 0;
+    plen = 0;
+    unsigned long cb = opal_csum_partial(buf_b, sizeof(buf_b), &plong, &plen);
+
+    test_verify("csum_partial: different inputs give different checksums", ca != cb);
+}
+
+static void test_csum_partial_zero_buf(void)
+{
+    /* All-zero buffer: checksum must be 0 */
+    static const unsigned char zeros[32] = {0};
+    unsigned long plong = 0;
+    size_t plen = 0;
+
+    unsigned long c = opal_csum_partial(zeros, sizeof(zeros), &plong, &plen);
+    test_verify("csum_partial: all-zeros buffer -> csum is 0", 0 == c);
+}
+
+static void test_csum_partial_nonaligned_length(void)
+{
+    /* Non-word-aligned length (5 bytes): two calls must match opal_csum */
+    static const unsigned char buf[5] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+    unsigned long plong = 0;
+    size_t plen = 0;
+
+    unsigned long c_partial = opal_csum_partial(buf, 5, &plong, &plen);
+    unsigned long c_inline = opal_csum(buf, 5);
+
+    test_verify("csum_partial: 5-byte (non-aligned) matches opal_csum", c_partial == c_inline);
+}
+
+static void test_csum_partial_incremental(void)
+{
+    /*
+     * Incremental: two partial calls over [A|B] must equal one call over [AB].
+     * The partial accumulator state is threaded between calls.
+     *
+     * We split a 20-byte buffer at byte 7 (non-word-aligned boundary).
+     */
+    static const unsigned char full[20] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+        0x12, 0x34, 0x56, 0x78
+    };
+    const size_t split = 7;
+
+    /* Single call over all 20 bytes */
+    unsigned long plong0 = 0;
+    size_t plen0 = 0;
+    unsigned long c_full = opal_csum_partial(full, sizeof(full), &plong0, &plen0);
+
+    /* Two incremental calls */
+    unsigned long plong_inc = 0;
+    size_t plen_inc = 0;
+    unsigned long c1 = opal_csum_partial(full, split, &plong_inc, &plen_inc);
+    unsigned long c2 = opal_csum_partial(full + split, sizeof(full) - split,
+                                         &plong_inc, &plen_inc);
+    unsigned long c_inc = c1 + c2;
+
+    test_verify("csum_partial: incremental over [0..7) + [7..20) == single over [0..20)",
+                c_inc == c_full);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_uicsum_partial / opal_uicsum (unsigned int variant)
+ * ---------------------------------------------------------------------- */
+
+static void test_uicsum_partial_determinism(void)
+{
+    static const unsigned char buf[16] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10
+    };
+    unsigned int pint1 = 0, pint2 = 0;
+    size_t plen1 = 0, plen2 = 0;
+
+    unsigned int c1 = opal_uicsum_partial(buf, sizeof(buf), &pint1, &plen1);
+    unsigned int c2 = opal_uicsum_partial(buf, sizeof(buf), &pint2, &plen2);
+
+    test_verify("uicsum_partial: determinism (c1==c2)", c1 == c2);
+    test_verify("uicsum_partial: inline opal_uicsum matches",
+                opal_uicsum(buf, sizeof(buf)) == c1);
+}
+
+static void test_uicsum_partial_zero_buf(void)
+{
+    static const unsigned char zeros[32] = {0};
+    unsigned int pint = 0;
+    size_t plen = 0;
+
+    unsigned int c = opal_uicsum_partial(zeros, sizeof(zeros), &pint, &plen);
+    test_verify("uicsum_partial: all-zeros buffer -> csum is 0", 0u == c);
+}
+
+static void test_uicsum_partial_nonaligned(void)
+{
+    /* 3-byte buffer: non-int-aligned */
+    static const unsigned char buf[3] = {0x01, 0x02, 0x03};
+    unsigned int pint = 0;
+    size_t plen = 0;
+
+    unsigned int c_partial = opal_uicsum_partial(buf, 3, &pint, &plen);
+    unsigned int c_inline  = opal_uicsum(buf, 3);
+
+    test_verify("uicsum_partial: 3-byte non-aligned matches opal_uicsum",
+                c_partial == c_inline);
+}
+
+static void test_uicsum_partial_incremental(void)
+{
+    /*
+     * Split a 20-byte buffer at a 5-byte boundary (non-int-aligned).
+     */
+    static const unsigned char full[20] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+        0x12, 0x34, 0x56, 0x78
+    };
+    const size_t split = 5;
+
+    unsigned int pint0 = 0;
+    size_t plen0 = 0;
+    unsigned int c_full = opal_uicsum_partial(full, sizeof(full), &pint0, &plen0);
+
+    unsigned int pint_inc = 0;
+    size_t plen_inc = 0;
+    unsigned int c1 = opal_uicsum_partial(full, split, &pint_inc, &plen_inc);
+    unsigned int c2 = opal_uicsum_partial(full + split, sizeof(full) - split,
+                                          &pint_inc, &plen_inc);
+    unsigned int c_inc = c1 + c2;
+
+    test_verify("uicsum_partial: incremental [0..5)+[5..20) == single [0..20)",
+                c_inc == c_full);
+}
+
+static void test_uicsum_partial_different_inputs(void)
+{
+    static const unsigned char a[8] = {0xAA, 0xBB, 0xCC, 0xDD,
+                                       0x11, 0x22, 0x33, 0x44};
+    static const unsigned char b[8] = {0x00, 0x01, 0x02, 0x03,
+                                       0x04, 0x05, 0x06, 0x07};
+    unsigned int pint = 0;
+    size_t plen = 0;
+
+    unsigned int ca = opal_uicsum_partial(a, sizeof(a), &pint, &plen);
+    pint = 0;
+    plen = 0;
+    unsigned int cb = opal_uicsum_partial(b, sizeof(b), &pint, &plen);
+
+    test_verify("uicsum_partial: different inputs -> different checksums", ca != cb);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_bcopy_csum_partial (unsigned long variant)
+ * ---------------------------------------------------------------------- */
+
+static void test_bcopy_csum_partial_copy(void)
+{
+    /* Verify that the bcopy variant actually copies src -> dst */
+    static const unsigned char src[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF
+    };
+    unsigned char dst[16];
+    unsigned long plong = 0;
+    size_t plen = 0;
+
+    memset(dst, 0, sizeof(dst));
+    opal_bcopy_csum_partial(src, dst, sizeof(src), sizeof(src), &plong, &plen);
+
+    test_verify("bcopy_csum_partial: destination contains copy of source",
+                0 == memcmp(src, dst, sizeof(src)));
+}
+
+static void test_bcopy_csum_partial_matches_csum(void)
+{
+    /*
+     * The checksum returned by bcopy_csum_partial must equal the one
+     * returned by csum_partial over the same data.
+     */
+    static const unsigned char src[16] = {
+        0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+        0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0x00
+    };
+    unsigned char dst[16];
+    unsigned long plong_bc = 0, plong_cs = 0;
+    size_t plen_bc = 0, plen_cs = 0;
+
+    unsigned long c_bc = opal_bcopy_csum_partial(src, dst, sizeof(src), sizeof(src),
+                                                 &plong_bc, &plen_bc);
+    unsigned long c_cs = opal_csum_partial(src, sizeof(src), &plong_cs, &plen_cs);
+
+    test_verify("bcopy_csum_partial: checksum matches csum_partial", c_bc == c_cs);
+}
+
+static void test_bcopy_csum_partial_nonaligned(void)
+{
+    /* 7-byte buffer: exercises the partial-word residue path */
+    static const unsigned char src[7] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    unsigned char dst[7];
+    unsigned long plong_bc = 0, plong_cs = 0;
+    size_t plen_bc = 0, plen_cs = 0;
+
+    memset(dst, 0, sizeof(dst));
+    unsigned long c_bc = opal_bcopy_csum_partial(src, dst, sizeof(src), sizeof(src),
+                                                 &plong_bc, &plen_bc);
+    unsigned long c_cs = opal_csum_partial(src, sizeof(src), &plong_cs, &plen_cs);
+
+    test_verify("bcopy_csum_partial 7-byte: dst is copy of src",
+                0 == memcmp(src, dst, sizeof(src)));
+    test_verify("bcopy_csum_partial 7-byte: checksum matches csum_partial", c_bc == c_cs);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_bcopy_uicsum_partial (unsigned int variant)
+ * ---------------------------------------------------------------------- */
+
+static void test_bcopy_uicsum_partial_copy(void)
+{
+    static const unsigned char src[12] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xAA, 0xBB, 0xCC
+    };
+    unsigned char dst[12];
+    unsigned int pint = 0;
+    size_t plen = 0;
+
+    memset(dst, 0, sizeof(dst));
+    opal_bcopy_uicsum_partial(src, dst, sizeof(src), sizeof(src), &pint, &plen);
+
+    test_verify("bcopy_uicsum_partial: dst is copy of src",
+                0 == memcmp(src, dst, sizeof(src)));
+}
+
+static void test_bcopy_uicsum_partial_matches_uicsum(void)
+{
+    static const unsigned char src[12] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xAA, 0xBB, 0xCC
+    };
+    unsigned char dst[12];
+    unsigned int pint_bc = 0, pint_ui = 0;
+    size_t plen_bc = 0, plen_ui = 0;
+
+    unsigned int c_bc = opal_bcopy_uicsum_partial(src, dst, sizeof(src), sizeof(src),
+                                                   &pint_bc, &plen_bc);
+    unsigned int c_ui = opal_uicsum_partial(src, sizeof(src), &pint_ui, &plen_ui);
+
+    test_verify("bcopy_uicsum_partial: checksum matches uicsum_partial", c_bc == c_ui);
+}
+
+static void test_bcopy_uicsum_partial_nonaligned(void)
+{
+    /* 5-byte: non-int-aligned */
+    static const unsigned char src[5] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+    unsigned char dst[5];
+    unsigned int pint_bc = 0, pint_ui = 0;
+    size_t plen_bc = 0, plen_ui = 0;
+
+    memset(dst, 0, sizeof(dst));
+    unsigned int c_bc = opal_bcopy_uicsum_partial(src, dst, sizeof(src), sizeof(src),
+                                                   &pint_bc, &plen_bc);
+    unsigned int c_ui = opal_uicsum_partial(src, sizeof(src), &pint_ui, &plen_ui);
+
+    test_verify("bcopy_uicsum_partial 5-byte: dst is copy of src",
+                0 == memcmp(src, dst, sizeof(src)));
+    test_verify("bcopy_uicsum_partial 5-byte: checksum matches uicsum_partial", c_bc == c_ui);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_uicrc_partial / opal_uicrc
+ * ---------------------------------------------------------------------- */
+
+static void test_uicrc_partial_table_init(void)
+{
+    /*
+     * Calling opal_initialize_crc_table explicitly then opal_uicrc_partial
+     * must produce the same result as calling opal_uicrc_partial cold (which
+     * will auto-init the table).
+     */
+    opal_initialize_crc_table();
+    static const unsigned char buf[8] = {0x01, 0x02, 0x03, 0x04,
+                                         0x05, 0x06, 0x07, 0x08};
+    unsigned int crc1 = opal_uicrc_partial(buf, sizeof(buf), CRC_INITIAL_REGISTER);
+    unsigned int crc2 = opal_uicrc(buf, sizeof(buf));
+
+    test_verify("uicrc: explicit table init matches inline opal_uicrc", crc1 == crc2);
+}
+
+static void test_uicrc_partial_determinism(void)
+{
+    static const unsigned char buf[16] = {
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70
+    };
+
+    unsigned int c1 = opal_uicrc(buf, sizeof(buf));
+    unsigned int c2 = opal_uicrc(buf, sizeof(buf));
+
+    test_verify("uicrc: determinism (c1==c2)", c1 == c2);
+}
+
+static void test_uicrc_partial_different_inputs(void)
+{
+    static const unsigned char a[4] = {0x01, 0x02, 0x03, 0x04};
+    static const unsigned char b[4] = {0x05, 0x06, 0x07, 0x08};
+
+    unsigned int ca = opal_uicrc(a, sizeof(a));
+    unsigned int cb = opal_uicrc(b, sizeof(b));
+
+    test_verify("uicrc: different inputs -> different CRCs", ca != cb);
+}
+
+static void test_uicrc_partial_nonaligned(void)
+{
+    /* 3-byte (non-int-aligned): exercises the unaligned source path */
+    static const unsigned char buf[3] = {0xDE, 0xAD, 0xBE};
+
+    unsigned int c1 = opal_uicrc(buf, 3);
+    unsigned int c2 = opal_uicrc(buf, 3);
+
+    test_verify("uicrc: 3-byte non-aligned, deterministic", c1 == c2);
+}
+
+static void test_uicrc_partial_incremental(void)
+{
+    /*
+     * CRC chaining: crc(A || B) via two partial calls must equal
+     * opal_uicrc over the concatenated buffer.
+     *
+     * opal_uicrc_partial(B, partial_crc) takes the running CRC as seed.
+     */
+    static const unsigned char full[16] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00
+    };
+    const size_t split = 7;   /* non-int-aligned split */
+
+    unsigned int c_full = opal_uicrc(full, sizeof(full));
+
+    /* chain: first call seeds with CRC_INITIAL_REGISTER */
+    unsigned int crc_mid = opal_uicrc_partial(full, split, CRC_INITIAL_REGISTER);
+    unsigned int c_chain = opal_uicrc_partial(full + split, sizeof(full) - split, crc_mid);
+
+    test_verify("uicrc_partial: chained [0..7)+[7..16) == single [0..16)",
+                c_chain == c_full);
+}
+
+static void test_uicrc_partial_all_zeros(void)
+{
+    /* All-zero buffer: CRC must be non-initial-register (CRC has diffusion) */
+    static const unsigned char zeros[8] = {0};
+    unsigned int crc = opal_uicrc(zeros, sizeof(zeros));
+
+    /* CRC of zeros with standard polynomial is not CRC_INITIAL_REGISTER */
+    test_verify("uicrc: CRC of all-zeros differs from initial register",
+                CRC_INITIAL_REGISTER != crc);
+}
+
+static void test_uicrc_partial_large_aligned(void)
+{
+    /* 64-byte (word-aligned) buffer: exercises the fast int-aligned path */
+    unsigned char buf[64];
+    unsigned int i;
+    for (i = 0; i < 64; i++) {
+        buf[i] = (unsigned char) (i & 0xff);
+    }
+
+    unsigned int c1 = opal_uicrc(buf, sizeof(buf));
+    unsigned int c2 = opal_uicrc(buf, sizeof(buf));
+
+    test_verify("uicrc: 64-byte aligned buffer, deterministic", c1 == c2);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_bcopy_uicrc_partial
+ * ---------------------------------------------------------------------- */
+
+static void test_bcopy_uicrc_partial_copy(void)
+{
+    static const unsigned char src[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF
+    };
+    unsigned char dst[16];
+
+    memset(dst, 0, sizeof(dst));
+    opal_bcopy_uicrc_partial(src, dst, sizeof(src), sizeof(src), CRC_INITIAL_REGISTER);
+
+    test_verify("bcopy_uicrc_partial: dst is copy of src",
+                0 == memcmp(src, dst, sizeof(src)));
+}
+
+static void test_bcopy_uicrc_partial_matches_uicrc(void)
+{
+    static const unsigned char src[16] = {
+        0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+        0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0x00
+    };
+    unsigned char dst[16];
+
+    unsigned int c_bc  = opal_bcopy_uicrc_partial(src, dst, sizeof(src), sizeof(src),
+                                                   CRC_INITIAL_REGISTER);
+    unsigned int c_crc = opal_uicrc(src, sizeof(src));
+
+    test_verify("bcopy_uicrc_partial: checksum matches opal_uicrc", c_bc == c_crc);
+}
+
+static void test_bcopy_uicrc_partial_nonaligned(void)
+{
+    /* 5-byte: exercises the non-int-aligned copy path */
+    static const unsigned char src[5] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    unsigned char dst[5];
+
+    memset(dst, 0, sizeof(dst));
+    unsigned int c_bc  = opal_bcopy_uicrc_partial(src, dst, sizeof(src), sizeof(src),
+                                                   CRC_INITIAL_REGISTER);
+    unsigned int c_crc = opal_uicrc(src, sizeof(src));
+
+    test_verify("bcopy_uicrc_partial 5-byte: dst is copy of src",
+                0 == memcmp(src, dst, sizeof(src)));
+    test_verify("bcopy_uicrc_partial 5-byte: checksum matches opal_uicrc", c_bc == c_crc);
+}
+
+static void test_bcopy_uicrc_partial_inline_helper(void)
+{
+    /* opal_bcopy_uicrc is a static inline wrapping bcopy_uicrc_partial */
+    static const unsigned char src[8] = {0xAA, 0xBB, 0xCC, 0xDD,
+                                         0x11, 0x22, 0x33, 0x44};
+    unsigned char dst1[8], dst2[8];
+
+    memset(dst1, 0, sizeof(dst1));
+    memset(dst2, 0, sizeof(dst2));
+
+    unsigned int c1 = opal_bcopy_uicrc(src, dst1, sizeof(src), sizeof(src));
+    unsigned int c2 = opal_uicrc(src, sizeof(src));
+
+    test_verify("bcopy_uicrc (inline helper): checksum matches opal_uicrc", c1 == c2);
+    test_verify("bcopy_uicrc (inline helper): dst is copy of src",
+                0 == memcmp(src, dst1, sizeof(src)));
+}
+
+static void test_bcopy_uicrc_partial_crconly_residue(void)
+{
+    /*
+     * Test crclen > copylen: the function must CRC crclen bytes total
+     * while only copying copylen bytes from source.
+     *
+     * Use a large source buffer; copy only first half, but CRC the full buf.
+     */
+    static const unsigned char src[16] = {
+        0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0x07, 0x18,
+        0x29, 0x3A, 0x4B, 0x5C, 0x6D, 0x7E, 0x8F, 0x90
+    };
+    unsigned char dst[16];
+    const size_t copylen = 8;
+    const size_t crclen  = 16;
+
+    memset(dst, 0, sizeof(dst));
+    /* Copy 8 bytes, CRC all 16 */
+    unsigned int c_partial = opal_bcopy_uicrc_partial(src, dst, copylen, crclen,
+                                                       CRC_INITIAL_REGISTER);
+    /* CRC of all 16 bytes via plain crc */
+    unsigned int c_full    = opal_uicrc(src, crclen);
+
+    test_verify("bcopy_uicrc_partial (crclen>copylen): only copylen bytes copied",
+                0 == memcmp(src, dst, copylen));
+    test_verify("bcopy_uicrc_partial (crclen>copylen): CRC covers full crclen",
+                c_partial == c_full);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: csum16 (inline in header -- test via the macro and direct call)
+ * ---------------------------------------------------------------------- */
+
+static void test_csum16_basic(void)
+{
+    /*
+     * opal_csum16 is a static inline computing a 16-bit Internet-style
+     * checksum (sum of 16-bit words, fold carry).
+     * For an all-zero buffer the checksum is 0.
+     */
+    static const unsigned char zeros[8] = {0};
+    uint16_t c = opal_csum16(zeros, sizeof(zeros));
+    test_verify("csum16: all-zeros -> 0", 0u == c);
+}
+
+static void test_csum16_determinism(void)
+{
+    static const unsigned char buf[10] = {
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05
+    };
+    uint16_t c1 = opal_csum16(buf, sizeof(buf));
+    uint16_t c2 = opal_csum16(buf, sizeof(buf));
+    test_verify("csum16: determinism (c1==c2)", c1 == c2);
+}
+
+static void test_csum16_different_inputs(void)
+{
+    static const unsigned char a[4] = {0x00, 0x01, 0x00, 0x02};
+    static const unsigned char b[4] = {0x00, 0x03, 0x00, 0x04};
+    uint16_t ca = opal_csum16(a, sizeof(a));
+    uint16_t cb = opal_csum16(b, sizeof(b));
+    test_verify("csum16: different inputs -> different checksums", ca != cb);
+}
+
+static void test_csum16_known_value(void)
+{
+    /*
+     * opal_csum16 sums native-endian uint16_t words and returns the
+     * carry-folded sum (not the one's complement -- see test_csum16_basic,
+     * where an all-zero buffer checksums to 0).  A buffer holding a single
+     * host-order uint16_t value therefore checksums to that exact value:
+     * one word is read, and a value <= 0xFFFF produces no carry to fold.
+     * Building the buffer from a uint16_t via memcpy makes the expected
+     * result endianness-portable.
+     */
+    const uint16_t expected = 0x1234;
+    unsigned char buf[sizeof(uint16_t)];
+    uint16_t c;
+
+    memcpy(buf, &expected, sizeof(expected));
+    c = opal_csum16(buf, sizeof(buf));
+    test_verify("csum16: single host-order uint16_t checksums to its own value",
+                expected == c);
+}
+
+static void test_csum16_odd_length(void)
+{
+    /* Odd length exercises the "leftover byte" path */
+    static const unsigned char buf[3] = {0x01, 0x02, 0x03};
+    uint16_t c1 = opal_csum16(buf, sizeof(buf));
+    uint16_t c2 = opal_csum16(buf, sizeof(buf));
+    test_verify("csum16: odd-length (3) deterministic", c1 == c2);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: OPAL_CSUM / OPAL_CSUM_PARTIAL macros
+ * ---------------------------------------------------------------------- */
+
+static void test_macro_csum(void)
+{
+    static const unsigned char buf[8] = {0xDE, 0xAD, 0xBE, 0xEF,
+                                         0xCA, 0xFE, 0xBA, 0xBE};
+    unsigned int pint = 0;
+    size_t plen = 0;
+
+    unsigned int c_macro = OPAL_CSUM(buf, sizeof(buf));
+    unsigned int c_direct = opal_uicsum(buf, sizeof(buf));
+
+    test_verify("OPAL_CSUM macro matches opal_uicsum", c_macro == c_direct);
+
+    unsigned int c_partial_macro =
+        OPAL_CSUM_PARTIAL(buf, sizeof(buf), &pint, &plen);
+    pint = 0;
+    plen = 0;
+    unsigned int c_partial_direct =
+        opal_uicsum_partial(buf, sizeof(buf), &pint, &plen);
+
+    test_verify("OPAL_CSUM_PARTIAL macro matches opal_uicsum_partial",
+                c_partial_macro == c_partial_direct);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ---------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_crc");
+
+    /* opal_csum_partial / opal_csum */
+    test_csum_partial_determinism();
+    test_csum_partial_different_inputs();
+    test_csum_partial_zero_buf();
+    test_csum_partial_nonaligned_length();
+    test_csum_partial_incremental();
+
+    /* opal_uicsum_partial / opal_uicsum */
+    test_uicsum_partial_determinism();
+    test_uicsum_partial_zero_buf();
+    test_uicsum_partial_nonaligned();
+    test_uicsum_partial_incremental();
+    test_uicsum_partial_different_inputs();
+
+    /* opal_bcopy_csum_partial */
+    test_bcopy_csum_partial_copy();
+    test_bcopy_csum_partial_matches_csum();
+    test_bcopy_csum_partial_nonaligned();
+
+    /* opal_bcopy_uicsum_partial */
+    test_bcopy_uicsum_partial_copy();
+    test_bcopy_uicsum_partial_matches_uicsum();
+    test_bcopy_uicsum_partial_nonaligned();
+
+    /* opal_uicrc_partial / opal_uicrc (CRC32) */
+    test_uicrc_partial_table_init();
+    test_uicrc_partial_determinism();
+    test_uicrc_partial_different_inputs();
+    test_uicrc_partial_nonaligned();
+    test_uicrc_partial_incremental();
+    test_uicrc_partial_all_zeros();
+    test_uicrc_partial_large_aligned();
+
+    /* opal_bcopy_uicrc_partial */
+    test_bcopy_uicrc_partial_copy();
+    test_bcopy_uicrc_partial_matches_uicrc();
+    test_bcopy_uicrc_partial_nonaligned();
+    test_bcopy_uicrc_partial_inline_helper();
+    test_bcopy_uicrc_partial_crconly_residue();
+
+    /* opal_csum16 */
+    test_csum16_basic();
+    test_csum16_determinism();
+    test_csum16_different_inputs();
+    test_csum16_known_value();
+    test_csum16_odd_length();
+
+    /* macros */
+    test_macro_csum();
+
+    return test_finalize();
+}

--- a/test/util/opal_environ.c
+++ b/test/util/opal_environ.c
@@ -1,0 +1,278 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include "support.h"
+#include "opal/util/opal_environ.h"
+#include "opal/util/argv.h"
+#include "opal/constants.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                              */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Return the value portion of a "NAME=value" entry in an env array,
+ * or NULL if not found.
+ */
+static const char *env_lookup(char **env, const char *name)
+{
+    size_t nlen;
+    int i;
+
+    if (NULL == env || NULL == name) {
+        return NULL;
+    }
+    nlen = strlen(name);
+    for (i = 0; NULL != env[i]; ++i) {
+        if (0 == strncmp(env[i], name, nlen) && '=' == env[i][nlen]) {
+            return env[i] + nlen + 1;
+        }
+    }
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_setenv                                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_setenv(void)
+{
+    char **env = NULL;
+    int rc;
+    const char *val;
+
+    /* Add to a NULL *env (env pointer itself is non-NULL, *env is NULL) */
+    rc = opal_setenv("FOO", "bar", true, &env);
+    test_verify("setenv into *env==NULL: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("setenv into *env==NULL: env non-NULL", NULL != env);
+    val = env_lookup(env, "FOO");
+    test_verify("setenv into *env==NULL: value stored", NULL != val);
+    test_verify("setenv into *env==NULL: value is 'bar'",
+                NULL != val && 0 == strcmp("bar", val));
+
+    /* Add a second distinct variable */
+    rc = opal_setenv("BAR", "qux", true, &env);
+    test_verify("setenv second var: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("setenv second var: 'qux' stored",
+                0 == strcmp("qux", env_lookup(env, "BAR")));
+    test_verify("setenv second var: FOO still present",
+                0 == strcmp("bar", env_lookup(env, "FOO")));
+
+    /* Overwrite existing variable (overwrite=true) */
+    rc = opal_setenv("FOO", "newval", true, &env);
+    test_verify("setenv overwrite=true: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("setenv overwrite=true: value updated",
+                0 == strcmp("newval", env_lookup(env, "FOO")));
+
+    /* Attempt overwrite with overwrite=false => OPAL_EXISTS, value unchanged */
+    rc = opal_setenv("FOO", "ignored", false, &env);
+    test_verify("setenv overwrite=false: OPAL_EXISTS", OPAL_EXISTS == rc);
+    test_verify("setenv overwrite=false: value unchanged",
+                0 == strcmp("newval", env_lookup(env, "FOO")));
+
+    /* New variable with overwrite=false -- should still append */
+    rc = opal_setenv("NEWVAR", "hello", false, &env);
+    test_verify("setenv new var overwrite=false: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("setenv new var overwrite=false: value stored",
+                0 == strcmp("hello", env_lookup(env, "NEWVAR")));
+
+    /* value==NULL: stores "NAME=" */
+    rc = opal_setenv("NULLVAL", NULL, true, &env);
+    test_verify("setenv NULL value: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    val = env_lookup(env, "NULLVAL");
+    test_verify("setenv NULL value: stored", NULL != val);
+    test_verify("setenv NULL value: empty string",
+                NULL != val && 0 == strcmp("", val));
+
+    /* bozo: NULL env pointer => OPAL_ERR_BAD_PARAM */
+    rc = opal_setenv("X", "y", true, NULL);
+    test_verify("setenv NULL env: OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+
+    opal_argv_free(env);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_unsetenv                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_unsetenv(void)
+{
+    char **env = NULL;
+    int rc;
+
+    /* Build a small env */
+    opal_setenv("A", "1", true, &env);
+    opal_setenv("B", "2", true, &env);
+    opal_setenv("C", "3", true, &env);
+
+    test_verify("unsetenv initial count == 3", 3 == opal_argv_count(env));
+
+    /* Remove a variable that exists */
+    rc = opal_unsetenv("B", &env);
+    test_verify("unsetenv existing: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("unsetenv existing: count decremented", 2 == opal_argv_count(env));
+    test_verify("unsetenv existing: B gone", NULL == env_lookup(env, "B"));
+    test_verify("unsetenv existing: A still there",
+                0 == strcmp("1", env_lookup(env, "A")));
+    test_verify("unsetenv existing: C still there",
+                0 == strcmp("3", env_lookup(env, "C")));
+
+    /* Remove a variable that does NOT exist => OPAL_ERR_NOT_FOUND */
+    rc = opal_unsetenv("NOTPRESENT", &env);
+    test_verify("unsetenv not found: OPAL_ERR_NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == rc);
+    test_verify("unsetenv not found: count unchanged", 2 == opal_argv_count(env));
+
+    /* Remove first element */
+    rc = opal_unsetenv("A", &env);
+    test_verify("unsetenv first: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("unsetenv first: count == 1", 1 == opal_argv_count(env));
+    test_verify("unsetenv first: A gone", NULL == env_lookup(env, "A"));
+
+    /* Remove last element */
+    rc = opal_unsetenv("C", &env);
+    test_verify("unsetenv last: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("unsetenv last: count == 0", 0 == opal_argv_count(env));
+
+    /* unsetenv on empty env (NULL *env) => OPAL_SUCCESS */
+    {
+        char **empty = NULL;
+        rc = opal_unsetenv("X", &empty);
+        test_verify("unsetenv on NULL env: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    }
+
+    opal_argv_free(env);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_environ_merge                                                   */
+/* ------------------------------------------------------------------ */
+
+static void test_environ_merge(void)
+{
+    char **minor;
+    char **major;
+    char **merged;
+
+    /* both NULL => NULL */
+    merged = opal_environ_merge(NULL, NULL);
+    test_verify("merge(NULL,NULL): NULL", NULL == merged);
+
+    /* minor NULL: result is copy of major */
+    major = NULL;
+    opal_setenv("X", "1", true, &major);
+    opal_setenv("Y", "2", true, &major);
+    merged = opal_environ_merge(NULL, major);
+    test_verify("merge(NULL,major): non-NULL", NULL != merged);
+    test_verify("merge(NULL,major): count == 2", 2 == opal_argv_count(merged));
+    test_verify("merge(NULL,major): X=1",
+                0 == strcmp("1", env_lookup(merged, "X")));
+    test_verify("merge(NULL,major): Y=2",
+                0 == strcmp("2", env_lookup(merged, "Y")));
+    opal_argv_free(merged);
+    opal_argv_free(major);
+
+    /* major NULL: result is copy of minor */
+    minor = NULL;
+    opal_setenv("A", "10", true, &minor);
+    opal_setenv("B", "20", true, &minor);
+    merged = opal_environ_merge(minor, NULL);
+    test_verify("merge(minor,NULL): non-NULL", NULL != merged);
+    test_verify("merge(minor,NULL): count == 2", 2 == opal_argv_count(merged));
+    test_verify("merge(minor,NULL): A=10",
+                0 == strcmp("10", env_lookup(merged, "A")));
+    opal_argv_free(merged);
+    opal_argv_free(minor);
+
+    /* conflict: major wins */
+    minor = NULL;
+    major = NULL;
+    opal_setenv("VAR", "minor_val", true, &minor);
+    opal_setenv("MINOR_ONLY", "only", true, &minor);
+    opal_setenv("VAR", "major_val", true, &major);
+    opal_setenv("MAJOR_ONLY", "monly", true, &major);
+
+    merged = opal_environ_merge(minor, major);
+    test_verify("merge conflict: non-NULL", NULL != merged);
+
+    /* Major wins on VAR */
+    test_verify("merge conflict: VAR == major_val",
+                0 == strcmp("major_val", env_lookup(merged, "VAR")));
+
+    /* Minor-only key should be present in result */
+    test_verify("merge conflict: MINOR_ONLY present",
+                0 == strcmp("only", env_lookup(merged, "MINOR_ONLY")));
+
+    /* Major-only key present */
+    test_verify("merge conflict: MAJOR_ONLY present",
+                0 == strcmp("monly", env_lookup(merged, "MAJOR_ONLY")));
+
+    /* Total count: VAR(1) + MINOR_ONLY(1) + MAJOR_ONLY(1) = 3 */
+    test_verify("merge conflict: count == 3", 3 == opal_argv_count(merged));
+
+    opal_argv_free(merged);
+    opal_argv_free(minor);
+    opal_argv_free(major);
+
+    /* merge disjoint sets */
+    minor = NULL;
+    major = NULL;
+    opal_setenv("M1", "a", true, &minor);
+    opal_setenv("M2", "b", true, &minor);
+    opal_setenv("J1", "c", true, &major);
+    opal_setenv("J2", "d", true, &major);
+
+    merged = opal_environ_merge(minor, major);
+    test_verify("merge disjoint: count == 4", 4 == opal_argv_count(merged));
+    test_verify("merge disjoint: M1=a",
+                0 == strcmp("a", env_lookup(merged, "M1")));
+    test_verify("merge disjoint: M2=b",
+                0 == strcmp("b", env_lookup(merged, "M2")));
+    test_verify("merge disjoint: J1=c",
+                0 == strcmp("c", env_lookup(merged, "J1")));
+    test_verify("merge disjoint: J2=d",
+                0 == strcmp("d", env_lookup(merged, "J2")));
+
+    opal_argv_free(merged);
+    opal_argv_free(minor);
+    opal_argv_free(major);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_environ");
+
+    test_setenv();
+    test_unsetenv();
+    test_environ_merge();
+
+    return test_finalize();
+}

--- a/test/util/opal_error.c
+++ b/test/util/opal_error.c
@@ -2,14 +2,14 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,73 +17,304 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
+/*
+ * Unit tests for opal/util/error.c.
+ *
+ * Tests: opal_strerror, opal_strerror_r, opal_perror,
+ *        opal_error_register.
+ *
+ * Note: the library is compiled with -DNDEBUG, so assert() is a no-op.
+ * All verification must go through test_verify().
+ *
+ * Implementation note on opal_strerror(OPAL_SUCCESS):
+ *   The OPAL error table is registered with err_base = OPAL_ERR_BASE (0)
+ *   and err_max = OPAL_ERR_MAX (-100).  opal_strerror_int() only invokes a
+ *   converter when (errnum < err_base && err_max < errnum), i.e. strictly
+ *   between -100 and 0.  OPAL_SUCCESS == 0 fails that range (0 < 0 is
+ *   false), so no converter runs.  opal_strerror_int() therefore defaults
+ *   to OPAL_ERROR for such codes (this is the fix in opal/util/error.c;
+ *   it previously defaulted to OPAL_SUCCESS and left *str == NULL).  Since
+ *   the result is now != OPAL_SUCCESS, opal_strerror() takes its
+ *   unknown-error path and returns a non-NULL "Unknown error: 0" string
+ *   rather than NULL.  The tests below assert that non-NULL result.
+ */
 
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/error.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <errno.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_SYS_PARAM_H
-#    include <sys/param.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-#    include <netinet/in.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-#ifdef HAVE_NETDB_H
-#    include <netdb.h>
-#endif
-#include <errno.h>
 
-#include "opal/constants.h"
-#include "opal/runtime/opal.h"
-#include "opal/util/error.h"
-#include "orte/constants.h"
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Converter used by test_error_register(). */
+#define MY_ERR_BASE (-2000)
+#define MY_ERR_FOO  (-2001)
+#define MY_ERR_BAR  (-2002)
+#define MY_ERR_MAX  (-2010)
+
+static int my_converter(int errnum, const char **str)
+{
+    switch (errnum) {
+    case MY_ERR_FOO:
+        *str = "custom foo error";
+        return OPAL_SUCCESS;
+    case MY_ERR_BAR:
+        *str = "custom bar error";
+        return OPAL_SUCCESS;
+    default:
+        *str = NULL;
+        return OPAL_ERROR;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_strerror                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_strerror(void)
+{
+    const char *s;
+
+    /*
+     * OPAL_SUCCESS (0) is matched by no registered converter (the OPAL
+     * converter covers the strictly-between (-100, 0) range), so it is
+     * treated as an unknown code and opal_strerror() returns a non-NULL
+     * "Unknown error: 0" string.  (It does not map to "Success": the
+     * opal_err2str converter is never reached for 0.)  The key contract
+     * is that the result is non-NULL so that callers can safely %s it.
+     */
+    s = opal_strerror(OPAL_SUCCESS);
+    test_verify("strerror(OPAL_SUCCESS): non-NULL", NULL != s);
+
+    /* OPAL_ERROR = -1, within range (-100,-1]: should return a non-NULL,
+     * non-empty string. */
+    s = opal_strerror(OPAL_ERROR);
+    test_verify("strerror(OPAL_ERROR): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(OPAL_ERROR): non-empty", '\0' != s[0]);
+        test_verify("strerror(OPAL_ERROR): equals 'Error'",
+                    0 == strcmp("Error", s));
+    }
+
+    /* OPAL_ERR_OUT_OF_RESOURCE = -2 */
+    s = opal_strerror(OPAL_ERR_OUT_OF_RESOURCE);
+    test_verify("strerror(OPAL_ERR_OUT_OF_RESOURCE): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(OPAL_ERR_OUT_OF_RESOURCE): equals 'Out of resource'",
+                    0 == strcmp("Out of resource", s));
+    }
+
+    /* OPAL_ERR_NOT_FOUND = -13 */
+    s = opal_strerror(OPAL_ERR_NOT_FOUND);
+    test_verify("strerror(OPAL_ERR_NOT_FOUND): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(OPAL_ERR_NOT_FOUND): equals 'Not found'",
+                    0 == strcmp("Not found", s));
+    }
+
+    /* OPAL_ERR_BAD_PARAM = -5 */
+    s = opal_strerror(OPAL_ERR_BAD_PARAM);
+    test_verify("strerror(OPAL_ERR_BAD_PARAM): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(OPAL_ERR_BAD_PARAM): equals 'Bad parameter'",
+                    0 == strcmp("Bad parameter", s));
+    }
+
+    /* Different codes must produce different strings. */
+    {
+        const char *s_error      = opal_strerror(OPAL_ERROR);
+        const char *s_not_found  = opal_strerror(OPAL_ERR_NOT_FOUND);
+        const char *s_bad_param  = opal_strerror(OPAL_ERR_BAD_PARAM);
+        test_verify("strerror: ERROR != NOT_FOUND",
+                    0 != strcmp(s_error, s_not_found));
+        test_verify("strerror: ERROR != BAD_PARAM",
+                    0 != strcmp(s_error, s_bad_param));
+    }
+
+    /* OPAL_ERR_IN_ERRNO: must return strerror(errno) for current errno.
+     * The exact string is system-dependent; just verify non-NULL. */
+    errno = EINVAL;
+    s = opal_strerror(OPAL_ERR_IN_ERRNO);
+    test_verify("strerror(OPAL_ERR_IN_ERRNO): non-NULL", NULL != s);
+
+    /* A completely unknown code (well outside any registered range)
+     * should return some non-NULL "Unknown error" string. */
+    s = opal_strerror(OPAL_ERR_MAX - 500);
+    test_verify("strerror(unknown code): non-NULL", NULL != s);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_strerror_r                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_strerror_r(void)
+{
+    char buf[256];
+    int rc;
+
+    /* OPAL_ERROR must fill the buffer with a non-empty string and
+     * return OPAL_SUCCESS. */
+    buf[0] = '\0';
+    rc = opal_strerror_r(OPAL_ERROR, buf, sizeof(buf));
+    test_verify("strerror_r(OPAL_ERROR): returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("strerror_r(OPAL_ERROR): buffer non-empty",
+                '\0' != buf[0]);
+    test_verify("strerror_r(OPAL_ERROR): buffer equals 'Error'",
+                0 == strcmp("Error", buf));
+
+    /* OPAL_ERR_NOT_FOUND */
+    buf[0] = '\0';
+    rc = opal_strerror_r(OPAL_ERR_NOT_FOUND, buf, sizeof(buf));
+    test_verify("strerror_r(OPAL_ERR_NOT_FOUND): returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("strerror_r(OPAL_ERR_NOT_FOUND): equals 'Not found'",
+                0 == strcmp("Not found", buf));
+
+    /* OPAL_ERR_BAD_PARAM */
+    buf[0] = '\0';
+    rc = opal_strerror_r(OPAL_ERR_BAD_PARAM, buf, sizeof(buf));
+    test_verify("strerror_r(OPAL_ERR_BAD_PARAM): returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("strerror_r(OPAL_ERR_BAD_PARAM): equals 'Bad parameter'",
+                0 == strcmp("Bad parameter", buf));
+
+    /* OPAL_ERR_IN_ERRNO: should copy strerror(errno) into buf. */
+    errno = EINVAL;
+    buf[0] = '\0';
+    rc = opal_strerror_r(OPAL_ERR_IN_ERRNO, buf, sizeof(buf));
+    test_verify("strerror_r(OPAL_ERR_IN_ERRNO): returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("strerror_r(OPAL_ERR_IN_ERRNO): buffer non-empty",
+                '\0' != buf[0]);
+
+    /* Unknown code: should still fill the buffer and return OPAL_SUCCESS. */
+    buf[0] = '\0';
+    rc = opal_strerror_r(OPAL_ERR_MAX - 500, buf, sizeof(buf));
+    test_verify("strerror_r(unknown): returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("strerror_r(unknown): buffer non-empty",
+                '\0' != buf[0]);
+
+    /* Multiple calls must not overwrite each other's result (since each
+     * call writes into a caller-supplied buffer). */
+    {
+        char buf1[256];
+        char buf2[256];
+        opal_strerror_r(OPAL_ERROR,         buf1, sizeof(buf1));
+        opal_strerror_r(OPAL_ERR_NOT_FOUND, buf2, sizeof(buf2));
+        test_verify("strerror_r: concurrent buffers independent",
+                    0 != strcmp(buf1, buf2));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_perror                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_perror(void)
+{
+    /*
+     * opal_perror() writes to stderr; we cannot easily capture that
+     * output here, so we just verify it does not crash for representative
+     * codes.  A visual inspection of stderr (when running the test) can
+     * be used as a secondary check.
+     */
+    opal_perror(OPAL_SUCCESS,        "perror OPAL_SUCCESS");
+    opal_perror(OPAL_ERROR,          "perror OPAL_ERROR");
+    opal_perror(OPAL_ERR_NOT_FOUND,  "perror OPAL_ERR_NOT_FOUND");
+    opal_perror(OPAL_ERR_BAD_PARAM,  NULL);   /* NULL msg: no prefix */
+    errno = EINVAL;
+    opal_perror(OPAL_ERR_IN_ERRNO,   "perror OPAL_ERR_IN_ERRNO");
+    opal_perror(OPAL_ERR_MAX - 500,  "perror unknown code");
+    test_verify("perror: did not crash", 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_error_register                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_error_register(void)
+{
+    int rc;
+    const char *s;
+    char buf[256];
+
+    /*
+     * Register a custom error-code range.  The range must be strictly
+     * wider than any code we intend to look up:
+     *   err_base = MY_ERR_BASE (-2000) -- exclusive upper bound
+     *   err_max  = MY_ERR_MAX  (-2010) -- exclusive lower bound
+     *
+     * opal_strerror_int fires for codes where:
+     *   errnum < err_base  AND  err_max < errnum
+     * i.e. -2010 < errnum < -2000, so MY_ERR_FOO (-2001) and
+     * MY_ERR_BAR (-2002) are both in range.
+     */
+    rc = opal_error_register("MYTEST", MY_ERR_BASE, MY_ERR_MAX, my_converter);
+    test_verify("error_register: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* opal_strerror for MY_ERR_FOO must return the custom string. */
+    s = opal_strerror(MY_ERR_FOO);
+    test_verify("strerror(MY_ERR_FOO): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(MY_ERR_FOO): equals 'custom foo error'",
+                    0 == strcmp("custom foo error", s));
+    }
+
+    /* opal_strerror for MY_ERR_BAR must return the custom string. */
+    s = opal_strerror(MY_ERR_BAR);
+    test_verify("strerror(MY_ERR_BAR): non-NULL", NULL != s);
+    if (NULL != s) {
+        test_verify("strerror(MY_ERR_BAR): equals 'custom bar error'",
+                    0 == strcmp("custom bar error", s));
+    }
+
+    /* opal_strerror_r for MY_ERR_FOO. */
+    buf[0] = '\0';
+    rc = opal_strerror_r(MY_ERR_FOO, buf, sizeof(buf));
+    test_verify("strerror_r(MY_ERR_FOO): OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("strerror_r(MY_ERR_FOO): equals 'custom foo error'",
+                0 == strcmp("custom foo error", buf));
+
+    /* opal_perror for a custom code must not crash. */
+    opal_perror(MY_ERR_FOO, "perror custom MY_ERR_FOO");
+    test_verify("perror custom code: did not crash", 1);
+
+    /* Re-registering the same range+project must succeed (update the
+     * converter) and return OPAL_SUCCESS. */
+    rc = opal_error_register("MYTEST", MY_ERR_BASE, MY_ERR_MAX, my_converter);
+    test_verify("error_register re-register: OPAL_SUCCESS", OPAL_SUCCESS == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char *argv[])
 {
-    int i;
-    int errors[] = {
-        OPAL_SUCCESS,
-        OPAL_ERROR,
-        OPAL_ERR_OUT_OF_RESOURCE,
-        OPAL_ERR_NOT_FOUND,
-        OPAL_ERR_BAD_PARAM,
-        OPAL_ERR_MAX + 10, /* bad value */
-        1,                 /* sentinel */
-    };
-    char buf[1024];
+    int r;
 
-    opal_init(&argc, &argv);
+    opal_init_util(&argc, &argv);
+    test_init("opal_error");
 
-    for (i = 0; errors[i] <= 0; ++i) {
-        printf("--> error code: %d\n", errors[i]);
-        opal_perror(errors[i], "perror test");
-        printf("strerror test: %s\n", opal_strerror(errors[i]));
-        opal_strerror_r(errors[i], buf, sizeof(buf));
-        printf("strerror_r test: %s\n", buf);
-    }
+    test_strerror();
+    test_strerror_r();
+    test_perror();
+    test_error_register();
 
-    printf("--> error in errno test\n");
-    errno = EINVAL;
-    opal_perror(OPAL_ERR_IN_ERRNO, "perror test");
-    errno = EINVAL;
-    printf("strerror test: %s\n", opal_strerror(OPAL_ERR_IN_ERRNO));
-    errno = EINVAL;
-    opal_strerror_r(OPAL_ERR_IN_ERRNO, buf, sizeof(buf));
-    printf("strerror_r test: %s\n", buf);
-
-    printf("--> orte error test\n");
-    opal_perror(ORTE_ERR_BUFFER, "orte test");
-
-    printf("--> orte unknown error test\n");
-    opal_perror(ORTE_ERR_MAX + 10, "orte unknown test");
-
-    printf("--> unknown error test\n");
-    opal_perror(ORTE_ERR_MAX - 200, "unknown error");
-
-    opal_finalize();
-
-    return 0;
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
 }

--- a/test/util/opal_fd.c
+++ b/test/util/opal_fd.c
@@ -1,0 +1,359 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/util/fd.h"
+#include "opal/constants.h"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_fd_write / opal_fd_read round-trip via pipe
+ * ---------------------------------------------------------------------- */
+
+static void test_write_read_roundtrip(void)
+{
+    int fds[2];
+    const char src[] = "Hello, OPAL fd test!";
+    const int len = (int) (sizeof(src) - 1);   /* exclude NUL */
+    char dst[64];
+    int rc;
+
+    memset(dst, 0, sizeof(dst));
+
+    if (0 != pipe(fds)) {
+        test_verify("fd_write/read: pipe() succeeded", 0 == 1);
+        return;
+    }
+
+    rc = opal_fd_write(fds[1], len, src);
+    test_verify("fd_write: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Close write end so read end does not block forever */
+    close(fds[1]);
+
+    rc = opal_fd_read(fds[0], len, dst);
+    test_verify("fd_read: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("fd_read: data matches what was written", 0 == memcmp(src, dst, (size_t) len));
+
+    close(fds[0]);
+}
+
+static void test_write_read_large_buffer(void)
+{
+    /*
+     * Exercise the multi-iteration write/read loops in opal_fd_write and
+     * opal_fd_read with a buffer larger than any platform's pipe capacity.
+     * opal_fd_write blocks until every byte is written, so the pipe must be
+     * drained concurrently -- writing a buffer bigger than the pipe with no
+     * reader would deadlock.  Fork a child to read while the parent writes;
+     * the child verifies the data (against its inherited copy of wbuf) and
+     * reports the result via its exit status.
+     */
+    const int len = 256 * 1024;   /* exceeds typical pipe capacities (16-64 KB) */
+    char *wbuf = malloc((size_t) len);
+    int fds[2];
+    int i;
+    pid_t pid;
+
+    if (NULL == wbuf) {
+        test_verify("fd_write/read large: malloc succeeded", 0 == 1);
+        return;
+    }
+
+    for (i = 0; i < len; i++) {
+        wbuf[i] = (char) (i & 0xff);
+    }
+
+    if (0 != pipe(fds)) {
+        test_verify("fd_write/read large: pipe() succeeded", 0 == 1);
+        free(wbuf);
+        return;
+    }
+
+    pid = fork();
+    if (-1 == pid) {
+        test_verify("fd_write/read large: fork() succeeded", 0 == 1);
+        close(fds[0]);
+        close(fds[1]);
+        free(wbuf);
+        return;
+    }
+
+    if (0 == pid) {
+        /* Child: drain the pipe and verify the bytes byte-for-byte against
+           the inherited copy of wbuf.  Exit 0 on success, non-zero on any
+           error or mismatch.  Do not call test_verify() here -- the child
+           has its own (separate) test counters. */
+        char *rbuf = malloc((size_t) len);
+        int child_status = 0;
+
+        close(fds[1]);   /* read end only */
+        if (NULL == rbuf) {
+            _exit(2);
+        }
+        if (OPAL_SUCCESS != opal_fd_read(fds[0], len, rbuf)
+            || 0 != memcmp(wbuf, rbuf, (size_t) len)) {
+            child_status = 1;
+        }
+        free(rbuf);
+        close(fds[0]);
+        _exit(child_status);
+    } else {
+        /* Parent: write the whole buffer, then reap the child. */
+        int rc;
+        int wstatus = 0;
+
+        close(fds[0]);   /* write end only */
+        rc = opal_fd_write(fds[1], len, wbuf);
+        test_verify("fd_write large: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+        close(fds[1]);
+
+        waitpid(pid, &wstatus, 0);
+        test_verify("fd_read large (child): data matches what was written",
+                    WIFEXITED(wstatus) && 0 == WEXITSTATUS(wstatus));
+        free(wbuf);
+    }
+}
+
+static void test_read_timeout_on_closed_pipe(void)
+{
+    /*
+     * Reading from a pipe whose write end has been closed with no data
+     * available should return OPAL_ERR_TIMEOUT (EOF before len bytes read).
+     */
+    int fds[2];
+    char buf[4];
+    int rc;
+
+    if (0 != pipe(fds)) {
+        test_verify("fd_read timeout: pipe() succeeded", 0 == 1);
+        return;
+    }
+
+    /* Close write end immediately -- no data written */
+    close(fds[1]);
+
+    rc = opal_fd_read(fds[0], (int) sizeof(buf), buf);
+    test_verify("fd_read: closed pipe with no data -> OPAL_ERR_TIMEOUT",
+                OPAL_ERR_TIMEOUT == rc);
+
+    close(fds[0]);
+}
+
+static void test_write_bad_fd(void)
+{
+    /*
+     * Writing to an invalid fd (-1) must return OPAL_ERR_IN_ERRNO.
+     */
+    const char buf[] = "data";
+    int rc = opal_fd_write(-1, (int) sizeof(buf), buf);
+    test_verify("fd_write to bad fd -> OPAL_ERR_IN_ERRNO", OPAL_ERR_IN_ERRNO == rc);
+}
+
+static void test_read_bad_fd(void)
+{
+    /*
+     * Reading from an invalid fd (-1) must return OPAL_ERR_IN_ERRNO.
+     */
+    char buf[4];
+    int rc = opal_fd_read(-1, (int) sizeof(buf), buf);
+    test_verify("fd_read from bad fd -> OPAL_ERR_IN_ERRNO", OPAL_ERR_IN_ERRNO == rc);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_fd_set_cloexec
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cloexec(void)
+{
+    int fds[2];
+    int flags;
+    int rc;
+
+    if (0 != pipe(fds)) {
+        test_verify("fd_set_cloexec: pipe() succeeded", 0 == 1);
+        return;
+    }
+
+    rc = opal_fd_set_cloexec(fds[0]);
+    test_verify("fd_set_cloexec: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    flags = fcntl(fds[0], F_GETFD, 0);
+    test_verify("fd_set_cloexec: FD_CLOEXEC bit is set in fd flags",
+                (flags & FD_CLOEXEC) != 0);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+static void test_set_cloexec_bad_fd(void)
+{
+    /*
+     * opal_fd_set_cloexec on an invalid fd: fcntl(F_GETFD) will fail
+     * so the function should return OPAL_ERR_IN_ERRNO.
+     * On platforms where FD_CLOEXEC is not defined the function is a no-op
+     * that returns OPAL_SUCCESS; we allow both outcomes.
+     */
+    int rc = opal_fd_set_cloexec(-1);
+    test_verify("fd_set_cloexec on bad fd: fails or is no-op (no crash)",
+                OPAL_ERR_IN_ERRNO == rc || OPAL_SUCCESS == rc);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_fd_is_regular
+ * ---------------------------------------------------------------------- */
+
+static void test_is_regular_tmpfile(void)
+{
+    char tmpfile[] = "/tmp/opal_fd_test_XXXXXX";
+    int fd = mkstemp(tmpfile);
+
+    if (-1 == fd) {
+        test_verify("fd_is_regular: mkstemp succeeded", 0 == 1);
+        return;
+    }
+
+    test_verify("fd_is_regular: mkstemp file is a regular file",
+                opal_fd_is_regular(fd));
+    test_verify("fd_is_regular: mkstemp file is NOT a char device",
+                !opal_fd_is_chardev(fd));
+    test_verify("fd_is_regular: mkstemp file is NOT a block device",
+                !opal_fd_is_blkdev(fd));
+
+    close(fd);
+    unlink(tmpfile);
+}
+
+static void test_is_regular_pipe(void)
+{
+    /*
+     * A pipe fd is NOT a regular file.
+     */
+    int fds[2];
+
+    if (0 != pipe(fds)) {
+        test_verify("fd_is_regular pipe: pipe() succeeded", 0 == 1);
+        return;
+    }
+
+    test_verify("fd_is_regular: pipe fd is NOT a regular file",
+                !opal_fd_is_regular(fds[0]));
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+static void test_is_regular_bad_fd(void)
+{
+    /* Invalid fd: fstat fails, so all three predicates return false */
+    test_verify("fd_is_regular bad fd: returns false", !opal_fd_is_regular(-1));
+    test_verify("fd_is_chardev bad fd: returns false", !opal_fd_is_chardev(-1));
+    test_verify("fd_is_blkdev bad fd: returns false",  !opal_fd_is_blkdev(-1));
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_fd_is_chardev
+ * ---------------------------------------------------------------------- */
+
+static void test_is_chardev_dev_null(void)
+{
+    /*
+     * /dev/null is always a character device on POSIX systems.
+     */
+    int fd = open("/dev/null", O_RDONLY);
+
+    if (-1 == fd) {
+        test_verify("fd_is_chardev: open /dev/null succeeded", 0 == 1);
+        return;
+    }
+
+    test_verify("fd_is_chardev: /dev/null is a character device",
+                opal_fd_is_chardev(fd));
+    test_verify("fd_is_regular: /dev/null is NOT a regular file",
+                !opal_fd_is_regular(fd));
+    test_verify("fd_is_blkdev: /dev/null is NOT a block device",
+                !opal_fd_is_blkdev(fd));
+
+    close(fd);
+}
+
+/* -----------------------------------------------------------------------
+ * Tests: opal_fd_is_blkdev
+ * ---------------------------------------------------------------------- */
+
+static void test_is_blkdev_tmpfile(void)
+{
+    /*
+     * A regular temp file is NOT a block device.
+     */
+    char tmpfile[] = "/tmp/opal_fd_blkdev_XXXXXX";
+    int fd = mkstemp(tmpfile);
+
+    if (-1 == fd) {
+        test_verify("fd_is_blkdev tmpfile: mkstemp succeeded", 0 == 1);
+        return;
+    }
+
+    test_verify("fd_is_blkdev: regular tmp file is NOT a block device",
+                !opal_fd_is_blkdev(fd));
+
+    close(fd);
+    unlink(tmpfile);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ---------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_fd");
+
+    /* opal_fd_write / opal_fd_read */
+    test_write_read_roundtrip();
+    test_write_read_large_buffer();
+    test_read_timeout_on_closed_pipe();
+    test_write_bad_fd();
+    test_read_bad_fd();
+
+    /* opal_fd_set_cloexec */
+    test_set_cloexec();
+    test_set_cloexec_bad_fd();
+
+    /* opal_fd_is_regular */
+    test_is_regular_tmpfile();
+    test_is_regular_pipe();
+    test_is_regular_bad_fd();
+
+    /* opal_fd_is_chardev */
+    test_is_chardev_dev_null();
+
+    /* opal_fd_is_blkdev */
+    test_is_blkdev_tmpfile();
+
+    return test_finalize();
+}

--- a/test/util/opal_few.c
+++ b/test/util/opal_few.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal_few().
+ *
+ * opal_few() forks/execs argv[0] (via execvp) and waits for it to exit.
+ * On success it returns OPAL_SUCCESS and fills *status with the raw
+ * waitpid(2) status word; the caller inspects it with the standard
+ * WIF* / WEXITSTATUS macros.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/few.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <sys/wait.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * These tests invoke "true" and "false" by name (no leading path) so that
+ * opal_few()'s execvp() resolves them via PATH.  Passing a name without a
+ * slash is more portable than a hard-coded path: macOS has no /bin/true, and
+ * not every environment places these utilities under /usr/bin either.
+ */
+
+/*
+ * test_true_exits_zero
+ *
+ * Invoke true; expect:
+ *  - opal_few returns OPAL_SUCCESS  (child launched and exited)
+ *  - WIFEXITED(status) is true     (child exited normally, not signalled)
+ *  - WEXITSTATUS(status) == 0      (child reported success)
+ */
+static void test_true_exits_zero(void)
+{
+    int status = -1;
+    int rc;
+    char prog[] = "true";
+    char *argv[] = {prog, NULL};
+
+    rc = opal_few(argv, &status);
+    test_verify("opal_few(true) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("opal_few(true): WIFEXITED", WIFEXITED(status));
+    test_verify("opal_few(true): WEXITSTATUS == 0", 0 == WEXITSTATUS(status));
+}
+
+/*
+ * test_false_exits_nonzero
+ *
+ * Invoke false; expect:
+ *  - opal_few returns OPAL_SUCCESS  (child launched and exited)
+ *  - WIFEXITED(status) is true     (normal exit, not signalled)
+ *  - WEXITSTATUS(status) != 0      (child reported failure)
+ */
+static void test_false_exits_nonzero(void)
+{
+    int status = -1;
+    int rc;
+    char prog[] = "false";
+    char *argv[] = {prog, NULL};
+
+    rc = opal_few(argv, &status);
+    test_verify("opal_few(false) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("opal_few(false): WIFEXITED", WIFEXITED(status));
+    test_verify("opal_few(false): WEXITSTATUS != 0", 0 != WEXITSTATUS(status));
+}
+
+/*
+ * test_status_word_is_waitpid_form
+ *
+ * Confirm that opal_few fills the raw waitpid status word, not just
+ * the exit code.  After a normal exit WIFSIGNALED must be false.
+ */
+static void test_status_word_is_waitpid_form(void)
+{
+    int status = -1;
+    char prog[] = "true";
+    char *argv[] = {prog, NULL};
+
+    opal_few(argv, &status);
+    test_verify("opal_few status: WIFSIGNALED is false for normal exit",
+                !WIFSIGNALED(status));
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_few");
+
+    opal_init_util(&argc, &argv);
+
+    test_true_exits_zero();
+    test_false_exits_nonzero();
+    test_status_word_is_waitpid_form();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_getcwd.c
+++ b/test/util/opal_getcwd.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+
+#include "support.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/constants.h"
+
+int main(int argc, char *argv[])
+{
+    char buf[OPAL_PATH_MAX];
+    char libc_cwd[OPAL_PATH_MAX];
+    int rc;
+
+    test_init("opal_getcwd");
+
+    /* ================================================================
+     * Get the ground-truth cwd from libc for comparison.
+     * Unset $PWD first so opal_getcwd() always falls back to getcwd()
+     * on the success path, giving us a deterministic string to compare.
+     * ================================================================ */
+    unsetenv("PWD");
+
+    if (NULL == getcwd(libc_cwd, sizeof(libc_cwd))) {
+        /* Cannot determine cwd; skip the comparison tests. */
+        test_verify("libc getcwd() baseline succeeded", 0 /* always fail: no cwd */);
+        return test_finalize();
+    }
+
+    /* ================================================================
+     * NULL buf -> OPAL_ERR_BAD_PARAM
+     * ================================================================ */
+    rc = opal_getcwd(NULL, sizeof(buf));
+    test_verify("NULL buf: returns OPAL_ERR_BAD_PARAM", OPAL_ERR_BAD_PARAM == rc);
+
+    /* ================================================================
+     * size > INT_MAX -> OPAL_ERR_BAD_PARAM
+     * ================================================================ */
+    rc = opal_getcwd(buf, (size_t) INT_MAX + 1);
+    test_verify("size>INT_MAX: returns OPAL_ERR_BAD_PARAM", OPAL_ERR_BAD_PARAM == rc);
+
+    /* ================================================================
+     * Normal success: $PWD is unset so opal_getcwd falls back to
+     * getcwd() result.
+     * ================================================================ */
+    memset(buf, 0, sizeof(buf));
+    rc = opal_getcwd(buf, sizeof(buf));
+    test_verify("normal success: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("normal success: buf matches getcwd()",
+                0 == strcmp(buf, libc_cwd));
+
+    /* ================================================================
+     * $PWD is set to the same value as getcwd() -> should succeed and
+     * return that same value.
+     * ================================================================ */
+    setenv("PWD", libc_cwd, 1 /*overwrite*/);
+    memset(buf, 0, sizeof(buf));
+    rc = opal_getcwd(buf, sizeof(buf));
+    test_verify("PWD==cwd: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("PWD==cwd: buf matches libc cwd", 0 == strcmp(buf, libc_cwd));
+    unsetenv("PWD");
+
+    /* ================================================================
+     * Buffer too small -> OPAL_ERR_TEMP_OUT_OF_RESOURCE.
+     * Provide a 1-byte buffer.  strlen(cwd) > 1 for any real directory.
+     * The function falls back to writing (part of) the basename.
+     * ================================================================ */
+    {
+        char tiny[2];
+        memset(tiny, 0xFF, sizeof(tiny));
+        rc = opal_getcwd(tiny, sizeof(tiny));
+        test_verify("tiny buf: returns OPAL_ERR_TEMP_OUT_OF_RESOURCE",
+                    OPAL_ERR_TEMP_OUT_OF_RESOURCE == rc);
+        /* buf must still be NUL-terminated within the provided size */
+        test_verify("tiny buf: NUL-terminated", '\0' == tiny[sizeof(tiny) - 1]);
+    }
+
+    /* ================================================================
+     * $PWD set to a stale / non-existent path -> opal_getcwd must fall
+     * back to getcwd() and still return OPAL_SUCCESS.
+     * ================================================================ */
+    setenv("PWD", "/this/path/does/not/exist/at/all/9z8y7x6w", 1);
+    memset(buf, 0, sizeof(buf));
+    rc = opal_getcwd(buf, sizeof(buf));
+    test_verify("stale PWD: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("stale PWD: buf matches getcwd()", 0 == strcmp(buf, libc_cwd));
+    unsetenv("PWD");
+
+    /*
+     * Boundary: a buffer of exactly strlen(cwd) bytes cannot hold the
+     * cwd plus its NUL terminator.  opal_getcwd() must report
+     * OPAL_ERR_TEMP_OUT_OF_RESOURCE rather than silently truncating and
+     * (incorrectly) returning OPAL_SUCCESS.
+     */
+    {
+        size_t exact = strlen(libc_cwd);
+        char small[OPAL_PATH_MAX];
+        memset(small, 0, sizeof(small));
+        rc = opal_getcwd(small, exact);
+        test_verify("buffer == strlen(cwd): reports OUT_OF_RESOURCE",
+                    OPAL_ERR_TEMP_OUT_OF_RESOURCE == rc);
+    }
+
+    return test_finalize();
+}

--- a/test/util/opal_if.c
+++ b/test/util/opal_if.c
@@ -2,15 +2,14 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2019      Triad National Security, LLC. All rights
- *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,118 +17,389 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
+/*
+ * Unit tests for the OPAL network-interface enumeration API (opal/util/if.h
+ * and the opal/mca/if framework).
+ *
+ * Strategy:
+ *   1. opal_init() brings up the MCA if framework (opal_init_util() alone
+ *      does not open it); only then is the interface list populated.
+ *   2. We assert opal_ifcount() >= 1 (at minimum a loopback exists).
+ *   3. We iterate all interfaces with opal_ifbegin()/opal_ifnext() and
+ *      cross-check every round-trip:
+ *        index -> name -> index
+ *        index -> kindex -> kindex-name  (must equal the index-name)
+ *        name  -> kindex
+ *   4. We locate the loopback by address (127.x.x.x) rather than by
+ *      name ("lo" vs "lo0"), then assert opal_ifisloopback() is true.
+ *   5. opal_ifislocal() is exercised with known-local / known-remote strings.
+ *
+ * The loopback interface is enumerated only when the MCA parameter
+ * if_base_retain_loopback is set: the BSD enumerator (opal/mca/if/bsdx_ipv4,
+ * used on the *BSDs including FreeBSD) honors it and drops loopback by
+ * default, while the posix_ipv4 component (used on Linux and macOS) has had
+ * its loopback filter #if 0'd out since 2010 and so always keeps loopback,
+ * regardless of the parameter.  To exercise the loopback-related API
+ * uniformly across platforms, main() sets that parameter before opal_init()
+ * (see below).  This long-standing cross-platform divergence (and the
+ * options for resolving it in OPAL) is tracked in
+ * https://github.com/open-mpi/ompi/issues/14029.
+ *
+ * NOTE: -DNDEBUG is set; assert() is a no-op.  All verification MUST
+ * use test_verify() / test_failure().  Never use assert().
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/if.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_SYS_PARAM_H
-#    include <sys/param.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-#    include <netinet/in.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-#ifdef HAVE_NETDB_H
-#    include <netdb.h>
-#endif
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
 
-#include "opal/constants.h"
-#include "opal/runtime/opal.h"
-#include "opal/util/if.h"
-#include "support.h"
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
 
-static bool test_ifaddrtoname(char *addr)
+/*
+ * Return true if the given sockaddr contains an IPv4 address in the
+ * 127.0.0.0/8 loopback range.
+ */
+static int
+addr_is_ipv4_loopback(const struct sockaddr *sa)
 {
-    int ret;
-    char addrname[100];
-    int len = 99;
-
-    ret = opal_ifaddrtoname(addr, addrname, len);
-
-    if (ret == OPAL_SUCCESS) {
-        return true;
-    } else {
-        return false;
+    if (NULL == sa || AF_INET != sa->sa_family) {
+        return 0;
+    }
+    {
+        const struct sockaddr_in *sin = (const struct sockaddr_in *) sa;
+        uint32_t h = ntohl(sin->sin_addr.s_addr);
+        return ((h & 0xFF000000u) == 0x7F000000u);
     }
 }
 
+/* ------------------------------------------------------------------ */
+/* Test: opal_ifcount                                                  */
+/* ------------------------------------------------------------------ */
+
+static void
+test_ifcount(void)
+{
+    int count = opal_ifcount();
+    test_verify("opal_ifcount() >= 1 (loopback always present)", count >= 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: iterate with opal_ifbegin / opal_ifnext                       */
+/* ------------------------------------------------------------------ */
+
+static void
+test_iteration(void)
+{
+    int idx;
+    int count_iter = 0;
+    int expected_count = opal_ifcount();
+
+    idx = opal_ifbegin();
+    test_verify("opal_ifbegin() > 0", idx > 0);
+
+    while (idx > 0) {
+        count_iter++;
+        idx = opal_ifnext(idx);
+    }
+
+    test_verify("iteration count equals opal_ifcount()", count_iter == expected_count);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: index <-> name round-trips and name -> kindex                 */
+/* ------------------------------------------------------------------ */
+
+static void
+test_index_name_roundtrips(void)
+{
+    int idx;
+
+    for (idx = opal_ifbegin(); idx > 0; idx = opal_ifnext(idx)) {
+        char name1[OPAL_IF_NAMESIZE];
+        char name2[OPAL_IF_NAMESIZE];
+        char kname[OPAL_IF_NAMESIZE];
+        int  back_idx;
+        int  kindex;
+        int  rc;
+
+        /* index -> name */
+        rc = opal_ifindextoname(idx, name1, (int) sizeof(name1));
+        test_verify("opal_ifindextoname() returns OPAL_SUCCESS",
+                    OPAL_SUCCESS == rc);
+        test_verify("opal_ifindextoname() produces non-empty name",
+                    '\0' != name1[0]);
+
+        /* name -> index (round-trip) */
+        back_idx = opal_ifnametoindex(name1);
+        test_verify("opal_ifnametoindex(opal_ifindextoname()) round-trips back",
+                    back_idx == idx);
+
+        /* index -> kindex */
+        kindex = opal_ifindextokindex(idx);
+        test_verify("opal_ifindextokindex() returns positive kindex",
+                    kindex > 0);
+
+        /* kindex -> name */
+        rc = opal_ifkindextoname(kindex, kname, (int) sizeof(kname));
+        test_verify("opal_ifkindextoname() returns OPAL_SUCCESS",
+                    OPAL_SUCCESS == rc);
+
+        /* kindex-name must match index-name */
+        test_verify("opal_ifkindextoname() matches opal_ifindextoname()",
+                    0 == strcmp(name1, kname));
+
+        /* name -> kindex (must match) */
+        {
+            int k2 = opal_ifnametokindex(name1);
+            test_verify("opal_ifnametokindex() matches opal_ifindextokindex()",
+                        k2 == kindex);
+        }
+
+        /* index -> name again via second call -- must be stable */
+        rc = opal_ifindextoname(idx, name2, (int) sizeof(name2));
+        test_verify("opal_ifindextoname() is stable across calls",
+                    OPAL_SUCCESS == rc && 0 == strcmp(name1, name2));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_ifnametoaddr / opal_ifaddrtoname round-trips             */
+/* ------------------------------------------------------------------ */
+
+static void
+test_name_addr_roundtrips(void)
+{
+    int idx;
+
+    /*
+     * Deterministic anchor: with if_base_retain_loopback set (see main()),
+     * 127.0.0.1 is in the interface list on any conforming host.
+     * opal_ifaddrtoname() must return OPAL_SUCCESS for it and fill in a
+     * non-empty interface name.
+     */
+    {
+        char loopback_ifname[OPAL_IF_NAMESIZE];
+        int rc = opal_ifaddrtoname("127.0.0.1",
+                                   loopback_ifname,
+                                   (int) sizeof(loopback_ifname));
+        test_verify("opal_ifaddrtoname(\"127.0.0.1\") returns OPAL_SUCCESS",
+                    OPAL_SUCCESS == rc);
+        test_verify("opal_ifaddrtoname(\"127.0.0.1\") produces non-empty name",
+                    '\0' != loopback_ifname[0]);
+    }
+
+    /*
+     * Per-interface: for each interface with an IPv4 address, convert
+     * the address to a dotted-quad string and call opal_ifaddrtoname().
+     * We also verify opal_ifnametoaddr() returns a non-zero address family.
+     */
+    for (idx = opal_ifbegin(); idx > 0; idx = opal_ifnext(idx)) {
+        char name[OPAL_IF_NAMESIZE];
+        struct sockaddr_storage ss;
+        int rc;
+
+        rc = opal_ifindextoname(idx, name, (int) sizeof(name));
+        if (OPAL_SUCCESS != rc) {
+            continue; /* already caught in test_index_name_roundtrips */
+        }
+
+        /* name -> addr */
+        rc = opal_ifnametoaddr(name,
+                               (struct sockaddr *) &ss,
+                               (int) sizeof(ss));
+        if (OPAL_SUCCESS != rc) {
+            /* some virtual interfaces may have no address; skip */
+            continue;
+        }
+
+        test_verify("opal_ifnametoaddr() address family is AF_INET or AF_INET6",
+                    AF_INET  == ((struct sockaddr *) &ss)->sa_family ||
+                    AF_INET6 == ((struct sockaddr *) &ss)->sa_family);
+
+        /*
+         * addr -> name (dotted-quad round-trip for IPv4 only).
+         * We do not assert the recovered name matches the original because
+         * a single address may appear under multiple interface indices.
+         * We assert the call returns OPAL_SUCCESS (the address exists in the
+         * list).
+         */
+        if (AF_INET == ((struct sockaddr *) &ss)->sa_family) {
+            char dotquad[INET_ADDRSTRLEN];
+            char back_name[OPAL_IF_NAMESIZE];
+
+            inet_ntop(AF_INET,
+                      &((struct sockaddr_in *) &ss)->sin_addr,
+                      dotquad, sizeof(dotquad));
+
+            rc = opal_ifaddrtoname(dotquad, back_name, (int) sizeof(back_name));
+            test_verify("opal_ifaddrtoname() succeeds for address from opal_ifnametoaddr()",
+                        OPAL_SUCCESS == rc);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: find the loopback interface; assert opal_ifisloopback         */
+/* ------------------------------------------------------------------ */
+
+static void
+test_loopback(void)
+{
+    int idx;
+    int found_loopback_index = -1;
+
+    for (idx = opal_ifbegin(); idx > 0; idx = opal_ifnext(idx)) {
+        struct sockaddr_storage ss;
+        int rc;
+        int is_loopback = 0;
+
+        rc = opal_ifindextoaddr(idx,
+                                (struct sockaddr *) &ss,
+                                (unsigned int) sizeof(ss));
+        if (OPAL_SUCCESS != rc) {
+            continue;
+        }
+
+        /* Accept IPv4 loopback (127.x.x.x) */
+        if (addr_is_ipv4_loopback((struct sockaddr *) &ss)) {
+            is_loopback = 1;
+        }
+
+#if OPAL_ENABLE_IPV6
+        /* Also accept IPv6 loopback (::1) */
+        if (!is_loopback && AF_INET6 == ((struct sockaddr *) &ss)->sa_family) {
+            const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *) &ss;
+            if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) {
+                is_loopback = 1;
+            }
+        }
+#endif /* OPAL_ENABLE_IPV6 */
+
+        if (is_loopback && -1 == found_loopback_index) {
+            found_loopback_index = idx;
+        }
+    }
+
+    test_verify("at least one loopback interface found",
+                found_loopback_index > 0);
+
+    if (found_loopback_index > 0) {
+        test_verify("opal_ifisloopback() true for loopback interface",
+                    opal_ifisloopback(found_loopback_index));
+    }
+
+    /* Check that 127.0.0.1 is reported as local */
+    test_verify("opal_ifislocal(\"127.0.0.1\") is true",
+                opal_ifislocal("127.0.0.1"));
+    test_verify("opal_ifislocal(\"localhost\") is true",
+                opal_ifislocal("localhost"));
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_ifislocal negative cases                                 */
+/* ------------------------------------------------------------------ */
+
+static void
+test_ifislocal_negative(void)
+{
+    /*
+     * foo.example.com is an IANA-reserved domain that will not resolve
+     * to any local interface on any conforming host.
+     */
+    test_verify("opal_ifislocal(\"foo.example.com\") is false",
+                !opal_ifislocal("foo.example.com"));
+
+    /* 0.0.0.0 is not a local interface address */
+    test_verify("opal_ifislocal(\"0.0.0.0\") is false",
+                !opal_ifislocal("0.0.0.0"));
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: error / boundary cases                                        */
+/* ------------------------------------------------------------------ */
+
+static void
+test_boundary_cases(void)
+{
+    char name[OPAL_IF_NAMESIZE];
+
+    /* Negative index must fail gracefully */
+    test_verify("opal_ifindextoname(-1) does not succeed",
+                OPAL_SUCCESS != opal_ifindextoname(-1, name, (int) sizeof(name)));
+
+    /* Zero index must fail gracefully */
+    test_verify("opal_ifindextoname(0) does not succeed",
+                OPAL_SUCCESS != opal_ifindextoname(0, name, (int) sizeof(name)));
+
+    /* Non-existent name */
+    test_verify("opal_ifnametoindex(\"__no_such_iface__\") returns negative",
+                opal_ifnametoindex("__no_such_iface__") < 0);
+
+    /* opal_ifnext at end must return <= 0 */
+    {
+        int last_idx = opal_ifbegin();
+        int next;
+        while ((next = opal_ifnext(last_idx)) > 0) {
+            last_idx = next;
+        }
+        test_verify("opal_ifnext() past last interface returns <= 0",
+                    opal_ifnext(last_idx) <= 0);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
 int main(int argc, char *argv[])
 {
-    const char *hostname;
+    int rc;
 
-    opal_init(&argc, &argv);
+    /*
+     * Ask the MCA "if" framework to retain loopback interfaces.  This
+     * parameter defaults to false, and the BSD interface enumerator
+     * (opal/mca/if/bsdx_ipv4, used on the *BSDs) honors it and drops the
+     * loopback interface -- so without this, 127.0.0.1 / lo0 would not be in
+     * the interface list and the loopback-related checks below could not run.
+     * (Linux and macOS use posix_ipv4, whose loopback filter has been #if 0'd
+     * out since 2010, so loopback is always present there regardless of this
+     * setting.)  Set the MCA parameter via the environment before opal_init()
+     * reads it; the "if" base registers the variable during opal_init(),
+     * overwriting any direct assignment to the global, so the environment is
+     * the reliable knob.  This platform divergence (and options for fixing it
+     * in OPAL) is tracked in https://github.com/open-mpi/ompi/issues/14029.
+     */
+    setenv("OMPI_MCA_if_base_retain_loopback", "1", 1);
+
+    rc = opal_init(&argc, &argv);
     test_init("opal_if");
+    test_verify("opal_init() succeeds", OPAL_SUCCESS == rc);
 
-    /* 127.0.0.1 */
-    if (test_ifaddrtoname("127.0.0.1")) {
-        test_success();
-    } else {
-        test_failure("ifaddrtoname test failed for 127.0.0.1");
-    }
-    if (opal_ifislocal("127.0.0.1")) {
-        test_success();
-    } else {
-        test_failure("ifislocal test failed for 127.0.0.1");
-    }
+    test_ifcount();
+    test_iteration();
+    test_index_name_roundtrips();
+    test_name_addr_roundtrips();
+    test_loopback();
+    test_ifislocal_negative();
+    test_boundary_cases();
 
-    /* localhost */
-    if (test_ifaddrtoname("localhost")) {
-        test_success();
-    } else {
-        test_failure("ifaddrtoname test failed for localhost");
+    {
+        int r = test_finalize();
+        opal_finalize();
+        return r;
     }
-    if (opal_ifislocal("localhost")) {
-        test_success();
-    } else {
-        test_failure("ifislocal test failed for localhost");
-    }
-
-    /* 0.0.0.0 */
-    if (test_ifaddrtoname("0.0.0.0")) {
-        test_failure("ifaddrtoname test failed for 0.0.0.0");
-    } else {
-        test_success();
-    }
-    if (opal_ifislocal("0.0.0.0")) {
-        test_failure("opal_ifislocal test failed for 0.0.0.0");
-    } else {
-        test_success();
-    }
-
-    /* foo.example.com */
-    printf("This should generate a warning:\n");
-    fflush(stdout);
-    if (test_ifaddrtoname("foo.example.com")) {
-        test_failure("ifaddrtoname test failed for foo.example.com");
-    } else {
-        test_success();
-    }
-    printf("This should generate a warning:\n");
-    fflush(stdout);
-    if (opal_ifislocal("foo.example.com")) {
-        test_failure("ifislocal test failed for foo.example.com");
-    } else {
-        test_success();
-    }
-
-    /* local host name */
-    hostname = opal_gethostname();
-    if (test_ifaddrtoname(hostname)) {
-        test_success();
-    } else {
-        test_failure("ifaddrtoname test failed for local host name");
-    }
-    if (opal_ifislocal(hostname)) {
-        test_success();
-    } else {
-        test_failure("ifislocal test failed for local host name");
-    }
-
-    test_finalize();
-    opal_finalize();
-
-    return 0;
 }

--- a/test/util/opal_info.c
+++ b/test/util/opal_info.c
@@ -1,0 +1,573 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal_info_t -- the key/value list backing MPI_Info.
+ *
+ * Library is compiled with -DNDEBUG, so assert() is a no-op.
+ * All verification must go through test_verify().
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/info.h"
+#include "opal/mca/base/mca_base_var_enum.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* Forward declarations                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_set_and_get(void);
+static void test_set_cstring(void);
+static void test_get_missing_key(void);
+static void test_overwrite(void);
+static void test_delete(void);
+static void test_get_nthkey(void);
+static void test_get_valuelen(void);
+static void test_get_nkeys(void);
+static void test_get_bool(void);
+static void test_get_value_enum(void);
+static void test_dup(void);
+static void test_dup_public(void);
+static void test_free(void);
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    test_init("opal_info_t");
+
+    opal_init_util(&argc, &argv);
+
+    test_set_and_get();
+    test_set_cstring();
+    test_get_missing_key();
+    test_overwrite();
+    test_delete();
+    test_get_nthkey();
+    test_get_valuelen();
+    test_get_nkeys();
+    test_get_bool();
+    test_get_value_enum();
+    test_dup();
+    test_dup_public();
+    test_free();
+
+    int r = test_finalize();
+    opal_finalize_util();
+    return r;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Create a new opal_info_t, set key=value, read it back, verify the
+ * string content and flag, then release the returned cstring and the
+ * info object.
+ */
+static void test_set_and_get(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    /* Basic set + get */
+    int rc = opal_info_set(info, "mykey", "myvalue");
+    test_verify("set returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    rc = opal_info_get(info, "mykey", &val, &flag);
+    test_verify("get returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for existing key", 1 == flag);
+    test_verify("value string matches", NULL != val && 0 == strcmp(val->string, "myvalue"));
+    test_verify("value length matches", NULL != val && val->length == strlen("myvalue"));
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_set_cstring(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    opal_cstring_t *cs = opal_cstring_create("cstring_val");
+    test_verify("cstring creation succeeds", NULL != cs);
+
+    int rc = opal_info_set_cstring(info, "cskey", cs);
+    test_verify("set_cstring returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* Release caller's reference -- info must have retained its own */
+    OBJ_RELEASE(cs);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    rc = opal_info_get(info, "cskey", &val, &flag);
+    test_verify("get after set_cstring succeeds", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 after set_cstring", 1 == flag);
+    test_verify("value matches cstring content",
+                NULL != val && 0 == strcmp(val->string, "cstring_val"));
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_missing_key(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    /* get on an empty info must set flag=0 and return OPAL_SUCCESS */
+    opal_cstring_t *val = NULL;
+    int flag = 42; /* sentinel -- should be set to 0 */
+    int rc = opal_info_get(info, "nosuchkey", &val, &flag);
+    test_verify("get on missing key returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 0 for missing key", 0 == flag);
+    /* val must not have been written when flag==0 */
+    test_verify("val pointer not modified when flag==0", NULL == val);
+
+    /* get_valuelen on missing key: flag=0, valuelen untouched */
+    int vlen = 999;
+    flag = 42;
+    rc = opal_info_get_valuelen(info, "nosuchkey", &vlen, &flag);
+    test_verify("get_valuelen on missing key returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 0 for missing key (valuelen)", 0 == flag);
+    test_verify("valuelen untouched for missing key", 999 == vlen);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_overwrite(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    opal_info_set(info, "key", "first");
+    int rc = opal_info_set(info, "key", "second");
+    test_verify("overwrite returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(info, "key", &val, &flag);
+    test_verify("flag is still 1 after overwrite", 1 == flag);
+    test_verify("value reflects new content after overwrite",
+                NULL != val && 0 == strcmp(val->string, "second"));
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    /* Only one key should exist (no phantom entries) */
+    int nkeys = -1;
+    opal_info_get_nkeys(info, &nkeys);
+    test_verify("only one entry after overwrite", 1 == nkeys);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_delete(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    opal_info_set(info, "a", "1");
+    opal_info_set(info, "b", "2");
+
+    /* delete existing key */
+    int rc = opal_info_delete(info, "a");
+    test_verify("delete existing key returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(info, "a", &val, &flag);
+    test_verify("deleted key is not found", 0 == flag);
+
+    /* "b" must still be accessible */
+    flag = 0;
+    opal_info_get(info, "b", &val, &flag);
+    test_verify("remaining key still accessible after delete", 1 == flag);
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    /* delete non-existent key */
+    rc = opal_info_delete(info, "nosuchkey");
+    test_verify("delete missing key returns OPAL_ERR_NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == rc);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_nthkey(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    opal_info_set(info, "alpha", "1");
+    opal_info_set(info, "beta",  "2");
+    opal_info_set(info, "gamma", "3");
+
+    /* Keys must be returned in insertion order (MPI-3.1 § 9.1) */
+    opal_cstring_t *key0 = NULL;
+    int rc = opal_info_get_nthkey(info, 0, &key0);
+    test_verify("get_nthkey(0) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("0th key is \"alpha\"",
+                NULL != key0 && 0 == strcmp(key0->string, "alpha"));
+    if (NULL != key0) {
+        OBJ_RELEASE(key0);
+    }
+
+    opal_cstring_t *key1 = NULL;
+    rc = opal_info_get_nthkey(info, 1, &key1);
+    test_verify("get_nthkey(1) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("1st key is \"beta\"",
+                NULL != key1 && 0 == strcmp(key1->string, "beta"));
+    if (NULL != key1) {
+        OBJ_RELEASE(key1);
+    }
+
+    opal_cstring_t *key2 = NULL;
+    rc = opal_info_get_nthkey(info, 2, &key2);
+    test_verify("get_nthkey(2) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("2nd key is \"gamma\"",
+                NULL != key2 && 0 == strcmp(key2->string, "gamma"));
+    if (NULL != key2) {
+        OBJ_RELEASE(key2);
+    }
+
+    /* Out-of-range index must return OPAL_ERR_BAD_PARAM */
+    opal_cstring_t *keyX = NULL;
+    rc = opal_info_get_nthkey(info, 3, &keyX);
+    test_verify("get_nthkey(out of range) returns OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_valuelen(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    const char *v = "hello";
+    opal_info_set(info, "k", v);
+
+    int vlen = 0;
+    int flag = 0;
+    int rc = opal_info_get_valuelen(info, "k", &vlen, &flag);
+    test_verify("get_valuelen returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for existing key", 1 == flag);
+    /* The spec says the C length does not include the NUL terminator */
+    test_verify("valuelen equals strlen(value)", (int) strlen(v) == vlen);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_nkeys(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    int nkeys = -1;
+    opal_info_get_nkeys(info, &nkeys);
+    test_verify("nkeys of fresh info is 0", 0 == nkeys);
+
+    opal_info_set(info, "x", "1");
+    opal_info_set(info, "y", "2");
+    opal_info_get_nkeys(info, &nkeys);
+    test_verify("nkeys is 2 after two sets", 2 == nkeys);
+
+    opal_info_delete(info, "x");
+    opal_info_get_nkeys(info, &nkeys);
+    test_verify("nkeys is 1 after a delete", 1 == nkeys);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_bool(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    /* "true" -> true */
+    opal_info_set(info, "btrue", "true");
+    bool bval = false;
+    int flag = 0;
+    int rc = opal_info_get_bool(info, "btrue", &bval, &flag);
+    test_verify("get_bool(\"true\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for \"true\"", 1 == flag);
+    test_verify("\"true\" parses as true", true == bval);
+
+    /* "false" -> false */
+    opal_info_set(info, "bfalse", "false");
+    bval = true;
+    flag = 0;
+    rc = opal_info_get_bool(info, "bfalse", &bval, &flag);
+    test_verify("get_bool(\"false\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for \"false\"", 1 == flag);
+    test_verify("\"false\" parses as false", false == bval);
+
+    /* "1" -> true */
+    opal_info_set(info, "bone", "1");
+    bval = false;
+    flag = 0;
+    rc = opal_info_get_bool(info, "bone", &bval, &flag);
+    test_verify("get_bool(\"1\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for \"1\"", 1 == flag);
+    test_verify("\"1\" parses as true", true == bval);
+
+    /* "0" -> false */
+    opal_info_set(info, "bzero", "0");
+    bval = true;
+    flag = 0;
+    rc = opal_info_get_bool(info, "bzero", &bval, &flag);
+    test_verify("get_bool(\"0\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for \"0\"", 1 == flag);
+    test_verify("\"0\" parses as false", false == bval);
+
+    /* "yes" -> true (case-insensitive) */
+    opal_info_set(info, "byes", "YES");
+    bval = false;
+    flag = 0;
+    rc = opal_info_get_bool(info, "byes", &bval, &flag);
+    test_verify("get_bool(\"YES\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("\"YES\" parses as true", true == bval);
+
+    /* "no" -> false (case-insensitive) */
+    opal_info_set(info, "bno", "NO");
+    bval = true;
+    flag = 0;
+    rc = opal_info_get_bool(info, "bno", &bval, &flag);
+    test_verify("get_bool(\"NO\") returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("\"NO\" parses as false", false == bval);
+
+    /* missing key: flag==0, return OPAL_SUCCESS */
+    flag = 42;
+    rc = opal_info_get_bool(info, "nosuchkey", &bval, &flag);
+    test_verify("get_bool(missing key) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 0 for missing key", 0 == flag);
+
+    /*
+     * Present key whose value "junk" is not a recognized boolean string.
+     * opal_info_get_bool() delegates to opal_cstring_to_bool(), which is
+     * documented (opal/class/opal_cstring.h) to return OPAL_ERR_BAD_PARAM
+     * and set its output to false for unrecognized values.  flag is 1
+     * because the key itself IS present; the "all other values are false"
+     * wording in info.h governs the bool output, not the return code.
+     */
+    opal_info_set(info, "bjunk", "junk");
+    bval = true;
+    flag = 0;
+    rc = opal_info_get_bool(info, "bjunk", &bval, &flag);
+    test_verify("flag is 1 for present key with junk value", 1 == flag);
+    test_verify("get_bool(\"junk\") returns OPAL_ERR_BAD_PARAM",
+                OPAL_ERR_BAD_PARAM == rc);
+    test_verify("\"junk\" yields false", false == bval);
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_get_value_enum(void)
+{
+    /* Build a tiny enumerator: "low"=0, "high"=1 */
+    mca_base_var_enum_value_t vals[] = {
+        { 0, "low"  },
+        { 1, "high" },
+        { 0, NULL   }  /* sentinel */
+    };
+    mca_base_var_enum_t *venum = NULL;
+    int rc = mca_base_var_enum_create("test_enum", vals, &venum);
+    test_verify("mca_base_var_enum_create succeeds", OPAL_SUCCESS == rc && NULL != venum);
+    if (NULL == venum) {
+        return;
+    }
+
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    opal_info_set(info, "level", "high");
+
+    int out_val = -1;
+    int flag = 0;
+    rc = opal_info_get_value_enum(info, "level", &out_val, 0, venum, &flag);
+    test_verify("get_value_enum returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for existing key", 1 == flag);
+    test_verify("\"high\" resolves to integer 1", 1 == out_val);
+
+    /* "low" -> 0 */
+    opal_info_set(info, "level2", "low");
+    out_val = -1;
+    flag = 0;
+    rc = opal_info_get_value_enum(info, "level2", &out_val, 99, venum, &flag);
+    test_verify("get_value_enum \"low\" returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("\"low\" resolves to integer 0", 0 == out_val);
+
+    /* missing key: default_value must be returned, flag==0 */
+    out_val = -1;
+    flag = 42;
+    rc = opal_info_get_value_enum(info, "nokey", &out_val, 77, venum, &flag);
+    test_verify("get_value_enum on missing key returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 0 for missing key", 0 == flag);
+    test_verify("default_value used when key missing", 77 == out_val);
+
+    OBJ_RELEASE(info);
+    OBJ_RELEASE(venum);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_dup(void)
+{
+    opal_info_t *src = OBJ_NEW(opal_info_t);
+
+    opal_info_set(src, "k1", "v1");
+    opal_info_set(src, "k2", "v2");
+    /* internal key -- dup() must copy it too */
+    opal_info_set_internal(src, "k3_internal", "v3");
+
+    /* opal_info_dup does NOT allocate *newinfo -- caller must do it */
+    opal_info_t *dst = OBJ_NEW(opal_info_t);
+    int rc = opal_info_dup(src, &dst);
+    test_verify("opal_info_dup returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* All three entries (including internal) must appear in dst */
+    int nkeys = -1;
+    opal_info_get_nkeys(dst, &nkeys);
+    test_verify("dup copies all keys including internal", 3 == nkeys);
+
+    /* Verify key order and values */
+    opal_cstring_t *key0 = NULL;
+    opal_info_get_nthkey(dst, 0, &key0);
+    test_verify("dup preserves key order (0 = k1)",
+                NULL != key0 && 0 == strcmp(key0->string, "k1"));
+    if (NULL != key0) OBJ_RELEASE(key0);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(dst, "k2", &val, &flag);
+    test_verify("dup copies value of k2", 1 == flag &&
+                NULL != val && 0 == strcmp(val->string, "v2"));
+    if (NULL != val) OBJ_RELEASE(val);
+
+    /* Changes to dst must not affect src */
+    opal_info_set(dst, "k1", "modified");
+    val = NULL; flag = 0;
+    opal_info_get(src, "k1", &val, &flag);
+    test_verify("dup is a deep copy -- src unaffected by dst change",
+                1 == flag && NULL != val && 0 == strcmp(val->string, "v1"));
+    if (NULL != val) OBJ_RELEASE(val);
+
+    OBJ_RELEASE(dst);
+    OBJ_RELEASE(src);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_dup_public(void)
+{
+    opal_info_t *src = OBJ_NEW(opal_info_t);
+
+    /* public key (not internal) */
+    opal_info_set(src, "pub_key", "pub_val");
+    /* internal key -- dup_public() must SKIP it */
+    opal_info_set_internal(src, "int_key", "int_val");
+
+    /* opal_info_dup_public also requires caller-allocated *newinfo */
+    opal_info_t *dst = OBJ_NEW(opal_info_t);
+    int rc = opal_info_dup_public(src, &dst);
+    test_verify("opal_info_dup_public returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    int nkeys = -1;
+    opal_info_get_nkeys(dst, &nkeys);
+    test_verify("dup_public omits internal key (nkeys==1)", 1 == nkeys);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(dst, "pub_key", &val, &flag);
+    test_verify("dup_public copies public key", 1 == flag &&
+                NULL != val && 0 == strcmp(val->string, "pub_val"));
+    if (NULL != val) OBJ_RELEASE(val);
+
+    flag = 0;
+    opal_info_get(dst, "int_key", &val, &flag);
+    test_verify("dup_public does not copy internal key", 0 == flag);
+
+    OBJ_RELEASE(dst);
+    OBJ_RELEASE(src);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * opal_info_free() is declared in info.h but its implementation lives
+ * in the OMPI layer (not compiled in the OPAL unit test build).
+ * We cover the lifecycle via OBJ_NEW / OBJ_RELEASE, which is the
+ * canonical OPAL mechanism for freeing reference-counted objects.
+ * The test verifies that creating an info, populating it, and
+ * releasing it does not crash or leak references on the contained keys.
+ */
+static void test_free(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+    opal_info_set(info, "k1", "v1");
+    opal_info_set(info, "k2", "v2");
+
+    /* Verify contents before release */
+    int nkeys = -1;
+    opal_info_get_nkeys(info, &nkeys);
+    test_verify("info has 2 keys before release", 2 == nkeys);
+
+    /* OBJ_RELEASE runs the destructor which removes all entries */
+    OBJ_RELEASE(info);
+
+    /*
+     * After OBJ_RELEASE the pointer value is undefined per the OPAL
+     * object model; we only verify no crash occurred (reaching here
+     * is the assertion).
+     */
+    test_verify("OBJ_RELEASE of info_t completed without crash", 1);
+}

--- a/test/util/opal_info_subscriber.c
+++ b/test/util/opal_info_subscriber.c
@@ -1,0 +1,432 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal_infosubscriber_t -- the subscribe/notify
+ * infrastructure layered on top of opal_info_t.
+ *
+ * opal_infosubscriber_t has OBJ_CLASS_INSTANCE(opal_object_t, ...),
+ * so OBJ_NEW(opal_infosubscriber_t) works standalone without a
+ * subclass.
+ *
+ * Library is compiled with -DNDEBUG, so assert() is a no-op.
+ * All verification must go through test_verify().
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/info_subscriber.h"
+#include "opal/util/info.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* Callback infrastructure                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Invocation counters, one per callback variant.  Reset before each
+ * test case that needs them.
+ */
+static int g_cb_invocations = 0;
+static const char *g_cb_last_key = NULL;
+static const char *g_cb_last_value = NULL;
+
+/*
+ * Simple pass-through callback: records arguments, returns value as-is.
+ * Must return a string literal (the impl never frees the return value).
+ */
+static const char *cb_passthrough(opal_infosubscriber_t *obj,
+                                  const char *key,
+                                  const char *value)
+{
+    (void) obj;
+    g_cb_invocations++;
+    g_cb_last_key   = key;
+    g_cb_last_value = value;
+    /* Return the value unchanged.  Static literals are safe here. */
+    return value;
+}
+
+/*
+ * Override callback: always returns "overridden" regardless of input.
+ */
+static int g_override_invocations = 0;
+
+static const char *cb_override(opal_infosubscriber_t *obj,
+                               const char *key,
+                               const char *value)
+{
+    (void) obj;
+    (void) key;
+    (void) value;
+    g_override_invocations++;
+    return "overridden";
+}
+
+/*
+ * Suppressing callback: returns NULL, which causes the key to be
+ * stored as internal (inaccessible to the public API).
+ */
+static int g_suppress_invocations = 0;
+
+static const char *cb_suppress(opal_infosubscriber_t *obj,
+                               const char *key,
+                               const char *value)
+{
+    (void) obj;
+    (void) key;
+    (void) value;
+    g_suppress_invocations++;
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Forward declarations                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_subscribe_fires_on_register(void);
+static void test_subscribe_uses_existing_info(void);
+static void test_change_info_fires_callback(void);
+static void test_change_info_no_callback_is_internal(void);
+static void test_override_callback(void);
+static void test_suppress_callback(void);
+static void test_multiple_subscriptions(void);
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    test_init("opal_infosubscriber_t");
+
+    opal_init_util(&argc, &argv);
+
+    test_subscribe_fires_on_register();
+    test_subscribe_uses_existing_info();
+    test_change_info_fires_callback();
+    test_change_info_no_callback_is_internal();
+    test_override_callback();
+    test_suppress_callback();
+    test_multiple_subscriptions();
+
+    int r = test_finalize();
+    opal_finalize_util();
+    return r;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper: read a value from obj->s_info by key; return 0 if missing  */
+/* ------------------------------------------------------------------ */
+static int read_sinfo(opal_infosubscriber_t *obj, const char *key,
+                      char *buf, size_t buflen)
+{
+    if (NULL == obj->s_info) {
+        return 0;
+    }
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(obj->s_info, key, &val, &flag);
+    if (flag && NULL != val) {
+        snprintf(buf, buflen, "%s", val->string);
+        OBJ_RELEASE(val);
+        return 1;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * When opal_infosubscribe_subscribe is called, it immediately
+ * invokes the callback with the default_value (or the value already
+ * stored in s_info for that key, whichever applies).  Here s_info is
+ * empty, so the default "default_val" is passed to the callback.
+ */
+static void test_subscribe_fires_on_register(void)
+{
+    g_cb_invocations = 0;
+    g_cb_last_key    = NULL;
+    g_cb_last_value  = NULL;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+
+    int rc = opal_infosubscribe_subscribe(obj, "mykey", "default_val", cb_passthrough);
+    test_verify("subscribe returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("callback invoked once on subscribe", 1 == g_cb_invocations);
+    test_verify("callback received correct key",
+                NULL != g_cb_last_key && 0 == strcmp(g_cb_last_key, "mykey"));
+    test_verify("callback received default value",
+                NULL != g_cb_last_value && 0 == strcmp(g_cb_last_value, "default_val"));
+
+    /* The returned value from the passthrough callback must be stored
+     * in s_info under "mykey". */
+    char buf[64] = {0};
+    int found = read_sinfo(obj, "mykey", buf, sizeof(buf));
+    test_verify("s_info populated after subscribe", 1 == found);
+    test_verify("s_info value matches callback return",
+                0 == strcmp(buf, "default_val"));
+
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * If s_info already has a value for the key when subscribe is called,
+ * the callback receives that existing value, not the default.
+ */
+static void test_subscribe_uses_existing_info(void)
+{
+    g_cb_invocations = 0;
+    g_cb_last_value  = NULL;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+
+    /* Pre-populate s_info before subscribing */
+    if (NULL == obj->s_info) {
+        obj->s_info = OBJ_NEW(opal_info_t);
+    }
+    opal_info_set(obj->s_info, "prekey", "existing_val");
+
+    int rc = opal_infosubscribe_subscribe(obj, "prekey", "fallback", cb_passthrough);
+    test_verify("subscribe with pre-existing info returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("callback still fires once", 1 == g_cb_invocations);
+    test_verify("callback received existing value, not default",
+                NULL != g_cb_last_value && 0 == strcmp(g_cb_last_value, "existing_val"));
+
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * opal_infosubscribe_change_info: iterates new_info keys, calls
+ * subscribers for each key that has one, and stores the result.
+ */
+static void test_change_info_fires_callback(void)
+{
+    g_cb_invocations = 0;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+
+    /* Subscribe first so the callback exists for "watched" */
+    opal_infosubscribe_subscribe(obj, "watched", "init", cb_passthrough);
+    /* Reset counter after the subscribe-time invocation */
+    g_cb_invocations = 0;
+
+    /* Build new_info with a value change for "watched" */
+    opal_info_t *new_info = OBJ_NEW(opal_info_t);
+    opal_info_set(new_info, "watched", "new_val");
+
+    int rc = opal_infosubscribe_change_info(obj, new_info);
+    test_verify("change_info returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("callback fired by change_info", 1 == g_cb_invocations);
+
+    /* The updated value must appear in s_info */
+    char buf[64] = {0};
+    int found = read_sinfo(obj, "watched", buf, sizeof(buf));
+    test_verify("s_info updated by change_info", 1 == found);
+    test_verify("s_info holds new value after change_info",
+                0 == strcmp(buf, "new_val"));
+
+    OBJ_RELEASE(new_info);
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Keys that arrive via change_info with NO registered callback are
+ * stored via opal_info_set_internal (ie_internal=true).  At the OPAL
+ * layer, opal_info_get() finds the key regardless of ie_internal --
+ * info_find_key() matches purely on the key string.  So flag comes
+ * back 1.  The observable that discriminates internal from public keys
+ * is opal_info_dup_public(): it skips ie_internal entries.
+ *
+ * This test verifies:
+ *   1. The key is reachable via opal_info_get (flag==1).
+ *   2. opal_info_dup (copies all)    -> key present in duplicate.
+ *   3. opal_info_dup_public (public only) -> key absent in duplicate.
+ */
+static void test_change_info_no_callback_is_internal(void)
+{
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+
+    /* No subscription for "unwatched" -- stored as internal */
+    opal_info_t *new_info = OBJ_NEW(opal_info_t);
+    opal_info_set(new_info, "unwatched", "some_val");
+
+    opal_infosubscribe_change_info(obj, new_info);
+
+    /*
+     * opal_info_get at the OPAL layer does NOT filter by ie_internal.
+     * The key is present and flag==1.
+     */
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    opal_info_get(obj->s_info, "unwatched", &val, &flag);
+    test_verify("unsubscribed key is findable via opal_info_get (flag==1)",
+                1 == flag);
+    test_verify("unsubscribed key holds expected value",
+                NULL != val && 0 == strcmp(val->string, "some_val"));
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    /*
+     * opal_info_dup (all keys) must copy the internal key.
+     */
+    opal_info_t *dup_all = OBJ_NEW(opal_info_t);
+    opal_info_dup(obj->s_info, &dup_all);
+    int nkeys_all = -1;
+    opal_info_get_nkeys(dup_all, &nkeys_all);
+    test_verify("opal_info_dup copies internal key", 1 == nkeys_all);
+    OBJ_RELEASE(dup_all);
+
+    /*
+     * opal_info_dup_public (public keys only) must SKIP the internal key.
+     * This is the observable that proves the key was stored internally.
+     */
+    opal_info_t *dup_pub = OBJ_NEW(opal_info_t);
+    opal_info_dup_public(obj->s_info, &dup_pub);
+    int nkeys_pub = -1;
+    opal_info_get_nkeys(dup_pub, &nkeys_pub);
+    test_verify("opal_info_dup_public skips key stored via change_info (no callback)",
+                0 == nkeys_pub);
+    OBJ_RELEASE(dup_pub);
+
+    OBJ_RELEASE(new_info);
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * A callback that returns a different value overrides what gets
+ * stored in s_info.
+ */
+static void test_override_callback(void)
+{
+    g_override_invocations = 0;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+    opal_infosubscribe_subscribe(obj, "k", "default", cb_override);
+    /* subscribe-time invocation already happened */
+    test_verify("override callback fired on subscribe", 1 == g_override_invocations);
+
+    /* s_info must hold the overridden value, not the default */
+    char buf[64] = {0};
+    int found = read_sinfo(obj, "k", buf, sizeof(buf));
+    test_verify("s_info holds overridden value after subscribe", 1 == found);
+    test_verify("overridden value is \"overridden\"", 0 == strcmp(buf, "overridden"));
+
+    /* A change_info must also produce the overridden value */
+    g_override_invocations = 0;
+    opal_info_t *new_info = OBJ_NEW(opal_info_t);
+    opal_info_set(new_info, "k", "user_val");
+
+    opal_infosubscribe_change_info(obj, new_info);
+    test_verify("override callback fires on change_info", 1 == g_override_invocations);
+
+    memset(buf, 0, sizeof(buf));
+    found = read_sinfo(obj, "k", buf, sizeof(buf));
+    test_verify("s_info still overridden after change_info", 1 == found);
+    test_verify("value still \"overridden\" after change_info",
+                0 == strcmp(buf, "overridden"));
+
+    OBJ_RELEASE(new_info);
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * A callback that returns NULL causes the key to be deleted from s_info
+ * (see info_subscriber.c: if (updated_value) set, else delete).
+ */
+static void test_suppress_callback(void)
+{
+    g_suppress_invocations = 0;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+    opal_infosubscribe_subscribe(obj, "sk", "default_sk", cb_suppress);
+    test_verify("suppress callback fires on subscribe", 1 == g_suppress_invocations);
+
+    /* The key must NOT be present in s_info (callback returned NULL) */
+    char buf[64] = {0};
+    int found = read_sinfo(obj, "sk", buf, sizeof(buf));
+    test_verify("key absent from s_info when callback returns NULL", 0 == found);
+
+    OBJ_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Subscribe two different callbacks on two different keys; verify
+ * each fires independently via change_info.
+ */
+static void test_multiple_subscriptions(void)
+{
+    g_cb_invocations       = 0;
+    g_override_invocations = 0;
+
+    opal_infosubscriber_t *obj = OBJ_NEW(opal_infosubscriber_t);
+    opal_infosubscribe_subscribe(obj, "key_a", "a_default", cb_passthrough);
+    opal_infosubscribe_subscribe(obj, "key_b", "b_default", cb_override);
+
+    /* Reset after subscribe-time invocations */
+    g_cb_invocations       = 0;
+    g_override_invocations = 0;
+
+    opal_info_t *new_info = OBJ_NEW(opal_info_t);
+    opal_info_set(new_info, "key_a", "new_a");
+    opal_info_set(new_info, "key_b", "new_b");
+
+    opal_infosubscribe_change_info(obj, new_info);
+
+    test_verify("passthrough callback fired for key_a", 1 == g_cb_invocations);
+    test_verify("override callback fired for key_b", 1 == g_override_invocations);
+
+    char buf[64] = {0};
+    int found = read_sinfo(obj, "key_a", buf, sizeof(buf));
+    test_verify("key_a holds passthrough value", 1 == found &&
+                0 == strcmp(buf, "new_a"));
+
+    memset(buf, 0, sizeof(buf));
+    found = read_sinfo(obj, "key_b", buf, sizeof(buf));
+    test_verify("key_b holds overridden value", 1 == found &&
+                0 == strcmp(buf, "overridden"));
+
+    OBJ_RELEASE(new_info);
+    OBJ_RELEASE(obj);
+}

--- a/test/util/opal_json.c
+++ b/test/util/opal_json.c
@@ -10,6 +10,7 @@
  */
 
 #include "opal_config.h"
+#include "opal/constants.h"
 #include "opal/util/json/opal_json.h"
 #include "opal/runtime/opal.h"
 #include "support.h"
@@ -264,9 +265,9 @@ static void test_invalid_json_string(void)
 
 int main(int argc, char **argv)
 {
-
-    opal_init(&argc, &argv);
+    int rc = opal_init(&argc, &argv);
     test_init("opal_util_json");
+    test_verify("opal_init() succeeds", OPAL_SUCCESS == rc);
     test_valid_json();
     test_invalid_json_string();
     opal_finalize();

--- a/test/util/opal_keyval_parse.c
+++ b/test/util/opal_keyval_parse.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal/util/keyval_parse.c.
+ *
+ * Tests: opal_util_keyval_parse (with various file formats).
+ *
+ * Note: assert() in the library may be a no-op (when built with -DNDEBUG)
+ * or active (otherwise), so this test's verification must go through
+ * test_verify() rather than relying on assert().
+ *
+ * Callback note: the keyval_parse.h header states that key and value
+ * are "pointers into static buffers" that "may be overwritten
+ * immediately after the callback returns."  Therefore the callback
+ * MUST copy the strings before returning.
+ *
+ * Lexer token notes (from keyval_lex.l):
+ *   CHAR = [A-Za-z0-9_\-\.]
+ *   A line "key = value\n" produces SINGLE_WORD → parse_line() →
+ *     callback(key, value) with key and value as lexed (no prefix
+ *     stripping).  So "mca_foo = bar" → callback("mca_foo", "bar").
+ *
+ *   A line "-mca foo bar\n" produces MCAVAR → parse_line_new() with
+ *     trim_name(key_buffer, "-mca", NULL) / trim_name(key_buffer,
+ *     "--mca", NULL).  The lex token text is the whole "-mca foo" span
+ *     (lexer rule: "-"?"-mca"{WHITE}+{CHAR}+{WHITE}+); after trimming
+ *     "-mca" and leading/trailing whitespace the key becomes "foo".
+ *
+ *   Comment lines ("#..." or "//...") return NEWLINE → zero callbacks.
+ *
+ * Do NOT call opal_util_keyval_parse_init() from this test:
+ * opal_init_util() (via opal_init_core.c) already calls it exactly once.
+ * A second call re-registers the cleanup and re-constructs keyval_mutex,
+ * so opal_finalize_util() then OBJ_DESTRUCTs the mutex twice -- which
+ * aborts on the OBJ magic-id assertion in builds with assertions enabled
+ * (i.e. without -DNDEBUG, as on some CI platforms).
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/keyval_parse.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------ */
+/* callback recording infrastructure                                   */
+/* ------------------------------------------------------------------ */
+
+#define MAX_PAIRS 32
+
+typedef struct {
+    char *key;
+    char *value; /* NULL when the parser provided NULL value */
+} kv_pair_t;
+
+static kv_pair_t g_pairs[MAX_PAIRS];
+static int       g_npairs;
+
+static void reset_pairs(void)
+{
+    int i;
+    for (i = 0; i < g_npairs; ++i) {
+        free(g_pairs[i].key);
+        free(g_pairs[i].value);
+        g_pairs[i].key   = NULL;
+        g_pairs[i].value = NULL;
+    }
+    g_npairs = 0;
+}
+
+static void record_callback(const char *key, const char *value)
+{
+    if (g_npairs >= MAX_PAIRS) {
+        return;
+    }
+    /* The buffers are static inside the parser -- must strdup. */
+    g_pairs[g_npairs].key   = (NULL != key)   ? strdup(key)   : NULL;
+    g_pairs[g_npairs].value = (NULL != value)  ? strdup(value) : NULL;
+    ++g_npairs;
+}
+
+/*
+ * Write 'content' to a temp file.  Fills 'tmppath' (must be >= 64 bytes)
+ * with the path on success.  Returns 0 on success, -1 on failure.
+ */
+static int write_temp_file(char *tmppath, size_t bufsz, const char *content)
+{
+    int fd;
+    FILE *fp;
+
+    snprintf(tmppath, bufsz, "/tmp/opal_keyval_test_XXXXXX");
+    fd = mkstemp(tmppath);
+    if (-1 == fd) {
+        return -1;
+    }
+    fp = fdopen(fd, "w");
+    if (NULL == fp) {
+        close(fd);
+        return -1;
+    }
+    fputs(content, fp);
+    fclose(fp);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: plain key = value lines                     */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_basic(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /* File with two plain key = value lines and a blank line. */
+    const char *content =
+        "key1 = value1\n"
+        "\n"
+        "key2 = value2\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_basic: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_basic: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("parse_basic: 2 pairs recorded", 2 == g_npairs);
+
+    if (2 == g_npairs) {
+        test_verify("parse_basic: pair[0].key == 'key1'",
+                    NULL != g_pairs[0].key &&
+                    0 == strcmp("key1", g_pairs[0].key));
+        test_verify("parse_basic: pair[0].value == 'value1'",
+                    NULL != g_pairs[0].value &&
+                    0 == strcmp("value1", g_pairs[0].value));
+
+        test_verify("parse_basic: pair[1].key == 'key2'",
+                    NULL != g_pairs[1].key &&
+                    0 == strcmp("key2", g_pairs[1].key));
+        test_verify("parse_basic: pair[1].value == 'value2'",
+                    NULL != g_pairs[1].value &&
+                    0 == strcmp("value2", g_pairs[1].value));
+    }
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: mca-prefixed key = value                   */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_mca_prefix(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /*
+     * A line "mca_foo = bar" uses CHAR tokens and the plain "=" path,
+     * so it goes through parse_line().  The key received by the callback
+     * is the literal lexed token "mca_foo" (no prefix stripping occurs
+     * in parse_line).
+     */
+    const char *content =
+        "mca_foo = bar\n"
+        "mca_btl = tcp\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_mca_prefix: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_mca_prefix: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("parse_mca_prefix: 2 pairs recorded", 2 == g_npairs);
+
+    if (2 == g_npairs) {
+        test_verify("parse_mca_prefix: pair[0].key == 'mca_foo'",
+                    NULL != g_pairs[0].key &&
+                    0 == strcmp("mca_foo", g_pairs[0].key));
+        test_verify("parse_mca_prefix: pair[0].value == 'bar'",
+                    NULL != g_pairs[0].value &&
+                    0 == strcmp("bar", g_pairs[0].value));
+
+        test_verify("parse_mca_prefix: pair[1].key == 'mca_btl'",
+                    NULL != g_pairs[1].key &&
+                    0 == strcmp("mca_btl", g_pairs[1].key));
+        test_verify("parse_mca_prefix: pair[1].value == 'tcp'",
+                    NULL != g_pairs[1].value &&
+                    0 == strcmp("tcp", g_pairs[1].value));
+    }
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: comment lines produce zero callbacks        */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_comments(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /* Only comment and blank lines: no callbacks expected. */
+    const char *content =
+        "# This is a comment\n"
+        "// Another comment\n"
+        "\n"
+        "# More comments\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_comments: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_comments: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("parse_comments: 0 pairs recorded", 0 == g_npairs);
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: mixed content                               */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_mixed(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /* Mix of comments, blank lines, and real key=value pairs. */
+    const char *content =
+        "# top comment\n"
+        "\n"
+        "alpha = one\n"
+        "# middle comment\n"
+        "beta = two\n"
+        "\n"
+        "gamma = three\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_mixed: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_mixed: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("parse_mixed: 3 pairs recorded", 3 == g_npairs);
+
+    if (3 == g_npairs) {
+        test_verify("parse_mixed: pair[0].key == 'alpha'",
+                    NULL != g_pairs[0].key &&
+                    0 == strcmp("alpha", g_pairs[0].key));
+        test_verify("parse_mixed: pair[0].value == 'one'",
+                    NULL != g_pairs[0].value &&
+                    0 == strcmp("one", g_pairs[0].value));
+
+        test_verify("parse_mixed: pair[1].key == 'beta'",
+                    NULL != g_pairs[1].key &&
+                    0 == strcmp("beta", g_pairs[1].key));
+        test_verify("parse_mixed: pair[1].value == 'two'",
+                    NULL != g_pairs[1].value &&
+                    0 == strcmp("two", g_pairs[1].value));
+
+        test_verify("parse_mixed: pair[2].key == 'gamma'",
+                    NULL != g_pairs[2].key &&
+                    0 == strcmp("gamma", g_pairs[2].key));
+        test_verify("parse_mixed: pair[2].value == 'three'",
+                    NULL != g_pairs[2].value &&
+                    0 == strcmp("three", g_pairs[2].value));
+    }
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: nonexistent file                            */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_nonexistent(void)
+{
+    int rc;
+    const char *nonexistent = "/tmp/opal_keyval_test_file_that_does_not_exist_xyzzy";
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(nonexistent, record_callback);
+
+    test_verify("parse_nonexistent: returns OPAL_ERR_NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == rc);
+    test_verify("parse_nonexistent: 0 callbacks", 0 == g_npairs);
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: key with no value (empty after =)          */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_empty_value(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /*
+     * A line "key =" with nothing after the '=' (only newline) causes
+     * the VALUE start condition to see {WHITE}*\n → NEWLINE.
+     * parse_line() then calls keyval_callback(key_buffer, NULL).
+     */
+    const char *content = "mykey =\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_empty_value: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_empty_value: returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("parse_empty_value: 1 pair recorded", 1 == g_npairs);
+
+    if (1 == g_npairs) {
+        test_verify("parse_empty_value: key == 'mykey'",
+                    NULL != g_pairs[0].key &&
+                    0 == strcmp("mykey", g_pairs[0].key));
+        /* Value is NULL for empty right-hand side. */
+        test_verify("parse_empty_value: value is NULL",
+                    NULL == g_pairs[0].value);
+    }
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_util_keyval_parse: whitespace-padded values                   */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_whitespace_value(void)
+{
+    char tmppath[64];
+    int rc;
+
+    /*
+     * The VALUE lex rule is:
+     *   <VALUE>[^\n]*[^\t \n]/[\t ]*  -> OPAL_UTIL_KEYVAL_PARSE_VALUE
+     * This captures everything up to (but not including) trailing
+     * whitespace.  So "key = hello world" produces value "hello world"
+     * (internal spaces preserved, trailing spaces stripped).
+     */
+    const char *content = "key = hello world\n";
+
+    if (0 != write_temp_file(tmppath, sizeof(tmppath), content)) {
+        test_failure("test_parse_whitespace_value: could not create temp file");
+        return;
+    }
+
+    reset_pairs();
+    rc = opal_util_keyval_parse(tmppath, record_callback);
+    unlink(tmppath);
+
+    test_verify("parse_whitespace_value: returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("parse_whitespace_value: 1 pair recorded", 1 == g_npairs);
+
+    if (1 == g_npairs) {
+        test_verify("parse_whitespace_value: key == 'key'",
+                    NULL != g_pairs[0].key &&
+                    0 == strcmp("key", g_pairs[0].key));
+        test_verify("parse_whitespace_value: value == 'hello world'",
+                    NULL != g_pairs[0].value &&
+                    0 == strcmp("hello world", g_pairs[0].value));
+    }
+
+    reset_pairs();
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    opal_init_util(&argc, &argv);
+    test_init("opal_keyval_parse");
+
+    test_parse_basic();
+    test_parse_mca_prefix();
+    test_parse_comments();
+    test_parse_mixed();
+    test_parse_nonexistent();
+    test_parse_empty_value();
+    test_parse_whitespace_value();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_malloc.c
+++ b/test/util/opal_malloc.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the opal_malloc / opal_calloc / opal_realloc / opal_free
+ * family and opal_malloc_debug().
+ *
+ * NOTE: malloc.h explicitly states these are back-end functions intended to
+ * be called with __FILE__ and __LINE__ by a front-end macro.  The tests call
+ * them directly with those literal arguments, which is the documented
+ * interface.
+ *
+ * NOTE: opal_malloc_debug() only changes observable state when
+ * OPAL_ENABLE_DEBUG is defined; in non-debug builds the call is a no-op.
+ * We therefore only test that allocations continue to succeed after calling
+ * it, not that it alters any internal diagnostic output.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/malloc.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Canary bytes we write into allocated memory to verify access. */
+#define CANARY_BYTE 0xAB
+#define ALLOC_SIZE  128
+
+static void test_malloc_basic(void)
+{
+    void *p = opal_malloc(ALLOC_SIZE, __FILE__, __LINE__);
+    test_verify("opal_malloc returns non-NULL", NULL != p);
+    if (NULL != p) {
+        /* write and read back to prove the memory is usable */
+        memset(p, CANARY_BYTE, ALLOC_SIZE);
+        test_verify("opal_malloc memory is writable/readable",
+                    (unsigned char) CANARY_BYTE == ((unsigned char *)p)[0]);
+        test_verify("opal_malloc memory last byte ok",
+                    (unsigned char) CANARY_BYTE == ((unsigned char *)p)[ALLOC_SIZE - 1]);
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+static void test_calloc_zeroes(void)
+{
+    size_t n = 16;
+    size_t sz = sizeof(int);
+    int i;
+    int all_zero;
+
+    void *p = opal_calloc(n, sz, __FILE__, __LINE__);
+    test_verify("opal_calloc returns non-NULL", NULL != p);
+    if (NULL != p) {
+        all_zero = 1;
+        for (i = 0; i < (int)(n * sz); ++i) {
+            if (0 != ((unsigned char *)p)[i]) {
+                all_zero = 0;
+                break;
+            }
+        }
+        test_verify("opal_calloc zeroes all bytes", all_zero);
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+static void test_realloc_grow(void)
+{
+    /* Allocate a small block, write a pattern, then grow it.
+     * The leading bytes must be preserved by realloc. */
+    size_t small = 8;
+    size_t large = 256;
+    void *p;
+    void *q;
+    int i;
+    int prefix_ok;
+
+    p = opal_malloc(small, __FILE__, __LINE__);
+    test_verify("realloc_grow: initial malloc non-NULL", NULL != p);
+    if (NULL == p) {
+        return;
+    }
+    for (i = 0; i < (int)small; ++i) {
+        ((unsigned char *)p)[i] = (unsigned char)(i + 1);
+    }
+
+    q = opal_realloc(p, large, __FILE__, __LINE__);
+    test_verify("realloc_grow: returns non-NULL", NULL != q);
+    if (NULL != q) {
+        prefix_ok = 1;
+        for (i = 0; i < (int)small; ++i) {
+            if ((unsigned char)(i + 1) != ((unsigned char *)q)[i]) {
+                prefix_ok = 0;
+                break;
+            }
+        }
+        test_verify("realloc_grow: old prefix bytes preserved", prefix_ok);
+        opal_free(q, __FILE__, __LINE__);
+    } else {
+        /* p is still valid when realloc fails; free it */
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+static void test_realloc_shrink(void)
+{
+    size_t large = 512;
+    size_t small = 4;
+    void *p;
+    void *q;
+    int i;
+    int prefix_ok;
+
+    p = opal_malloc(large, __FILE__, __LINE__);
+    test_verify("realloc_shrink: initial malloc non-NULL", NULL != p);
+    if (NULL == p) {
+        return;
+    }
+    for (i = 0; i < (int)large; ++i) {
+        ((unsigned char *)p)[i] = 0xFF;
+    }
+
+    q = opal_realloc(p, small, __FILE__, __LINE__);
+    test_verify("realloc_shrink: returns non-NULL", NULL != q);
+    if (NULL != q) {
+        /* first 'small' bytes must still be 0xFF */
+        prefix_ok = 1;
+        for (i = 0; i < (int)small; ++i) {
+            if (0xFF != ((unsigned char *)q)[i]) {
+                prefix_ok = 0;
+                break;
+            }
+        }
+        test_verify("realloc_shrink: retained bytes intact", prefix_ok);
+        opal_free(q, __FILE__, __LINE__);
+    } else {
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+/*
+ * test_malloc_debug_does_not_break_alloc
+ *
+ * opal_malloc_debug() is a no-op in non-debug builds; in debug builds
+ * it adjusts an internal diagnostic level.  In either case allocations
+ * must succeed afterwards.
+ */
+static void test_malloc_debug_does_not_break_alloc(void)
+{
+    void *p;
+
+    opal_malloc_debug(0);
+    p = opal_malloc(64, __FILE__, __LINE__);
+    test_verify("after opal_malloc_debug(0): malloc succeeds", NULL != p);
+    if (NULL != p) {
+        opal_free(p, __FILE__, __LINE__);
+    }
+
+    opal_malloc_debug(1);
+    p = opal_malloc(64, __FILE__, __LINE__);
+    test_verify("after opal_malloc_debug(1): malloc succeeds", NULL != p);
+    if (NULL != p) {
+        opal_free(p, __FILE__, __LINE__);
+    }
+
+    opal_malloc_debug(2);
+    p = opal_malloc(64, __FILE__, __LINE__);
+    test_verify("after opal_malloc_debug(2): malloc succeeds", NULL != p);
+    if (NULL != p) {
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+static void test_free_null_is_safe(void)
+{
+    void *p;
+
+    /* opal_free maps directly to free(); passing NULL is defined in C
+     * to be a no-op.  Rather than assert a constant, verify the wrapper
+     * adds no unexpected behavior by confirming the allocator is still
+     * functional after the NULL free -- an observable condition. */
+    opal_free(NULL, __FILE__, __LINE__);
+
+    p = opal_malloc(32, __FILE__, __LINE__);
+    test_verify("opal_malloc still works after opal_free(NULL)", NULL != p);
+    if (NULL != p) {
+        opal_free(p, __FILE__, __LINE__);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_malloc");
+
+    opal_init_util(&argc, &argv);
+
+    test_malloc_basic();
+    test_calloc_zeroes();
+    test_realloc_grow();
+    test_realloc_shrink();
+    test_malloc_debug_does_not_break_alloc();
+    test_free_null_is_safe();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_net.c
+++ b/test/util/opal_net.c
@@ -1,0 +1,591 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal/util/net.h — IPv4/IPv6 address helpers.
+ *
+ * All inputs are constructed from literal constants so the tests are
+ * fully deterministic and independent of runtime DNS or network state.
+ *
+ * Init order (mandatory):
+ *   opal_init_util()  -- registers MCA parameters including
+ *                        opal_net_private_ipv4 with its default value
+ *                        "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16;169.254.0.0/16"
+ *   opal_net_init()   -- parses that string and fills the private_ipv4
+ *                        table (without this, addr_isipv4public returns
+ *                        true for everything -- see net.c line ~314)
+ *
+ * NOTE: -DNDEBUG is set; assert() is a no-op.  All verification MUST
+ * use test_verify() / test_failure().  Never use assert().
+ *
+ * NOTE: opal_net_get_hostname() returns a per-thread static buffer
+ * that must NOT be freed.
+ *
+ * NOTE: We skip /0 and /32 in prefix2netmask tests because the
+ * underlying computation uses (1u << 32) which is undefined behaviour
+ * in C; any value produced is non-deterministic on untested hardware.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/net.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+/* ------------------------------------------------------------------ */
+/* Helpers to build sockaddr structs from literal strings              */
+/* ------------------------------------------------------------------ */
+
+static struct sockaddr_in
+make_sin(const char *dotquad, uint16_t port_host_order)
+{
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port   = htons(port_host_order);
+    inet_pton(AF_INET, dotquad, &sin.sin_addr);
+    return sin;
+}
+
+#if OPAL_ENABLE_IPV6
+static struct sockaddr_in6
+make_sin6(const char *addr_str, uint16_t port_host_order)
+{
+    struct sockaddr_in6 sin6;
+    memset(&sin6, 0, sizeof(sin6));
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_port   = htons(port_host_order);
+    inet_pton(AF_INET6, addr_str, &sin6.sin6_addr);
+    return sin6;
+}
+#endif /* OPAL_ENABLE_IPV6 */
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_isaddr                                               */
+/* ------------------------------------------------------------------ */
+
+static void
+test_isaddr(void)
+{
+    /* Valid IPv4 dotted-quad */
+    test_verify("opal_net_isaddr(\"127.0.0.1\") is true",
+                opal_net_isaddr("127.0.0.1"));
+    test_verify("opal_net_isaddr(\"192.168.1.100\") is true",
+                opal_net_isaddr("192.168.1.100"));
+    test_verify("opal_net_isaddr(\"8.8.8.8\") is true",
+                opal_net_isaddr("8.8.8.8"));
+
+#if OPAL_ENABLE_IPV6
+    /* Valid IPv6 literals */
+    test_verify("opal_net_isaddr(\"::1\") is true",
+                opal_net_isaddr("::1"));
+    test_verify("opal_net_isaddr(\"fe80::1\") is true",
+                opal_net_isaddr("fe80::1"));
+    test_verify("opal_net_isaddr(\"2001:db8::1\") is true",
+                opal_net_isaddr("2001:db8::1"));
+#endif /* OPAL_ENABLE_IPV6 */
+
+    /* Hostnames -- NOT numeric addresses */
+    test_verify("opal_net_isaddr(\"localhost\") is false",
+                !opal_net_isaddr("localhost"));
+    test_verify("opal_net_isaddr(\"example.com\") is false",
+                !opal_net_isaddr("example.com"));
+    test_verify("opal_net_isaddr(\"\") is false",
+                !opal_net_isaddr(""));
+    test_verify("opal_net_isaddr(\"not_an_address\") is false",
+                !opal_net_isaddr("not_an_address"));
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_prefix2netmask                                       */
+/*                                                                     */
+/* The function returns htonl(((1u<<prefixlen)-1u) << (32-prefixlen)) */
+/* i.e. the result is in NETWORK byte order.  We compare by applying  */
+/* the same htonl() to our host-order expected values.                */
+/*                                                                     */
+/* We deliberately SKIP /0 and /32: both trigger shift-by-32 UB.      */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prefix2netmask(void)
+{
+    /* /8  -> 0xFF000000 host-order */
+    test_verify("prefix2netmask(8) == htonl(0xFF000000)",
+                htonl(0xFF000000u) == opal_net_prefix2netmask(8));
+
+    /* /16 -> 0xFFFF0000 host-order */
+    test_verify("prefix2netmask(16) == htonl(0xFFFF0000)",
+                htonl(0xFFFF0000u) == opal_net_prefix2netmask(16));
+
+    /* /24 -> 0xFFFFFF00 host-order */
+    test_verify("prefix2netmask(24) == htonl(0xFFFFFF00)",
+                htonl(0xFFFFFF00u) == opal_net_prefix2netmask(24));
+
+    /* /1  -> 0x80000000 host-order */
+    test_verify("prefix2netmask(1) == htonl(0x80000000)",
+                htonl(0x80000000u) == opal_net_prefix2netmask(1));
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_islocalhost                                          */
+/* ------------------------------------------------------------------ */
+
+static void
+test_islocalhost(void)
+{
+    /* 127.0.0.1 */
+    {
+        struct sockaddr_in sin = make_sin("127.0.0.1", 0);
+        test_verify("opal_net_islocalhost(127.0.0.1) is true",
+                    opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /* 127.0.0.2 -- still in 127.0.0.0/8 */
+    {
+        struct sockaddr_in sin = make_sin("127.0.0.2", 0);
+        test_verify("opal_net_islocalhost(127.0.0.2) is true",
+                    opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /* 127.255.255.255 -- still in 127.0.0.0/8 */
+    {
+        struct sockaddr_in sin = make_sin("127.255.255.255", 0);
+        test_verify("opal_net_islocalhost(127.255.255.255) is true",
+                    opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /* 128.0.0.1 -- just outside 127.0.0.0/8 */
+    {
+        struct sockaddr_in sin = make_sin("128.0.0.1", 0);
+        test_verify("opal_net_islocalhost(128.0.0.1) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /* 192.168.1.1 -- private but not loopback */
+    {
+        struct sockaddr_in sin = make_sin("192.168.1.1", 0);
+        test_verify("opal_net_islocalhost(192.168.1.1) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /* 8.8.8.8 -- public, definitely not localhost */
+    {
+        struct sockaddr_in sin = make_sin("8.8.8.8", 0);
+        test_verify("opal_net_islocalhost(8.8.8.8) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+    /*
+     * Regression guard for the 255.0.0.0 bug (now fixed in opal/util/net.c):
+     * the check previously masked only bit 7 of the top byte
+     * (0x7F000000 == (0x7F000000 & ntohl(s_addr))), so 255.x.x.x
+     * (0xFF000000) also matched as localhost.  It now masks the full top
+     * byte (0xFF000000 == (0xFF000000 & ntohl(s_addr))), so 255.0.0.0 is
+     * correctly not localhost, per the "127.0.0.0/8" contract.
+     */
+    {
+        struct sockaddr_in sin = make_sin("255.0.0.0", 0);
+        test_verify("opal_net_islocalhost(255.0.0.0) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin));
+    }
+
+#if OPAL_ENABLE_IPV6
+    /* ::1 is the IPv6 loopback */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("::1", 0);
+        test_verify("opal_net_islocalhost(::1) is true",
+                    opal_net_islocalhost((struct sockaddr *) &sin6));
+    }
+
+    /* fe80::1 is link-local, not loopback */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("fe80::1", 0);
+        test_verify("opal_net_islocalhost(fe80::1) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin6));
+    }
+
+    /* 2001:db8::1 is a documentation prefix, not loopback */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("2001:db8::1", 0);
+        test_verify("opal_net_islocalhost(2001:db8::1) is false",
+                    !opal_net_islocalhost((struct sockaddr *) &sin6));
+    }
+#endif /* OPAL_ENABLE_IPV6 */
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_samenetwork                                          */
+/* ------------------------------------------------------------------ */
+
+static void
+test_samenetwork(void)
+{
+    /* Two addresses on the same /24 */
+    {
+        struct sockaddr_in a = make_sin("192.168.1.10", 0);
+        struct sockaddr_in b = make_sin("192.168.1.20", 0);
+        test_verify("samenetwork: 192.168.1.x/24 match",
+                    opal_net_samenetwork((struct sockaddr *) &a,
+                                        (struct sockaddr *) &b, 24));
+    }
+
+    /* Two addresses on different /24 subnets */
+    {
+        struct sockaddr_in a = make_sin("192.168.1.10", 0);
+        struct sockaddr_in b = make_sin("192.168.2.10", 0);
+        test_verify("samenetwork: 192.168.1.x vs 192.168.2.x /24 differ",
+                    !opal_net_samenetwork((struct sockaddr *) &a,
+                                         (struct sockaddr *) &b, 24));
+    }
+
+    /* Same /16, different /24 -> still same network at /16 */
+    {
+        struct sockaddr_in a = make_sin("10.1.1.5", 0);
+        struct sockaddr_in b = make_sin("10.1.200.5", 0);
+        test_verify("samenetwork: 10.1.x.x/16 match",
+                    opal_net_samenetwork((struct sockaddr *) &a,
+                                        (struct sockaddr *) &b, 16));
+    }
+
+    /* Same /16, different /24 -> different at /24 */
+    {
+        struct sockaddr_in a = make_sin("10.1.1.5", 0);
+        struct sockaddr_in b = make_sin("10.1.200.5", 0);
+        test_verify("samenetwork: 10.1.1.x vs 10.1.200.x /24 differ",
+                    !opal_net_samenetwork((struct sockaddr *) &a,
+                                         (struct sockaddr *) &b, 24));
+    }
+
+    /* Different families must not be the same network */
+#if OPAL_ENABLE_IPV6
+    {
+        struct sockaddr_in  a4  = make_sin("127.0.0.1", 0);
+        struct sockaddr_in6 a6  = make_sin6("::1", 0);
+        test_verify("samenetwork: AF_INET vs AF_INET6 is always false",
+                    !opal_net_samenetwork((struct sockaddr *) &a4,
+                                         (struct sockaddr *) &a6, 8));
+    }
+
+    /* Two IPv6 addresses in the same /64 prefix */
+    {
+        struct sockaddr_in6 a = make_sin6("2001:db8::1", 0);
+        struct sockaddr_in6 b = make_sin6("2001:db8::2", 0);
+        test_verify("samenetwork: 2001:db8::/64 match",
+                    opal_net_samenetwork((struct sockaddr *) &a,
+                                        (struct sockaddr *) &b, 64));
+    }
+
+    /* Two IPv6 addresses in different /64 prefixes */
+    {
+        struct sockaddr_in6 a = make_sin6("2001:db8:1::1", 0);
+        struct sockaddr_in6 b = make_sin6("2001:db8:2::1", 0);
+        test_verify("samenetwork: 2001:db8:1:: vs 2001:db8:2:: /64 differ",
+                    !opal_net_samenetwork((struct sockaddr *) &a,
+                                         (struct sockaddr *) &b, 64));
+    }
+#endif /* OPAL_ENABLE_IPV6 */
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_addr_isipv4public                                    */
+/*                                                                     */
+/* The default opal_net_private_ipv4 (set in opal_params_core.c) is:  */
+/*   "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16;169.254.0.0/16"        */
+/* After opal_net_init() these are loaded, so RFC1918 addrs return    */
+/* false and public addresses return true.                             */
+/* ------------------------------------------------------------------ */
+
+static void
+test_addr_isipv4public(void)
+{
+    /* Google DNS -- unambiguously public */
+    {
+        struct sockaddr_in sin = make_sin("8.8.8.8", 0);
+        test_verify("opal_net_addr_isipv4public(8.8.8.8) is true",
+                    opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 1.1.1.1 -- Cloudflare DNS, public */
+    {
+        struct sockaddr_in sin = make_sin("1.1.1.1", 0);
+        test_verify("opal_net_addr_isipv4public(1.1.1.1) is true",
+                    opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 10.0.0.1 -- RFC1918 private (10.0.0.0/8) */
+    {
+        struct sockaddr_in sin = make_sin("10.0.0.1", 0);
+        test_verify("opal_net_addr_isipv4public(10.0.0.1) is false (RFC1918)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 10.255.255.255 -- still in 10.0.0.0/8 */
+    {
+        struct sockaddr_in sin = make_sin("10.255.255.255", 0);
+        test_verify("opal_net_addr_isipv4public(10.255.255.255) is false (RFC1918)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 172.16.0.1 -- RFC1918 private (172.16.0.0/12) */
+    {
+        struct sockaddr_in sin = make_sin("172.16.0.1", 0);
+        test_verify("opal_net_addr_isipv4public(172.16.0.1) is false (RFC1918)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 172.31.255.255 -- still in 172.16.0.0/12 */
+    {
+        struct sockaddr_in sin = make_sin("172.31.255.255", 0);
+        test_verify("opal_net_addr_isipv4public(172.31.255.255) is false (RFC1918)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 172.32.0.1 -- just outside 172.16.0.0/12 (172.16-31.x.x only) */
+    {
+        struct sockaddr_in sin = make_sin("172.32.0.1", 0);
+        test_verify("opal_net_addr_isipv4public(172.32.0.1) is true (outside RFC1918)",
+                    opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 192.168.0.1 -- RFC1918 private (192.168.0.0/16) */
+    {
+        struct sockaddr_in sin = make_sin("192.168.0.1", 0);
+        test_verify("opal_net_addr_isipv4public(192.168.0.1) is false (RFC1918)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+    /* 169.254.1.1 -- link-local (169.254.0.0/16) */
+    {
+        struct sockaddr_in sin = make_sin("169.254.1.1", 0);
+        test_verify("opal_net_addr_isipv4public(169.254.1.1) is false (link-local)",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin));
+    }
+
+#if OPAL_ENABLE_IPV6
+    /* IPv6 addresses always return false from this function */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("2001:db8::1", 0);
+        test_verify("opal_net_addr_isipv4public(IPv6 addr) is false",
+                    !opal_net_addr_isipv4public((struct sockaddr *) &sin6));
+    }
+#endif /* OPAL_ENABLE_IPV6 */
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_addr_isipv6linklocal                                 */
+/* ------------------------------------------------------------------ */
+
+#if OPAL_ENABLE_IPV6
+static void
+test_addr_isipv6linklocal(void)
+{
+    /* fe80::1 is a link-local address */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("fe80::1", 0);
+        test_verify("opal_net_addr_isipv6linklocal(fe80::1) is true",
+                    opal_net_addr_isipv6linklocal((struct sockaddr *) &sin6));
+    }
+
+    /* fe80::ffff is still link-local */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("fe80::ffff", 0);
+        test_verify("opal_net_addr_isipv6linklocal(fe80::ffff) is true",
+                    opal_net_addr_isipv6linklocal((struct sockaddr *) &sin6));
+    }
+
+    /* ::1 is loopback, not link-local */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("::1", 0);
+        test_verify("opal_net_addr_isipv6linklocal(::1) is false",
+                    !opal_net_addr_isipv6linklocal((struct sockaddr *) &sin6));
+    }
+
+    /* 2001:db8::1 is a global unicast address, not link-local */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("2001:db8::1", 0);
+        test_verify("opal_net_addr_isipv6linklocal(2001:db8::1) is false",
+                    !opal_net_addr_isipv6linklocal((struct sockaddr *) &sin6));
+    }
+
+    /* IPv4 address -> always false */
+    {
+        struct sockaddr_in sin = make_sin("127.0.0.1", 0);
+        test_verify("opal_net_addr_isipv6linklocal(IPv4 addr) is false",
+                    !opal_net_addr_isipv6linklocal((struct sockaddr *) &sin));
+    }
+}
+#endif /* OPAL_ENABLE_IPV6 */
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_get_hostname                                         */
+/*                                                                     */
+/* Returns a per-thread static buffer -- do NOT free the result.      */
+/* ------------------------------------------------------------------ */
+
+static void
+test_get_hostname(void)
+{
+    /* 127.0.0.1 -> should produce the string "127.0.0.1" */
+    {
+        struct sockaddr_in sin = make_sin("127.0.0.1", 0);
+        const char *h = opal_net_get_hostname((struct sockaddr *) &sin);
+        test_verify("opal_net_get_hostname(127.0.0.1) is non-NULL",
+                    NULL != h);
+        if (NULL != h) {
+            test_verify("opal_net_get_hostname(127.0.0.1) == \"127.0.0.1\"",
+                        0 == strcmp("127.0.0.1", h));
+        }
+    }
+
+    /* 8.8.8.8 -> should produce the string "8.8.8.8" */
+    {
+        struct sockaddr_in sin = make_sin("8.8.8.8", 0);
+        const char *h = opal_net_get_hostname((struct sockaddr *) &sin);
+        test_verify("opal_net_get_hostname(8.8.8.8) is non-NULL",
+                    NULL != h);
+        if (NULL != h) {
+            test_verify("opal_net_get_hostname(8.8.8.8) == \"8.8.8.8\"",
+                        0 == strcmp("8.8.8.8", h));
+        }
+    }
+
+#if OPAL_ENABLE_IPV6
+    /* ::1 should produce "::1" (or equivalent minimal form) */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("::1", 0);
+        const char *h = opal_net_get_hostname((struct sockaddr *) &sin6);
+        test_verify("opal_net_get_hostname(::1) is non-NULL",
+                    NULL != h);
+        if (NULL != h) {
+            test_verify("opal_net_get_hostname(::1) is non-empty",
+                        '\0' != h[0]);
+        }
+    }
+
+    /* fe80::1 */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("fe80::1", 0);
+        const char *h = opal_net_get_hostname((struct sockaddr *) &sin6);
+        test_verify("opal_net_get_hostname(fe80::1) is non-NULL",
+                    NULL != h);
+    }
+#endif /* OPAL_ENABLE_IPV6 */
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: opal_net_get_port                                             */
+/* ------------------------------------------------------------------ */
+
+static void
+test_get_port(void)
+{
+    /* IPv4: port 80 */
+    {
+        struct sockaddr_in sin = make_sin("192.168.1.1", 80);
+        test_verify("opal_net_get_port(sin, port=80) == 80",
+                    80 == opal_net_get_port((struct sockaddr *) &sin));
+    }
+
+    /* IPv4: port 0 */
+    {
+        struct sockaddr_in sin = make_sin("0.0.0.0", 0);
+        test_verify("opal_net_get_port(sin, port=0) == 0",
+                    0 == opal_net_get_port((struct sockaddr *) &sin));
+    }
+
+    /* IPv4: port 65535 */
+    {
+        struct sockaddr_in sin = make_sin("127.0.0.1", 65535);
+        test_verify("opal_net_get_port(sin, port=65535) == 65535",
+                    65535 == opal_net_get_port((struct sockaddr *) &sin));
+    }
+
+#if OPAL_ENABLE_IPV6
+    /* IPv6: port 443 */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("::1", 443);
+        test_verify("opal_net_get_port(sin6, port=443) == 443",
+                    443 == opal_net_get_port((struct sockaddr *) &sin6));
+    }
+
+    /* IPv6: port 0 */
+    {
+        struct sockaddr_in6 sin6 = make_sin6("2001:db8::1", 0);
+        test_verify("opal_net_get_port(sin6, port=0) == 0",
+                    0 == opal_net_get_port((struct sockaddr *) &sin6));
+    }
+#endif /* OPAL_ENABLE_IPV6 */
+
+    /* Unknown family -> returns -1 */
+    {
+        struct sockaddr sa;
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_family = AF_UNSPEC;
+        test_verify("opal_net_get_port(AF_UNSPEC) == -1",
+                    -1 == opal_net_get_port(&sa));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int rc;
+
+    /* test_addr_isipv4public()'s RFC1918 assertions assume the built-in
+       default private-address table.  Clear any inherited
+       OMPI_MCA_opal_net_private_ipv4 so the test exercises those defaults
+       rather than a table injected via the environment. */
+    unsetenv("OMPI_MCA_opal_net_private_ipv4");
+
+    rc = opal_init_util(&argc, &argv);
+    test_init("opal_net");
+    test_verify("opal_init_util() succeeds", OPAL_SUCCESS == rc);
+
+    rc = opal_net_init();
+    test_verify("opal_net_init() succeeds", OPAL_SUCCESS == rc);
+
+    test_isaddr();
+    test_prefix2netmask();
+    test_islocalhost();
+    test_samenetwork();
+    test_addr_isipv4public();
+#if OPAL_ENABLE_IPV6
+    test_addr_isipv6linklocal();
+#endif /* OPAL_ENABLE_IPV6 */
+    test_get_hostname();
+    test_get_port();
+
+    {
+        int r = test_finalize();
+        opal_finalize_util();
+        return r;
+    }
+}

--- a/test/util/opal_os_dirpath.c
+++ b/test/util/opal_os_dirpath.c
@@ -1,0 +1,417 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal/util/os_dirpath.c
+ *
+ * Covers: opal_os_dirpath_create, opal_os_dirpath_is_empty,
+ *         opal_os_dirpath_access, opal_os_dirpath_destroy.
+ *
+ * All temp directories are created under a mkdtemp base and cleaned
+ * up before the process exits.  We use S_IRWXU throughout to avoid
+ * umask stripping group/other bits and making mode assertions flaky.
+ *
+ * Library is compiled with -DNDEBUG, so assert() is a no-op.
+ * All verification must go through test_verify().
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/os_dirpath.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Create a regular file at the given path.  Returns 0 on success.
+ */
+static int create_file(const char *path)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (-1 == fd) {
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+/*
+ * Build a path string from two components without using opal_os_path().
+ * Result is malloc'd; caller must free().
+ */
+static char *path_join(const char *base, const char *sub)
+{
+    size_t len = strlen(base) + 1 + strlen(sub) + 1;
+    char *p = malloc(len);
+    if (NULL != p) {
+        snprintf(p, len, "%s/%s", base, sub);
+    }
+    return p;
+}
+
+/*
+ * Build a path string from three components.  Result is malloc'd.
+ */
+static char *path_join3(const char *a, const char *b, const char *c)
+{
+    size_t len = strlen(a) + 1 + strlen(b) + 1 + strlen(c) + 1;
+    char *p = malloc(len);
+    if (NULL != p) {
+        snprintf(p, len, "%s/%s/%s", a, b, c);
+    }
+    return p;
+}
+
+/* ------------------------------------------------------------------ */
+/* Forward declarations                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_create_null_path(void);
+static void test_create_existing_dir(void);
+static void test_create_nested_dirs(void);
+static void test_is_empty(void);
+static void test_access_nonexistent(void);
+static void test_access_exists_match(void);
+static void test_access_exists_no_match(void);
+static void test_destroy_recursive_no_callback(void);
+static void test_destroy_recursive_with_callback(void);
+static void test_destroy_nonexistent(void);
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    test_init("opal_os_dirpath");
+
+    opal_init_util(&argc, &argv);
+
+    test_create_null_path();
+    test_create_existing_dir();
+    test_create_nested_dirs();
+    test_is_empty();
+    test_access_nonexistent();
+    test_access_exists_match();
+    test_access_exists_no_match();
+    test_destroy_recursive_no_callback();
+    test_destroy_recursive_with_callback();
+    test_destroy_nonexistent();
+
+    int r = test_finalize();
+    opal_finalize_util();
+    return r;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_create_null_path(void)
+{
+    int rc = opal_os_dirpath_create(NULL, S_IRWXU);
+    test_verify("create(NULL) returns error", OPAL_SUCCESS != rc);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_create_existing_dir(void)
+{
+    /* Create a temp dir with mkdtemp, then call opal_os_dirpath_create
+     * on it.  It already exists with the right permissions, so the
+     * function should succeed immediately. */
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_create_existing_dir: mkdtemp failed");
+        return;
+    }
+
+    int rc = opal_os_dirpath_create(base, S_IRWXU);
+    test_verify("create on existing dir returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Force the "build our way down the tree" branch by requesting a
+ * two-level path that does not yet exist under the temp root.
+ */
+static void test_create_nested_dirs(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_create_nested_dirs: mkdtemp failed");
+        return;
+    }
+
+    char *leaf = path_join3(base, "level1", "level2");
+    if (NULL == leaf) {
+        test_failure("test_create_nested_dirs: OOM building path");
+        rmdir(base);
+        return;
+    }
+
+    int rc = opal_os_dirpath_create(leaf, S_IRWXU);
+    test_verify("create nested dirs returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* The leaf must exist and be a directory */
+    struct stat buf;
+    int sr = stat(leaf, &buf);
+    test_verify("nested leaf directory exists after create", 0 == sr);
+    test_verify("nested leaf is a directory", 0 == sr && S_ISDIR(buf.st_mode));
+
+    /* The required mode bits must be set */
+    test_verify("nested leaf has S_IRWXU permission bits",
+                0 == sr && (S_IRWXU == (buf.st_mode & S_IRWXU)));
+
+    /* Clean up */
+    rmdir(leaf);
+    char *mid = path_join(base, "level1");
+    if (NULL != mid) {
+        rmdir(mid);
+        free(mid);
+    }
+    rmdir(base);
+    free(leaf);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_is_empty(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_is_empty: mkdtemp failed");
+        return;
+    }
+
+    /* Fresh directory must be empty */
+    test_verify("fresh dir is empty", true == opal_os_dirpath_is_empty(base));
+
+    /* Create a file inside */
+    char *fpath = path_join(base, "afile");
+    if (NULL == fpath) {
+        test_failure("test_is_empty: OOM");
+        rmdir(base);
+        return;
+    }
+
+    int cr = create_file(fpath);
+    if (0 != cr) {
+        test_failure("test_is_empty: could not create file");
+        free(fpath);
+        rmdir(base);
+        return;
+    }
+
+    test_verify("dir with file is not empty",
+                false == opal_os_dirpath_is_empty(base));
+
+    unlink(fpath);
+    free(fpath);
+
+    test_verify("dir is empty again after file removed",
+                true == opal_os_dirpath_is_empty(base));
+
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_access_nonexistent(void)
+{
+    /* A path that certainly does not exist */
+    int rc = opal_os_dirpath_access("/tmp/opal_nonexistent_dir_xyz987", S_IRWXU);
+    test_verify("access on non-existent path returns OPAL_ERR_NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == rc);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_access_exists_match(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_access_exists_match: mkdtemp failed");
+        return;
+    }
+    /* mkdtemp creates with 0700 = S_IRWXU; requesting S_IRWXU must succeed */
+    int rc = opal_os_dirpath_access(base, S_IRWXU);
+    test_verify("access on dir with matching mode returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_access_exists_no_match(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_access_exists_no_match: mkdtemp failed");
+        return;
+    }
+    /* Strip all permissions so S_IRWXU won't match */
+    chmod(base, 0);
+
+    int rc = opal_os_dirpath_access(base, S_IRWXU);
+    test_verify("access on dir with wrong mode returns OPAL_ERROR",
+                OPAL_ERROR == rc);
+
+    /* Restore so rmdir can proceed */
+    chmod(base, S_IRWXU);
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_destroy_recursive_no_callback(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_recursive_no_callback: mkdtemp failed");
+        return;
+    }
+
+    /* Populate: base/sub/ and base/sub/file */
+    char *sub = path_join(base, "sub");
+    if (NULL == sub) {
+        test_failure("test_destroy_recursive_no_callback: OOM");
+        rmdir(base);
+        return;
+    }
+    mkdir(sub, S_IRWXU);
+
+    char *fpath = path_join(sub, "file");
+    if (NULL == fpath) {
+        test_failure("test_destroy_recursive_no_callback: OOM fpath");
+        rmdir(sub);
+        rmdir(base);
+        free(sub);
+        return;
+    }
+    create_file(fpath);
+
+    int rc = opal_os_dirpath_destroy(base, true /*recursive*/, NULL /*no cb*/);
+    test_verify("recursive destroy (no cb) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* base itself must be gone (destroy rmdir's it when empty) */
+    struct stat buf;
+    test_verify("top dir removed after recursive destroy", 0 != stat(base, &buf));
+
+    free(fpath);
+    free(sub);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Callback that vetoes removal of files named "protected".
+ */
+static bool cb_protect(const char *root, const char *name)
+{
+    (void) root;
+    if (0 == strcmp(name, "protected")) {
+        return false; /* do NOT remove */
+    }
+    return true; /* allow removal */
+}
+
+static void test_destroy_recursive_with_callback(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_recursive_with_callback: mkdtemp failed");
+        return;
+    }
+
+    /* Create base/protected and base/removable */
+    char *prot = path_join(base, "protected");
+    char *remo = path_join(base, "removable");
+    if (NULL == prot || NULL == remo) {
+        test_failure("test_destroy_recursive_with_callback: OOM");
+        if (NULL != prot) { free(prot); }
+        if (NULL != remo) { free(remo); }
+        rmdir(base);
+        return;
+    }
+    create_file(prot);
+    create_file(remo);
+
+    /*
+     * destroy with the protecting callback.  The callback returns
+     * false for "protected", so that file stays.  "removable" gets
+     * unlinked.  Because the directory is not empty (protected is
+     * still there), the top dir itself is NOT removed by the
+     * cleanup block.
+     */
+    int rc = opal_os_dirpath_destroy(base, true, cb_protect);
+    test_verify("destroy with protect callback returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    /* "protected" must still exist */
+    struct stat buf;
+    test_verify("protected file survives callback veto", 0 == stat(prot, &buf));
+
+    /* "removable" must be gone */
+    test_verify("removable file was removed", 0 != stat(remo, &buf));
+
+    /* base dir must still exist (not empty) */
+    test_verify("base dir survives (not empty)", 0 == stat(base, &buf));
+
+    /* Manual cleanup */
+    unlink(prot);
+    rmdir(base);
+
+    free(prot);
+    free(remo);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_destroy_nonexistent(void)
+{
+    int rc = opal_os_dirpath_destroy("/tmp/opal_nonexistent_dir_xyz987",
+                                    true, NULL);
+    test_verify("destroy on non-existent path returns OPAL_ERR_NOT_FOUND",
+                OPAL_ERR_NOT_FOUND == rc);
+}

--- a/test/util/opal_os_path.c
+++ b/test/util/opal_os_path.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,178 +17,142 @@
  * $HEADER$
  */
 
-#include "orte_config.h"
-#include <stdio.h>
+#include "opal_config.h"
+
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_SYS_PARAM_H
 #    include <sys/param.h>
 #endif
 
-#include "opal/runtime/opal.h"
-#include "opal/util/os_path.h"
 #include "support.h"
-
-#define PATH_SEP "/"
-
-static const char *path_sep = PATH_SEP;
-
-static bool test1(void); /* trivial answer test */
-static bool test2(void); /* relative path test */
-static bool test3(void); /* absolute path test */
-static bool test4(void); /* missing path separator test */
+#include "opal/util/os_path.h"
+#include "opal/constants.h"
 
 int main(int argc, char *argv[])
 {
-    opal_init(&argc, &argv);
-
-    test_init("opal_os_path_t");
-
-    if (test1()) {
-        test_success();
-    } else {
-        test_failure("opal_os_path_t test1 failed");
-    }
-
-    if (test2()) {
-        test_success();
-    } else {
-        test_failure("opal_os_path_t test2 failed");
-    }
-
-    if (test3()) {
-        test_success();
-    } else {
-        test_failure("opal_os_path_t test3 failed");
-    }
-
-    if (test4()) {
-        test_success();
-    } else {
-        test_failure("opal_os_path_t test4 failed");
-    }
-
-    opal_finalize();
-
-    test_finalize();
-    return 0;
-}
-
-static bool test1(void)
-{
-    char *out, answer[100];
-
-    /* Test trivial functionality. Program should return ".[separator]" when called in relative
-     * mode, and the separator character when called in absolute mode. */
-    if (NULL != (out = opal_os_path(true, NULL))) {
-        answer[0] = '\0';
-        strcat(answer, ".");
-        strcat(answer, path_sep);
-        if (0 != strcmp(answer, out))
-            return false;
-        free(out);
-    }
-    if (NULL != (out = opal_os_path(false, NULL))) {
-        if (0 != strcmp(path_sep, out))
-            return false;
-        free(out);
-    }
-
-    return true;
-}
-
-static bool test2(void)
-{
-    char out[1024];
-    char *tmp;
-    char *a[] = {"aaa", "bbb", "ccc", NULL};
-
-    if (NULL == path_sep) {
-        printf("test2 cannot be run\n");
-        return false;
-    }
-
-    /* Construct a relative path name and see if it comes back correctly. Check multiple depths. */
-    out[0] = '\0';
-    strcat(out, ".");
-    strcat(out, path_sep);
-    strcat(out, a[0]);
-
-    tmp = opal_os_path(true, a[0], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    strcat(out, path_sep);
-    strcat(out, a[1]);
-    tmp = opal_os_path(true, a[0], a[1], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    strcat(out, path_sep);
-    strcat(out, a[2]);
-    tmp = opal_os_path(true, a[0], a[1], a[2], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    return true;
-}
-
-static bool test3(void)
-{
-    char out[1024];
-    char *tmp;
-    char *a[] = {"aaa", "bbb", "ccc", NULL};
-
-    if (NULL == path_sep) {
-        printf("test3 cannot be run\n");
-        return false;
-    }
-
-    /* Same as prior test, only with absolute path name */
-    out[0] = '\0';
-    strcat(out, path_sep);
-    strcat(out, a[0]);
-    tmp = opal_os_path(false, a[0], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    strcat(out, path_sep);
-    strcat(out, a[1]);
-    tmp = opal_os_path(false, a[0], a[1], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    strcat(out, path_sep);
-    strcat(out, a[2]);
-    tmp = opal_os_path(false, a[0], a[1], a[2], NULL);
-    if (0 != strcmp(out, tmp))
-        return false;
-    free(tmp);
-
-    return true;
-}
-
-static bool test4(void)
-{
-    char a[OPAL_PATH_MAX + 10];
+    char *result;
+    char long_elem[OPAL_PATH_MAX + 16];
     int i;
 
-    if (NULL == path_sep) {
-        printf("test4 cannot be run\n");
-        return false;
+    test_init("opal_os_path");
+
+    /* ================================================================
+     * Trivial: no path elements
+     * ================================================================ */
+
+    /* Relative, no elements -> "./" */
+    result = opal_os_path(1 /*relative*/, NULL);
+    test_verify("relative no-args: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("relative no-args: equals './'", 0 == strcmp(result, "./"));
+        free(result);
     }
 
-    for (i = 0; i < OPAL_PATH_MAX + 5; i++) {
-        a[i] = 'a';
+    /* Absolute, no elements -> "/" */
+    result = opal_os_path(0 /*absolute*/, NULL);
+    test_verify("absolute no-args: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("absolute no-args: equals '/'", 0 == strcmp(result, "/"));
+        free(result);
     }
-    a[i] = '\0';
-    if (NULL != opal_os_path(false, a, NULL)) {
-        return false;
+
+    /* ================================================================
+     * Relative paths
+     * ================================================================ */
+
+    /* Single element */
+    result = opal_os_path(1, "aaa", NULL);
+    test_verify("relative 1-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("relative 1-elem: equals './aaa'", 0 == strcmp(result, "./aaa"));
+        free(result);
     }
-    return true;
+
+    /* Two elements */
+    result = opal_os_path(1, "aaa", "bbb", NULL);
+    test_verify("relative 2-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("relative 2-elem: equals './aaa/bbb'",
+                    0 == strcmp(result, "./aaa/bbb"));
+        free(result);
+    }
+
+    /* Three elements */
+    result = opal_os_path(1, "aaa", "bbb", "ccc", NULL);
+    test_verify("relative 3-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("relative 3-elem: equals './aaa/bbb/ccc'",
+                    0 == strcmp(result, "./aaa/bbb/ccc"));
+        free(result);
+    }
+
+    /* ================================================================
+     * Absolute paths
+     * ================================================================ */
+
+    /* Single element */
+    result = opal_os_path(0, "aaa", NULL);
+    test_verify("absolute 1-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("absolute 1-elem: equals '/aaa'", 0 == strcmp(result, "/aaa"));
+        free(result);
+    }
+
+    /* Two elements */
+    result = opal_os_path(0, "aaa", "bbb", NULL);
+    test_verify("absolute 2-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("absolute 2-elem: equals '/aaa/bbb'",
+                    0 == strcmp(result, "/aaa/bbb"));
+        free(result);
+    }
+
+    /* Three elements */
+    result = opal_os_path(0, "aaa", "bbb", "ccc", NULL);
+    test_verify("absolute 3-elem: not NULL", NULL != result);
+    if (NULL != result) {
+        test_verify("absolute 3-elem: equals '/aaa/bbb/ccc'",
+                    0 == strcmp(result, "/aaa/bbb/ccc"));
+        free(result);
+    }
+
+    /* ================================================================
+     * Element that already starts with the path separator:
+     * the implementation skips inserting an extra separator.
+     * ================================================================ */
+
+    result = opal_os_path(0, "/absolute_elem", NULL);
+    test_verify("elem starting with '/': not NULL", NULL != result);
+    if (NULL != result) {
+        /* The element already has the separator, so the result should
+         * be "/absolute_elem" (not "//absolute_elem"). */
+        test_verify("elem starting with '/': equals '/absolute_elem'",
+                    0 == strcmp(result, "/absolute_elem"));
+        free(result);
+    }
+
+    /* ================================================================
+     * Path length limit: element too long -> NULL
+     * ================================================================ */
+
+    for (i = 0; i < OPAL_PATH_MAX + 10; ++i) {
+        long_elem[i] = 'a';
+    }
+    long_elem[OPAL_PATH_MAX + 10] = '\0';
+
+    result = opal_os_path(0, long_elem, NULL);
+    test_verify("too-long elem: returns NULL", NULL == result);
+    if (NULL != result) {
+        free(result);
+    }
+
+    /* Same test for relative mode */
+    result = opal_os_path(1, long_elem, NULL);
+    test_verify("too-long elem (relative): returns NULL", NULL == result);
+    if (NULL != result) {
+        free(result);
+    }
+
+    return test_finalize();
 }

--- a/test/util/opal_output.c
+++ b/test/util/opal_output.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the opal_output subsystem.
+ *
+ * Functions exercised:
+ *   opal_output_init      (called implicitly by opal_init_util)
+ *   opal_output_open      (open a new stream with an opal_output_stream_t)
+ *   opal_output_close     (close a stream)
+ *   opal_output           (formatted output to a stream)
+ *   opal_output_verbose   (macro -- output gated by verbosity level)
+ *   opal_output_set_verbosity / opal_output_get_verbosity
+ *   opal_output_check_verbosity
+ *   opal_output_string    (return output as a malloc'd string)
+ *   opal_output_reopen    (redirect an existing stream)
+ *   opal_output_set_output_file_info (control file naming for file streams)
+ *
+ * File output strategy:
+ *   We call opal_output_set_output_file_info() to set a known, process-
+ *   unique directory (mkdtemp) and a fixed prefix so the filename is
+ *   predictable.  The file is only created lazily on the first write, so
+ *   we call opal_output() before attempting to fopen() it.  After each
+ *   test we close the stream, unlink the file, and restore the old
+ *   output dir/prefix.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/output.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Build a predictable filename: dir + "/" + prefix + suffix. */
+static void build_filename(char *buf, size_t bufsz,
+                           const char *dir, const char *prefix,
+                           const char *suffix)
+{
+    snprintf(buf, bufsz, "%s/%s%s", dir, prefix, suffix);
+}
+
+/*
+ * Read the entire content of a file into a malloc'd buffer.
+ * Returns NULL on failure.  Caller must free().
+ */
+static char *slurp_file(const char *path)
+{
+    FILE *fp;
+    long len;
+    char *buf;
+    size_t nread;
+
+    fp = fopen(path, "r");
+    if (NULL == fp) {
+        return NULL;
+    }
+    if (0 != fseek(fp, 0, SEEK_END)) {
+        fclose(fp);
+        return NULL;
+    }
+    len = ftell(fp);
+    if (len < 0) {
+        fclose(fp);
+        return NULL;
+    }
+    rewind(fp);
+    buf = (char *) malloc((size_t) len + 1);
+    if (NULL == buf) {
+        fclose(fp);
+        return NULL;
+    }
+    nread = fread(buf, 1, (size_t) len, fp);
+    buf[nread] = '\0';
+    fclose(fp);
+    return buf;
+}
+
+/* ------------------------------------------------------------------ */
+/* test_open_close_stderr                                              */
+/*                                                                     */
+/* Open a stream directed only to stderr; verify handle is >= 0;      */
+/* then close it.                                                      */
+/* ------------------------------------------------------------------ */
+static void test_open_close_stderr(void)
+{
+    opal_output_stream_t lds;
+    int h;
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr = true;
+
+    h = opal_output_open(&lds);
+    test_verify("opal_output_open(stderr) returns valid handle", h >= 0);
+    if (h >= 0) {
+        opal_output_close(h);
+    }
+    OBJ_DESTRUCT(&lds);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_verbosity_get_set                                              */
+/*                                                                     */
+/* Open a stream, set its verbosity, read it back, and check the      */
+/* gating predicate opal_output_check_verbosity.                      */
+/* ------------------------------------------------------------------ */
+static void test_verbosity_get_set(void)
+{
+    opal_output_stream_t lds;
+    int h;
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr  = true;
+    lds.lds_verbose_level = 0;
+
+    h = opal_output_open(&lds);
+    test_verify("verbosity test: open succeeds", h >= 0);
+    if (h < 0) {
+        OBJ_DESTRUCT(&lds);
+        return;
+    }
+
+    /* After open, verbosity should be 0 (set in lds). */
+    test_verify("verbosity: initial get_verbosity == 0",
+                0 == opal_output_get_verbosity(h));
+
+    /* check_verbosity(0, h): level 0 <= stream verbosity 0 -> true */
+    test_verify("verbosity: check_verbosity(0) true when level == 0",
+                opal_output_check_verbosity(0, h));
+
+    /* check_verbosity(1, h): level 1 > stream verbosity 0 -> false */
+    test_verify("verbosity: check_verbosity(1) false when stream_level == 0",
+                !opal_output_check_verbosity(1, h));
+
+    opal_output_set_verbosity(h, 5);
+    test_verify("verbosity: set_verbosity(5) -> get == 5",
+                5 == opal_output_get_verbosity(h));
+
+    /* Now level 5 should pass, level 6 should not. */
+    test_verify("verbosity: check_verbosity(5) true when stream_level == 5",
+                opal_output_check_verbosity(5, h));
+    test_verify("verbosity: check_verbosity(6) false when stream_level == 5",
+                !opal_output_check_verbosity(6, h));
+
+    opal_output_close(h);
+    OBJ_DESTRUCT(&lds);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_output_string                                                  */
+/*                                                                     */
+/* opal_output_string returns a malloc'd string when verbose_level    */
+/* permits, and NULL when it does not.                                 */
+/* ------------------------------------------------------------------ */
+static void test_output_string(void)
+{
+    opal_output_stream_t lds;
+    int h;
+    char *s;
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr   = false;
+    lds.lds_verbose_level = 3;
+
+    h = opal_output_open(&lds);
+    test_verify("output_string: open succeeds", h >= 0);
+    if (h < 0) {
+        OBJ_DESTRUCT(&lds);
+        return;
+    }
+
+    /* level 3 <= stream verbosity 3 -> should return a string */
+    s = opal_output_string(3, h, "hello %s", "world");
+    test_verify("output_string: returns non-NULL when level <= verbosity",
+                NULL != s);
+    if (NULL != s) {
+        test_verify("output_string: payload present in returned string",
+                    NULL != strstr(s, "hello world"));
+        free(s);
+    }
+
+    /* level 4 > stream verbosity 3 -> should return NULL */
+    s = opal_output_string(4, h, "should not appear");
+    test_verify("output_string: returns NULL when level > verbosity",
+                NULL == s);
+
+    opal_output_close(h);
+    OBJ_DESTRUCT(&lds);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_output_verbose_macro                                           */
+/*                                                                     */
+/* opal_output_verbose is a macro gated by opal_output_check_verbosity*/
+/* We can only verify it compiles and doesn't crash; side effects are  */
+/* to stderr so we can't capture them here.                            */
+/* ------------------------------------------------------------------ */
+static void test_output_verbose_macro(void)
+{
+    opal_output_stream_t lds;
+    int h;
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr   = true;
+    lds.lds_verbose_level = 2;
+
+    h = opal_output_open(&lds);
+    test_verify("output_verbose: open succeeds", h >= 0);
+    if (h < 0) {
+        OBJ_DESTRUCT(&lds);
+        return;
+    }
+
+    /* These calls must not crash (level 2 passes; level 3 is suppressed). */
+    opal_output_verbose(2, h, "verbose message at level 2");
+    opal_output_verbose(3, h, "this should be suppressed");
+
+    test_verify("output_verbose: survived both calls without crash", 1);
+
+    opal_output_close(h);
+    OBJ_DESTRUCT(&lds);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_file_output                                                    */
+/*                                                                     */
+/* Direct output to a file in a temp directory, then verify the file  */
+/* received the payload.                                               */
+/*                                                                     */
+/* File naming: output_dir + "/" + output_prefix + suffix             */
+/*   We set output_dir = our tmpdir                                   */
+/*      and output_prefix = "opaltest-"                               */
+/*      suffix = "output-test.txt"                                    */
+/* ------------------------------------------------------------------ */
+static void test_file_output(void)
+{
+    char tmpdir[] = "/tmp/opaltest.XXXXXX";
+    char *dir;
+    char *olddir  = NULL;
+    char *oldpfx  = NULL;
+    opal_output_stream_t lds;
+    int h;
+    char filename[1024];
+    char *content;
+    const char *prefix = "opaltest-";
+    const char *suffix = "output-test.txt";
+    const char *payload = "TESTPAYLOAD_12345";
+
+    dir = mkdtemp(tmpdir);
+    test_verify("test_file_output: mkdtemp succeeded", NULL != dir);
+    if (NULL == dir) {
+        return;
+    }
+
+    /* Redirect output infrastructure to our temp directory. */
+    opal_output_set_output_file_info(dir, prefix, &olddir, &oldpfx);
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr      = false;
+    lds.lds_want_file        = true;
+    lds.lds_want_file_append = false;
+    lds.lds_file_suffix      = strdup(suffix); /* owned + freed by OBJ_DESTRUCT */
+
+    h = opal_output_open(&lds);
+    test_verify("test_file_output: open returns valid handle", h >= 0);
+    if (h < 0) {
+        OBJ_DESTRUCT(&lds);
+        opal_output_set_output_file_info(olddir, oldpfx, NULL, NULL);
+        free(olddir);
+        free(oldpfx);
+        rmdir(dir);
+        return;
+    }
+
+    /* The file is created lazily on first write. */
+    opal_output(h, "%s", payload);
+
+    opal_output_close(h);
+    OBJ_DESTRUCT(&lds);
+
+    /* Check content. */
+    build_filename(filename, sizeof(filename), dir, prefix, suffix);
+    content = slurp_file(filename);
+    test_verify("test_file_output: output file exists and is readable",
+                NULL != content);
+    if (NULL != content) {
+        test_verify("test_file_output: payload found in file content",
+                    NULL != strstr(content, payload));
+        free(content);
+    }
+
+    /* Cleanup. */
+    unlink(filename);
+    rmdir(dir);
+
+    /* Restore previous output dir/prefix. */
+    opal_output_set_output_file_info(olddir, oldpfx, NULL, NULL);
+    free(olddir);
+    free(oldpfx);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_reopen                                                         */
+/*                                                                     */
+/* opal_output_reopen() redirects an existing stream to a new set of  */
+/* destinations.  We open a stream to stderr, reopen it with a        */
+/* different verbosity level, and verify the new level took effect.   */
+/* ------------------------------------------------------------------ */
+static void test_reopen(void)
+{
+    opal_output_stream_t lds;
+    int h;
+    int h2;
+
+    OBJ_CONSTRUCT(&lds, opal_output_stream_t);
+    lds.lds_want_stderr   = true;
+    lds.lds_verbose_level = 0;
+
+    h = opal_output_open(&lds);
+    test_verify("reopen: initial open succeeds", h >= 0);
+    if (h < 0) {
+        OBJ_DESTRUCT(&lds);
+        return;
+    }
+
+    /* Reopen with a new verbosity level. */
+    lds.lds_verbose_level = 7;
+    h2 = opal_output_reopen(h, &lds);
+
+    /*
+     * opal_output_reopen returns the stream id (same as h when reopening an
+     * existing id).
+     */
+    test_verify("reopen: returns the same stream id", h == h2);
+    test_verify("reopen: new verbosity level is visible",
+                7 == opal_output_get_verbosity(h));
+
+    opal_output_close(h);
+    OBJ_DESTRUCT(&lds);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_get_verbosity_invalid_handle                                   */
+/*                                                                     */
+/* opal_output_get_verbosity with an unused/invalid id must return -1.*/
+/* ------------------------------------------------------------------ */
+static void test_get_verbosity_invalid_handle(void)
+{
+    /* Stream id 63 is within OPAL_OUTPUT_MAX_STREAMS (64) but we never
+     * open it, so ldi_used should be false and get_verbosity must return -1. */
+    test_verify("get_verbosity(unused id) returns -1",
+                -1 == opal_output_get_verbosity(63));
+
+    /* Negative id: also returns -1. */
+    test_verify("get_verbosity(-1) returns -1",
+                -1 == opal_output_get_verbosity(-1));
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_output");
+
+    opal_init_util(&argc, &argv);
+
+    test_open_close_stderr();
+    test_verbosity_get_set();
+    test_output_string();
+    test_output_verbose_macro();
+    test_file_output();
+    test_reopen();
+    test_get_verbosity_invalid_handle();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_path.c
+++ b/test/util/opal_path.c
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal/util/path.c.
+ *
+ * Note: the library is compiled with -DNDEBUG, so assert() is a no-op.
+ * All verification must go through test_verify().
+ *
+ * opal_path_nfs is covered elsewhere (test/util/opal_path_nfs.c) and
+ * is intentionally omitted here.
+ *
+ * opal_path_access, opal_path_find, and opal_path_findv take char*
+ * (non-const) for fname/path arguments.  To avoid -Wwrite-strings
+ * warnings, all file-name arguments are passed as mutable char arrays.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/path.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Create a temporary regular file (mode 0600) and return its path via
+ * buf (which must be at least 64 bytes).  Returns 0 on success.
+ */
+static int make_temp_file(char *buf, size_t bufsz)
+{
+    int fd;
+
+    snprintf(buf, bufsz, "/tmp/opal_path_test_XXXXXX");
+    fd = mkstemp(buf);
+    if (-1 == fd) {
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_path_is_absolute                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_is_absolute(void)
+{
+    /* An absolute path starts with '/' on UNIX. */
+    test_verify("is_absolute('/x') == true",
+                true == opal_path_is_absolute("/x"));
+
+    test_verify("is_absolute('/') == true",
+                true == opal_path_is_absolute("/"));
+
+    test_verify("is_absolute('/usr/bin/sh') == true",
+                true == opal_path_is_absolute("/usr/bin/sh"));
+
+    /* A relative path must return false. */
+    test_verify("is_absolute('x') == false",
+                false == opal_path_is_absolute("x"));
+
+    test_verify("is_absolute('foo/bar') == false",
+                false == opal_path_is_absolute("foo/bar"));
+
+    test_verify("is_absolute('./foo') == false",
+                false == opal_path_is_absolute("./foo"));
+
+    /* An empty string has no leading '/'. */
+    test_verify("is_absolute('') == false",
+                false == opal_path_is_absolute(""));
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_path_access                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_path_access(void)
+{
+    char tmppath[64];
+    char *result;
+
+    /* Create a regular temporary file (mode 0600 -- user r/w, no x). */
+    if (0 != make_temp_file(tmppath, sizeof(tmppath))) {
+        test_failure("opal_path_access: could not create temp file");
+        return;
+    }
+
+    /* Access an existing regular file with R_OK -- should succeed. */
+    {
+        char fname[64];
+        snprintf(fname, sizeof(fname), "%s", tmppath);
+        result = opal_path_access(fname, NULL, R_OK);
+        test_verify("access existing file R_OK: non-NULL", NULL != result);
+        if (NULL != result) {
+            free(result);
+        }
+    }
+
+    /* Access with mode 0 (existence check) -- should also succeed. */
+    {
+        char fname[64];
+        snprintf(fname, sizeof(fname), "%s", tmppath);
+        result = opal_path_access(fname, NULL, 0);
+        test_verify("access existing file mode=0: non-NULL", NULL != result);
+        if (NULL != result) {
+            free(result);
+        }
+    }
+
+    /* A non-existent path should return NULL. */
+    {
+        char fname[] = "/tmp/opal_path_test_does_not_exist_xyzzy_42";
+        result = opal_path_access(fname, NULL, R_OK);
+        test_verify("access nonexistent file: NULL", NULL == result);
+    }
+
+    /* The temp file has no execute permission (mode 0600), so X_OK
+     * should return NULL.  The stat-based check in opal_path_access
+     * looks at S_IXUSR, not the access(2) syscall, so it behaves
+     * consistently regardless of effective UID. */
+    {
+        char fname[64];
+        snprintf(fname, sizeof(fname), "%s", tmppath);
+        result = opal_path_access(fname, NULL, X_OK);
+        test_verify("access file without X_OK bit: NULL", NULL == result);
+    }
+
+    /* opal_path_access on a directory should return NULL (not a
+     * regular file or symlink). */
+    {
+        char fname[] = "/tmp";
+        result = opal_path_access(fname, NULL, R_OK);
+        test_verify("access directory: NULL", NULL == result);
+    }
+
+    unlink(tmppath);
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_path_find                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_path_find(void)
+{
+    char *result;
+
+    /* Build a pathv containing common binary directories.  We look for
+     * "sh" which is universally available.  envv is NULL so environment
+     * substitution is skipped. */
+    {
+        char fname[] = "sh";
+        char *pathv[] = {"/bin", "/usr/bin", "/usr/local/bin", NULL};
+        result = opal_path_find(fname, pathv, X_OK, NULL);
+        test_verify("find 'sh' in /bin:/usr/bin: non-NULL", NULL != result);
+        if (NULL != result) {
+            /* Result must be an absolute path. */
+            test_verify("find 'sh': result is absolute",
+                        true == opal_path_is_absolute(result));
+            free(result);
+        }
+    }
+
+    /* Searching for a file that definitely does not exist must return
+     * NULL. */
+    {
+        char fname[] = "opal_test_binary_that_does_not_exist_xyzzy";
+        char *pathv[] = {"/bin", "/usr/bin", NULL};
+        result = opal_path_find(fname, pathv, X_OK, NULL);
+        test_verify("find nonexistent binary: NULL", NULL == result);
+    }
+
+    /* Single-element pathv with a known directory and file. */
+    {
+        char tmppath[64];
+        if (0 == make_temp_file(tmppath, sizeof(tmppath))) {
+            /* Extract directory and basename from tmppath. */
+            char dir[64];
+            char base[64];
+            char *slash;
+
+            snprintf(dir, sizeof(dir), "%s", tmppath);
+            slash = strrchr(dir, '/');
+            if (NULL != slash) {
+                *slash = '\0';
+                snprintf(base, sizeof(base), "%s", slash + 1);
+
+                char *pathv_single[] = {dir, NULL};
+                result = opal_path_find(base, pathv_single, R_OK, NULL);
+                test_verify("find temp file in its dir: non-NULL",
+                            NULL != result);
+                if (NULL != result) {
+                    free(result);
+                }
+            }
+            unlink(tmppath);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_path_findv                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_path_findv(void)
+{
+    char *result;
+
+    /* Build an envv that contains PATH=/bin:/usr/bin.  opal_path_findv
+     * extracts PATH from envv.  We search for "sh" with X_OK. */
+    {
+        char fname[] = "sh";
+        char pathenv[] = "PATH=/bin:/usr/bin:/usr/local/bin";
+        char *envv[] = {pathenv, NULL};
+        result = opal_path_findv(fname, X_OK, envv, NULL);
+        test_verify("findv 'sh' via PATH envv: non-NULL", NULL != result);
+        if (NULL != result) {
+            test_verify("findv 'sh': result is absolute",
+                        true == opal_path_is_absolute(result));
+            free(result);
+        }
+    }
+
+    /* Non-existent binary must return NULL. */
+    {
+        char fname[] = "opal_test_binary_that_does_not_exist_xyzzy";
+        char pathenv[] = "PATH=/bin:/usr/bin";
+        char *envv[] = {pathenv, NULL};
+        result = opal_path_findv(fname, X_OK, envv, NULL);
+        test_verify("findv nonexistent binary: NULL", NULL == result);
+    }
+
+    /* envv=NULL and no system PATH: no binaries should be found in
+     * an environment where PATH truly contains nothing.  We pass a
+     * custom envv with an empty PATH to force a NULL result. */
+    {
+        char fname[] = "sh";
+        char pathenv[] = "PATH=";
+        char *envv[] = {pathenv, NULL};
+        result = opal_path_findv(fname, X_OK, envv, NULL);
+        /* With an empty PATH, "sh" cannot be found. */
+        test_verify("findv 'sh' with empty PATH: NULL", NULL == result);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_find_absolute_path                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_find_absolute_path(void)
+{
+    char *result;
+
+    /* An already-absolute path to a real binary should return the
+     * canonical path (via realpath).  The result must be non-NULL and
+     * absolute. */
+    {
+        char input[] = "/bin/sh";
+        result = opal_find_absolute_path(input);
+        test_verify("find_absolute_path('/bin/sh'): non-NULL",
+                    NULL != result);
+        if (NULL != result) {
+            test_verify("find_absolute_path('/bin/sh'): result is absolute",
+                        true == opal_path_is_absolute(result));
+            free(result);
+        }
+    }
+
+    /* A path that does not exist should return NULL. */
+    {
+        char input[] = "/bin/opal_test_binary_does_not_exist_xyzzy";
+        result = opal_find_absolute_path(input);
+        test_verify("find_absolute_path nonexistent: NULL", NULL == result);
+    }
+
+    /* A relative name that is present in $PATH (using the real environment)
+     * should be found.  We ask for "sh" which is always in PATH. */
+    {
+        char input[] = "sh";
+        result = opal_find_absolute_path(input);
+        test_verify("find_absolute_path('sh') via PATH: non-NULL",
+                    NULL != result);
+        if (NULL != result) {
+            test_verify("find_absolute_path('sh'): result is absolute",
+                        true == opal_path_is_absolute(result));
+            free(result);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* opal_path_df                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_path_df(void)
+{
+    uint64_t avail;
+    int rc;
+
+    /* Querying '/' must succeed. */
+    avail = 0;
+    rc = opal_path_df("/", &avail);
+    test_verify("path_df('/') returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    /* avail can legitimately be 0 on full filesystems; we just verify
+     * the call succeeded without requiring a particular value. */
+
+    /* NULL path must return OPAL_ERROR. */
+    avail = 0;
+    rc = opal_path_df(NULL, &avail);
+    test_verify("path_df(NULL, &avail) returns OPAL_ERROR",
+                OPAL_ERROR == rc);
+
+    /* NULL out_avail must return OPAL_ERROR. */
+    rc = opal_path_df("/", NULL);
+    test_verify("path_df('/', NULL) returns OPAL_ERROR",
+                OPAL_ERROR == rc);
+
+    /* Query /tmp -- must succeed on any POSIX system. */
+    avail = 0;
+    rc = opal_path_df("/tmp", &avail);
+    test_verify("path_df('/tmp') returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    /* A path that does not exist should return OPAL_ERROR. */
+    avail = 0;
+    rc = opal_path_df("/opal_path_test_nonexistent_dir_xyzzy", &avail);
+    test_verify("path_df(nonexistent) returns OPAL_ERROR",
+                OPAL_ERROR == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    opal_init_util(&argc, &argv);
+    test_init("opal_path");
+
+    test_is_absolute();
+    test_path_access();
+    test_path_find();
+    test_path_findv();
+    test_find_absolute_path();
+    test_path_df();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_printf.c
+++ b/test/util/opal_printf.c
@@ -1,0 +1,341 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/util/printf.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* -----------------------------------------------------------------------
+ * Helpers to exercise the va_list variants
+ * ----------------------------------------------------------------------- */
+
+static int call_vasprintf(char **ptr, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start(ap, fmt);
+    rc = opal_vasprintf(ptr, fmt, ap);
+    va_end(ap);
+    return rc;
+}
+
+static int call_vsnprintf(char *str, size_t size, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start(ap, fmt);
+    rc = opal_vsnprintf(str, size, fmt, ap);
+    va_end(ap);
+    return rc;
+}
+
+/* -----------------------------------------------------------------------
+ * opal_asprintf tests
+ * ----------------------------------------------------------------------- */
+
+static void test_asprintf_string(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = opal_asprintf(&s, "%s", "hello");
+    test_verify("asprintf %s: rc == 5", 5 == rc);
+    test_verify("asprintf %s: string matches", NULL != s && 0 == strcmp("hello", s));
+    free(s);
+}
+
+static void test_asprintf_int(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = opal_asprintf(&s, "%d", 42);
+    test_verify("asprintf %d: rc == 2", 2 == rc);
+    test_verify("asprintf %d: string matches", NULL != s && 0 == strcmp("42", s));
+    free(s);
+}
+
+static void test_asprintf_negative_int(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = opal_asprintf(&s, "%d", -7);
+    test_verify("asprintf negative int: rc == 2", 2 == rc);
+    test_verify("asprintf negative int: string matches", NULL != s && 0 == strcmp("-7", s));
+    free(s);
+}
+
+static void test_asprintf_float(void)
+{
+    char *s = NULL;
+    int rc;
+
+    /* Use %.1f for predictable output */
+    rc = opal_asprintf(&s, "%.1f", 3.5);
+    test_verify("asprintf %.1f: rc > 0", rc > 0);
+    test_verify("asprintf %.1f: string matches", NULL != s && 0 == strcmp("3.5", s));
+    free(s);
+}
+
+static void test_asprintf_empty_format(void)
+{
+    char *s = NULL;
+    int rc;
+    /* Use a variable to avoid -Wformat-zero-length on a string literal "" */
+    const char *fmt = "";
+
+    rc = opal_asprintf(&s, fmt);
+    test_verify("asprintf empty format: rc == 0", 0 == rc);
+    test_verify("asprintf empty format: string is empty", NULL != s && 0 == strcmp("", s));
+    free(s);
+}
+
+static void test_asprintf_mixed(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = opal_asprintf(&s, "%s=%d", "x", 1);
+    test_verify("asprintf mixed: rc == 3", 3 == rc);
+    test_verify("asprintf mixed: string matches", NULL != s && 0 == strcmp("x=1", s));
+    free(s);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_vasprintf tests
+ * ----------------------------------------------------------------------- */
+
+static void test_vasprintf_string(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = call_vasprintf(&s, "%s", "world");
+    test_verify("vasprintf %s: rc == 5", 5 == rc);
+    test_verify("vasprintf %s: string matches", NULL != s && 0 == strcmp("world", s));
+    free(s);
+}
+
+static void test_vasprintf_int(void)
+{
+    char *s = NULL;
+    int rc;
+
+    rc = call_vasprintf(&s, "%d", 100);
+    test_verify("vasprintf %d: rc == 3", 3 == rc);
+    test_verify("vasprintf %d: string matches", NULL != s && 0 == strcmp("100", s));
+    free(s);
+}
+
+static void test_vasprintf_empty_format(void)
+{
+    char *s = NULL;
+    int rc;
+    const char *fmt = "";
+
+    rc = call_vasprintf(&s, fmt);
+    test_verify("vasprintf empty format: rc == 0", 0 == rc);
+    test_verify("vasprintf empty format: empty string", NULL != s && 0 == strcmp("", s));
+    free(s);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_snprintf tests
+ * ----------------------------------------------------------------------- */
+
+static void test_snprintf_fits(void)
+{
+    char buf[64];
+    int rc;
+
+    rc = opal_snprintf(buf, sizeof(buf), "%s=%d", "key", 99);
+    test_verify("snprintf fits: rc == 6", 6 == rc);
+    test_verify("snprintf fits: content", 0 == strcmp("key=99", buf));
+}
+
+static void test_snprintf_exact_fit(void)
+{
+    /* "hello" is 5 chars; buffer of 6 is exactly big enough (5 + NUL) */
+    char buf[6];
+    int rc;
+
+    rc = opal_snprintf(buf, sizeof(buf), "%s", "hello");
+    /* Returns full would-have-been length = 5 */
+    test_verify("snprintf exact fit: rc == 5", 5 == rc);
+    test_verify("snprintf exact fit: content", 0 == strcmp("hello", buf));
+}
+
+static void test_snprintf_truncation(void)
+{
+    /* Buffer of 5 forces truncation of "hello" (needs 6 bytes) */
+    char buf[5];
+    int rc;
+
+    rc = opal_snprintf(buf, sizeof(buf), "%s", "hello");
+    /* Returns the would-have-been length (5), not the truncated length */
+    test_verify("snprintf truncation: rc == 5 (would-have-been)", 5 == rc);
+    /* Output must be NUL-terminated */
+    test_verify("snprintf truncation: NUL-terminated", '\0' == buf[4]);
+    /* Truncated content: "hell\0" */
+    test_verify("snprintf truncation: first 4 chars", 0 == strncmp("hell", buf, 4));
+    test_verify("snprintf truncation: strlen == 4", 4 == (int) strlen(buf));
+}
+
+static void test_snprintf_null_buffer_zero_size(void)
+{
+    int rc;
+
+    /* C99: NULL/0 returns the would-have-been length without writing */
+    rc = opal_snprintf(NULL, 0, "%s %d", "test", 1004);
+    test_verify("snprintf NULL/0: returns full length", rc > 0);
+    /* "test 1004" is 9 chars */
+    test_verify("snprintf NULL/0: rc == 9", 9 == rc);
+}
+
+static void test_snprintf_empty_format(void)
+{
+    char buf[8];
+    int rc;
+    const char *fmt = "";
+
+    rc = opal_snprintf(buf, sizeof(buf), fmt);
+    test_verify("snprintf empty format: rc == 0", 0 == rc);
+    test_verify("snprintf empty format: empty string", 0 == strcmp("", buf));
+}
+
+static void test_snprintf_one_byte_buffer(void)
+{
+    /* A 1-byte buffer can only hold the NUL terminator */
+    char buf[1];
+    int rc;
+
+    rc = opal_snprintf(buf, sizeof(buf), "%d", 42);
+    test_verify("snprintf 1-byte buf: returns full length 2", 2 == rc);
+    test_verify("snprintf 1-byte buf: buf[0] is NUL", '\0' == buf[0]);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_vsnprintf tests
+ * ----------------------------------------------------------------------- */
+
+static void test_vsnprintf_fits(void)
+{
+    char buf[64];
+    int rc;
+
+    rc = call_vsnprintf(buf, sizeof(buf), "%s", "vsnprintf");
+    test_verify("vsnprintf fits: rc == 9", 9 == rc);
+    test_verify("vsnprintf fits: content", 0 == strcmp("vsnprintf", buf));
+}
+
+static void test_vsnprintf_truncation(void)
+{
+    char buf[4];
+    int rc;
+
+    /* "abc" fits in 4 bytes ("abc\0"), "abcd" does not */
+    rc = call_vsnprintf(buf, sizeof(buf), "%s", "abcd");
+    /* Returns the full would-have-been length = 4 */
+    test_verify("vsnprintf truncation: rc == 4", 4 == rc);
+    test_verify("vsnprintf truncation: NUL-terminated", '\0' == buf[3]);
+    test_verify("vsnprintf truncation: first 3 chars", 0 == strncmp("abc", buf, 3));
+}
+
+static void test_vsnprintf_length_equals_size_minus_one(void)
+{
+    /* content "abc" is 3 chars; buffer size=4 => fits exactly */
+    char buf[4];
+    int rc;
+
+    rc = call_vsnprintf(buf, sizeof(buf), "%s", "abc");
+    test_verify("vsnprintf length==size-1: rc == 3", 3 == rc);
+    test_verify("vsnprintf length==size-1: content", 0 == strcmp("abc", buf));
+}
+
+static void test_vsnprintf_length_equals_size(void)
+{
+    /* "abcd" is 4 chars; buffer size=4 means last char is dropped */
+    char buf[4];
+    int rc;
+
+    rc = call_vsnprintf(buf, sizeof(buf), "%s", "abcd");
+    test_verify("vsnprintf length==size: rc == 4", 4 == rc);
+    /* Only "abc" fits plus NUL */
+    test_verify("vsnprintf length==size: content truncated", 0 == strcmp("abc", buf));
+}
+
+static void test_vsnprintf_null_zero(void)
+{
+    int rc;
+
+    rc = call_vsnprintf(NULL, 0, "%d", 999);
+    test_verify("vsnprintf NULL/0: returns 3", 3 == rc);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_printf");
+
+    /* opal_asprintf */
+    test_asprintf_string();
+    test_asprintf_int();
+    test_asprintf_negative_int();
+    test_asprintf_float();
+    test_asprintf_empty_format();
+    test_asprintf_mixed();
+
+    /* opal_vasprintf */
+    test_vasprintf_string();
+    test_vasprintf_int();
+    test_vasprintf_empty_format();
+
+    /* opal_snprintf */
+    test_snprintf_fits();
+    test_snprintf_exact_fit();
+    test_snprintf_truncation();
+    test_snprintf_null_buffer_zero_size();
+    test_snprintf_empty_format();
+    test_snprintf_one_byte_buffer();
+
+    /* opal_vsnprintf */
+    test_vsnprintf_fits();
+    test_vsnprintf_truncation();
+    test_vsnprintf_length_equals_size_minus_one();
+    test_vsnprintf_length_equals_size();
+    test_vsnprintf_null_zero();
+
+    return test_finalize();
+}

--- a/test/util/opal_proc.c
+++ b/test/util/opal_proc.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the opal proc / local-proc identity API:
+ *   opal_proc_local_get()  -- return the current local proc pointer
+ *   opal_proc_local_set()  -- replace the local proc pointer
+ *   opal_proc_set_name()   -- write a process name into the default local proc
+ *
+ * Behaviour from proc.c:
+ *   - A static opal_local_proc is always present; opal_proc_local_get()
+ *     returns &opal_local_proc by default (never NULL).
+ *   - opal_proc_local_set(p) retains p and releases the old pointer (unless
+ *     the old pointer is the built-in &opal_local_proc).
+ *   - opal_proc_local_set(NULL) restores the built-in default.
+ *   - opal_proc_set_name(name) copies name into the default local proc's
+ *     proc_name field using memcpy.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/proc.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* test_local_get_not_null                                            */
+/*                                                                     */
+/* opal_proc_local_get() must return non-NULL both before and after   */
+/* opal_init_util.  (We call it here, after init_util.)               */
+/* ------------------------------------------------------------------ */
+static void test_local_get_not_null(void)
+{
+    opal_proc_t *p = opal_proc_local_get();
+    test_verify("opal_proc_local_get() is non-NULL after init_util", NULL != p);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_local_set_get_roundtrip                                       */
+/*                                                                     */
+/* Create a new opal_proc_t, install it as the local proc, verify     */
+/* get returns the new pointer, then restore the default.             */
+/*                                                                     */
+/* Refcount protocol (from proc.c):                                   */
+/*   1. OBJ_NEW(proc_t)  -- refcount = 1 (our ref)                   */
+/*   2. local_set(p)     -- retains p   (refcount = 2)               */
+/*   3. local_set(NULL)  -- releases p  (refcount = 1)               */
+/*   4. OBJ_RELEASE(p)   -- refcount = 0 -> freed                    */
+/* ------------------------------------------------------------------ */
+static void test_local_set_get_roundtrip(void)
+{
+    opal_proc_t *original;
+    opal_proc_t *p;
+    opal_proc_t *got;
+    int rc;
+
+    original = opal_proc_local_get();
+
+    p = OBJ_NEW(opal_proc_t);
+    test_verify("OBJ_NEW(opal_proc_t) returns non-NULL", NULL != p);
+    if (NULL == p) {
+        return;
+    }
+
+    rc = opal_proc_local_set(p);
+    test_verify("opal_proc_local_set(p) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    got = opal_proc_local_get();
+    test_verify("opal_proc_local_get() returns the newly set proc", p == got);
+
+    /* Restore default: set(NULL) => reverts to &opal_local_proc */
+    rc = opal_proc_local_set(NULL);
+    test_verify("opal_proc_local_set(NULL) returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    got = opal_proc_local_get();
+    test_verify("after set(NULL), get() returns original default",
+                original == got);
+
+    /* Release our own reference (the set/unset already handled the lib's ref). */
+    OBJ_RELEASE(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_proc_set_name                                                  */
+/*                                                                     */
+/* opal_proc_set_name() copies a process name struct into the default */
+/* local proc.  We write a recognisable jobid/vpid pair and read it   */
+/* back through opal_proc_local_get()->proc_name.                     */
+/* ------------------------------------------------------------------ */
+static void test_proc_set_name(void)
+{
+    opal_process_name_t name;
+    opal_proc_t *lp;
+
+    /* Use values well within OPAL_JOBID_MAX / OPAL_VPID_MAX. */
+    name.jobid = 42;
+    name.vpid  = 7;
+
+    /* Make sure we are operating on the default local proc (no custom set). */
+    opal_proc_local_set(NULL);
+
+    opal_proc_set_name(&name);
+
+    lp = opal_proc_local_get();
+    test_verify("opal_proc_set_name: local proc non-NULL", NULL != lp);
+    if (NULL != lp) {
+        test_verify("opal_proc_set_name: jobid round-trips",
+                    (opal_jobid_t) 42 == lp->proc_name.jobid);
+        test_verify("opal_proc_set_name: vpid round-trips",
+                    (opal_vpid_t) 7 == lp->proc_name.vpid);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* test_set_same_pointer_is_noop                                      */
+/*                                                                     */
+/* Setting the local proc to the current value (same pointer) must    */
+/* not double-retain or crash; it must still return OPAL_SUCCESS.     */
+/* ------------------------------------------------------------------ */
+static void test_set_same_pointer_is_noop(void)
+{
+    opal_proc_t *cur = opal_proc_local_get();
+    int rc = opal_proc_local_set(cur);
+    test_verify("opal_proc_local_set(same pointer) returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("opal_proc_local_get() unchanged after same-pointer set",
+                cur == opal_proc_local_get());
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_proc");
+
+    opal_init_util(&argc, &argv);
+
+    test_local_get_not_null();
+    test_local_set_get_roundtrip();
+    test_proc_set_name();
+    test_set_same_pointer_is_noop();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_qsort.c
+++ b/test/util/opal_qsort.c
@@ -1,0 +1,231 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * opal_qsort is only compiled when OPAL_HAVE_BROKEN_QSORT is defined (non-zero).
+ * On platforms where the system qsort is fine, opal_qsort does not exist and
+ * including qsort.h directly emits a compile-time #error.  This file guards
+ * all opal_qsort usage inside #if OPAL_HAVE_BROKEN_QSORT so it still
+ * produces a valid (passing, no-op) test binary on those platforms.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/constants.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#if OPAL_HAVE_BROKEN_QSORT
+
+#include "opal/util/qsort.h"
+
+/* -----------------------------------------------------------------------
+ * Comparator: ascending integer order (overflow-safe)
+ * ----------------------------------------------------------------------- */
+
+static int int_cmp(const void *a, const void *b)
+{
+    int ia = *(const int *) a;
+    int ib = *(const int *) b;
+
+    return (ia > ib) - (ia < ib);
+}
+
+/* -----------------------------------------------------------------------
+ * Helper: verify array is sorted in non-decreasing order
+ * ----------------------------------------------------------------------- */
+
+static int is_sorted(const int *arr, size_t n)
+{
+    size_t i;
+
+    for (i = 1; i < n; i++) {
+        if (arr[i] < arr[i - 1]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* -----------------------------------------------------------------------
+ * Tests
+ * ----------------------------------------------------------------------- */
+
+static void test_empty_array(void)
+{
+    int arr[1]; /* unused memory; n=0 */
+
+    opal_qsort(arr, 0, sizeof(int), int_cmp);
+    test_verify("qsort empty array: no crash", 1);
+}
+
+static void test_single_element(void)
+{
+    int arr[1] = {42};
+
+    opal_qsort(arr, 1, sizeof(int), int_cmp);
+    test_verify("qsort single element: value preserved", 42 == arr[0]);
+}
+
+static void test_already_sorted(void)
+{
+    int arr[] = {1, 2, 3, 4, 5};
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort already sorted", is_sorted(arr, n));
+}
+
+static void test_reverse_sorted(void)
+{
+    int arr[] = {5, 4, 3, 2, 1};
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort reverse sorted: sorted", is_sorted(arr, n));
+    test_verify("qsort reverse sorted: arr[0]==1", 1 == arr[0]);
+    test_verify("qsort reverse sorted: arr[4]==5", 5 == arr[4]);
+}
+
+static void test_duplicates(void)
+{
+    int arr[] = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort duplicates: sorted", is_sorted(arr, n));
+    test_verify("qsort duplicates: arr[0]==1", 1 == arr[0]);
+    test_verify("qsort duplicates: arr[9]==9", 9 == arr[9]);
+}
+
+static void test_all_equal(void)
+{
+    int arr[] = {7, 7, 7, 7, 7};
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort all equal: sorted", is_sorted(arr, n));
+    test_verify("qsort all equal: arr[0]==7", 7 == arr[0]);
+}
+
+static void test_two_elements_ordered(void)
+{
+    int arr[] = {1, 2};
+
+    opal_qsort(arr, 2, sizeof(int), int_cmp);
+    test_verify("qsort two elements ordered: arr[0]==1", 1 == arr[0]);
+    test_verify("qsort two elements ordered: arr[1]==2", 2 == arr[1]);
+}
+
+static void test_two_elements_reversed(void)
+{
+    int arr[] = {2, 1};
+
+    opal_qsort(arr, 2, sizeof(int), int_cmp);
+    test_verify("qsort two elements reversed: arr[0]==1", 1 == arr[0]);
+    test_verify("qsort two elements reversed: arr[1]==2", 2 == arr[1]);
+}
+
+static void test_negative_values(void)
+{
+    int arr[] = {0, -3, 5, -1, 2, -7};
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort negative values: sorted", is_sorted(arr, n));
+    test_verify("qsort negative values: arr[0]==-7", -7 == arr[0]);
+    test_verify("qsort negative values: arr[5]==5", 5 == arr[5]);
+}
+
+/*
+ * Array > 40 elements exercises the median-of-3 pivot selection and recursive
+ * partition paths that are dead code for small inputs.
+ */
+static void test_large_array(void)
+{
+    /* 50 elements in reverse order */
+    int arr[50];
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        arr[i] = (int)(n - i); /* 50, 49, ..., 1 */
+    }
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort large array (>40): sorted", is_sorted(arr, n));
+    test_verify("qsort large array: arr[0]==1", 1 == arr[0]);
+    test_verify("qsort large array: arr[49]==50", 50 == arr[49]);
+}
+
+static void test_large_array_random_like(void)
+{
+    /* 60 elements with varied values to cover all partition branches */
+    int arr[] = {
+        34, 7,  23, 32, 5,  62,  32, 78, 1,  88,
+        45, 21, 14, 57, 44, 99,  0,  -5, 33, 27,
+        19, 84, 65, 11, 36, 100, 72, 48, 56, 13,
+        93, 29, 8,  61, 41, 77,  52, 3,  66, 17,
+        39, 85, 24, 71, 46, 58,  12, 90, 37, 2,
+        55, 18, 43, 76, 31, 64,  9,  83, 50, 25
+    };
+    size_t n = sizeof(arr) / sizeof(arr[0]);
+
+    opal_qsort(arr, n, sizeof(int), int_cmp);
+    test_verify("qsort large random-like (60 elems): sorted", is_sorted(arr, n));
+    test_verify("qsort large random-like: arr[0]==-5", -5 == arr[0]);
+    test_verify("qsort large random-like: arr[59]==100", 100 == arr[59]);
+}
+
+#endif /* OPAL_HAVE_BROKEN_QSORT */
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_qsort");
+
+#if OPAL_HAVE_BROKEN_QSORT
+    test_empty_array();
+    test_single_element();
+    test_already_sorted();
+    test_reverse_sorted();
+    test_duplicates();
+    test_all_equal();
+    test_two_elements_ordered();
+    test_two_elements_reversed();
+    test_negative_values();
+    test_large_array();
+    test_large_array_random_like();
+#else
+    test_comment("opal_qsort is not compiled on this platform (OPAL_HAVE_BROKEN_QSORT==0); "
+                 "tests skipped");
+    test_success();
+#endif
+
+    return test_finalize();
+}

--- a/test/util/opal_string_copy.c
+++ b/test/util/opal_string_copy.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "support.h"
+#include "opal/util/string_copy.h"
+#include "opal/constants.h"
+
+int main(int argc, char *argv[])
+{
+    char dest[64];
+    const char *src;
+
+    test_init("opal_string_copy");
+
+    /* --- Normal: source shorter than dest_len --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "hello";
+    opal_string_copy(dest, src, sizeof(dest));
+    test_verify("normal copy: content matches", 0 == strcmp(dest, "hello"));
+    test_verify("normal copy: NUL terminated", '\0' == dest[5]);
+
+    /* --- Exact fit: source length == dest_len - 1 (plus NUL = dest_len) --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "abcde";          /* 5 chars + NUL = 6 bytes; dest_len=6 */
+    opal_string_copy(dest, src, 6);
+    test_verify("exact fit: content matches", 0 == strcmp(dest, "abcde"));
+    test_verify("exact fit: NUL at position 5", '\0' == dest[5]);
+
+    /* --- Truncation: source longer than dest_len --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "abcdefghij";     /* 10 chars; dest_len=5 -> copy 4 chars + NUL */
+    opal_string_copy(dest, src, 5);
+    test_verify("truncation: dest[4] is NUL", '\0' == dest[4]);
+    test_verify("truncation: dest[3] is 'd'", 'd' == dest[3]);
+    test_verify("truncation: result is NUL-terminated string of 4 chars",
+                0 == strcmp(dest, "abcd"));
+
+    /* --- Truncation: dest_len == 1 -> result is empty string --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "xyz";
+    opal_string_copy(dest, src, 1);
+    test_verify("len==1: dest[0] is NUL", '\0' == dest[0]);
+
+    /* --- Empty source string --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "";
+    opal_string_copy(dest, src, sizeof(dest));
+    test_verify("empty src: dest[0] is NUL", '\0' == dest[0]);
+    test_verify("empty src: result is empty string", 0 == strcmp(dest, ""));
+
+    /* --- Source length exactly dest_len - 1 (another boundary check) --- */
+    memset(dest, 0xFF, sizeof(dest));
+    src = "A";              /* 1 char + NUL; dest_len=2 */
+    opal_string_copy(dest, src, 2);
+    test_verify("len=2 fit: content is 'A'", 'A' == dest[0]);
+    test_verify("len=2 fit: NUL at position 1", '\0' == dest[1]);
+
+    /* (The dest_len == 0 case -- previously an out-of-bounds write, now
+     * guarded in opal_string_copy() -- is exercised at the end of this
+     * file: "Zero-length dst: must write nothing and not crash".) */
+
+    /* --- Large but valid source (within 128K limit) --- */
+    {
+        char *big_src = (char *) malloc(1024);
+        char *big_dest = (char *) malloc(512);
+        if (NULL != big_src && NULL != big_dest) {
+            int i;
+            for (i = 0; i < 1023; ++i) {
+                big_src[i] = 'x';
+            }
+            big_src[1023] = '\0';
+            opal_string_copy(big_dest, big_src, 512);
+            test_verify("large src truncated: dest[511] is NUL", '\0' == big_dest[511]);
+            test_verify("large src truncated: first char is 'x'", 'x' == big_dest[0]);
+            free(big_src);
+            free(big_dest);
+        }
+    }
+
+    /* --- Zero-length destination: must write nothing and not crash --- */
+    {
+        char z[4] = {'a', 'b', 'c', 'd'};
+        opal_string_copy(z, "hello", 0);
+        test_verify("dest_len==0 leaves buffer untouched", 'a' == z[0]);
+    }
+
+    return test_finalize();
+}

--- a/test/util/opal_sys_limits.c
+++ b/test/util/opal_sys_limits.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for opal_getpagesize() and opal_util_init_sys_limits().
+ *
+ * opal_getpagesize() wraps getpagesize() / sysconf(_SC_PAGESIZE) and caches
+ * the result.  A valid page size must be:
+ *   - positive
+ *   - a power of two (every real system page size is a power of two)
+ *   - equal to the value returned by sysconf(_SC_PAGESIZE)
+ *
+ * opal_util_init_sys_limits() reads opal_set_max_sys_limits (a module-level
+ * string from opal_params).  With the default configuration from
+ * opal_init_util(), opal_set_max_sys_limits is NULL, so the function returns
+ * OPAL_SUCCESS immediately without touching *errmsg.
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+
+#include "opal/util/sys_limits.h"
+#include "opal/constants.h"
+#include "opal/runtime/opal.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Returns 1 if n is a positive power of two, 0 otherwise. */
+static int is_power_of_two(int n)
+{
+    if (n <= 0) {
+        return 0;
+    }
+    return 0 == (n & (n - 1));
+}
+
+static void test_getpagesize(void)
+{
+    int ps;
+    long sc_ps;
+
+    ps = opal_getpagesize();
+    test_verify("opal_getpagesize() returns positive value", ps > 0);
+    test_verify("opal_getpagesize() returns a power of two", is_power_of_two(ps));
+
+    /* Compare to sysconf(_SC_PAGESIZE) which is the authoritative source
+     * on POSIX systems.  sysconf() may legally return -1 (unsupported or
+     * error), in which case there is nothing to compare against and we
+     * simply skip this check rather than failing a correct
+     * opal_getpagesize(). */
+    sc_ps = sysconf(_SC_PAGESIZE);
+    if (sc_ps > 0) {
+        test_verify("opal_getpagesize() matches sysconf(_SC_PAGESIZE)",
+                    (long) ps == sc_ps);
+    } else {
+        test_comment("sysconf(_SC_PAGESIZE) unavailable; skipping comparison");
+    }
+
+    /* Second call must return the same (cached) value. */
+    test_verify("opal_getpagesize() is idempotent", ps == opal_getpagesize());
+}
+
+static void test_init_sys_limits_default(void)
+{
+    /*
+     * With opal_set_max_sys_limits == NULL (the default set by opal_init_util),
+     * opal_util_init_sys_limits() returns OPAL_SUCCESS immediately.
+     * The errmsg pointer must not be written in this case; we pass NULL to
+     * confirm the function doesn't dereference it when there is nothing to do.
+     */
+    int rc = opal_util_init_sys_limits(NULL);
+    test_verify("opal_util_init_sys_limits(NULL limits) returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+}
+
+static void test_init_sys_limits_errmsg_untouched(void)
+{
+    /*
+     * Pass a valid errmsg pointer initialised to NULL; confirm it stays NULL
+     * when opal_set_max_sys_limits is NULL (nothing to process).
+     */
+    char *errmsg = NULL;
+    int rc = opal_util_init_sys_limits(&errmsg);
+    test_verify("opal_util_init_sys_limits: rc == OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("opal_util_init_sys_limits: errmsg untouched when no limits set",
+                NULL == errmsg);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int r;
+
+    test_init("opal_sys_limits");
+
+    /* test_init_sys_limits_default() passes a NULL errmsg and relies on
+       opal_set_max_sys_limits being NULL (its default) so the call is a
+       no-op.  An inherited OMPI_MCA_opal_set_max_sys_limits would make it
+       non-NULL, taking the processing path (which could dereference the NULL
+       errmsg).  Clear it so the default-path assumption holds. */
+    unsetenv("OMPI_MCA_opal_set_max_sys_limits");
+
+    opal_init_util(&argc, &argv);
+
+    test_getpagesize();
+    test_init_sys_limits_default();
+    test_init_sys_limits_errmsg_untouched();
+
+    r = test_finalize();
+    opal_finalize_util();
+    return r;
+}

--- a/test/util/opal_timer.c
+++ b/test/util/opal_timer.c
@@ -20,14 +20,20 @@
 
 #include <unistd.h>
 
+#include "opal/constants.h"
 #include "opal/mca/timer/base/base.h"
 #include "opal/runtime/opal.h"
 
 int main(int argc, char *argv[])
 {
     opal_timer_t start, end, diff;
+    int rc;
 
-    opal_init(&argc, &argv);
+    rc = opal_init(&argc, &argv);
+    if (OPAL_SUCCESS != rc) {
+        fprintf(stderr, "opal_init() failed: %d\n", rc);
+        return 1;
+    }
 
     printf("--> frequency: %llu\n", (unsigned long long) opal_timer_base_get_freq());
 

--- a/test/util/opal_uri.c
+++ b/test/util/opal_uri.c
@@ -1,0 +1,342 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "support.h"
+#include "opal/util/uri.h"
+#include "opal/constants.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* -----------------------------------------------------------------------
+ * opal_uri_get_scheme
+ * ----------------------------------------------------------------------- */
+
+static void test_get_scheme_file(void)
+{
+    char *scheme;
+
+    scheme = opal_uri_get_scheme("file:///tmp/foo");
+    test_verify("get_scheme file:///tmp/foo returns 'file'",
+                NULL != scheme && 0 == strcmp("file", scheme));
+    free(scheme);
+}
+
+static void test_get_scheme_http(void)
+{
+    char *scheme;
+
+    scheme = opal_uri_get_scheme("http://example.com/path");
+    test_verify("get_scheme http://... returns 'http'",
+                NULL != scheme && 0 == strcmp("http", scheme));
+    free(scheme);
+}
+
+static void test_get_scheme_custom(void)
+{
+    char *scheme;
+
+    scheme = opal_uri_get_scheme("myscheme://host/resource");
+    test_verify("get_scheme myscheme://... returns 'myscheme'",
+                NULL != scheme && 0 == strcmp("myscheme", scheme));
+    free(scheme);
+}
+
+static void test_get_scheme_malformed(void)
+{
+    char *scheme;
+
+    /* No colon -> documented to return NULL */
+    scheme = opal_uri_get_scheme("nocolon");
+    test_verify("get_scheme malformed (no colon) returns NULL", NULL == scheme);
+    /* scheme is NULL; nothing to free */
+}
+
+/* -----------------------------------------------------------------------
+ * opal_filename_to_uri  (NULL hostname = local file)
+ * ----------------------------------------------------------------------- */
+
+static void test_to_uri_local_simple(void)
+{
+    char *uri;
+
+    uri = opal_filename_to_uri("/tmp/foo.txt", NULL);
+    test_verify("to_uri /tmp/foo.txt local: not NULL", NULL != uri);
+    test_verify("to_uri /tmp/foo.txt local: == 'file:///tmp/foo.txt'",
+                NULL != uri && 0 == strcmp("file:///tmp/foo.txt", uri));
+    free(uri);
+}
+
+static void test_to_uri_local_deep_path(void)
+{
+    char *uri;
+
+    uri = opal_filename_to_uri("/a/b/c/d.dat", NULL);
+    test_verify("to_uri /a/b/c/d.dat local: == 'file:///a/b/c/d.dat'",
+                NULL != uri && 0 == strcmp("file:///a/b/c/d.dat", uri));
+    free(uri);
+}
+
+static void test_to_uri_relative_path(void)
+{
+    char *uri;
+
+    /* A relative path is not allowed; function must return NULL */
+    uri = opal_filename_to_uri("relative/path", NULL);
+    test_verify("to_uri relative path returns NULL", NULL == uri);
+}
+
+static void test_to_uri_with_hostname(void)
+{
+    char *uri;
+
+    uri = opal_filename_to_uri("/data/file.txt", "myhost");
+    test_verify("to_uri with hostname: not NULL", NULL != uri);
+    /* Expected: file://myhost/data/file.txt */
+    test_verify("to_uri with hostname: correct URI",
+                NULL != uri && 0 == strcmp("file://myhost/data/file.txt", uri));
+    free(uri);
+}
+
+/* -----------------------------------------------------------------------
+ * opal_filename_from_uri
+ * ----------------------------------------------------------------------- */
+
+static void test_from_uri_local_triple_slash(void)
+{
+    char *fn;
+    char *host = (char *) "sentinel"; /* should be set to NULL */
+
+    fn = opal_filename_from_uri("file:///tmp/foo.txt", &host);
+    test_verify("from_uri file:///tmp/foo.txt: filename not NULL", NULL != fn);
+    test_verify("from_uri file:///tmp/foo.txt: == '/tmp/foo.txt'",
+                NULL != fn && 0 == strcmp("/tmp/foo.txt", fn));
+    test_verify("from_uri file:///tmp/foo.txt: host is NULL", NULL == host);
+    free(fn);
+    /* host is NULL; nothing to free */
+}
+
+static void test_from_uri_with_hostname(void)
+{
+    char *fn;
+    char *host = NULL;
+
+    fn = opal_filename_from_uri("file://myhost/data/file.txt", &host);
+    test_verify("from_uri with hostname: filename not NULL", NULL != fn);
+    test_verify("from_uri with hostname: == '/data/file.txt'",
+                NULL != fn && 0 == strcmp("/data/file.txt", fn));
+    test_verify("from_uri with hostname: host == 'myhost'",
+                NULL != host && 0 == strcmp("myhost", host));
+    free(fn);
+    free(host);
+}
+
+static void test_from_uri_hostname_param_null(void)
+{
+    char *fn;
+
+    /* Documented: passing NULL for hostname is valid */
+    fn = opal_filename_from_uri("file:///tmp/bar", NULL);
+    test_verify("from_uri NULL hostname param: filename not NULL", NULL != fn);
+    test_verify("from_uri NULL hostname param: == '/tmp/bar'",
+                NULL != fn && 0 == strcmp("/tmp/bar", fn));
+    free(fn);
+}
+
+static void test_from_uri_malformed_no_colon(void)
+{
+    char *fn;
+
+    fn = opal_filename_from_uri("nocolon", NULL);
+    test_verify("from_uri malformed (no colon) returns NULL", NULL == fn);
+}
+
+static void test_from_uri_malformed_single_slash(void)
+{
+    char *fn;
+
+    /* "file:/x" has only one slash after ':' -- not "//", not "///" */
+    fn = opal_filename_from_uri("file:/x", NULL);
+    test_verify("from_uri malformed (single slash) returns NULL", NULL == fn);
+}
+
+static void test_from_uri_malformed_no_path_slash(void)
+{
+    char *fn;
+
+    /* "file://hostonly" has no '/' to separate host from path */
+    fn = opal_filename_from_uri("file://hostonly", NULL);
+    test_verify("from_uri malformed (no path slash) returns NULL", NULL == fn);
+}
+
+/* -----------------------------------------------------------------------
+ * Round-trip: path -> URI -> path (local, no hostname)
+ * ----------------------------------------------------------------------- */
+
+static void test_roundtrip_local(void)
+{
+    const char *original = "/usr/local/bin/mpirun";
+    char *uri;
+    char *recovered;
+    char *host = (char *) "sentinel";
+
+    uri = opal_filename_to_uri(original, NULL);
+    test_verify("roundtrip local: to_uri not NULL", NULL != uri);
+
+    recovered = opal_filename_from_uri(uri, &host);
+    test_verify("roundtrip local: from_uri not NULL", NULL != recovered);
+    test_verify("roundtrip local: recovered == original",
+                NULL != recovered && 0 == strcmp(original, recovered));
+    test_verify("roundtrip local: host is NULL after from_uri", NULL == host);
+
+    free(uri);
+    free(recovered);
+}
+
+/* -----------------------------------------------------------------------
+ * Round-trip: path -> URI -> path (with hostname)
+ * ----------------------------------------------------------------------- */
+
+static void test_roundtrip_with_hostname(void)
+{
+    const char *original = "/home/user/data.txt";
+    const char *hostname_in = "compute01";
+    char *uri;
+    char *recovered;
+    char *host = NULL;
+
+    uri = opal_filename_to_uri(original, hostname_in);
+    test_verify("roundtrip hostname: to_uri not NULL", NULL != uri);
+
+    recovered = opal_filename_from_uri(uri, &host);
+    test_verify("roundtrip hostname: from_uri not NULL", NULL != recovered);
+    test_verify("roundtrip hostname: recovered == original",
+                NULL != recovered && 0 == strcmp(original, recovered));
+    test_verify("roundtrip hostname: host == hostname_in",
+                NULL != host && 0 == strcmp(hostname_in, host));
+
+    free(uri);
+    free(recovered);
+    free(host);
+}
+
+/* -----------------------------------------------------------------------
+ * get_scheme on a file:// URI
+ * ----------------------------------------------------------------------- */
+
+static void test_get_scheme_on_file_uri(void)
+{
+    char *uri;
+    char *scheme;
+
+    uri = opal_filename_to_uri("/etc/passwd", NULL);
+    test_verify("get_scheme on built URI: uri not NULL", NULL != uri);
+
+    scheme = opal_uri_get_scheme(uri);
+    test_verify("get_scheme on built URI: == 'file'",
+                NULL != scheme && 0 == strcmp("file", scheme));
+
+    free(uri);
+    free(scheme);
+}
+
+/* -----------------------------------------------------------------------
+ * reserved-char escaping preserves every filename character
+ *
+ * opal_filename_to_uri escapes reserved chars when a hostname is present
+ * by prefixing each with a backslash.  A previous off-by-one in the
+ * escaping loop (`k < strlen(filename) - 1`) dropped the last character
+ * of the filename whenever escaping occurred; e.g. "/a;b/c" produced
+ * "file://host/a\;b/" (the trailing 'c' was lost).  This test asserts the
+ * full, correct result so the bound stays fixed.
+ * ----------------------------------------------------------------------- */
+
+static void test_to_uri_reserved_char_escaping(void)
+{
+    const char *original = "/a;b/c";
+    const char *expected = "file://host/a\\;b/c";
+    char *uri;
+
+    uri = opal_filename_to_uri(original, "host");
+    test_verify("to_uri with reserved char (';'): uri not NULL", NULL != uri);
+    /* The reserved ';' is backslash-escaped and no characters are dropped. */
+    test_verify("to_uri with reserved char (';'): escapes and preserves all chars",
+                NULL != uri && 0 == strcmp(expected, uri));
+    free(uri);
+
+    /*
+     * A reserved character that repeats is escaped at every occurrence, so
+     * the output can grow to 2 bytes per input character.  This exercises
+     * the buffer sizing (each ';' adds a backslash) and confirms no
+     * characters are dropped.
+     */
+    original = "/a;b;c";
+    expected = "file://host/a\\;b\\;c";
+    uri = opal_filename_to_uri(original, "host");
+    test_verify("to_uri with repeated reserved char: uri not NULL", NULL != uri);
+    test_verify("to_uri with repeated reserved char: escapes each occurrence",
+                NULL != uri && 0 == strcmp(expected, uri));
+    free(uri);
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * ----------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    test_init("opal_uri");
+
+    /* opal_uri_get_scheme */
+    test_get_scheme_file();
+    test_get_scheme_http();
+    test_get_scheme_custom();
+    test_get_scheme_malformed();
+
+    /* opal_filename_to_uri */
+    test_to_uri_local_simple();
+    test_to_uri_local_deep_path();
+    test_to_uri_relative_path();
+    test_to_uri_with_hostname();
+
+    /* opal_filename_from_uri */
+    test_from_uri_local_triple_slash();
+    test_from_uri_with_hostname();
+    test_from_uri_hostname_param_null();
+    test_from_uri_malformed_no_colon();
+    test_from_uri_malformed_single_slash();
+    test_from_uri_malformed_no_path_slash();
+
+    /* Round-trips */
+    test_roundtrip_local();
+    test_roundtrip_with_hostname();
+    test_get_scheme_on_file_uri();
+
+    /* Suspected-bug coverage */
+    test_to_uri_reserved_char_escaping();
+
+    return test_finalize();
+}


### PR DESCRIPTION
## Summary

Adds a broad set of self-checking unit tests for previously-untested OPAL `class`, `util`, and `datatype` code, wired into `make check` (and therefore run in CI). Test expectations were validated against the documented contracts.

The new tests uncovered a number of pre-existing OPAL bugs. **Those fixes have been split out into their own PRs** (one self-contained fix each), tracked by the epic **#14050**. This branch currently carries those fix commits (below the test commit) so the suite passes in CI; once the fix PRs merge to `main`, this branch will be rebased down to just the single test commit.

## What's in this branch

- One commit adding the tests (`test/class`, `test/util`, `test/datatype`, `test/support`) — at the tip.
- Ten bug-fix commits (the cherry-picks under #14050), carried here only so `make check` is green until they land on `main`.

## New / expanded unit tests

- **test/class**: rewritten/expanded `opal_bitmap`; new `opal_interval_tree`, `opal_ring_buffer`, `opal_hotel`, `opal_graph`; expanded `opal_hash_table`, `opal_list`, `opal_pointer_array`, `opal_value_array`.
- **test/util**: `opal_argv`, `opal_basename`, `opal_environ`, `opal_printf`, `opal_uri`, `opal_qsort`, `opal_alfg`, `opal_crc`, `opal_fd`, `opal_getcwd`, `opal_string_copy`, `opal_arch`, `opal_cmd_line`, `opal_few`, `opal_error`, `opal_if`, `opal_info`, `opal_info_subscriber`, `opal_keyval_parse`, `opal_malloc`, `opal_net`, `opal_os_dirpath`, `opal_output`, `opal_path`, `opal_proc`, `opal_sys_limits`.
- **test/datatype**: new `opal_ddt_api`; `opal_ddt_hetero` is added but intentionally **not** wired into `make check` (see its file-level note).
- **test/support**: `test_verify()` macro made `-Wshadow`-clean.

## Bugs found by these tests (each fixed in its own PR — epic #14050)

| Bug | Fix PR |
|-----|--------|
| `opal_infosubscriber_t` leaves `s_info` uninitialized | #14031 |
| `opal_strerror()` returns NULL for unknown codes | #14033 |
| `opal_net_islocalhost()` matches `255.x.x.x` | #14035 |
| `opal_graph` wrong edge count on vertex removal | #14037 |
| `opal_filename_to_uri()` drops last filename char | #14039 |
| `opal_dirname()` crashes on NULL | #14041 |
| `opal_argv_delete()` wrong `argc` on over-delete | #14043 |
| `opal_getcwd()` off-by-one length check | #14045 |
| `opal_string_copy()` OOB write for zero-length dest | #14047 |
| `opal_bitmap` max_size units / `find_and_set` cap | #14049 |

The tests also surfaced a separate, currently-dormant cross-platform inconsistency in the `opal/mca/if` loopback handling, documented in #14029 (the `opal_if` test sets `OMPI_MCA_if_base_retain_loopback=1` to work around it on the *BSDs).

## Test plan

`make check` passes on **Linux** (x86-64 in CI; aarch64 locally), **macOS**, and **FreeBSD 15** (aarch64) — verified across all three locally.
