### PR TITLE
opal/util: fix opal_getcwd off-by-one buffer length check

### DIFF
--- a/opal/util/opal_getcwd.c
+++ b/opal/util/opal_getcwd.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,9 +84,10 @@ int opal_getcwd(char *buf, size_t size)
 #endif
 
     /* If we got here, pwd is pointing to the result that we want to
-       give.  Ensure the user's buffer is long enough.  If it is, copy
-       in the value and be done. */
-    if (strlen(pwd) > size) {
+       give.  Ensure the user's buffer is long enough (it must hold the
+       string *and* a NUL terminator, so it needs strlen(pwd)+1 bytes).
+       If it is long enough, copy in the value and be done. */
+    if (strlen(pwd) >= size) {
         /* if it isn't big enough, give them as much
          * of the basename as possible
          */


### PR DESCRIPTION
opal/util: fix opal_getcwd off-by-one buffer length check

The buffer must hold the path string plus a NUL terminator, i.e.
strlen(pwd) + 1 bytes.  The check used "strlen(pwd) > size", so when
strlen(pwd) == size it fell through to opal_string_copy(buf, pwd, size),
which truncated the last character yet the function still returned
OPAL_SUCCESS.  Use ">=" so an exactly-too-small buffer correctly returns
OPAL_ERR_TEMP_OUT_OF_RESOURCE.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14044
