### PR TITLE
opal/class: fix opal_bitmap max_size units mismatch

### DIFF
--- a/opal/class/opal_bitmap.c
+++ b/opal/class/opal_bitmap.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2025      Jeffrey M. Squyres. All rights reserved.
+ * Copyright (c) 2025-2026 Jeffrey M. Squyres. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,32 +62,34 @@ int opal_bitmap_set_max_size(opal_bitmap_t *bm, int max_size)
     }
 
     /*
-     * Only if the caller wants to set the maximum size,
-     * we set it (in numbers of bits!), otherwise it is
-     * set to INT_MAX in the constructor.
+     * Store the cap in bits, matching the documented contract (see the
+     * header).  When the caller does not set it, it is INT_MAX (set in
+     * the constructor).
      */
-    bm->max_size = (int) (((size_t) max_size + SIZE_OF_BASE_TYPE - 1) / SIZE_OF_BASE_TYPE);
+    bm->max_size = max_size;
 
     return OPAL_SUCCESS;
 }
 
 int opal_bitmap_init(opal_bitmap_t *bm, int size)
 {
+    if ((size <= 0) || (NULL == bm)) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
     /*
-     * Only if the caller set the maximum size before initializing,
-     * we test here (in numbers of bits!)
-     * By default, the max size is INT_MAX, set in the constructor.
+     * Enforce the optional maximum (in bits) on the requested size before
+     * rounding up to a whole number of array elements.  bm->max_size is
+     * expressed in bits (see opal_bitmap_set_max_size()); by default it is
+     * INT_MAX, set in the constructor.
      */
-    if ((size <= 0) || (NULL == bm) || (size > bm->max_size)) {
+    if (size > bm->max_size) {
         return OPAL_ERR_BAD_PARAM;
     }
 
     bm->array_size = (int) (((size_t) size + SIZE_OF_BASE_TYPE - 1) / SIZE_OF_BASE_TYPE);
     if (NULL != bm->bitmap) {
         free(bm->bitmap);
-        if (bm->max_size < bm->array_size) {
-            bm->max_size = bm->array_size;
-        }
     }
     bm->bitmap = (uint64_t *) malloc(bm->array_size * sizeof(uint64_t));
     if (NULL == bm->bitmap) {
@@ -100,9 +102,11 @@ int opal_bitmap_init(opal_bitmap_t *bm, int size)
 
 int opal_bitmap_set_bit(opal_bitmap_t *bm, int bit)
 {
-    int index, offset, new_size;
+    int index, offset, new_size, max_array_size;
 
-    if ((bit < 0) || (NULL == bm) || (bit > bm->max_size)) {
+    /* bm->max_size is the optional cap in bits; valid bit indices are
+       0 .. max_size-1. */
+    if ((bit < 0) || (NULL == bm) || (bit >= bm->max_size)) {
         return OPAL_ERR_BAD_PARAM;
     }
 
@@ -116,8 +120,13 @@ int opal_bitmap_set_bit(opal_bitmap_t *bm, int bit)
          valid and we simply expand the bitmap */
 
         new_size = index + 1;
-        if (new_size > bm->max_size) {
-            new_size = bm->max_size;
+        /* Clamp growth to the cap, converted from bits to array elements.
+           The bit-range check above already guarantees new_size stays
+           within this bound, but keep the clamp consistent with max_size. */
+        max_array_size = (int) (((size_t) bm->max_size + SIZE_OF_BASE_TYPE - 1)
+                                / SIZE_OF_BASE_TYPE);
+        if (new_size > max_array_size) {
+            new_size = max_array_size;
         }
 
         /* New size is just a multiple of the original size to fit in
@@ -226,6 +235,22 @@ int opal_bitmap_find_and_set_first_unset_bit(opal_bitmap_t *bm, int *position)
     }
 
     (*position) += i * SIZE_OF_BASE_TYPE;
+
+    /*
+     * The fast path above sets the first unset bit in word i directly,
+     * without consulting bm->max_size.  When max_size is not a multiple of
+     * SIZE_OF_BASE_TYPE, the last allocated word can contain unset bits that
+     * lie beyond the cap, so this path can otherwise hand back (and set) a
+     * bit at/after max_size.  If that happened the bitmap is full within its
+     * valid range [0, max_size): undo the speculative set and report it,
+     * matching opal_bitmap_set_bit() -- which the all-words-full grow path
+     * above already goes through.
+     */
+    if (*position >= bm->max_size) {
+        bm->bitmap[i] &= ~(1UL << (*position - i * SIZE_OF_BASE_TYPE));
+        return OPAL_ERR_BAD_PARAM;
+    }
+
     return OPAL_SUCCESS;
 }
 


### PR DESCRIPTION
opal/class: fix opal_bitmap max_size units mismatch

opal_bitmap_set_max_size() stores the cap in array elements (it divides
the requested bit count by SIZE_OF_BASE_TYPE), and the internal growth
logic in opal_bitmap_set_bit() already treats max_size as a count of
array elements.  However, the bounds checks in opal_bitmap_init() and
opal_bitmap_set_bit() compared a bit count directly against max_size,
mixing units.

As a result, once a finite maximum was set, those functions rejected
bit positions that were actually within the documented limit.  For
example, after opal_bitmap_set_max_size(bm, 64) (i.e. "at most 64
bits"), opal_bitmap_init(bm, 64) returned OPAL_ERR_BAD_PARAM, even
though the header documents both arguments as being expressed in bits.

Convert the requested size/bit to array elements before comparing
against max_size in both functions.  The only in-tree caller
(ompi/attribute) sets the maximum to OMPI_FORTRAN_HANDLE_MAX (INT_MAX),
for which the behavior is unchanged.

Signed-off-by: Jeff Squyres <jeff@squyres.com>


Fixes #14048
