### PR TITLE
opal/util: guard opal_dirname against NULL input

### DIFF
--- a/opal/util/basename.c
+++ b/opal/util/basename.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2014-2024 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,6 +104,11 @@ char *opal_basename(const char *filename)
 
 char *opal_dirname(const char *filename)
 {
+    /* Check for the bozo case (mirrors opal_basename()) */
+    if (NULL == filename) {
+        return NULL;
+    }
+
 #if defined(HAVE_DIRNAME) || OPAL_HAVE_DIRNAME
     char *safe_tmp = strdup(filename), *result;
     if (NULL == safe_tmp) {


### PR DESCRIPTION
opal/util: guard opal_dirname against NULL input

opal_basename() returns NULL when passed a NULL filename, but
opal_dirname() had no such guard: it passed the NULL straight to
strdup()/strlen(), which is undefined behavior (typically a crash).  Add
the same bozo-case guard so the two functions behave consistently.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14040
