### PR TITLE
Fix MPI_Get_count_c to handle counts > INT_MAX

### DIFF
--- a/ompi/mpi/c/get_count.c.in
+++ b/ompi/mpi/c/get_count.c.in
@@ -63,11 +63,21 @@ PROTOTYPE ERROR_CLASS get_count(STATUS status, DATATYPE datatype, COUNT_OUT coun
             *count = 0;
         } else {
             internal_count = status->_ucount / size; /* count the number of complete datatypes */
-            if( (internal_count * size) != status->_ucount ||
-                internal_count > ((size_t) INT_MAX) ) {
+            if( (internal_count * size) != status->_ucount ) {
+                /* received bytes are not a whole number of datatype copies */
+                *count = MPI_UNDEFINED;
+#if OMPI_BIGCOUNT_SRC
+            } else if( internal_count > ((size_t) MPI_COUNT_MAX) ) {
+                /* bound against the OUT parameter's own limit, not INT_MAX */
+                *count = MPI_UNDEFINED;
+            } else {
+                *count = (MPI_Count) internal_count;
+#else
+            } else if( internal_count > ((size_t) INT_MAX) ) {
                 *count = MPI_UNDEFINED;
             } else {
                 *count = (int)internal_count;
+#endif
             }
         }
     }


### PR DESCRIPTION
MPI_Get_count_c now correctly returns element counts exceeding INT_MAX when they fit in MPI_Count, instead of incorrectly returning MPI_UNDEFINED.

The fix branches the upper-bound check and assignment based on OMPI_BIGCOUNT_SRC:
- MPI_Get_count_c: checks against MPI_COUNT_MAX, casts to MPI_Count
- MPI_Get_count: unchanged, still checks against INT_MAX, casts to int

This brings Open MPI into conformance with MPI-5.0 §3.2.5, which states that MPI_GET_COUNT returns MPI_UNDEFINED only when the count exceeds the limits of the count parameter. For the _c binding, that limit is MPI_COUNT_MAX, not INT_MAX.

Fixes #14002