### PR TITLE
fix(datatype): always align packed-description word-size accesses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -555,29 +555,6 @@ OPAL_C_GET_ALIGNMENT(size_t, OPAL_ALIGNMENT_SIZE_T)
 
 OPAL_CHECK_ALT_SHORT_FLOAT
 
-# Check system alignment requirements
-if test "$opal_want_heterogeneous" = 1; then
-    ompi_cv_c_word_size_align=yes
-else
-    AC_CACHE_CHECK([if word-sized integers must be word-size aligned],
-        [ompi_cv_c_word_size_align],
-        [AC_LANG_PUSH(C)
-         AC_RUN_IFELSE([AC_LANG_PROGRAM([dnl
-#include <stdlib.h>], [[    long data[2] = {0, 0};
-    long *lp;
-    int *ip;
-    ip = (int*) data;
-    ip++;
-    lp = (long*) ip;
-    return lp[0]; ]])],
-            [ompi_cv_c_word_size_align=no],
-            [ompi_cv_c_word_size_align=yes],
-            [ompi_cv_c_word_size_align=yes])])
-fi
-AS_IF([test $ompi_cv_c_word_size_align = yes], [results=1], [results=0])
-AC_DEFINE_UNQUOTED([OPAL_ALIGN_WORD_SIZE_INTEGERS], [$results],
-    [set to 1 if word-size integers must be aligned to word-size padding to prevent bus errors])
-
 #
 # Check for other compiler characteristics
 #

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025-2026 Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,19 +61,16 @@ typedef struct __dt_args {
 } ompi_datatype_args_t;
 
 /**
- * Some architectures really don't like having unaligned
- * accesses.  We'll be int aligned, because any sane system will
- * require that.  But we might not be long aligned, and some
- * architectures will complain if a long is accessed on int
- * alignment (but not long alignment).  On those architectures,
- * copy the buffer into an aligned buffer first.
+ * The packed datatype description interleaves 32-bit ints with word-size
+ * (size_t / ptrdiff_t) values.  After writing an int the running pointer is
+ * only int-aligned, so accessing the following word-size value through it is
+ * an unaligned access -- which is undefined behavior and faults on
+ * strict-alignment architectures (e.g. RISC-V).  Realign the pointer up to
+ * word size before every word-size access.  The pack and unpack paths apply
+ * this identically, so the on-the-wire layout stays consistent.
  */
-#if OPAL_ALIGN_WORD_SIZE_INTEGERS
 #define OMPI_DATATYPE_ALIGN_PTR(PTR, TYPE) \
     (PTR) = OPAL_ALIGN_PTR((PTR), sizeof(ptrdiff_t), TYPE)
-#else
-#define OMPI_DATATYPE_ALIGN_PTR(PTR, TYPE)
-#endif  /* OPAL_ALIGN_WORD_SIZE_INTEGERS */
 
 /**
  * Copies count elements from the given count array into either
@@ -514,8 +512,10 @@ static inline int __ompi_datatype_pack_description( ompi_datatype_t* datatype,
     next_packed += sizeof(int) * args->cd;
 
     /* copy the array of 32bit counts at the end */
-    memcpy( next_packed, args->i, sizeof(int) * args->ci );
-    next_packed += args->ci * sizeof(int);
+    if( 0 < args->ci ) {
+        memcpy( next_packed, args->i, sizeof(int) * args->ci );
+        next_packed += args->ci * sizeof(int);
+    }
 
     /* copy the rest of the data */
     for( i = 0; i < args->cd; i++ ) {
@@ -1061,6 +1061,15 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( const int* i, const si
     return datatype;
 }
 
+/*
+ * Note: *packed_buffer must be at least word-size (sizeof(ptrdiff_t))
+ * aligned.  The description interleaves 32-bit ints with word-size values
+ * and the unpack code realigns the running pointer to word size before each
+ * word-size access (see OMPI_DATATYPE_ALIGN_PTR); that realignment is
+ * relative to the buffer base, so the base must itself be word aligned for
+ * the reads to land on the same offsets the packer wrote.  Buffers produced
+ * by ompi_datatype_get_pack_description() (malloc'd) satisfy this.
+ */
 ompi_datatype_t* ompi_datatype_create_from_packed_description( void** packed_buffer,
                                                                struct ompi_proc_t* remote_processor )
 {


### PR DESCRIPTION
`__ompi_datatype_pack_description()` and its unpack counterpart accessed word-size values (`size_t`/`ptrdiff_t`) at only int-aligned offsets -- undefined behavior that faults on strict-alignment architectures. The realignment had been gated on `OPAL_ALIGN_WORD_SIZE_INTEGERS`, but that configure probe itself does an unaligned access and silently succeeds under emulation (qemu), compiling the alignment out even where the target hardware would fault. The gate also produced two different wire layouts (padded on strict arches, unpadded on tolerant ones).

Align unconditionally on both the pack and unpack paths. This removes the UB and makes every architecture emit the same (padded) layout. That leaves `OPAL_ALIGN_WORD_SIZE_INTEGERS` with no users anywhere in the tree, so the probe and the `#define` are dropped from `configure.ac` entirely.

Also guards a zero-count/NULL `memcpy` -- separate UB. `ompi_datatype_set_args()` leaves `args->i` NULL when `ci == 0`, which is the case for `MPI_Type_create_resized` (both interfaces) and for every large-count constructor, since those store their counts in `args->l` instead; the two neighboring copies (`args->a`, `args->l`) already carry the identical guard.

Finally, documents that the top-level packed buffer must be word aligned. Found via UBSan (`-fsanitize=alignment`) on aarch64.

Note (pre-existing, intentionally not addressed here): the packed layout aligns relative to the buffer's absolute address, so the description is position-dependent and must be unpacked from a word-aligned buffer (the documented precondition). Making the layout position-independent, or enforcing the alignment at the API boundary, can be tracked as a follow-up.

Fixes #14052
