### PR TITLE
Make mpi_f08 parameter names, types, and intents conform to the standard

### DIFF
--- a/ompi/mpi/Makefile.am
+++ b/ompi/mpi/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2025-2026 Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,6 +24,7 @@ EXTRA_DIST += \
         mpi/fortran/configure-fortran-output-bottom.h \
         mpi/help-mpi-api.txt \
         mpi/bindings/bindings.py \
+        mpi/bindings/check_f08_names.py \
         mpi/bindings/ompi_bindings/consts.py \
         mpi/bindings/ompi_bindings/c.py \
         mpi/bindings/ompi_bindings/c_type.py \

--- a/ompi/mpi/bindings/bindings.py
+++ b/ompi/mpi/bindings/bindings.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024-2025 Triad National Security, LLC. All rights
 #                         reserved.
 #
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,6 +36,9 @@ def main():
                                 help='generate ts suffixes for appropriate routines')
     parser_fortran.add_argument('--fort-std', choices=('f90', 'f08'),
                              help='fortran standard to use for fortran module and code generation')
+    parser_fortran.add_argument('--pympistd-dir', default=None,
+                             help='path to the pympistandard submodule; when given, the generated '
+                                  'Fortran interfaces use the standard MPI dummy-argument names')
     # Handler for generating actual code
     subparsers_fortran = parser_fortran.add_subparsers()
     parser_code = subparsers_fortran.add_parser('code', help='generate binding code')

