### PR TITLE
MPI pack/unpack: fix type casting for size comparisons

### DIFF
--- a/ompi/mpi/c/pack.c.in
+++ b/ompi/mpi/c/pack.c.in
@@ -90,7 +90,7 @@ PROTOTYPE ERROR_CLASS pack(BUFFER inbuf, COUNT incount, DATATYPE datatype,
 
     /* Check for truncation */
     opal_convertor_get_packed_size( &local_convertor, &size );
-    if( (*position + size) > (unsigned int)outsize ) {  /* we can cast as we already checked for < 0 */
+    if( (*position + size) > (size_t)outsize ) {  /* we can cast as we already checked for < 0 */
         OBJ_DESTRUCT( &local_convertor );
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
     }

--- a/ompi/mpi/c/pack_size.c.in
+++ b/ompi/mpi/c/pack_size.c.in
@@ -60,7 +60,7 @@ PROTOTYPE ERROR_CLASS pack_size(COUNT incount, DATATYPE datatype, COMM comm,
                                               incount, NULL, 0, &local_convertor );
 
     opal_convertor_get_packed_size( &local_convertor, &length );
-    *size = (int)length;
+    *size = length;
     OBJ_DESTRUCT( &local_convertor );
 
     return MPI_SUCCESS;

--- a/ompi/mpi/c/unpack.c.in
+++ b/ompi/mpi/c/unpack.c.in
@@ -97,7 +97,7 @@ PROTOTYPE ERROR_CLASS unpack(BUFFER inbuf,
 
         /* Check for truncation */
         opal_convertor_get_packed_size( &local_convertor, &size );
-        if( (*position + size) > (unsigned int)insize ) {
+        if( (*position + size) > (size_t)insize ) {
             OBJ_DESTRUCT( &local_convertor );
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
         }


### PR DESCRIPTION
Replace inappropriate unsigned int casts with size_t in MPI_Pack and MPI_Unpack truncation checks, and remove unnecessary int cast in MPI_Pack_size. This ensures proper type compatibility when comparing sizes and avoids potential truncation issues with large message sizes.

Fixes #14004