### PR TITLE
opal/util: initialize opal_infosubscriber_t s_info in constructor

### DIFF
--- a/opal/util/info_subscriber.c
+++ b/opal/util/info_subscriber.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation. All rights reserved.
  * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,6 +77,14 @@ static void infosubscriber_construct(opal_infosubscriber_t *obj)
 {
     OBJ_CONSTRUCT(&obj->s_subscriber_table, opal_hash_table_t);
     opal_hash_table_init(&obj->s_subscriber_table, 10);
+
+    /* s_info is created lazily (see opal_infosubscribe_subscribe) and is
+     * released in the destructor only when non-NULL, so it must start out
+     * NULL.  Subclasses (communicator, win, file) run after this base
+     * constructor; a standalone OBJ_NEW(opal_infosubscriber_t) has no
+     * subclass constructor, so without this it would be left uninitialized
+     * and dereferenced as a garbage pointer. */
+    obj->s_info = NULL;
 }
 
 static void infosubscriber_destruct(opal_infosubscriber_t *obj)


### PR DESCRIPTION
opal/util: initialize opal_infosubscriber_t s_info in constructor

infosubscriber_construct() initialized s_subscriber_table but left
s_info uninitialized, while infosubscriber_destruct() releases s_info
only when it is non-NULL.  In normal use a subclass constructor
(communicator, win, file) runs after this base constructor and sets
s_info, masking the omission.  A standalone
OBJ_NEW(opal_infosubscriber_t) -- as exercised by the new
opal_info_subscriber unit test -- has no subclass, so s_info held
whatever the heap returned.  On a platform where that memory was not
zero (observed on riscv64) opal_infosubscribe_subscribe dereferenced
the garbage pointer through opal_info_get and crashed.

Initialize s_info to NULL in the constructor.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14030