--- a/ompi/mpi/bindings/check_f08_names.py
+++ b/ompi/mpi/bindings/check_f08_names.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+"""Validate the Open MPI mpi_f08 interfaces against the MPI standard.
+
+The mpi_f08 module is the only Fortran binding whose dummy-argument
+*names* are part of the user-visible contract (keyword arguments).  This
+script loads the MPI Forum's pympistandard metadata and checks that every
+mpi_f08 procedure's dummy arguments agree with the standard on three
+things:
+
+  * name      -- the dummy-argument name (case-insensitive)
+  * intent    -- INTENT(IN|OUT|INOUT)
+  * type      -- the declared Fortran type
+
+It is intended to be run at build time over the generated Fortran source
+(api_f08_generated.F90 and the interface headers) plus the hand-written
+*_f08.F90 files, and exits non-zero -- failing the build -- if any
+mpi_f08 interface has drifted from the standard.  Only the mpi_f08
+module is in scope; the C back-end and the older mpi (f90) module are
+not checked.
+
+Things the standard deliberately leaves to the implementation are not
+flagged:
+
+  * choice buffers (standard type 'TYPE(*), ...'); Open MPI renders
+    these with its own ignore-TKR macro and may attach INTENT(IN).
+  * any argument whose standard F08 intent is unspecified (None), e.g.
+    a TYPE(MPI_Status) argument that must also accept MPI_STATUS_IGNORE.
+  * a large-count (_c) procedure that the standard does not provide an
+    F08 binding for.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+
+# Automake-style result colors (PASS=green, FAIL=red, SKIP=blue), matching
+# Automake's color-tests palette.
+_STATUS_COLOR = {'PASS': '\033[0;32m', 'FAIL': '\033[0;31m', 'SKIP': '\033[1;34m'}
+_COLOR_RESET = '\033[m'
+
+
+def _use_color():
+    """Colorize like Automake: AM_COLOR_TESTS=always forces it; otherwise a TTY."""
+    setting = os.environ.get('AM_COLOR_TESTS', '')
+    if setting == 'always':
+        return True
+    if setting == 'no' or os.environ.get('NO_COLOR'):
+        return False
+    return sys.stdout.isatty()
+
+
+def emit_status(status, label, reason=None):
+    """Print an Automake-style '<STATUS>: <label>' line, colorized if appropriate."""
+    tag = status
+    if _use_color():
+        tag = f'{_STATUS_COLOR[status]}{status}{_COLOR_RESET}'
+    line = f'{tag}: {label}'
+    if reason:
+        line += f' ({reason})'
+    print(line)
+
+
+def load_standard(pympistd_dir):
+    """Load {function_key: {'r': params, 'c': params}} from pympistandard.
+
+    Each params entry is a list of (name, intent, type) tuples for the
+    regular ('r') and large-count/embiggened ('c') F08 bindings.
+    """
+    sys.path.insert(0, os.path.join(pympistd_dir, 'src'))
+    import pympistandard as std
+    std.use_api_version(1)
+
+    def params_of(express):
+        f08 = getattr(express, 'f08', None) if express is not None else None
+        if f08 is None:
+            return None
+        return [(p.name.lower(), p.intent, p.type) for p in f08.parameters]
+
+    table = {}
+    for key, proc in std.PROCEDURES.items():
+        entry = {}
+        regular = params_of(proc.express)
+        if regular is not None:
+            entry['r'] = regular
+        embiggened = params_of(proc.express.embiggen)
+        if embiggened is not None:
+            entry['c'] = embiggened
+        if entry:
+            table[key.lower()] = entry
+    return table
+
+
+# Procedures whose Open MPI mpi_f08 binding intentionally has a different
+# argument count than the standard's F08 expression, so an argument-count
+# mismatch is expected rather than drift: MPI_Pcontrol is variadic, and the
+# Open MPI bindings for MPI_Type_get_contents / MPI_Type_get_envelope take a
+# different argument shape than pympistandard's rendering.
+COUNT_MISMATCH_EXEMPT = {
+    'mpi_pcontrol',
+    'mpi_type_get_contents',
+    'mpi_type_get_envelope',
+}
+
+
+def function_key(subroutine_name):
+    """Map an mpi_f08 subroutine name to a (pympistandard key, is_large_count) pair.
+
+    Large-count variants use two suffix conventions: the template-generated
+    routines use '_c_f08'/'_c_f08ts', while the hand-written ones use
+    '_f08_c'/'_f08ts_c'.  Both must be recognized so the large-count routines
+    resolve to the embiggened standard entry instead of being skipped.
+    """
+    is_c = bool(re.search(r'(_c_f08(ts)?|_f08(ts)?_c)$', subroutine_name))
+    base = re.sub(r'(_c_f08(ts)?|_f08(ts)?_c|_f08(ts)?)$', '', subroutine_name).lower()
+    if not base.startswith('mpi_'):
+        base = 'mpi_' + base
+    return base, is_c
+
+
+def normalize_type(text):
+    """Normalize a Fortran type for comparison."""
+    text = re.sub(r'\s+', '', text).upper().replace('KIND=', '')
+    # CHARACTER(LEN=*) and friends are all just CHARACTER for our purposes.
+    text = re.sub(r'CHARACTER\(.*\)', 'CHARACTER', text)
+    return text
+
+
+def is_choice_buffer(std_type):
+    """A standard choice-buffer argument renders as 'TYPE(*), ...'."""
+    return 'TYPE(*)' in std_type
+
+
+def parse_fortran(path):
+    """Yield (subroutine_name, [arg_names], {arg: (intent, base_type)}) per top-level routine."""
+    lines = open(path).read().split('\n')
+    i, n = 0, len(lines)
+    while i < n:
+        s = lines[i].strip()
+        m = re.match(r'(?:pure\s+|elemental\s+)?subroutine\s+(MPI_\w+)\s*\(', s)
+        if not m:
+            i += 1
+            continue
+        name = m.group(1)
+        # Gather a possibly continued signature.
+        sig, j = s, i
+        while sig.rstrip().endswith('&'):
+            j += 1
+            sig = sig.rstrip()[:-1] + lines[j].strip()
+        arglist = re.search(r'\((.*)\)', sig).group(1)
+        args = [a.strip().lower() for a in arglist.split(',')
+                if a.strip() and a.strip().lower() != 'ierror']
+        # Collect dummy declarations up to the first nested interface / end.
+        decls = {}
+        k = j + 1
+        while k < n:
+            low = lines[k].strip().lower()
+            if re.match(r'^interface\b', low) or re.match(r'^end\s+subroutine', low):
+                break
+            if '::' in lines[k]:
+                upper = lines[k].upper()
+                has_intent = 'INTENT(' in upper
+                is_buffer = 'TYPE(*)' in upper or 'IGNORE_TKR' in upper
+                if has_intent or is_buffer:
+                    intent = ('INTENT(INOUT)' if 'INTENT(INOUT)' in upper else
+                              'INTENT(OUT)' if 'INTENT(OUT)' in upper else
+                              'INTENT(IN)' if 'INTENT(IN)' in upper else None)
+                    # Base type: text before the first top-level comma of the LHS.
+                    lhs = lines[k].split('::', 1)[0]
+                    base, depth = '', 0
+                    for ch in lhs:
+                        if ch == '(':
+                            depth += 1
+                        elif ch == ')':
+                            depth -= 1
+                        elif ch == ',' and depth == 0:
+                            break
+                        base += ch
+                    # Declared names (before any '(' dimension spec, top-level commas).
+                    rhs = lines[k].split('::', 1)[1].split('!')[0]
+                    buf, depth, names = '', 0, []
+                    for ch in rhs:
+                        if ch == '(':
+                            depth += 1
+                            if depth == 1:
+                                names.append(buf)
+                                buf = ''
+                        elif ch == ')':
+                            depth -= 1
+                        elif ch == ',' and depth == 0:
+                            names.append(buf)
+                            buf = ''
+                        elif depth == 0:
+                            buf += ch
+                    names.append(buf)
+                    for nm in names:
+                        nm = nm.strip().lower()
+                        if re.match(r'^[a-z]\w*$', nm):
+                            decls[nm] = (intent, base.strip())
+            k += 1
+        yield name, args, decls
+        i = j + 1
+
+
+def check_file(path, table, matched):
+    """Return mismatch strings for one file; add fully-checked routines to `matched`."""
+    problems = []
+    for name, args, decls in parse_fortran(path):
+        key, is_c = function_key(name)
+        entry = table.get(key)
+        if entry is None:
+            # No standard metadata for this routine (an Open MPI extension, or
+            # a routine newer than the pympistandard in use) -- nothing to
+            # check it against.
+            continue
+        expected = entry.get('c') if is_c else entry.get('r')
+        if expected is None:
+            # OMPI provides a large-count variant the standard does not.
+            continue
+        expected = [(n, i, t) for (n, i, t) in expected if n != 'ierror']
+        if len(args) != len(expected):
+            # An unexpected argument-count difference is real drift; a few
+            # routines legitimately differ (see COUNT_MISMATCH_EXEMPT).
+            if key not in COUNT_MISMATCH_EXEMPT:
+                problems.append(f'{name}: has {len(args)} non-ierror argument(s) but the '
+                                f'standard specifies {len(expected)} (argument added or removed?)')
+            continue
+        matched.add(name)
+        for got_name, (std_name, std_intent, std_type) in zip(args, expected):
+            if got_name != std_name:
+                problems.append(f'{name}: argument {got_name!r} should be named '
+                                f'{std_name!r}')
+            got_intent, got_type = decls.get(got_name, (None, None))
+            # Intent: skip where the standard leaves it unspecified.
+            if std_intent is not None and got_intent is not None and got_intent != std_intent:
+                problems.append(f'{name}: argument {std_name!r} has {got_intent}, '
+                                f'standard requires {std_intent}')
+            # Type: skip choice buffers (implementation-defined rendering).
+            if (got_type is not None and not is_choice_buffer(std_type)
+                    and 'IGNORE_TKR' not in got_type.upper()):
+                if normalize_type(got_type) != normalize_type(std_type):
+                    problems.append(f'{name}: argument {std_name!r} is declared '
+                                    f'{got_type!r}, standard requires {std_type!r}')
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Validate mpi_f08 interfaces against the MPI standard (pympistandard).')
+    parser.add_argument('--pympistd-dir', required=True,
+                        help='path to the pympistandard submodule')
+    parser.add_argument('--label', default='mpi_f08 interfaces',
+                        help='label for the Automake-style PASS/FAIL/SKIP result line')
+    parser.add_argument('files', nargs='+',
+                        help='Fortran files containing mpi_f08 interfaces to check')
+    args = parser.parse_args()
+    label = args.label
+
+    # Skip (don't fail) when the mpi_f08 sources are not present -- e.g. the
+    # Fortran bindings were not built.  (The Makefiles only run this during
+    # "make check" when the f08 bindings are enabled, but stay robust anyway.)
+    if not any(os.path.exists(f) for f in args.files):
+        emit_status('SKIP', label, 'mpi_f08 sources not built')
+        return
+
+    # Skip when pympistandard is unavailable (e.g. the submodule was not
+    # checked out).  The generator falls back the same way; a build with
+    # pympistandard present is what enforces standard names.
+    if not os.path.isdir(os.path.join(args.pympistd_dir, 'src')):
+        emit_status('SKIP', label, 'pympistandard not available')
+        return
+    try:
+        table = load_standard(args.pympistd_dir)
+    except ImportError as e:
+        emit_status('SKIP', label, f'pympistandard could not be loaded: {e}')
+        return
+
+    problems = []
+    matched = set()
+    for path in args.files:
+        if os.path.exists(path):
+            problems.extend(check_file(path, table, matched))
+
+    # Guard against silently validating nothing: if files were present but not
+    # a single routine matched a standard entry, the pympistandard key format
+    # has almost certainly drifted from what this script expects, so a "pass"
+    # would be meaningless.  Fail loudly instead.
+    if not matched:
+        emit_status('FAIL', label, 'matched 0 procedures; pympistandard key format may have changed')
+        sys.exit(1)
+
+    if problems:
+        print('mpi_f08 interfaces disagree with the MPI standard:')
+        for p in problems:
+            print(f'  {p}')
+        print(f'{len(problems)} mismatch(es) found ({len(matched)} procedures validated).')
+        emit_status('FAIL', label)
+        sys.exit(1)
+
+    emit_status('PASS', label, f'{len(matched)} procedures validated')
+
+
+if __name__ == '__main__':
+    main()

--- a/ompi/mpi/bindings/ompi_bindings/fortran.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024-2026 Triad National Security, LLC. All rights
 #                         reserved.
 #
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,16 +17,57 @@ listed.
 """
 from collections import namedtuple
 import json
