### PR TITLE
mpi/tool: Implement MPI_T_pvar_readreset

### DIFF
--- a/ompi/mpi/tool/pvar_readreset.c
+++ b/ompi/mpi/tool/pvar_readreset.c
@@ -26,10 +26,31 @@
 int MPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle,
                          void *buf)
 {
+    int ret;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    /* XXX -- TODO -- Implement me */
-    return MPI_T_ERR_INVALID_HANDLE;
+    // MPI_T_PVAR_ALL_HANDLES is explicitly disallowed for readreset
+    // (no single buffer to fill).
+    if (MPI_T_PVAR_ALL_HANDLES == handle || session != handle->session) {
+        return MPI_T_ERR_INVALID_HANDLE;
+    }
+
+    ompi_mpit_lock ();
+
+    if (!mca_base_pvar_is_atomic (handle->pvar)) {
+        ompi_mpit_unlock ();
+        return MPI_T_ERR_PVAR_NO_ATOMIC;   // direct: not via ompit_opal_to_mpit_error
+    }
+
+    ret = mca_base_pvar_handle_read_value (handle, buf);
+    if (OPAL_SUCCESS == ret) {
+        ret = mca_base_pvar_handle_reset (handle);
+    }
+
+    ompi_mpit_unlock ();
+
+    return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/mpi/tool/pvar_readreset.c
+++ b/ompi/mpi/tool/pvar_readreset.c
@@ -34,7 +34,7 @@ int MPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle,
 
     // MPI_T_PVAR_ALL_HANDLES is explicitly disallowed for readreset
     // (no single buffer to fill).
-    if (MPI_T_PVAR_ALL_HANDLES == handle || session != handle->session) {
+    if (MPI_T_PVAR_ALL_HANDLES == handle || NULL == handle || session != handle->session) {
         return MPI_T_ERR_INVALID_HANDLE;
     }
 
@@ -43,6 +43,12 @@ int MPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle,
     if (!mca_base_pvar_is_atomic (handle->pvar)) {
         ompi_mpit_unlock ();
         return MPI_T_ERR_PVAR_NO_ATOMIC;   // direct: not via ompit_opal_to_mpit_error
+    }
+
+    // Readreset is not allowed on read-only pvars
+    if (mca_base_pvar_is_readonly (handle->pvar)) {
+        ompi_mpit_unlock ();
+        return MPI_T_ERR_PVAR_NO_WRITE;
     }
 
     ret = mca_base_pvar_handle_read_value (handle, buf);


### PR DESCRIPTION
Fixes the unimplemented stub in MPI_T_pvar_readreset that was unconditionally returning MPI_T_ERR_INVALID_HANDLE. The function now:

- Validates handles (rejects MPI_T_PVAR_ALL_HANDLES and session mismatches)
- Checks atomic capability via mca_base_pvar_is_atomic
- Returns MPI_T_ERR_PVAR_NO_ATOMIC for non-atomic pvars (current default)
- Composes read and reset operations under the MPI_T lock for atomic-capable pvars

This minimal implementation (Option A from issue discussion) is conformant with MPI-5.0 §15.3.7: valid handles no longer incorrectly return MPI_T_ERR_INVALID_HANDLE, and the return value is consistent with the atomic flag reported by MPI_T_pvar_get_info.

Since no pvar currently sets MCA_BASE_PVAR_FLAG_ATOMIC, all pvars return MPI_T_ERR_PVAR_NO_ATOMIC, which is conformant behavior.

Fixes #14016