### PR TITLE
opal/class: fix opal_graph edge count on vertex removal

### DIFF
--- a/opal/class/opal_graph.c
+++ b/opal/class/opal_graph.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026 Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -179,6 +180,8 @@ static void delete_all_edges_conceded_to_vertex(opal_graph_t *graph, opal_graph_
                 opal_list_remove_item(edge->in_adj_list->edges, (opal_list_item_t *) edge);
                 /* distract this edge */
                 OBJ_RELEASE(edge);
+                /* keep the graph's edge count in sync */
+                graph->number_of_edges--;
             }
         }
     }
@@ -298,8 +301,11 @@ void opal_graph_remove_vertex(opal_graph_t *graph, opal_graph_vertex_t *vertex)
     adj_list = vertex->in_adj_list;
     /**
      * remove the adjscency list of this vertex from the graph and
-     * destruct it.
+     * destruct it.  The outgoing edges of this vertex are released
+     * along with the adjacency list, so account for them in the graph's
+     * edge count.
      */
+    graph->number_of_edges -= opal_list_get_size(adj_list->edges);
     opal_list_remove_item(graph->adjacency_list, (opal_list_item_t *) adj_list);
     OBJ_RELEASE(adj_list);
     /**


### PR DESCRIPTION
opal/class: fix opal_graph edge count on vertex removal

opal_graph_remove_vertex() releases both the outgoing edges (via
OBJ_RELEASE of the vertex's adjacency list) and the incoming edges (via
delete_all_edges_conceded_to_vertex()), but neither path decremented
graph->number_of_edges.  As a result opal_graph_get_size() reported a
stale, too-large edge count after a vertex was removed.

Decrement number_of_edges for each incoming edge that is deleted, and by
the number of outgoing edges when the adjacency list is released.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14036
