### PR TITLE
MPI_T: validate cat_index in category event queries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1552,7 +1552,7 @@ AC_CONFIG_FILES([
     test/util/Makefile
 ])
 
-m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile])])
+m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile test/mpi/Makefile test/mpi/t/Makefile])])
 
 AC_CONFIG_FILES([contrib/dist/mofed/debian/rules],
                 [chmod +x contrib/dist/mofed/debian/rules])

--- a/docs/man-openmpi/man3/MPI_T_category_get_num_events.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_category_get_num_events.3.rst
@@ -33,3 +33,5 @@ ERRORS
 :ref:`MPI_T_category_get_num_events` will fail if:
 
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized
+
+* ``MPI_T_ERR_INVALID_INDEX``: The category index is invalid

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -68,3 +68,8 @@ Open MPI version v6.0.0
 
   - Extended the ``accelerator`` collective component to support
     more collective operations on device buffers.
+
+- ``MPI_T_category_get_events`` and ``MPI_T_category_get_num_events``
+  now validate their ``cat_index`` argument and return
+  ``MPI_T_ERR_INVALID_INDEX`` for an out-of-range index, consistent
+  with the other ``MPI_T_category_get_*`` query functions.

--- a/ompi/mpi/tool/category_get_events.c
+++ b/ompi/mpi/tool/category_get_events.c
@@ -11,6 +11,7 @@
  *                         reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,10 +32,32 @@
 
 int MPI_T_category_get_events(int cat_index, int len, int indices[])
 {
+    const mca_base_var_group_t *group;
     int rc = MPI_SUCCESS;
 
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
+
+    ompi_mpit_lock ();
+
+    do {
+        /* Look up the category to validate cat_index, consistent with the
+           sibling MPI_T_category_get_{cvars,pvars,categories} functions. */
+        rc = mca_base_var_group_get (cat_index, &group);
+        if (0 > rc) {
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
+            break;
+        }
+
+        /* Open MPI does not yet register any MPI_T events, so there is
+           nothing to copy into the caller's len-element indices[] array.
+           When events are implemented, populate indices[] from the
+           per-category event list here. */
+        rc = MPI_SUCCESS;
+    } while (0);
+
+    ompi_mpit_unlock ();
+
     return rc;
 }

--- a/ompi/mpi/tool/category_get_num_events.c
+++ b/ompi/mpi/tool/category_get_num_events.c
@@ -11,6 +11,7 @@
  *                         reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,6 +32,9 @@
 
 int MPI_T_category_get_num_events (int cat_index, int *num_events)
 {
+    const mca_base_var_group_t *group;
+    int rc = MPI_SUCCESS;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
@@ -39,7 +43,23 @@ int MPI_T_category_get_num_events (int cat_index, int *num_events)
         return MPI_T_ERR_INVALID;
     }
 
-    *num_events = 0;
+    ompi_mpit_lock ();
 
