### PR TITLE
errhandler: Fix Session error handler segfault

### DIFF
--- a/docs/man-openmpi/man3/MPI_Session_set_errhandler.3.rst
+++ b/docs/man-openmpi/man3/MPI_Session_set_errhandler.3.rst
@@ -29,6 +29,21 @@ The error handler must be either a predefined error handler or an error
 handler created by a call to :ref:`MPI_Session_create_errhandler`.
 
 
+NOTES
+-----
+
+When using MPI_ERRORS_ABORT with a session, note that per MPI-5.0 Sec 9.3
+(pp.447-448), this error handler aborts ONLY the local MPI process, not the
+entire job. When using the PRRTE runtime (the default for Open MPI), you must
+use the ``--enable-recovery`` option with ``mpirun(1)`` or ``mpiexec(1)`` to
+prevent the runtime from automatically aborting other processes in the job
+when the local process aborts.
+
+For example::
+
+   mpirun --enable-recovery -n 4 ./my_program
+
+
 ERRORS
 ------
 

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -202,6 +202,7 @@ int ompi_errhandler_init(void)
   ompi_mpi_errors_abort.eh.eh_comm_fn = ompi_mpi_errors_abort_comm_handler;
   ompi_mpi_errors_abort.eh.eh_file_fn = ompi_mpi_errors_abort_file_handler;
   ompi_mpi_errors_abort.eh.eh_win_fn  = ompi_mpi_errors_abort_win_handler ;