+import os
 import re
+import sys
 from ompi_bindings import consts, util
 from ompi_bindings.fortran_type import FortranType
 from ompi_bindings.parser import SourceTemplate
 
 
+# Cache of {function_name_lower: [standard f08 dummy-argument names]} loaded
+# from pympistandard.  None means "not yet attempted"; an empty dict means
+# "attempted but unavailable" (the generator then falls back to the names
+# hard-coded in the *.in PROTOTYPE lines).
+_STANDARD_F08_NAMES = None
+
+
+def standard_f08_names(pympistd_dir):
+    """Load the standard MPI F08 dummy-argument names from pympistandard.
+
+    The Open MPI templates use generic internal names (e.g. 'x', 'x1') for
+    the choice-buffer arguments; the C back-end code refers to those names.
+    The user-visible mpi_f08 interfaces, however, must use the parameter
+    names mandated by the MPI standard so that keyword arguments work.  This
+    returns, per function, the ordered list of standard F08 dummy names
+    (excluding ierror), which the Fortran generator substitutes for the
+    template names -- without touching the C back-end.
+    """
+    global _STANDARD_F08_NAMES
+    if _STANDARD_F08_NAMES is not None:
+        return _STANDARD_F08_NAMES
+    names = {}
+    if pympistd_dir:
+        src = os.path.join(pympistd_dir, 'src')
+        if os.path.isdir(src):
+            sys.path.insert(0, src)
+            import pympistandard as std
+            std.use_api_version(1)
+            for key, proc in std.PROCEDURES.items():
+                f08 = getattr(proc.express, 'f08', None)
+                if f08 is None:
+                    continue
+                names[key.lower()] = [p.name.lower() for p in f08.parameters
+                                      if p.name.lower() != consts.FORTRAN_ERROR_NAME]
+    _STANDARD_F08_NAMES = names
+    return names
+
+
 class FortranBinding:
     """Class for generating the binding for a single function."""
 