-    return MPI_SUCCESS;
+    do {
+        /* Look up the category to validate cat_index, consistent with the
+           sibling MPI_T_category_get_events function. */
+        rc = mca_base_var_group_get (cat_index, &group);
+        if (0 > rc) {
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
+            break;
+        }
+
+        /* Open MPI does not yet register any MPI_T events. */
+        *num_events = 0;
+        rc = MPI_SUCCESS;
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return rc;
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      IBM Corporation. All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,6 +25,6 @@
 # support needs to be first for dependencies
 SUBDIRS = support asm class threads datatype util mpool
 if PROJECT_OMPI
-SUBDIRS += monitoring spc
+SUBDIRS += monitoring spc mpi
 endif
 DIST_SUBDIRS = event $(SUBDIRS)

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,4 +18,7 @@
 # $HEADER$
 #
 
-SUBDIRS = environment
+# Note: the "environment" subdirectory is stale (it links against a
+# long-gone src/ library layout) and is not part of the build; only the
+# "t" MPI_T tests are wired in.
+SUBDIRS = t

--- a/test/mpi/t/Makefile.am
+++ b/test/mpi/t/Makefile.am
@@ -1,0 +1,26 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# These are singleton MPI_T tests: they exercise the MPI tool
+# information interface without MPI_Init, so they need no launcher and
+# can run as part of 'make check'.
+if PROJECT_OMPI
+    check_PROGRAMS = mpi_t_category_get_events
+    TESTS = $(check_PROGRAMS)
+
+    mpi_t_category_get_events_SOURCES = mpi_t_category_get_events.c
+    mpi_t_category_get_events_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+    mpi_t_category_get_events_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+endif # PROJECT_OMPI
+
+distclean-local:
+	rm -rf *.dSYM .deps .libs *.la *.lo mpi_t_category_get_events *.log *.o *.trs Makefile

--- a/test/mpi/t/mpi_t_category_get_events.c
+++ b/test/mpi/t/mpi_t_category_get_events.c
@@ -1,0 +1,88 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Singleton (no launcher required) regression test for the cat_index
+ * validation performed by MPI_T_category_get_events and
+ * MPI_T_category_get_num_events.
+ *
+ * Both functions are specified with cat_index in the range
+ * [0, num_cat-1] (MPI-5.0 sec. 15.3.9).  An out-of-range index must be
+ * reported as MPI_T_ERR_INVALID_INDEX, consistent with the sibling
+ * MPI_T_category_get_{cvars,pvars,categories} query functions.  This
+ * test asserts that contract for cat_index = -1 and cat_index = num_cat,
+ * and that a valid index still returns MPI_SUCCESS (writing nothing
+ * while Open MPI registers no MPI_T events).
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+static int failures = 0;
+
+static void check(const char *what, int got, int expected)
+{
+    if (got != expected) {
+        ++failures;
+        printf("FAIL: %s returned %d, expected %d\n", what, got, expected);
+    } else {
+        printf("PASS: %s returned %d\n", what, got);
+    }
+}
+
+int main(void)
+{
+    int provided, num_cat = 0, num_events = 0;
+    int indices[8];
+
+    MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
+    MPI_T_category_get_num(&num_cat);
+    printf("num_cat = %d\n", num_cat);
+
+    /* cat_index = -1 is always out of range, even when num_cat == 0. */
+    check("MPI_T_category_get_events(-1)",
+          MPI_T_category_get_events(-1, 8, indices),
+          MPI_T_ERR_INVALID_INDEX);
+    check("MPI_T_category_get_num_events(-1)",
+          MPI_T_category_get_num_events(-1, &num_events),
+          MPI_T_ERR_INVALID_INDEX);
+
+    /* cat_index = num_cat is one past the last valid index. */
+    check("MPI_T_category_get_events(num_cat)",
+          MPI_T_category_get_events(num_cat, 8, indices),
+          MPI_T_ERR_INVALID_INDEX);
+    check("MPI_T_category_get_num_events(num_cat)",
+          MPI_T_category_get_num_events(num_cat, &num_events),
+          MPI_T_ERR_INVALID_INDEX);
+
+    /* A valid index must still succeed (no events registered yet). */
+    if (num_cat > 0) {
+        check("MPI_T_category_get_events(0)",
+              MPI_T_category_get_events(0, 8, indices),
+              MPI_SUCCESS);
+
+        num_events = -1;
+        check("MPI_T_category_get_num_events(0)",
+              MPI_T_category_get_num_events(0, &num_events),
+              MPI_SUCCESS);
+        if (0 != num_events) {
+            ++failures;
+            printf("FAIL: MPI_T_category_get_num_events(0) wrote num_events=%d, "
+                   "expected 0\n", num_events);
+        }
+    }
+
+    MPI_T_finalize();
+
+    if (0 == failures) {
+        printf("All MPI_T category event index checks passed.\n");
+        return 0;
+    }
+    printf("%d MPI_T category event index check(s) failed.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

`MPI_T_category_get_events` and `MPI_T_category_get_num_events` did no
validation of their `cat_index` argument: for any value (including `-1`
or `>= num_cat`) they returned `MPI_SUCCESS` and wrote nothing. Every
sibling category-member query function (`MPI_T_category_get_cvars`,
`_get_pvars`, `_get_categories`, and `_get_info`) validates `cat_index`
and returns `MPI_T_ERR_INVALID_INDEX` for an out-of-range index, so a
tool that probed an invalid index got contradictory answers depending
on which function it happened to call. The `get_events` man page even
documented `MPI_T_ERR_INVALID_INDEX` that the code never returned.

Closes #14017. While the issue only mentions `get_events`, its
count companion `get_num_events` has the identical gap, so both are
fixed here for true internal consistency.

## What changed

- `ompi/mpi/tool/category_get_events.c` and `category_get_num_events.c`
  now mirror the established sibling idiom: look the category up via
  `mca_base_var_group_get()` under the MPI_T lock and map a failed
  lookup to `MPI_T_ERR_INVALID_INDEX`. Open MPI registers no MPI_T
  events yet, so the lookup serves purely to validate `cat_index`; a
  valid index still returns `MPI_SUCCESS` with no entries written.
  A comment marks where `indices[]` should be populated once events are
  implemented (#14019).
- Documented `MPI_T_ERR_INVALID_INDEX` in the `get_num_events` man page
  (the `get_events` page already listed it).
- Added a changelog entry.
- Added a singleton (no launcher) `make check` test under `test/mpi/t/`
  that exercises `cat_index = -1` and `cat_index = num_cat` against both
  functions and asserts `MPI_T_ERR_INVALID_INDEX`, plus a valid index
  returning `MPI_SUCCESS`. `test/mpi/` was not wired into the build, so
  it (and the new `t/` subdir) are added to `configure.ac` and the test
  Makefiles; the stale `environment/` subdir is left out.

## Standards note

Per MPI-5.0 §15.3.10, an implementation is not *required* to reject an
invalid `cat_index` (it is undefined behavior). This is therefore a
robustness/consistency improvement rather than a mandated MUST-fix:
it makes the behavior defined and consistent with the sibling functions
and with the already-shipped `get_events` man page.

## Testing

- `autogen.pl` → `configure` → `make` clean, no new compiler warnings.
- New `make check` test passes; before the fix, `events(-1)` and
  `num_events(-1)` returned `MPI_SUCCESS` (0) while `cvars(-1)` returned
  `MPI_T_ERR_INVALID_INDEX` (57); after, all four invalid-index cases
  return 57 and a valid index returns 0.
- Sphinx docs (man page + changelog) build clean.

