### PR TITLE
Enable verbose output in community Jenkins build/test

### DIFF
--- a/.ci/community-jenkins/pr-builder.sh
+++ b/.ci/community-jenkins/pr-builder.sh
@@ -3,6 +3,7 @@
 # Copyright (c) 2022-2023 Amazon.com, Inc. or its affiliates.  All rights
 #                         reserved.
 # Copyright (c) 2022-2023 Joe Downs.  All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,7 +18,7 @@ COMPILER=
 DISTCHECK=0
 AUTOGEN_ARGS=
 CONFIGURE_ARGS=
-MAKE_ARGS=
+MAKE_ARGS="V=1 VERBOSE=1"
 MAKE_J="-j 8"
 PREFIX="${WORKSPACE}/install"
 MPIRUN_MODE=${MPIRUN_MODE:-runall}


### PR DESCRIPTION
Add V=1 and VERBOSE=1 to MAKE_ARGS in the community Jenkins pr-builder.sh so all make invocations consistently use verbose Automake and test harness output. Verbose output makes CI logs far more useful when diagnosing failures: V=1 shows the full compiler/linker command lines instead of the terse Automake summaries, and VERBOSE=1 makes the test harness print each test's full output rather than just a pass/fail summary.