-    def __init__(self, prototype, out, template=None, bigcount=False, needs_ts=False, gen_f90=False):
+    def __init__(self, prototype, out, template=None, bigcount=False, needs_ts=False,
+                 gen_f90=False, f08_names=None):
         # Generate bigcount interface version
         self.bigcount = bigcount
         self.fn_name = template.prototype.name
@@ -38,6 +80,16 @@ class FortranBinding:
             self.parameters.append(param.construct(fn_name=self.fn_name,
                                                    bigcount=bigcount,
                                                    gen_f90=gen_f90))
+        # For Fortran generation, replace the template's internal parameter
+        # names with the standard MPI F08 dummy-argument names.  Only done
+        # when the count of standard names matches (i.e. the prototype and the
+        # standard agree on the number of non-ierror arguments); otherwise the
+        # template names are kept so a misaligned prototype never silently
+        # emits a wrong name.  The C back-end (print_c_source) constructs its
+        # own FortranBinding without f08_names, so it is unaffected.
+        if f08_names is not None and len(f08_names) == len(self.parameters):
+            for param, std_name in zip(self.parameters, f08_names):
+                param.name = std_name
 
     def dump(self, *pargs, **kwargs):
         """Write to the output file."""
@@ -274,9 +326,10 @@ def print_c_source_header(out):
     out.dump('#include "bigcount.h"')
 
 