+  ompi_mpi_errors_abort.eh.eh_instance_fn = ompi_mpi_errors_abort_instance_handler;
   ompi_mpi_errors_abort.eh.eh_fort_fn = NULL;
   opal_string_copy(ompi_mpi_errors_abort.eh.eh_name,
                    "MPI_ERRORS_ABORT",

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -85,13 +85,17 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
         comm = (ompi_communicator_t *) mpi_object;
         switch (errhandler->eh_lang) {
         case OMPI_ERRHANDLER_LANG_C:
-            errhandler->eh_comm_fn(&comm, &err_code, message, NULL);
+            if (NULL != errhandler->eh_comm_fn) {
+                errhandler->eh_comm_fn(&comm, &err_code, message, NULL);
+            }
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
-            fortran_handle = OMPI_INT_2_FINT(comm->c_f_to_c_index);
-            errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
-            err_code = OMPI_FINT_2_INT(fortran_err_code);
+            if (NULL != errhandler->eh_fort_fn) {
+                fortran_handle = OMPI_INT_2_FINT(comm->c_f_to_c_index);
+                errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
+                err_code = OMPI_FINT_2_INT(fortran_err_code);
+            }
             break;
         }
         break;
@@ -100,13 +104,17 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
         win = (ompi_win_t *) mpi_object;
         switch (errhandler->eh_lang) {
         case OMPI_ERRHANDLER_LANG_C:
-            errhandler->eh_win_fn(&win, &err_code, message, NULL);
+            if (NULL != errhandler->eh_win_fn) {
+                errhandler->eh_win_fn(&win, &err_code, message, NULL);
+            }
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
-            fortran_handle = OMPI_INT_2_FINT(win->w_f_to_c_index);
-            errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
-            err_code = OMPI_FINT_2_INT(fortran_err_code);
+            if (NULL != errhandler->eh_fort_fn) {
+                fortran_handle = OMPI_INT_2_FINT(win->w_f_to_c_index);
+                errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
+                err_code = OMPI_FINT_2_INT(fortran_err_code);
+            }
             break;
         }
         break;
@@ -115,13 +123,17 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
         file = (ompi_file_t *) mpi_object;
         switch (errhandler->eh_lang) {
         case OMPI_ERRHANDLER_LANG_C:
-            errhandler->eh_file_fn(&file, &err_code, message, NULL);
+            if (NULL != errhandler->eh_file_fn) {
+                errhandler->eh_file_fn(&file, &err_code, message, NULL);
+            }
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
-            fortran_handle = OMPI_INT_2_FINT(file->f_f_to_c_index);
-            errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
-            err_code = OMPI_FINT_2_INT(fortran_err_code);
+            if (NULL != errhandler->eh_fort_fn) {
+                fortran_handle = OMPI_INT_2_FINT(file->f_f_to_c_index);
+                errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
+                err_code = OMPI_FINT_2_INT(fortran_err_code);
+            }
             break;
         }
         break;
@@ -130,13 +142,17 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
         instance = (ompi_instance_t *) mpi_object;
         switch (errhandler->eh_lang) {
         case OMPI_ERRHANDLER_LANG_C:
-            errhandler->eh_instance_fn(&instance, &err_code, message, NULL);
+            if (NULL != errhandler->eh_instance_fn) {
+                errhandler->eh_instance_fn(&instance, &err_code, message, NULL);
+            }
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
-            fortran_handle = OMPI_INT_2_FINT(instance->i_f_to_c_index);
-            errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
-            err_code = OMPI_FINT_2_INT(fortran_err_code);
+            if (NULL != errhandler->eh_fort_fn) {
+                fortran_handle = OMPI_INT_2_FINT(instance->i_f_to_c_index);
+                errhandler->eh_fort_fn(&fortran_handle, &fortran_err_code);
+                err_code = OMPI_FINT_2_INT(fortran_err_code);
+            }
             break;
         }
         break;

--- a/ompi/errhandler/errhandler_predefined.c
+++ b/ompi/errhandler/errhandler_predefined.c
@@ -48,6 +48,7 @@
 #include "opal/util/printf.h"
 #include "opal/util/output.h"
 #include "ompi/runtime/mpiruntime.h"
+#include "ompi/proc/proc.h"
 
 /*
  * Local functions
@@ -183,6 +184,54 @@ void ompi_mpi_errors_abort_win_handler(struct ompi_win_t **win,
   }
   backend_abort(false, "win", abort_comm, name, error_code, arglist);
   va_end(arglist);
+}
+
+void ompi_mpi_errors_abort_instance_handler(struct ompi_instance_t **instance,
+                                            int *error_code, ...)
+{
+  char *name;
+  va_list arglist;
+  int err = MPI_ERR_UNKNOWN;
+  opal_proc_t *local_proc;
+  pmix_proc_t my_pmix_proc = PMIX_PROC_STATIC_INIT;
+
+  va_start(arglist, error_code);
+
+  if (NULL != instance && NULL != *instance) {
+      name = (*instance)->i_name;
+  } else {
+      name = NULL;
+  }
+
+  if (NULL != error_code) {
+     err = *error_code;
+  }
+
+  /* We only want aggregation while the rte is initialized */
+  if (ompi_rte_initialized) {
+      backend_abort_aggregate(false, "session", NULL, name, error_code, arglist);
+  } else {
+      backend_abort_no_aggregate(false, "session", NULL, name, error_code, arglist);
+  }
+
+  va_end(arglist);
+
+  /* 
+   * MPI-5.0 Sec 9.3 (pp.447-448): ERRORS_ABORT on a session aborts ONLY the
+   * local MPI process.  We signal the PMIx runtime that the local process
+   * is to be aborted by explicitly specifying the pmix_proc_t of the local
+   * process in the call to PMIx_Abort.  Note that when using the PRRTe
+   * PMIx server one must use the mpirun --enable-recovery option
+   * to prevent the server from aborting the other processes in the job.
+   */
+
+  local_proc = opal_proc_local_get();
+  OPAL_PMIX_CONVERT_NAME(&my_pmix_proc, &local_proc->proc_name);
+  PMIx_Abort(err, NULL, &my_pmix_proc, 1);
+
+  /* Now Exit */
+  _exit(err);
+
 }
 
 void ompi_mpi_errors_are_fatal_instance_handler (struct ompi_instance_t **instance,

--- a/ompi/errhandler/errhandler_predefined.h
+++ b/ompi/errhandler/errhandler_predefined.h
@@ -50,6 +50,8 @@ OMPI_DECLSPEC void ompi_mpi_errors_abort_file_handler(struct ompi_file_t **file,
 					    int *error_code, ...);
 OMPI_DECLSPEC void ompi_mpi_errors_abort_win_handler(struct ompi_win_t **win,
 					    int *error_code, ...);
+OMPI_DECLSPEC void ompi_mpi_errors_abort_instance_handler(struct ompi_instance_t **instance,
+					    int *error_code, ...);
 
 /**
  * Handler function for MPI_ERRORS_RETURN


### PR DESCRIPTION
MPI_ERRORS_ABORT on a session was causing a NULL pointer dereference because the instance error handler function pointer was not initialized. This commit fixes issue #14009 by:

1. Adding ompi_mpi_errors_abort_instance_handler() function to handle MPI_ERRORS_ABORT for session objects
2. Wiring the handler by setting ompi_mpi_errors_abort.eh_instance_fn
3. Adding a NULL guard check in ompi_errhandler_invoke() as defensive programming

The fix allows MPI_Session_call_errhandler() to abort cleanly via the MPI error handler path instead of crashing with a segmentation fault.

Note this functionality is difficult to test as the runtime system by default kills off other MPI processses in the job if one process tries to locally abort.

Fixes #14009