### PR TITLE
fix(datatype): match only basic scalar types in ompi_datatype_match_size

### DIFF
--- a/docs/man-openmpi/man3/MPI_Type_match_size.3.rst
+++ b/docs/man-openmpi/man3/MPI_Type_match_size.3.rst
@@ -41,6 +41,25 @@ suitable datatype. In C use the sizeof builtin instead of :ref:`MPI_Sizeof`.
 It is erroneous to specify a size not supported by the compiler.
 
 
+NOTES
+-----
+
+In Open MPI, *typeclass* always refers to a Fortran numeric intrinsic
+type, and :ref:`MPI_Type_match_size` only ever returns an intrinsic
+Fortran predefined datatype (for example, ``MPI_REAL8``,
+``MPI_INTEGER4``, or ``MPI_COMPLEX8``) |mdash| regardless of whether it
+is called from C or Fortran. It does not return C predefined datatypes
+(such as ``MPI_DOUBLE``), nor composite predefined datatypes (such as
+``MPI_2REAL`` or ``MPI_2INTEGER``), even when one of those happens to
+have the requested *size*.
+
+Consequently, if Open MPI was built with ``--disable-mpi-fortran``, the
+Fortran intrinsic datatypes are unavailable. In that case no datatype
+can match any *typeclass* / *size* combination: every such request is
+treated as a size not supported by the compiler, and the call fails with
+error class ``MPI_ERR_ARG`` (subject to the relevant error handler).
+
+
 ERRORS
 ------
 

--- a/ompi/datatype/ompi_datatype_match_size.c
+++ b/ompi/datatype/ompi_datatype_match_size.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +43,16 @@ const ompi_datatype_t* ompi_datatype_match_size( size_t size, uint16_t datakind,
 
         datatype = (ompi_datatype_t*)opal_pointer_array_get_item(&ompi_datatype_f_to_c_table, i);
 
+        /* Only basic scalar predefined types are valid matches for a
+         * (typeclass, size) request.  Requiring OPAL_DATATYPE_FLAG_BASIC
+         * skips two kinds of entries that would otherwise produce bogus
+         * matches: types that are unavailable in this build (e.g. the
+         * Fortran types in a --disable-mpi-fortran build, which have size 0
+         * and would spuriously match a size-0 request), and composite
+         * predefined types (e.g. MPI_2REAL, a pair of REALs whose 8-byte
+         * size would otherwise be returned for a request of REAL/8). */
+        if( (datatype->super.flags & OPAL_DATATYPE_FLAG_BASIC) != OPAL_DATATYPE_FLAG_BASIC )
+            continue;
         if( (datatype->super.flags & OMPI_DATATYPE_FLAG_DATA_LANGUAGE) != datalang )
             continue;
         if( (datatype->super.flags & OMPI_DATATYPE_FLAG_DATA_TYPE) != datakind )


### PR DESCRIPTION
`ompi_datatype_match_size()` (used by `MPI_Type_match_size`) selected a predefined datatype by language + kind + size only, so it could return a composite type (e.g. `MPI_2REAL` for `(MPI_TYPECLASS_REAL, 8)`) or an unavailable type (size 0) and report success.

Require `OPAL_DATATYPE_FLAG_BASIC` so only basic scalar intrinsics are eligible; `match_size` now returns the correct scalar intrinsic when one exists and fails (`MPI_ERR_ARG`) otherwise -- including failing cleanly for every typeclass/size on a `--disable-mpi-fortran` build, per MPI-5.0 19.1. The `MPI_Type_match_size` man page is updated accordingly.

Fixes #14053
