### PR TITLE
Implement the MPI_T events interface (mca_base_event framework + producers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -541,6 +541,7 @@ test/threads/opal_atomic_thread_bench
 
 test/util/aaa
 test/util/test_session_dir_out
+test/util/mca_base_event_test
 test/util/opal_os_path
 test/util/opal_argv
 test/util/opal_os_create_dirpath

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,15 @@ ompi/mpi/tool/profile/*.c
 
 ompi/test/t/mpi_t_category_get_events
 ompi/test/t/mpi_t_concurrent_init
+ompi/test/t/mpi_t_errcodes
+ompi/test/t/mpi_t_event_14019
+ompi/test/t/mpi_t_event_comm_name
+ompi/test/t/mpi_t_event_inert_ok
+ompi/test/t/mpi_t_event_producers
+ompi/test/t/mpi_t_event_reinit
+ompi/test/t/mpi_t_event_selftest
+ompi/test/t/mpi_t_event_smoke
+ompi/test/t/mpi_t_event_world
 ompi/test/t/mpi_t_level_no_downgrade
 ompi/test/t/mpi_t_level_pinning
 ompi/test/t/mpi_t_lifecycle

--- a/config/ompi_find_mpi_aint_count_offset.m4
+++ b/config/ompi_find_mpi_aint_count_offset.m4
@@ -18,6 +18,7 @@
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -58,79 +59,30 @@ AC_DEFUN([_OMPI_FIND_MPI_AINT_TYPE], [
 dnl #########################################################################
 
 AC_DEFUN([_OMPI_FIND_MPI_COUNT_TYPE], [
-    # Find the type of MPI_Count.  Per MPI-3.0 2.5.8, it needs to be
-    # as least as large as an int, MPI_Aint, and MPI_Offset (we'll
-    # define MPI_Offset later to be the same as an MPI_Count).
+    # MPI_Count shares its backing type with opal_count_t.  Rather than
+    # recompute it here, derive it from the OPAL_COUNT_* shell variables that
+    # OPAL_FIND_COUNT_TYPE already computed (the single source of truth, run
+    # unconditionally in configure.ac before this macro).  This guarantees
+    # sizeof(MPI_Count) == sizeof(opal_count_t); a build-time _Static_assert in
+    # OMPI enforces it.  See config/opal_find_count_type.m4 for the rationale
+    # behind the type selection (<= size_t, >= ptrdiff_t, not the widest type).
 
-    # Note, however, that per
-    # https://svn.open-mpi.org/trac/ompi/ticket/4205, MPI_Count cannot
-    # be larger than a size_t (e.g., if you're compiling in 32 bit
-    # more on a 64 bit platform, long long will be 8 bytes, but size_t
-    # will only be 4 bytes).  The entire BTL, PML, and convertor
-    # infrastructure rely on sizeof(MPI_Count) being <=
-    # sizeof(size_t).  So artificially limit the size of MPI_Count, if
-    # necessary.
-
-    # Also note: do not search for int64_t or int32_t, because using
-    # these types mean that we would need to include <stdint.h> in
-    # mpi.h, which we probably shouldn't do.
-
-    # Finally, note that MPI_Count has an impact on the extent of a
-    # datatype, extent defined by the MPI standard as an MPI_Aint.
-    # This MPI_Aint is also the largest different between two memory
-    # pointers -- the well-known ptrdiff_t.  There *are* systems where
-    # the address space is 32 bit but the filesystem space is 64 bit
-    # (e.g., BlueGene), and therefore MPI_Aint is 32 bit and
-    # MPI_Offset (and therefore MPI_Count) is 64 bit.  Open MPI
-    # doesn't currently support this configuration -- re-tooling in
-    # the convertor/PML/BML/BTL will be necessary before that can work
-    # properly.
-
-    # Keep in mind, however, that while ptrdiff_t and size_t represent
-    # similar concepts (length or displacement in memory), one is
-    # slightly larger than the other (one is unsigned and the other
-    # signed) and there is no requirement for them to be of the same
-    # width.  On systems with non-monolithic memory space, the scheme
-    # we use below may not work.  On systems with non-monolithic
-    # memory space, the scheme we use below may not work.  ...but such
-    # systems are pretty rare today.
-
-    MPI_COUNT_TYPE=unknown
     AC_MSG_CHECKING([for type of MPI_Count])
-    if test $ac_cv_sizeof_long_long -le $ac_cv_sizeof_size_t && \
-       test $ac_cv_sizeof_long_long -ge $MPI_AINT_SIZE; then
-        MPI_COUNT_TYPE="long long"
-        MPI_COUNT_DATATYPE=MPI_LONG_LONG
-        MPI_COUNT_SIZE=$ac_cv_sizeof_long_long
-    elif test $ac_cv_sizeof_long -le $ac_cv_sizeof_size_t && \
-         test $ac_cv_sizeof_long -ge $MPI_AINT_SIZE; then
-        MPI_COUNT_TYPE=long
-        MPI_COUNT_DATATYPE=MPI_LONG
-        MPI_COUNT_SIZE=$ac_cv_sizeof_long
-    elif test $ac_cv_sizeof_int -le $ac_cv_sizeof_size_t && \
-         test $ac_cv_sizeof_int -ge $MPI_AINT_SIZE; then
-        MPI_COUNT_TYPE=int
-        MPI_COUNT_DATATYPE=MPI_INT
-        MPI_COUNT_SIZE=$ac_cv_sizeof_int
-    fi
 
-    if test "$MPI_COUNT_TYPE" = "unknown"; then
-        AC_MSG_RESULT([not found])
-        AC_MSG_WARN([*** Unable to find a good type for MPI_Count])
-        AC_MSG_ERROR([Cannot continue])
-    fi
+    MPI_COUNT_TYPE=$OPAL_COUNT_TYPE
+    MPI_COUNT_SIZE=$OPAL_COUNT_SIZE
+    MPI_COUNT_MAX=$OPAL_COUNT_MAX
 
-    if test $MPI_COUNT_SIZE -eq 8 ; then
-        MPI_COUNT_MAX="0x7fffffffffffffffll"
-    elif test $MPI_COUNT_SIZE -eq 4 ; then
-        MPI_COUNT_MAX="0x7fffffffl"
-    elif test $MPI_COUNT_SIZE -eq 2 ; then
-        MPI_COUNT_MAX="0x7fff"
-    else
-        AC_MSG_RESULT([$MPI_COUNT_TYPE (size: $MPI_COUNT_SIZE)])
-        AC_MSG_WARN([*** Configure cannot handle this size -- contact Open MPI developers])
-        AC_MSG_ERROR([Cannot continue])
-    fi
+    # The corresponding MPI datatype (also reused for MPI_Offset, below).
+    case "$MPI_COUNT_TYPE" in
+        "long long") MPI_COUNT_DATATYPE=MPI_LONG_LONG ;;
+        long)        MPI_COUNT_DATATYPE=MPI_LONG ;;
+        int)         MPI_COUNT_DATATYPE=MPI_INT ;;
+        *)
+            AC_MSG_RESULT([$MPI_COUNT_TYPE])
+            AC_MSG_ERROR([*** No corresponding MPI datatype for MPI_Count type "$MPI_COUNT_TYPE"])
+            ;;
+    esac
 
     AC_DEFINE_UNQUOTED(OMPI_MPI_COUNT_SIZE, $MPI_COUNT_SIZE,
                        [Size of the MPI_Count datatype])

--- a/config/opal_find_count_type.m4
+++ b/config/opal_find_count_type.m4
@@ -1,0 +1,80 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OPAL_FIND_COUNT_TYPE()
+# ----------------------
+# Determine the C integer type that backs opal_count_t, and expose it (and
+# its maximum value and size) to OPAL via the OPAL_COUNT_TYPE / OPAL_COUNT_MAX
+# / OPAL_COUNT_SIZE preprocessor symbols.
+#
+# This is the SINGLE source of truth for the count type: when the OMPI project
+# is built, OMPI_FIND_MPI_AINT_COUNT_OFFSET derives MPI_Count from the same
+# OPAL_COUNT_* shell variables rather than recomputing them, so opal_count_t
+# and MPI_Count are guaranteed to be the same type (a build-time
+# _Static_assert in OMPI enforces this).  Because OPAL must build standalone
+# (with or without OMPI), the computation lives here at the OPAL level and runs
+# unconditionally.
+#
+# opal_count_t is a SIGNED integer type that must be:
+#   - no larger than size_t -- the BTL/PML/convertor infrastructure relies on
+#     sizeof(count) <= sizeof(size_t) (e.g., a 32-bit size_t on a 64-bit ABI;
+#     see the historical Open MPI ticket 4205); and
+#   - at least as large as ptrdiff_t (the type of MPI_Aint), since a count can
+#     describe a datatype extent.
+#
+# We deliberately do NOT pick the widest available type: we pick the widest of
+# { long long, long, int } that still fits within a size_t.  We do not consider
+# int64_t/int32_t, because naming them would force <stdint.h> into mpi.h, which
+# must stay self-contained.
+AC_DEFUN([OPAL_FIND_COUNT_TYPE], [
+    AC_REQUIRE([AC_PROG_CC])
+
+    AC_MSG_CHECKING([for the type backing opal_count_t])
+
+    OPAL_COUNT_TYPE=unknown
+    if test $ac_cv_sizeof_long_long -le $ac_cv_sizeof_size_t && \
+       test $ac_cv_sizeof_long_long -ge $ac_cv_sizeof_ptrdiff_t; then
+        OPAL_COUNT_TYPE="long long"
+        OPAL_COUNT_SIZE=$ac_cv_sizeof_long_long
+    elif test $ac_cv_sizeof_long -le $ac_cv_sizeof_size_t && \
+         test $ac_cv_sizeof_long -ge $ac_cv_sizeof_ptrdiff_t; then
+        OPAL_COUNT_TYPE=long
+        OPAL_COUNT_SIZE=$ac_cv_sizeof_long
+    elif test $ac_cv_sizeof_int -le $ac_cv_sizeof_size_t && \
+         test $ac_cv_sizeof_int -ge $ac_cv_sizeof_ptrdiff_t; then
+        OPAL_COUNT_TYPE=int
+        OPAL_COUNT_SIZE=$ac_cv_sizeof_int
+    fi
+
+    if test "$OPAL_COUNT_TYPE" = "unknown"; then
+        AC_MSG_RESULT([not found])
+        AC_MSG_ERROR([*** Unable to find a suitable type for opal_count_t])
+    fi
+
+    if test $OPAL_COUNT_SIZE -eq 8 ; then
+        OPAL_COUNT_MAX="0x7fffffffffffffffll"
+    elif test $OPAL_COUNT_SIZE -eq 4 ; then
+        OPAL_COUNT_MAX="0x7fffffffl"
+    elif test $OPAL_COUNT_SIZE -eq 2 ; then
+        OPAL_COUNT_MAX="0x7fff"
+    else
+        AC_MSG_RESULT([$OPAL_COUNT_TYPE (size: $OPAL_COUNT_SIZE)])
+        AC_MSG_ERROR([*** Configure cannot handle an opal_count_t of size $OPAL_COUNT_SIZE -- contact Open MPI developers])
+    fi
+
+    AC_DEFINE_UNQUOTED([OPAL_COUNT_TYPE], [$OPAL_COUNT_TYPE],
+                       [Type backing opal_count_t (and MPI_Count when OMPI is built)])
+    AC_DEFINE_UNQUOTED([OPAL_COUNT_SIZE], [$OPAL_COUNT_SIZE],
+                       [Size (in bytes) of opal_count_t])
+    AC_DEFINE_UNQUOTED([OPAL_COUNT_MAX], [$OPAL_COUNT_MAX],
+                       [Maximum value representable in an opal_count_t])
+
+    AC_MSG_RESULT([$OPAL_COUNT_TYPE (size: $OPAL_COUNT_SIZE)])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -882,6 +882,14 @@ AC_CHECK_MEMBERS([struct timespec.tv_nsec],
 #endif])
 
 #
+# Determine the type backing opal_count_t.  This runs unconditionally (OPAL
+# must build standalone) and is the single source of truth for the count type:
+# OMPI_FIND_MPI_AINT_COUNT_OFFSET (below) derives MPI_Count from the same
+# OPAL_COUNT_* values rather than recomputing them.
+#
+OPAL_FIND_COUNT_TYPE
+
+#
 # Find corresponding types for MPI_Aint, MPI_Count, and MPI_Offset.
 # And if relevant, find the corresponding MPI_ADDRESS_KIND,
 # MPI_COUNT_KIND, and MPI_OFFSET_KIND.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -464,6 +464,7 @@ OMPI_MAN3 = \
         MPI_Status_set_source.3 \
         MPI_Status_set_tag.3 \
         MPI_T.3 \
+        MPI_T_Events.3 \
         MPI_T_category_changed.3 \
         MPI_T_category_get_categories.3 \
         MPI_T_category_get_cvars.3 \

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -19,6 +19,7 @@ probably don't need to read this section.
    terminology
    source-code
    frameworks
+   mpi-t-event-producers
    gnu-autotools
    sphinx
    rst-for-markdown-expats.rst

--- a/docs/developers/mpi-t-event-producers.rst
+++ b/docs/developers/mpi-t-event-producers.rst
@@ -1,0 +1,156 @@
+Writing an MPI_T event producer
+===============================
+
+The MPI_T events interface (MPI-5.0 section 15.3.8) lets tools subscribe to
+discrete, typed events that Open MPI raises at run time. The back end is the
+OPAL ``mca_base_event`` framework (``opal/mca/base/mca_base_event.h``), which
+mirrors ``mca_base_pvar``. A *producer* is any piece of Open MPI that registers
+an event *source* and one or more event *types* and raises them. This page is a
+short how-to; the authoritative design is in ``specs/mpi-t-events/spec.md``.
+
+The model
+---------
+
+* An **event source** is a clock domain plus some metadata. Every event type
+  belongs to exactly one source (the v1 single-source invariant).
+* An **event type** has a name, a description, and a fixed *element layout* (an
+  ordered list of typed fields the payload carries), like a struct definition.
+* A **raise** delivers one event instance, carrying a payload that matches the
+  type's element layout, to every subscribed tool callback.
+
+Registering a source and an event type
+---------------------------------------
+
+Register the source, then the event type(s) on it. Do this once, from a
+registration entry point that is reachable when MCA parameters are registered
+(the in-tree producers register from ``ompi_mpit_register_events()``).
+Registration is idempotent by name, so it is safe to call more than once.
+
+.. code-block:: c
+
+   #include "opal/mca/base/mca_base_event.h"
+
+   static mca_base_event_t *my_event = NULL;
+
+   void my_producer_register(void)
+   {
+       mca_base_event_source_t *source;
+       /* {value:int32} -- a single 4-byte element at offset 0. */
+       const mca_base_var_type_t types[1] = {MCA_BASE_VAR_TYPE_INT32_T};
+       const ptrdiff_t offsets[1] = {0};
+       int si, ei;
+
+       si = mca_base_event_source_register("ompi.mything",
+                                           "My subsystem events",
+                                           MCA_BASE_EVENT_SOURCE_ORDERED,
+                                           1000000000 /* ticks/sec */,
+                                           OPAL_COUNT_MAX /* max_ticks */,
+                                           NULL /* default clock */,
+                                           true /* allow ad-hoc timestamp reads:
+                                                   the default clock is freely
+                                                   readable */,
+                                           NULL);
+       if (0 > si || OPAL_SUCCESS != mca_base_event_source_get_by_index(si, &source)) {
+           return;
+       }
+       /* The exported event-type name is "ompi.mything_base_happened" -- see
+          the note on the "ompi." prefix below. */
+       ei = mca_base_event_register("ompi", "mything", "base", "happened",
+                                    "My thing happened", OPAL_INFO_LVL_4,
+                                    1, types, offsets, NULL,
+                                    MCA_BASE_VAR_BIND_NO_OBJECT, 0, source, NULL);
+       if (0 <= ei) {
+           (void) mca_base_event_get_by_index(ei, &my_event);
+       }
+   }
+
+Event *source* names are taken verbatim from the caller (so this source is named
+``ompi.mything``).  Event *type* names, by contrast, are always exported under
+the ``ompi.`` namespace: ``mca_base_event_register()`` builds the name from the
+``framework``/``component``/``name`` arguments and forces an ``ompi.`` prefix
+regardless of the ``project`` argument, so the example above produces
+``ompi.mything_base_happened``.  Name your source ``ompi.*`` too, as here, so a
+producer's source and its event types share one namespace.
+
+Use exact-width element types (``MCA_BASE_VAR_TYPE_INT32_T``,
+``..._UINT64_T``, ``..._DOUBLE``, etc.), not ``SIZE_T``, so the payload has a
+portable, well-defined layout. Element offsets must be ascending and start at
+0; the computed buffer size must not exceed ``MCA_BASE_EVENT_MAX_PAYLOAD``.
+
+Raising an event
+----------------
+
+At the point the event occurs, build the payload to match the element layout
+and raise it. The event-type handle is ``NULL`` until registration succeeds, so
+NULL-check it.
+
+.. code-block:: c
+
+   if (NULL != my_event) {
+       int32_t value = compute_value();
+       mca_base_event_raise(my_event, my_event->source, &value);
+   }
+
+``mca_base_event_raise()`` returns immediately when no tool is listening (a
+single relaxed atomic read plus a predicted branch), so a raise site costs
+almost nothing when unused. If building the payload is itself expensive, guard
+it with ``mca_base_event_active(my_event)``.
+
+Binding an event to a specific object
+-------------------------------------
+
+Most events are ``MCA_BASE_VAR_BIND_NO_OBJECT``: a single tool registration sees
+every instance. An event type can instead be *bound* to a class of MPI object,
+so a tool subscribes per-object (for example, "tell me when *this* communicator
+is named"). Register such an event with the matching ``MCA_BASE_VAR_BIND_*``
+value (these mirror the public ``MPI_T_BIND_*`` ordering, so the framework
+reports the binding to tools verbatim):
+
+.. code-block:: c
+
+   my_event = register_bound_event("mpi.communicator_name_set", "...",
+                                   OPAL_INFO_LVL_4, MCA_BASE_VAR_BIND_MPI_COMM,
+                                   1, types, offsets, source);
+
+At the raise site, use ``mca_base_event_raise_bound()`` and pass the *internal
+object identity* (the same pointer the tool's handle resolves to -- e.g. the
+``ompi_communicator_t *``). Only registrations the tool bound to that object are
+notified:
+
+.. code-block:: c
+
+   if (NULL != my_event) {
+       struct { uint64_t handle; } payload = { (uint64_t) (uintptr_t) comm };
+       mca_base_event_raise_bound(my_event, NULL, comm, &payload);
+   }
+
+Restrict bound events to the same non-performance-critical paths as the other
+producers (object lifecycle, environmental/config calls), since binding adds a
+per-registration comparison on the dispatch path. Keep the payload to the
+minimum the callback needs: the tool already knows the bound object, and can
+query further detail (such as the new name) from it directly. See section 6.1 of
+the specification.
+
+The producer contract
+---------------------
+
+* **Never hold the MPI_T big lock (or, in OMPI, raise while holding it).** A
+  tool callback may call back into the MPI_T interface, which would deadlock. A
+  debug build asserts that no event is raised while ``ompi_mpit_big_lock`` is
+  held.
+* **Raise from a normal thread context.** v1 delivers callbacks synchronously
+  at ``C in {NONE, MPI_RESTRICTED, THREAD_SAFE}``; it does not deliver from a
+  signal handler or other async-signal context.
+* **Keep the payload fixed-size and matching the registered layout.** The raise
+  path copies it into preallocated storage; it never allocates on the hot path.
+* **Gate registration on availability.** If a producer depends on an optional
+  facility (for example the OPAL memory hooks), register the source/event only
+  when it is present; an absent event is conformant (a smaller event set).
+
+A producer that cannot safely deliver from its raise context -- for example the
+OS memory-release producer behind ``ompi.mca.memory.patcher.released``, whose
+hook runs inside ``free()`` / ``munmap()`` where it may not lock or allocate --
+can instead accumulate its occurrences in a lock-free sink and let the framework
+*drain* that sink at a later safe operation, delivering one aggregated,
+data-bearing event (a registration with only a dropped handler observes each
+aggregated batch as a single drop). See section 7.1 of the specification.

--- a/docs/man-openmpi/man1/ompi_info.1.rst
+++ b/docs/man-openmpi/man1/ompi_info.1.rst
@@ -48,6 +48,12 @@ OPTIONS
 
 * ``-c``, ``--config``: Show configuration options
 
+* ``--event``: Show the registered MPI_T event sources and event
+  types. With no explicit ``--level``, all event-type levels are shown
+  (unlike ``--param``, whose default is level 1); pass ``--level`` to
+  narrow the event types displayed. Event sources have no level and are
+  always shown.
+
 * ``-gmca``, ``--gmca <param> <value>``: Pass global MCA parameters
   that are applicable to all contexts.
 
@@ -59,10 +65,11 @@ OPTIONS
 * ``--internal``: Show internal MCA parameters (not meant to be
   modified by users).
 
-* ``--level <level>``: Show only variables with at most this level
-  (1-9). The default is 1 unless ``--all`` is specified without
-  ``--level``, in which case the default is 9. See the :ref:`LEVELS
-  <man1-ompi_info-levels>` section for more information.
+* ``--level <level>``: Show only variables and MPI_T event types with
+  at most this level (1-9). The default is 1 unless ``--all`` is
+  specified without ``--level``, in which case the default is 9. See
+  the :ref:`LEVELS <man1-ompi_info-levels>` section for more
+  information.
 
 * ``-mca``, ``--mca <param> <value>``: Pass context-specific MCA
   parameters; they are considered global if ``--gmca`` is not used and

--- a/docs/man-openmpi/man3/MPI_T.3.rst
+++ b/docs/man-openmpi/man3/MPI_T.3.rst
@@ -124,10 +124,17 @@ Open MPI's MPI_T categories are organized hierarchically:
 MPI_T Events
 ^^^^^^^^^^^^
 
-Open MPI provides a set of stub interfaces for MPI_T events. More complete
-support for MPI_T events will be provided in a future release of Open MPI.
+Open MPI implements the MPI_T events interface: it exports a set of event
+*sources* and event *types* that a tool can enumerate, bind registration
+handles to, and receive through callbacks. Event delivery is synchronous and,
+in this release, occurs only in normal (non-signal) execution contexts.
+
+See :ref:`MPI_T_Events` for an overview and a detailed description of the
+built-in event sources and event types, and use ``ompi_info --event`` to list
+those available in a given installation.
 
 .. seealso::
+   * :ref:`MPI_T_Events`
    * :ref:`MPI_T_category_changed`
    * :ref:`MPI_T_category_get_categories`
    * :ref:`MPI_T_category_get_cvars`

--- a/docs/man-openmpi/man3/MPI_T_Events.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_Events.3.rst
@@ -1,0 +1,380 @@
+.. _mpi_t_events:
+
+
+MPI_T_Events
+============
+
+.. include_body
+
+Open MPI's MPI_T events - overview and the built-in event sources and types
+
+DESCRIPTION
+-----------
+
+The MPI tool information interface ("MPI_T") events facility (MPI-5.0 §15.3.8)
+lets a tool register callback functions that the MPI implementation invokes
+when it *raises* an event. Each event instance carries a timestamp, originates
+from a *source* (a clock and ordering domain), and conveys a typed data
+payload. See :ref:`MPI_T` for the broader MPI_T interface and
+:ref:`MPI_T_init_thread` to initialize it.
+
+Open MPI implements this facility and ships a set of built-in event sources and
+event types, described below.
+
+.. note:: The sources and event types listed on this page are an **initial set**
+   -- implemented in large part as worked examples and to exercise Open MPI's
+   MPI_T events infrastructure -- and are **not exhaustive**. They may be only a
+   subset of what a given Open MPI installation exposes: the exported set depends
+   on the platform, the Open MPI version, and MCA parameters, and more sources
+   and event types may be added over time. **Do not hard-code these names**;
+   discover the actual set at run time. From a program, enumerate with the MPI_T
+   API
+   (:ref:`MPI_T_source_get_num` / :ref:`MPI_T_source_get_info`, and
+   :ref:`MPI_T_event_get_num` / :ref:`MPI_T_event_get_info` /
+   :ref:`MPI_T_event_get_index`). From the command line, list them with
+   ``ompi_info --event``.
+
+Scope of the current implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Event delivery is synchronous and occurs only in normal (non-signal) execution
+contexts. A callback registered at the
+``MPI_T_CB_REQUIRE_ASYNC_SIGNAL_SAFE`` safety level is accepted but is never
+selected for delivery in this release. Raising an event is near-free when no
+tool is listening (a single atomic read plus a predicted branch), so the
+built-in producers impose negligible overhead on applications that do not use
+MPI_T.
+
+Discovering and controlling the built-in events
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+List the registered sources and event types on an installation with:
+
+.. code:: sh
+
+   shell$ ompi_info --event
+
+Event types are filtered by verbosity with ``--level``: the built-in types
+register at levels 2 through 4. A plain ``ompi_info --event`` shows all of them
+(``--event`` defaults to showing every event-type level); pass ``--level`` to
+narrow the set. Event sources are always listed, regardless of ``--level``. Add ``--parsable`` for
+machine-readable output.
+
+The MCA parameter ``mca_base_event_register_producers`` is the master switch
+for all built-in producers (default: enabled). When set to 0, no sources or
+event types are registered, which exercises (and is a valid, conformant) empty
+event set.
+
+RECEIVING EVENTS
+----------------
+
+A tool receives events by registering a callback on an event type. The typical
+sequence is:
+
+#. Initialize MPI_T with :ref:`MPI_T_init_thread`.
+#. Locate the event type, either by name with :ref:`MPI_T_event_get_index` or
+   by iterating 0..N-1 from :ref:`MPI_T_event_get_num` and inspecting each with
+   :ref:`MPI_T_event_get_info`.
+#. Allocate a *registration handle* with :ref:`MPI_T_event_handle_alloc`. All
+   built-in event types use ``MPI_T_BIND_NO_OBJECT``, so pass a NULL object
+   handle.
+#. Attach a callback with :ref:`MPI_T_event_register_callback`, choosing a
+   *callback safety level* (``MPI_T_CB_REQUIRE_NONE``,
+   ``MPI_T_CB_REQUIRE_MPI_RESTRICTED``, or ``MPI_T_CB_REQUIRE_THREAD_SAFE``;
+   see *Scope* above for the ``ASYNC_SIGNAL_SAFE`` limitation). Optionally,
+   register a dropped-event handler with
+   :ref:`MPI_T_event_set_dropped_handler`.
+#. The implementation invokes the callback whenever it raises the event. Inside
+   the callback, read the payload element by element with
+   :ref:`MPI_T_event_read` (or copy it whole with :ref:`MPI_T_event_copy`),
+   obtain the originating source with :ref:`MPI_T_event_get_source`, and the
+   timestamp with :ref:`MPI_T_event_get_timestamp`.
+#. Tear down with :ref:`MPI_T_event_handle_free`, then
+   :ref:`MPI_T_finalize`.
+
+For example, to observe communicator creation:
+
+.. code:: c
+
+   void my_cb(MPI_T_event_instance event, MPI_T_event_registration reg,
+              MPI_T_cb_safety cb_safety, void *user_data)
+   {
+       int32_t size;
+       uint32_t context_id;
+       int source_index;
+       MPI_Count timestamp;
+
+       MPI_T_event_read(event, 0, &size);        /* element 0: communicator size */
+       MPI_T_event_read(event, 1, &context_id);  /* element 1: context id        */
+       MPI_T_event_get_source(event, &source_index);
+       MPI_T_event_get_timestamp(event, &timestamp);
+       /* ... record the observation ... */
+   }
+
+   /* ... elsewhere, during setup ... */
+   int provided, index;
+   MPI_T_event_registration reg;
+
+   MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
+   if (MPI_SUCCESS == MPI_T_event_get_index("ompi.mpi.communicator_created", &index)) {
+       MPI_T_event_handle_alloc(index, NULL, MPI_INFO_NULL, &reg);
+       MPI_T_event_register_callback(reg, MPI_T_CB_REQUIRE_THREAD_SAFE,
+                                     MPI_INFO_NULL, NULL, my_cb);
+       /* ... run the application; my_cb fires as communicators are created ... */
+       MPI_T_event_handle_free(reg, NULL, NULL);
+   }
+   MPI_T_finalize();
+
+EVENT SOURCES
+-------------
+
+All built-in event types are split across just two sources, distinguished by
+the one property that differs between them: *ordering*. Both use Open MPI's
+default event clock -- the same underlying system clock that backs
+:ref:`MPI_Wtime` (``ticks_per_second`` is 1,000,000,000, i.e. nanoseconds, and
+``max_ticks`` is the largest value representable in an ``MPI_Count``) -- and
+both support *ad-hoc* timestamp reads via :ref:`MPI_T_source_get_timestamp`.
+Query these properties at run time with :ref:`MPI_T_source_get_info`.
+
+``ompi``
+   Ordered (``MPI_T_SOURCE_ORDERED``); default clock; supports ad-hoc timestamp
+   reads. The domain for essentially all of Open MPI's lifecycle events:
+   initialization/finalization, communicator, RMA window, and error-handler
+   events. Because the source is ordered, the timestamps of
+   successive events from it are monotonically non-decreasing, so a tool can use
+   them to order the events.
+
+``ompi.unordered``
+   Unordered (``MPI_T_SOURCE_UNORDERED``); default clock; supports ad-hoc
+   timestamp reads. **Registered only on platforms whose memory-release hooks
+   can report releases** (for example, Linux); absent elsewhere. The domain for
+   events whose underlying occurrences are aggregated before delivery, so
+   per-occurrence chronology is not preserved -- currently just the OS-level
+   memory-release event (``ompi.mca.memory.patcher.released``, below).
+
+Why two sources, and what timestamps mean
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A *source* in MPI_T is fundamentally a clock-and-ordering domain, not a way to
+group events by subsystem (event names and MPI_T categories already serve that
+purpose). Two sources suffice here because the built-in events differ in
+exactly one source-visible property: the ``ompi`` events are individually
+timestamped and ordered, whereas the ``ompi.unordered`` memory-release event is
+aggregated and therefore unordered.
+
+**Timestamps are only comparable within a single source.** A timestamp obtained
+from one source must not be compared against a timestamp from another; only
+timestamps that share a source establish an ordering.
+
+.. note:: The event clock and :ref:`MPI_Wtime` read the *same* underlying
+   system clock and advance at the same rate, but their values are **not
+   directly comparable**: an event timestamp is a 64-bit integer count of
+   nanoseconds from a lazily-captured origin, whereas ``MPI_Wtime`` returns
+   double-precision seconds from a different origin. The unit (integer
+   nanoseconds vs. floating-point seconds) and the zero-point both differ, and
+   the MPI standard does not require any relationship between the two.
+
+EVENT TYPES
+-----------
+
+Most built-in event types bind to no MPI object: the ``bind`` value returned by
+:ref:`MPI_T_event_get_info` is ``MPI_T_BIND_NO_OBJECT``, so a tool passes a NULL
+object handle to :ref:`MPI_T_event_handle_alloc` and a single registration
+observes every instance. One event type, ``ompi.mpi.communicator_name_set``, is
+instead *bound* to a communicator (``bind`` is ``MPI_T_BIND_MPI_COMM``): a tool
+binds each registration to one specific communicator and is notified only when
+*that* communicator is affected. See `Binding an event to a specific object`_
+below. The *element layout* described for each event is the ordered sequence of
+typed fields each instance carries, read with :ref:`MPI_T_event_read` or copied
+with :ref:`MPI_T_event_copy`. The *source* of an instance can be queried in the
+callback with :ref:`MPI_T_event_get_source`. The "level" shown is the MPI_T
+verbosity level (on the 1-9 scale used by ``ompi_info --level``).
+
+Binding an event to a specific object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For an event type whose ``bind`` is not ``MPI_T_BIND_NO_OBJECT``, a tool binds
+each registration handle to one specific object: it passes the *address of that
+object's handle* as the ``obj_handle`` argument of
+:ref:`MPI_T_event_handle_alloc`. The registration is then notified only when the
+event occurs for that particular object; the event for any other object of the
+same class is not delivered to that registration. (To watch several objects, a
+tool allocates one registration per object.) For a ``MPI_T_BIND_NO_OBJECT``
+event, ``obj_handle`` is ignored.
+
+The bound object is not passed as a callback argument -- the tool already knows
+it, having bound to it, and typically records it in the callback's ``user_data``.
+A bound event whose payload would otherwise just echo the bound object instead
+carries only the minimal data the callback needs; a callback queries any further
+detail directly from the object it bound to.
+
+.. note:: Several payloads carry an MPI object's *handle* (a communicator,
+   window, error-handler, or session) as a ``uint64`` element. This is an opaque
+   token, reported in the MPI ABI representation of the tool that registered the
+   callback, and intended for identifying the object and correlating related
+   events (for example pairing a "created" event with its "freed"). Do not
+   dereference it. Under the Open MPI ABI the value is the C handle the
+   application holds; with the (forthcoming) MPI Standard ABI it is that ABI's
+   integer handle.
+
+``ompi.mpi.communicator_created``
+   Source ``ompi``; level 2. Raised after Open MPI successfully creates a new
+   communicator -- for example via :ref:`MPI_Comm_dup`, :ref:`MPI_Comm_split`,
+   :ref:`MPI_Comm_create`, the intercommunicator calls, and the communicators
+   Open MPI builds internally -- once the communicator is usable. Payload
+   (2 elements):
+
+   * ``size`` (``int32``) -- the new communicator's group size.
+   * ``handle`` (``uint64``) -- the ``MPI_Comm`` handle value, an opaque token
+     for identifying the communicator and pairing this event with its "freed"
+     event; it must not be dereferenced.
+
+``ompi.mpi.communicator_freed``
+   Source ``ompi``; level 2. Raised while a communicator is being destroyed (for
+   example via :ref:`MPI_Comm_free`, or when Open MPI tears down an internal
+   communicator), while its handle is still valid. Payload (1 element):
+
+   * ``handle`` (``uint64``) -- the ``MPI_Comm`` handle value; matching it
+     against a "created" event pairs creation with destruction.
+
+``ompi.mpi.communicator_name_set``
+   Source ``ompi``; level 4. **Bound to a communicator** (``bind`` =
+   ``MPI_T_BIND_MPI_COMM``; see `Binding an event to a specific object`_): a tool
+   binds a registration to one communicator and is notified only when *that*
+   communicator's name is set with :ref:`MPI_Comm_set_name`. Payload (1 element):
+
+   * ``handle`` (``uint64``) -- the ``MPI_Comm`` handle value (the bound
+     communicator); an opaque token that must not be dereferenced.
+
+   The new name itself is not in the payload: a callback reads it with
+   :ref:`MPI_Comm_get_name` on the communicator it bound to. Open MPI also names
+   some predefined and internal communicators, so a registration bound to such a
+   communicator may observe those namings too.
+
+``ompi.mpi.initialization``
+   Source ``ompi``; level 2. Raised when an MPI instance has been initialized
+   and is ready for use, for **both** MPI models: the world model
+   (:ref:`MPI_Init` / :ref:`MPI_Init_thread`) and the session model
+   (:ref:`MPI_Session_init`), which run through the same internal instance-init
+   path. Payload (5 elements):
+
+   * ``model`` (``int32``) -- the MPI model, as an ``OMPI_T_MODEL_*`` value from
+     ``<mpi.h>``: ``OMPI_T_MODEL_WORLD`` or ``OMPI_T_MODEL_SESSION``.
+   * ``thread_level`` (``int32``) -- the thread-support level the implementation
+     provided (e.g. ``MPI_THREAD_MULTIPLE``).
+   * ``world_rank`` (``int32``) -- this process' rank in ``MPI_COMM_WORLD``;
+     meaningful only for the world model, and ``-1`` for a session (a process
+     has no rank until a communicator is derived from a session).
+   * ``world_size`` (``int32``) -- the size of ``MPI_COMM_WORLD``; meaningful
+     only for the world model, and ``-1`` for a session.
+   * ``instance_id`` (``uint64``) -- an opaque token that correlates this event
+     with the matching ``ompi.mpi.finalization`` event for the same instance
+     (most useful in the session model, where many instances may coexist); it
+     must not be dereferenced.
+
+   The world-model event fires during ``MPI_Init`` once ``MPI_COMM_WORLD``
+   exists, so a tool must attach before ``MPI_Init`` to observe it.
+
+``ompi.mpi.finalization``
+   Source ``ompi``; level 2. Raised when an MPI instance is about to be
+   finalized, for both models: the world model (:ref:`MPI_Finalize`) and the
+   session model (:ref:`MPI_Session_finalize`). Payload (3 elements):
+
+   * ``model`` (``int32``) -- the MPI model, as an ``OMPI_T_MODEL_*`` value from
+     ``<mpi.h>``: ``OMPI_T_MODEL_WORLD`` or ``OMPI_T_MODEL_SESSION``.
+   * ``world_rank`` (``int32``) -- this process' rank in ``MPI_COMM_WORLD`` for
+     the world model; ``-1`` for a session.
+   * ``instance_id`` (``uint64``) -- correlates with the
+     ``ompi.mpi.initialization`` event for the same instance.
+
+``ompi.mpi.errhandler_invoked``
+   Source ``ompi``; level 4. Raised each time Open MPI invokes an error handler
+   -- that is, whenever an MPI operation detects an error and calls the error
+   handler attached to the relevant communicator, window, file, or session
+   (including the predefined ``MPI_ERRORS_ARE_FATAL`` / ``MPI_ERRORS_RETURN``) --
+   before the handler's effect (such as aborting the job) takes place. Payload
+   (4 elements):
+
+   * ``err_code`` (``int32``) -- the MPI error code being raised.
+   * ``object_type`` (``int32``) -- which kind of MPI object the handler is
+     associated with, as an ``MPI_T_BIND_*`` value: ``MPI_T_BIND_NO_OBJECT``
+     (a predefined handler, or none), ``MPI_T_BIND_MPI_COMM``,
+     ``MPI_T_BIND_MPI_WIN``, ``MPI_T_BIND_MPI_FILE``, or
+     ``MPI_T_BIND_MPI_SESSION``.
+   * ``errhandler_handle`` (``uint64``) -- the ``MPI_Errhandler`` handle value.
+   * ``object_handle`` (``uint64``) -- the handle of the MPI object the handler
+     is invoked on, of the kind given by ``object_type``.
+
+   The two handle values are opaque tokens (each ``0`` when not available -- for
+   example when an error is routed to a predefined handler before ``MPI_Init``);
+   they must not be dereferenced.
+
+``ompi.mpi.win_created``
+   Source ``ompi``; level 4. Raised after Open MPI successfully creates a new
+   RMA window, for any window flavor (:ref:`MPI_Win_create`,
+   :ref:`MPI_Win_allocate`, :ref:`MPI_Win_allocate_shared`, or
+   :ref:`MPI_Win_create_dynamic`), once the window is usable. Payload
+   (4 elements):
+
+   * ``size`` (``int64``) -- the local window size in bytes; ``0`` for a
+     dynamic window.
+   * ``disp_unit`` (``int32``) -- the displacement unit.
+   * ``flavor`` (``int32``) -- the ``MPI_WIN_FLAVOR_*`` value identifying how the
+     window was created.
+   * ``handle`` (``uint64``) -- the ``MPI_Win`` handle value, an opaque token for
+     identifying the window and pairing this event with its "freed" event.
+
+``ompi.mpi.win_freed``
+   Source ``ompi``; level 4. Raised by :ref:`MPI_Win_free`, before the window is
+   torn down. Payload (2 elements):
+
+   * ``flavor`` (``int32``) -- the ``MPI_WIN_FLAVOR_*`` value of the window being
+     freed.
+   * ``handle`` (``uint64``) -- the ``MPI_Win`` handle value.
+
+``ompi.mca.memory.patcher.released``
+   Source ``ompi.unordered``; level 4. Present only where the ``ompi.unordered``
+   source is (see above). It reports memory returned to the operating system, as
+   observed by Open MPI's memory-release hooks (the "patcher" memory component,
+   which intercepts ``munmap``, ``mremap``, ``madvise``, ``brk`` / ``sbrk``
+   shrink, and SysV ``shmdt``). Payload (2 elements, both ``uint64``):
+
+   * ``count`` -- the number of release operations aggregated since the previous
+     delivery.
+   * ``bytes`` -- their cumulative size in bytes.
+
+   This event differs from the others in how it is produced and delivered. The
+   hook runs *inside* the intercepted call (e.g. ``munmap``), a context where it
+   may not lock, allocate, or walk data structures, so it cannot deliver an
+   event there. Instead it accumulates ``count`` and ``bytes`` in a lock-free
+   sink, and the framework *drains* that sink and delivers one aggregated event
+   at the next safe framework operation -- notably a
+   :ref:`MPI_T_source_get_timestamp` read of the ``ompi.unordered`` source (and
+   also event-handle allocation and free). A registration that has only a
+   dropped-event handler (no callback) instead observes each aggregated batch as
+   a single dropped event (see :ref:`MPI_T_event_set_dropped_handler`).
+
+   Two consequences follow from relying on these memory hooks. First, the hooks
+   are *chunk-level*: they fire only when memory is actually returned to the OS
+   (for example a large ``free()`` that unmaps, or a heap-shrinking ``sbrk``),
+   not on every ``free()``. Second, the hook cannot distinguish which call
+   caused a release, so the payload is a coarse aggregate. A per-API breakdown,
+   and capture of the individual freed addresses, are possible future extensions
+   but are intentionally not provided here: they would require extending the
+   memory-hook interface and, for addresses, allocating memory in a context
+   where allocation is unsafe.
+
+.. seealso::
+   * :ref:`MPI_T`
+   * :ref:`MPI_T_init_thread`
+   * :ref:`MPI_T_source_get_num`
+   * :ref:`MPI_T_source_get_info`
+   * :ref:`MPI_T_source_get_timestamp`
+   * :ref:`MPI_T_event_get_num`
+   * :ref:`MPI_T_event_get_info`
+   * :ref:`MPI_T_event_get_index`
+   * :ref:`MPI_T_event_handle_alloc`
+   * :ref:`MPI_T_event_register_callback`
+   * :ref:`MPI_T_event_get_source`
+   * :ref:`MPI_T_event_read`
+   * :ref:`MPI_T_event_set_dropped_handler`

--- a/docs/man-openmpi/man3/MPI_T_event_callback_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_callback_get_info.3.rst
@@ -35,3 +35,7 @@ ERRORS
 :ref:`MPI_T_event_callback_get_info` will fail if:
 
 .. include:: ./MPI_T_ERRORS.rst
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_callback_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_callback_set_info.3.rst
@@ -29,3 +29,7 @@ ERRORS
 :ref:`MPI_T_event_callback_set_info` will fail if:
 
 .. include:: ./MPI_T_ERRORS.rst
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_copy.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_copy.3.rst
@@ -33,3 +33,5 @@ ERRORS
 
 .. seealso::
    * :ref:`MPI_T_event_read`
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_get_index.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_get_index.3.rst
@@ -38,3 +38,7 @@ ERRORS
 
 * ``MPI_T_ERR_INVALID_NAME``:  The event name is invalid
   initialized
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_get_info.3.rst
@@ -50,3 +50,7 @@ ERRORS
 * ``MPI_T_ERR_INVALID``: Invalid use of the interface or bad parameter values(s).
 
 * ``MPI_ERR_OTHER``: Other error
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_get_num.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_get_num.3.rst
@@ -27,7 +27,45 @@ The number of available event types can be queried with a call to
 execution of an MPI process. However, MPI implementations are not allowed to change the
 index of an event type or to delete an event type once it has been made visible to the user.
 
-.. note:: Open MPI will currently return that there are 0 event types.
+.. note:: The set of event types Open MPI exports depends on the platform and
+   on MCA parameters. With all built-in producers disabled (the MCA parameter
+   ``mca_base_event_register_producers`` set to 0) the count is 0.
+
+
+DISCOVERING AVAILABLE EVENTS
+----------------------------
+
+Open MPI registers a set of event types and sources, such as communicator and
+session lifecycle, error-handler invocations, and (where the OS supports it)
+memory releases. To list the registered sources and event types from the
+command line, use:
+
+.. code-block:: sh
+
+   ompi_info --event
+
+To enumerate them programmatically, query the count and then each event's
+metadata with :ref:`MPI_T_event_get_info`:
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <stdio.h>
+
+   int main(void) {
+       int provided, i, num = 0;
+       MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
+       MPI_T_event_get_num(&num);
+       for (i = 0; i < num; ++i) {
+           char name[256];
+           int name_len = sizeof(name), num_elements = 0, verbosity, bind;
+           MPI_T_event_get_info(i, name, &name_len, &verbosity, NULL, NULL,
+                                &num_elements, NULL, NULL, NULL, NULL, &bind);
+           printf("event %d: %s (%d elements)\n", i, name, num_elements);
+       }
+       MPI_T_finalize();
+       return 0;
+   }
 
 
 ERRORS
@@ -37,3 +75,7 @@ ERRORS
 
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface is not
   initialized
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_get_source.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_get_source.3.rst
@@ -36,3 +36,7 @@ ERRORS
 * ``MPI_T_ERR_INVALID``: Invalid use of the interface or bad parameter values(s)
 
 * ``MPI_ERR_OTHER``: Other error
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_get_timestamp.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_get_timestamp.3.rst
@@ -32,3 +32,7 @@ ERRORS
 :ref:`MPI_T_event_get_timestamp` will fail if:
 
 .. include:: ./MPI_T_ERRORS.rst
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_handle_alloc.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_handle_alloc.3.rst
@@ -30,6 +30,13 @@ DESCRIPTION
 :ref:`MPI_T_event_get_info` returns MPI_T_BIND_NO_OBJECT as the binding of the
 variable the *obj_handle* argument is ignored.
 
+.. note:: When the event type is bound to an object, *obj_handle* is the address
+   of the variable holding that MPI object's handle, and the resulting
+   registration is notified only when the event occurs for that specific object.
+   For the list of Open MPI's built-in event types -- which are bound to an
+   object and which are ``MPI_T_BIND_NO_OBJECT`` -- and a fuller description of
+   binding, see :ref:`MPI_T_Events`.
+
 ERRORS
 ------
 
@@ -39,3 +46,5 @@ ERRORS
 
 .. seealso::
    * :ref:`MPI_T_event_get_info`
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_handle_free.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_handle_free.3.rst
@@ -36,3 +36,5 @@ ERRORS
 
 .. seealso::
    * :ref:`MPI_T_event_get_info`
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_handle_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_handle_get_info.3.rst
@@ -34,3 +34,7 @@ ERRORS
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized
 
 * ``MPI_T_ERR_INVALID_INDEX``: The event registration is invalid
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_handle_set_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_handle_set_info.3.rst
@@ -33,3 +33,7 @@ ERRORS
 * ``MPI_T_ERR_INVALID_INDEX``: The event registration is invalid
 
 * ``MPI_T_ERR_INFO``: Invalid info
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_read.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_read.3.rst
@@ -32,3 +32,5 @@ ERRORS
 
 .. seealso::
    * :ref:`MPI_T_event_copy`
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_register_callback.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_register_callback.3.rst
@@ -39,3 +39,7 @@ ERRORS
 * ``MPI_T_ERR_INFO``: Invalid info
 
 * ``MPI_T_ERR_OTHER``: Other error
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_event_set_dropped_handler.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_event_set_dropped_handler.3.rst
@@ -30,3 +30,7 @@ ERRORS
 :ref:`MPI_T_event_set_dropped_handler` will fail if:
 
 .. include:: ./MPI_T_ERRORS.rst
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_source_get_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_source_get_info.3.rst
@@ -44,3 +44,7 @@ ERRORS
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized
 
 * ``MPI_T_ERR_INVALID_INDEX``: The source index is invalid
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_source_get_num.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_source_get_num.3.rst
@@ -32,8 +32,11 @@ made visible to the user (e.g., if new event sources become available
 via dynamic loading of additional components in the MPI
 implementation).
 
-.. note:: Open MPI will currently return that there are 0 sources of
-          MPI_T events.
+.. note:: The set of event sources Open MPI exports depends on the platform and
+          on MCA parameters. With all built-in producers disabled (the MCA
+          parameter ``mca_base_event_register_producers`` set to 0) the count is
+          0. Use ``ompi_info --event`` to list the registered sources and event
+          types.
 
 
 ERRORS
@@ -43,3 +46,7 @@ ERRORS
 
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface is not
   initialized
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/MPI_T_source_get_timestamp.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_source_get_timestamp.3.rst
@@ -33,3 +33,7 @@ ERRORS
 * ``MPI_T_ERR_NOT_INITIALIZED``: The MPI Tools interface not initialized
 
 * ``MPI_T_ERR_INVALID_INDEX``: The source index is invalid
+
+.. seealso::
+   * :ref:`MPI_T_Events`
+   * :ref:`MPI_T`

--- a/docs/man-openmpi/man3/index.rst
+++ b/docs/man-openmpi/man3/index.rst
@@ -375,6 +375,7 @@ MPI API manual pages (section 3)
    MPI_Status_set_source.3.rst
    MPI_Status_set_tag.3.rst
    MPI_T.3.rst
+   MPI_T_Events.3.rst
    MPI_T_category_changed.3.rst
    MPI_T_category_get_categories.3.rst
    MPI_T_category_get_cvars.3.rst

--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -11,6 +11,15 @@ Open MPI version v6.0.0
 - Added support for the MPI-4.0 embiggened APIs (i.e., functions with
   ``MPI_Count`` parameters).
 
+- Implemented the MPI_T events interface (MPI-5.0 section 15.3.8): event
+  sources and types, event handles (including events bound to a specific MPI
+  object), callbacks honoring the callback-safety levels, and dropped-event
+  handlers, plus a set of built-in event producers (MPI
+  initialization/finalization for both the world and session models,
+  communicator and RMA window lifecycle, communicator naming, error-handler
+  invocations, and OS-level memory release). List the registered sources and
+  event types with ``ompi_info --event``.
+
 - Fix build system and some internal code to support compiler
   link-time optimization (LTO).
 

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -29,6 +29,7 @@
  * Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2025      BULL S.A.S. All rights reserved.
  * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,6 +59,7 @@
 
 #include "ompi/attribute/attribute.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/request/request.h"
 #include "ompi/info/info_memkind.h"
@@ -2337,6 +2339,26 @@ int ompi_comm_set_name (ompi_communicator_t *comm, const char *name )
     comm->c_flags |= OMPI_COMM_NAMEISSET;
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
 
+    /* MPI_T: notify tools bound to THIS communicator that it was (re)named
+       (sec. 6.1).  Object-bound delivery means only registrations bound to this
+       communicator are invoked.  Raised after the lock is dropped so a callback
+       may re-enter MPI on the communicator (e.g. MPI_Comm_get_name to read the
+       new name, which the fixed payload does not carry). */
+    if (NULL != ompi_event_comm_name_set) {
+        struct {
+            uint64_t handle;
+        } payload;
+        /* XXX ABI (#13280): the MPI_Comm handle must match the registering
+           tool's ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.handle = (uint64_t) (uintptr_t) comm;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value. */
+            payload.handle = 0;
+        }
+        mca_base_event_raise_bound(ompi_event_comm_name_set, NULL, comm, &payload);
+    }
+
     return OMPI_SUCCESS;
 }
 /**********************************************************************/
@@ -2473,6 +2495,35 @@ int ompi_comm_free( ompi_communicator_t **comm )
             return ret;
         }
         OBJ_RELEASE((*comm)->c_keyhash);
+    }
+
+    /* Raise the MPI_T communicator-freed event now that teardown is committed
+       (the fallible attribute-delete step above has succeeded); the remaining
+       teardown cannot fail, and the context id is still valid until the final
+       release below.  Raising here (not at entry) keeps the freed event off the
+       attribute-delete failure path, so it pairs with the created event.  The
+       participation guard mirrors the created producer (raised in
+       ompi_comm_activate_complete only for ranks that join the new communicator),
+       so a rank that built a transient communicator it never joined -- e.g. an
+       MPI_UNDEFINED color in MPI_Comm_split, or a non-member of MPI_Comm_create's
+       group -- does not emit an unpaired freed.  No-op when no tool is listening
+       or the producer is disabled.  (comm and the communicator it points to are
+       already dereferenced above, so no NULL check here.) */
+    if (NULL != ompi_event_comm_freed && NULL != (*comm)->c_local_group
+        && MPI_UNDEFINED != (*comm)->c_local_group->grp_my_rank) {
+        struct {
+            uint64_t handle;
+        } payload;
+        /* XXX ABI: the MPI_Comm handle value must match the registering MPI_T
+           tool's ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.handle = (uint64_t) (uintptr_t) *comm;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value for the
+               communicator *comm. */
+            payload.handle = 0;
+        }
+        mca_base_event_raise(ompi_event_comm_freed, NULL, &payload);
     }
 
     if ( OMPI_COMM_IS_INTER(*comm) ) {

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -27,6 +27,7 @@
  * Copyright (c) 2020-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +55,7 @@
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/request/request.h"
 #include "ompi/runtime/mpiruntime.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 #include "ompi/runtime/ompi_rte.h"
 
 #include "pmix.h"
@@ -923,6 +925,34 @@ static int ompi_comm_activate_complete (ompi_comm_cid_context_t *context)
         OBJ_RELEASE(*newcomm);
         *newcomm = MPI_COMM_NULL;
         return ret;
+    }
+
+    /* Raise the MPI_T communicator-created event here, in the shared completion
+       reached by BOTH the blocking (ompi_comm_activate) and non-blocking
+       (ompi_comm_activate_nb, used by MPI_Comm_idup) creation paths, so every
+       new communicator a process joins is observed and pairs with its "freed"
+       event.  Only processes in the new communicator reach this point (others
+       returned above at the MPI_UNDEFINED check).  No-op when no tool is
+       listening or the producer is disabled.  (newcomm and the communicator it
+       points to are already dereferenced above, so no NULL check here.) */
+    if (NULL != ompi_event_comm_created) {
+        struct {
+            int32_t  size;
+            int32_t  pad;
+            uint64_t handle;
+        } payload;
+        payload.size = (int32_t) ompi_comm_size(*newcomm);
+        payload.pad = 0;
+        /* XXX ABI: the MPI_Comm handle value carried here must match the ABI of
+           the registering MPI_T tool (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.handle = (uint64_t) (uintptr_t) *newcomm;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value for the
+               communicator *newcomm. */
+            payload.handle = 0;
+        }
+        mca_base_event_raise(ompi_event_comm_created, NULL, &payload);
     }
 
     /* done */

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -19,6 +19,7 @@
  * Copyright (c) 2023      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +35,7 @@
 #include "ompi/request/request.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mpi/fortran/base/fint_2_int.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 
 
 int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
@@ -44,6 +46,45 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
     ompi_win_t *win;
     ompi_file_t *file;
     ompi_instance_t *instance;
+
+    /* Raise the MPI_T errhandler-invoked event (no-op when no tool is
+       listening or the producer is disabled).  The payload carries the
+       MPI_Errhandler handle and the handle of the MPI object the handler is
+       invoked on (both as opaque handle values; either is 0 when not available,
+       e.g. routing to a predefined handler before MPI_INIT). */
+    if (NULL != ompi_event_errhandler_invoked) {
+        struct {
+            int32_t  err_code;
+            int32_t  object_type;
+            uint64_t errhandler_handle;
+            uint64_t object_handle;
+        } payload;
+        /* Report object_type as the MPI_T_BIND_* binding kind of the object the
+           handler is invoked on, rather than the internal errhandler-type enum. */
+        int32_t object_bind;
+        switch (object_type) {
+        case OMPI_ERRHANDLER_TYPE_COMM:     object_bind = MPI_T_BIND_MPI_COMM;    break;
+        case OMPI_ERRHANDLER_TYPE_WIN:      object_bind = MPI_T_BIND_MPI_WIN;     break;
+        case OMPI_ERRHANDLER_TYPE_FILE:     object_bind = MPI_T_BIND_MPI_FILE;    break;
+        case OMPI_ERRHANDLER_TYPE_INSTANCE: object_bind = MPI_T_BIND_MPI_SESSION; break;
+        default:                            object_bind = MPI_T_BIND_NO_OBJECT;   break;
+        }
+        payload.err_code = (int32_t) err_code;
+        payload.object_type = object_bind;
+        /* XXX ABI: the MPI_Errhandler handle and the invoking object's handle
+           must match the registering MPI_T tool's ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.errhandler_handle = (uint64_t) (uintptr_t) errhandler;
+            payload.object_handle = (uint64_t) (uintptr_t) mpi_object;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle values -- the
+               MPI_Errhandler, and mpi_object converted per object_type
+               (MPI_Comm / MPI_Win / MPI_File / MPI_Session). */
+            payload.errhandler_handle = 0;
+            payload.object_handle = 0;
+        }
+        mca_base_event_raise(ompi_event_errhandler_invoked, NULL, &payload);
+    }
 
     /* If we got no errorhandler, then route the error to the appropriate
      * predefined error handler */

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -923,6 +923,17 @@ enum {
 };
 
 /*
+ * MPI_T event "model" values (Open MPI extension): which MPI model an
+ * instance-lifecycle event (the ompi.mpi.initialization / ompi.mpi.finalization
+ * MPI_T events) describes -- the world model (MPI_Init / MPI_Finalize) or the
+ * session model (MPI_Session_init / MPI_Session_finalize).
+ */
+enum {
+  OMPI_T_MODEL_WORLD,
+  OMPI_T_MODEL_SESSION
+};
+
+/*
  * MPIT pvar classes
  */
 enum {

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      BULL S.A.S.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +29,7 @@
 
 #include "ompi/mca/pml/pml.h"
 #include "ompi/runtime/params.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 #include "ompi/runtime/mpiruntime.h"
 
 #include "ompi/interlib/interlib.h"
@@ -1077,6 +1079,38 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
     *instance = new_instance;
     opal_mutex_unlock (&instance_lock);
 
+    /* Raise the MPI_T initialization event after dropping instance_lock (no-op
+       when no tool is listening or the producer is disabled).  This common path
+       serves BOTH MPI models; the world model (whose instance storage is the
+       ompi_mpi_instance_default global) instead raises from ompi_mpi_init() once
+       MPI_COMM_WORLD exists and world_rank/size are known, so raise here only
+       for the session model.  A process has no rank in a session, so world_rank
+       and world_size are reported as -1. */
+    if (instance != &ompi_mpi_instance_default && NULL != ompi_event_initialization) {
+        struct {
+            int32_t  model;
+            int32_t  thread_level;
+            int32_t  world_rank;
+            int32_t  world_size;
+            uint64_t instance_id;
+        } payload;
+        payload.model = OMPI_T_MODEL_SESSION;
+        payload.thread_level = (int32_t) ts_level;
+        payload.world_rank = -1;
+        payload.world_size = -1;
+        /* For the session model the instance is the MPI_Session, so instance_id
+           is its handle.  XXX ABI: it must match the registering MPI_T tool's
+           ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.instance_id = (uint64_t) (uintptr_t) new_instance;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value for the
+               session new_instance. */
+            payload.instance_id = 0;
+        }
+        mca_base_event_raise(ompi_event_initialization, NULL, &payload);
+    }
+
     return OMPI_SUCCESS;
 }
 
@@ -1188,6 +1222,31 @@ static int ompi_mpi_instance_finalize_common (void)
 int ompi_mpi_instance_finalize (ompi_instance_t **instance)
 {
     int ret = OMPI_SUCCESS;
+
+    /* Raise the MPI_T finalization event before teardown (no-op when no tool is
+       listening or the producer is disabled).  As with initialization, the world
+       model raises from ompi_mpi_finalize() (where MPI_COMM_WORLD still exists),
+       so raise here only for the session model; world_rank is -1 (no rank in a
+       session). */
+    if (instance != &ompi_mpi_instance_default && NULL != ompi_event_finalization) {
+        struct {
+            int32_t  model;
+            int32_t  world_rank;
+            uint64_t instance_id;
+        } payload;
+        payload.model = OMPI_T_MODEL_SESSION;
+        payload.world_rank = -1;
+        /* instance_id is the MPI_Session handle.  XXX ABI: it must match the
+           registering MPI_T tool's ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.instance_id = (uint64_t) (uintptr_t) *instance;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value for the
+               session *instance. */
+            payload.instance_id = 0;
+        }
+        mca_base_event_raise(ompi_event_finalization, NULL, &payload);
+    }
 
     OBJ_RELEASE(*instance);
 

--- a/ompi/mpi/c/free_mem.c.in
+++ b/ompi/mpi/c/free_mem.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,8 +41,11 @@ PROTOTYPE ERROR_CLASS free_mem(BUFFER_OUT baseptr)
 
        If you call MPI_ALLOC_MEM with a size of 0, you get NULL
        back.  So don't consider a NULL==baseptr an error. */
-    if (NULL != baseptr && OMPI_SUCCESS != mca_mpool_base_free(baseptr)) {
-        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM, FUNC_NAME);
+
+    if (NULL != baseptr) {
+        if (OMPI_SUCCESS != mca_mpool_base_free(baseptr)) {
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM, FUNC_NAME);
+        }
     }
 
     return MPI_SUCCESS;

--- a/ompi/mpi/tool/category_get_events.c
+++ b/ompi/mpi/tool/category_get_events.c
@@ -34,6 +34,8 @@ int MPI_T_category_get_events(int cat_index, int len, int indices[])
 {
     const mca_base_var_group_t *group;
     int rc = MPI_SUCCESS;
+    int size, i;
+    const int *events;
 
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
@@ -50,10 +52,13 @@ int MPI_T_category_get_events(int cat_index, int len, int indices[])
             break;
         }
 
-        /* Open MPI does not yet register any MPI_T events, so there is
-           nothing to copy into the caller's len-element indices[] array.
-           When events are implemented, populate indices[] from the
-           per-category event list here. */
+        /* Copy this category's (stable, append-only) event indices into the
+           caller's len-element indices[] array. */
+        size = opal_value_array_get_size ((opal_value_array_t *) &group->group_events);
+        events = OPAL_VALUE_ARRAY_GET_BASE (&group->group_events, int);
+        for (i = 0; i < len && i < size; ++i) {
+            indices[i] = events[i];
+        }
         rc = MPI_SUCCESS;
     } while (0);
 

--- a/ompi/mpi/tool/category_get_num_events.c
+++ b/ompi/mpi/tool/category_get_num_events.c
@@ -54,8 +54,8 @@ int MPI_T_category_get_num_events (int cat_index, int *num_events)
             break;
         }
 
-        /* Open MPI does not yet register any MPI_T events. */
-        *num_events = 0;
+        *num_events = (int) opal_value_array_get_size (
+            (opal_value_array_t *) &group->group_events);
         rc = MPI_SUCCESS;
     } while (0);
 

--- a/ompi/mpi/tool/event_callback_get_info.c
+++ b/ompi/mpi/tool/event_callback_get_info.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2019      Google, LLC. All rights reserved.
  * Copyright (c) 2019-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +18,7 @@
 
 #include "ompi_config.h"
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -29,10 +31,43 @@
 int MPI_T_event_callback_get_info (MPI_T_event_registration event_registration,
                                    MPI_T_cb_safety cb_safety, MPI_Info *info_used)
 {
+    opal_info_t *opal_info_used = NULL;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
-}
+    if (MPI_PARAM_CHECK && (NULL == info_used)) {
+        return MPI_ERR_ARG;
+    }
 
+    ompi_mpit_lock ();
+    rc = mca_base_event_callback_get_info (ompit_event_reg (event_registration),
+                                           (mca_base_event_cb_safety_t) cb_safety,
+                                           &opal_info_used);
+    ompi_mpit_unlock ();
+
+    if (OPAL_SUCCESS != rc) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    /* OPAL handed back a fresh, OPAL-owned opal_info_t; copy its contents into
+       a user-freeable MPI_Info (mirrors MPI_Comm_get_info) and release OPAL's. */
+    *info_used = ompi_info_allocate ();
+    if (NULL == *info_used) {
+        OBJ_RELEASE (opal_info_used);
+        return MPI_T_ERR_MEMORY;
+    }
+
+    opal_info_t *opal_dst = &(*info_used)->super;
+    rc = opal_info_dup (opal_info_used, &opal_dst);
+    OBJ_RELEASE (opal_info_used);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE (*info_used);
+        *info_used = MPI_INFO_NULL;
+        return MPI_T_ERR_MEMORY;
+    }
+
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/tool/event_callback_set_info.c
+++ b/ompi/mpi/tool/event_callback_set_info.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2019      Google, LLC. All rights reserved.
  * Copyright (c) 2019-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +18,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -28,9 +30,20 @@
 int MPI_T_event_callback_set_info (MPI_T_event_registration event_registration,
                                    MPI_T_cb_safety cb_safety, MPI_Info info)
 {
+    opal_info_t *opal_info;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    /* MPI_Info is an ompi_info_t whose first member is an opal_info_t. */
+    opal_info = (MPI_INFO_NULL == info) ? NULL : &info->super;
+
+    ompi_mpit_lock ();
+    rc = mca_base_event_callback_set_info (ompit_event_reg (event_registration),
+                                           (mca_base_event_cb_safety_t) cb_safety, opal_info);
+    ompi_mpit_unlock ();
+
+    return (OPAL_SUCCESS == rc) ? MPI_SUCCESS : MPI_T_ERR_INVALID_HANDLE;
 }

--- a/ompi/mpi/tool/event_copy.c
+++ b/ompi/mpi/tool/event_copy.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,9 +28,20 @@
 
 int MPI_T_event_copy (MPI_T_event_instance event, void *buffer)
 {
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    if (MPI_PARAM_CHECK && NULL == buffer) {
+        return MPI_ERR_ARG;
+    }
+
+    rc = mca_base_event_copy (ompit_event_inst (event), buffer);
+    if (OPAL_SUCCESS != rc) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_get_index.c
+++ b/ompi/mpi/tool/event_get_index.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,6 +26,8 @@
 
 int MPI_T_event_get_index (const char *name, int *event_index)
 {
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
@@ -33,5 +36,9 @@ int MPI_T_event_get_index (const char *name, int *event_index)
         return MPI_ERR_ARG;
     }
 
-    return MPI_T_ERR_INVALID_NAME;
+    ompi_mpit_lock ();
+    rc = mca_base_event_get_by_name (name, event_index);
+    ompi_mpit_unlock ();
+
+    return (OPAL_SUCCESS == rc) ? MPI_SUCCESS : MPI_T_ERR_INVALID_NAME;
 }

--- a/ompi/mpi/tool/event_get_info.c
+++ b/ompi/mpi/tool/event_get_info.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +17,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -30,9 +32,72 @@ int MPI_T_event_get_info (int event_index, char *name, int *name_len,
                           MPI_T_enum *enumtype, MPI_Info *info,
                           char *desc, int *desc_len, int *bind)
 {
+    mca_base_event_t *event;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_INDEX;
+    ompi_mpit_lock ();
+
+    do {
+        rc = mca_base_event_get_by_index (event_index, &event);
+        if (OPAL_SUCCESS != rc) {
+            rc = MPI_T_ERR_INVALID_INDEX;
+            break;
+        }
+
+        mpit_copy_string (name, name_len, event->name);
+        mpit_copy_string (desc, desc_len, event->description);
+
+        if (NULL != verbosity) {
+            *verbosity = event->verbosity;
+        }
+
+        if (NULL != bind) {
+            *bind = event->bind;
+        }
+
+        if (NULL != enumtype) {
+            *enumtype = event->enumerator ? (MPI_T_enum) event->enumerator : MPI_T_ENUM_NULL;
+        }
+
+        /* The caller passes the array capacity in *num_elements on input; fill
+           at most that many datatype/displacement entries, then report the true
+           element count.  NULL array pointers and a NULL num_elements pointer
+           are all tolerated (the standard allows the tool to skip these). */
+        if (NULL != num_elements) {
+            int capacity = *num_elements;
+
+            for (int i = 0; i < capacity && i < event->num_elements; ++i) {
+                if (NULL != array_of_datatypes) {
+                    ompit_var_type_to_datatype (event->element_types[i],
+                                                array_of_datatypes + i);
+                }
+
+                if (NULL != array_of_displacements) {
+                    array_of_displacements[i] = (MPI_Aint) event->element_offsets[i];
+                }
+            }
+
+            *num_elements = event->num_elements;
+        }
+
+        /* The standard requires a fresh, user-freeable MPI_Info.  An event type
+           carries no info hints in this implementation, so return an empty one
+           (ompi_info_allocate yields a valid, user-freeable handle). */
+        rc = MPI_SUCCESS;
+        if (NULL != info) {
+            *info = ompi_info_allocate ();
+            if (NULL == *info) {
+                rc = MPI_T_ERR_MEMORY;
+                break;
+            }
+        }
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return rc;
 }

--- a/ompi/mpi/tool/event_get_num.c
+++ b/ompi/mpi/tool/event_get_num.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,9 @@ int MPI_T_event_get_num (int *num_event)
         return MPI_ERR_ARG;
     }
 
-    *num_event = 0;
+    ompi_mpit_lock ();
+    (void) mca_base_event_get_count (num_event);
+    ompi_mpit_unlock ();
+
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_get_source.c
+++ b/ompi/mpi/tool/event_get_source.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,9 +27,20 @@
 
 int MPI_T_event_get_source (MPI_T_event_instance event, int *source_index)
 {
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    if (MPI_PARAM_CHECK && NULL == source_index) {
+        return MPI_ERR_ARG;
+    }
+
+    rc = mca_base_event_instance_get_source (ompit_event_inst (event), source_index);
+    if (OPAL_SUCCESS != rc) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_get_timestamp.c
+++ b/ompi/mpi/tool/event_get_timestamp.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,9 +27,22 @@
 
 int MPI_T_event_get_timestamp (MPI_T_event_instance event, MPI_Count *event_time)
 {
+    int rc;
+    opal_count_t ts = 0;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    if (MPI_PARAM_CHECK && NULL == event_time) {
+        return MPI_ERR_ARG;
+    }
+
+    rc = mca_base_event_instance_get_timestamp (ompit_event_inst (event), &ts);
+    if (OPAL_SUCCESS != rc) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+    *event_time = (MPI_Count) ts;
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_handle_alloc.c
+++ b/ompi/mpi/tool/event_handle_alloc.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +17,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -27,9 +29,41 @@
 int MPI_T_event_handle_alloc (int event_index, void *obj_handle, MPI_Info info,
                               MPI_T_event_registration *event_registration)
 {
+    mca_base_event_registration_t *reg;
+    opal_info_t *opal_info;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_INDEX;
+    if (MPI_PARAM_CHECK && (NULL == event_registration)) {
+        return MPI_ERR_ARG;
+    }
+
+    /* MPI_Info is an ompi_info_t whose first member is an opal_info_t. */
+    opal_info = (MPI_INFO_NULL == info) ? NULL : &info->super;
+
+    /* No big lock: the OPAL framework is internally synchronized, and the fold
+       this can drive invokes user dropped handlers, which must not run with
+       ompi_mpit_big_lock held (sec. 5.10) -- a handler re-entering MPI_T would
+       deadlock on the non-recursive lock. */
+    rc = mca_base_event_handle_alloc (event_index, obj_handle, opal_info, &reg);
+
+    switch (rc) {
+    case OPAL_SUCCESS:
+        *event_registration = ompit_event_handle (reg);
+        return MPI_SUCCESS;
+    case OPAL_ERR_VALUE_OUT_OF_BOUNDS:
+        return MPI_T_ERR_INVALID_INDEX;
+    case OPAL_ERR_BAD_PARAM:
+        /* An object-bound event type was given a NULL obj_handle. */
+        return MPI_T_ERR_INVALID_HANDLE;
+    case OPAL_ERR_NOT_SUPPORTED:
+        return MPI_T_ERR_INVALID_HANDLE;
+    case OPAL_ERR_OUT_OF_RESOURCE:
+        return MPI_T_ERR_OUT_OF_HANDLES;
+    default:
+        return MPI_T_ERR_INVALID;
+    }
 }

--- a/ompi/mpi/tool/event_handle_free.c
+++ b/ompi/mpi/tool/event_handle_free.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,9 +29,36 @@ int MPI_T_event_handle_free (MPI_T_event_registration event_registration,
                              void *user_data,
                              MPI_T_event_free_cb_function free_cb_function)
 {
+    ompi_mpit_event_cb_ctx_t *ctx = NULL;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    /* Wrap the user's free callback + user pointer so the OPAL-signature
+       trampoline can forward to the MPI_T callback at teardown. */
+    if (NULL != free_cb_function) {
+        ctx = ompit_event_cb_ctx_new ((ompit_generic_fn_t) free_cb_function, user_data);
+        if (NULL == ctx) {
+            return MPI_T_ERR_MEMORY;
+        }
+    }
+
+    /* Do NOT hold ompi_mpit_big_lock here: the OPAL framework is internally
+       synchronized, and handle_free flushes the dropped handler and invokes the
+       free callback.  Per sec. 5.10 no user callback may run while the big lock
+       is held -- the standard lets such a callback re-enter MPI_T, which would
+       deadlock on the non-recursive lock. */
+    rc = mca_base_event_handle_free (ompit_event_reg (event_registration), ctx,
+                                     (NULL != free_cb_function) ? ompit_event_free_trampoline
+                                                               : NULL);
+
+    if (OPAL_SUCCESS != rc) {
+        /* Stale / double free: OPAL did not take ownership of the ctx. */
+        ompit_event_ctx_release (ctx);
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_handle_get_info.c
+++ b/ompi/mpi/tool/event_handle_get_info.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2019      Google, LLC. All rights reserved.
  * Copyright (c) 2019-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +18,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -28,9 +30,41 @@
 int MPI_T_event_handle_get_info (MPI_T_event_registration event_registration,
                                  MPI_Info *info_used)
 {
+    opal_info_t *opal_info_used = NULL;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    if (MPI_PARAM_CHECK && (NULL == info_used)) {
+        return MPI_ERR_ARG;
+    }
+
+    ompi_mpit_lock ();
+    rc = mca_base_event_handle_get_info (ompit_event_reg (event_registration), &opal_info_used);
+    ompi_mpit_unlock ();
+
+    if (OPAL_SUCCESS != rc) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    /* OPAL handed back a fresh, OPAL-owned opal_info_t; copy its contents into
+       a user-freeable MPI_Info (mirrors MPI_Comm_get_info) and release OPAL's. */
+    *info_used = ompi_info_allocate ();
+    if (NULL == *info_used) {
+        OBJ_RELEASE (opal_info_used);
+        return MPI_T_ERR_MEMORY;
+    }
+
+    opal_info_t *opal_dst = &(*info_used)->super;
+    rc = opal_info_dup (opal_info_used, &opal_dst);
+    OBJ_RELEASE (opal_info_used);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE (*info_used);
+        *info_used = MPI_INFO_NULL;
+        return MPI_T_ERR_MEMORY;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_handle_set_info.c
+++ b/ompi/mpi/tool/event_handle_set_info.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2019      Google, LLC. All rights reserved.
  * Copyright (c) 2019-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +18,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -28,9 +30,19 @@
 int MPI_T_event_handle_set_info (MPI_T_event_registration event_registration,
                                  MPI_Info info)
 {
+    opal_info_t *opal_info;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    /* MPI_Info is an ompi_info_t whose first member is an opal_info_t. */
+    opal_info = (MPI_INFO_NULL == info) ? NULL : &info->super;
+
+    ompi_mpit_lock ();
+    rc = mca_base_event_handle_set_info (ompit_event_reg (event_registration), opal_info);
+    ompi_mpit_unlock ();
+
+    return (OPAL_SUCCESS == rc) ? MPI_SUCCESS : MPI_T_ERR_INVALID_HANDLE;
 }

--- a/ompi/mpi/tool/event_read.c
+++ b/ompi/mpi/tool/event_read.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,9 +27,22 @@
 
 int MPI_T_event_read (MPI_T_event_instance event, int element_index, void *buffer)
 {
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    if (MPI_PARAM_CHECK && NULL == buffer) {
+        return MPI_ERR_ARG;
+    }
+
+    /* In-callback accessors are lock-free (they read instance-owned data). */
+    rc = mca_base_event_read (ompit_event_inst (event), element_index, buffer);
+    if (OPAL_SUCCESS != rc) {
+        return (OPAL_ERR_VALUE_OUT_OF_BOUNDS == rc) ? MPI_T_ERR_INVALID_INDEX
+                                                    : MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_register_callback.c
+++ b/ompi/mpi/tool/event_register_callback.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +17,8 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -28,9 +31,52 @@ int MPI_T_event_register_callback (MPI_T_event_registration event_registration,
                                    MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data,
                                    MPI_T_event_cb_function event_cb_function)
 {
+    ompi_mpit_event_cb_ctx_t *ctx = NULL;
+    mca_base_event_ctx_release_fn_t release_cb = NULL;
+    mca_base_event_cb_fn_t cb = NULL;
+    opal_info_t *opal_info;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    /* Record which MPI ABI this registering tool is using, so the producers
+       emit object handles (MPI_Comm / MPI_Win / MPI_Errhandler / MPI_Session)
+       in the matching representation.  This entry point is the Open MPI ABI one,
+       so hard-code the Open MPI ABI; when the MPI Standard ABI lands
+       (open-mpi/ompi#13280) its separate entry point will set
+       OMPI_MPIT_ABI_STANDARD here instead. */
+    ompi_mpit_callback_abi = OMPI_MPIT_ABI_OMPI;
+
+    /* MPI_Info is an ompi_info_t whose first member is an opal_info_t. */
+    opal_info = (MPI_INFO_NULL == info) ? NULL : &info->super;
+
+    /* A non-NULL callback is wrapped in a context owned by OPAL until the
+       slot's refcount hits 0, at which point OPAL invokes our release_cb.
+       A NULL callback removes any installed callback (no context needed). */
+    if (NULL != event_cb_function) {
+        ctx = ompit_event_cb_ctx_new ((ompit_generic_fn_t) event_cb_function, user_data);
+        if (NULL == ctx) {
+            return MPI_T_ERR_MEMORY;
+        }
+        release_cb = ompit_event_ctx_release;
+        cb = ompit_event_cb_trampoline;
+    }
+
+    /* No big lock: the OPAL framework is internally synchronized, and replacing
+       a callback can run a slot's release_cb at teardown, which must not run
+       with ompi_mpit_big_lock held (sec. 5.10). */
+    rc = mca_base_event_register_callback (ompit_event_reg (event_registration),
+                                           (mca_base_event_cb_safety_t) cb_safety, opal_info,
+                                           ctx, release_cb, cb);
+
+    if (OPAL_SUCCESS != rc) {
+        /* On immediate failure OPAL does NOT invoke release_cb, so free the
+           context ourselves to avoid a leak. */
+        ompit_event_ctx_release (ctx);
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/event_set_dropped_handler.c
+++ b/ompi/mpi/tool/event_set_dropped_handler.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,9 +28,40 @@
 int MPI_T_event_set_dropped_handler (MPI_T_event_registration handle, MPI_T_event_dropped_cb_function dropped_cb_function)
 
 {
+    ompi_mpit_event_cb_ctx_t *ctx = NULL;
+    mca_base_event_ctx_release_fn_t release_cb = NULL;
+    mca_base_event_dropped_cb_fn_t dropped_cb = NULL;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_HANDLE;
+    /* A non-NULL handler is wrapped in a context owned by OPAL until the
+       slot's refcount hits 0, at which point OPAL invokes our release_cb.
+       The MPI_T dropped-handler signature has no user_data, so pass NULL.
+       A NULL handler clears any installed handler (no context needed). */
+    if (NULL != dropped_cb_function) {
+        ctx = ompit_event_cb_ctx_new ((ompit_generic_fn_t) dropped_cb_function, NULL);
+        if (NULL == ctx) {
+            return MPI_T_ERR_MEMORY;
+        }
+        release_cb = ompit_event_ctx_release;
+        dropped_cb = ompit_event_dropped_trampoline;
+    }
+
+    /* No big lock: the OPAL framework is internally synchronized, and replacing
+       the handler can run a slot's release_cb at teardown, which must not run
+       with ompi_mpit_big_lock held (sec. 5.10). */
+    rc = mca_base_event_set_dropped_handler (ompit_event_reg (handle), dropped_cb, ctx,
+                                             release_cb);
+
+    if (OPAL_SUCCESS != rc) {
+        /* On immediate failure OPAL does NOT invoke release_cb, so free the
+           context ourselves to avoid a leak. */
+        ompit_event_ctx_release (ctx);
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -142,6 +142,11 @@ int MPI_T_init_thread (int required, int *provided)
         goto unlock;
     }
 
+    /* Install the OPAL debug raise-check hook so a producer that raises an
+       MPI_T event while holding the big lock trips an assert rather than
+       deadlocking (no-op unless OPAL_ENABLE_DEBUG; sec. 5.10). */
+    ompit_install_event_debug_hook ();
+
     /* The thread level of the MPI tool information interface is its
        own, scoped to MPI_T routines only (MPI 5.0 sec. 15.3.4).  It
        must NOT be written into the World Model's globals: those back

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -21,6 +21,7 @@
 #include "opal/util/string_copy.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_event.h"
 
 #include "ompi/include/ompi_config.h"
 #include "ompi/runtime/params.h"
@@ -65,6 +66,52 @@ extern bool ompi_mpit_init_failed;
 int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype);
 int ompit_opal_to_mpit_error (int rc);
 bool ompit_obj_invalid(void *obj_handle);
+
+/* --- MPI_T events support (see specs/mpi-t-events/spec.md sec. 6) --------- */
+
+/* The opaque MPI_T event handles are the OPAL pointers, cast.  These helpers
+   round-trip them so the casts live in one place. */
+static inline mca_base_event_registration_t *ompit_event_reg(MPI_T_event_registration h)
+{
+    return (mca_base_event_registration_t *) (void *) h;
+}
+static inline MPI_T_event_registration ompit_event_handle(mca_base_event_registration_t *reg)
+{
+    return (MPI_T_event_registration) (void *) reg;
+}
+static inline mca_base_event_instance_t *ompit_event_inst(MPI_T_event_instance h)
+{
+    return (mca_base_event_instance_t *) (void *) h;
+}
+
+/* OMPI-owned context for an MPI_T event/dropped/free callback: the user's
+   callback function pointer + user pointer.  Allocated per registration and
+   freed (via ompit_event_ctx_release) only after the OPAL slot's refcount hits
+   0 -- OPAL never frees it. */
+typedef void (*ompit_generic_fn_t)(void);
+typedef struct ompi_mpit_event_cb_ctx_t {
+    ompit_generic_fn_t fn;
+    void              *user_data;
+} ompi_mpit_event_cb_ctx_t;
+
+ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new(ompit_generic_fn_t fn, void *user_data);
+void ompit_event_ctx_release(void *user_data);
+
+/* Trampolines with the OPAL callback signatures; each forwards to the user's
+   MPI_T callback after casting the opaque handles.  Calling an MPI_T callback
+   through an OPAL function-pointer type would be undefined behaviour, so these
+   bridge the (function-pointer) type mismatch. */
+void ompit_event_cb_trampoline(mca_base_event_instance_t *inst,
+                               mca_base_event_registration_t *reg,
+                               mca_base_event_cb_safety_t cb_safety, void *user_data);
+void ompit_event_dropped_trampoline(opal_count_t count, mca_base_event_registration_t *reg,
+                                    int source_index, mca_base_event_cb_safety_t cb_safety,
+                                    void *user_data);
+void ompit_event_free_trampoline(mca_base_event_registration_t *reg,
+                                 mca_base_event_cb_safety_t cb_safety, void *user_data);
+
+/* Install the OPAL debug raise-check hook (a no-op unless OPAL_ENABLE_DEBUG). */
+void ompit_install_event_debug_hook(void);
 
 static inline int mpit_is_initialized (void)
 {

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -20,6 +20,11 @@
 
 #include "ompi/mpi/tool/mpit-internal.h"
 
+#include "opal/mca/threads/thread_usage.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
 opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
 
 volatile uint32_t ompi_mpit_init_count = 0;
@@ -28,14 +33,94 @@ int ompi_mpit_thread_level = MPI_THREAD_SINGLE;
 
 bool ompi_mpit_init_failed = false;
 
+#if OPAL_ENABLE_DEBUG
+/* Per-thread depth of MPI_T big-lock sections this thread holds (debug only),
+   used by the OPAL raise-check hook to detect a producer raising an event
+   while this thread holds the big lock (a deadlock hazard -- sec. 5.10). */
+static opal_thread_local int ompi_mpit_locked_depth = 0;
+#endif
+
 void ompi_mpit_lock (void)
 {
     opal_mutex_lock (&ompi_mpit_big_lock);
+#if OPAL_ENABLE_DEBUG
+    ++ompi_mpit_locked_depth;
+#endif
 }
 
 void ompi_mpit_unlock (void)
 {
+#if OPAL_ENABLE_DEBUG
+    --ompi_mpit_locked_depth;
+#endif
     opal_mutex_unlock (&ompi_mpit_big_lock);
+}
+
+/* --- MPI_T events: callback contexts, trampolines, debug hook ------------ */
+
+ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new (ompit_generic_fn_t fn, void *user_data)
+{
+    ompi_mpit_event_cb_ctx_t *ctx = malloc (sizeof (*ctx));
+    if (NULL != ctx) {
+        ctx->fn = fn;
+        ctx->user_data = user_data;
+    }
+    return ctx;
+}
+
+void ompit_event_ctx_release (void *user_data)
+{
+    free (user_data);
+}
+
+void ompit_event_cb_trampoline (mca_base_event_instance_t *inst,
+                                mca_base_event_registration_t *reg,
+                                mca_base_event_cb_safety_t cb_safety, void *user_data)
+{
+    ompi_mpit_event_cb_ctx_t *ctx = (ompi_mpit_event_cb_ctx_t *) user_data;
+    MPI_T_event_cb_function fn = (MPI_T_event_cb_function) ctx->fn;
+
+    fn ((MPI_T_event_instance) (void *) inst, ompit_event_handle (reg),
+        (MPI_T_cb_safety) cb_safety, ctx->user_data);
+}
+
+void ompit_event_dropped_trampoline (opal_count_t count, mca_base_event_registration_t *reg,
+                                     int source_index, mca_base_event_cb_safety_t cb_safety,
+                                     void *user_data)
+{
+    ompi_mpit_event_cb_ctx_t *ctx = (ompi_mpit_event_cb_ctx_t *) user_data;
+    MPI_T_event_dropped_cb_function fn = (MPI_T_event_dropped_cb_function) ctx->fn;
+
+    fn ((MPI_Count) count, ompit_event_handle (reg), source_index, (MPI_T_cb_safety) cb_safety,
+        ctx->user_data);
+}
+
+void ompit_event_free_trampoline (mca_base_event_registration_t *reg,
+                                  mca_base_event_cb_safety_t cb_safety, void *user_data)
+{
+    ompi_mpit_event_cb_ctx_t *ctx = (ompi_mpit_event_cb_ctx_t *) user_data;
+    MPI_T_event_free_cb_function fn = (MPI_T_event_free_cb_function) ctx->fn;
+
+    fn (ompit_event_handle (reg), (MPI_T_cb_safety) cb_safety, ctx->user_data);
+
+    /* The free callback fires exactly once, at registration teardown; OPAL does
+       not release free_user_data, so free our context here. */
+    ompit_event_ctx_release (ctx);
+}
+
+#if OPAL_ENABLE_DEBUG
+static void ompit_event_assert_no_big_lock (void)
+{
+    assert (0 == ompi_mpit_locked_depth
+            && "an MPI_T event was raised while this thread holds ompi_mpit_big_lock");
+}
+#endif
+
+void ompit_install_event_debug_hook (void)
+{
+#if OPAL_ENABLE_DEBUG
+    mca_base_event_debug_raise_check_fn = ompit_event_assert_no_big_lock;
+#endif
 }
 
 static MPI_Datatype mca_to_mpi_datatypes[MCA_BASE_VAR_TYPE_MAX] = {

--- a/ompi/mpi/tool/source_get_info.c
+++ b/ompi/mpi/tool/source_get_info.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +16,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/tool/mpit-internal.h"
+#include "ompi/info/info.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -26,9 +28,53 @@
 int MPI_T_source_get_info (int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering,
                            MPI_Count *ticks_per_second, MPI_Count *max_timestamp, MPI_Info *info)
 {
+    mca_base_event_source_t *source;
+    int rc;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    return MPI_T_ERR_INVALID_INDEX;
+    ompi_mpit_lock ();
+
+    do {
+        rc = mca_base_event_source_get_by_index (source_index, &source);
+        if (OPAL_SUCCESS != rc) {
+            rc = MPI_T_ERR_INVALID_INDEX;
+            break;
+        }
+
+        mpit_copy_string (name, name_len, source->name);
+        mpit_copy_string (desc, desc_len, source->description);
+
+        if (NULL != ordering) {
+            *ordering = (MCA_BASE_EVENT_SOURCE_ORDERED == source->ordering)
+                            ? MPI_T_SOURCE_ORDERED
+                            : MPI_T_SOURCE_UNORDERED;
+        }
+
+        if (NULL != ticks_per_second) {
+            *ticks_per_second = (MPI_Count) source->ticks_per_second;
+        }
+
+        if (NULL != max_timestamp) {
+            *max_timestamp = (MPI_Count) source->max_ticks;
+        }
+
+        /* The standard requires a fresh, user-freeable MPI_Info.  An event
+           source carries no info hints in this implementation, so return an
+           empty one (ompi_info_allocate yields a valid, user-freeable handle). */
+        rc = MPI_SUCCESS;
+        if (NULL != info) {
+            *info = ompi_info_allocate ();
+            if (NULL == *info) {
+                rc = MPI_T_ERR_MEMORY;
+                break;
+            }
+        }
+    } while (0);
+
+    ompi_mpit_unlock ();
+
+    return rc;
 }

--- a/ompi/mpi/tool/source_get_num.c
+++ b/ompi/mpi/tool/source_get_num.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,9 @@ int MPI_T_source_get_num (int *num_source)
         return MPI_ERR_ARG;
     }
 
-    *num_source = 0;
+    ompi_mpit_lock ();
+    (void) mca_base_event_source_get_count (num_source);
+    ompi_mpit_unlock ();
+
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/source_get_timestamp.c
+++ b/ompi/mpi/tool/source_get_timestamp.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,13 +26,27 @@
 
 int MPI_T_source_get_timestamp (int source_index, MPI_Count *timestamp)
 {
+    int rc;
+    opal_count_t ts = 0;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    if (MPI_PARAM_CHECK && !timestamp) {
+    if (MPI_PARAM_CHECK && NULL == timestamp) {
         return MPI_ERR_ARG;
     }
 
-    return MPI_T_ERR_INVALID_INDEX;
+    /* No big lock: the OPAL framework is internally synchronized, and a read of
+       a deferred-release source drives the fold, which can deliver events and
+       invoke user callbacks -- they must not run with ompi_mpit_big_lock held
+       (sec. 5.10). */
+    rc = mca_base_event_source_get_timestamp (source_index, &ts);
+
+    if (OPAL_SUCCESS != rc) {
+        return (OPAL_ERR_NOT_SUPPORTED == rc) ? MPI_T_ERR_NOT_SUPPORTED : MPI_T_ERR_INVALID_INDEX;
+    }
+    *timestamp = (MPI_Count) ts;
+
+    return MPI_SUCCESS;
 }

--- a/ompi/runtime/Makefile.am
+++ b/ompi/runtime/Makefile.am
@@ -29,7 +29,8 @@ headers += \
         runtime/params.h \
 	runtime/ompi_info_support.h \
 	runtime/ompi_spc.h \
-	runtime/ompi_rte.h
+	runtime/ompi_rte.h \
+	runtime/ompi_mpit_events.h
 
 lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         runtime/ompi_mpi_init.c \
@@ -40,4 +41,5 @@ lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         runtime/ompi_mpi_preconnect.c \
 	runtime/ompi_info_support.c \
 	runtime/ompi_spc.c \
-	runtime/ompi_rte.c
+	runtime/ompi_rte.c \
+	runtime/ompi_mpit_register_events.c

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -92,6 +92,7 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/attribute/attribute.h"
 #include "ompi/instance/instance.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 
 #include "mpi.h"
 #include "ompi/constants.h"
@@ -137,6 +138,24 @@ int ompi_mpi_finalize(void)
     }
     opal_atomic_wmb();
     opal_atomic_swap_32(&ompi_mpi_state, OMPI_MPI_STATE_FINALIZE_STARTED);
+
+    /* Raise the MPI_T finalization event for the world model at the very start
+       of finalization, while MPI_COMM_WORLD still exists so the payload can
+       carry this process' rank (the session model raises its own finalization
+       event from ompi_mpi_instance_finalize(), with world_rank = -1).  No-op
+       when no tool is listening or the producer is disabled. */
+    if (NULL != ompi_event_finalization) {
+        /* The world model has no user-facing instance handle, so instance_id is
+           an ABI-independent internal correlation token (see ompi_mpi_init.c);
+           the session model's instance_id is the ABI-gated MPI_Session handle. */
+        struct {
+            int32_t  model;
+            int32_t  world_rank;
+            uint64_t instance_id;
+        } payload = {OMPI_T_MODEL_WORLD, ompi_comm_rank(&ompi_mpi_comm_world.comm),
+                     (uint64_t) (uintptr_t) ompi_mpi_instance_default};
+        mca_base_event_raise(ompi_event_finalization, NULL, &payload);
+    }
 
     /* Per MPI-2:4.8, we have to free MPI_COMM_SELF before doing
        anything else in MPI_FINALIZE (to include setting up such that

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2021-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,6 +104,19 @@
 #include "ompi/mpiext/mpiext.h"
 #include "ompi/mca/hook/base/base.h"
 #include "ompi/util/timings.h"
+#include "opal/types.h"
+
+/* opal_count_t is the layer-safe backing type for MPI_Count: both are derived
+   from a single configure-computed value (OPAL_FIND_COUNT_TYPE), so OPAL code
+   can manipulate counts without referencing any MPI type.  Guarantee at build
+   time that the two stay the same width. */
+_Static_assert(sizeof(opal_count_t) == sizeof(MPI_Count),
+               "opal_count_t and MPI_Count must be the same size");
+/* opal_count_t must be signed: later code (e.g. the mca_base_event drop
+   accounting) saturates against OPAL_COUNT_MAX and relies on negative values
+   being representable / detectable. */
+_Static_assert((opal_count_t) -1 < 0,
+               "opal_count_t must be a signed type");
 
 /* newer versions of gcc have poisoned this deprecated feature */
 #ifdef HAVE___MALLOC_INITIALIZE_HOOK

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -76,6 +76,7 @@
 #include "ompi/instance/instance.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 #include "ompi/info/info.h"
 #include "ompi/errhandler/errcode.h"
 #include "ompi/errhandler/errhandler.h"
@@ -727,6 +728,28 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     OMPI_TIMING_FINALIZE;
 
     ompi_hook_base_mpi_init_bottom(argc, argv, requested, provided);
+
+    /* Raise the MPI_T initialization event for the world model now that init is
+       complete and MPI_COMM_WORLD exists, so the payload can carry this process'
+       rank and the world size (the session model raises its own initialization
+       event from ompi_mpi_instance_init(), with world_rank/size = -1).  No-op
+       when no tool is listening or the producer is disabled. */
+    if (NULL != ompi_event_initialization) {
+        /* The world model exposes no user-facing instance handle (MPI_Init
+           returns none), so instance_id is purely an internal correlation token
+           (init<->finalize) and is ABI-independent -- unlike the session model,
+           where instance_id is the MPI_Session handle and is ABI-gated. */
+        struct {
+            int32_t  model;
+            int32_t  thread_level;
+            int32_t  world_rank;
+            int32_t  world_size;
+            uint64_t instance_id;
+        } payload = {OMPI_T_MODEL_WORLD, (int32_t) *provided,
+                     ompi_comm_rank(MPI_COMM_WORLD), ompi_comm_size(MPI_COMM_WORLD),
+                     (uint64_t) (uintptr_t) ompi_mpi_instance_default};
+        mca_base_event_raise(ompi_event_initialization, NULL, &payload);
+    }
 
     return MPI_SUCCESS;
 }

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -42,6 +42,7 @@
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/runtime/params.h"
 #include "ompi/runtime/ompi_rte.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 
 #include "opal/mca/pmix/base/base.h"
 #include "opal/util/argv.h"
@@ -451,6 +452,10 @@ int ompi_mpi_register_params(void)
                                   "Verbosity level for communicator management subsystem",
                                   MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                   OPAL_INFO_LVL_8, MCA_BASE_VAR_SCOPE_LOCAL, &ompi_comm_verbose_level);
+
+    /* Register the in-tree MPI_T event producers (idempotent / one-shot, so
+       it is harmless that this runs from every MCA-parameter path). */
+    ompi_mpit_register_events ();
 
     return OMPI_SUCCESS;
 }

--- a/ompi/runtime/ompi_mpit_events.h
+++ b/ompi/runtime/ompi_mpit_events.h
@@ -1,0 +1,69 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Registration of Open MPI's in-tree MPI_T event producers, and the event
+ * type handles the producer raise sites use.  See specs/mpi-t-events/spec.md
+ * section 7.
+ */
+
+#ifndef OMPI_MPIT_EVENTS_H
+#define OMPI_MPIT_EVENTS_H
+
+#include "ompi_config.h"
+
+#include "opal/mca/base/mca_base_event.h"
+
+BEGIN_C_DECLS
+
+/* The "model" element of the ompi.mpi.initialization / ompi.mpi.finalization
+   event payloads uses the public OMPI_T_MODEL_* values from <mpi.h>
+   (OMPI_T_MODEL_WORLD / OMPI_T_MODEL_SESSION).  The world_rank / world_size
+   elements are meaningful only for the world model (a process has no rank in a
+   session) and are -1 otherwise. */
+
+/* Which MPI ABI a registering MPI_T tool is using.  This governs the
+   representation of the MPI object handles carried in event payloads
+   (communicator, window, error-handler, session): the Open MPI ABI uses the
+   internal object pointer; the MPI Standard ABI uses an integer handle.  A
+   process links exactly one ABI, so this is process-global; it is set by
+   MPI_T_event_register_callback() and read by the producer raise sites. */
+typedef enum {
+    OMPI_MPIT_ABI_OMPI = 0,     /* Open MPI ABI: handle == internal object pointer */
+    OMPI_MPIT_ABI_STANDARD = 1  /* MPI Standard ABI: handle == integer handle */
+} ompi_mpit_abi_t;
+
+/* Hard-coded to the Open MPI ABI for now.  When the MPI Standard ABI lands
+   (open-mpi/ompi#13280), its MPI_T_event_register_callback entry point will set
+   this to OMPI_MPIT_ABI_STANDARD, and the producers' "else" branches (marked
+   "TODO ABI") will fill in the Standard-ABI handle values. */
+OMPI_DECLSPEC extern ompi_mpit_abi_t ompi_mpit_callback_abi;
+
+/* Event type handles for the in-tree producers.  NULL until (and unless) the
+   producers are registered, so a raise site must NULL-check before raising. */
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_comm_created;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_comm_freed;
+/* Object-bound (MPI_T_BIND_MPI_COMM): raised for the specific communicator being
+   named, so only registrations bound to that communicator are notified. */
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_comm_name_set;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_initialization;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_finalization;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_errhandler_invoked;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_win_created;
+OMPI_DECLSPEC extern mca_base_event_t *ompi_event_win_freed;
+
+/* Register all in-tree MPI_T event producers (sources + event types).  This is
+   the single core-producer entry point; it is idempotent and one-shot, so it
+   may be called from every path that registers MCA parameters (ompi_info,
+   instance init, MPI_T_init_thread).  Gated by the master MCA parameter
+   mca_base_event_register_producers (default on). */
+OMPI_DECLSPEC void ompi_mpit_register_events(void);
+
+END_C_DECLS
+
+#endif /* OMPI_MPIT_EVENTS_H */

--- a/ompi/runtime/ompi_mpit_register_events.c
+++ b/ompi/runtime/ompi_mpit_register_events.c
@@ -1,0 +1,245 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Registration of Open MPI's in-tree MPI_T event producers (sources and
+ * event types).  The producer raise sites live in their respective
+ * subsystems (the communicator, instance, and error-handler code); this
+ * file only declares the event types and hands back the event-type
+ * handles those sites raise.  See specs/mpi-t-events/spec.md section 7.
+ */
+
+#include "ompi_config.h"
+
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_event.h"
+#include "opal/mca/threads/thread_usage.h"
+
+#include "ompi/runtime/ompi_mpit_events.h"
+
+/* The MPI ABI of the registering MPI_T tool (process-global; see the header).
+   Hard-coded to the Open MPI ABI until open-mpi/ompi#13280. */
+ompi_mpit_abi_t ompi_mpit_callback_abi = OMPI_MPIT_ABI_OMPI;
+
+mca_base_event_t *ompi_event_comm_created = NULL;
+mca_base_event_t *ompi_event_comm_freed = NULL;
+mca_base_event_t *ompi_event_comm_name_set = NULL;
+mca_base_event_t *ompi_event_initialization = NULL;
+mca_base_event_t *ompi_event_finalization = NULL;
+mca_base_event_t *ompi_event_errhandler_invoked = NULL;
+mca_base_event_t *ompi_event_win_created = NULL;
+mca_base_event_t *ompi_event_win_freed = NULL;
+
+/* The default-clock domain the producers advertise (nanoseconds). */
+#define PRODUCER_TICKS_PER_SECOND ((opal_count_t) 1000000000)
+
+static mca_base_event_t *register_event(const char *framework, const char *component,
+                                        const char *name, const char *description,
+                                        mca_base_var_info_lvl_t verbosity, int num_elements,
+                                        const mca_base_var_type_t *types, const ptrdiff_t *offsets,
+                                        mca_base_event_source_t *source)
+{
+    mca_base_event_t *event = NULL;
+    int index = mca_base_event_register("ompi", framework, component, name, description, verbosity,
+                                        num_elements, types, offsets, NULL,
+                                        MCA_BASE_VAR_BIND_NO_OBJECT, 0, source, NULL);
+    if (0 <= index) {
+        (void) mca_base_event_get_by_index(index, &event);
+    }
+    return event;
+}
+
+/* Like register_event, but for an object-bound event type (sec. 6.1).  `bind` is
+   an MCA_BASE_VAR_BIND_* value, reported verbatim to tools as the MPI_T_BIND_*
+   binding (the two enumerations share their ordering); a tool then binds each
+   registration to a specific object via MPI_T_event_handle_alloc. */
+static mca_base_event_t *register_bound_event(const char *name, const char *description,
+                                              mca_base_var_info_lvl_t verbosity, int bind,
+                                              int num_elements, const mca_base_var_type_t *types,
+                                              const ptrdiff_t *offsets,
+                                              mca_base_event_source_t *source)
+{
+    mca_base_event_t *event = NULL;
+    int index = mca_base_event_register("ompi", NULL, NULL, name, description, verbosity,
+                                        num_elements, types, offsets, NULL, bind, 0, source, NULL);
+    if (0 <= index) {
+        (void) mca_base_event_get_by_index(index, &event);
+    }
+    return event;
+}
+
+void ompi_mpit_register_events(void)
+{
+    static int register_producers = 1;
+    int src_index;
+    mca_base_event_source_t *ompi_src, *unordered_src;
+    /* Element layouts.  A trailing uint64 carrying an MPI handle / instance ID
+       is aligned to offset 8 (its natural alignment), so the producer's payload
+       struct and these offsets agree. */
+    const mca_base_var_type_t t_init[5] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_INT32_T,
+                                           MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_INT32_T,
+                                           MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_init[5] = {0, 4, 8, 12, 16};
+    const mca_base_var_type_t t_final[3] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_INT32_T,
+                                            MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_final[3] = {0, 4, 8};
+    const mca_base_var_type_t t_cc[2] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_cc[2] = {0, 8};
+    const mca_base_var_type_t t_cf[1] = {MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_cf[1] = {0};
+    const mca_base_var_type_t t_wc[4] = {MCA_BASE_VAR_TYPE_INT64_T, MCA_BASE_VAR_TYPE_INT32_T,
+                                         MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_wc[4] = {0, 8, 12, 16};
+    const mca_base_var_type_t t_wf[2] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_wf[2] = {0, 8};
+    const mca_base_var_type_t t_eh[4] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_INT32_T,
+                                         MCA_BASE_VAR_TYPE_UINT64_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_eh[4] = {0, 4, 8, 16};
+    const mca_base_var_type_t t_mem[2] = {MCA_BASE_VAR_TYPE_UINT64_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    const ptrdiff_t o_mem[2] = {0, 8};
+
+    /* This entry point is reachable from several MCA-parameter registration
+       paths and across MPI_T_init/finalize cycles.  It does not use a one-shot
+       guard: registration is idempotent by name (mca_base_event_register etc.
+       return the existing index), so a redundant call is cheap, and a call
+       after the event registry was torn down (a finalize that dropped the var
+       system) correctly re-registers -- keeping the exported set stable. */
+    (void) mca_base_var_register("opal", "mca", "base", "event_register_producers",
+                                 "Whether to register Open MPI's built-in MPI_T event "
+                                 "producers (default: enabled)",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &register_producers);
+
+    /* Clear any handles left from a prior registration cycle before (possibly)
+       re-registering.  The OPAL event registry may have been torn down by
+       mca_base_event_finalize() since the last call, freeing the event objects
+       these globals point at; resetting here ensures neither the disabled path
+       below nor a partial (per-source failure) re-registration can leave a
+       raise site holding a dangling pointer. */
+    ompi_event_comm_created = ompi_event_comm_freed = NULL;
+    ompi_event_comm_name_set = NULL;
+    ompi_event_initialization = ompi_event_finalization = NULL;
+    ompi_event_errhandler_invoked = NULL;
+    ompi_event_win_created = ompi_event_win_freed = NULL;
+
+    if (!register_producers) {
+        return;
+    }
+
+    /* All in-tree producers share a single clock domain (the default,
+       MPI_Wtime-equivalent clock).  They are split across only TWO sources, by
+       the one characteristic that actually differs -- ordering:
+
+         "ompi"           ORDERED: every event carries a timestamp from the
+                          monotonic default clock, so timestamps within this
+                          source order the events.  Holds all the lifecycle
+                          events (init/finalize, communicator, window,
+                          error-handler).
+         "ompi.unordered" UNORDERED: the OS memory-release producer aggregates
+                          many underlying releases into one delivered event, so
+                          per-release chronology is not preserved.
+
+       Both support ad-hoc reads (MPI_T_source_get_timestamp): the default clock
+       is freely readable, so a tool can sample it on demand and compare the
+       result to event timestamps FROM THE SAME SOURCE.  (Timestamps are only
+       comparable within a source, and are not directly comparable to MPI_Wtime:
+       same underlying clock, but integer nanoseconds vs. double seconds and a
+       different, lazily-captured epoch.)
+
+       Object handles in payloads (communicator/window/error-handler events) and
+       the instance ID (init/finalize) are the C handle / object pointer value as
+       a uint64 -- an opaque token for identifying and correlating objects (e.g.
+       pairing a "created" event with its "freed", or a "finalization" with its
+       "initialization"); it must not be dereferenced. */
+    src_index = mca_base_event_source_register("ompi", "Open MPI runtime events (ordered)",
+                                               MCA_BASE_EVENT_SOURCE_ORDERED,
+                                               PRODUCER_TICKS_PER_SECOND, OPAL_COUNT_MAX, NULL, true,
+                                               NULL);
+    if (0 <= src_index && OPAL_SUCCESS == mca_base_event_source_get_by_index(src_index, &ompi_src)) {
+        /* MPI initialization / finalization, for BOTH the world model
+           (MPI_Init / MPI_Finalize) and the session model (MPI_Session_init /
+           MPI_Session_finalize), which share the same internal instance path.
+           The "model" element distinguishes them (0 == world, 1 == session);
+           world_rank / world_size are meaningful only when model == world (a
+           process has no rank in a session) and are -1 otherwise.  instance_id
+           correlates a finalization with its initialization. */
+        ompi_event_initialization = register_event(NULL, NULL, "mpi.initialization",
+                                                   "An MPI instance was initialized "
+                                                   "(MPI_Init or MPI_Session_init)",
+                                                   OPAL_INFO_LVL_2, 5, t_init, o_init, ompi_src);
+        ompi_event_finalization = register_event(NULL, NULL, "mpi.finalization",
+                                                 "An MPI instance was finalized "
+                                                 "(MPI_Finalize or MPI_Session_finalize)",
+                                                 OPAL_INFO_LVL_2, 3, t_final, o_final, ompi_src);
+
+        /* Communicator lifecycle.  Payloads carry the MPI_Comm handle for
+           identification (and to pair "created" with "freed"). */
+        ompi_event_comm_created = register_event(NULL, NULL, "mpi.communicator_created",
+                                                 "An MPI communicator was created", OPAL_INFO_LVL_2,
+                                                 2, t_cc, o_cc, ompi_src);
+        ompi_event_comm_freed = register_event(NULL, NULL, "mpi.communicator_freed",
+                                               "An MPI communicator was freed", OPAL_INFO_LVL_2, 1,
+                                               t_cf, o_cf, ompi_src);
+
+        /* Communicator naming (MPI_Comm_set_name).  Object-bound (sec. 6.1): a
+           tool binds a registration to a specific communicator and is notified
+           only when THAT communicator is (re)named.  The payload carries the
+           MPI_Comm handle (== the bound object); the new name is not in the
+           fixed payload -- a callback queries it with MPI_Comm_get_name on the
+           communicator it bound to. */
+        ompi_event_comm_name_set = register_bound_event("mpi.communicator_name_set",
+                                                        "An MPI communicator was named "
+                                                        "(MPI_Comm_set_name)",
+                                                        OPAL_INFO_LVL_4, MCA_BASE_VAR_BIND_MPI_COMM,
+                                                        1, t_cf, o_cf, ompi_src);
+
+        /* Error-handler invocations.  Payload carries the MPI_Errhandler handle
+           and the handle of the MPI object the handler is invoked on. */
+        ompi_event_errhandler_invoked = register_event(NULL, NULL, "mpi.errhandler_invoked",
+                                                       "An MPI error handler was invoked",
+                                                       OPAL_INFO_LVL_4, 4, t_eh, o_eh, ompi_src);
+
+        /* RMA window lifecycle.  Payloads carry the MPI_Win handle. */
+        ompi_event_win_created = register_event(NULL, NULL, "mpi.win_created",
+                                                "An MPI RMA window was created", OPAL_INFO_LVL_4, 4,
+                                                t_wc, o_wc, ompi_src);
+        ompi_event_win_freed = register_event(NULL, NULL, "mpi.win_freed",
+                                              "An MPI RMA window was freed", OPAL_INFO_LVL_4, 2, t_wf,
+                                              o_wf, ompi_src);
+    }
+
+    /* OS-level memory release tracking (sec. 7.1): the source/event are
+       registered here in the OMPI layer; the OPAL memory-release hook (the
+       "patcher" memory component intercepting munmap/brk/etc.) and its
+       never-freed sink live in OPAL and are wired in via
+       mca_base_event_memory_attach().  Registered only where the OPAL memory
+       hooks can report releases (absent, e.g., on platforms with no active
+       memory component).  The hooks are chunk-level (they fire only when memory
+       is actually returned to the OS) and cannot distinguish the releasing API,
+       so the payload is a coarse aggregate: {count, bytes} delivered as one
+       data-bearing event when the framework drains the sink (sec. 7.1). */
+    if (mca_base_event_memory_supported()) {
+        src_index = mca_base_event_source_register("ompi.unordered",
+                                                   "Open MPI unordered events "
+                                                   "(deferred, aggregated delivery)",
+                                                   MCA_BASE_EVENT_SOURCE_UNORDERED,
+                                                   PRODUCER_TICKS_PER_SECOND, OPAL_COUNT_MAX, NULL,
+                                                   true, NULL);
+        if (0 <= src_index
+            && OPAL_SUCCESS == mca_base_event_source_get_by_index(src_index, &unordered_src)) {
+            mca_base_event_t *released
+                = register_event(NULL, NULL, "mca.memory.patcher.released",
+                                 "Memory was released to the OS (aggregate count and bytes)",
+                                 OPAL_INFO_LVL_4, 2, t_mem, o_mem, unordered_src);
+            if (NULL != released) {
+                mca_base_event_memory_attach(unordered_src, released);
+            }
+        }
+    }
+}

--- a/ompi/test/t/Makefile.am
+++ b/ompi/test/t/Makefile.am
@@ -26,6 +26,15 @@ include $(top_srcdir)/Makefile.mca-dso-check
 check_PROGRAMS = \
         mpi_t_category_get_events \
         mpi_t_concurrent_init \
+        mpi_t_errcodes \
+        mpi_t_event_14019 \
+        mpi_t_event_comm_name \
+        mpi_t_event_inert_ok \
+        mpi_t_event_producers \
+        mpi_t_event_reinit \
+        mpi_t_event_selftest \
+        mpi_t_event_smoke \
+        mpi_t_event_world \
         mpi_t_level_no_downgrade \
         mpi_t_level_pinning \
         mpi_t_lifecycle \
@@ -57,6 +66,42 @@ mpi_t_concurrent_init_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 # framework selected (not necessarily pthreads), and are only applied
 # to the wrapper compilers -- they are not AC_SUBSTed for Makefile use.
 mpi_t_concurrent_init_LDADD = $(test_ldadd) -lpthread
+
+mpi_t_errcodes_SOURCES = mpi_t_errcodes.c
+mpi_t_errcodes_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_errcodes_LDADD = $(test_ldadd)
+
+mpi_t_event_14019_SOURCES = mpi_t_event_14019.c
+mpi_t_event_14019_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_14019_LDADD = $(test_ldadd)
+
+mpi_t_event_comm_name_SOURCES = mpi_t_event_comm_name.c
+mpi_t_event_comm_name_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_comm_name_LDADD = $(test_ldadd)
+
+mpi_t_event_inert_ok_SOURCES = mpi_t_event_inert_ok.c
+mpi_t_event_inert_ok_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_inert_ok_LDADD = $(test_ldadd)
+
+mpi_t_event_producers_SOURCES = mpi_t_event_producers.c
+mpi_t_event_producers_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_producers_LDADD = $(test_ldadd)
+
+mpi_t_event_reinit_SOURCES = mpi_t_event_reinit.c
+mpi_t_event_reinit_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_reinit_LDADD = $(test_ldadd)
+
+mpi_t_event_selftest_SOURCES = mpi_t_event_selftest.c
+mpi_t_event_selftest_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_selftest_LDADD = $(test_ldadd)
+
+mpi_t_event_smoke_SOURCES = mpi_t_event_smoke.c
+mpi_t_event_smoke_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_smoke_LDADD = $(test_ldadd)
+
+mpi_t_event_world_SOURCES = mpi_t_event_world.c
+mpi_t_event_world_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_event_world_LDADD = $(test_ldadd)
 
 mpi_t_level_no_downgrade_SOURCES = mpi_t_level_no_downgrade.c mpi_t_lifecycle.h
 mpi_t_level_no_downgrade_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)

--- a/ompi/test/t/mpi_t_errcodes.c
+++ b/ompi/test/t/mpi_t_errcodes.c
@@ -1,0 +1,84 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Singleton regression test for the MPI_T events foundation (Phase 0):
+ *
+ *  - The MPI-4.0 MPI_T error classes MPI_T_ERR_NOT_SUPPORTED and
+ *    MPI_T_ERR_NOT_ACCESSIBLE exist, are distinct from each other and
+ *    from the neighbouring predefined classes, lie within
+ *    MPI_ERR_LASTCODE, and are registered with the error machinery
+ *    (MPI_Error_string resolves each to a distinct, non-empty string).
+ *
+ *  - opal_count_t backs MPI_Count without changing its width: the
+ *    MPI_COUNT datatype size equals sizeof(MPI_Count).  (The
+ *    same-width invariant itself is enforced at build time by a
+ *    _Static_assert in ompi_mpi_init.c; this checks the runtime view.)
+ *
+ * Runs as a 'make check' singleton (singleton MPI_Init needs no
+ * launcher).
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+static void expect(const char *what, int cond)
+{
+    if (cond) {
+        printf("PASS: %s\n", what);
+    } else {
+        ++failures;
+        printf("FAIL: %s\n", what);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+
+    /* The two new classes must be distinct and within range. */
+    expect("MPI_T_ERR_NOT_SUPPORTED != MPI_T_ERR_NOT_ACCESSIBLE",
+           MPI_T_ERR_NOT_SUPPORTED != MPI_T_ERR_NOT_ACCESSIBLE);
+    expect("MPI_T_ERR_NOT_SUPPORTED != MPI_T_ERR_INVALID_NAME",
+           MPI_T_ERR_NOT_SUPPORTED != MPI_T_ERR_INVALID_NAME);
+    expect("MPI_T_ERR_NOT_ACCESSIBLE != MPI_T_ERR_INVALID_NAME",
+           MPI_T_ERR_NOT_ACCESSIBLE != MPI_T_ERR_INVALID_NAME);
+    expect("MPI_T_ERR_NOT_SUPPORTED <= MPI_ERR_LASTCODE",
+           MPI_T_ERR_NOT_SUPPORTED <= MPI_ERR_LASTCODE);
+    expect("MPI_T_ERR_NOT_ACCESSIBLE <= MPI_ERR_LASTCODE",
+           MPI_T_ERR_NOT_ACCESSIBLE <= MPI_ERR_LASTCODE);
+
+    /* Both classes must be registered: MPI_Error_string resolves each
+       to a non-empty string, and the two strings differ (so a copy
+       /paste registration error is caught). */
+    char s1[MPI_MAX_ERROR_STRING], s2[MPI_MAX_ERROR_STRING];
+    int l1 = 0, l2 = 0;
+    MPI_Error_string(MPI_T_ERR_NOT_SUPPORTED, s1, &l1);
+    MPI_Error_string(MPI_T_ERR_NOT_ACCESSIBLE, s2, &l2);
+    printf("string(NOT_SUPPORTED)  = \"%s\"\n", s1);
+    printf("string(NOT_ACCESSIBLE) = \"%s\"\n", s2);
+    expect("MPI_Error_string(NOT_SUPPORTED) is non-empty", l1 > 0);
+    expect("MPI_Error_string(NOT_ACCESSIBLE) is non-empty", l2 > 0);
+    expect("the two error strings differ", 0 != strcmp(s1, s2));
+
+    /* MPI_Count width is unchanged (opal_count_t is a no-op for it). */
+    int tsize = 0;
+    MPI_Type_size(MPI_COUNT, &tsize);
+    printf("MPI_Type_size(MPI_COUNT) = %d ; sizeof(MPI_Count) = %d\n",
+           tsize, (int) sizeof(MPI_Count));
+    expect("MPI_Type_size(MPI_COUNT) == sizeof(MPI_Count)",
+           tsize == (int) sizeof(MPI_Count));
+
+    MPI_Finalize();
+
+    printf("RESULT: %s\n", 0 == failures ? "PASS" : "FAIL");
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_14019.c
+++ b/ompi/test/t/mpi_t_event_14019.c
@@ -1,0 +1,56 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Functional reproducer for open-mpi/ompi#14019 ("MPI_T events not
+ * implemented"): a minimal tool flow -- initialize MPI_T, confirm at least one
+ * event type and source are exported, allocate a handle on the first event,
+ * register a callback, and clean up.  Prints "RESULT: HAS_EVENTS" on success.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+static void noop_cb(MPI_T_event_instance ev, MPI_T_event_registration h, MPI_T_cb_safety s,
+                    void *u)
+{
+    (void) ev; (void) h; (void) s; (void) u;
+}
+
+int main(void)
+{
+    int provided, num_events = 0, num_sources = 0;
+    MPI_T_event_registration reg;
+
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("RESULT: NO_MPI_T\n");
+        return 1;
+    }
+
+    MPI_T_event_get_num(&num_events);
+    MPI_T_source_get_num(&num_sources);
+    if (num_events < 1 || num_sources < 1) {
+        printf("RESULT: NO_EVENTS (events=%d sources=%d)\n", num_events, num_sources);
+        MPI_T_finalize();
+        return 1;
+    }
+
+    if (MPI_SUCCESS != MPI_T_event_handle_alloc(0, NULL, MPI_INFO_NULL, &reg)
+        || MPI_SUCCESS
+               != MPI_T_event_register_callback(reg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                noop_cb)) {
+        printf("RESULT: HANDLE_FAILED\n");
+        MPI_T_finalize();
+        return 1;
+    }
+    MPI_T_event_handle_free(reg, NULL, NULL);
+
+    MPI_T_finalize();
+    printf("RESULT: HAS_EVENTS (events=%d sources=%d)\n", num_events, num_sources);
+    return 0;
+}

--- a/ompi/test/t/mpi_t_event_comm_name.c
+++ b/ompi/test/t/mpi_t_event_comm_name.c
@@ -1,0 +1,123 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Coverage for the object-bound ompi.mpi.communicator_name_set event.  Unlike
+ * the other producer events (which are NO_OBJECT and reach every registration),
+ * this event is bound to a specific communicator: a tool allocates a
+ * registration handle bound to one MPI_Comm and is notified ONLY when THAT
+ * communicator is named.  We bind one registration to each of two communicators
+ * and confirm that naming one fires only its own bound callback, that the
+ * payload carries that communicator's handle, and that the new name is queryable
+ * on the bound communicator (the fixed payload does not carry the name string).
+ */
+
+#include "opal_config.h"
+
+#include <mpi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int      failures = 0;
+static int      a_fired = 0;
+static int      b_fired = 0;
+static uint64_t a_handle = 0;
+
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+static void cb_a(MPI_T_event_instance ev,
+                 MPI_T_event_registration h __opal_attribute_unused__,
+                 MPI_T_cb_safety s __opal_attribute_unused__,
+                 void *u __opal_attribute_unused__)
+{
+    ++a_fired;
+    (void) MPI_T_event_read(ev, 0, &a_handle);
+}
+
+static void cb_b(MPI_T_event_instance ev __opal_attribute_unused__,
+                 MPI_T_event_registration h __opal_attribute_unused__,
+                 MPI_T_cb_safety s __opal_attribute_unused__,
+                 void *u __opal_attribute_unused__)
+{
+    ++b_fired;
+}
+
+int main(int argc, char **argv)
+{
+    int provided, idx, rlen;
+    MPI_Comm comm_a, comm_b;
+    MPI_T_event_registration reg_a, reg_b;
+    char namebuf[MPI_MAX_OBJECT_NAME];
+
+    if (MPI_SUCCESS != MPI_Init(&argc, &argv)) {
+        printf("SKIP: MPI_Init failed (no singleton support here)\n");
+        return 77;
+    }
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("SKIP: MPI_T_init_thread failed\n");
+        MPI_Finalize();
+        return 77;
+    }
+    if (MPI_SUCCESS != MPI_T_event_get_index("ompi.mpi.communicator_name_set", &idx)) {
+        printf("SKIP: ompi.mpi.communicator_name_set event not registered\n");
+        MPI_T_finalize();
+        MPI_Finalize();
+        return 77;
+    }
+
+    MPI_Comm_dup(MPI_COMM_SELF, &comm_a);
+    MPI_Comm_dup(MPI_COMM_SELF, &comm_b);
+
+    /* Bind one registration to each communicator (obj_handle is the ADDRESS of
+       the MPI_Comm handle variable). */
+    expect("alloc handle bound to comm_a",
+           MPI_SUCCESS == MPI_T_event_handle_alloc(idx, &comm_a, MPI_INFO_NULL, &reg_a));
+    expect("alloc handle bound to comm_b",
+           MPI_SUCCESS == MPI_T_event_handle_alloc(idx, &comm_b, MPI_INFO_NULL, &reg_b));
+    (void) MPI_T_event_register_callback(reg_a, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL, cb_a);
+    (void) MPI_T_event_register_callback(reg_b, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL, cb_b);
+
+    /* Name comm_a: only comm_a's bound registration is notified. */
+    a_fired = b_fired = 0;
+    a_handle = 0;
+    MPI_Comm_set_name(comm_a, "alpha");
+    expect("naming comm_a fired its bound callback exactly once", 1 == a_fired);
+    expect("naming comm_a did NOT fire comm_b's bound callback", 0 == b_fired);
+    expect("name_set payload handle is comm_a's MPI_Comm handle",
+           a_handle == (uint64_t) (uintptr_t) comm_a);
+
+    /* The new name is queryable on the bound communicator. */
+    rlen = 0;
+    namebuf[0] = '\0';
+    MPI_Comm_get_name(comm_a, namebuf, &rlen);
+    expect("MPI_Comm_get_name on the bound communicator returns the new name",
+           0 == strcmp(namebuf, "alpha"));
+
+    /* Name comm_b: only comm_b's bound registration is notified. */
+    a_fired = b_fired = 0;
+    MPI_Comm_set_name(comm_b, "beta");
+    expect("naming comm_b fired its bound callback exactly once", 1 == b_fired);
+    expect("naming comm_b did NOT fire comm_a's bound callback", 0 == a_fired);
+
+    (void) MPI_T_event_handle_free(reg_a, NULL, NULL);
+    (void) MPI_T_event_handle_free(reg_b, NULL, NULL);
+    MPI_Comm_free(&comm_a);
+    MPI_Comm_free(&comm_b);
+    MPI_T_finalize();
+    MPI_Finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_inert_ok.c
+++ b/ompi/test/t/mpi_t_event_inert_ok.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * With all in-tree producers disabled, the event interface must be inert but
+ * correct: zero events/sources, and the standard error contracts hold.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int failures = 0;
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+int main(void)
+{
+    int provided, num = -1, idx = -1, nevents = -1;
+
+    /* Disable the master producer switch before MPI_T initialization. */
+    setenv("OMPI_MCA_mca_base_event_register_producers", "0", 1);
+
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("FAIL: MPI_T_init_thread\nRESULT: FAIL\n");
+        return 1;
+    }
+
+    (void) MPI_T_event_get_num(&num);
+    expect("event count is 0 with producers disabled", 0 == num);
+    (void) MPI_T_source_get_num(&num);
+    expect("source count is 0 with producers disabled", 0 == num);
+
+    expect("event_get_info(0) -> INVALID_INDEX",
+           MPI_T_ERR_INVALID_INDEX
+               == MPI_T_event_get_info(0, NULL, NULL, NULL, NULL, NULL, &num, NULL, NULL, NULL,
+                                       NULL, NULL));
+    expect("event_get_index -> INVALID_NAME",
+           MPI_T_ERR_INVALID_NAME == MPI_T_event_get_index("anything", &idx));
+
+    /* A valid category still reports zero events. */
+    if (MPI_SUCCESS == MPI_T_category_get_num_events(0, &nevents)) {
+        expect("category_get_num_events(valid) == 0", 0 == nevents);
+    }
+
+    MPI_T_finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_producers.c
+++ b/ompi/test/t/mpi_t_event_producers.c
@@ -1,0 +1,357 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Singleton test for the in-tree MPI_T event producers: after MPI_Init the
+ * built-in event types must be registered, and a real MPI operation must drive
+ * the corresponding producer.  It registers callbacks on the communicator,
+ * error-handler, and RMA window producers and confirms they fire with the
+ * expected payloads (including the MPI object handles) across MPI_Comm_dup/free,
+ * a returning error handler, and MPI_Win_create/free.  It also exercises the
+ * initialization/finalization events via the session model -- checking the
+ * model element and that the instance ID correlates finalization with
+ * initialization -- and checks the two-source layout: "ompi" is ORDERED and
+ * "ompi.unordered" is UNORDERED.
+ */
+
+#include "opal_config.h"
+
+#include <mpi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+static int      created_fired = 0;
+static int      freed_fired = 0;
+static int32_t  created_size = -1;
+static uint64_t created_handle = 0;
+static uint64_t freed_handle = 0;
+
+static int      init_fired = 0;
+static int      final_fired = 0;
+static int32_t  init_model = -1;
+static int32_t  init_world_rank = 999;
+static int32_t  init_world_size = 999;
+static uint64_t init_instance_id = 0;
+static int32_t  final_model = -1;
+static int32_t  final_world_rank = 999;
+static uint64_t final_instance_id = 0;
+
+static int      errh_fired = 0;
+static int32_t  errh_object_type = -1;
+static uint64_t errh_errhandler_handle = 0;
+static uint64_t errh_object_handle = 0;
+
+static int      win_created_fired = 0;
+static int      win_freed_fired = 0;
+static int64_t  win_size = -1;
+static int32_t  win_disp = -1;
+static int32_t  win_flavor = -1;
+static uint64_t win_created_handle = 0;
+static uint64_t win_freed_handle = 0;
+
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+static void created_cb(MPI_T_event_instance ev,
+                       MPI_T_event_registration h __opal_attribute_unused__,
+                       MPI_T_cb_safety s __opal_attribute_unused__,
+                       void *u __opal_attribute_unused__)
+{
+    ++created_fired;
+    (void) MPI_T_event_read(ev, 0, &created_size);    /* int32 size        */
+    (void) MPI_T_event_read(ev, 1, &created_handle);  /* uint64 MPI_Comm   */
+}
+
+static void freed_cb(MPI_T_event_instance ev,
+                     MPI_T_event_registration h __opal_attribute_unused__,
+                     MPI_T_cb_safety s __opal_attribute_unused__,
+                     void *u __opal_attribute_unused__)
+{
+    ++freed_fired;
+    (void) MPI_T_event_read(ev, 0, &freed_handle);    /* uint64 MPI_Comm   */
+}
+
+static void init_cb(MPI_T_event_instance ev,
+                    MPI_T_event_registration h __opal_attribute_unused__,
+                    MPI_T_cb_safety s __opal_attribute_unused__,
+                    void *u __opal_attribute_unused__)
+{
+    ++init_fired;
+    (void) MPI_T_event_read(ev, 0, &init_model);
+    (void) MPI_T_event_read(ev, 2, &init_world_rank); /* -1 for a session  */
+    (void) MPI_T_event_read(ev, 3, &init_world_size); /* -1 for a session  */
+    (void) MPI_T_event_read(ev, 4, &init_instance_id);
+}
+
+static void final_cb(MPI_T_event_instance ev,
+                     MPI_T_event_registration h __opal_attribute_unused__,
+                     MPI_T_cb_safety s __opal_attribute_unused__,
+                     void *u __opal_attribute_unused__)
+{
+    ++final_fired;
+    (void) MPI_T_event_read(ev, 0, &final_model);
+    (void) MPI_T_event_read(ev, 1, &final_world_rank);
+    (void) MPI_T_event_read(ev, 2, &final_instance_id);
+}
+
+static void errh_cb(MPI_T_event_instance ev,
+                    MPI_T_event_registration h __opal_attribute_unused__,
+                    MPI_T_cb_safety s __opal_attribute_unused__,
+                    void *u __opal_attribute_unused__)
+{
+    ++errh_fired;
+    (void) MPI_T_event_read(ev, 1, &errh_object_type);
+    (void) MPI_T_event_read(ev, 2, &errh_errhandler_handle);
+    (void) MPI_T_event_read(ev, 3, &errh_object_handle);
+}
+
+static void win_created_cb(MPI_T_event_instance ev,
+                           MPI_T_event_registration h __opal_attribute_unused__,
+                           MPI_T_cb_safety s __opal_attribute_unused__,
+                           void *u __opal_attribute_unused__)
+{
+    ++win_created_fired;
+    (void) MPI_T_event_read(ev, 0, &win_size);          /* int64 local size  */
+    (void) MPI_T_event_read(ev, 1, &win_disp);          /* int32 disp_unit   */
+    (void) MPI_T_event_read(ev, 2, &win_flavor);        /* int32 win flavor  */
+    (void) MPI_T_event_read(ev, 3, &win_created_handle); /* uint64 MPI_Win   */
+}
+
+static void win_freed_cb(MPI_T_event_instance ev,
+                         MPI_T_event_registration h __opal_attribute_unused__,
+                         MPI_T_cb_safety s __opal_attribute_unused__,
+                         void *u __opal_attribute_unused__)
+{
+    ++win_freed_fired;
+    (void) MPI_T_event_read(ev, 1, &win_freed_handle);  /* uint64 MPI_Win    */
+}
+
+/* Find an event whose name contains both substrings; -1 if none. */
+static int find_event(int num, const char *a, const char *b)
+{
+    int i;
+    for (i = 0; i < num; ++i) {
+        char name[256];
+        int name_len = sizeof(name), nelem = 0;
+        if (MPI_SUCCESS
+            == MPI_T_event_get_info(i, name, &name_len, NULL, NULL, NULL, &nelem, NULL, NULL,
+                                    NULL, NULL, NULL)) {
+            if (NULL != strstr(name, a) && NULL != strstr(name, b)) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    int provided, num = 0, created_idx, freed_idx;
+    MPI_T_event_registration creg, freg;
+    MPI_Comm dup;
+
+    if (MPI_SUCCESS != MPI_Init(&argc, &argv)) {
+        printf("SKIP: MPI_Init failed (no singleton support here)\n");
+        return 77;
+    }
+    (void) MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
+
+    (void) MPI_T_event_get_num(&num);
+    expect("at least the built-in producers are registered", num >= 7);
+
+    created_idx = find_event(num, "communicator", "created");
+    freed_idx = find_event(num, "communicator", "freed");
+    expect("communicator-created event is registered", created_idx >= 0);
+    expect("communicator-freed event is registered", freed_idx >= 0);
+
+    if (created_idx >= 0 && freed_idx >= 0) {
+        expect("alloc created handle",
+               MPI_SUCCESS == MPI_T_event_handle_alloc(created_idx, NULL, MPI_INFO_NULL, &creg));
+        expect("alloc freed handle",
+               MPI_SUCCESS == MPI_T_event_handle_alloc(freed_idx, NULL, MPI_INFO_NULL, &freg));
+        (void) MPI_T_event_register_callback(creg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                             created_cb);
+        (void) MPI_T_event_register_callback(freg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                             freed_cb);
+
+        created_fired = freed_fired = 0;
+        created_handle = freed_handle = 0;
+        MPI_Comm_dup(MPI_COMM_WORLD, &dup);
+        expect("communicator-created fired on MPI_Comm_dup", created_fired >= 1);
+        expect("created payload carries the new comm size", 1 == created_size);
+        expect("created payload carries the MPI_Comm handle", created_handle == (uint64_t) (uintptr_t) dup);
+
+        MPI_Comm_free(&dup);
+        expect("communicator-freed fired on MPI_Comm_free", freed_fired >= 1);
+        expect("freed handle pairs with the created handle", freed_handle == created_handle);
+
+        /* The non-blocking creation path (MPI_Comm_idup) must also raise the
+           created event, so it pairs with the freed event the same way the
+           blocking path does. */
+        {
+            MPI_Comm idup;
+            MPI_Request req;
+            created_fired = freed_fired = 0;
+            MPI_Comm_idup(MPI_COMM_SELF, &idup, &req);
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+            expect("communicator-created fired on MPI_Comm_idup", created_fired >= 1);
+            MPI_Comm_free(&idup);
+            expect("communicator-freed fired after MPI_Comm_idup", freed_fired >= 1);
+        }
+
+        (void) MPI_T_event_handle_free(creg, NULL, NULL);
+        (void) MPI_T_event_handle_free(freg, NULL, NULL);
+    }
+
+    /* Initialization/finalization producer: ompi.mpi.initialization and
+       ompi.mpi.finalization fire for BOTH MPI models.  The world-model events
+       fire during MPI_Init/MPI_Finalize (outside this test's observation
+       window), so drive them here via the session model, which works in a
+       singleton, and confirm the model element says "session" with
+       world_rank/size = -1 (a process has no rank in a session) and that the
+       instance ID correlates finalization with initialization. */
+    {
+        int init_idx = find_event(num, "initialization", "");
+        int final_idx = find_event(num, "finalization", "");
+        expect("initialization event is registered", init_idx >= 0);
+        expect("finalization event is registered", final_idx >= 0);
+        if (init_idx >= 0 && final_idx >= 0) {
+            MPI_T_event_registration ireg, freg2;
+            MPI_Session session;
+            (void) MPI_T_event_handle_alloc(init_idx, NULL, MPI_INFO_NULL, &ireg);
+            (void) MPI_T_event_handle_alloc(final_idx, NULL, MPI_INFO_NULL, &freg2);
+            (void) MPI_T_event_register_callback(ireg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                 init_cb);
+            (void) MPI_T_event_register_callback(freg2, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                 final_cb);
+            init_fired = final_fired = 0;
+            init_instance_id = final_instance_id = 0;
+            MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &session);
+            expect("initialization fired on MPI_Session_init", init_fired >= 1);
+            expect("initialization model says session", OMPI_T_MODEL_SESSION == init_model);
+            expect("initialization world_rank is -1 for a session", -1 == init_world_rank);
+            expect("initialization world_size is -1 for a session", -1 == init_world_size);
+            expect("initialization carries a non-zero instance id", 0 != init_instance_id);
+            MPI_Session_finalize(&session);
+            expect("finalization fired on MPI_Session_finalize", final_fired >= 1);
+            expect("finalization model says session", OMPI_T_MODEL_SESSION == final_model);
+            expect("finalization world_rank is -1 for a session", -1 == final_world_rank);
+            expect("finalization instance id correlates with initialization",
+                   final_instance_id == init_instance_id);
+            (void) MPI_T_event_handle_free(ireg, NULL, NULL);
+            (void) MPI_T_event_handle_free(freg2, NULL, NULL);
+        }
+    }
+
+    /* Error-handler producer: errhandler.invoked fires whenever an MPI error
+       handler runs.  Trigger one with a returning handler (no abort) on
+       MPI_COMM_SELF and confirm the payload identifies the object. */
+    {
+        int eidx = find_event(num, "errhandler", "invoked");
+        expect("errhandler-invoked event registered", eidx >= 0);
+        if (eidx >= 0) {
+            MPI_T_event_registration ereg;
+            int dummy = 0;
+            (void) MPI_T_event_handle_alloc(eidx, NULL, MPI_INFO_NULL, &ereg);
+            (void) MPI_T_event_register_callback(ereg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                 errh_cb);
+            errh_fired = 0;
+            errh_object_handle = 0;
+            MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_RETURN);
+            /* An invalid count is rejected and routed to the comm's (returning)
+               error handler, which raises errhandler.invoked. */
+            (void) MPI_Bcast(&dummy, -1, MPI_INT, 0, MPI_COMM_SELF);
+            expect("errhandler-invoked fired when an error handler ran", errh_fired >= 1);
+            expect("errhandler payload object_type is MPI_T_BIND_MPI_COMM",
+                   MPI_T_BIND_MPI_COMM == errh_object_type);
+            expect("errhandler payload carries the MPI object handle (MPI_COMM_SELF)",
+                   errh_object_handle == (uint64_t) (uintptr_t) MPI_COMM_SELF);
+            expect("errhandler payload carries a non-zero errhandler handle",
+                   0 != errh_errhandler_handle);
+            (void) MPI_T_event_handle_free(ereg, NULL, NULL);
+        }
+    }
+
+    /* RMA window producer: window-created/freed fire on MPI_Win_create/free.
+       The "created" payload is {size, disp_unit, flavor, handle}. */
+    {
+        int wc_idx = find_event(num, "win", "created");
+        int wf_idx = find_event(num, "win", "freed");
+        expect("window-created event registered", wc_idx >= 0);
+        expect("window-freed event registered", wf_idx >= 0);
+        if (wc_idx >= 0 && wf_idx >= 0) {
+            MPI_T_event_registration wcreg, wfreg;
+            MPI_Win win;
+            int buf[16];
+            (void) MPI_T_event_handle_alloc(wc_idx, NULL, MPI_INFO_NULL, &wcreg);
+            (void) MPI_T_event_handle_alloc(wf_idx, NULL, MPI_INFO_NULL, &wfreg);
+            (void) MPI_T_event_register_callback(wcreg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                 win_created_cb);
+            (void) MPI_T_event_register_callback(wfreg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                                 win_freed_cb);
+            win_created_fired = win_freed_fired = 0;
+            win_created_handle = win_freed_handle = 0;
+            MPI_Win_create(buf, sizeof(buf), 4, MPI_INFO_NULL, MPI_COMM_SELF, &win);
+            expect("window-created fired on MPI_Win_create", win_created_fired >= 1);
+            expect("created payload carries the local size", (int64_t) sizeof(buf) == win_size);
+            expect("created payload carries the disp_unit", 4 == win_disp);
+            expect("created payload carries the flavor", MPI_WIN_FLAVOR_CREATE == win_flavor);
+            expect("created payload carries the MPI_Win handle",
+                   win_created_handle == (uint64_t) (uintptr_t) win);
+            MPI_Win_free(&win);
+            expect("window-freed fired on MPI_Win_free", win_freed_fired >= 1);
+            expect("freed handle pairs with the created handle",
+                   win_freed_handle == win_created_handle);
+            (void) MPI_T_event_handle_free(wcreg, NULL, NULL);
+            (void) MPI_T_event_handle_free(wfreg, NULL, NULL);
+        }
+    }
+
+    /* The in-tree producers use exactly two sources, distinguished by ordering:
+       the consolidated "ompi" source is ORDERED (it carries every lifecycle
+       event, including the error handler), and "ompi.unordered" -- present only
+       where the OS memory-release hooks are supported -- is UNORDERED. */
+    {
+        int ns = 0, i, found_ordered = -1, found_unordered = -1;
+        (void) MPI_T_source_get_num(&ns);
+        for (i = 0; i < ns; ++i) {
+            char sname[256];
+            int slen = sizeof(sname);
+            MPI_T_source_order ordering = MPI_T_SOURCE_ORDERED;
+            MPI_Count tps = 0, mt = 0;
+            if (MPI_SUCCESS
+                != MPI_T_source_get_info(i, sname, &slen, NULL, NULL, &ordering, &tps, &mt, NULL)) {
+                continue;
+            }
+            if (0 == strcmp(sname, "ompi")) {
+                found_ordered = i;
+                expect("the ompi source is ORDERED", MPI_T_SOURCE_ORDERED == ordering);
+            } else if (0 == strcmp(sname, "ompi.unordered")) {
+                found_unordered = i;
+                expect("the ompi.unordered source is UNORDERED",
+                       MPI_T_SOURCE_UNORDERED == ordering);
+            }
+        }
+        expect("found the ompi (ordered) source", found_ordered >= 0);
+        (void) found_unordered; /* ompi.unordered is platform-dependent */
+    }
+
+    MPI_T_finalize();
+    MPI_Finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_reinit.c
+++ b/ompi/test/t/mpi_t_event_reinit.c
@@ -1,0 +1,63 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Repeated MPI_T_init_thread / MPI_T_finalize must leave the event registry
+ * stable: the same counts and the same name->index mapping (registration is
+ * idempotent by name and one-shot).
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+static int snapshot(int *num_events, int *num_sources, char *first_name, int first_name_cap)
+{
+    int provided, rc;
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        return 0;
+    }
+    (void) MPI_T_event_get_num(num_events);
+    (void) MPI_T_source_get_num(num_sources);
+    first_name[0] = '\0';
+    if (*num_events > 0) {
+        int nl = first_name_cap, ne = 0;
+        rc = MPI_T_event_get_info(0, first_name, &nl, NULL, NULL, NULL, &ne, NULL, NULL, NULL,
+                                  NULL, NULL);
+        (void) rc;
+    }
+    MPI_T_finalize();
+    return 1;
+}
+
+int main(void)
+{
+    int n1 = 0, s1 = 0, n2 = 0, s2 = 0;
+    char name1[256], name2[256];
+
+    if (!snapshot(&n1, &s1, name1, sizeof(name1)) || !snapshot(&n2, &s2, name2, sizeof(name2))) {
+        printf("FAIL: MPI_T_init_thread\nRESULT: FAIL\n");
+        return 1;
+    }
+
+    expect("event count stable across init/finalize", n1 == n2);
+    expect("source count stable across init/finalize", s1 == s2);
+    expect("event index 0 maps to the same name", 0 == strcmp(name1, name2));
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_selftest.c
+++ b/ompi/test/t/mpi_t_event_selftest.c
@@ -1,0 +1,302 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Self-contained MPI_T events test: the test program itself acts as an event
+ * *producer*, registering its own event source(s) and event type(s) through the
+ * internal mca_base_event_* API, then driving every MPI_T-level path against
+ * them.  This keeps the tool-facing paths covered without relying on any shipped
+ * (and possibly platform-dependent) producer:
+ *
+ *   1. ad-hoc MPI_T_source_get_timestamp on a default-clock source, read
+ *      BEFORE any handle is allocated -- so the clock origin is captured on the
+ *      read itself, not left at zero (a zero origin would return a timestamp in
+ *      the wrong epoch);
+ *   2. MPI_T_ERR_NOT_SUPPORTED from a source without ad-hoc timestamp support;
+ *   3. safety-level dropping: a NONE callback is delivered at a NONE-context
+ *      raise but dropped at a THREAD_SAFE-context raise, and the dropped-event
+ *      handler reports the accumulated count at handle_free;
+ *   4. a multi-field payload read element-by-element and copied whole, plus the
+ *      in-callback MPI_T_event_get_source accessor.
+ */
+
+#include <mpi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "opal/constants.h"
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_event.h"
+
+static int       failures = 0;
+static int       cb_fired = 0;
+static int       dropped_fired = 0;
+static MPI_Count dropped_count = 0;
+static int32_t   ms_a = 0;
+static int64_t   ms_b = 0;
+static uint32_t  ms_c = 0;
+static int       got_source = -1;
+static int       copy_ok = 0;
+static int       copy_canary_ok = 0;
+
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+static void lossy_cb(MPI_T_event_instance ev __opal_attribute_unused__,
+                     MPI_T_event_registration h __opal_attribute_unused__,
+                     MPI_T_cb_safety s __opal_attribute_unused__,
+                     void *u __opal_attribute_unused__)
+{
+    ++cb_fired;
+}
+
+static void dropped_cb(MPI_Count count, MPI_T_event_registration h __opal_attribute_unused__,
+                       int src __opal_attribute_unused__, MPI_T_cb_safety s __opal_attribute_unused__,
+                       void *u __opal_attribute_unused__)
+{
+    ++dropped_fired;
+    dropped_count = count;
+}
+
+static void multi_cb(MPI_T_event_instance ev,
+                     MPI_T_event_registration h __opal_attribute_unused__,
+                     MPI_T_cb_safety s __opal_attribute_unused__,
+                     void *u __opal_attribute_unused__)
+{
+    struct {
+        int32_t  a;
+        int32_t  pad;
+        int64_t  b;
+        uint32_t c;
+    } buf;
+    (void) MPI_T_event_read(ev, 0, &ms_a);
+    (void) MPI_T_event_read(ev, 1, &ms_b);
+    (void) MPI_T_event_read(ev, 2, &ms_c);
+    (void) MPI_T_event_get_source(ev, &got_source);
+    memset(&buf, 0, sizeof(buf));
+    if (MPI_SUCCESS == MPI_T_event_copy(ev, &buf)) {
+        copy_ok = (buf.a == ms_a && buf.b == ms_b && buf.c == ms_c);
+    }
+
+    /* Regression: a conforming tool sizes its buffer to the un-rounded element
+       extent (here 20 bytes = offset 16 + a 4-byte uint32), so event_copy must
+       not write past it -- it must not memset the internally 8-byte-rounded
+       buffer_size (24).  Copy into a buffer whose bytes from offset 20 on are a
+       canary and confirm they survive. */
+    {
+        unsigned char guarded[32];
+        memset(guarded, 0x5a, sizeof(guarded));
+        if (MPI_SUCCESS == MPI_T_event_copy(ev, guarded)) {
+            int k;
+            copy_canary_ok = 1;
+            for (k = 20; k < (int) sizeof(guarded); ++k) {
+                if (0x5a != guarded[k]) {
+                    copy_canary_ok = 0;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/* Find an event whose name contains both substrings; -1 if none. */
+static int find_event(int num, const char *a, const char *b)
+{
+    for (int i = 0; i < num; ++i) {
+        char name[256];
+        int nl = sizeof(name), ne = 0;
+        if (MPI_SUCCESS
+                == MPI_T_event_get_info(i, name, &nl, NULL, NULL, NULL, &ne, NULL, NULL, NULL, NULL,
+                                        NULL)
+            && NULL != strstr(name, a) && NULL != strstr(name, b)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    int provided, ev_num = 0, src_num = 0;
+    int src_a, src_b, lossy_idx, multi_idx;
+    mca_base_event_source_t *sp = NULL;
+    mca_base_event_t *lossy_ev = NULL, *multi_ev = NULL;
+
+    const mca_base_var_type_t lossy_types[1] = {MCA_BASE_VAR_TYPE_INT32_T};
+    const ptrdiff_t lossy_off[1] = {0};
+    const mca_base_var_type_t multi_types[3] = {MCA_BASE_VAR_TYPE_INT32_T,
+                                                MCA_BASE_VAR_TYPE_INT64_T,
+                                                MCA_BASE_VAR_TYPE_UINT32_T};
+    const ptrdiff_t multi_off[3] = {0, 8, 16};
+
+    if (MPI_SUCCESS != MPI_Init(&argc, &argv)) {
+        printf("SKIP: MPI_Init failed (no singleton support here)\n");
+        return 77;
+    }
+    (void) MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);
+
+    /* ---- The test registers its OWN source(s) and event type(s). ---- */
+    src_a = mca_base_event_source_register("test.selftest", "self-test default-clock source",
+                                           MCA_BASE_EVENT_SOURCE_ORDERED, (opal_count_t) 1000000000,
+                                           (opal_count_t) INT64_MAX, NULL, true, NULL);
+    src_b = mca_base_event_source_register("test.selftest.noclock", "self-test no-adhoc source",
+                                           MCA_BASE_EVENT_SOURCE_ORDERED, (opal_count_t) 1000000000,
+                                           (opal_count_t) INT64_MAX, NULL, false, NULL);
+    expect("test source A (ad-hoc) registered", src_a >= 0);
+    expect("test source B (no ad-hoc) registered", src_b >= 0);
+    expect("got source A pointer",
+           src_a >= 0 && OPAL_SUCCESS == mca_base_event_source_get_by_index(src_a, &sp));
+
+    if (NULL != sp) {
+        lossy_idx = mca_base_event_register("test", "selftest", "base", "lossy",
+                                            "self-test lossy event", OPAL_INFO_LVL_4, 1, lossy_types,
+                                            lossy_off, NULL, MCA_BASE_VAR_BIND_NO_OBJECT, 0, sp, NULL);
+        multi_idx = mca_base_event_register("test", "selftest", "base", "multi",
+                                            "self-test multi-field event", OPAL_INFO_LVL_4, 3,
+                                            multi_types, multi_off, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                            0, sp, NULL);
+        expect("test lossy event registered", lossy_idx >= 0);
+        expect("test multi event registered", multi_idx >= 0);
+        (void) mca_base_event_get_by_index(lossy_idx, &lossy_ev);
+        (void) mca_base_event_get_by_index(multi_idx, &multi_ev);
+    }
+
+    /* The test producer must now be visible through the MPI_T enumeration. */
+    (void) MPI_T_event_get_num(&ev_num);
+    (void) MPI_T_source_get_num(&src_num);
+    expect("MPI_T enumerates the test lossy event", find_event(ev_num, "selftest", "lossy") >= 0);
+    expect("MPI_T enumerates the test multi event", find_event(ev_num, "selftest", "multi") >= 0);
+    expect("MPI_T enumerates the test sources", src_num > src_a && src_num > src_b);
+
+    /* ---- 1. Ad-hoc timestamp on the default clock, read BEFORE any handle is
+       allocated, so the origin is captured on this read (not left at zero). ---- */
+    if (src_a >= 0) {
+        MPI_Count ts1 = -1, ts2 = -1;
+        int rc1 = MPI_T_source_get_timestamp(src_a, &ts1);
+        int rc2 = MPI_T_source_get_timestamp(src_a, &ts2);
+        expect("ad-hoc source_get_timestamp returns MPI_SUCCESS", MPI_SUCCESS == rc1);
+        /* A captured origin yields a tiny value; a zero origin would yield
+           ~1.7e18 ns (since the Unix epoch).  Reject the latter. */
+        expect("ad-hoc timestamp is relative to the source origin, not the epoch",
+               ts1 >= 0 && ts1 < (MPI_Count) 1000000000000000LL);
+        expect("ad-hoc timestamp is monotonic", MPI_SUCCESS == rc2 && ts2 >= ts1);
+    }
+
+    /* ---- 2. A source without ad-hoc support reports NOT_SUPPORTED. ---- */
+    if (src_b >= 0) {
+        MPI_Count ts = -1;
+        int rc = MPI_T_source_get_timestamp(src_b, &ts);
+        expect("no-adhoc source_get_timestamp returns MPI_T_ERR_NOT_SUPPORTED",
+               MPI_T_ERR_NOT_SUPPORTED == rc);
+    }
+
+    /* ---- 3. Safety-level dropping + the dropped-event handler. ---- */
+    if (NULL != lossy_ev) {
+        const int deliver = 3, drop = 5;
+        MPI_T_event_registration reg;
+        int32_t v = 7;
+        lossy_idx = find_event(ev_num, "selftest", "lossy");
+        (void) MPI_T_event_handle_alloc(lossy_idx, NULL, MPI_INFO_NULL, &reg);
+        (void) MPI_T_event_register_callback(reg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                             lossy_cb);
+        (void) MPI_T_event_set_dropped_handler(reg, dropped_cb);
+
+        cb_fired = dropped_fired = 0;
+        dropped_count = 0;
+        /* Delivered: a NONE callback is selectable at a NONE-context raise. */
+        for (int i = 0; i < deliver; ++i) {
+            mca_base_event_raise(lossy_ev, NULL, &v);
+        }
+        /* Dropped: the same NONE callback cannot be selected at a THREAD_SAFE
+           raise, so every one of these is accounted as a drop. */
+        for (int i = 0; i < drop; ++i) {
+            mca_base_event_raise_internal(lossy_ev, NULL, NULL, &v,
+                                          MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+        }
+        expect("NONE callback delivered at a NONE-context raise", cb_fired == deliver);
+
+        /* Info round-trip on the live handle and its NONE-level callback:
+           get_info hands back a fresh, user-freeable MPI_Info (never
+           MPI_INFO_NULL); set_info with MPI_INFO_NULL is accepted.  The
+           callback-info calls use the level the callback was registered at. */
+        {
+            MPI_Info hinfo = MPI_INFO_NULL, cinfo = MPI_INFO_NULL;
+            expect("event_handle_get_info returns MPI_SUCCESS",
+                   MPI_SUCCESS == MPI_T_event_handle_get_info(reg, &hinfo));
+            expect("event_handle_get_info returns a non-null info", MPI_INFO_NULL != hinfo);
+            if (MPI_INFO_NULL != hinfo) {
+                MPI_Info_free(&hinfo);
+            }
+            expect("event_callback_get_info returns MPI_SUCCESS",
+                   MPI_SUCCESS
+                       == MPI_T_event_callback_get_info(reg, MPI_T_CB_REQUIRE_NONE, &cinfo));
+            expect("event_callback_get_info returns a non-null info", MPI_INFO_NULL != cinfo);
+            if (MPI_INFO_NULL != cinfo) {
+                MPI_Info_free(&cinfo);
+            }
+            expect("event_handle_set_info(MPI_INFO_NULL) returns MPI_SUCCESS",
+                   MPI_SUCCESS == MPI_T_event_handle_set_info(reg, MPI_INFO_NULL));
+            expect("event_callback_set_info(MPI_INFO_NULL) returns MPI_SUCCESS",
+                   MPI_SUCCESS
+                       == MPI_T_event_callback_set_info(reg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL));
+        }
+
+        (void) MPI_T_event_handle_free(reg, NULL, NULL);
+        expect("dropped handler flushed at handle_free", dropped_fired >= 1);
+        expect("dropped handler reported every THREAD_SAFE raise as dropped",
+               (int) dropped_count == drop);
+
+        /* get_info on the now-freed handle reports an invalid handle. */
+        {
+            MPI_Info dead = MPI_INFO_NULL;
+            expect("event_handle_get_info on a freed handle returns MPI_T_ERR_INVALID_HANDLE",
+                   MPI_T_ERR_INVALID_HANDLE == MPI_T_event_handle_get_info(reg, &dead));
+        }
+    }
+
+    /* ---- 4. Multi-field payload: read each element, copy the whole buffer,
+       and read the source from inside the callback. ---- */
+    if (NULL != multi_ev) {
+        struct {
+            int32_t  a;
+            int32_t  pad;
+            int64_t  b;
+            uint32_t c;
+        } payload;
+        MPI_T_event_registration reg;
+        memset(&payload, 0, sizeof(payload));
+        payload.a = -42;
+        payload.b = 0x1122334455667788LL;
+        payload.c = 0xdeadbeefu;
+        multi_idx = find_event(ev_num, "selftest", "multi");
+        ms_a = 0; ms_b = 0; ms_c = 0; got_source = -1; copy_ok = 0; copy_canary_ok = 0;
+        (void) MPI_T_event_handle_alloc(multi_idx, NULL, MPI_INFO_NULL, &reg);
+        (void) MPI_T_event_register_callback(reg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL,
+                                             multi_cb);
+        mca_base_event_raise(multi_ev, NULL, &payload);
+        expect("multi-field event_read returns each element",
+               ms_a == payload.a && ms_b == payload.b && ms_c == payload.c);
+        expect("event_copy returns the full payload", copy_ok);
+        expect("event_copy does not write past the element extent", copy_canary_ok);
+        expect("in-callback get_source returns the event's source", got_source == src_a);
+        (void) MPI_T_event_handle_free(reg, NULL, NULL);
+    }
+
+    MPI_T_finalize();
+    MPI_Finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_smoke.c
+++ b/ompi/test/t/mpi_t_event_smoke.c
@@ -1,0 +1,162 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Singleton smoke test for the MPI_T events tool layer (Phase 3): it
+ * registers a source + event type directly via the OPAL mca_base_event
+ * API, then drives the full MPI_T path -- enumerate, get_info,
+ * handle_alloc, register_callback -- raises the event through OPAL, and
+ * confirms the user callback fires THROUGH the OMPI trampoline with the
+ * payload, timestamp, and source readable via the MPI_T accessors.
+ * Also checks the index/name error contracts.
+ */
+
+#include <mpi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "opal/mca/base/mca_base_event.h"
+
+static int      failures = 0;
+static int      cb_fired = 0;
+static int32_t  cb_a = 0;
+static uint64_t cb_b = 0;
+static int      cb_src = -1;
+
+static void expect(const char *what, int cond)
+{
+    if (cond) {
+        printf("PASS: %s\n", what);
+    } else {
+        ++failures;
+        printf("FAIL: %s\n", what);
+    }
+}
+
+/* User MPI_T event callback -- reached only through the OMPI trampoline. */
+static void my_cb(MPI_T_event_instance event,
+                  MPI_T_event_registration handle __opal_attribute_unused__,
+                  MPI_T_cb_safety cb_safety __opal_attribute_unused__,
+                  void *user_data __opal_attribute_unused__)
+{
+    MPI_Count ts = 0;
+    ++cb_fired;
+    (void) MPI_T_event_read(event, 0, &cb_a);
+    (void) MPI_T_event_read(event, 1, &cb_b);
+    (void) MPI_T_event_get_timestamp(event, &ts);
+    (void) MPI_T_event_get_source(event, &cb_src);
+}
+
+int main(void)
+{
+    int provided, rc, ev_index, src_index, num, bind, verbosity;
+    mca_base_event_source_t *source;
+    mca_base_event_t *event;
+    MPI_T_event_registration reg;
+    mca_base_var_type_t types[2] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    ptrdiff_t offsets[2] = {0, 8};
+    unsigned char buf[16];
+    char name[256];
+    int name_len = sizeof(name);
+
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("FAIL: MPI_T_init_thread\nRESULT: FAIL\n");
+        return 1;
+    }
+
+    /* Register a source + event type via the OPAL back end. */
+    src_index = mca_base_event_source_register("test.smoke.src", "smoke source",
+                                               MCA_BASE_EVENT_SOURCE_ORDERED, 1000000000,
+                                               OPAL_COUNT_MAX, NULL, true, NULL);
+    expect("OPAL source_register", src_index >= 0);
+    (void) mca_base_event_source_get_by_index(src_index, &source);
+    ev_index = mca_base_event_register("test", "smoke", "comp", "event", "smoke event",
+                                       OPAL_INFO_LVL_4, 2, types, offsets, NULL,
+                                       MPI_T_BIND_NO_OBJECT, 0, source, NULL);
+    expect("OPAL event_register", ev_index >= 0);
+    (void) mca_base_event_get_by_index(ev_index, &event);
+
+    /* MPI_T sees the registered event. */
+    (void) MPI_T_event_get_num(&num);
+    expect("MPI_T_event_get_num >= 1", num >= 1);
+
+    rc = MPI_T_event_get_info(ev_index, name, &name_len, &verbosity, NULL, NULL, &num, NULL, NULL,
+                              NULL, NULL, &bind);
+    expect("MPI_T_event_get_info ok", MPI_SUCCESS == rc);
+    expect("get_info reports 2 elements", 2 == num);
+    expect("get_info reports NO_OBJECT bind", MPI_T_BIND_NO_OBJECT == bind);
+
+    /* The event appears in its category (category_get_events, Phase 4). */
+    {
+        int cat = event->group_index, nevents = 0, idx[32], k, found = 0;
+        expect("event has a category", cat >= 0);
+        (void) MPI_T_category_get_num_events(cat, &nevents);
+        expect("category_get_num_events >= 1", nevents >= 1);
+        expect("category_get_events ok", MPI_SUCCESS == MPI_T_category_get_events(cat, 32, idx));
+        for (k = 0; k < nevents && k < 32; ++k) {
+            if (idx[k] == ev_index) {
+                found = 1;
+            }
+        }
+        expect("category_get_events lists our event", found);
+    }
+
+    /* Index/name error contracts. */
+    expect("event_get_info(bad index) -> INVALID_INDEX",
+           MPI_T_ERR_INVALID_INDEX == MPI_T_event_get_info(999999, NULL, NULL, NULL, NULL, NULL,
+                                                           &num, NULL, NULL, NULL, NULL, NULL));
+    {
+        int bogus;
+        expect("event_get_index(bogus) -> INVALID_NAME",
+               MPI_T_ERR_INVALID_NAME == MPI_T_event_get_index("no.such.event", &bogus));
+        expect("event_get_index(real name) round-trips",
+               MPI_SUCCESS == MPI_T_event_get_index(event->name, &bogus) && bogus == ev_index);
+    }
+
+    /* Alloc a handle + register a callback through the MPI_T API. */
+    rc = MPI_T_event_handle_alloc(ev_index, NULL, MPI_INFO_NULL, &reg);
+    expect("MPI_T_event_handle_alloc", MPI_SUCCESS == rc);
+    rc = MPI_T_event_register_callback(reg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL, my_cb);
+    expect("MPI_T_event_register_callback", MPI_SUCCESS == rc);
+
+    /* Raise through OPAL; the user callback must fire through the trampoline. */
+    {
+        int32_t v32 = 7;
+        uint64_t v64 = 0xfeedface;
+        /* memcpy, not an aligned store: buf[] (a char array) has no guaranteed
+           8-byte alignment, so *(uint64_t *)(buf + 8) would be a misaligned
+           access (SIGBUS on strict-alignment targets). */
+        memcpy(buf + 0, &v32, sizeof(v32));
+        memcpy(buf + 8, &v64, sizeof(v64));
+    }
+    cb_fired = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    expect("callback fired through the trampoline", 1 == cb_fired);
+    expect("MPI_T_event_read element 0 (via trampoline path)", 7 == cb_a);
+    expect("MPI_T_event_read element 1", 0xfeedface == cb_b);
+    expect("MPI_T_event_get_source", src_index == cb_src);
+
+    /* For a NO_OBJECT event, a non-NULL obj_handle must be IGNORED, not rejected
+       (MPI-5.0 sec. 15.3.8): handle_alloc succeeds and ignores the pointer. */
+    {
+        int dummy = 0;
+        MPI_T_event_registration r2;
+        expect("non-NULL obj_handle ignored for a NO_OBJECT event",
+               MPI_SUCCESS == MPI_T_event_handle_alloc(ev_index, &dummy, MPI_INFO_NULL, &r2));
+        (void) MPI_T_event_handle_free(r2, NULL, NULL);
+    }
+
+    rc = MPI_T_event_handle_free(reg, NULL, NULL);
+    expect("MPI_T_event_handle_free", MPI_SUCCESS == rc);
+
+    MPI_T_finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/test/t/mpi_t_event_world.c
+++ b/ompi/test/t/mpi_t_event_world.c
@@ -1,0 +1,120 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * World-model coverage for the ompi.initialization / ompi.finalization events.
+ * The producers test exercises the SESSION model (it calls MPI_Init first, so
+ * the world-model events have already fired by the time it can register a
+ * callback).  Here we initialize MPI_T *before* MPI_Init and register callbacks,
+ * so the world-model events -- raised during MPI_Init (once MPI_COMM_WORLD
+ * exists) and during MPI_Finalize -- are observed.  We confirm the model
+ * payload element says "world" and that world_rank / world_size are populated
+ * (they are -1 only for the session model).
+ */
+
+#include "opal_config.h"
+
+#include <mpi.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static int     failures = 0;
+static int      init_fired = 0;
+static int      final_fired = 0;
+static int32_t  init_model = -99;
+static int32_t  init_world_rank = -99;
+static int32_t  init_world_size = -99;
+static uint64_t init_instance_id = 0;
+static int32_t  final_model = -99;
+static int32_t  final_world_rank = -99;
+static uint64_t final_instance_id = 0;
+
+static void expect(const char *what, int cond)
+{
+    printf("%s: %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) {
+        ++failures;
+    }
+}
+
+static void init_cb(MPI_T_event_instance ev,
+                    MPI_T_event_registration h __opal_attribute_unused__,
+                    MPI_T_cb_safety s __opal_attribute_unused__,
+                    void *u __opal_attribute_unused__)
+{
+    ++init_fired;
+    (void) MPI_T_event_read(ev, 0, &init_model);
+    (void) MPI_T_event_read(ev, 2, &init_world_rank);
+    (void) MPI_T_event_read(ev, 3, &init_world_size);
+    (void) MPI_T_event_read(ev, 4, &init_instance_id);
+}
+
+static void final_cb(MPI_T_event_instance ev,
+                     MPI_T_event_registration h __opal_attribute_unused__,
+                     MPI_T_cb_safety s __opal_attribute_unused__,
+                     void *u __opal_attribute_unused__)
+{
+    ++final_fired;
+    (void) MPI_T_event_read(ev, 0, &final_model);
+    (void) MPI_T_event_read(ev, 1, &final_world_rank);
+    (void) MPI_T_event_read(ev, 2, &final_instance_id);
+}
+
+int main(int argc, char **argv)
+{
+    int provided, init_idx, final_idx;
+    MPI_T_event_registration ireg, freg;
+
+    /* MPI_T BEFORE MPI_Init, so a callback is in place when the world-model
+       initialization event fires during MPI_Init. */
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("SKIP: MPI_T_init_thread failed\n");
+        return 77;
+    }
+    if (MPI_SUCCESS != MPI_T_event_get_index("ompi.mpi.initialization", &init_idx)
+        || MPI_SUCCESS != MPI_T_event_get_index("ompi.mpi.finalization", &final_idx)) {
+        printf("SKIP: built-in initialization/finalization events not registered\n");
+        MPI_T_finalize();
+        return 77;
+    }
+
+    expect("alloc initialization handle",
+           MPI_SUCCESS == MPI_T_event_handle_alloc(init_idx, NULL, MPI_INFO_NULL, &ireg));
+    expect("alloc finalization handle",
+           MPI_SUCCESS == MPI_T_event_handle_alloc(final_idx, NULL, MPI_INFO_NULL, &freg));
+    (void) MPI_T_event_register_callback(ireg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL, init_cb);
+    (void) MPI_T_event_register_callback(freg, MPI_T_CB_REQUIRE_NONE, MPI_INFO_NULL, NULL, final_cb);
+
+    if (MPI_SUCCESS != MPI_Init(&argc, &argv)) {
+        printf("SKIP: MPI_Init failed (no singleton support here)\n");
+        return 77;
+    }
+
+    expect("initialization fired for the world model during MPI_Init", init_fired >= 1);
+    expect("initialization model says world", OMPI_T_MODEL_WORLD == init_model);
+    expect("initialization world_rank is a real rank (>= 0)", init_world_rank >= 0);
+    expect("initialization world_size is at least 1", init_world_size >= 1);
+    expect("initialization carries a non-zero instance id", 0 != init_instance_id);
+
+    MPI_Finalize();
+
+    expect("finalization fired for the world model during MPI_Finalize", final_fired >= 1);
+    expect("finalization model says world", OMPI_T_MODEL_WORLD == final_model);
+    expect("finalization world_rank is a real rank (>= 0)", final_world_rank >= 0);
+    expect("finalization instance id correlates with initialization",
+           final_instance_id == init_instance_id);
+
+    /* The handles were allocated on events that outlive MPI_Finalize; free them
+       and tear MPI_T down. */
+    (void) MPI_T_event_handle_free(ireg, NULL, NULL);
+    (void) MPI_T_event_handle_free(freg, NULL, NULL);
+    MPI_T_finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}

--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2010-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -154,6 +155,10 @@ int main(int argc, char *argv[])
     }
     if (opal_cmd_line_is_taken(ompi_info_cmd_line, "type")) {
         opal_info_do_type(ompi_info_cmd_line);
+        acted = true;
+    }
+    if (want_all || opal_cmd_line_is_taken(ompi_info_cmd_line, "event")) {
+        opal_info_do_event(want_all, ompi_info_cmd_line);
         acted = true;
     }
 

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -42,6 +42,7 @@
 #include "ompi/info/info_memkind.h"
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/osc.h"
+#include "ompi/runtime/ompi_mpit_events.h"
 
 #include "ompi/runtime/params.h"
 
@@ -252,6 +253,31 @@ config_window(void *base, size_t size, ptrdiff_t disp_unit,
     win->w_f_to_c_index = opal_pointer_array_add(&ompi_mpi_windows, win);
     if (-1 == win->w_f_to_c_index) return OMPI_ERR_OUT_OF_RESOURCE;
 
+    /* Raise the MPI_T window-created event (no-op when no tool is listening or
+       the producer is disabled).  Covers all window flavors, since every
+       flavor's creation path funnels through config_window. */
+    if (NULL != ompi_event_win_created) {
+        struct {
+            int64_t  size;
+            int32_t  disp_unit;
+            int32_t  flavor;
+            uint64_t handle;
+        } payload;
+        payload.size = (int64_t) size;
+        payload.disp_unit = (int32_t) disp_unit;
+        payload.flavor = (int32_t) flavor;
+        /* XXX ABI: the MPI_Win handle value must match the registering MPI_T
+           tool's ABI (ompi_mpit_callback_abi). */
+        if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+            payload.handle = (uint64_t) (uintptr_t) win;
+        } else {
+            /* TODO ABI (#13280): set the MPI Standard ABI handle value for the
+               window win. */
+            payload.handle = 0;
+        }
+        mca_base_event_raise(ompi_event_win_created, NULL, &payload);
+    }
+
     return OMPI_SUCCESS;
 }
 
@@ -396,6 +422,30 @@ ompi_win_free(ompi_win_t *win)
     }
 
     if (OMPI_SUCCESS == ret) {
+        /* Raise the MPI_T window-freed event now that teardown has succeeded,
+           while the window object is still valid (raising here, not at entry,
+           keeps the freed event off the osc_free() failure path, so it pairs
+           with the created event).  No-op when no tool is listening or the
+           producer is disabled. */
+        if (NULL != ompi_event_win_freed) {
+            struct {
+                int32_t  flavor;
+                uint32_t pad;
+                uint64_t handle;
+            } payload;
+            payload.flavor = (int32_t) win->w_flavor;
+            payload.pad = 0;
+            /* XXX ABI: the MPI_Win handle value must match the registering MPI_T
+               tool's ABI (ompi_mpit_callback_abi). */
+            if (OMPI_MPIT_ABI_OMPI == ompi_mpit_callback_abi) {
+                payload.handle = (uint64_t) (uintptr_t) win;
+            } else {
+                /* TODO ABI (#13280): set the MPI Standard ABI handle value for
+                   the window win. */
+                payload.handle = 0;
+            }
+            mca_base_event_raise(ompi_event_win_freed, NULL, &payload);
+        }
         OBJ_RELEASE(win);
     }
 

--- a/opal/include/opal/types.h
+++ b/opal/include/opal/types.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +43,16 @@
 #if OPAL_ENABLE_DEBUG
 #    include "opal/util/output.h"
 #endif
+
+/*
+ * opal_count_t: a signed integer "count" type whose backing C type is chosen
+ * once at configure time (OPAL_FIND_COUNT_TYPE); OPAL_COUNT_MAX is its maximum
+ * value.  It is the layer-safe backing type for MPI_Count -- when OMPI is
+ * built, MPI_Count is derived from the same configure-computed value, so the
+ * two are guaranteed to be the same width (enforced by a _Static_assert in
+ * OMPI).  OPAL code must use opal_count_t and must NOT reference MPI_Count.
+ */
+typedef OPAL_COUNT_TYPE opal_count_t;
 
 /*
  * portable assignment of pointer to int

--- a/opal/mca/base/Makefile.am
+++ b/opal/mca/base/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2020      Google LLC. All rights reserved.
-# Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2025-2026 Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +37,7 @@ headers = \
         mca_base_component_repository.h \
         mca_base_var.h \
         mca_base_pvar.h \
+        mca_base_event.h \
 	mca_base_var_enum.h \
         mca_base_var_group.h \
         mca_base_vari.h \
@@ -59,6 +60,9 @@ libmca_base_la_SOURCES = \
         mca_base_open.c \
         mca_base_var.c \
         mca_base_pvar.c \
+        mca_base_event.c \
+        mca_base_event_dispatch.c \
+        mca_base_event_memory.c \
 	mca_base_var_enum.c \
         mca_base_var_group.c \
         mca_base_parse_paramfile.c \

--- a/opal/mca/base/mca_base_event.c
+++ b/opal/mca/base/mca_base_event.c
@@ -1,0 +1,774 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * The mca_base_event framework -- registry and registration (Phase 1).
+ * Dispatch, handle/callback management, the instance pool, and
+ * timestamps are added in Phase 2.  See specs/mpi-t-events/spec.md.
+ */
+
+#include "opal_config.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "opal/class/opal_hash_table.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/mca/base/mca_base_event.h"
+#include "opal/mca/base/mca_base_vari.h"
+#include "opal/util/printf.h"
+
+/* --- Process-wide registry ----------------------------------------------- */
+
+static opal_pointer_array_t registered_events;
+static opal_pointer_array_t registered_event_sources;
+static opal_hash_table_t    event_name_to_index;
+static int                  event_count = 0;
+static int                  source_count = 0;
+static bool                 mca_base_event_initialized = false;
+
+/* The single framework lock (sec. 5.10): guards the per-event registration
+   lists and the dispatch snapshot/reconcile windows.  No user callback ever
+   runs while it is held.  The process-wide registry itself (the event/source
+   arrays and their counts below) is append-only and populated during
+   initialization -- before any tool enumerates or allocates a handle -- so,
+   like mca_base_pvar's registry, it is read and written without the lock. */
+opal_mutex_t mca_base_event_lock = OPAL_MUTEX_STATIC_INIT;
+
+/* MCA parameter values, registered in mca_base_event_init and read by the
+   dispatch TU.  Defaults per sec. 5.9 / sec. 9.1. */
+int mca_base_event_pool_size = 8;
+int mca_base_event_pool_max = 256;
+int mca_base_event_max_registrations = 1024;
+
+/* The dispatch TU registers its pool-teardown function here when it lazily
+   creates the instance pool, so finalize can tear it down without the core TU
+   having a static link dependency on the dispatch TU (which pulls
+   opal_free_list -> mpool, absent from libopen-pal_core). */
+static void (*dispatch_finalize_fn)(void) = NULL;
+
+void mca_base_event_set_dispatch_finalize(void (*fn)(void))
+{
+    dispatch_finalize_fn = fn;
+}
+
+/* --- Lifecycle ----------------------------------------------------------- */
+
+int mca_base_event_init(void)
+{
+    int ret = OPAL_SUCCESS;
+
+    if (!mca_base_event_initialized) {
+        mca_base_event_initialized = true;
+
+        OBJ_CONSTRUCT(&registered_events, opal_pointer_array_t);
+        opal_pointer_array_init(&registered_events, 32, 2048, 32);
+
+        OBJ_CONSTRUCT(&registered_event_sources, opal_pointer_array_t);
+        opal_pointer_array_init(&registered_event_sources, 8, 256, 8);
+
+        OBJ_CONSTRUCT(&event_name_to_index, opal_hash_table_t);
+        ret = opal_hash_table_init(&event_name_to_index, 256);
+        if (OPAL_SUCCESS != ret) {
+            mca_base_event_initialized = false;
+            OBJ_DESTRUCT(&registered_events);
+            OBJ_DESTRUCT(&registered_event_sources);
+            OBJ_DESTRUCT(&event_name_to_index);
+            return ret;
+        }
+
+        /* Register the framework's MCA parameters.  The instance pool and the
+           default clock origin are created LAZILY by the dispatch TU on first
+           listener-attach -- not here -- so the zero-listener case stays free of
+           a free list and any allocation. */
+        (void) mca_base_var_register("opal", "mca", "base", "event_pool_size",
+                                     "Number of MPI_T event instances to pre-allocate in the "
+                                     "instance pool (created lazily on first listener attach)",
+                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                     MCA_BASE_VAR_SCOPE_LOCAL, &mca_base_event_pool_size);
+        (void) mca_base_var_register("opal", "mca", "base", "event_pool_max",
+                                     "Maximum number of MPI_T event instances in the instance "
+                                     "pool; raises beyond this are dropped (must be > 0)",
+                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                     MCA_BASE_VAR_SCOPE_LOCAL, &mca_base_event_pool_max);
+        (void) mca_base_var_register("opal", "mca", "base", "event_max_registrations",
+                                     "Maximum number of live MPI_T event registrations (handles) "
+                                     "per process; allocation past this fails (DoS guard)",
+                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                     MCA_BASE_VAR_SCOPE_LOCAL, &mca_base_event_max_registrations);
+
+        /* Read-only cvars exposing the live registry counts (bound to the
+           counters, so a tool reads the current value). */
+        (void) mca_base_var_register("opal", "mca", "base", "event_count",
+                                     "Number of registered MPI_T event types",
+                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY,
+                                     OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &event_count);
+        (void) mca_base_var_register("opal", "mca", "base", "event_source_count",
+                                     "Number of registered MPI_T event sources",
+                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY,
+                                     OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &source_count);
+    }
+
+    return ret;
+}
+
+int mca_base_event_finalize(void)
+{
+    int i;
+
+    if (mca_base_event_initialized) {
+        mca_base_event_initialized = false;
+
+        /* Tear down the instance pool / dispatch state first, if the dispatch
+           TU was ever engaged (a listener attached).  No dispatch is in flight
+           during finalize. */
+        if (NULL != dispatch_finalize_fn) {
+            dispatch_finalize_fn();
+            dispatch_finalize_fn = NULL;
+        }
+
+        for (i = 0; i < event_count; ++i) {
+            mca_base_event_t *event = opal_pointer_array_get_item(&registered_events, i);
+            if (NULL != event) {
+                OBJ_RELEASE(event);
+            }
+        }
+        event_count = 0;
+
+        for (i = 0; i < source_count; ++i) {
+            mca_base_event_source_t *source
+                = opal_pointer_array_get_item(&registered_event_sources, i);
+            if (NULL != source) {
+                OBJ_RELEASE(source);
+            }
+        }
+        source_count = 0;
+
+        OBJ_DESTRUCT(&registered_events);
+        OBJ_DESTRUCT(&registered_event_sources);
+        OBJ_DESTRUCT(&event_name_to_index);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/* --- Internal lookups ---------------------------------------------------- */
+
+static int event_get_internal(int index, mca_base_event_t **event)
+{
+    if (index < 0 || index >= event_count) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    *event = opal_pointer_array_get_item(&registered_events, index);
+    if (NULL == *event || ((*event)->flags & MCA_BASE_EVENT_FLAG_INVALID)) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+static int source_get_internal(int index, mca_base_event_source_t **source)
+{
+    if (index < 0 || index >= source_count) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    *source = opal_pointer_array_get_item(&registered_event_sources, index);
+    if (NULL == *source) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/* --- Event sources ------------------------------------------------------- */
+
+int mca_base_event_source_register(const char *name, const char *description,
+                                   mca_base_event_source_order_t ordering,
+                                   opal_count_t ticks_per_second, opal_count_t max_ticks,
+                                   mca_base_event_source_time_fn_t get_timestamp,
+                                   bool supports_adhoc, void *ctx)
+{
+    mca_base_event_source_t *source;
+    int i, source_index;
+
+    if (NULL == name || '\0' == name[0]) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* Idempotent by name: return the existing source without mutating it. */
+    for (i = 0; i < source_count; ++i) {
+        source = opal_pointer_array_get_item(&registered_event_sources, i);
+        if (NULL != source && 0 == strcmp(source->name, name)) {
+            return source->source_index;
+        }
+    }
+
+    source = OBJ_NEW(mca_base_event_source_t);
+    if (NULL == source) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    source->name = strdup(name);
+    if (NULL == source->name) {
+        OBJ_RELEASE(source);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+    if (NULL != description) {
+        source->description = strdup(description);
+        if (NULL == source->description) {
+            OBJ_RELEASE(source);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    source->ordering = ordering;
+    source->ticks_per_second = ticks_per_second;
+    source->max_ticks = max_ticks;
+    source->get_timestamp = get_timestamp;
+    source->supports_adhoc = supports_adhoc;
+    source->ctx = ctx;
+
+    source_index = opal_pointer_array_add(&registered_event_sources, source);
+    if (0 > source_index) {
+        OBJ_RELEASE(source);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+    source->source_index = source_index;
+    source_count++;
+
+    return source->source_index;
+}
+
+/* --- Event types --------------------------------------------------------- */
+
+/* Compute the inline payload extent from the element layout, validating the
+   layout UNCONDITIONALLY (sec. 5.4/sec. 6): offsets ascending and
+   non-overlapping starting at 0, element types in range, no overflow.  On
+   success *buffer_size receives the (8-byte-aligned) extent. */
+static int event_compute_buffer_size(int num_elements, const mca_base_var_type_t *element_types,
+                                     const ptrdiff_t *element_offsets, size_t *buffer_size,
+                                     size_t *data_extent)
+{
+    size_t extent = 0;
+    int i;
+
+    if (num_elements < 0) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    if (0 == num_elements) {
+        *buffer_size = 0;
+        *data_extent = 0;
+        return OPAL_SUCCESS;
+    }
+    if (NULL == element_types || NULL == element_offsets) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    for (i = 0; i < num_elements; ++i) {
+        size_t tsize, end;
+
+        if (element_types[i] < 0 || element_types[i] >= MCA_BASE_VAR_TYPE_MAX) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+        tsize = ompi_var_type_sizes[element_types[i]];
+        if (0 == tsize) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+
+        /* Offsets must be non-negative, start at 0, and be ascending and
+           non-overlapping (offset[i] >= offset[i-1] + size[i-1]). */
+        if (element_offsets[i] < 0) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+        if (0 == i) {
+            if (0 != element_offsets[i]) {
+                return OPAL_ERR_BAD_PARAM;
+            }
+        } else if ((size_t) element_offsets[i] < extent) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+
+        end = (size_t) element_offsets[i] + tsize;
+        if (end < (size_t) element_offsets[i]) {
+            /* size_t overflow */
+            return OPAL_ERR_BAD_PARAM;
+        }
+        if (end > extent) {
+            extent = end;
+        }
+    }
+
+    /* The un-rounded extent is what a producer's payload and a tool's buffer are
+       actually sized to (the element layout); the raise/copy paths bound their
+       memcpys to it, not to the rounded buffer_size. */
+    *data_extent = extent;
+
+    /* Round the extent up to an 8-byte boundary (overflow-safe). */
+    if (extent > SIZE_MAX - 7) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    extent = (extent + 7) & ~((size_t) 7);
+
+    *buffer_size = extent;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_register(const char *project, const char *framework, const char *component,
+                            const char *name, const char *description,
+                            mca_base_var_info_lvl_t verbosity, int num_elements,
+                            const mca_base_var_type_t *element_types,
+                            const ptrdiff_t *element_offsets, mca_base_var_enum_t *enumerator,
+                            int bind, mca_base_event_flag_t flags,
+                            mca_base_event_source_t *source, void *ctx)
+{
+    mca_base_event_t *event;
+    char *full_name = NULL;
+    size_t buffer_size = 0;
+    size_t data_extent = 0;
+    void *tmp;
+    int ret, event_index;
+
+    if (NULL == name || '\0' == name[0] || NULL == source) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    flags &= ~MCA_BASE_EVENT_FLAG_INVALID;
+
+    ret = event_compute_buffer_size(num_elements, element_types, element_offsets, &buffer_size,
+                                    &data_extent);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+    if (buffer_size > MCA_BASE_EVENT_MAX_PAYLOAD) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    ret = mca_base_var_generate_full_name4(NULL, framework, component, name, &full_name);
+    if (OPAL_SUCCESS != ret) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* Export event-type names under the "ompi." namespace, matching the
+       event-source naming convention.  Prepend it to the generated MCA-style
+       full name (which is otherwise framework_component_name). */
+    {
+        char *prefixed_name = NULL;
+        if (0 > opal_asprintf(&prefixed_name, "ompi.%s", full_name)) {
+            free(full_name);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+        free(full_name);
+        full_name = prefixed_name;
+    }
+
+    /* Idempotent by full name: a duplicate returns the existing index and
+       must NOT mutate the layout/source/bind (a live handle's event_copy
+       sizing depends on it). */
+    ret = opal_hash_table_get_value_ptr(&event_name_to_index, full_name, strlen(full_name), &tmp);
+    if (OPAL_SUCCESS == ret) {
+        event_index = (int) (uintptr_t) tmp;
+        free(full_name);
+        /* Fetch the raw registry slot rather than via event_get_internal(),
+           which rejects an invalidated event: a duplicate-by-name of an event
+           whose owning MCA group was deregistered (MCA_BASE_EVENT_FLAG_INVALID,
+           set by mca_base_event_mark_invalid) must be REVALIDATED and reused,
+           mirroring register_variable(), not failed.  The layout/source/bind
+           must still match (a live handle's event_copy sizing depends on it). */
+        if (event_index < 0 || event_index >= event_count
+            || NULL == (event = opal_pointer_array_get_item(&registered_events, event_index))) {
+            return OPAL_ERROR;
+        }
+#if OPAL_ENABLE_DEBUG
+        assert(event->buffer_size == buffer_size && event->data_extent == data_extent
+               && event->source == source
+               && event->bind == bind && event->num_elements == num_elements);
+#endif
+        if (event->flags & MCA_BASE_EVENT_FLAG_INVALID) {
+            event->flags &= ~MCA_BASE_EVENT_FLAG_INVALID;
+            if (0 <= event->group_index) {
+                (void) mca_base_var_group_add_event(event->group_index, event_index);
+            }
+        }
+        return event_index;
+    }
+
+    event = OBJ_NEW(mca_base_event_t);
+    if (NULL == event) {
+        free(full_name);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    event->name = full_name; /* take ownership */
+    if (NULL != description) {
+        event->description = strdup(description);
+        if (NULL == event->description) {
+            OBJ_RELEASE(event);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    if (num_elements > 0) {
+        event->element_types = malloc(num_elements * sizeof(*element_types));
+        event->element_offsets = malloc(num_elements * sizeof(*element_offsets));
+        if (NULL == event->element_types || NULL == event->element_offsets) {
+            OBJ_RELEASE(event);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+        memcpy(event->element_types, element_types, num_elements * sizeof(*element_types));
+        memcpy(event->element_offsets, element_offsets, num_elements * sizeof(*element_offsets));
+    }
+
+    event->num_elements = num_elements;
+    event->buffer_size = buffer_size;
+    event->data_extent = data_extent;
+    event->verbosity = verbosity;
+    event->enumerator = enumerator;
+    if (NULL != enumerator) {
+        OBJ_RETAIN(enumerator);
+    }
+    event->bind = bind;
+    event->flags = flags;
+    event->source = source;
+    event->ctx = ctx;
+
+    /* Find/register the MCA variable group for this event's category (sec. 6.1). */
+    event->group_index = mca_base_var_group_register(project, framework, component, NULL);
+
+    event_index = opal_pointer_array_add(&registered_events, event);
+    if (0 > event_index) {
+        OBJ_RELEASE(event);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+    event->event_index = event_index;
+
+    /* Append this event to the category's append-only event list.  This is
+       reached only on FIRST registration (the idempotent-reuse path returns
+       above without re-appending), so a repeat registration cannot inflate the
+       per-category count (sec. 9.1 / sec. 15.3.9). */
+    if (0 <= event->group_index) {
+        (void) mca_base_var_group_add_event(event->group_index, event_index);
+    }
+
+    opal_hash_table_set_value_ptr(&event_name_to_index, event->name, strlen(event->name),
+                                  (void *) (uintptr_t) event_index);
+    event_count++;
+
+    return event->event_index;
+}
+
+int mca_base_component_event_register(const mca_base_component_t *component, const char *name,
+                                      const char *description, mca_base_var_info_lvl_t verbosity,
+                                      int num_elements, const mca_base_var_type_t *element_types,
+                                      const ptrdiff_t *element_offsets,
+                                      mca_base_var_enum_t *enumerator, int bind,
+                                      mca_base_event_flag_t flags, mca_base_event_source_t *source,
+                                      void *ctx)
+{
+    return mca_base_event_register(component->mca_project_name, component->mca_type_name,
+                                   component->mca_component_name, name, description, verbosity,
+                                   num_elements, element_types, element_offsets, enumerator, bind,
+                                   flags | MCA_BASE_EVENT_FLAG_IWG, source, ctx);
+}
+
+/* --- Enumeration / query ------------------------------------------------- */
+
+int mca_base_event_get_count(int *count)
+{
+    *count = event_count;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_get_by_index(int index, mca_base_event_t **event)
+{
+    return event_get_internal(index, event);
+}
+
+/* Mark an event invalid so it can no longer be looked up or allocated,
+   mirroring mca_base_pvar_mark_invalid().  Used when an event's owning MCA
+   group is deregistered (e.g. its component is unloaded).  Fetches the raw
+   registry slot (not event_get_internal(), which rejects invalid events) so a
+   redundant call is idempotent. */
+int mca_base_event_mark_invalid(int index)
+{
+    mca_base_event_t *event;
+
+    if (index < 0 || index >= event_count) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+    event = opal_pointer_array_get_item(&registered_events, index);
+    if (NULL == event) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+    event->flags |= MCA_BASE_EVENT_FLAG_INVALID;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_get_by_name(const char *full_name, int *index)
+{
+    void *tmp;
+    int ret;
+
+    if (NULL == full_name) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    ret = opal_hash_table_get_value_ptr(&event_name_to_index, full_name, strlen(full_name), &tmp);
+    if (OPAL_SUCCESS != ret) {
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    {
+        mca_base_event_t *event;
+        int idx = (int) (uintptr_t) tmp;
+        /* The name->index map retains entries for invalidated events (an event
+           whose owning MCA group was deregistered keeps MCA_BASE_EVENT_FLAG_INVALID
+           but stays in the hash).  Reject those here so this lookup agrees with
+           mca_base_event_get_by_index() / event_get_internal(). */
+        if (OPAL_SUCCESS != event_get_internal(idx, &event)) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        *index = idx;
+    }
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_source_get_count(int *count)
+{
+    *count = source_count;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_source_get_by_index(int index, mca_base_event_source_t **source)
+{
+    return source_get_internal(index, source);
+}
+
+/* mca_base_event_source_get_timestamp lives in mca_base_event_dispatch.c (it
+   needs the default clock, which lives there). */
+
+/* --- Introspection (ompi_info) ------------------------------------------- */
+
+/* Map an event type's bind (MCA_BASE_VAR_BIND_*) to a stable lowercase token
+   for the parsable dump (the MPI object type a handle must be bound to). */
+static const char *event_bind_name(int bind)
+{
+    switch (bind) {
+    case MCA_BASE_VAR_BIND_NO_OBJECT:
+        return "no_object";
+    case MCA_BASE_VAR_BIND_MPI_COMM:
+        return "mpi_comm";
+    case MCA_BASE_VAR_BIND_MPI_DATATYPE:
+        return "mpi_datatype";
+    case MCA_BASE_VAR_BIND_MPI_ERRHANDLER:
+        return "mpi_errhandler";
+    case MCA_BASE_VAR_BIND_MPI_FILE:
+        return "mpi_file";
+    case MCA_BASE_VAR_BIND_MPI_GROUP:
+        return "mpi_group";
+    case MCA_BASE_VAR_BIND_MPI_OP:
+        return "mpi_op";
+    case MCA_BASE_VAR_BIND_MPI_REQUEST:
+        return "mpi_request";
+    case MCA_BASE_VAR_BIND_MPI_WIN:
+        return "mpi_win";
+    case MCA_BASE_VAR_BIND_MPI_MESSAGE:
+        return "mpi_message";
+    case MCA_BASE_VAR_BIND_MPI_INFO:
+        return "mpi_info";
+    default:
+        return "unknown";
+    }
+}
+
+int mca_base_event_dump(int index, char ***out, mca_base_var_dump_type_t output_type)
+{
+    mca_base_event_t *event;
+    int ret, line = 0;
+
+    ret = event_get_internal(index, &event);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    if (MCA_BASE_VAR_DUMP_PARSABLE == output_type) {
+        /* One keyed line per field, in the same colon-delimited style as
+           mca_base_var/pvar_dump but under the MPI_T-event namespace:
+           mpi_t_event:type:<name>:<field>:<value> (4 fixed lines + optional
+           help + NULL terminator). */
+        char *tmp;
+
+        *out = calloc(6, sizeof(char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        (void) opal_asprintf(&tmp, "mpi_t_event:type:%s:", event->name);
+        (void) opal_asprintf(out[0] + line++, "%ssource:%s", tmp,
+                             event->source ? event->source->name : "");
+        (void) opal_asprintf(out[0] + line++, "%slevel:%d", tmp, event->verbosity + 1);
+        (void) opal_asprintf(out[0] + line++, "%snum_elements:%d", tmp, event->num_elements);
+        (void) opal_asprintf(out[0] + line++, "%sbind:%s", tmp, event_bind_name(event->bind));
+        if (NULL != event->description) {
+            (void) opal_asprintf(out[0] + line++, "%shelp:%s", tmp, event->description);
+        }
+        free(tmp);
+    } else {
+        /* Readable: a summary line plus an optional description (+ NULL). */
+        *out = calloc(3, sizeof(char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        (void) opal_asprintf(out[0] + line++, "%s (source: %s, elements: %d)", event->name,
+                             event->source ? event->source->name : "(none)", event->num_elements);
+        if (NULL != event->description) {
+            (void) opal_asprintf(out[0] + line++, "%s", event->description);
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_source_dump(int index, char ***out, mca_base_var_dump_type_t output_type)
+{
+    mca_base_event_source_t *source;
+    int ret, line = 0;
+
+    ret = source_get_internal(index, &source);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    if (MCA_BASE_VAR_DUMP_PARSABLE == output_type) {
+        /* One keyed line per field, in the same colon-delimited style as
+           mca_base_var/pvar_dump but under the MPI_T-event namespace:
+           mpi_t_event:source:<name>:<field>:<value> (4 fixed lines + optional
+           help + NULL terminator). */
+        char *tmp;
+
+        *out = calloc(6, sizeof(char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        (void) opal_asprintf(&tmp, "mpi_t_event:source:%s:", source->name);
+        (void) opal_asprintf(out[0] + line++, "%sordering:%s", tmp,
+                             MCA_BASE_EVENT_SOURCE_ORDERED == source->ordering ? "ordered"
+                                                                              : "unordered");
+        (void) opal_asprintf(out[0] + line++, "%sticks_per_second:%lld", tmp,
+                             (long long) source->ticks_per_second);
+        (void) opal_asprintf(out[0] + line++, "%smax_ticks:%lld", tmp,
+                             (long long) source->max_ticks);
+        (void) opal_asprintf(out[0] + line++, "%sadhoc:%s", tmp,
+                             source->supports_adhoc ? "true" : "false");
+        if (NULL != source->description) {
+            (void) opal_asprintf(out[0] + line++, "%shelp:%s", tmp, source->description);
+        }
+        free(tmp);
+    } else {
+        /* Readable: a summary line plus an optional description (+ NULL). */
+        *out = calloc(3, sizeof(char *));
+        if (NULL == *out) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        (void) opal_asprintf(out[0] + line++, "%s (%s, ticks/sec: %lld)", source->name,
+                             MCA_BASE_EVENT_SOURCE_ORDERED == source->ordering ? "ordered"
+                                                                              : "unordered",
+                             (long long) source->ticks_per_second);
+        if (NULL != source->description) {
+            (void) opal_asprintf(out[0] + line++, "%s", source->description);
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/* --- OBJ classes --------------------------------------------------------- */
+
+static void event_source_constructor(mca_base_event_source_t *source)
+{
+    source->source_index = -1;
+    source->name = NULL;
+    source->description = NULL;
+    source->ordering = MCA_BASE_EVENT_SOURCE_UNORDERED;
+    source->ticks_per_second = 0;
+    source->max_ticks = 0;
+    source->get_timestamp = NULL;
+    source->supports_adhoc = false;
+    source->last_ts = 0;
+    source->ctx = NULL;
+    source->fold_consume_fn = NULL;
+    source->activate_fn = NULL;
+    source->fold_event = NULL;
+}
+
+static void event_source_destructor(mca_base_event_source_t *source)
+{
+    free(source->name);
+    free(source->description);
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_source_t, opal_object_t, event_source_constructor,
+                   event_source_destructor);
+
+static void event_constructor(mca_base_event_t *event)
+{
+    memset((char *) event + sizeof(event->super), 0, sizeof(*event) - sizeof(event->super));
+    event->event_index = -1;
+    event->group_index = -1;
+    OBJ_CONSTRUCT(&event->registrations, opal_list_t);
+}
+
+static void event_destructor(mca_base_event_t *event)
+{
+    free(event->name);
+    free(event->description);
+    free(event->element_types);
+    free(event->element_offsets);
+    if (NULL != event->enumerator) {
+        OBJ_RELEASE(event->enumerator);
+    }
+    OBJ_DESTRUCT(&event->registrations);
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_t, opal_object_t, event_constructor, event_destructor);
+
+static void event_registration_constructor(mca_base_event_registration_t *reg)
+{
+    memset((char *) reg + sizeof(reg->super), 0, sizeof(*reg) - sizeof(reg->super));
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_registration_t, opal_list_item_t,
+                   event_registration_constructor, NULL);
+
+static void event_cb_constructor(mca_base_event_cb_t *cb)
+{
+    memset((char *) cb + sizeof(cb->super), 0, sizeof(*cb) - sizeof(cb->super));
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_cb_t, opal_list_item_t, event_cb_constructor, NULL);
+
+static void event_dropped_cb_constructor(mca_base_event_dropped_cb_t *dcb)
+{
+    memset((char *) dcb + sizeof(dcb->super), 0, sizeof(*dcb) - sizeof(dcb->super));
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_dropped_cb_t, opal_list_item_t, event_dropped_cb_constructor,
+                   NULL);
+
+/* NOTE: the mca_base_event_instance_t OBJ class, the instance pool, and the
+   whole dispatch path live in mca_base_event_dispatch.c (Phase 2).  They use
+   opal_free_list, which depends on the mpool base -- a dependency that is NOT
+   present in libopen-pal_core (the minimal library linked by tools such as
+   opal_wrapper).  Keeping that code in a separate translation unit, reachable
+   only from raise/handle callers (the OMPI MPI_T layer), keeps THIS file --
+   pulled into core via mca_base_var's init/finalize -- free of that
+   dependency. */

--- a/opal/mca/base/mca_base_event.h
+++ b/opal/mca/base/mca_base_event.h
@@ -1,0 +1,460 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * The mca_base_event framework: the OPAL-level back end for the MPI_T
+ * events interface (MPI-5.0 sec. 15.3.8).  It mirrors mca_base_pvar: a
+ * process-wide registry of event "sources" and event "types" that
+ * producers register and tools (via the OMPI MPI_T layer) enumerate,
+ * bind handles to, install callbacks on, and read typed data from.
+ *
+ * This header is OPAL-only: it references no MPI / ompi_ symbol.  Counts
+ * that the MPI_T layer exposes as MPI_Count use opal_count_t (see
+ * opal/types.h).  See specs/mpi-t-events/spec.md for the full design.
+ */
+
+#ifndef OPAL_MCA_BASE_EVENT_H
+#define OPAL_MCA_BASE_EVENT_H
+
+#include "opal_config.h"
+
+#include "opal/class/opal_free_list.h"
+#include "opal/class/opal_list.h"
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/threads/mutex.h"
+#include "opal/types.h"
+#include "opal/util/info.h"
+
+BEGIN_C_DECLS
+
+struct mca_base_event_t;
+struct mca_base_event_source_t;
+struct mca_base_event_registration_t;
+struct mca_base_event_instance_t;
+
+/*
+ * Callback safety levels (Table 15.5).  A callback registered at level L
+ * promises it is safe in every context requiring <= L.  The dense 0..3
+ * encoding matches OPAL_MCA_BASE_CB_REQUIRE_* (set by configure) so the
+ * callbacks[] array can be indexed directly.
+ */
+typedef enum {
+    MCA_BASE_EVENT_CB_REQUIRE_NONE = OPAL_MCA_BASE_CB_REQUIRE_NONE,
+    MCA_BASE_EVENT_CB_REQUIRE_MPI_RESTRICTED = OPAL_MCA_BASE_CB_REQUIRE_MPI_RESTRICTED,
+    MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE = OPAL_MCA_BASE_CB_REQUIRE_THREAD_SAFE,
+    MCA_BASE_EVENT_CB_REQUIRE_ASYNC_SIGNAL_SAFE = OPAL_MCA_BASE_CB_REQUIRE_ASYNC_SIGNAL_SAFE,
+    /** Number of safety levels; sizes the callbacks[] array. */
+    MCA_BASE_EVENT_CB_REQUIRE_MAX = 4
+} mca_base_event_cb_safety_t;
+
+/* A future ABI renumber of the safety levels must fail to compile rather
+   than silently index callbacks[] out of bounds. */
+_Static_assert(MCA_BASE_EVENT_CB_REQUIRE_NONE == 0
+                   && MCA_BASE_EVENT_CB_REQUIRE_MPI_RESTRICTED == 1
+                   && MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE == 2
+                   && MCA_BASE_EVENT_CB_REQUIRE_ASYNC_SIGNAL_SAFE == 3,
+               "mca_base_event safety levels must be the dense encoding 0..3");
+
+/** The highest safety level v1 ever *selects* for delivery (sec. 5.12). */
+#define MCA_BASE_EVENT_CB_REQUIRE_V1_MAX MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE
+
+/** Timestamp ordering guarantee of an event source. */
+typedef enum {
+    MCA_BASE_EVENT_SOURCE_ORDERED,
+    MCA_BASE_EVENT_SOURCE_UNORDERED
+} mca_base_event_source_order_t;
+
+/** Flags passed when registering an event type. */
+typedef enum {
+    /** Invalidate-with-group: invalidated when the owning MCA group is
+        deregistered (set automatically by mca_base_component_event_register). */
+    MCA_BASE_EVENT_FLAG_IWG = 0x040,
+    /** This event type has been marked invalid. */
+    MCA_BASE_EVENT_FLAG_INVALID = 0x400
+} mca_base_event_flag_t;
+
+/** Compile-time size of an event instance's inline payload buffer.  A
+    registration whose computed buffer_size exceeds this is rejected, so
+    the raise path copies into fixed storage and never allocates. */
+#define MCA_BASE_EVENT_MAX_PAYLOAD 256
+
+/** Maximum re-entrant dispatch depth: a raise nested deeper than this (a
+    callback that re-raises) is dropped, to bound the C stack (sec. 5.9 step 0). */
+#define MCA_BASE_EVENT_MAX_DISPATCH_DEPTH 8
+
+/* --- Callback function types (no MPI types) ------------------------------ */
+
+/** An event callback.  inst is valid only for the duration of the call. */
+typedef void (*mca_base_event_cb_fn_t)(struct mca_base_event_instance_t *inst,
+                                       struct mca_base_event_registration_t *reg,
+                                       mca_base_event_cb_safety_t cb_safety, void *user_data);
+
+/** A dropped-event handler: count events were dropped for this registration. */
+typedef void (*mca_base_event_dropped_cb_fn_t)(opal_count_t count,
+                                               struct mca_base_event_registration_t *reg,
+                                               int source_index,
+                                               mca_base_event_cb_safety_t cb_safety,
+                                               void *user_data);
+
+/** A free callback: the registration is being torn down. */
+typedef void (*mca_base_event_free_cb_fn_t)(struct mca_base_event_registration_t *reg,
+                                            mca_base_event_cb_safety_t cb_safety, void *user_data);
+
+/** A per-source timestamp reader returning ticks in the source's domain. */
+typedef opal_count_t (*mca_base_event_source_time_fn_t)(void *ctx);
+
+/** OMPI-supplied destructor for a callback/dropped slot's opaque user_data.
+    OPAL invokes it once at slot refcount 0, outside any lock; may be NULL. */
+typedef void (*mca_base_event_ctx_release_fn_t)(void *user_data);
+
+/** A deferred-release fold consumer (sec. 7.1): hands back BOTH the count of
+    releases and their cumulative byte total that a deferred producer (e.g. the
+    OS-memory producer) has accumulated since the last fold, consuming-and-
+    clearing both.  The framework then delivers them as one aggregated,
+    data-bearing event.  The producer's sink is lock-free; no framework lock is
+    held across this call. */
+typedef void (*mca_base_event_fold_consume_fn_t)(void *ctx, int64_t *count, int64_t *bytes);
+
+/** A source activation hook (sec. 7.1): called with active=true when the
+    source's event goes 0->active (first listener attaches) and active=false at
+    the last detach, so a producer can lazily install/remove an OS hook.  Called
+    under the framework lock. */
+typedef void (*mca_base_event_activate_fn_t)(void *ctx, bool active);
+
+/* --- Event source -------------------------------------------------------- */
+
+typedef struct mca_base_event_source_t {
+    opal_object_t                   super;
+    int                             source_index;
+    char                           *name;
+    char                           *description;
+    mca_base_event_source_order_t   ordering;
+    opal_count_t                    ticks_per_second;
+    opal_count_t                    max_ticks;
+    /** Optional per-source clock; NULL => the default (MPI_Wtime-equivalent). */
+    mca_base_event_source_time_fn_t get_timestamp;
+    /** Whether MPI_T_source_get_timestamp may read this source ad hoc. */
+    bool                            supports_adhoc;
+    /** Per-source monotonicity backstop for ORDERED sources (sec. 5.11). */
+    opal_atomic_int64_t             last_ts;
+    void                           *ctx;
+    /** Deferred-release producer hooks (sec. 7.1); NULL for ordinary sources.
+        A source with a fold_consume_fn produces its releases in a context where
+        immediate delivery is unsafe (inside free()/munmap()/brk()): the
+        framework drains the accumulated {count, bytes} at safe framework
+        operations and delivers them as ONE aggregated, data-bearing event.  A
+        registration that has only a dropped handler (no callback) instead
+        observes the aggregated event as a single drop. */
+    mca_base_event_fold_consume_fn_t fold_consume_fn;
+    mca_base_event_activate_fn_t     activate_fn;
+    /** The single event a deferred-release source folds into (v1 has one event
+        per such source); lets source_get_timestamp drive the fold.  NULL for
+        ordinary sources. */
+    struct mca_base_event_t         *fold_event;
+} mca_base_event_source_t;
+OBJ_CLASS_DECLARATION(mca_base_event_source_t);
+
+/* --- Callback slot (one per safety level) -------------------------------- */
+/* Refcounted so a dispatch snapshot can retain it and invoke outside the
+   lock while a concurrent remove/replace defers its free (sec. 5.10). */
+typedef struct mca_base_event_cb_t {
+    opal_list_item_t                super;
+    mca_base_event_cb_safety_t      cb_safety;
+    mca_base_event_cb_fn_t          cb_function;
+    void                           *user_data;     /* opaque to OPAL */
+    mca_base_event_ctx_release_fn_t release_cb;    /* frees user_data; may be NULL */
+    opal_info_t                    *info;
+    opal_atomic_int32_t             refcount;
+    bool                            dead;
+} mca_base_event_cb_t;
+OBJ_CLASS_DECLARATION(mca_base_event_cb_t);
+
+/* --- Dropped-handler slot (parallel to the callback slot) ---------------- */
+typedef struct mca_base_event_dropped_cb_t {
+    opal_list_item_t                super;
+    mca_base_event_dropped_cb_fn_t  dropped_cb;
+    void                           *user_data;     /* opaque to OPAL */
+    mca_base_event_ctx_release_fn_t release_cb;    /* frees user_data; may be NULL */
+    opal_atomic_int32_t             refcount;
+    bool                            dead;
+} mca_base_event_dropped_cb_t;
+OBJ_CLASS_DECLARATION(mca_base_event_dropped_cb_t);
+
+/* --- Event type ---------------------------------------------------------- */
+
+typedef struct mca_base_event_t {
+    opal_object_t                   super;
+    int                             event_index;
+    char                           *name;
+    char                           *description;
+    int                             group_index;
+    mca_base_var_info_lvl_t         verbosity;
+    int                             num_elements;
+    mca_base_var_type_t            *element_types;     /* copied at register */
+    ptrdiff_t                      *element_offsets;   /* copied at register */
+    size_t                          buffer_size;       /* element extent, rounded up to 8 */
+    size_t                          data_extent;       /* un-rounded element extent; bounds the
+                                                          raise/copy memcpys (buffer_size's pad is
+                                                          never read or written across the API) */
+    mca_base_var_enum_t            *enumerator;        /* optional */
+    int                             bind;              /* MCA_BASE_VAR_BIND_* */
+    mca_base_event_source_t        *source;            /* single-source invariant */
+    mca_base_event_flag_t           flags;
+    /** # registrations with >=1 callback OR a dropped handler; gates raise. */
+    opal_atomic_int32_t             num_active;
+    opal_list_t                     registrations;     /* mca_base_event_registration_t */
+    void                           *ctx;
+} mca_base_event_t;
+OBJ_CLASS_DECLARATION(mca_base_event_t);
+
+/* --- Registration handle (one per handle_alloc) -------------------------- */
+
+typedef struct mca_base_event_registration_t {
+    opal_list_item_t                super;          /* member of event->registrations */
+    mca_base_event_t               *event;
+    void                           *obj_handle;     /* bound object, opaque to OPAL */
+    opal_info_t                    *info;
+    mca_base_event_cb_t            *callbacks[MCA_BASE_EVENT_CB_REQUIRE_MAX];
+    mca_base_event_dropped_cb_t    *dropped_slot;   /* NULL == no dropped handler */
+    opal_atomic_int64_t             dropped;        /* pending-drop counter */
+    opal_atomic_int32_t             refcount;
+    bool                            dead;
+    mca_base_event_free_cb_fn_t     free_cb;
+    void                           *free_user_data;
+} mca_base_event_registration_t;
+OBJ_CLASS_DECLARATION(mca_base_event_registration_t);
+
+/* --- Transient event instance (pooled; valid only inside a callback) ----- */
+
+typedef struct mca_base_event_instance_t {
+    opal_free_list_item_t           super;          /* poolable */
+    mca_base_event_t               *event;
+    mca_base_event_source_t        *source;
+    opal_count_t                    timestamp;
+    size_t                          data_len;       /* == event->buffer_size */
+    unsigned char                   data[MCA_BASE_EVENT_MAX_PAYLOAD];
+} mca_base_event_instance_t;
+OBJ_CLASS_DECLARATION(mca_base_event_instance_t);
+
+/****************************************************************************
+ * Framework lifecycle (called from mca_base_var_init / _finalize).
+ ****************************************************************************/
+OPAL_DECLSPEC int mca_base_event_init(void);
+OPAL_DECLSPEC int mca_base_event_finalize(void);
+
+/****************************************************************************
+ * Registration (producers).
+ ****************************************************************************/
+
+/** Register an event source.  Returns source_index (>=0) or an OPAL error.
+    Idempotent by name.  get_timestamp may be NULL for the default clock. */
+OPAL_DECLSPEC int mca_base_event_source_register(const char *name, const char *description,
+                                                 mca_base_event_source_order_t ordering,
+                                                 opal_count_t ticks_per_second,
+                                                 opal_count_t max_ticks,
+                                                 mca_base_event_source_time_fn_t get_timestamp,
+                                                 bool supports_adhoc, void *ctx);
+
+/** Register an event type.  Returns event_index (>=0) or an OPAL error.
+    Idempotent by full name; copies the element arrays. */
+OPAL_DECLSPEC int mca_base_event_register(const char *project, const char *framework,
+                                          const char *component, const char *name,
+                                          const char *description,
+                                          mca_base_var_info_lvl_t verbosity, int num_elements,
+                                          const mca_base_var_type_t *element_types,
+                                          const ptrdiff_t *element_offsets,
+                                          mca_base_var_enum_t *enumerator, int bind,
+                                          mca_base_event_flag_t flags,
+                                          mca_base_event_source_t *source, void *ctx);
+
+/** Convenience: register from a component (auto IWG flag + names). */
+OPAL_DECLSPEC int mca_base_component_event_register(
+    const mca_base_component_t *component, const char *name, const char *description,
+    mca_base_var_info_lvl_t verbosity, int num_elements,
+    const mca_base_var_type_t *element_types, const ptrdiff_t *element_offsets,
+    mca_base_var_enum_t *enumerator, int bind, mca_base_event_flag_t flags,
+    mca_base_event_source_t *source, void *ctx);
+
+/****************************************************************************
+ * Enumeration / query.
+ ****************************************************************************/
+OPAL_DECLSPEC int mca_base_event_get_count(int *count);
+OPAL_DECLSPEC int mca_base_event_get_by_index(int index, mca_base_event_t **event);
+OPAL_DECLSPEC int mca_base_event_get_by_name(const char *full_name, int *index);
+OPAL_DECLSPEC int mca_base_event_mark_invalid(int index);
+OPAL_DECLSPEC int mca_base_event_source_get_count(int *count);
+OPAL_DECLSPEC int mca_base_event_source_get_by_index(int index, mca_base_event_source_t **source);
+OPAL_DECLSPEC int mca_base_event_source_get_timestamp(int source_index, opal_count_t *timestamp);
+
+/** Introspection for ompi_info. */
+OPAL_DECLSPEC int mca_base_event_dump(int index, char ***out, mca_base_var_dump_type_t output_type);
+OPAL_DECLSPEC int mca_base_event_source_dump(int index, char ***out,
+                                             mca_base_var_dump_type_t output_type);
+
+/****************************************************************************
+ * The raise / dispatch path (Phase 2; implemented in
+ * mca_base_event_dispatch.c).
+ ****************************************************************************/
+
+/** Optional debug hook installed by OMPI to assert the MPI_T big lock is
+    not held on the raise path (keeps OPAL free of any OMPI symbol).  NULL
+    in release builds and until OMPI installs it. */
+OPAL_DECLSPEC extern void (*mca_base_event_debug_raise_check_fn)(void);
+
+/** Slow-path dispatch.  Producers should call the inline mca_base_event_raise
+    (NO_OBJECT events) or mca_base_event_raise_bound (object-bound events) below,
+    not this directly.  `obj_handle` is the opaque bound-object identity the event
+    is raised for: it MUST be NULL for a NO_OBJECT event and equal the identity
+    stored at handle_alloc for a bound event (sec. 6.1).  Delivery reaches only
+    registrations whose bound object matches `obj_handle`. */
+OPAL_DECLSPEC void mca_base_event_raise_internal(mca_base_event_t *event,
+                                                 mca_base_event_source_t *source, void *obj_handle,
+                                                 const void *data,
+                                                 mca_base_event_cb_safety_t context);
+
+/** Cheap predicate: is anyone listening for this event type?  A plain
+    relaxed read of the gate (the opal_progress.c idiom). */
+static inline bool mca_base_event_active(const mca_base_event_t *event)
+{
+    return 0 != event->num_active;
+}
+
+/** Raise a NO_OBJECT event from a NORMAL (thread-safe, non-async) context.  The
+    common no-listener case is a relaxed read + predicted branch.  `data`
+    points to the element buffer matching the event type's layout; `source`
+    may be NULL for the event type's source. */
+static inline void mca_base_event_raise(mca_base_event_t *event, mca_base_event_source_t *source,
+                                        const void *data)
+{
+    if (OPAL_LIKELY(!mca_base_event_active(event))) {
+        return;
+    }
+    mca_base_event_raise_internal(event, source, NULL, data, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+}
+
+/** Raise an object-bound event for the object identified by `obj_handle`.  Only
+    registrations bound to that same object (via handle_alloc) are notified
+    (sec. 6.1).  `obj_handle` is the internal object identity the producer holds
+    (e.g. the ompi_communicator_t*), matching what handle_alloc resolved from the
+    tool's MPI handle. */
+static inline void mca_base_event_raise_bound(mca_base_event_t *event,
+                                              mca_base_event_source_t *source, void *obj_handle,
+                                              const void *data)
+{
+    if (OPAL_LIKELY(!mca_base_event_active(event))) {
+        return;
+    }
+    mca_base_event_raise_internal(event, source, obj_handle, data, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+}
+
+/****************************************************************************
+ * Handle / callback / dropped-handler management (Phase 2).
+ ****************************************************************************/
+OPAL_DECLSPEC int mca_base_event_handle_alloc(int event_index, void *obj_handle, opal_info_t *info,
+                                              mca_base_event_registration_t **reg);
+OPAL_DECLSPEC int mca_base_event_handle_free(mca_base_event_registration_t *reg, void *user_data,
+                                             mca_base_event_free_cb_fn_t free_cb);
+OPAL_DECLSPEC int mca_base_event_handle_set_info(mca_base_event_registration_t *reg,
+                                                 opal_info_t *info);
+OPAL_DECLSPEC int mca_base_event_handle_get_info(mca_base_event_registration_t *reg,
+                                                 opal_info_t **info_used);
+/** Validate a registration handle WITHOUT dereferencing it (sec. 5.10). */
+OPAL_DECLSPEC bool mca_base_event_handle_is_valid(mca_base_event_registration_t *reg);
+
+OPAL_DECLSPEC int mca_base_event_register_callback(mca_base_event_registration_t *reg,
+                                                   mca_base_event_cb_safety_t cb_safety,
+                                                   opal_info_t *info, void *user_data,
+                                                   mca_base_event_ctx_release_fn_t release_cb,
+                                                   mca_base_event_cb_fn_t cb);
+OPAL_DECLSPEC int mca_base_event_callback_set_info(mca_base_event_registration_t *reg,
+                                                   mca_base_event_cb_safety_t cb_safety,
+                                                   opal_info_t *info);
+OPAL_DECLSPEC int mca_base_event_callback_get_info(mca_base_event_registration_t *reg,
+                                                   mca_base_event_cb_safety_t cb_safety,
+                                                   opal_info_t **info_used);
+OPAL_DECLSPEC int mca_base_event_set_dropped_handler(mca_base_event_registration_t *reg,
+                                                     mca_base_event_dropped_cb_fn_t dropped_cb,
+                                                     void *user_data,
+                                                     mca_base_event_ctx_release_fn_t release_cb);
+
+/****************************************************************************
+ * In-callback data accessors (instance valid only inside the callback).
+ ****************************************************************************/
+OPAL_DECLSPEC int mca_base_event_read(mca_base_event_instance_t *inst, int element_index,
+                                      void *buf);
+OPAL_DECLSPEC int mca_base_event_copy(mca_base_event_instance_t *inst, void *buf);
+OPAL_DECLSPEC int mca_base_event_instance_get_timestamp(mca_base_event_instance_t *inst,
+                                                        opal_count_t *timestamp);
+OPAL_DECLSPEC int mca_base_event_instance_get_source(mca_base_event_instance_t *inst,
+                                                     int *source_index);
+
+/****************************************************************************
+ * Saturate a captured drop count to a ceiling before narrowing (sec. 5.4).
+ * Exposed so the white-box test can drive the clamp with an injected 32-bit
+ * ceiling on 64-bit hosts.
+ ****************************************************************************/
+OPAL_DECLSPEC opal_count_t mca_base_event_saturate_to(int64_t value, int64_t ceiling);
+
+/****************************************************************************
+ * Internal coupling between the core TU (mca_base_event.c) and the dispatch
+ * TU (mca_base_event_dispatch.c).  Not part of the producer/tool API.
+ ****************************************************************************/
+
+/** The single framework lock guarding the per-event registration lists and the
+    dispatch snapshot/reconcile windows (sec. 5.10).  No user callback ever runs
+    while it is held.  The process-wide registry (event/source arrays + counts)
+    is append-only and populated during initialization, before any tool
+    interacts with the framework, so it needs no lock (as in mca_base_pvar). */
+OPAL_DECLSPEC extern opal_mutex_t mca_base_event_lock;
+
+/** Pool / DoS-cap MCA parameter values (registered in mca_base_event_init,
+    read by the dispatch TU). */
+OPAL_DECLSPEC extern int mca_base_event_pool_size;
+OPAL_DECLSPEC extern int mca_base_event_pool_max;
+OPAL_DECLSPEC extern int mca_base_event_max_registrations;
+
+/** The dispatch TU registers a teardown function here (when it lazily creates
+    the instance pool) so the core finalize can tear it down without a static
+    link dependency on the dispatch TU. */
+OPAL_DECLSPEC void mca_base_event_set_dispatch_finalize(void (*fn)(void));
+
+/* --- The OS-memory-release deferred producer mechanism (sec. 7.1) --------- */
+/* The machinery lives here in OPAL (it hooks the OS allocator via
+   opal_mem_hooks); the source/event registration and user-facing naming are
+   done in the OMPI producer layer, which calls mca_base_event_memory_attach(). */
+
+/** Whether this platform can report OS-level memory releases (the OPAL memory
+    hooks provide OPAL_MEMORY_FREE_SUPPORT).  A producer should register its
+    source/event for this producer only when this returns true; otherwise the
+    producer is simply absent (a smaller, still-conformant event set). */
+OPAL_DECLSPEC bool mca_base_event_memory_supported(void);
+
+/** Wire the OS-memory-release machinery (the free()/munmap() hook, the
+    never-freed {count, bytes} sink, and the fold/activate callbacks) into a
+    source and event the caller has already registered.  The accumulated
+    releases are drained and delivered as one aggregated, data-bearing event.
+    The caller -- the OMPI producer layer -- chooses the user-facing names.
+    Idempotent across MPI_T_init/finalize cycles. */
+OPAL_DECLSPEC void mca_base_event_memory_attach(mca_base_event_source_t *source,
+                                                mca_base_event_t *event);
+
+/** Test-only seam: pretend `count` memory releases totalling `bytes` bytes
+    occurred (bumps the sink the real free()/munmap() hook would bump), so the
+    fold path is exercisable deterministically without intercepting real frees.
+    Returns false if the machinery has not been attached to a source. */
+OPAL_DECLSPEC bool mca_base_event_memory_test_bump(int64_t count, int64_t bytes);
+
+/** Test-only seam: when suppressed, the producer does NOT install the real
+    OS free()/munmap() hook on listener-attach, so the sink is bumped only by
+    mca_base_event_memory_test_bump() -- making the fold count deterministic in
+    a test.  Set before attaching a listener. */
+OPAL_DECLSPEC void mca_base_event_memory_test_suppress_hook(bool suppress);
+
+END_C_DECLS
+
+#endif /* OPAL_MCA_BASE_EVENT_H */

--- a/opal/mca/base/mca_base_event_dispatch.c
+++ b/opal/mca/base/mca_base_event_dispatch.c
@@ -1,0 +1,1182 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * The mca_base_event dispatch path (Phase 2): the instance pool, the
+ * raise/dispatch algorithm, handle/callback/dropped-handler management,
+ * timestamps, and the in-callback accessors.  See specs/mpi-t-events/spec.md
+ * sections 5.9-5.11.
+ *
+ * This translation unit uses opal_free_list (instance pool), which depends on
+ * the mpool base.  That dependency is absent from libopen-pal_core, so this
+ * file is deliberately kept separate from mca_base_event.c (which is reachable
+ * from core via mca_base_var's init/finalize): this file is pulled in only by
+ * callers of raise/handle_alloc -- the OMPI MPI_T layer -- which link the full
+ * library.
+ */
+
+#include "opal_config.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include "opal/class/opal_free_list.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/mca/base/mca_base_event.h"
+#include "opal/mca/base/mca_base_vari.h"
+#include "opal/mca/threads/thread_usage.h"
+#include "opal/util/clock_gettime.h"
+
+/* OMPI-installed debug hook (sec. 5.10); NULL until/unless installed. */
+void (*mca_base_event_debug_raise_check_fn)(void) = NULL;
+
+/* Count of instance-pool acquisitions, for the white-box test to assert that an
+   all-drops raise consumes no instance (sec. 12.4).  Atomic because it is bumped
+   in the lock-free Step-3 delivery section, where concurrent raises would
+   otherwise race on a plain counter. */
+static opal_atomic_int64_t pool_acquire_count = 0;
+
+int64_t mca_base_event_test_pool_acquires(void)
+{
+    return (int64_t) pool_acquire_count;
+}
+
+/* --- Instance pool (lazy) ------------------------------------------------ */
+
+static opal_free_list_t instance_pool;
+static bool             pool_created = false;
+
+/* --- Default clock origin (lazy, captured at first listener-attach) ------ */
+
+static struct timespec  clock_origin;
+static bool             clock_origin_set = false;
+
+/* --- Live-registration table + generation (sec. 5.10) -------------------- */
+
+static opal_hash_table_t live_registrations;
+static bool              live_table_created = false;
+static int               live_registration_count = 0;
+
+/* --- Per-thread dispatch-depth recursion cap (sec. 5.9 step 0); the cap
+   constant MCA_BASE_EVENT_MAX_DISPATCH_DEPTH is in mca_base_event.h ---------- */
+
+static opal_thread_local int dispatch_depth = 0;
+
+/* Test-only seam: force the instance pool to appear exhausted, so the white-box
+   test can exercise the drop-restore path with a production-sized pool (rather
+   than a size-1 pool that would mask the recursion-depth cap). */
+static bool force_pool_exhaustion = false;
+
+void mca_base_event_test_set_force_exhaustion(bool v)
+{
+    force_pool_exhaustion = v;
+}
+
+/* ======================================================================== */
+/* Saturating drop-count clamp (sec. 5.4)                                    */
+/* ======================================================================== */
+
+opal_count_t mca_base_event_saturate_to(int64_t value, int64_t ceiling)
+{
+    /* Compare at full width BEFORE narrowing, so a 32-bit ceiling on a 64-bit
+       host clamps correctly and never wraps negative.  A negative `value` means
+       the (lock-free) drop counter itself overflowed past INT64_MAX -- treat
+       that as saturated rather than reporting a negative count. */
+    if (value < 0 || value > ceiling) {
+        return (opal_count_t) ceiling;
+    }
+    return (opal_count_t) value;
+}
+
+/* ======================================================================== */
+/* Timestamps (sec. 5.11)                                                    */
+/* ======================================================================== */
+
+/* Default clock: nanoseconds since the lazily-captured origin, integer math.
+   Matches the MPI_Wtime backend (opal_clock_gettime). */
+static opal_count_t default_timestamp(void)
+{
+    struct timespec now;
+
+    opal_clock_gettime(&now);
+    return (opal_count_t) (now.tv_sec - clock_origin.tv_sec) * 1000000000
+           + (opal_count_t) (now.tv_nsec - clock_origin.tv_nsec);
+}
+
+/* Read a source's timestamp, enforcing ORDERED monotonicity with an atomic
+   CAS-max on last_ts (sec. 5.11) so two threads can never publish out of
+   order and a backward-stepping wall clock cannot regress. */
+static opal_count_t source_timestamp(mca_base_event_source_t *source)
+{
+    opal_count_t ts;
+
+    if (NULL != source->get_timestamp) {
+        ts = source->get_timestamp(source->ctx);
+    } else {
+        ts = default_timestamp();
+    }
+
+    if (MCA_BASE_EVENT_SOURCE_ORDERED == source->ordering) {
+        int64_t prev = source->last_ts;
+        while (ts > prev) {
+            if (opal_atomic_compare_exchange_strong_64(&source->last_ts, &prev, (int64_t) ts)) {
+                break;
+            }
+            /* prev was reloaded by the CAS; retry if still behind. */
+        }
+        if (ts < prev) {
+            ts = (opal_count_t) prev; /* never go backwards */
+        }
+    }
+
+    return ts;
+}
+
+/* Ad-hoc source timestamp read (sec. 5.8).  Implemented here (not in the core
+   TU) because the default clock lives here. */
+static void fold_event(mca_base_event_t *event);
+
+int mca_base_event_source_get_timestamp(int source_index, opal_count_t *timestamp)
+{
+    mca_base_event_source_t *source;
+    int rc;
+
+    if (NULL == timestamp) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    rc = mca_base_event_source_get_by_index(source_index, &source);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+    if (!source->supports_adhoc) {
+        return OPAL_ERR_NOT_SUPPORTED;
+    }
+
+    /* For a default-clock source the origin is normally captured on first
+       listener attach (ensure_dispatch_state()).  A tool may read an ad-hoc
+       timestamp before any handle is allocated, so capture it here too --
+       otherwise default_timestamp() would subtract a zero origin and return a
+       timestamp in the wrong epoch. */
+    if (NULL == source->get_timestamp) {
+        opal_mutex_lock(&mca_base_event_lock);
+        if (!clock_origin_set) {
+            opal_clock_gettime(&clock_origin);
+            clock_origin_set = true;
+        }
+        opal_mutex_unlock(&mca_base_event_lock);
+    }
+
+    /* A read of a deferred-release source drains its accumulated releases and
+       delivers them as one aggregated event (sec. 7.1); a no-op otherwise. */
+    fold_event(source->fold_event);
+
+    *timestamp = source_timestamp(source);
+    return OPAL_SUCCESS;
+}
+
+/* ======================================================================== */
+/* Pool lifecycle                                                            */
+/* ======================================================================== */
+
+/* Tear down the pool + dispatch state.  Registered with the core finalize via
+   mca_base_event_set_dispatch_finalize() the first time the pool is created. */
+static void dispatch_finalize(void)
+{
+    /* v1 limitation: any registration a tool failed to free before finalize
+       leaks here (it remains on its event's registration list and in the live
+       table).  Freeing a handle is the tool's responsibility (the standard
+       treats use-after-finalize as erroneous); this is a one-time process-exit
+       leak only. */
+    if (pool_created) {
+        OBJ_DESTRUCT(&instance_pool);
+        pool_created = false;
+    }
+    if (live_table_created) {
+        OBJ_DESTRUCT(&live_registrations);
+        live_table_created = false;
+    }
+    /* Reset the DoS-guard counter together with the table it tracks: otherwise a
+       handle leaked past finalize (acknowledged above) leaves the count nonzero,
+       and across MPI_T init/finalize cycles it drifts up against a rebuilt-empty
+       table until it reaches mca_base_event_max_registrations and every later
+       handle_alloc fails with no handles actually live. */
+    live_registration_count = 0;
+    clock_origin_set = false;
+}
+
+/* Lazily create the pool, live table, and clock origin on first attach.
+   MUST be called with mca_base_event_lock held. */
+static int ensure_dispatch_state(void)
+{
+    int rc, pool_max;
+
+    if (!clock_origin_set) {
+        opal_clock_gettime(&clock_origin);
+        clock_origin_set = true;
+    }
+
+    if (!live_table_created) {
+        OBJ_CONSTRUCT(&live_registrations, opal_hash_table_t);
+        rc = opal_hash_table_init(&live_registrations, 256);
+        if (OPAL_SUCCESS != rc) {
+            OBJ_DESTRUCT(&live_registrations);
+            return rc;
+        }
+        live_table_created = true;
+    }
+
+    if (!pool_created) {
+        int pool_grow;
+        pool_max = mca_base_event_pool_max;
+        if (pool_max < 1) {
+            pool_max = 256; /* never unbounded (sec. 5.9) */
+        }
+        /* The grow quantum is independent of the pre-allocation count, so
+           event_pool_size == 0 means "pre-allocate nothing, grow on demand"
+           rather than "never grow" -- which (with a zero grow quantum) would
+           leave the pool permanently empty and drop every event forever. */
+        pool_grow = (mca_base_event_pool_size > 0) ? mca_base_event_pool_size : 8;
+        OBJ_CONSTRUCT(&instance_pool, opal_free_list_t);
+        rc = opal_free_list_init(&instance_pool, sizeof(mca_base_event_instance_t), 8,
+                                 OBJ_CLASS(mca_base_event_instance_t), 0, 0,
+                                 mca_base_event_pool_size, pool_max, pool_grow, NULL,
+                                 0, NULL, NULL, NULL);
+        if (OPAL_SUCCESS != rc) {
+            OBJ_DESTRUCT(&instance_pool);
+            return rc;
+        }
+        pool_created = true;
+    }
+
+    /* (Re-)register the teardown hook so finalize can reach us. */
+    mca_base_event_set_dispatch_finalize(dispatch_finalize);
+
+    return OPAL_SUCCESS;
+}
+
+/* ======================================================================== */
+/* num_active state machine (sec. 5.10) -- caller holds the lock             */
+/* ======================================================================== */
+
+static bool reg_is_active(const mca_base_event_registration_t *reg)
+{
+    int l;
+
+    if (NULL != reg->dropped_slot) {
+        return true;
+    }
+    for (l = 0; l < MCA_BASE_EVENT_CB_REQUIRE_MAX; ++l) {
+        if (NULL != reg->callbacks[l]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void update_num_active(mca_base_event_registration_t *reg, bool was_active)
+{
+    bool now_active = reg_is_active(reg);
+    mca_base_event_source_t *source = reg->event->source;
+    int32_t n;
+
+    if (was_active && !now_active) {
+        n = opal_atomic_sub_fetch_32(&reg->event->num_active, 1);
+        /* Last listener on this event detached: let a deferred-release source
+           remove its OS hook (sec. 7.1).  Called under the lock. */
+        if (0 == n && NULL != source && NULL != source->activate_fn) {
+            source->activate_fn(source->ctx, false);
+        }
+    } else if (!was_active && now_active) {
+        n = opal_atomic_add_fetch_32(&reg->event->num_active, 1);
+        /* First listener attached: let a deferred-release source install its
+           OS hook lazily (sec. 7.1).  Called under the lock. */
+        if (1 == n && NULL != source && NULL != source->activate_fn) {
+            source->activate_fn(source->ctx, true);
+        }
+    }
+}
+
+/* ======================================================================== */
+/* Deferred-free helpers (sec. 5.10) -- caller holds the lock                */
+/* ======================================================================== */
+
+/* Objects whose refcount reached 0 while dead are collected here (via their
+   own opal_list_item_t super, so the collection is UNBOUNDED -- a single
+   reconcile can free arbitrarily many handles); their user callbacks +
+   release_cbs + OBJ_RELEASE run AFTER the lock is dropped.  A dead reg has
+   already been removed from event->registrations, and a dead slot is no longer
+   referenced by reg->callbacks[]/dropped_slot, so reusing each object's super
+   list item here is safe. */
+typedef struct {
+    opal_list_t cb_slots;
+    opal_list_t dropped_slots;
+    opal_list_t regs;
+} to_free_t;
+
+static void to_free_init(to_free_t *tf)
+{
+    OBJ_CONSTRUCT(&tf->cb_slots, opal_list_t);
+    OBJ_CONSTRUCT(&tf->dropped_slots, opal_list_t);
+    OBJ_CONSTRUCT(&tf->regs, opal_list_t);
+}
+
+static void release_cb_slot(mca_base_event_cb_t *slot, to_free_t *tf)
+{
+    if (NULL == slot) {
+        return;
+    }
+    if (0 == opal_atomic_sub_fetch_32(&slot->refcount, 1) && slot->dead) {
+        opal_list_append(&tf->cb_slots, &slot->super);
+    }
+}
+
+static void release_dropped_slot(mca_base_event_dropped_cb_t *slot, to_free_t *tf)
+{
+    if (NULL == slot) {
+        return;
+    }
+    if (0 == opal_atomic_sub_fetch_32(&slot->refcount, 1) && slot->dead) {
+        opal_list_append(&tf->dropped_slots, &slot->super);
+    }
+}
+
+static void release_reg(mca_base_event_registration_t *reg, to_free_t *tf)
+{
+    if (NULL == reg) {
+        return;
+    }
+    if (0 == opal_atomic_sub_fetch_32(&reg->refcount, 1) && reg->dead) {
+        opal_list_append(&tf->regs, &reg->super);
+    }
+}
+
+/* Run the deferred frees collected in tf.  MUST be called with the lock NOT
+   held (user callbacks + release_cbs run here).  Empties + destructs tf. */
+static void process_to_free(to_free_t *tf)
+{
+    opal_list_item_t *item;
+
+    while (NULL != (item = opal_list_remove_first(&tf->cb_slots))) {
+        mca_base_event_cb_t *slot = (mca_base_event_cb_t *) item;
+        if (NULL != slot->release_cb) {
+            slot->release_cb(slot->user_data);
+        }
+        if (NULL != slot->info) {
+            OBJ_RELEASE(slot->info);
+        }
+        OBJ_RELEASE(slot);
+    }
+    while (NULL != (item = opal_list_remove_first(&tf->dropped_slots))) {
+        mca_base_event_dropped_cb_t *slot = (mca_base_event_dropped_cb_t *) item;
+        if (NULL != slot->release_cb) {
+            slot->release_cb(slot->user_data);
+        }
+        OBJ_RELEASE(slot);
+    }
+    while (NULL != (item = opal_list_remove_first(&tf->regs))) {
+        mca_base_event_registration_t *reg = (mca_base_event_registration_t *) item;
+        if (NULL != reg->free_cb) {
+            reg->free_cb(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, reg->free_user_data);
+        }
+        if (NULL != reg->info) {
+            OBJ_RELEASE(reg->info);
+        }
+        OBJ_RELEASE(reg);
+    }
+    OBJ_DESTRUCT(&tf->cb_slots);
+    OBJ_DESTRUCT(&tf->dropped_slots);
+    OBJ_DESTRUCT(&tf->regs);
+}
+
+/* ======================================================================== */
+/* Deferred-release fold (sec. 7.1)                                          */
+/* ======================================================================== */
+
+/* Drain a deferred-release source's accumulated {count, bytes} and deliver them
+   as ONE aggregated, data-bearing event (sec. 7.1).  The underlying releases
+   occurred inside free()/munmap()/brk() where delivery is unsafe; this runs at
+   safe framework operations -- and before any change to the attached-
+   registration set, so a newly-attached registration is never credited with
+   pre-attach releases.  Runs with NO framework lock held: mca_base_event_raise()
+   takes the lock itself.  A no-op for ordinary sources. */
+static void fold_event(mca_base_event_t *event)
+{
+    mca_base_event_source_t *source;
+    int64_t count = 0, bytes = 0;
+    struct {
+        uint64_t count;
+        uint64_t bytes;
+    } payload;
+
+    if (NULL == event || NULL == (source = event->source) || NULL == source->fold_consume_fn) {
+        return;
+    }
+
+    /* Consume-and-clear the producer's pending releases (the sink is a
+       never-freed, lock-free atomic pair). */
+    source->fold_consume_fn(source->ctx, &count, &bytes);
+    if (0 == count) {
+        return;
+    }
+
+    /* Deliver the batch as one event.  raise() snapshots the registrations and
+       delivers under its own lock; a registration whose callback cannot run in
+       this (NORMAL) context -- or that has only a dropped handler, no callback --
+       instead observes a single drop.  Saturate the aggregates into the
+       payload's unsigned elements. */
+    payload.count = (uint64_t) mca_base_event_saturate_to(count, OPAL_COUNT_MAX);
+    payload.bytes = (uint64_t) mca_base_event_saturate_to(bytes, OPAL_COUNT_MAX);
+    mca_base_event_raise(event, source, &payload);
+}
+
+/* ======================================================================== */
+/* Handle alloc / free / info / validation                                   */
+/* ======================================================================== */
+
+/* v1 stores no handle-level hints, so info is ignored. */
+int mca_base_event_handle_alloc(int event_index, void *obj_handle,
+                                opal_info_t *info __opal_attribute_unused__,
+                                mca_base_event_registration_t **reg_out)
+{
+    mca_base_event_t *event;
+    mca_base_event_registration_t *reg;
+    int rc;
+
+    rc = mca_base_event_get_by_index(event_index, &event);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* Resolve the bound-object identity (sec. 6.1).  For a NO_OBJECT event the
+       standard requires obj_handle to be IGNORED, so a conformant tool may pass
+       any value and must not be rejected (MPI-5.0 sec. 15.3.8); store NULL so a
+       NO_OBJECT raise (obj_handle == NULL) matches every registration.  For an
+       object-bound event obj_handle references the tool's MPI handle -- the
+       "address to a local variable that stores the object's handle" (MPI-5.0
+       p.751) -- so dereference it to the identity a producer raises with, and
+       reject a missing object.
+       XXX ABI (#13280): under the Open MPI ABI the MPI handle IS the internal
+       object pointer the producer raises with, so a single deref suffices; the
+       MPI Standard ABI path must convert its integer handle to that internal
+       pointer here. */
+    void *bound_obj = NULL;
+    if (MCA_BASE_VAR_BIND_NO_OBJECT != event->bind) {
+        if (NULL == obj_handle) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+        bound_obj = *(void **) obj_handle;
+    }
+
+    /* Drain a deferred-release source's pending releases BEFORE this new
+       registration joins event->registrations, so it never receives an
+       aggregated event covering releases that predate it (sec. 7.1
+       fold-before-membership-change); a no-op for ordinary sources. */
+    fold_event(event);
+
+    opal_mutex_lock(&mca_base_event_lock);
+
+    rc = ensure_dispatch_state();
+    if (OPAL_SUCCESS != rc) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        return rc;
+    }
+
+    {
+        /* DoS guard (sec. 9.1).  Clamp the (user-settable) cap to a sane range:
+           it bounds the dispatch snapshot, so a pathological value must not let
+           the snapshot capacity arithmetic overflow. */
+        int max_regs = mca_base_event_max_registrations;
+        if (max_regs < 1) {
+            max_regs = 1;
+        } else if (max_regs > (1 << 20)) {
+            max_regs = (1 << 20);
+        }
+        if (live_registration_count >= max_regs) {
+            opal_mutex_unlock(&mca_base_event_lock);
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    reg = OBJ_NEW(mca_base_event_registration_t);
+    if (NULL == reg) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    reg->event = event;
+    reg->obj_handle = bound_obj;
+    reg->refcount = 1;
+    reg->dead = false;
+
+    opal_list_append(&event->registrations, &reg->super);
+    rc = opal_hash_table_set_value_uint64(&live_registrations, (uint64_t) (uintptr_t) reg, reg);
+    if (OPAL_SUCCESS != rc) {
+        /* The live table is what handle validity keys off (handle_is_valid_locked
+           looks the registration up there); if the insert failed (e.g. OOM while
+           growing the table) unwind instead of returning a handle every later
+           operation would reject as MPI_T_ERR_INVALID_HANDLE. */
+        opal_list_remove_item(&event->registrations, &reg->super);
+        opal_mutex_unlock(&mca_base_event_lock);
+        OBJ_RELEASE(reg);
+        return rc;
+    }
+    live_registration_count++;
+
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    *reg_out = reg;
+    return OPAL_SUCCESS;
+}
+
+/* Validate a registration handle WITHOUT dereferencing it -- the live table is
+   keyed by the pointer VALUE, so a lookup on a stale pointer to freed memory is
+   safe (sec. 5.10).  MUST be called with mca_base_event_lock held.
+
+   Guarantee: this prevents use-after-free (a freed handle is removed from the
+   table at handle_free, so it validates as invalid and is never dereferenced).
+   It does NOT distinguish a handle whose address was reused by a *new*
+   registration after the original was fully freed -- but reuse can only happen
+   once no reference remains (deferred free keeps the memory alive while any
+   snapshot/handle references it), and using a freed handle is erroneous tool
+   behaviour per the standard, so validating-as-the-new-handle (no crash) is
+   conformant. */
+static bool handle_is_valid_locked(mca_base_event_registration_t *reg)
+{
+    void *tmp;
+
+    if (NULL == reg) {
+        return false;
+    }
+    return live_table_created
+           && OPAL_SUCCESS
+                  == opal_hash_table_get_value_uint64(&live_registrations,
+                                                      (uint64_t) (uintptr_t) reg, &tmp)
+           && tmp == (void *) reg;
+}
+
+bool mca_base_event_handle_is_valid(mca_base_event_registration_t *reg)
+{
+    bool valid;
+
+    opal_mutex_lock(&mca_base_event_lock);
+    valid = handle_is_valid_locked(reg);
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    return valid;
+}
+
+int mca_base_event_handle_free(mca_base_event_registration_t *reg, void *user_data,
+                               mca_base_event_free_cb_fn_t free_cb)
+{
+    to_free_t tf;
+    mca_base_event_dropped_cb_t *flush_slot = NULL;
+    mca_base_event_dropped_cb_fn_t flush_cb = NULL;
+    void *flush_user_data = NULL;
+    int flush_source_index = -1;
+    int64_t flush_n = 0;
+    bool was_active;
+    int l;
+
+    /* Drain a deferred-release source's pending releases -- delivering the final
+       aggregated event to this still-live registration -- BEFORE it detaches
+       (sec. 7.1), so a tool that frees the handle without first polling
+       source_get_timestamp still observes the last batch.  Validate first to
+       safely read reg->event; fold_event is a no-op for ordinary sources.  (A
+       concurrent erroneous double-free only makes the drain best-effort; the
+       validate-and-mutate section below still rejects the stale free.) */
+    {
+        mca_base_event_t *event = NULL;
+        opal_mutex_lock(&mca_base_event_lock);
+        if (handle_is_valid_locked(reg)) {
+            event = reg->event;
+        }
+        opal_mutex_unlock(&mca_base_event_lock);
+        if (NULL != event) {
+            fold_event(event);
+        }
+    }
+
+    /* Validate AND mutate under one lock acquisition (no TOCTOU): a dead handle
+       is absent from the live table, so this rejects a stale/double free. */
+    opal_mutex_lock(&mca_base_event_lock);
+
+    if (!handle_is_valid_locked(reg)) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        return OPAL_ERR_BAD_PARAM; /* stale / double free -> INVALID_HANDLE */
+    }
+
+    to_free_init(&tf);
+
+    was_active = reg_is_active(reg);
+
+    /* Final delivery-independent flush for a registration with no selectable
+       callback (sec. 5.8): pinned ordering -- retain, swap, THEN mark dead. */
+    if (NULL != reg->dropped_slot) {
+        flush_n = opal_atomic_swap_64(&reg->dropped, 0);
+        if (flush_n != 0) { /* != 0 also catches an overflow-wrapped count */
+            (void) opal_atomic_add_fetch_32(&reg->dropped_slot->refcount, 1);
+            flush_slot = reg->dropped_slot;
+            flush_cb = reg->dropped_slot->dropped_cb;
+            flush_user_data = reg->dropped_slot->user_data;
+            flush_source_index = (NULL != reg->event->source)
+                                     ? reg->event->source->source_index
+                                     : -1;
+        }
+    }
+
+    /* Logical death: remove from the live table at once (a second free then
+       fails immediately) but keep the object alive for in-flight dispatch. */
+    reg->dead = true;
+    opal_hash_table_remove_value_uint64(&live_registrations, (uint64_t) (uintptr_t) reg);
+    if (live_registration_count > 0) {
+        live_registration_count--;
+    }
+    opal_list_remove_item(&reg->event->registrations, &reg->super);
+
+    /* Mark all slots dead so later dispatch skips them. */
+    for (l = 0; l < MCA_BASE_EVENT_CB_REQUIRE_MAX; ++l) {
+        if (NULL != reg->callbacks[l]) {
+            reg->callbacks[l]->dead = true;
+        }
+    }
+    if (NULL != reg->dropped_slot) {
+        reg->dropped_slot->dead = true;
+    }
+
+    /* The reg is leaving; remove its contribution to the gate (the slots are
+       marked dead but not NULLed, so reg_is_active can't detect the change).
+       On the last-listener (1->0) transition, fire the source deactivate hook
+       too -- this path bypasses update_num_active, so a deferred-release
+       source (e.g. ompi.unordered) would otherwise never remove its OS hook. */
+    if (was_active) {
+        int32_t n = opal_atomic_sub_fetch_32(&reg->event->num_active, 1);
+        mca_base_event_source_t *source = reg->event->source;
+        if (0 == n && NULL != source && NULL != source->activate_fn) {
+            source->activate_fn(source->ctx, false);
+        }
+    }
+
+    reg->free_cb = free_cb;
+    reg->free_user_data = user_data;
+
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    /* Invoke the final dropped-handler flush OUTSIDE the lock. */
+    if (NULL != flush_cb) {
+        flush_cb(mca_base_event_saturate_to(flush_n, OPAL_COUNT_MAX), reg, flush_source_index,
+                 MCA_BASE_EVENT_CB_REQUIRE_NONE, flush_user_data);
+    }
+
+    /* Release the owning reference (and the flush retain).  When the refcount
+       reaches 0, the reg/slots are collected and freed outside the lock. */
+    opal_mutex_lock(&mca_base_event_lock);
+    if (NULL != flush_slot) {
+        release_dropped_slot(flush_slot, &tf);
+    }
+    for (l = 0; l < MCA_BASE_EVENT_CB_REQUIRE_MAX; ++l) {
+        release_cb_slot(reg->callbacks[l], &tf);
+    }
+    if (NULL != reg->dropped_slot) {
+        release_dropped_slot(reg->dropped_slot, &tf);
+    }
+    release_reg(reg, &tf);
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    process_to_free(&tf);
+    return OPAL_SUCCESS;
+}
+
+/* v1 stores no handle-level hints, so info is ignored. */
+int mca_base_event_handle_set_info(mca_base_event_registration_t *reg,
+                                   opal_info_t *info __opal_attribute_unused__)
+{
+    if (!mca_base_event_handle_is_valid(reg)) {
+        return OPAL_ERR_BAD_PARAM; /* stale / invalid handle */
+    }
+    return OPAL_SUCCESS; /* v1 acts on no handle-level hints */
+}
+
+int mca_base_event_handle_get_info(mca_base_event_registration_t *reg, opal_info_t **info_used)
+{
+    if (!mca_base_event_handle_is_valid(reg)) {
+        return OPAL_ERR_BAD_PARAM; /* stale / invalid handle */
+    }
+    *info_used = OBJ_NEW(opal_info_t); /* fresh, user-owned, possibly empty */
+    return (NULL != *info_used) ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;
+}
+
+/* ======================================================================== */
+/* Callback / dropped-handler management                                     */
+/* ======================================================================== */
+
+/* v1 stores no per-callback hints, so info is ignored. */
+int mca_base_event_register_callback(mca_base_event_registration_t *reg,
+                                     mca_base_event_cb_safety_t cb_safety,
+                                     opal_info_t *info __opal_attribute_unused__,
+                                     void *user_data, mca_base_event_ctx_release_fn_t release_cb,
+                                     mca_base_event_cb_fn_t cb)
+{
+    to_free_t tf;
+    mca_base_event_cb_t *old_slot, *new_slot = NULL;
+    bool was_active;
+
+    if (cb_safety < 0 || cb_safety >= MCA_BASE_EVENT_CB_REQUIRE_MAX) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* Allocate the new slot before taking the lock. */
+    if (NULL != cb) {
+        new_slot = OBJ_NEW(mca_base_event_cb_t);
+        if (NULL == new_slot) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+        new_slot->cb_safety = cb_safety;
+        new_slot->cb_function = cb;
+        new_slot->user_data = user_data;
+        new_slot->release_cb = release_cb;
+        new_slot->refcount = 1;
+        new_slot->dead = false;
+    }
+
+    /* Validate AND mutate under one lock acquisition (no TOCTOU). */
+    opal_mutex_lock(&mca_base_event_lock);
+    if (!handle_is_valid_locked(reg)) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        if (NULL != new_slot) {
+            OBJ_RELEASE(new_slot);
+        }
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    to_free_init(&tf);
+    was_active = reg_is_active(reg);
+
+    old_slot = reg->callbacks[cb_safety];
+    if (NULL != old_slot) {
+        old_slot->dead = true; /* detach; freed when in-flight snapshots release it */
+    }
+    reg->callbacks[cb_safety] = new_slot; /* NULL on removal */
+
+    update_num_active(reg, was_active);
+
+    release_cb_slot(old_slot, &tf);
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    process_to_free(&tf);
+    return OPAL_SUCCESS;
+}
+
+/* v1 stores no per-callback hints, so info is ignored. */
+int mca_base_event_callback_set_info(mca_base_event_registration_t *reg,
+                                     mca_base_event_cb_safety_t cb_safety,
+                                     opal_info_t *info __opal_attribute_unused__)
+{
+    if ((int) cb_safety < 0 || (int) cb_safety >= MCA_BASE_EVENT_CB_REQUIRE_MAX) {
+        return OPAL_ERR_BAD_PARAM; /* out-of-range safety level */
+    }
+    /* The hints apply to the callback registered at cb_safety; reject a level
+       with no registered callback (and a stale handle).  Read the slot under the
+       lock. */
+    opal_mutex_lock(&mca_base_event_lock);
+    if (!handle_is_valid_locked(reg) || NULL == reg->callbacks[cb_safety]) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        return OPAL_ERR_BAD_PARAM;
+    }
+    opal_mutex_unlock(&mca_base_event_lock);
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_callback_get_info(mca_base_event_registration_t *reg,
+                                     mca_base_event_cb_safety_t cb_safety, opal_info_t **info_used)
+{
+    if ((int) cb_safety < 0 || (int) cb_safety >= MCA_BASE_EVENT_CB_REQUIRE_MAX) {
+        return OPAL_ERR_BAD_PARAM; /* out-of-range safety level */
+    }
+    /* Return the hints of the callback registered at cb_safety; reject a level
+       with no registered callback (and a stale handle). */
+    opal_mutex_lock(&mca_base_event_lock);
+    if (!handle_is_valid_locked(reg) || NULL == reg->callbacks[cb_safety]) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        return OPAL_ERR_BAD_PARAM;
+    }
+    opal_mutex_unlock(&mca_base_event_lock);
+    *info_used = OBJ_NEW(opal_info_t);
+    return (NULL != *info_used) ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;
+}
+
+int mca_base_event_set_dropped_handler(mca_base_event_registration_t *reg,
+                                       mca_base_event_dropped_cb_fn_t dropped_cb, void *user_data,
+                                       mca_base_event_ctx_release_fn_t release_cb)
+{
+    to_free_t tf;
+    mca_base_event_dropped_cb_t *old_slot, *new_slot = NULL;
+    bool was_active;
+
+    /* Allocate the new slot before taking the lock. */
+    if (NULL != dropped_cb) {
+        new_slot = OBJ_NEW(mca_base_event_dropped_cb_t);
+        if (NULL == new_slot) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+        new_slot->dropped_cb = dropped_cb;
+        new_slot->user_data = user_data;
+        new_slot->release_cb = release_cb;
+        new_slot->refcount = 1;
+        new_slot->dead = false;
+    }
+
+    /* Drain a deferred-release source's pending releases -- delivering the
+       aggregated event under this registration's CURRENT (old) dropped handler --
+       BEFORE swapping or clearing it, so releases that accumulated under the old
+       handler are reported to it rather than mis-attributed to the replacement.
+       Validate first to safely read reg->event; fold_event is a no-op for
+       ordinary sources.  (Mirrors the drain prologue in handle_free; the
+       validate-and-mutate section below still rejects a stale handle.) */
+    {
+        mca_base_event_t *event = NULL;
+        opal_mutex_lock(&mca_base_event_lock);
+        if (handle_is_valid_locked(reg)) {
+            event = reg->event;
+        }
+        opal_mutex_unlock(&mca_base_event_lock);
+        if (NULL != event) {
+            fold_event(event);
+        }
+    }
+
+    /* Validate AND mutate under one lock acquisition (no TOCTOU). */
+    opal_mutex_lock(&mca_base_event_lock);
+    if (!handle_is_valid_locked(reg)) {
+        opal_mutex_unlock(&mca_base_event_lock);
+        if (NULL != new_slot) {
+            OBJ_RELEASE(new_slot);
+        }
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    to_free_init(&tf);
+    was_active = reg_is_active(reg);
+
+    old_slot = reg->dropped_slot;
+    if (NULL != old_slot) {
+        old_slot->dead = true;
+    }
+    reg->dropped_slot = new_slot;
+
+    /* (Re)installing or clearing the handler resets pending drops: MPI-5.0
+       sec. 15.3.8 (p.755) scopes the dropped count to "since the registration of
+       the dropped-callback handler", so a newly installed handler must not
+       observe drops that predate it (and clearing discards them).  A
+       deferred-release source already drained its pending releases to the OLD
+       handler in the fold prologue above, so nothing owed to it is lost here. */
+    (void) opal_atomic_swap_64(&reg->dropped, 0);
+
+    update_num_active(reg, was_active);
+
+    release_dropped_slot(old_slot, &tf);
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    process_to_free(&tf);
+    return OPAL_SUCCESS;
+}
+
+/* ======================================================================== */
+/* In-callback accessors (lock-free; instance-owned data)                    */
+/* ======================================================================== */
+
+int mca_base_event_read(mca_base_event_instance_t *inst, int element_index, void *buf)
+{
+    mca_base_event_t *event;
+    size_t tsize, offset;
+
+    if (NULL == inst || NULL == buf) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    event = inst->event;
+    if (NULL == event || element_index < 0 || element_index >= event->num_elements) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    /* Write exactly the validated element's width from instance-owned memory;
+       no tool-supplied length participates (sec. 6). */
+    tsize = ompi_var_type_sizes[event->element_types[element_index]];
+    offset = (size_t) event->element_offsets[element_index];
+    memcpy(buf, inst->data + offset, tsize);
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_copy(mca_base_event_instance_t *inst, void *buf)
+{
+    mca_base_event_t *event;
+    int i;
+
+    if (NULL == inst || NULL == buf) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    event = inst->event;
+    if (NULL == event) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* Zero then per-element copy from the validated layout (not a raw memcpy of
+       padding, sec. 6).  Bound the zero-fill to the un-rounded element extent --
+       what the caller sized buf from via MPI_T_event_get_info -- NOT the internal
+       8-byte-rounded buffer_size, or the trailing rounding pad would overflow the
+       caller's buffer. */
+    memset(buf, 0, event->data_extent);
+    for (i = 0; i < event->num_elements; ++i) {
+        size_t tsize = ompi_var_type_sizes[event->element_types[i]];
+        size_t offset = (size_t) event->element_offsets[i];
+        memcpy((unsigned char *) buf + offset, inst->data + offset, tsize);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_instance_get_timestamp(mca_base_event_instance_t *inst, opal_count_t *timestamp)
+{
+    if (NULL == inst || NULL == timestamp) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    *timestamp = inst->timestamp;
+    return OPAL_SUCCESS;
+}
+
+int mca_base_event_instance_get_source(mca_base_event_instance_t *inst, int *source_index)
+{
+    if (NULL == inst || NULL == source_index) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    *source_index = (NULL != inst->source) ? inst->source->source_index : -1;
+    return OPAL_SUCCESS;
+}
+
+/* ======================================================================== */
+/* The raise / dispatch path (sec. 5.9)                                      */
+/* ======================================================================== */
+
+typedef struct {
+    mca_base_event_registration_t  *reg;
+    mca_base_event_cb_t            *slot;
+    mca_base_event_cb_fn_t          cb_function;
+    void                           *cb_user_data;
+    mca_base_event_dropped_cb_t    *dropped_slot;
+    mca_base_event_dropped_cb_fn_t  dropped_cb;
+    void                           *dropped_user_data;
+    int64_t                         n;
+} dispatch_entry_t;
+
+#define MCA_BASE_EVENT_SNAP_INLINE 32
+
+/* Select the callback for context C: smallest L in [C, THREAD_SAFE] with a
+   slot.  ASYNC_SIGNAL_SAFE is registrable but never selected in v1. */
+static mca_base_event_cb_t *select_callback(mca_base_event_registration_t *reg,
+                                            mca_base_event_cb_safety_t context)
+{
+    int l;
+
+    for (l = context; l <= MCA_BASE_EVENT_CB_REQUIRE_V1_MAX; ++l) {
+        if (NULL != reg->callbacks[l]) {
+            return reg->callbacks[l];
+        }
+    }
+    return NULL;
+}
+
+void mca_base_event_raise_internal(mca_base_event_t *event, mca_base_event_source_t *source,
+                                   void *obj_handle, const void *data,
+                                   mca_base_event_cb_safety_t context)
+{
+    dispatch_entry_t inline_snap[MCA_BASE_EVENT_SNAP_INLINE];
+    dispatch_entry_t *snap = inline_snap;
+    int snap_cap = MCA_BASE_EVENT_SNAP_INLINE;
+    int num_deliveries = 0;
+    mca_base_event_instance_t *inst = NULL;
+    to_free_t tf;
+    opal_list_item_t *item;
+    int i;
+
+    /* Step 0: recursion-depth gate at ENTRY (sec. 5.9). */
+    if (++dispatch_depth > MCA_BASE_EVENT_MAX_DISPATCH_DEPTH) {
+        --dispatch_depth;
+        return;
+    }
+
+#if OPAL_ENABLE_DEBUG
+    if (NULL != mca_base_event_debug_raise_check_fn) {
+        mca_base_event_debug_raise_check_fn();
+    }
+    assert(context != MCA_BASE_EVENT_CB_REQUIRE_ASYNC_SIGNAL_SAFE);
+#endif
+
+    /* Step 1: single-source check. */
+    if (NULL == source) {
+        source = event->source;
+    } else if (source != event->source) {
+        --dispatch_depth;
+        return;
+    }
+
+    to_free_init(&tf);
+
+    /* Step 2: snapshot the live registration set ONCE under the lock. */
+    opal_mutex_lock(&mca_base_event_lock);
+    for (item = opal_list_get_first(&event->registrations);
+         item != opal_list_get_end(&event->registrations); item = opal_list_get_next(item)) {
+        mca_base_event_registration_t *reg = (mca_base_event_registration_t *) item;
+        mca_base_event_cb_t *slot;
+
+        if (reg->dead) {
+            continue;
+        }
+        /* Object-binding filter (sec. 6.1): a bound event reaches only
+           registrations bound to the raised object.  For a NO_OBJECT event both
+           sides are NULL, so every registration matches.  A non-matching bound
+           registration is simply not a recipient -- it is skipped, NOT counted
+           as a dropped event. */
+        if (reg->obj_handle != obj_handle) {
+            continue;
+        }
+        slot = select_callback(reg, context);
+
+        if (NULL != slot) {
+            /* Delivery: capture-and-clear pending drops, retain everything. */
+            if (num_deliveries >= snap_cap) {
+                int new_cap = snap_cap * 2;
+                dispatch_entry_t *grown;
+                grown = (snap == inline_snap) ? malloc(new_cap * sizeof(*grown))
+                                              : realloc(snap, new_cap * sizeof(*grown));
+                if (NULL == grown) {
+                    /* Heap-fallback OOM: count this raise as a drop for the
+                       remaining (un-snapshotted) registrations, within the same
+                       lock hold, and stop snapshotting (sec. 5.9). */
+                    (void) opal_atomic_add_fetch_64(&reg->dropped, 1);
+                    for (item = opal_list_get_next(item);
+                         item != opal_list_get_end(&event->registrations);
+                         item = opal_list_get_next(item)) {
+                        mca_base_event_registration_t *tail
+                            = (mca_base_event_registration_t *) item;
+                        if (!tail->dead && tail->obj_handle == obj_handle) {
+                            (void) opal_atomic_add_fetch_64(&tail->dropped, 1);
+                        }
+                    }
+                    break;
+                }
+                if (snap == inline_snap) {
+                    memcpy(grown, inline_snap, snap_cap * sizeof(*grown));
+                }
+                snap = grown;
+                snap_cap = new_cap;
+            }
+            snap[num_deliveries].reg = reg;
+            snap[num_deliveries].slot = slot;
+            snap[num_deliveries].cb_function = slot->cb_function;
+            snap[num_deliveries].cb_user_data = slot->user_data;
+            snap[num_deliveries].dropped_slot = reg->dropped_slot;
+            snap[num_deliveries].dropped_cb = (NULL != reg->dropped_slot)
+                                                  ? reg->dropped_slot->dropped_cb
+                                                  : NULL;
+            snap[num_deliveries].dropped_user_data = (NULL != reg->dropped_slot)
+                                                         ? reg->dropped_slot->user_data
+                                                         : NULL;
+            snap[num_deliveries].n = opal_atomic_swap_64(&reg->dropped, 0);
+
+            (void) opal_atomic_add_fetch_32(&reg->refcount, 1);
+            (void) opal_atomic_add_fetch_32(&slot->refcount, 1);
+            if (NULL != reg->dropped_slot) {
+                (void) opal_atomic_add_fetch_32(&reg->dropped_slot->refcount, 1);
+            }
+            num_deliveries++;
+        } else {
+            /* Drop: accumulate, record nothing (flushed before next delivery). */
+            (void) opal_atomic_add_fetch_64(&reg->dropped, 1);
+        }
+    }
+    opal_mutex_unlock(&mca_base_event_lock);
+
+    /* Step 3: acquire one instance (lazy), copy payload, invoke -- NO lock. */
+    if (num_deliveries > 0) {
+        opal_free_list_item_t *fli = force_pool_exhaustion ? NULL
+                                                           : opal_free_list_get(&instance_pool);
+        if (NULL == fli) {
+            /* Pool exhaustion: restore the captured counts (sec. 5.9 step 3),
+               saturating -- a near-max or already-wrapped captured count must
+               not overflow the (non-atomic) n+1 computation. */
+            for (i = 0; i < num_deliveries; ++i) {
+                int64_t addend;
+                if (snap[i].n < 0 || snap[i].n >= INT64_MAX) {
+                    addend = OPAL_COUNT_MAX;
+                } else {
+                    addend = snap[i].n + 1;
+                }
+                (void) opal_atomic_add_fetch_64(&snap[i].reg->dropped, addend);
+            }
+        } else {
+            inst = (mca_base_event_instance_t *) fli;
+            (void) opal_atomic_add_fetch_64(&pool_acquire_count, 1);
+            inst->event = event;
+            inst->source = source;
+            inst->timestamp = source_timestamp(source);
+            /* Copy only the un-rounded element extent the producer supplied, not
+               the 8-byte-rounded buffer_size -- otherwise this would over-read
+               past a producer payload sized to the element layout, e.g. a bare
+               int32 (sec. 6).  inst->data is buffer_size bytes; the trailing pad
+               stays uninitialized and is never read (event_read/copy are bounded
+               by per-element offsets / data_extent). */
+            inst->data_len = event->data_extent;
+            if (event->data_extent > 0 && NULL != data) {
+                memcpy(inst->data, data, event->data_extent);
+            }
+
+            for (i = 0; i < num_deliveries; ++i) {
+                if (snap[i].n != 0 && NULL != snap[i].dropped_cb) {
+                    snap[i].dropped_cb(mca_base_event_saturate_to(snap[i].n, OPAL_COUNT_MAX),
+                                       snap[i].reg, source->source_index, context,
+                                       snap[i].dropped_user_data);
+                }
+                snap[i].cb_function(inst, snap[i].reg, context, snap[i].cb_user_data);
+            }
+        }
+    }
+
+    /* Step 4: reconcile -- release retained refs, collect dead objects. */
+    opal_mutex_lock(&mca_base_event_lock);
+    for (i = 0; i < num_deliveries; ++i) {
+        release_dropped_slot(snap[i].dropped_slot, &tf);
+        release_cb_slot(snap[i].slot, &tf);
+        release_reg(snap[i].reg, &tf);
+    }
+    opal_mutex_unlock(&mca_base_event_lock);
+    process_to_free(&tf);
+
+    /* Step 5: return the instance; decrement the depth counter. */
+    if (NULL != inst) {
+        opal_free_list_return(&instance_pool, &inst->super);
+    }
+    if (snap != inline_snap) {
+        free(snap);
+    }
+    --dispatch_depth;
+}
+
+/* ======================================================================== */
+/* Instance OBJ class (kept here so opal_free_list stays out of core)        */
+/* ======================================================================== */
+
+static void event_instance_constructor(mca_base_event_instance_t *inst)
+{
+    inst->event = NULL;
+    inst->source = NULL;
+    inst->timestamp = 0;
+    inst->data_len = 0;
+}
+
+OBJ_CLASS_INSTANCE(mca_base_event_instance_t, opal_free_list_item_t, event_instance_constructor,
+                   NULL);

--- a/opal/mca/base/mca_base_event_memory.c
+++ b/opal/mca/base/mca_base_event_memory.c
@@ -1,0 +1,154 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * The OS memory-release producer behind ompi.mca.memory.patcher.released
+ * (spec sec. 7.1).
+ *
+ * The OPAL memory-release hook runs *inside* intercepted free()/munmap()/brk()
+ * (etc.): it is re-entrant and not thread-safe, and may not take a lock,
+ * allocate, or walk the registration list.  So the hook does the minimum -- if
+ * a listener is attached, two atomic adds into a single never-freed sink: one
+ * bumping the release COUNT and one adding the release length to a cumulative
+ * BYTE total.  The framework later *folds* that {count, bytes} pair (at safe
+ * framework operations touching the event, never in the hook) and delivers it
+ * as ONE aggregated, data-bearing event whose payload carries the count and
+ * byte total.  A registration that has only a dropped handler (no callback)
+ * instead observes the aggregated event as a single drop.
+ *
+ * The OPAL memory hooks are chunk-level (they fire only when memory is actually
+ * returned to the OS -- munmap, brk shrink, etc. -- not on every free()), and
+ * the hook callback cannot distinguish which API caused the release, so the
+ * payload is a coarse aggregate, not a per-API breakdown.
+ *
+ * Hard invariant: the sink is allocated once (static) and NEVER freed for the
+ * process lifetime, and the hook body touches only the sink, so an in-flight
+ * hook racing unregister_release is safe by construction.
+ */
+
+#include "opal_config.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "opal/mca/base/mca_base_event.h"
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/base/mca_base_pvar.h"
+#include "opal/sys/atomic.h"
+#include "opal/memoryhooks/memory.h"
+#include "opal/constants.h"
+
+/* The single, never-freed sink (spec sec. 7.1): the number of releases seen
+   and their cumulative byte total since the last fold. */
+typedef struct {
+    opal_atomic_int32_t active;
+    opal_atomic_int64_t count;
+    opal_atomic_int64_t bytes;
+} memory_sink_t;
+
+static memory_sink_t memory_sink = {.active = 0, .count = 0, .bytes = 0};
+static bool memory_registered = false;
+
+/* Test seam: suppress installing the real OS hook so a test's sink bumps are
+   the only source of releases (deterministic fold count). */
+static bool memory_suppress_hook = false;
+
+/* Runs inside free()/munmap()/brk() (etc.): no lock, no alloc, no list walk.
+   The body is an atomic load plus two inline atomic adds, so it cannot reach
+   free()/munmap()/brk() and cannot recurse; concurrent hooks on other threads
+   are handled by the atomics.
+
+   `active` is a plain load of an atomic (opal_atomic_int32_t is _Atomic int32_t
+   under C11 atomics, volatile int32_t otherwise -- never a torn read), paired
+   with the full-barrier swap at detach.  A hook already past this load when
+   detach stores false will still bump the sink; that is deliberate best-effort.
+   Such residue is never mis-attributed: mca_base_event_handle_alloc() folds the
+   event before a new registration joins it (fold-before-membership-change), so
+   the stale count is consumed and raised to the then-current -- empty --
+   registration set rather than credited to the next listener.
+
+   Only ever touches the never-freed sink.  `length` is the number of bytes the
+   release returned to the OS; `from_alloc` is not recorded -- it cannot
+   distinguish the releasing API (munmap/brk/etc. all report identically), only
+   SysV shm vs the heap/anon family, which is not a useful split here. */
+static void memory_release_hook(void *buf __opal_attribute_unused__, size_t length,
+                                void *cbdata __opal_attribute_unused__,
+                                bool from_alloc __opal_attribute_unused__)
+{
+    if (memory_sink.active) {
+        (void) opal_atomic_add_fetch_64(&memory_sink.count, 1);
+        (void) opal_atomic_add_fetch_64(&memory_sink.bytes, (int64_t) length);
+    }
+}
+
+/* Consume-and-clear the pending release count and byte total; called by the
+   fold (spec sec. 7.1).  The sink is lock-free, so no framework lock is held. */
+static void memory_fold_consume(void *ctx __opal_attribute_unused__, int64_t *count,
+                                int64_t *bytes)
+{
+    *count = opal_atomic_swap_64(&memory_sink.count, 0);
+    *bytes = opal_atomic_swap_64(&memory_sink.bytes, 0);
+}
+
+/* Lazily install the OS hook on the first listener-attach and remove it on the
+   last detach; called under the framework lock (spec sec. 7.1). */
+static void memory_activate(void *ctx __opal_attribute_unused__, bool active)
+{
+    if (active) {
+        /* Publish active=true (full-barrier swap), then install the hook. */
+        (void) opal_atomic_swap_32(&memory_sink.active, 1);
+        if (!memory_suppress_hook) {
+            (void) opal_mem_hooks_register_release(memory_release_hook, NULL);
+        }
+    } else {
+        /* Release store active=false (paired with the hook's read) BEFORE
+           unregister, so an in-flight hook sees inactive and only touches the
+           never-freed sink even if it races the unregister. */
+        (void) opal_atomic_swap_32(&memory_sink.active, 0);
+        if (!memory_suppress_hook) {
+            (void) opal_mem_hooks_unregister_release(memory_release_hook);
+        }
+    }
+}
+
+bool mca_base_event_memory_supported(void)
+{
+    /* This producer can only be offered where the OPAL memory hooks can report
+       releases; without them the producer is simply absent (a smaller,
+       still-conformant event set; spec sec. 7.1). */
+    return 0 != (opal_mem_hooks_support_level() & OPAL_MEMORY_FREE_SUPPORT);
+}
+
+void mca_base_event_memory_attach(mca_base_event_source_t *source, mca_base_event_t *event)
+{
+    /* Wire the deferred-release machinery (the framework drives it) into a
+       source/event registered by the caller (the OMPI producer layer chooses
+       the user-facing names).  Idempotent across MPI_T_init/finalize cycles. */
+    source->fold_consume_fn = memory_fold_consume;
+    source->activate_fn = memory_activate;
+    source->fold_event = event;
+    source->ctx = NULL;
+
+    memory_registered = true;
+}
+
+bool mca_base_event_memory_test_bump(int64_t count, int64_t bytes)
+{
+    if (!memory_registered) {
+        return false;
+    }
+    (void) opal_atomic_add_fetch_64(&memory_sink.count, count);
+    (void) opal_atomic_add_fetch_64(&memory_sink.bytes, bytes);
+    return true;
+}
+
+void mca_base_event_memory_test_suppress_hook(bool suppress)
+{
+    memory_suppress_hook = suppress;
+}

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -24,7 +24,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Computer Architecture and VLSI Systems (CARV)
  *                         Laboratory, ICS Forth. All rights reserved.
- * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2023, 2026 Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +48,7 @@
 #include "opal/constants.h"
 #include "opal/include/opal_stdint.h"
 #include "opal/mca/base/mca_base_alias.h"
+#include "opal/mca/base/mca_base_event.h"
 #include "opal/mca/base/mca_base_vari.h"
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/mca/mca.h"
@@ -282,6 +283,19 @@ int mca_base_var_init(void)
         /* Set this before we register the parameter, below */
 
         mca_base_var_initialized = true;
+
+        /* Initialize the MPI_T event registry only after the var system is
+           marked initialized.  mca_base_event_init() registers its own MCA
+           parameters via mca_base_var_register(), and register_variable()
+           re-enters mca_base_var_init() while !mca_base_var_initialized -- which
+           would re-run this initializer and leak the just-built var storage.
+           (mca_base_pvar_init() above is safe here: it registers no MCA
+           parameters during init.) */
+        ret = mca_base_event_init();
+        if (OPAL_SUCCESS != ret) {
+            mca_base_var_initialized = false;
+            return ret;
+        }
     }
 
     opal_finalize_register_cleanup(mca_base_var_finalize);
@@ -1155,6 +1169,7 @@ static void mca_base_var_finalize(void)
 
         (void) mca_base_var_group_finalize();
         (void) mca_base_pvar_finalize();
+        (void) mca_base_event_finalize();
 
         OBJ_DESTRUCT(&mca_base_var_index_hash);
 

--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +42,7 @@
 #include "opal/constants.h"
 #include "opal/include/opal_stdint.h"
 #include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_event.h"
 #include "opal/mca/base/mca_base_vari.h"
 #include "opal/mca/mca.h"
 #include "opal/runtime/opal.h"
@@ -372,6 +374,21 @@ int mca_base_var_group_deregister(int group_index)
         (void) mca_base_pvar_mark_invalid(params[i]);
     }
 
+    /* invalidate all associated mca events (mirrors the pvar loop above) */
+    size = opal_value_array_get_size(&group->group_events);
+    params = OPAL_VALUE_ARRAY_GET_BASE(&group->group_events, int);
+
+    for (int i = 0; i < size; ++i) {
+        mca_base_event_t *event;
+
+        ret = mca_base_event_get_by_index(params[i], &event);
+        if (OPAL_SUCCESS != ret || !(event->flags & MCA_BASE_EVENT_FLAG_IWG)) {
+            continue;
+        }
+
+        (void) mca_base_event_mark_invalid(params[i]);
+    }
+
     size = opal_value_array_get_size(&group->group_enums);
     enums = OPAL_VALUE_ARRAY_GET_BASE(&group->group_enums, opal_object_t *);
     for (int i = 0; i < size; ++i) {
@@ -463,6 +480,35 @@ int mca_base_var_group_add_pvar(const int group_index, const int param_index)
     return (int) opal_value_array_get_size(&group->group_pvars) - 1;
 }
 
+int mca_base_var_group_add_event(const int group_index, const int event_index)
+{
+    mca_base_var_group_t *group;
+    int size, i, ret;
+    int *events;
+
+    ret = mca_base_var_group_get_internal(group_index, &group, false);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    size = opal_value_array_get_size(&group->group_events);
+    events = OPAL_VALUE_ARRAY_GET_BASE(&group->group_events, int);
+    for (i = 0; i < size; ++i) {
+        if (events[i] == event_index) {
+            return i;
+        }
+    }
+
+    if (OPAL_SUCCESS != (ret = opal_value_array_append_item(&group->group_events, &event_index))) {
+        return ret;
+    }
+
+    mca_base_var_groups_timestamp++;
+
+    /* return the group index */
+    return (int) opal_value_array_get_size(&group->group_events) - 1;
+}
+
 int mca_base_var_group_add_enum(const int group_index, const void *storage)
 {
     mca_base_var_group_t *group;
@@ -532,6 +578,9 @@ static void mca_base_var_group_constructor(mca_base_var_group_t *group)
     OBJ_CONSTRUCT(&group->group_pvars, opal_value_array_t);
     opal_value_array_init(&group->group_pvars, sizeof(int));
 
+    OBJ_CONSTRUCT(&group->group_events, opal_value_array_t);
+    opal_value_array_init(&group->group_events, sizeof(int));
+
     OBJ_CONSTRUCT(&group->group_enums, opal_value_array_t);
     opal_value_array_init(&group->group_enums, sizeof(void *));
 }
@@ -556,6 +605,7 @@ static void mca_base_var_group_destructor(mca_base_var_group_t *group)
     OBJ_DESTRUCT(&group->group_subgroups);
     OBJ_DESTRUCT(&group->group_vars);
     OBJ_DESTRUCT(&group->group_pvars);
+    OBJ_DESTRUCT(&group->group_events);
     OBJ_DESTRUCT(&group->group_enums);
 }
 

--- a/opal/mca/base/mca_base_var_group.h
+++ b/opal/mca/base/mca_base_var_group.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +55,9 @@ struct mca_base_var_group_t {
 
     /** Integer array of group performance variables */
     opal_value_array_t group_pvars;
+
+    /** Integer array of group MPI_T events */
+    opal_value_array_t group_events;
 
     /** Pointer array of group enums */
     opal_value_array_t group_enums;

--- a/opal/mca/base/mca_base_vari.h
+++ b/opal/mca/base/mca_base_vari.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -139,6 +140,12 @@ OPAL_DECLSPEC int mca_base_var_group_add_var(const int group_index, const int pa
  * Add a performance variable to a group
  */
 OPAL_DECLSPEC int mca_base_var_group_add_pvar(const int group_index, const int param_index);
+
+/**
+ * Add an MPI_T event (by index) to a group.  Append-only and order-preserving
+ * (sec. 15.3.9): an event is never removed from or reordered within a category.
+ */
+OPAL_DECLSPEC int mca_base_var_group_add_event(const int group_index, const int event_index);
 
 /**
  * \internal

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -43,6 +43,7 @@
 #include "opal/class/opal_pointer_array.h"
 
 #include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/base/mca_base_event.h"
 #include "opal/runtime/opal.h"
 #include "opal/util/argv.h"
 #include "opal/util/cmd_line.h"
@@ -152,6 +153,8 @@ int opal_info_init(int argc, char **argv, opal_cmd_line_t *opal_info_cmd_line)
                             "Show configuration options");
     opal_cmd_line_make_opt3(opal_info_cmd_line, 't', NULL, "type", 1,
                             "Show internal MCA parameters with the type specified in parameter.");
+    opal_cmd_line_make_opt3(opal_info_cmd_line, '\0', NULL, "event", 0,
+                            "Show registered MPI_T event sources and event types.");
     opal_cmd_line_make_opt3(opal_info_cmd_line, 'h', NULL, "help", 0, "Show this help message");
     opal_cmd_line_make_opt3(opal_info_cmd_line, '\0', NULL, "pretty-print", 0,
                             "When used in conjunction with other parameters, the output is "
@@ -168,7 +171,8 @@ int opal_info_init(int argc, char **argv, opal_cmd_line_t *opal_info_cmd_line)
     opal_cmd_line_make_opt3(opal_info_cmd_line, 'a', NULL, "all", 0,
                             "Show all configuration options and MCA parameters");
     opal_cmd_line_make_opt3(opal_info_cmd_line, 'l', NULL, "level", 1,
-                            "Show only variables with at most this level (1-9)");
+                            "Show only variables and MPI_T event types with at most this "
+                            "level (1-9)");
     opal_cmd_line_make_opt3(opal_info_cmd_line, 's', NULL, "selected-only", 0,
                             "Show only variables from selected components");
     opal_cmd_line_make_opt3(
@@ -843,6 +847,104 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group,
         opal_info_show_mca_group_params(group, max_level, want_internal);
     }
     free(component_msg);
+}
+
+/* Parse the --level option (1-9) into an internal max verbosity, exiting on a
+   malformed value, exactly as opal_info_do_params/opal_info_do_type do.  With
+   no --level given, default to showing everything when want_all is set,
+   otherwise only the most basic (level 1) items. */
+static mca_base_var_info_lvl_t opal_info_max_level(opal_cmd_line_t *opal_info_cmd_line,
+                                                   bool want_all)
+{
+    mca_base_var_info_lvl_t max_level = OPAL_INFO_LVL_1;
+    char *str, *tmp;
+
+    if (NULL != (str = opal_cmd_line_get_param(opal_info_cmd_line, "level", 0, 0))) {
+        errno = 0;
+        max_level = strtol(str, &tmp, 10) + OPAL_INFO_LVL_1 - 1;
+        if (0 != errno || '\0' != tmp[0] || max_level < OPAL_INFO_LVL_1
+            || max_level > OPAL_INFO_LVL_9) {
+            char *usage = opal_cmd_line_get_usage_msg(opal_info_cmd_line);
+            opal_show_help("help-opal_info.txt", "invalid-level", true, str);
+            free(usage);
+            exit(1);
+        }
+    } else if (want_all) {
+        max_level = OPAL_INFO_LVL_9;
+    }
+
+    return max_level;
+}
+
+void opal_info_do_event(bool want_all, opal_cmd_line_t *opal_info_cmd_line)
+{
+    mca_base_var_dump_type_t dump_type = (!opal_info_pretty
+                                              ? MCA_BASE_VAR_DUMP_PARSABLE
+                                              : (opal_info_color ? MCA_BASE_VAR_DUMP_READABLE_COLOR
+                                                                 : MCA_BASE_VAR_DUMP_READABLE));
+    /* For --event, default to showing all event-type levels unless the user
+       narrowed it with --level: every built-in event type registers at level
+       2-4, so a level-1 default (as --param uses) would hide ALL types and make
+       a plain "ompi_info --event" print only sources, contradicting the option's
+       help text.  An explicit --level still narrows the set. */
+    bool level_given = (NULL != opal_cmd_line_get_param(opal_info_cmd_line, "level", 0, 0));
+    mca_base_var_info_lvl_t max_level = opal_info_max_level(opal_info_cmd_line,
+                                                            want_all || !level_given);
+    bool printed_sources_header = false;
+    bool printed_types_header = false;
+    int count = 0, i, j, ret;
+    char **strings;
+
+    /* Event sources are always shown (a source has no verbosity level, so the
+       --level filter does not apply to them), but defer the section header until
+       the first source actually prints, so a build with the producers disabled
+       does not emit an empty, dangling header -- matching the event-types half
+       below. */
+    (void) mca_base_event_source_get_count(&count);
+    for (i = 0; i < count; ++i) {
+        ret = mca_base_event_source_dump(i, &strings, dump_type);
+        if (OPAL_SUCCESS != ret) {
+            continue;
+        }
+        if (opal_info_pretty && !printed_sources_header) {
+            opal_info_out("MPI_T event sources", "mpi_t_event:sources",
+                          "---------------------------------------------------");
+            printed_sources_header = true;
+        }
+        for (j = 0; strings[j]; ++j) {
+            opal_info_out("", "", strings[j]);
+            free(strings[j]);
+        }
+        free(strings);
+    }
+
+    /* Event types are filtered by --level against the event's verbosity,
+       mirroring the MCA parameter path.  Defer the section header until the
+       first type passes, so a fully-filtered run prints no empty header. */
+    count = 0;
+    (void) mca_base_event_get_count(&count);
+    for (i = 0; i < count; ++i) {
+        mca_base_event_t *event;
+
+        if (OPAL_SUCCESS != mca_base_event_get_by_index(i, &event)
+            || max_level < event->verbosity) {
+            continue;
+        }
+        if (opal_info_pretty && !printed_types_header) {
+            opal_info_out("MPI_T event types", "mpi_t_event:types",
+                          "---------------------------------------------------");
+            printed_types_header = true;
+        }
+        ret = mca_base_event_dump(i, &strings, dump_type);
+        if (OPAL_SUCCESS != ret) {
+            continue;
+        }
+        for (j = 0; strings[j]; ++j) {
+            opal_info_out("", "", strings[j]);
+            free(strings[j]);
+        }
+        free(strings);
+    }
 }
 
 void opal_info_show_mca_params(const char *type, const char *component,

--- a/opal/runtime/opal_info_support.h
+++ b/opal/runtime/opal_info_support.h
@@ -3,6 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -96,6 +97,8 @@ OPAL_DECLSPEC void opal_info_do_arch(void);
 OPAL_DECLSPEC void opal_info_do_hostname(void);
 
 OPAL_DECLSPEC void opal_info_do_type(opal_cmd_line_t *opal_info_cmd_line);
+
+OPAL_DECLSPEC void opal_info_do_event(bool want_all, opal_cmd_line_t *opal_info_cmd_line);
 
 OPAL_DECLSPEC void opal_info_out(const char *pretty_message, const char *plain_message,
                                  const char *value);

--- a/specs/mpi-t-events/spec.md
+++ b/specs/mpi-t-events/spec.md
@@ -1,0 +1,571 @@
+# MPI_T events implementation specification
+
+This document specifies Open MPI's implementation of the MPI tool
+information interface ("MPI_T") *events* facility defined in MPI-5.0
+§15.3.8. It describes the current state of the implementation: the OPAL
+event engine, the OMPI tool-layer bindings, the built-in event
+producers (including events bound to specific MPI objects), and the
+invariants the implementation guarantees. Section numbers in this
+document are referenced from the source code (e.g. `sec. 5.10`).
+
+Citations of the form "MPI-5.0 §15.3.8" or "MPI-5.0 p.751" refer to the
+MPI-5.0 standard; they mark behavior the standard *requires*, *permits*,
+or otherwise governs.
+
+---
+
+## 1. Overview and scope
+
+The MPI_T events facility lets a tool register callbacks that the MPI
+implementation invokes when it *raises* an event. Each event instance
+carries a timestamp, originates from a *source* (a clock-and-ordering
+domain), and conveys a typed data payload (MPI-5.0 §15.3.8).
+
+Open MPI implements the full set of MPI_T event entry points and ships a
+set of built-in event sources and event types. That built-in set is an
+initial, deliberately non-exhaustive collection — implemented largely as
+worked examples and to exercise the infrastructure — and may grow over
+time. Tools must discover the available sources and events at run time
+(MPI-5.0 §15.3.8); they must not hard-code names.
+
+In scope:
+
+- The OPAL `mca_base_event` engine (`opal/mca/base/mca_base_event*.[ch]`).
+- The OMPI MPI_T tool-layer entry points (`ompi/mpi/tool/`).
+- The built-in producers (`ompi/runtime/ompi_mpit_*`, plus raise sites
+  in `ompi/communicator`, `ompi/win`, `ompi/errhandler`, `ompi/instance`,
+  `ompi/runtime`).
+- `ompi_info --event` integration.
+
+Out of scope: control variables and performance variables (MPI-5.0
+§15.3.6–15.3.7), which share the underlying `mca_base_var`/`mca_base_pvar`
+machinery but are separate interfaces.
+
+---
+
+## 2. Standard background
+
+MPI-5.0 §15.3.8 defines the events model. The salient points the
+implementation must honor:
+
+- **Sources** (MPI-5.0 §15.3.8, `MPI_T_source_get_num` /
+  `MPI_T_source_get_info` / `MPI_T_source_get_timestamp`): each source is
+  a clock with an ordering guarantee. `MPI_T_source_get_info` reports the
+  source's `ordering` (`MPI_T_SOURCE_ORDERED` vs `_UNORDERED`),
+  `ticks_per_second`, and `max_ticks`. Timestamps are only meaningful
+  *within* a source.
+- **Event types** (`MPI_T_event_get_num` / `_get_info` / `_get_index`):
+  each event type has an index, a name, a verbosity level, an ordered
+  list of typed payload elements (`array_of_datatypes`), and a *binding*
+  (`bind`) naming the class of MPI object it is associated with, or
+  `MPI_T_BIND_NO_OBJECT`.
+- **Registration handles** (`MPI_T_event_handle_alloc` /
+  `_handle_free`): a tool allocates a registration handle for an event
+  type, optionally bound to a specific MPI object via `obj_handle`
+  (MPI-5.0 p.751). For a `MPI_T_BIND_NO_OBJECT` event, `obj_handle` is
+  ignored.
+- **Callbacks** (`MPI_T_event_register_callback`): a tool installs a
+  callback at a *callback-safety level* (`MPI_T_CB_REQUIRE_NONE`,
+  `_MPI_RESTRICTED`, `_THREAD_SAFE`, `_ASYNC_SIGNAL_SAFE`). The callback
+  signature is `(MPI_T_event_instance, MPI_T_event_registration,
+  MPI_T_cb_safety, void *user_data)`. The bound object is *not* a
+  callback argument; the registration handle identifies it (MPI-5.0
+  §15.3.8).
+- **Reading data** (`MPI_T_event_read` / `MPI_T_event_copy`): inside the
+  callback, the tool reads individual payload elements or copies the
+  whole buffer. The event instance is valid only for the duration of the
+  callback.
+- **Dropped events** (`MPI_T_event_set_dropped_handler`): if the
+  implementation cannot deliver an event, it may instead count it as
+  dropped and report the count to a dropped-event handler.
+- **Timestamps** (`MPI_T_event_get_timestamp`, `MPI_T_source_get_timestamp`):
+  the per-instance timestamp and the ad-hoc source clock read share the
+  source's clock.
+
+---
+
+## 3. Architecture
+
+The implementation respects the OPAL → OMPI layering:
+
+```mermaid
+flowchart TD
+    tools["Tools&nbsp;— MPI_T_* user API"]
+    ompi["OMPI tool layer — ompi/mpi/tool/*.c<br/>ABI-aware shims; MPI handles"]
+    opal["OPAL event engine — opal/mca/base/<br/>mca_base_event: registry, handles, dispatch, clocks"]
+    prod["Producers — OMPI + OPAL raise sites"]
+
+    tools -->|"MPI_T_* calls"| ompi
+    ompi -->|"mca_base_event_* primitives"| opal
+    prod -->|"mca_base_event_raise()<br/>(downward only)"| opal
+```
+
+- The **OPAL engine** (`mca_base_event`) owns the event/source
+  registries, registration handles, the dispatch path, drop accounting,
+  the instance pool, and clocks. It knows nothing about MPI types; object
+  identities are opaque `void *` tokens to it.
+- The **OMPI tool layer** implements the public `MPI_T_event_*` and
+  `MPI_T_source_*` functions as thin shims over the engine, translating
+  between MPI handles/types and the engine's primitives, and mapping OPAL
+  return codes to `MPI_T_ERR_*`.
+- **Producers** are the in-tree raise sites. Core producers register
+  through `ompi_mpit_register_events()` (`ompi/runtime/`). Each raise site
+  is a guarded call to `mca_base_event_raise()` (or
+  `mca_base_event_raise_bound()`, sec. 6.1).
+
+The OPAL engine never calls upward; the OS memory producer reaches OMPI's
+registration only by being *registered from* OMPI and *driven by* an OPAL
+hook plus a callback installed downward (sec. 7.1).
+
+---
+
+## 4. Sources
+
+The built-in producers advertise their events on two sources, split by
+the single source-visible property that differs between them — *ordering*
+(MPI-5.0 §15.3.8, `MPI_T_source_get_info`). A source is fundamentally a
+clock-and-ordering domain, not a subsystem grouping; event names and
+MPI_T categories already group by subsystem.
+
+- **`ompi`** — `MPI_T_SOURCE_ORDERED`. Carries all individually
+  timestamped lifecycle events (initialization/finalization,
+  communicator, RMA window, error-handler). Successive timestamps are
+  monotonically non-decreasing, so a tool can order events by timestamp.
+- **`ompi.unordered`** — `MPI_T_SOURCE_UNORDERED`. Carries events whose
+  underlying occurrences are aggregated before delivery, so
+  per-occurrence chronology is not preserved (currently just the OS
+  memory-release event, sec. 7.1). Registered only where the OPAL
+  memory-release hooks are available.
+
+Both use Open MPI's default event clock — the same underlying system
+clock that backs `MPI_Wtime` — with `ticks_per_second` = 1,000,000,000
+(nanoseconds) and `max_ticks` = the largest `MPI_Count`. Both support
+ad-hoc timestamp reads (sec. 5.8).
+
+**Timestamps are only comparable within one source** (MPI-5.0 §15.3.8).
+Event timestamps are also *not* directly comparable to `MPI_Wtime`: same
+clock and rate, but integer nanoseconds vs. double seconds and a
+different, lazily-captured origin. The standard requires no relationship
+between the two.
+
+---
+
+## 5. The OPAL event engine (`mca_base_event`)
+
+### 5.1 Event and source registries
+
+`mca_base_event_register()` and `mca_base_event_source_register()`
+populate global registries indexed by a dense integer (the event/source
+*index* exposed to tools). Registration is **idempotent by name**: a
+repeated registration of the same name returns the existing index. This
+lets `ompi_mpit_register_events()` be called from several paths
+(`ompi_info`, instance init, `MPI_T_init_thread`) without duplicating
+entries. Event-type names are forced into the `ompi.` namespace by the
+registration helper.
+
+`mca_base_event_get_by_index()` / `_source_get_by_index()` /
+`_get_count()` provide lookup, backing `MPI_T_event_get_num` /
+`_get_index` / `_get_info` and the source equivalents.
+
+### 5.2 Registration handles
+
+A registration handle (`mca_base_event_registration_t`) is the engine's
+representation of one `MPI_T_event_handle_alloc` result. It records the
+event it belongs to, its bound object identity (NULL for a
+`NO_OBJECT` event, sec. 6.1), a reference count, a liveness flag, the
+installed callbacks (one slot per safety level, sec. 5.12), the
+dropped-event handler slot, and an atomic dropped-event counter
+(sec. 5.4).
+
+### 5.3 Callbacks and user data
+
+`mca_base_event_register_callback()` installs a callback at a given
+safety level with an opaque `user_data` and an optional context-release
+callback. Re-registering replaces the slot. The callback is invoked with
+the event instance, the registration handle, the actual delivery safety
+level, and `user_data` (MPI-5.0 §15.3.8). Because the bound object is not
+a callback argument, a tool that binds to an object typically stashes it
+in `user_data`.
+
+### 5.4 Drop accounting
+
+When an event cannot be delivered to a registration, the engine
+increments that registration's atomic dropped counter rather than
+losing the fact silently (MPI-5.0 §15.3.8 permits counting drops). The
+count is captured and cleared atomically at the next successful delivery
+and reported to the dropped-event handler (sec. 5.5). The counter is a
+64-bit value; before being narrowed for delivery it is **saturated** to a
+ceiling so a near-overflow or already-wrapped value cannot become
+negative or wrap (`mca_base_event_saturate_to`).
+
+### 5.5 Dropped-event handlers
+
+`mca_base_event_set_dropped_handler()` installs a per-registration
+handler (`MPI_T_event_set_dropped_handler`). The captured drop count is
+**flushed to the handler immediately before the next successful
+delivery** to the same registration, so a callback never observes a
+delivery that silently elides earlier drops. A registration may carry a
+dropped handler with no event callback; it then observes each aggregated
+batch from a deferred-release source as a single dropped event
+(sec. 7.1).
+
+### 5.6 Reading payload elements
+
+`mca_base_event_read()` (backing `MPI_T_event_read`) copies one typed
+element out of the instance buffer at the registered offset;
+`mca_base_event_copy()` copies the whole buffer (`MPI_T_event_copy`).
+Reads are by `memcpy` (no aligned-load assumption), so the payload buffer
+need not be naturally aligned. The instance is valid only inside the
+callback invocation (MPI-5.0 §15.3.8).
+
+### 5.7 Clocks
+
+Sources advertise a `ticks_per_second` and `max_ticks`
+(`MPI_T_source_get_info`). The built-in producers use the default clock
+(`opal_clock_gettime`), the same backend as `MPI_Wtime`, reported in
+integer nanoseconds. The clock origin is captured lazily.
+
+### 5.8 Ad-hoc timestamps
+
+`MPI_T_source_get_timestamp` lets a tool sample a source's clock on
+demand, independent of any event, and compare the result to event
+timestamps *from the same source* (MPI-5.0 §15.3.8). Both built-in
+sources support ad-hoc reads because the default clock is freely
+readable. For a deferred-release source, the ad-hoc read is also the
+primary moment at which the engine drains the source's sink and delivers
+its aggregated event (sec. 7.1).
+
+### 5.9 Dispatch safety
+
+The raise path (`mca_base_event_raise_internal`) is engineered to be safe
+to call from arbitrary normal-context producers:
+
+- **Recursion-depth gate.** A per-thread dispatch-depth counter is
+  checked at entry; if a callback re-raises the event (or any event)
+  beyond a bounded depth, the raise is skipped, preventing unbounded
+  recursion.
+- **Snapshot-then-invoke.** Under the engine lock, the live, matching
+  registrations are *snapshotted* into a small array (inline for the
+  common case, heap-grown if needed); the lock is dropped before any
+  callback runs. Callbacks therefore never run under the engine lock,
+  so a callback may freely re-enter the MPI_T interface.
+- **Heap-fallback OOM.** If growing the snapshot fails, the current and
+  remaining matching registrations are credited a drop (sec. 5.4) within
+  the same lock hold, and snapshotting stops, rather than risking an
+  inconsistent dispatch.
+- **Instance-pool exhaustion.** If no event instance can be acquired
+  (sec. 12.4), the captured drop counts are restored (saturating,
+  sec. 5.4) and no callback runs.
+
+### 5.10 Registration-handle lifetime
+
+Handles are reference-counted and freed via a **deferred-free** scheme so
+a callback can free its own handle safely (MPI-5.0 §15.3.8 requires
+free-from-callback to be legal):
+
+- A live-handle hash table keyed by the pointer *value* validates handles
+  without dereferencing them, so a lookup on a stale pointer is safe.
+- `mca_base_event_handle_free()` marks the handle dead and drops the
+  creator's reference; the memory is reclaimed only once the last
+  reference (e.g. an in-flight dispatch snapshot, or the callback that
+  is freeing itself) is gone.
+- A double free is rejected (the handle validates as not-live).
+- Using a handle after its bound object is freed is erroneous tool
+  behavior (sec. 6.1); the engine's by-value validation guarantees it
+  never dereferences freed memory, but it cannot detect address reuse, so
+  the standard's "do not use a freed handle" rule applies.
+- For a deferred-release source, `handle_free` first drains pending
+  releases to the still-live registration (sec. 7.1), so a tool that
+  frees without a final ad-hoc read still observes the last batch.
+
+### 5.11 Timestamps and ordering
+
+For an `MPI_T_SOURCE_ORDERED` source, the engine enforces a per-source
+**monotonicity backstop**: a delivered timestamp is never less than the
+previous one from the same source, even across a non-monotonic clock
+read, preserving the ordering guarantee `MPI_T_source_get_info` advertises
+(MPI-5.0 §15.3.8). Unordered sources make no such guarantee.
+
+### 5.12 Callback safety levels
+
+A callback is registered at one of the MPI-5.0 safety levels
+(`MPI_T_CB_REQUIRE_NONE` < `_MPI_RESTRICTED` < `_THREAD_SAFE` <
+`_ASYNC_SIGNAL_SAFE`). A raise carries the safety level of its calling
+context; the engine selects, for each registration, the most capable
+installed callback that is **no stricter** than the raise context (i.e.
+it never invokes a callback that requires more safety than the context
+provides). This release delivers only in normal contexts (`NONE`,
+`MPI_RESTRICTED`, `THREAD_SAFE`); an `ASYNC_SIGNAL_SAFE` callback is
+accepted but never selected, because no producer raises from an
+async-signal context. That is conformant: the standard permits an
+implementation never to deliver at a level it does not support.
+
+---
+
+## 6. Event type definitions and payloads
+
+An event type is registered with an ordered list of fixed, exact-width
+typed elements (`MCA_BASE_VAR_TYPE_INT32_T`, `_UINT64_T`, `_INT64_T`,
+etc.) at ascending offsets starting at 0; the computed buffer size must
+not exceed `MCA_BASE_EVENT_MAX_PAYLOAD` (sec. 9.1). The element list is
+reported to tools as `array_of_datatypes` by `MPI_T_event_get_info`
+(MPI-5.0 §15.3.8). A producer's raise-time payload `struct` must match
+the registered offsets exactly; a trailing `uint64` handle is placed at
+its natural 8-byte alignment so struct and offsets agree.
+
+Object handles carried in payloads are the C handle / internal object
+pointer as a `uint64` — an opaque correlation token (e.g. pairing a
+"created" event with its "freed", or a "finalization" with its
+"initialization"). It must not be dereferenced by the tool. Its
+representation depends on the tool's MPI ABI (sec. 10).
+
+### 6.1 Object binding
+
+An event type's *binding* (`bind`, reported by `MPI_T_event_get_info`)
+names the class of MPI object the event is associated with, or
+`MPI_T_BIND_NO_OBJECT` (MPI-5.0 §15.3.8). The engine stores `bind` as an
+`MCA_BASE_VAR_BIND_*` value whose enumeration mirrors the public
+`MPI_T_BIND_*` ordering, so the tool layer reports it verbatim.
+
+**Semantics.** An event type is *either* `NO_OBJECT` *or* bound to one
+object class — the `bind` value is fixed per event type. There is no
+"bind, or all" mode:
+
+- For a `NO_OBJECT` event, `MPI_T_event_handle_alloc` ignores
+  `obj_handle` (MPI-5.0 p.751), and a single registration observes every
+  instance.
+- For a bound event, a tool passes the *address of the object's handle*
+  as `obj_handle`; the registration is then notified **only** when the
+  event occurs for that specific object. To watch several objects, a tool
+  allocates one registration per object.
+
+**Resolution.** `mca_base_event_handle_alloc` resolves the bound-object
+identity once, at allocation: for a `NO_OBJECT` event it stores NULL; for
+a bound event it dereferences `obj_handle` (the "address to a local
+variable that stores the object's handle", MPI-5.0 p.751) to the identity
+a producer will raise with, and rejects a NULL `obj_handle`
+(`OPAL_ERR_BAD_PARAM` → `MPI_T_ERR_INVALID_HANDLE`). The stored identity
+is opaque to OPAL and is only ever compared by value, never dereferenced.
+
+**Dispatch filter.** A producer raises a bound event with
+`mca_base_event_raise_bound(event, source, obj, data)`, passing the
+object identity (e.g. an `ompi_communicator_t *`). The dispatch snapshot
+(sec. 5.9) delivers to a registration iff its stored bound identity
+equals the raised object. The same comparison serves `NO_OBJECT` events
+uniformly: both the raised object and every registration's stored
+identity are NULL, so all match. A non-matching bound registration is
+*skipped*, not credited a drop — the event was not for it.
+
+**Callback.** The bound object is not a callback argument (MPI-5.0
+§15.3.8); the tool knows it (it bound to it) and typically records it in
+`user_data`. A bound event whose payload would merely echo the bound
+object carries only the minimal data a callback needs and lets the
+callback query further detail from the object directly.
+
+**Lifetime.** Binding a registration to an object the tool later frees,
+then continuing to use the registration, is erroneous (sec. 5.10): the
+engine never dereferences the stored identity, but it cannot detect
+address reuse.
+
+---
+
+## 7. Built-in producers
+
+Core producers are registered by `ompi_mpit_register_events()`, gated by
+the MCA parameter `mca_base_event_register_producers` (default on) and by
+per-facility availability (sec. 5; absent facilities simply yield a
+smaller, still-conformant event set). The current set:
+
+| Event type | Source | Bind | Payload |
+|---|---|---|---|
+| `ompi.mpi.initialization` | `ompi` | NO_OBJECT | model, thread_level, world_rank, world_size, instance_id |
+| `ompi.mpi.finalization` | `ompi` | NO_OBJECT | model, world_rank, instance_id |
+| `ompi.mpi.communicator_created` | `ompi` | NO_OBJECT | size, handle |
+| `ompi.mpi.communicator_freed` | `ompi` | NO_OBJECT | handle |
+| `ompi.mpi.communicator_name_set` | `ompi` | **MPI_COMM** | handle |
+| `ompi.mpi.errhandler_invoked` | `ompi` | NO_OBJECT | err_code, object_type, errhandler_handle, object_handle |
+| `ompi.mpi.win_created` | `ompi` | NO_OBJECT | size, disp_unit, flavor, handle |
+| `ompi.mpi.win_freed` | `ompi` | NO_OBJECT | flavor, handle |
+| `ompi.mca.memory.patcher.released` | `ompi.unordered` | NO_OBJECT | count, bytes |
+
+Notes:
+
+- **initialization / finalization** fire for *both* MPI models, which
+  share the internal instance path. `model` is `OMPI_T_MODEL_WORLD` or
+  `OMPI_T_MODEL_SESSION` (public enums in `<mpi.h>`). `world_rank` /
+  `world_size` are meaningful only for the world model and are `-1`
+  otherwise (a process has no rank in a session). `instance_id`
+  correlates a finalization with its initialization. The world-model
+  initialization fires during `MPI_Init` once `MPI_COMM_WORLD` exists, so
+  a tool must attach before `MPI_Init` to observe it.
+- **communicator_name_set** is the bound event (sec. 6.1): raised from
+  `MPI_Comm_set_name` after the lock is dropped (so a callback may
+  re-enter MPI on the communicator). The new name is not in the payload;
+  a callback reads it with `MPI_Comm_get_name` on the bound communicator.
+- **errhandler_invoked** reports `object_type` as the `MPI_T_BIND_*` kind
+  of the object the handler runs on (`NO_OBJECT` for a predefined handler
+  or none, else `MPI_COMM` / `MPI_WIN` / `MPI_FILE` / `MPI_SESSION`),
+  plus the errhandler handle and the object handle (each `0` when not
+  available). This event is `NO_OBJECT` (it reports all errors and lets a
+  tool filter by handle); a per-errhandler bound variant is a possible
+  future addition, not a replacement.
+- Raise sites are guarded by a NULL check on the event handle (NULL until
+  registered) and pay almost nothing when no tool listens (sec. 5.9).
+
+### 7.1 Deferred-release aggregation (OS memory)
+
+The OS memory-release producer cannot deliver from its raise context. Its
+hook — the OPAL "patcher" memory component intercepting `munmap`,
+`mremap`, `madvise`, `brk`/`sbrk` shrink, and SysV `shmdt` — runs *inside*
+the intercepted call, where it may not lock, allocate, or walk data
+structures. Therefore:
+
+- The hook only **accumulates** `{count, bytes}` into a lock-free,
+  never-freed sink (`mca_base_event_memory.c`).
+- The engine **drains** that sink and delivers one aggregated,
+  data-bearing event at the next safe operation — notably an ad-hoc
+  `MPI_T_source_get_timestamp` read of `ompi.unordered` (sec. 5.8), and
+  also event-handle allocation/free (sec. 5.10).
+- The drain happens **before any registration-set change** (a new
+  registration must not receive an aggregate covering releases that
+  predate it; a freeing registration must receive its final batch).
+- A registration with only a dropped handler observes each aggregated
+  batch as one dropped event (sec. 5.5).
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Hook as OS-memory hook (in free/munmap)
+    participant Sink as Lock-free sink
+    participant Engine as mca_base_event engine
+    participant Tool as Tool callback
+
+    App->>Hook: munmap / sbrk shrink / ...
+    Hook->>Sink: accumulate {count, bytes} (no lock, no alloc)
+    Note over Sink: many releases accrue between drains
+    Tool->>Engine: MPI_T_source_get_timestamp (or handle alloc/free)
+    Engine->>Sink: drain {count, bytes} (consume-and-clear)
+    Engine->>Tool: deliver ONE aggregated data-bearing event
+```
+
+Two properties follow from relying on these hooks. They are *chunk-level*
+(they fire only when memory is actually returned to the OS, not on every
+`free`), and they cannot distinguish the releasing API, so the payload is
+a coarse `{count, bytes}` aggregate. A per-API breakdown and capture of
+individual freed addresses are deliberately not provided: they would
+require extending the memory-hook interface and, for addresses,
+allocating in a context where allocation is unsafe.
+
+This is wired across the layers without an upward call: the source/event
+are registered in OMPI; the hook and sink live in OPAL; OMPI installs the
+drain via `mca_base_event_memory_attach()` and a consume callback handed
+downward.
+
+---
+
+## 8. `ompi_info` integration
+
+`ompi_info --event` lists the registered sources and event types
+(triggering `ompi_mpit_register_events()` via the normal MCA registration
+path, sec. 5.1). Each event's name, source, level, binding, and element
+layout is dumped in both parsable and human-readable forms via
+`mca_base_event_dump()` / `mca_base_event_source_dump()`. This is the
+command-line counterpart to run-time discovery with the MPI_T API.
+
+---
+
+## 9. Robustness
+
+### 9.1 Registration cap (denial-of-service guard)
+
+The number of simultaneously live registrations is capped by the
+user-settable MCA parameter `mca_base_event_max_registrations`. The cap
+is clamped to a sane range before use, because it also bounds the
+dispatch snapshot capacity arithmetic (sec. 5.9); an attempt to exceed it
+fails `MPI_T_event_handle_alloc` with `MPI_T_ERR_OUT_OF_HANDLES`. The
+per-event payload size is likewise bounded by `MCA_BASE_EVENT_MAX_PAYLOAD`
+(sec. 6). These bounds prevent a buggy or hostile tool from exhausting
+memory through unbounded registration or oversized payloads.
+
+---
+
+## 10. MPI ABI considerations
+
+Open MPI is gaining a second MPI ABI (the MPI Standard ABI, open-mpi/ompi
+#13280) alongside its native ABI. The two represent MPI object handles
+differently: the Open MPI ABI uses the internal object pointer; the
+Standard ABI uses an integer handle. A process links exactly one ABI.
+
+This affects the object handles carried in payloads (sec. 6) and the
+bound-object resolution (sec. 6.1), because both must match the ABI of
+the tool that registered the callback:
+
+- A process-global flag `ompi_mpit_callback_abi`
+  (`OMPI_MPIT_ABI_OMPI` / `_STANDARD`) records which ABI the registering
+  tool uses. It is set by `MPI_T_event_register_callback` and is, for now,
+  hard-coded to the Open MPI ABI.
+- Each handle-emitting raise site branches on this flag. The Open MPI ABI
+  branch emits the internal pointer; the Standard ABI branch is a marked
+  `TODO ABI` stub (handle `0`) that #13280 will fill in.
+- Bound-object resolution (sec. 6.1) dereferences the tool's `obj_handle`
+  to the internal identity; under the Open MPI ABI the MPI handle *is*
+  that pointer, so a single deref suffices. The Standard ABI must convert
+  its integer handle to the internal pointer there (marked `XXX ABI`).
+
+Because the engine's `mca_base_event_read` is a raw `memcpy` with no ABI
+translation, a tool always reads back the representation the producer
+emitted; matching the emitted representation to the tool's ABI is the
+producer's responsibility, hence the per-raise-site branch.
+
+---
+
+## 11. Testing
+
+- **White-box engine test** (`test/util/mca_base_event_test.c`, run under
+  `make check`): exercises registration, delivery, payload reads,
+  timestamps, drop accounting and dropped-handler flush, deferred-release
+  folding, handle lifetime (self-free, double-free), the registration
+  cap, dump routines, and **object binding** (a bound event reaches only
+  the registration bound to the raised object; a NULL `obj_handle` is
+  rejected; an unbound object reaches no one).
+- **MPI-level tests** (`ompi/test/t/`, run as singletons under
+  `make check`): producer coverage for the session model
+  (`mpi_t_event_producers.c`) and the world model
+  (`mpi_t_event_world.c`); object binding end-to-end via
+  `MPI_Comm_set_name` (`mpi_t_event_comm_name.c`, confirming bound
+  delivery isolation, the payload handle, and name re-query); plus
+  smoke/self/reinit/inert tests.
+
+---
+
+## 12. Implementation internals
+
+### 12.1 Locking
+
+A single engine mutex (`mca_base_event_lock`) guards the registries and
+the registration sets. It is held only for bookkeeping and the dispatch
+snapshot, never across a callback (sec. 5.9). The OMPI tool layer does
+*not* hold the MPI_T big lock across calls into the engine, because a
+drained deferred-release event can invoke a tool dropped handler that
+re-enters MPI_T (sec. 5.10) — which would deadlock a non-recursive lock.
+
+### 12.2 Atomicity
+
+Drop counters and the deferred-release sink are atomics, so the
+no-lock-held producer/hook paths are safe against concurrent dispatch.
+
+### 12.3 Idempotent registration and teardown
+
+Event-handle globals are cleared before each (re-)registration cycle so a
+torn-down registry (e.g. after a `MPI_T` finalize that dropped the var
+system) cannot leave a raise site holding a dangling event pointer
+(sec. 5.1).
+
+### 12.4 Instance pool
+
+Event instances (the per-delivery objects backing
+`MPI_T_event_instance`) are drawn from a free-list pool rather than
+allocated on the raise path. A raise that delivers to at least one
+registration lazily acquires one instance; an all-drops raise consumes
+none. On pool exhaustion the raise restores the captured drop counts and
+delivers nothing (sec. 5.9), so the hot path never blocks on allocation.

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -36,6 +36,7 @@ check_PROGRAMS = \
 	opal_path_nfs \
         opal_json \
         opal_sha256 \
+        mca_base_event_test \
 	opal_timer \
 	opal_string_copy \
 	opal_numtostr \
@@ -221,6 +222,12 @@ opal_sha256_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
         $(top_builddir)/test/support/libsupport.a
 opal_sha256_DEPENDENCIES = $(opal_sha256_LDADD)
+
+mca_base_event_test_SOURCES = mca_base_event_test.c
+mca_base_event_test_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+        $(top_builddir)/test/support/libsupport.a
+mca_base_event_test_DEPENDENCIES = $(mca_base_event_test_LDADD)
 
 clean-local:
 	rm -f test_session_dir_out test-file opal_path_nfs.out

--- a/test/util/mca_base_event_test.c
+++ b/test/util/mca_base_event_test.c
@@ -1,0 +1,854 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit test for the OPAL mca_base_event framework (dispatch
+ * core).  Links libopen-pal directly and drives mca_base_event_* with no
+ * MPI/MPI_T layer.  Runs as a 'make check' program.
+ */
+
+#include "opal_config.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "opal/mca/base/mca_base_event.h"
+#include "opal/mca/base/mca_base_pvar.h" /* MCA_BASE_VAR_BIND_NO_OBJECT */
+#include "opal/mca/memory/base/base.h"   /* opal_memory_base_framework */
+#include "opal/runtime/opal.h"
+
+/* White-box hooks exported by mca_base_event_dispatch.c (not in the public
+   header). */
+extern int64_t mca_base_event_test_pool_acquires(void);
+extern void    mca_base_event_test_set_force_exhaustion(bool v);
+
+static int failures = 0;
+
+static void check(const char *what, int cond)
+{
+    if (cond) {
+        printf("PASS: %s\n", what);
+    } else {
+        ++failures;
+        printf("FAIL: %s\n", what);
+    }
+}
+
+/* Shared test state reachable from the callbacks. */
+static int          cb_fired = 0;
+static int32_t      cb_read_a = 0;
+static uint64_t     cb_read_b = 0;
+static opal_count_t cb_safety_seen = -1;
+static opal_count_t cb_timestamp = 0;
+static int          cb_source_index = -1;
+
+static opal_count_t dropped_count_seen = 0;
+static int          dropped_fired = 0;
+
+static int          free_fired = 0;
+static mca_base_event_registration_t *self_free_reg = NULL;
+
+static void event_cb(mca_base_event_instance_t *inst,
+                     mca_base_event_registration_t *reg __opal_attribute_unused__,
+                     mca_base_event_cb_safety_t cb_safety, void *user_data __opal_attribute_unused__)
+{
+    int src = -1;
+    opal_count_t ts = 0;
+
+    ++cb_fired;
+    cb_safety_seen = cb_safety;
+    (void) mca_base_event_read(inst, 0, &cb_read_a);
+    (void) mca_base_event_read(inst, 1, &cb_read_b);
+    (void) mca_base_event_instance_get_timestamp(inst, &ts);
+    (void) mca_base_event_instance_get_source(inst, &src);
+    cb_timestamp = ts;
+    cb_source_index = src;
+}
+
+/* --- Object binding (sec. 6.1): record which bound registration was reached
+   (its object, passed through as user_data). */
+static int   bound_count = 0;
+static void *bound_last = NULL;
+static void bound_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                     mca_base_event_registration_t *reg __opal_attribute_unused__,
+                     mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                     void *user_data)
+{
+    ++bound_count;
+    bound_last = user_data;
+}
+
+static void dropped_cb(opal_count_t count, mca_base_event_registration_t *reg __opal_attribute_unused__,
+                       int source_index __opal_attribute_unused__,
+                       mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                       void *user_data __opal_attribute_unused__)
+{
+    ++dropped_fired;
+    dropped_count_seen += count;
+}
+
+/* A synthetic deferred-release producer's consume hook, so the fold mechanism
+   (sec. 7.1) is exercised on every platform regardless of whether the real
+   OS-memory free-hooks are available.  Hands back an accumulated {count, bytes}
+   pair the framework delivers as one aggregated, data-bearing event. */
+static opal_atomic_int64_t fold_test_counter = 0;
+static opal_atomic_int64_t fold_test_bytes = 0;
+static void fold_test_consume(void *ctx __opal_attribute_unused__, int64_t *count, int64_t *bytes)
+{
+    *count = opal_atomic_swap_64(&fold_test_counter, 0);
+    *bytes = opal_atomic_swap_64(&fold_test_bytes, 0);
+}
+
+/* Records the aggregated payload the fold delivers to a registration's callback. */
+static int      fold_cb_fired = 0;
+static uint64_t fold_cb_count = 0;
+static uint64_t fold_cb_bytes = 0;
+static void fold_event_cb(mca_base_event_instance_t *inst,
+                          mca_base_event_registration_t *reg __opal_attribute_unused__,
+                          mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                          void *user_data __opal_attribute_unused__)
+{
+    ++fold_cb_fired;
+    (void) mca_base_event_read(inst, 0, &fold_cb_count);
+    (void) mca_base_event_read(inst, 1, &fold_cb_bytes);
+}
+
+static void self_free_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                         mca_base_event_registration_t *reg,
+                         mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                         void *user_data __opal_attribute_unused__)
+{
+    /* Free our own handle from inside the callback (sec. 5.10). */
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+}
+
+static void free_marker_cb(mca_base_event_registration_t *reg __opal_attribute_unused__,
+                           mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                           void *user_data __opal_attribute_unused__)
+{
+    ++free_fired;
+}
+
+static void self_free_event_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                               mca_base_event_registration_t *reg,
+                               mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                               void *user_data __opal_attribute_unused__)
+{
+    self_free_reg = reg;
+}
+
+/* --- Ordering: record D (dropped handler) and C (event callback) in sequence. */
+static char seq[8];
+static int  seq_n = 0;
+
+static void seq_event_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                         mca_base_event_registration_t *reg __opal_attribute_unused__,
+                         mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                         void *user_data __opal_attribute_unused__)
+{
+    if (seq_n < (int) sizeof(seq)) {
+        seq[seq_n++] = 'C';
+    }
+}
+
+static void seq_dropped_cb(opal_count_t count __opal_attribute_unused__,
+                           mca_base_event_registration_t *reg __opal_attribute_unused__,
+                           int source_index __opal_attribute_unused__,
+                           mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                           void *user_data __opal_attribute_unused__)
+{
+    if (seq_n < (int) sizeof(seq)) {
+        seq[seq_n++] = 'D';
+    }
+}
+
+/* --- Selection: record which safety level was delivered. */
+static mca_base_event_cb_safety_t selected_level = -1;
+
+static void level_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                     mca_base_event_registration_t *reg __opal_attribute_unused__,
+                     mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__, void *user_data)
+{
+    /* user_data carries the registered level so we can tell which slot fired. */
+    selected_level = (mca_base_event_cb_safety_t) (intptr_t) user_data;
+}
+
+/* --- Recursion depth: re-raise unconditionally, track max observed nesting. */
+static int depth_now = 0;
+static int depth_max = 0;
+
+static void depth_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                     mca_base_event_registration_t *reg,
+                     mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                     void *user_data __opal_attribute_unused__)
+{
+    unsigned char b[16] = {0};
+    ++depth_now;
+    if (depth_now > depth_max) {
+        depth_max = depth_now;
+    }
+    /* Re-raise the same delivered event; the framework's depth cap must stop
+       the unbounded recursion. */
+    mca_base_event_raise_internal(reg->event, reg->event->source, NULL, b,
+                                  MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    --depth_now;
+}
+
+/* --- Concurrency stress: producer raises while consumer allocs/frees. */
+static volatile int stress_stop = 0;
+static mca_base_event_t        *stress_event = NULL;
+static mca_base_event_source_t *stress_source = NULL;
+static int                      stress_ev_index = -1;
+
+static void stress_cb(mca_base_event_instance_t *inst __opal_attribute_unused__,
+                      mca_base_event_registration_t *reg __opal_attribute_unused__,
+                      mca_base_event_cb_safety_t cb_safety __opal_attribute_unused__,
+                      void *user_data __opal_attribute_unused__)
+{
+}
+
+static void *stress_producer(void *arg __opal_attribute_unused__)
+{
+    unsigned char b[16] = {0};
+    while (!stress_stop) {
+        mca_base_event_raise_internal(stress_event, stress_source, NULL, b,
+                                      MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    }
+    return NULL;
+}
+
+static void *stress_consumer(void *arg __opal_attribute_unused__)
+{
+    int i;
+    for (i = 0; i < 20000; ++i) {
+        mca_base_event_registration_t *r;
+        if (OPAL_SUCCESS == mca_base_event_handle_alloc(stress_ev_index, NULL, NULL, &r)) {
+            (void) mca_base_event_register_callback(r, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL,
+                                                    NULL, stress_cb);
+            (void) mca_base_event_handle_free(r, NULL, NULL);
+        }
+    }
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int rc, src_index, ev_index, i;
+    mca_base_event_source_t *source;
+    mca_base_event_t *event;
+    mca_base_event_registration_t *reg;
+    mca_base_var_type_t types[2] = {MCA_BASE_VAR_TYPE_INT32_T, MCA_BASE_VAR_TYPE_UINT64_T};
+    ptrdiff_t offsets[2] = {0, 8};
+    unsigned char buf[16];
+
+    opal_init(&argc, &argv);
+
+    /* --- saturate_to: clamp at an INJECTED 32-bit ceiling on a 64-bit host. */
+    {
+        int64_t c32 = 0x7fffffffLL;
+        check("saturate below ceiling is identity",
+              c32 - 1 == (int64_t) mca_base_event_saturate_to(c32 - 1, c32));
+        check("saturate above ceiling clamps (no negative wrap)",
+              c32 == (int64_t) mca_base_event_saturate_to(c32 + 1000, c32)
+                  && (int64_t) mca_base_event_saturate_to(c32 + 1000, c32) > 0);
+    }
+
+    /* --- Register a source + a 2-element event type. */
+    src_index = mca_base_event_source_register("test.src", "test source",
+                                               MCA_BASE_EVENT_SOURCE_ORDERED, 1000000000,
+                                               OPAL_COUNT_MAX, NULL, true, NULL);
+    check("source_register succeeds", src_index >= 0);
+    rc = mca_base_event_source_get_by_index(src_index, &source);
+    check("source_get_by_index", OPAL_SUCCESS == rc);
+
+    ev_index = mca_base_event_register("test", "test", "comp", "event", "a test event",
+                                       OPAL_INFO_LVL_4, 2, types, offsets, NULL,
+                                       MCA_BASE_VAR_BIND_NO_OBJECT, 0, source, NULL);
+    check("event_register succeeds", ev_index >= 0);
+    rc = mca_base_event_get_by_index(ev_index, &event);
+    check("event_get_by_index", OPAL_SUCCESS == rc);
+    check("buffer_size computed (16)", 16 == (int) event->buffer_size);
+
+    /* --- Oversized payload is rejected. */
+    {
+        mca_base_var_type_t big_types[1] = {MCA_BASE_VAR_TYPE_UINT64_T};
+        ptrdiff_t big_offsets[1] = {MCA_BASE_EVENT_MAX_PAYLOAD};
+        rc = mca_base_event_register("test", "test", "comp", "toobig", "oversized",
+                                     OPAL_INFO_LVL_4, 1, big_types, big_offsets, NULL,
+                                     MCA_BASE_VAR_BIND_NO_OBJECT, 0, source, NULL);
+        check("oversized payload rejected", rc < 0);
+    }
+
+    /* --- Basic raise -> callback delivery, payload read, timestamp, source. */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc", OPAL_SUCCESS == rc);
+    rc = mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                          event_cb);
+    check("register NONE callback", OPAL_SUCCESS == rc);
+    check("event is now active", mca_base_event_active(event));
+
+    {
+        int32_t v32 = 42;
+        uint64_t v64 = 0x1122334455667788ULL;
+        /* memcpy, not an aligned store: buf[] (a char array) has no guaranteed
+           8-byte alignment, so *(uint64_t *)(buf + 8) would be a misaligned
+           access (SIGBUS on strict-alignment targets). */
+        memcpy(buf + 0, &v32, sizeof(v32));
+        memcpy(buf + 8, &v64, sizeof(v64));
+    }
+    cb_fired = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("callback fired once", 1 == cb_fired);
+    check("event_read element 0", 42 == cb_read_a);
+    check("event_read element 1", 0x1122334455667788ULL == cb_read_b);
+    check("cb_safety == raise context (NONE)", MCA_BASE_EVENT_CB_REQUIRE_NONE == cb_safety_seen);
+    check("event_get_source", src_index == cb_source_index);
+    check("timestamp is non-negative", cb_timestamp >= 0);
+
+    /* --- Drop accounting + dropped-handler flush before next delivery. */
+    rc = mca_base_event_set_dropped_handler(reg, dropped_cb, NULL, NULL);
+    check("set_dropped_handler", OPAL_SUCCESS == rc);
+    dropped_fired = 0;
+    dropped_count_seen = 0;
+    /* Raise N times at THREAD_SAFE: only a NONE callback exists, so none is
+       selected (cap at THREAD_SAFE means NONE<THREAD_SAFE is not searched up) ->
+       all drop. */
+    for (i = 0; i < 5; ++i) {
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+    }
+    check("no dropped-handler fire mid-run (no delivery yet)", 0 == dropped_fired);
+    /* Now a NONE-context raise IS delivered, flushing the 5 drops first. */
+    cb_fired = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("delivery after drops fired callback", 1 == cb_fired);
+    check("dropped handler fired once on flush", 1 == dropped_fired);
+    check("dropped count == 5", 5 == (int) dropped_count_seen);
+
+    /* A clean delivery does not re-fire the dropped handler. */
+    dropped_fired = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("clean delivery does not re-fire dropped handler", 0 == dropped_fired);
+
+    rc = mca_base_event_handle_free(reg, NULL, NULL);
+    check("handle_free", OPAL_SUCCESS == rc);
+    check("double handle_free rejected", OPAL_SUCCESS != mca_base_event_handle_free(reg, NULL, NULL));
+    check("event inactive after free", !mca_base_event_active(event));
+
+    /* --- Free-from-inside-its-own-callback + free_cb fires exactly once. */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (2)", OPAL_SUCCESS == rc);
+    rc = mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                          self_free_cb);
+    check("register self-free callback", OPAL_SUCCESS == rc);
+    free_fired = 0;
+    /* Use a wrapper free path: the self_free_cb calls handle_free(reg, NULL,
+       NULL); to observe free_cb we instead free via a marker.  Re-register a
+       handle that records its reg, then free it with a marker free_cb. */
+    self_free_reg = NULL;
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            self_free_event_cb);
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("callback captured its reg", self_free_reg == reg);
+    rc = mca_base_event_handle_free(reg, NULL, free_marker_cb);
+    check("handle_free with free_cb", OPAL_SUCCESS == rc);
+    check("free_cb fired exactly once", 1 == free_fired);
+
+    /* --- ASYNC-only callback never fires; drops accrue; flush at handle_free. */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (3)", OPAL_SUCCESS == rc);
+    rc = mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_ASYNC_SIGNAL_SAFE, NULL,
+                                          NULL, NULL, event_cb);
+    check("register ASYNC-only callback succeeds", OPAL_SUCCESS == rc);
+    rc = mca_base_event_set_dropped_handler(reg, dropped_cb, NULL, NULL);
+    check("set dropped handler (async-only)", OPAL_SUCCESS == rc);
+    cb_fired = 0;
+    dropped_fired = 0;
+    dropped_count_seen = 0;
+    for (i = 0; i < 3; ++i) {
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    }
+    check("ASYNC-only callback never fires", 0 == cb_fired);
+    check("ASYNC-only drops do not flush mid-run", 0 == dropped_fired);
+    rc = mca_base_event_handle_free(reg, NULL, NULL);
+    check("handle_free flushes ASYNC-only drops", OPAL_SUCCESS == rc);
+    check("final flush fired dropped handler once", 1 == dropped_fired);
+    check("final flush count == 3", 3 == (int) dropped_count_seen);
+
+    /* --- All-drops raise consumes no pool instance (sec. 12.4); a delivery
+       does (lazy acquisition). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (4)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            event_cb);
+    {
+        int64_t acq_before = mca_base_event_test_pool_acquires();
+        for (i = 0; i < 5; ++i) {
+            mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+        }
+        check("all-drops raise consumes no instance",
+              acq_before == mca_base_event_test_pool_acquires());
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        check("a delivery acquires exactly one instance",
+              acq_before + 1 == mca_base_event_test_pool_acquires());
+    }
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- ORDERED timestamps are monotonic across successive deliveries. */
+    {
+        opal_count_t t1, t2;
+        cb_timestamp = 0;
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        /* No callback now (handle freed); read the source ad hoc instead. */
+        (void) mca_base_event_source_get_timestamp(src_index, &t1);
+        (void) mca_base_event_source_get_timestamp(src_index, &t2);
+        check("ORDERED source timestamps are non-decreasing", t2 >= t1);
+    }
+
+    /* --- Drop-restore on (forced) pool exhaustion: with m pending drops, a
+       delivery that finds the pool exhausted must restore reg->dropped to
+       m + 1 (the captured m plus this now-dropped raise). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (5)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            event_cb);
+    {
+        int m = 4;
+        /* Accumulate m drops (THREAD_SAFE finds no selectable callback). */
+        for (i = 0; i < m; ++i) {
+            mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+        }
+        mca_base_event_test_set_force_exhaustion(true);
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        mca_base_event_test_set_force_exhaustion(false);
+        check("drop-restore on exhaustion: reg->dropped == m + 1",
+              (int64_t) m + 1 == (int64_t) reg->dropped);
+    }
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- Ordering: the dropped handler runs BEFORE the event callback within
+       the flushing delivery (sec. 5.9 step 3). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (ordering)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            seq_event_cb);
+    (void) mca_base_event_set_dropped_handler(reg, seq_dropped_cb, NULL, NULL);
+    seq_n = 0;
+    for (i = 0; i < 2; ++i) {
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+    }
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("dropped handler runs before event callback (sequence 'DC')",
+          2 == seq_n && 'D' == seq[0] && 'C' == seq[1]);
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- Selection: deliver to the SMALLEST valid safety level, not the most
+       permissive (sec. 2 / sec. 5.9). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (selection)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_MPI_RESTRICTED, NULL,
+                                            (void *) (intptr_t) MCA_BASE_EVENT_CB_REQUIRE_MPI_RESTRICTED,
+                                            NULL, level_cb);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE, NULL,
+                                            (void *) (intptr_t) MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE,
+                                            NULL, level_cb);
+    selected_level = -1;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("NONE-context raise picks the smallest valid level (MPI_RESTRICTED)",
+          MCA_BASE_EVENT_CB_REQUIRE_MPI_RESTRICTED == selected_level);
+    selected_level = -1;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+    check("THREAD_SAFE-context raise picks the THREAD_SAFE level",
+          MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE == selected_level);
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- set_dropped_handler(NULL) discards pending drops (p.755). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (clear-drops)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            event_cb);
+    (void) mca_base_event_set_dropped_handler(reg, dropped_cb, NULL, NULL);
+    for (i = 0; i < 4; ++i) {
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_THREAD_SAFE);
+    }
+    (void) mca_base_event_set_dropped_handler(reg, NULL, NULL, NULL);       /* clears */
+    (void) mca_base_event_set_dropped_handler(reg, dropped_cb, NULL, NULL); /* re-arm */
+    dropped_fired = 0;
+    dropped_count_seen = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("set_dropped_handler(NULL) discarded the pending drops", 0 == dropped_fired);
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- The per-thread dispatch-depth cap bounds an unconditional re-raise at
+       exactly MCA_BASE_EVENT_MAX_DISPATCH_DEPTH (with a production-sized pool,
+       so the depth cap -- not pool exhaustion -- is the limiter). */
+    rc = mca_base_event_handle_alloc(ev_index, NULL, NULL, &reg);
+    check("handle_alloc (recursion)", OPAL_SUCCESS == rc);
+    (void) mca_base_event_register_callback(reg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                            depth_cb);
+    depth_now = 0;
+    depth_max = 0;
+    mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+    check("re-raising callback is bounded at the dispatch-depth cap",
+          MCA_BASE_EVENT_MAX_DISPATCH_DEPTH == depth_max);
+    (void) mca_base_event_handle_free(reg, NULL, NULL);
+
+    /* --- Heap-fallback snapshot: > 32 registrations on one event all deliver. */
+    {
+        mca_base_event_registration_t *many[40];
+        int n = 40, ok_all = 1;
+        for (i = 0; i < n; ++i) {
+            if (OPAL_SUCCESS != mca_base_event_handle_alloc(ev_index, NULL, NULL, &many[i])) {
+                ok_all = 0;
+                break;
+            }
+            (void) mca_base_event_register_callback(many[i], MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL,
+                                                    NULL, NULL, event_cb);
+        }
+        check("alloc 40 registrations on one event", ok_all);
+        cb_fired = 0;
+        mca_base_event_raise_internal(event, source, NULL, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        check("one raise delivers to all 40 registrations (heap-grown snapshot)", 40 == cb_fired);
+        for (i = 0; i < n; ++i) {
+            (void) mca_base_event_handle_free(many[i], NULL, NULL);
+        }
+        check("event inactive after freeing all 40", !mca_base_event_active(event));
+    }
+
+    /* --- Concurrency: producer raising while consumer allocs/frees handles. */
+    {
+        pthread_t prod, cons;
+        stress_event = event;
+        stress_source = source;
+        stress_ev_index = ev_index;
+        stress_stop = 0;
+        pthread_create(&prod, NULL, stress_producer, NULL);
+        pthread_create(&cons, NULL, stress_consumer, NULL);
+        pthread_join(cons, NULL);
+        stress_stop = 1;
+        pthread_join(prod, NULL);
+        check("concurrent raise vs. alloc/free completes without crash/deadlock", 1);
+        check("event inactive after concurrent stress", !mca_base_event_active(event));
+    }
+
+    /* --- For a NO_OBJECT event, a non-NULL obj_handle is IGNORED, not rejected
+       (MPI-5.0 sec. 15.3.8): handle_alloc succeeds and ignores the pointer. */
+    {
+        int dummy = 0;
+        rc = mca_base_event_handle_alloc(ev_index, &dummy, NULL, &reg);
+        check("non-NULL obj_handle ignored for a NO_OBJECT event", OPAL_SUCCESS == rc);
+        if (OPAL_SUCCESS == rc) {
+            (void) mca_base_event_handle_free(reg, NULL, NULL);
+        }
+    }
+
+    /* --- The fold mechanism (sec. 7.1) via a synthetic deferred-release
+       source: a source with a fold-consume hook accumulates a {count, bytes}
+       pair that the framework drains at a framework op (here
+       source_get_timestamp) and delivers as ONE aggregated, data-bearing event.
+       This runs on every platform (it does not need the real free-hooks). */
+    {
+        int fsi, fei, fsrc;
+        mca_base_event_source_t *fsource = NULL;
+        mca_base_event_t *fevent = NULL;
+        mca_base_event_registration_t *freg = NULL;
+        opal_count_t fts = 0;
+        mca_base_var_type_t fu64x2[2] = {MCA_BASE_VAR_TYPE_UINT64_T, MCA_BASE_VAR_TYPE_UINT64_T};
+        ptrdiff_t foff[2] = {0, 8};
+
+        fsi = mca_base_event_source_register("test.fold", "synthetic fold source",
+                                             MCA_BASE_EVENT_SOURCE_UNORDERED,
+                                             (opal_count_t) 1000000000, OPAL_COUNT_MAX, NULL, true,
+                                             NULL);
+        check("fold source registered", fsi >= 0);
+        (void) mca_base_event_source_get_by_index(fsi, &fsource);
+        fei = mca_base_event_register("test", "fold", "comp", "released", "synthetic released",
+                                      OPAL_INFO_LVL_4, 2, fu64x2, foff, NULL,
+                                      MCA_BASE_VAR_BIND_NO_OBJECT, 0, fsource, NULL);
+        check("fold event registered", fei >= 0);
+        (void) mca_base_event_get_by_index(fei, &fevent);
+
+        /* Wire the deferred-release hooks exactly as a real producer would. */
+        fsource->fold_consume_fn = fold_test_consume;
+        fsource->fold_event = fevent;
+        fsrc = fsource->source_index;
+
+        rc = mca_base_event_handle_alloc(fei, NULL, NULL, &freg);
+        check("fold handle_alloc", OPAL_SUCCESS == rc);
+        rc = mca_base_event_register_callback(freg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                              fold_event_cb);
+        check("fold register_callback", OPAL_SUCCESS == rc);
+
+        (void) opal_atomic_swap_64(&fold_test_counter, 5);    /* 5 pending releases  */
+        (void) opal_atomic_swap_64(&fold_test_bytes, 4096);   /* totalling 4096 bytes */
+        fold_cb_fired = 0;
+        fold_cb_count = fold_cb_bytes = 0;
+        (void) mca_base_event_source_get_timestamp(fsrc, &fts); /* drives the fold */
+        check("fold delivered one aggregated event", 1 == fold_cb_fired);
+        check("aggregated event reports 5 releases", 5 == (int) fold_cb_count);
+        check("aggregated event reports 4096 bytes", 4096 == (int) fold_cb_bytes);
+
+        /* Consume-and-clear: a second fold with no new releases must not re-deliver. */
+        fold_cb_fired = 0;
+        (void) mca_base_event_source_get_timestamp(fsrc, &fts);
+        check("repeated fold is non-cumulative (no second delivery)", 0 == fold_cb_fired);
+
+        /* handle_free drains the source's pending releases before the
+           registration detaches (sec. 7.1), so a tool that frees the handle
+           WITHOUT first polling source_get_timestamp still observes its final
+           batch. */
+        (void) opal_atomic_swap_64(&fold_test_counter, 3);
+        (void) opal_atomic_swap_64(&fold_test_bytes, 2048);
+        fold_cb_fired = 0;
+        fold_cb_count = fold_cb_bytes = 0;
+        (void) mca_base_event_handle_free(freg, NULL, NULL);
+        check("handle_free drains pending releases before detach", 1 == fold_cb_fired);
+        check("handle_free fold reports 3 releases", 3 == (int) fold_cb_count);
+    }
+
+    /* --- OS-memory deferred-release fold (sec. 7.1): a tool's
+       source_get_timestamp drains accumulated releases and delivers them as one
+       aggregated {count, bytes} event.  The OS free-hook machinery lives in
+       OPAL; here we register a local source/event and wire it up with
+       mca_base_event_memory_attach() (the OMPI producer layer does the same with
+       the real ompi.mca.memory.patcher.released name).  Only runs where the OPAL
+       free-hooks are supported (e.g. Linux; absent on macOS).
+
+       opal_init() does not open the memory framework -- nothing in this test
+       pulls in an rcache or a common/{ofi,ucx} that would -- so the free-hook
+       support level is 0 until we open it ourselves.  Without this, the block
+       below silently never runs on any platform. */
+    (void) mca_base_framework_open(&opal_memory_base_framework, 0);
+    if (mca_base_event_memory_supported()) {
+        const mca_base_var_type_t u64x2[2] = {MCA_BASE_VAR_TYPE_UINT64_T,
+                                              MCA_BASE_VAR_TYPE_UINT64_T};
+        const ptrdiff_t off[2] = {0, 8};
+        mca_base_event_source_t *msource = NULL;
+        mca_base_event_t *mev = NULL;
+        mca_base_event_registration_t *mreg = NULL;
+        opal_count_t mts = 0;
+        int midx, msrc, si;
+
+        /* Suppress the real free() hook so our bumps are the only releases. */
+        mca_base_event_memory_test_suppress_hook(true);
+
+        si = mca_base_event_source_register("test.os.memory", "white-box OS memory",
+                                            MCA_BASE_EVENT_SOURCE_UNORDERED,
+                                            (opal_count_t) 1000000000, OPAL_COUNT_MAX, NULL, true,
+                                            NULL);
+        check("os-memory source registered",
+              0 <= si && OPAL_SUCCESS == mca_base_event_source_get_by_index(si, &msource));
+        midx = mca_base_event_register("opal", "test", "osmem", "released", "released (white-box)",
+                                       OPAL_INFO_LVL_4, 2, u64x2, off, NULL,
+                                       MCA_BASE_VAR_BIND_NO_OBJECT, 0, msource, NULL);
+        check("os-memory event registered",
+              0 <= midx && OPAL_SUCCESS == mca_base_event_get_by_index(midx, &mev));
+
+        /* Wire the OPAL OS-memory machinery into our source/event. */
+        mca_base_event_memory_attach(msource, mev);
+        msrc = mev->source->source_index;
+
+        rc = mca_base_event_handle_alloc(midx, NULL, NULL, &mreg);
+        check("memory handle_alloc", OPAL_SUCCESS == rc);
+        rc = mca_base_event_register_callback(mreg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                              fold_event_cb);
+        check("memory register_callback", OPAL_SUCCESS == rc);
+
+        (void) mca_base_event_memory_test_bump(5, 8192); /* 5 releases, 8192 bytes */
+        fold_cb_fired = 0;
+        fold_cb_count = fold_cb_bytes = 0;
+        (void) mca_base_event_source_get_timestamp(msrc, &mts); /* drives the fold */
+        check("memory fold delivered one aggregated event", 1 == fold_cb_fired);
+        check("memory fold reports 5 releases", 5 == (int) fold_cb_count);
+        check("memory fold reports 8192 bytes", 8192 == (int) fold_cb_bytes);
+
+        /* Consume-and-clear: a second fold with no new releases must not re-deliver. */
+        fold_cb_fired = 0;
+        (void) mca_base_event_source_get_timestamp(msrc, &mts);
+        check("repeated fold is non-cumulative (no second delivery)", 0 == fold_cb_fired);
+
+        /* Detaching the last listener deactivates the producer. */
+        (void) mca_base_event_handle_free(mreg, NULL, NULL);
+
+        /* A hook still in flight when detach stored active=false can land a bump
+           after the producer is deactivated.  Such residue must never be
+           credited to the *next* listener: handle_alloc() folds the event before
+           the new registration joins it (fold-before-membership-change, sec.
+           7.1), so the stale count is raised to the then-empty registration set
+           and discarded.  Watch the whole re-attach, not just the final fold. */
+        (void) mca_base_event_memory_test_bump(3, 1024);
+
+        fold_cb_fired = 0;
+        fold_cb_count = fold_cb_bytes = 0;
+
+        mreg = NULL;
+        rc = mca_base_event_handle_alloc(midx, NULL, NULL, &mreg);
+        check("memory handle_alloc (re-attach)", OPAL_SUCCESS == rc);
+        rc = mca_base_event_register_callback(mreg, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, NULL, NULL,
+                                              fold_event_cb);
+        check("memory register_callback (re-attach)", OPAL_SUCCESS == rc);
+        (void) mca_base_event_source_get_timestamp(msrc, &mts);
+
+        check("post-detach residue is not credited to the next listener",
+              0 == fold_cb_fired && 0 == (int) fold_cb_count && 0 == (int) fold_cb_bytes);
+
+        (void) mca_base_event_handle_free(mreg, NULL, NULL);
+        mca_base_event_memory_test_suppress_hook(false);
+    } else {
+        printf("(ompi.unordered memory producer absent: no free-hook support on this platform)\n");
+    }
+
+    /* --- Dump routines: parsable + readable formatting for an event and a
+       source.  Each hands back a fresh, NULL-terminated, caller-owned char*
+       array (calloc'd by the dump routine, one opal_asprintf'd string per
+       line); the caller frees every line, then the array. */
+    {
+        char **strings;
+        int    j, n;
+
+        /* Event, parsable: lines look like
+           "mpi_t_event:type:<name>:<field>:<value>". */
+        strings = NULL;
+        check("event_dump (parsable) succeeds",
+              OPAL_SUCCESS == mca_base_event_dump(ev_index, &strings, MCA_BASE_VAR_DUMP_PARSABLE));
+        check("event_dump (parsable) returned an array", NULL != strings);
+        if (NULL != strings) {
+            int saw_prefix = 0;
+            for (n = 0; NULL != strings[n]; ++n) {
+                if (NULL != strstr(strings[n], "mpi_t_event:")) {
+                    saw_prefix = 1;
+                }
+            }
+            check("event_dump (parsable) is NULL-terminated with >= 1 line", n >= 1);
+            check("event_dump (parsable) line carries the mpi_t_event: prefix", saw_prefix);
+            for (j = 0; j < n; ++j) {
+                free(strings[j]);
+            }
+            free(strings);
+        }
+
+        /* Event, readable: a human summary line (+ optional description). */
+        strings = NULL;
+        check("event_dump (readable) succeeds",
+              OPAL_SUCCESS == mca_base_event_dump(ev_index, &strings, MCA_BASE_VAR_DUMP_READABLE));
+        check("event_dump (readable) returned an array", NULL != strings);
+        if (NULL != strings) {
+            for (n = 0; NULL != strings[n]; ++n) {
+                continue;
+            }
+            check("event_dump (readable) is NULL-terminated with >= 1 line", n >= 1);
+            for (j = 0; j < n; ++j) {
+                free(strings[j]);
+            }
+            free(strings);
+        }
+
+        /* Source, parsable: lines look like
+           "mpi_t_event:source:<name>:<field>:<value>". */
+        strings = NULL;
+        check("source_dump (parsable) succeeds",
+              OPAL_SUCCESS
+                  == mca_base_event_source_dump(src_index, &strings, MCA_BASE_VAR_DUMP_PARSABLE));
+        check("source_dump (parsable) returned an array", NULL != strings);
+        if (NULL != strings) {
+            int saw_prefix = 0;
+            for (n = 0; NULL != strings[n]; ++n) {
+                if (NULL != strstr(strings[n], "mpi_t_event:")) {
+                    saw_prefix = 1;
+                }
+            }
+            check("source_dump (parsable) is NULL-terminated with >= 1 line", n >= 1);
+            check("source_dump (parsable) line carries the mpi_t_event: prefix", saw_prefix);
+            for (j = 0; j < n; ++j) {
+                free(strings[j]);
+            }
+            free(strings);
+        }
+
+        /* Source, readable: a human summary line (+ optional description). */
+        strings = NULL;
+        check("source_dump (readable) succeeds",
+              OPAL_SUCCESS
+                  == mca_base_event_source_dump(src_index, &strings, MCA_BASE_VAR_DUMP_READABLE));
+        check("source_dump (readable) returned an array", NULL != strings);
+        if (NULL != strings) {
+            for (n = 0; NULL != strings[n]; ++n) {
+                continue;
+            }
+            check("source_dump (readable) is NULL-terminated with >= 1 line", n >= 1);
+            for (j = 0; j < n; ++j) {
+                free(strings[j]);
+            }
+            free(strings);
+        }
+    }
+
+    /* --- Object binding (sec. 6.1): a bound event reaches ONLY the registration
+       bound to the raised object; NO_OBJECT raises (above) reach everyone. */
+    {
+        int bev_index;
+        mca_base_event_t *bevent;
+        mca_base_event_registration_t *regA, *regB;
+        /* Opaque fake object identities (never dereferenced; matched by value). */
+        void *objA = (void *) (uintptr_t) 0xA1A1;
+        void *objB = (void *) (uintptr_t) 0xB2B2;
+
+        bev_index = mca_base_event_register("test", "test", "bound", "bound",
+                                            "an object-bound test event", OPAL_INFO_LVL_4, 2, types,
+                                            offsets, NULL, MCA_BASE_VAR_BIND_MPI_COMM, 0, source,
+                                            NULL);
+        check("bound event_register succeeds", bev_index >= 0);
+        rc = mca_base_event_get_by_index(bev_index, &bevent);
+        check("bound event_get_by_index", OPAL_SUCCESS == rc);
+        check("bound event reports its MPI_COMM binding", MCA_BASE_VAR_BIND_MPI_COMM == bevent->bind);
+
+        /* A bound event requires an object: a NULL obj_handle is rejected. */
+        rc = mca_base_event_handle_alloc(bev_index, NULL, NULL, &regA);
+        check("bound handle_alloc rejects a NULL obj_handle", OPAL_ERR_BAD_PARAM == rc);
+
+        /* obj_handle is the ADDRESS of the handle variable (MPI-5.0 p.751). */
+        rc = mca_base_event_handle_alloc(bev_index, &objA, NULL, &regA);
+        check("bound handle_alloc (object A)", OPAL_SUCCESS == rc);
+        rc = mca_base_event_handle_alloc(bev_index, &objB, NULL, &regB);
+        check("bound handle_alloc (object B)", OPAL_SUCCESS == rc);
+        (void) mca_base_event_register_callback(regA, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, objA,
+                                                NULL, bound_cb);
+        (void) mca_base_event_register_callback(regB, MCA_BASE_EVENT_CB_REQUIRE_NONE, NULL, objB,
+                                                NULL, bound_cb);
+
+        /* Raise for object A: only A's registration is notified. */
+        bound_count = 0;
+        bound_last = NULL;
+        mca_base_event_raise_internal(bevent, source, objA, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        check("bound raise(A) delivered exactly once", 1 == bound_count);
+        check("bound raise(A) reached the A registration only", objA == bound_last);
+
+        /* Raise for object B: only B's registration is notified. */
+        bound_count = 0;
+        bound_last = NULL;
+        mca_base_event_raise_internal(bevent, source, objB, buf, MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        check("bound raise(B) delivered exactly once", 1 == bound_count);
+        check("bound raise(B) reached the B registration only", objB == bound_last);
+
+        /* Raise for an object nobody bound to: delivered to no one. */
+        bound_count = 0;
+        mca_base_event_raise_internal(bevent, source, (void *) (uintptr_t) 0xCCCC, buf,
+                                      MCA_BASE_EVENT_CB_REQUIRE_NONE);
+        check("bound raise(unbound object) reaches no registration", 0 == bound_count);
+
+        (void) mca_base_event_handle_free(regA, NULL, NULL);
+        (void) mca_base_event_handle_free(regB, NULL, NULL);
+    }
+
+    opal_finalize();
+
+    printf("RESULT: %s (%d failures)\n", 0 == failures ? "PASS" : "FAIL", failures);
+    return 0 == failures ? 0 : 1;
+}


### PR DESCRIPTION
Parent issue: #14019

## Summary

The MPI_T *events* interface (MPI-5.0 §15.3.8) has shipped in Open MPI as inert stubs: every `MPI_T_event_*` / `MPI_T_source_*` symbol is present, but `MPI_T_event_get_num` and `MPI_T_source_get_num` always return 0, there is no `mca_base_event` framework, and no producer ever registers a source or event (see #14019 for the full conformance analysis).

This PR implements the facility end to end:

- a new OPAL **`mca_base_event` framework** (modeled on `mca_base_pvar`): source/event registration, enumeration, handle management, callbacks with safety-level dispatch, dropped-event accounting, and a raise path;
- the **MPI_T tool layer** wired to that framework (all `event_*`/`source_*` entry points, plus `MPI_T_category_get_events`, #14017);
- a set of **in-tree producers** for control-plane events — communicator and session lifecycle, error-handler invocations, MPI memory allocation (`ompi.mpi.memory`), an OS-memory drop demonstrator (`ompi.os.memory`), and a family of example events — all registered in the OMPI layer;
- **visibility** via `ompi_info --event` and two read-only cvars;
- **tests** (an OPAL white-box test plus MPI_T singletons) and **docs** (man pages and a developer guide).

With the default build, the events facility is now non-empty (7 sources, 12 event types) and the #14019 reproducer prints `RESULT: HAS_EVENTS` (exit 0).

## How to review this PR

This is a large change, but it is organized as **7 self-contained commits** in dependency order. Please **review commit by commit** — each commit is a small, coherent unit and its commit message explains the *why* in detail:

1. **Add opal_count_t** — a layer-safe `MPI_Count` backing type usable below the OMPI boundary (the framework stores counts in OPAL).
2. **Add the mca_base_event framework** — the heart of the PR: registry, hardened lock-free dispatch, deferred free, instance pool, timestamps, drop accounting, the OS-memory drop-demonstrator *mechanism* (the OS free-hook, name-agnostic), and the white-box test. (The producers themselves are registered in the OMPI layer; this commit keeps only the generic framework and the OS-hook machinery.)
3. **Wire the MPI_T events tool layer** — the entry points + the OMPI callback trampolines.
4. **Populate MPI_T_category_get_events** — the per-category event list (#14017).
5. **Add the in-tree event producers** — all registered in the OMPI layer: the communicator / session / error-handler / MPI-memory sources and their raise sites, the `ompi.os.memory` drop demonstrator (wiring in OPAL's mechanism), and the `ompi.example*` producers.
6. **Expose MPI_T events via `ompi_info --event`** — the listings, `--level` filtering of event types, and cvars.
7. **Tests and documentation** — the MPI_T singletons, man pages, changelog, and the developer guide.

(The two error classes the interface returns — `MPI_T_ERR_NOT_SUPPORTED` / `MPI_T_ERR_NOT_ACCESSIBLE` — are already on `main` via #14018, so the earlier commit that defined them has been dropped from this branch.)

## Basic design

The framework mirrors `mca_base_pvar`. An **event source** is a clock domain plus metadata (ordering, ticks/sec, max ticks, ad-hoc timestamp support); every **event type** belongs to exactly one source and has a fixed *element layout* (typed fields, like a struct). A tool allocates a **registration handle** on an event type, attaches **callbacks** keyed by the Table 15.5 safety level (`NONE`/`MPI_RESTRICTED`/`THREAD_SAFE`/`ASYNC_SIGNAL_SAFE`) and/or a **dropped-event handler**, and the implementation **raises** the event to deliver one instance per attached, safety-compatible callback.

Dispatch is a **snapshot-under-lock → invoke-callbacks-lock-free → reconcile** design with refcounted deferred free, so **no user callback of any kind runs while a framework lock (or `ompi_mpit_big_lock`) is held** — a callback may free its own handle or re-enter MPI_T without deadlock, as the standard permits. Lifetime is managed by refcounts with a live-registration table so a stale/double `handle_free` returns `MPI_T_ERR_INVALID_HANDLE` without dereferencing freed memory.

## Design precepts

- **Near-zero overhead when unused.** Each raise site is a single relaxed atomic read of a per-event `num_active` gate plus a predicted branch; when no tool is listening it returns immediately, before building any payload. No per-MPI-object storage is added anywhere.
- **No allocation/locks on the no-listener path.** The instance pool, the clock origin, and (for `ompi.os.memory`) the OS memory hook are all created/installed **lazily on first listener-attach** and torn down on last detach — when the facility is unused, the allocator and the rest of the runtime are untouched.
- **The empty-event-space path stays conformant.** A master MCA switch (`mca_base_event_register_producers=0`) disables every producer, so N=0 is reachable and tested; the entry points then return the standard error codes.
- **Bounded, robustly implementable v1.** Synchronous, normal-context delivery only; the instance pool is capped (drops, never unbounded allocation) and the per-thread re-entrant dispatch depth is capped. `ASYNC_SIGNAL_SAFE` delivery and data-bearing memory events are explicitly deferred (see *v1 scope* below).

## Producers (`ompi_info --event`)

The producers register control-plane / environmental events, listable with `ompi_info --event` (also covered by `--all`). Event **sources** are always listed; event **types** are filtered by `--level` against the type's verbosity (the in-tree types register at levels 2-4), so `--level 9` shows them all:

```
     MPI_T event sources: --------------------------------------------------
                          ompi.communicator (ordered, ticks/sec: 1000000000)
                          ompi.session (ordered, ticks/sec: 1000000000)
                          ompi.errhandler (ordered, ticks/sec: 1000000000)
                          ompi.mpi.memory (ordered, ticks/sec: 1000000000)
                          ompi.example / ompi.example.unordered / ompi.example.noadhoc
       MPI_T event types: --------------------------------------------------
                          ompi.communicator_base_created (source: ompi.communicator, elements: 2)
                          ompi.communicator_base_freed   (source: ompi.communicator, elements: 1)
                          ompi.session_base_created / ompi.session_base_destroyed
                          ompi.errhandler_base_invoked   (source: ompi.errhandler, elements: 2)
                          ompi.mpi.memory_base_allocated / ompi.mpi.memory_base_freed
                          ompi.example_base_heartbeat / _lossy / _multi_element / _unordered_event / _noadhoc_event
```

Event-type names carry the same `ompi.` namespace prefix as the source names. `--parsable` emits the same data as stable, colon-delimited records — `mpi_t_event:source:<name>:<field>:<value>` and `mpi_t_event:type:<name>:<field>:<value>`. (On platforms whose OPAL memory hooks report frees, an additional `ompi.os.memory` source and its `ompi.os.memory_base_released` drop-demonstrator event also appear.)

## Documentation

- A developer guide, **`docs/developers/mpi-t-event-producers.rst`**, explains how to write an event producer (register a source/event type, raise events, and the producer contract — no MPI_T lock held, fixed-size payloads, near-zero cost when unused, gating registration on availability).
- A new **`MPI_T_Events(3)`** man page gives a user-facing overview of Open MPI's MPI_T events support, a **receiving-events** walkthrough (the registration/callback flow), and itemizes each built-in event source and event type — including **when each event is raised and what its payload fields mean** — framed as examples / a possible subset (discover the real set via the MPI_T API or `ompi_info --event`). The **`MPI_T(3)`** overview page's events section is updated from its old "stub interfaces" text to point at it, and every `MPI_T_event_*` / `MPI_T_source_*` man page now cross-links to it.
- The `MPI_T_event_get_num` / `MPI_T_source_get_num` man pages are updated from the old "returns 0" notes and gain a "discovering available events" section (`ompi_info --event` plus a short enumeration program).
- The `ompi_info(1)` man page documents the new `--event` option and notes that `--level` filters the listed event types.
- A changelog entry under `docs/release-notes/changelog/v6.0.x.rst`.

## Tests

- **OPAL white-box test** (`test/util/mca_base_event_test.c`, ~60 assertions wired into `make check`): registration, raise → callback delivery + payload read, drop accounting + flush, free-from-callback, saturation, drop-restore on pool exhaustion, all-drops-consumes-no-instance, ORDERED CAS-max monotonic timestamps, the drop-fold mechanism, smallest-valid-safety-level selection, bounded re-entrant dispatch, and a concurrency stress test.
- **MPI_T singletons** under `test/mpi/t/` (all wired into `make check`): `mpi_t_event_smoke`, `_producers`, `_examples`, `_inert_ok`, `_reinit`, `_async_only`, and `mpi_t_event_14019` (the issue reproducer), plus `mpi_t_errcodes` and the updated `mpi_t_category_get_events`.

Built **warning-free** and all tests pass on **Linux and macOS**.

## How this PR meets the #14019 success criteria

| # | Success criterion (#14019) | Status |
|---|---|---|
| 1 | `mca_base_event` framework in `opal/mca/base/`, mirroring `mca_base_pvar` (registration, enumeration, handles, dispatch, raise path) | ✅ `mca_base_event.{h,c}` + `mca_base_event_dispatch.c` |
| 2 | ≥1 producer → nonzero `source_get_num` / `event_get_num` | ✅ **7 sources, 12 event types** |
| 3 | `source_get_info` → ordering / ticks_per_second / max_ticks; `INVALID_INDEX` out of range | ✅ implemented |
| 4 | `source_get_timestamp` → SUCCESS+timestamp / `INVALID_INDEX` / `NOT_SUPPORTED` | ✅ implemented (SUCCESS + `NOT_SUPPORTED` asserted in `mpi_t_event_examples`) |
| 5 | `event_get_info` / `get_index`; `handle_alloc` / `handle_free` | ✅ asserted (`mpi_t_event_smoke`) |
| 6 | `register_callback` at the requested safety level; actual safety passed to the callback (Table 15.5) | ✅ asserted (white-box: `cb_safety == context`; smallest-valid-level selection) |
| 7 | `set_dropped_handler` invoked with the dropped count | ✅ asserted (`_examples` lossy = count *n*; `_async_only` = *n+1*) |
| 8 | in-callback `event_read` / `copy` / `get_timestamp` / `get_source` | ✅ read/timestamp/source asserted (`_smoke`, `_examples`) |
| 9 | reproducer prints `HAS_EVENTS` (exit 0); callback fires | ✅ `mpi_t_event_14019` → `RESULT: HAS_EVENTS`; callback firing asserted (`_smoke`/`_producers`/`_examples`) |
| 10 | empty-event-space stays conformant when no producer is enabled | ✅ asserted (`mpi_t_event_inert_ok`) |

The issue's verbatim C reproducer, compiled against this build, prints:

```
num_sources=7 num_events=12
RESULT: HAS_EVENTS
```

**Honest coverage note (implementation vs. tests):** every facet above is implemented and functional. Three narrow sub-facets are implemented but not yet covered by a dedicated MPI_T-level assertion (they are partly covered by the OPAL white-box test): the field values returned by `MPI_T_source_get_info` (ordering/ticks/max), the `MPI_T_source_get_timestamp` `INVALID_INDEX` branch, and `MPI_T_event_copy`. These are easy follow-on singletons if reviewers want each criterion individually asserted.

## Relationship to PR #13133 (a different approach)

#13133 (a rebase of the long-standing #8057) targets the same conformance gap but takes a fundamentally different approach, and this PR deliberately diverges on the points that drew review pushback there:

- **Critical performance path.** #13133 instruments the message-passing hot path (`pml/ob1` send/recv requests, `osc/rdma` RMA). **This PR intentionally adds no events to any critical performance path** — confirmed: it touches no `mca/pml`, `mca/osc`, or datatype code. Its producers are all control-plane/cold (communicator/session/errhandler lifecycle, memory alloc/free). This is exactly the lower-risk producer option #14019 itself lists ("runtime/process-management events") and directly honors the issue's own Risk note that hot-path raising must stay zero-overhead.
- **Locking / threading.** #13133 hit a self-deadlock in CI (`mca_base_source_register` → `..._get_by_name`, both taking a non-recursive `mca_base_source_lock`) and a muddled locking model. This PR uses one framework lock, **never runs a user callback under it**, and makes registration idempotent-by-name (no recursive-lock trap). (An early revision of this work had the same class of bug — a big lock held across a callback — but it was caught and fixed during review, with a regression test that re-enters MPI_T from a handler.)
- **No separate `mca_base_source` framework.** Sources are a sub-object inside the single `mca_base_event` framework (sources are registered during init, a single sequential context), avoiding the separate framework that carried the locking bugs in #13133.
- **No new datatype machinery.** Element types reuse the existing `mca_base_var_type_t` + `ompit_var_type_to_datatype` path (exact-width types), rather than #13133's `ompi_datatype_lookup_by_opal_id` mapping that was an open design question there.
- **Bounded v1 scope.** The trade-off: #13133 aims for rich per-message telemetry (which is *why* it must touch the hot path); this PR delivers lifecycle/environmental events plus the robust infrastructure, and defers per-message/async/data-bearing delivery to future work — addressing the "too ambitious / reconsider the basic design" feedback on #13133.

## v1 scope (explicitly deferred)

Synchronous normal-context delivery only; no `ASYNC_SIGNAL_SAFE` delivery (such a callback registers successfully but is never selected in v1); the `ompi.os.memory` producer is a drop-accounting demonstrator (its in-`free()` hook cannot safely deliver, so it counts releases and surfaces them to dropped handlers); and a few example events (`cycle_clock`, `info_tunable`) and dedicated per-entry-point test singletons are left as follow-ons. None of these are required by the #14019 success criteria.



