### PR TITLE
Sym link AGENTS.md to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Apparently recent versions of Claude Code do not automatically read AGENTS.md.  Make a sym link to CLAUDE.md so that that context is automatically read in when Claude Code starts.