### PR TITLE
fix(datatype): bound MPI_Type_get_contents loop by actual count

### DIFF
--- a/ompi/mpi/c/type_get_contents.c
+++ b/ompi/mpi/c/type_get_contents.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +47,8 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
                           MPI_Aint array_of_addresses[],
                           MPI_Datatype array_of_datatypes[])
 {
-    int rc, i;
+    int rc;
+    size_t i;
     MPI_Datatype newtype;
 
     MEMCHECKER(
@@ -85,7 +87,6 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
                                 MPI_ERR_TYPE, FUNC_NAME );
     }
     // now get the contents
-    ci = max_integers, cl = 0, ca = max_addresses, cd = max_datatypes;
     rc = ompi_datatype_get_args( mtype, 1, &ci, array_of_integers,
                                 &cl, NULL,
                                 &ca, array_of_addresses,
@@ -95,7 +96,7 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
                                 MPI_ERR_INTERN, FUNC_NAME );
     }
 
-    for( i = 0; i < max_datatypes; i++ ) {
+    for( i = 0; i < cd; i++ ) {
         /* if we have a predefined datatype then we return directly a pointer to
          * the datatype, otherwise we should create a copy and give back the copy.
          */

--- a/ompi/mpi/c/type_get_contents_c.c
+++ b/ompi/mpi/c/type_get_contents_c.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,7 +49,8 @@ int MPI_Type_get_contents_c(MPI_Datatype mtype,
                             MPI_Count  array_of_large_counts[],
                             MPI_Datatype array_of_datatypes[])
 {
-    int rc, i;
+    int rc;
+    size_t i;
     MPI_Datatype newtype;
 
     MEMCHECKER(
@@ -96,7 +98,11 @@ int MPI_Type_get_contents_c(MPI_Datatype mtype,
                                 MPI_ERR_INTERN, FUNC_NAME );
     }
 
-    for( i = 0; i < max_datatypes; i++ ) {
+    /* Iterate over the actual number of constituent datatypes (cd), not
+     * the caller-provided capacity (max_datatypes): only the first cd
+     * entries of array_of_datatypes[] were filled in above, so iterating
+     * to max_datatypes would dereference uninitialized handles. */
+    for( i = 0; i < cd; i++ ) {
         /* if we have a predefined datatype then we return directly a pointer to
          * the datatype, otherwise we should create a copy and give back the copy.
          */


### PR DESCRIPTION
Found while adding single-process unit tests for the OMPI layer (the tests are in a separate PR).

`MPI_Type_get_contents()` / `MPI_Type_get_contents_c()` post-processed `array_of_datatypes[]` in a loop bounded by `max_datatypes` (the caller's buffer capacity) instead of the actual number of constituent datatypes returned by `ompi_datatype_get_args()`. When a caller passes an oversized array -- which the standard permits, since the required size is discovered via `MPI_Type_get_envelope()` -- the loop dereferenced uninitialized handles and segfaulted.

Iterate over the real count instead: in `type_get_contents.c` the second `ompi_datatype_get_args()` call resets `cd` to the capacity, so capture the real count beforehand; in `type_get_contents_c.c` `cd` still holds the real count at the loop, so use it directly.

Fixes #14051