-def print_binding(prototype, lang, out, bigcount=False, template=None, needs_ts=False, gen_f90=False):
+def print_binding(prototype, lang, out, bigcount=False, template=None, needs_ts=False, gen_f90=False, f08_names=None):
     """Print the binding with or without bigcount."""
-    binding = FortranBinding(prototype, out=out, bigcount=bigcount, template=template, needs_ts=needs_ts, gen_f90=gen_f90)
+    binding = FortranBinding(prototype, out=out, bigcount=bigcount, template=template, needs_ts=needs_ts,
+                             gen_f90=gen_f90, f08_names=f08_names)
     if lang == 'fortran':
         binding.print_f_source()
     else:
@@ -300,6 +353,11 @@ def generate_code(args, out):
     else:
         gen_f90 = True
 
+    # Standard F08 dummy-argument names are only applied to the F08 Fortran
+    # interfaces, never to the C back-end (whose body refers to the template's
+    # internal names) and not to the older mpi (f90) module.
+    std_names = standard_f08_names(args.pympistd_dir) if (args.lang == 'fortran' and not gen_f90) else {}
+
     if args.lang == 'fortran':
         print_f_source_header(out)
         out.dump()
@@ -312,10 +370,13 @@ def generate_code(args, out):
         out.dump()
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        print_binding(template.prototype, args.lang, out, template=template, needs_ts=needs_ts, gen_f90=gen_f90)
+        f08_names = std_names.get('mpi_' + template.prototype.name.lower())
+        print_binding(template.prototype, args.lang, out, template=template, needs_ts=needs_ts,
+                      gen_f90=gen_f90, f08_names=f08_names)
         if util.prototype_has_bigcount(template.prototype) and gen_f90 == False:
             out.dump()
-            print_binding(template.prototype, args.lang, bigcount=True, out=out, template=template, needs_ts=needs_ts)
+            print_binding(template.prototype, args.lang, bigcount=True, out=out, template=template,
+                          needs_ts=needs_ts, f08_names=f08_names)
 
 
 def generate_interface(args, out):
@@ -330,16 +391,23 @@ def generate_interface(args, out):
     else:
         gen_f90 = True
 
+    # The interface specifications are part of the user-visible mpi_f08
+    # module, so they use the standard MPI dummy-argument names too.  The
+    # older mpi (f90) module is out of scope.
+    std_names = standard_f08_names(args.pympistd_dir) if not gen_f90 else {}
+
     for template in templates:
         ext_name = util.ext_api_func_name(template.prototype.name)
         out.dump(f'interface {ext_name}')
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        binding = FortranBinding(template.prototype, template=template, needs_ts=needs_ts, gen_f90=gen_f90, out=out)
+        f08_names = std_names.get('mpi_' + template.prototype.name.lower())
+        binding = FortranBinding(template.prototype, template=template, needs_ts=needs_ts,
+                                 gen_f90=gen_f90, out=out, f08_names=f08_names)
         binding.print_interface()
         if util.prototype_has_bigcount(template.prototype) and gen_f90 == False:
             out.dump()
             binding_c = FortranBinding(template.prototype, out=out, template=template,
-                                       needs_ts=needs_ts, bigcount=True)
+                                       needs_ts=needs_ts, bigcount=True, f08_names=f08_names)
             binding_c.print_interface()
         out.dump(f'end interface {ext_name}')

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -460,6 +460,23 @@ endif
 
 ###########################################################################
 
+# Validate that the mpi_f08 interfaces -- both the generated
+# (api_f08_generated.F90) and the hand-written (*_f08.F90) ones -- use the
+# parameter names, types, and intents mandated by the MPI standard, as
+# provided by the pympistandard submodule.  Run during "make check"; fails
+# if any mpi_f08 interface drifts from the standard.  The hand-written
+# sources live in $(srcdir); api_f08_generated.F90 is in the build directory
+# (built by "all", on which "check" depends).
+f08_name_check_handwritten = $(filter-out api_f08_generated.F90,$(mpi_api_files))
+
+check-local:
+	@$(PYTHON) $(top_srcdir)/ompi/mpi/bindings/check_f08_names.py \
+	    --label "mpi_f08 bindings (generated + hand-written)" \
+	    --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
+	    api_f08_generated.F90 $(f08_name_check_handwritten:%=$(srcdir)/%)
+
+###########################################################################
+
 # Install the generated .mod files.  Unfortunately, each F90 compiler
 # may generate different filenames, so we have to use a glob.  :-(
 

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -15,7 +15,7 @@
 #                         reserved.
 # Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2022      IBM Corporation.  All rights reserved.
-# Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2025-2026 Jeffrey M. Squyres.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -445,6 +445,7 @@ api_f08_generated.F90: $(template_files)
 	    --output $(abs_builddir)/$@ \
 	    fortran \
 	    $(gen_ts) \
+	    --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
 	    code \
 	    --lang fortran \
 	    --prototype-files $(template_files)

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c.in
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID buffer_detach(C_PTR_OUT buffer, COUNT size)
+PROTOTYPE VOID buffer_detach(C_PTR_OUT buffer, COUNT_OUT size)
 {
     int c_ierr;
     @COUNT_TYPE@ c_size;

--- a/ompi/mpi/fortran/use-mpi-f08/comm_detach_buffer.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_detach_buffer.c.in
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID comm_detach_buffer(COMM comm, C_PTR_OUT buffer, COUNT size)
+PROTOTYPE VOID comm_detach_buffer(COMM comm, C_PTR_OUT buffer, COUNT_OUT size)
 {
     int c_ierr;
     MPI_Comm c_comm;

--- a/ompi/mpi/fortran/use-mpi-f08/get_address_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/get_address_ts.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID get_address(BUFFER_ASYNC x, AINT address)
+PROTOTYPE VOID get_address(BUFFER_ASYNC x, AINT_OUT address)
 {
     int c_ierr;
     MPI_Aint c_address;

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -105,6 +105,18 @@ if OPAL_DEVEL_BUILD
 CLEANFILES += mpi-f08-interfaces-generated.h
 endif
 
+# Validate that the mpi_f08 interface specifications -- the user-visible
+# explicit interfaces, generated separately from the implementations -- use
+# the parameter names, types, and intents mandated by the MPI standard (via
+# the pympistandard submodule).  Run during "make check"; fails on any
+# drift.  Both headers are generated in the build directory (built by
+# "all", on which "check" depends).
+check-local:
+	@$(PYTHON) $(top_srcdir)/ompi/mpi/bindings/check_f08_names.py \
+	    --label "mpi_f08 interface specifications" \
+	    --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
+	    mpi-f08-interfaces-generated.h mpi-f08-interfaces.h
+
 #
 # Automake doesn't do Fortran dependency analysis, so must list them
 # manually here.  Bummer!

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (C) 2024-2026 Triad National Security, LLC. All rights
 #                         reserved.
 #
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -93,6 +94,7 @@ mpi-f08-interfaces-generated.h: $(template_files)
 	    --output $(abs_builddir)/$@ \
 	    fortran \
 	    $(gen_ts) \
+	    --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
 	    --fort-std f08 \
 	    interface \
 	    --prototype-files $(template_files)

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.h.in
@@ -13,6 +13,7 @@
 ! Copyright (c) 2021-2023 Triad National Security, LLC. All rights
 !                         reserved.
 ! Copyright (c) 2025      UT-Battelle, LLC.  All rights reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -52,11 +53,11 @@ end subroutine MPI_Pready_f08
 end interface  MPI_Pready
 
 interface  MPI_Pready_list
-subroutine MPI_Pready_list_f08(length,partitions,request,ierror)
+subroutine MPI_Pready_list_f08(length,array_of_partitions,request,ierror)
    use :: mpi_f08_types, only : MPI_Request
    implicit none
    INTEGER, INTENT(IN) :: length
-   INTEGER, DIMENSION(*), INTENT(IN) :: partitions
+   INTEGER, DIMENSION(*), INTENT(IN) :: array_of_partitions
    TYPE(MPI_Request), INTENT(IN) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Pready_list_f08
@@ -135,11 +136,11 @@ end subroutine MPI_Session_get_errhandler_f08
 end interface MPI_Session_get_errhandler
 
 interface MPI_Session_get_info
-subroutine MPI_Session_get_info_f08(session, info, ierror)
+subroutine MPI_Session_get_info_f08(session, info_used, ierror)
    use :: mpi_f08_types, only : MPI_Session, MPI_Info
    implicit none
    TYPE(MPI_Session), INTENT(IN) :: session
-   TYPE(MPI_Info), INTENT(OUT) :: info
+   TYPE(MPI_Info), INTENT(OUT) :: info_used
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Session_get_info_f08
 end interface MPI_Session_get_info

--- a/ompi/mpi/fortran/use-mpi-f08/pready_list_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pready_list_f08.F90
@@ -6,22 +6,23 @@
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2020      Sandia National Laboratories. All rights reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "mpi-f08-rename.h"
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-subroutine MPI_Pready_list_f08(length,partitions,request,ierror)
+subroutine MPI_Pready_list_f08(length,array_of_partitions,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: ompi_mpifh_bindings, only : ompi_pready_list_f
    implicit none
    INTEGER, INTENT(IN) :: length
-   INTEGER, dimension(*), INTENT(IN) :: partitions
+   INTEGER, dimension(*), INTENT(IN) :: array_of_partitions
    TYPE(MPI_Request), INTENT(IN) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_pready_list_f(length,partitions,request%MPI_VAL,c_ierror)
+   call ompi_pready_list_f(length,array_of_partitions,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Pready_list_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_detach_buffer.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/session_detach_buffer.c.in
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID session_detach_buffer(SESSION session, C_PTR_OUT buffer, COUNT size)
+PROTOTYPE VOID session_detach_buffer(SESSION session, C_PTR_OUT buffer, COUNT_OUT size)
 {
     int c_ierr;
     MPI_Session c_session;

--- a/ompi/mpi/fortran/use-mpi-f08/session_finalize_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_finalize_f08.F90
@@ -7,6 +7,7 @@
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2019      Triad National Security, LLC. All rights
 !                         reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "mpi-f08-rename.h"
@@ -15,7 +16,7 @@ subroutine MPI_Session_finalize_f08(session,ierror)
    use :: mpi_f08_types, only : MPI_Session
    use :: ompi_mpifh_bindings, only : ompi_session_finalize_f
    implicit none
-   TYPE(MPI_Session), INTENT(OUT) :: session
+   TYPE(MPI_Session), INTENT(INOUT) :: session
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_info_f08.F90
@@ -7,20 +7,21 @@
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2019-2022 Triad National Security, LLC. All rights
 !                         reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "mpi-f08-rename.h"
 
-subroutine MPI_Session_get_info_f08(session, info, ierror)
+subroutine MPI_Session_get_info_f08(session, info_used, ierror)
    use :: mpi_f08_types, only : MPI_Session, MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_session_get_info_f
    implicit none
    TYPE(MPI_Session), INTENT(IN) :: session
-   TYPE(MPI_Info), INTENT(OUT) :: info
+   TYPE(MPI_Info), INTENT(OUT) :: info_used
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_session_get_info_f(session%MPI_VAL, info%MPI_VAL, c_ierror)
+   call ompi_session_get_info_f(session%MPI_VAL, info_used%MPI_VAL, c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Session_get_info_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_init_f08.F90
@@ -7,6 +7,7 @@
 !                         and Technology (RIST).  All rights reserved.
 ! Copyright (c) 2019-2021 Triad National Security, LLC. All rights
 !                         reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -18,7 +19,7 @@ subroutine MPI_Session_init_f08(info,errhandler,session,ierror)
    use :: ompi_mpifh_bindings, only : ompi_session_init_f
    implicit none
    TYPE(MPI_Info), INTENT(IN) :: info
-   TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
    TYPE(MPI_Session), INTENT(OUT) :: session
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror

--- a/ompi/mpi/fortran/use-mpi-f08/testany.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/testany.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID testany(INT count, REQUEST_ARRAY_INOUT array_of_requests:count, INT indx,
+PROTOTYPE VOID testany(INT count, REQUEST_ARRAY_INOUT array_of_requests:count, INDEX_OUT indx,
                        LOGICAL_OUT flag, STATUS_OUT status)
 {
     MPI_Request *c_req;

--- a/ompi/mpi/fortran/use-mpi-f08/type_size.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/type_size.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
  * $HEADER$
  */
 
-PROTOTYPE VOID type_size(DATATYPE type, COUNT size)
+PROTOTYPE VOID type_size(DATATYPE type, COUNT_OUT size)
 {
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);

--- a/ompi/mpi/fortran/use-mpi-f08/unpack_external_ts.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/unpack_external_ts.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@
 
 PROTOTYPE VOID unpack_external(CHAR_ARRAY datarep, BUFFER x1, AINT_COUNT insize,
                                AINT_COUNT_INOUT position, BUFFER x2,
-                               COUNT_OUT outcount,  DATATYPE datatype)
+                               COUNT outcount,  DATATYPE datatype)
 {
     int c_ierr;
     MPI_Datatype c_datatype, c_type = PMPI_Type_f2c(*datatype);

--- a/ompi/mpi/fortran/use-mpi-f08/win_allocate_shared.c.in
+++ b/ompi/mpi/fortran/use-mpi-f08/win_allocate_shared.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@
 
 PROTOTYPE VOID win_allocate_shared(AINT size, DISP disp_unit,
                                    INFO info, COMM comm, C_PTR_OUT baseptr,
-                                   WIN win)
+                                   WIN_OUT win)
 {
     int c_ierr;
     MPI_Info c_info;

--- a/ompi/mpi/fortran/use-mpi-f08/win_get_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_get_info_f08.F90
@@ -2,20 +2,21 @@
 !
 ! Copyright (c) 2015-2020 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "mpi-f08-rename.h"
 
-subroutine MPI_Win_get_info_f08(win,info,ierror)
+subroutine MPI_Win_get_info_f08(win,info_used,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_Info
    use :: ompi_mpifh_bindings, only : ompi_win_get_info_f
    implicit none
    TYPE(MPI_Win), INTENT(IN) :: win
-   TYPE(MPI_Info), INTENT(OUT) :: info
+   TYPE(MPI_Info), INTENT(OUT) :: info_used
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_win_get_info_f(win%MPI_VAL,info%MPI_VAL,c_ierror)
+   call ompi_win_get_info_f(win%MPI_VAL,info_used%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Win_get_info_f08


### PR DESCRIPTION
## Summary

Make the `mpi_f08` bindings' parameter **names, types, and intents** conform
to the MPI standard, and add a `make check` gate that keeps them in sync. The
`mpi_f08` dummy-argument names are part of the user-visible API (Fortran
keyword arguments), so disagreements with the standard are real conformance
bugs -- e.g. `call MPI_Send(buf=...)` did not compile.

Companion to #14060 (the buffer attach/detach warning fixes). The two PRs
address different concerns; they both touch the buffer-detach bindings but on
different lines, so they can merge in either order.

Commits:

- **INTENT fixes** -- size arguments of `MPI_Buffer_detach`,
  `MPI_Comm_detach_buffer`, `MPI_Session_detach_buffer`, `MPI_Type_size`
  (`IN`->`OUT`); directions of `MPI_Get_address`, `MPI_Unpack_external`,
  `MPI_Win_allocate_shared`, `MPI_Session_init`, `MPI_Session_finalize`; and
  `MPI_Testany`'s `index` (`IN`->`OUT`).
- **Standard parameter names** -- teach the Fortran generator to source the
  standard F08 dummy-argument names from the `pympistandard` submodule, so the
  generated bindings use `buf`/`sendbuf`/... instead of the template-internal
  `x`/`x1`/... . The C back-end and template bodies are untouched (the Fortran
  call passes arguments positionally). The hand-written bindings are fixed too
  (`array_of_partitions`, `info_used`).
- **Validation** -- `check_f08_names.py`, run during `make check` with
  Automake-style PASS/FAIL/SKIP output, compares every `mpi_f08` interface
  (generated and hand-written, implementations and explicit interfaces)
  against `pympistandard` and fails on any name/type/intent drift. It is
  fail-safe: it aborts if it matches zero procedures (key-format drift) rather
  than passing vacuously; skips cleanly when the f08 bindings or pympistandard
  are not present; and ignores only what the standard leaves implementation-
  defined (choice buffers, unspecified intents, large-count variants the
  standard does not provide).

## Test plan

- `make check` in `ompi/mpi/fortran/use-mpi-f08` and `.../mod` runs the
  validator (`PASS: mpi_f08 ...`); it has teeth (an injected name/intent drift
  fails `make check`) and skips when the f08 bindings are not built.
- Keyword calls with the standard names (`MPI_Send(buf=...)`,
  `MPI_Comm_rank(comm=..., rank=...)`, ...) compile; the old template names no
  longer do.
- Validated the generated and hand-written interfaces against `pympistandard`:
  0 mismatches across ~540 procedures.

`pympistandard` is already a submodule and is shipped in the dist tarball, so
released bindings regenerate conformantly.
