### PR TITLE
opal/util: fix opal_net_islocalhost matching 255.0.0.0

### DIFF
--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -20,6 +20,7 @@
  *                         reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -211,8 +212,11 @@ bool opal_net_islocalhost(const struct sockaddr *addr)
     case AF_INET: {
         const struct sockaddr_in *inaddr = (struct sockaddr_in *) addr;
         /* if it's in the 127. domain, it shouldn't be routed
-           (0x7f == 127) */
-        if (0x7F000000 == (0x7F000000 & ntohl(inaddr->sin_addr.s_addr))) {
+           (0x7f == 127).  Mask the full top byte (0xFF000000), not just
+           its low 7 bits (0x7F000000): the latter also matches 255.x.x.x
+           because 0xFF & 0x7F == 0x7F, incorrectly reporting 255.0.0.0 as
+           localhost. */
+        if (0x7F000000 == (0xFF000000 & ntohl(inaddr->sin_addr.s_addr))) {
             return true;
         }
         return false;


### PR DESCRIPTION
opal/util: fix opal_net_islocalhost matching 255.0.0.0

opal_net_islocalhost() tested whether the low 7 bits of the address's
top byte matched 0x7F:

    0x7F000000 == (0x7F000000 & ntohl(s_addr))

That mask only clears the high bit, so it also matches 255.x.x.x
(0xFF & 0x7F == 0x7F), incorrectly reporting e.g. 255.0.0.0 as a
localhost address.  The documented contract (opal/util/net.h) is the
127.0.0.0/8 range only.

Mask the full top byte (0xFF000000) so only 127.x.x.x matches.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14034
