### PR TITLE
Big count datatype tests, plus three big-count datatype fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -458,6 +458,9 @@ test/datatype/position_noncontig
 test/datatype/reduce_local
 test/datatype/unpack_ooo
 test/datatype/unpack_hetero
+test/datatype/opal_datatype_bigcount
+test/datatype/ompi_datatype_bigcount
+test/datatype/mpi_datatype_bigcount
 
 test/event/signal-test
 test/event/event-test

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -1044,7 +1044,7 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( const int* i, const si
             size_t ca;
             opal_disp_array_t displacements; // for create_hindexed_block
             opal_disp_array_t disp_args; // for set_args
-            opal_count_array_t a_i[3];// = {OMPI_COUNT_ARRAY_CREATE(&count), OMPI_COUNT_ARRAY_CREATE(&bLength)};
+            opal_count_array_t a_i[3];
             if (l == NULL) {
                 count = i[0];
                 bLength = i[1];
@@ -1060,7 +1060,10 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( const int* i, const si
                 a_i[0] = OMPI_COUNT_ARRAY_CREATE(l);
                 a_i[1] = OMPI_COUNT_ARRAY_CREATE(l + 1);
                 a_i[2] = OMPI_COUNT_ARRAY_CREATE(l + 2);
-                cl = 3;
+                /* count + blocklength + count displacements; hardcoding 3
+                 * here (the count == 1 case) under-allocates the large-count
+                 * array in set_args and corrupts the envelope. */
+                cl = 2 + count;
                 displacements = OMPI_DISP_ARRAY_CREATE(l + 2); // displacements are MPI_Count
                 disp_args = OMPI_DISP_ARRAY_NULL;
                 ca = 0;

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -238,6 +238,13 @@ int32_t ompi_datatype_set_args( ompi_datatype_t* pData,
         break;
 
     case MPI_COMBINER_RESIZED:
+        /* The large-count interface passes lb and extent as two MPI_Count
+         * values in counts[0]; the classic interface passes them through
+         * the displacement array instead (cl == 0 here, handled by the
+         * generic MPI_Aint copy below). */
+        if (cl > 0) {
+            copy_count_array(2, &pi, &pl, counts[0]);
+        }
         break;
 
     case MPI_COMBINER_HINDEXED_BLOCK:
@@ -1017,8 +1024,18 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( const int* i, const si
         break;
         /******************************************************************/
     case MPI_COMBINER_RESIZED:
-        ompi_datatype_create_resized(d[0], a[0], a[1], &datatype);
-        ompi_datatype_set_args( datatype, 0, 0, NULL, 2, disp_array, 1, d, MPI_COMBINER_RESIZED );
+        if (NULL == l) {
+            /* classic: lb/extent were stored as MPI_Aint displacements */
+            ompi_datatype_create_resized(d[0], a[0], a[1], &datatype);
+            ompi_datatype_set_args( datatype, 0, 0, NULL, 2, disp_array, 1, d, MPI_COMBINER_RESIZED );
+        } else {
+            /* large count: lb/extent were stored as MPI_Count large counts.
+             * lb may be negative; the size_t -> ptrdiff_t cast restores the
+             * signed value via a two's-complement round-trip. */
+            ompi_count_array_t a_i[1] = {OMPI_COUNT_ARRAY_CREATE(l)};
+            ompi_datatype_create_resized(d[0], (ptrdiff_t) l[0], (ptrdiff_t) l[1], &datatype);
+            ompi_datatype_set_args( datatype, 0, 2, a_i, 0, OMPI_DISP_ARRAY_NULL, 1, d, MPI_COMBINER_RESIZED );
+        }
         break;
         /******************************************************************/
     case MPI_COMBINER_HINDEXED_BLOCK:

--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -36,13 +36,19 @@ block(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
       ompi_datatype_t *type_old, ompi_datatype_t **type_new,
       ptrdiff_t *st_offset)
 {
-    int blksize, global_size, mysize, i, j, rc, start_loop, step;
+    int i, rc, start_loop, step;
+    /* global_size and the derived block/local sizes can exceed INT_MAX for
+     * big-count gsizes, so they must be 64 bit (signed: mysize/j can go
+     * negative before clamping). */
+    ptrdiff_t blksize, global_size, mysize, j;
     ptrdiff_t stride, disps[2];
 
     global_size = ompi_count_array_get(gsize_array, dim);
 
     if (darg == MPI_DISTRIBUTE_DFLT_DARG)
-        blksize = (global_size + nprocs - 1) / nprocs;
+        /* ceil(global_size/nprocs) without the "+ nprocs - 1" addition, which
+         * would overflow ptrdiff_t for a global_size near PTRDIFF_MAX. */
+        blksize = global_size / nprocs + (0 != global_size % nprocs);
     else {
         blksize = darg;
     }
@@ -59,13 +65,13 @@ block(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
 
     stride = orig_extent;
     if (dim == start_loop) {
-        rc = ompi_datatype_create_contiguous(mysize, type_old, type_new);
+        rc = ompi_datatype_create_contiguous((size_t) mysize, type_old, type_new);
         if (OMPI_SUCCESS != rc) return rc;
     } else {
         for (i = start_loop ; i != dim ; i += step) {
             stride *= ompi_count_array_get(gsize_array, i);
         }
-        rc = ompi_datatype_create_hvector(mysize, 1, stride, type_old, type_new);
+        rc = ompi_datatype_create_hvector((size_t) mysize, 1, stride, type_old, type_new);
         if (OMPI_SUCCESS != rc) return rc;
     }
 
@@ -97,7 +103,11 @@ cyclic(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
        ompi_datatype_t* type_old, ompi_datatype_t **type_new,
        ptrdiff_t *st_offset)
 {
-    int blksize, i, blklens[2], st_index, end_index, local_size, rem, count, rc;
+    int blksize, i, blklens[2], rc;
+    /* The global index range and local element count can exceed INT_MAX
+     * for big-count gsizes (blksize stays int -- it is the int-typed
+     * distribution argument). */
+    ptrdiff_t st_index, end_index, local_size, rem, count;
     ptrdiff_t stride, disps[2];
     ompi_datatype_t *type_tmp, *types[2];
 
@@ -107,21 +117,24 @@ cyclic(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
         blksize = darg;
     }
 
-    st_index = rank * blksize;
+    /* blksize stays int (it is the int distribution argument), but force the
+     * index/stride products to 64 bits so they cannot overflow before being
+     * stored in the (widened) ptrdiff_t locals. */
+    st_index = (ptrdiff_t) rank * blksize;
     end_index = ompi_count_array_get(gsize_array, dim) - 1;
 
     if (end_index < st_index) {
         local_size = 0;
     } else {
-        local_size = ((end_index - st_index + 1)/(nprocs*blksize))*blksize;
-        rem = (end_index - st_index + 1) % (nprocs*blksize);
+        local_size = ((end_index - st_index + 1)/((ptrdiff_t) nprocs*blksize))*blksize;
+        rem = (end_index - st_index + 1) % ((ptrdiff_t) nprocs*blksize);
         local_size += rem < blksize ? rem : blksize;
     }
 
     count = local_size / blksize;
     rem = local_size % blksize;
 
-    stride = nprocs*blksize*orig_extent;
+    stride = (ptrdiff_t) nprocs*blksize*orig_extent;
     if (order == MPI_ORDER_FORTRAN) {
         for (i=0; i<dim; i++) {
             stride *= ompi_count_array_get(gsize_array, i);
@@ -132,7 +145,7 @@ cyclic(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
         }
     }
 
-    rc = ompi_datatype_create_hvector(count, blksize, stride, type_old, type_new);
+    rc = ompi_datatype_create_hvector((size_t) count, blksize, stride, type_old, type_new);
     if (OMPI_SUCCESS != rc) return rc;
 
     if (rem) {
@@ -141,7 +154,7 @@ cyclic(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
 
         types  [0] = *type_new; types  [1] = type_old;
         disps  [0] = 0;         disps  [1] = count*stride;
-        blklens[0] = 1;         blklens[1] = rem;
+        blklens[0] = 1;         blklens[1] = (int) rem; /* rem < blksize (int) */
 
         rc = ompi_datatype_create_struct(2, OMPI_COUNT_ARRAY_CREATE(blklens), OMPI_DISP_ARRAY_CREATE(disps), types, &type_tmp);
         ompi_datatype_destroy(type_new);
@@ -165,7 +178,7 @@ cyclic(ompi_count_array_t gsize_array, int dim, int ndims, int nprocs,
     rc = opal_datatype_resize( &(*type_new)->super, disps[0], disps[1] );
     if (OMPI_SUCCESS != rc) return rc;
 
-    *st_offset = rank * blksize;
+    *st_offset = (ptrdiff_t) rank * blksize;
     /* in terms of no. of elements of type oldtype in this dimension */
     if (local_size == 0) *st_offset = 0;
 

--- a/ompi/mpi/c/type_create_resized.c.in
+++ b/ompi/mpi/c/type_create_resized.c.in
@@ -56,9 +56,25 @@ PROTOTYPE ERROR_CLASS type_create_resized(DATATYPE oldtype,
       OMPI_ERRHANDLER_NOHANDLE_RETURN( rc, rc, FUNC_NAME );
    }
 
+   /* lb and extent are byte displacements that may apply in both memory
+    * and file contexts, so the large-count interface types them as
+    * MPI_Count rather than MPI_Aint (MPI-5.0 sec 19.2).  Store them where
+    * MPI_Type_get_contents[_c] is required to return them: in the
+    * large-count array for the _c interface (so num_addresses == 0,
+    * num_large_counts == 2), and in the address array for the classic
+    * interface (num_addresses == 2). */
    {
-      MPI_Count a_a[2] = {lb, extent};
-      ompi_datatype_set_args( *newtype, 0, 0, NULL, 2, OMPI_DISP_ARRAY_CREATE(a_a), 1, &oldtype, MPI_COMBINER_RESIZED );
+#if OMPI_BIGCOUNT_SRC
+      MPI_Count a_l[2] = {lb, extent};
+      ompi_count_array_t a_i[1] = {OMPI_COUNT_ARRAY_CREATE(a_l)};
+      ompi_datatype_set_args( *newtype, 0, 2, a_i, 0, OMPI_DISP_ARRAY_NULL,
+                              1, &oldtype, MPI_COMBINER_RESIZED );
+#else
+      MPI_Aint a_a[2] = {lb, extent};
+      ompi_datatype_set_args( *newtype, 0, 0, NULL, 2,
+                              OMPI_DISP_ARRAY_CREATE(a_a),
+                              1, &oldtype, MPI_COMBINER_RESIZED );
+#endif
    }
 
    return MPI_SUCCESS;

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -15,10 +15,10 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial ompi_datatype_bigcount mpi_datatype_bigcount
     MPI_CHECKS = to_self reduce_local
 endif
-TESTS = opal_datatype_test unpack_hetero $(MPI_TESTS)
+TESTS = opal_datatype_test opal_datatype_bigcount unpack_hetero $(MPI_TESTS)
 
 check_PROGRAMS = $(TESTS) $(MPI_CHECKS)
 
@@ -80,9 +80,26 @@ large_data_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 
+ompi_datatype_bigcount_SOURCES = ompi_datatype_bigcount.c
+ompi_datatype_bigcount_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+ompi_datatype_bigcount_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+mpi_datatype_bigcount_SOURCES = mpi_datatype_bigcount.c
+mpi_datatype_bigcount_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_datatype_bigcount_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
 opal_datatype_test_SOURCES = opal_datatype_test.c opal_ddt_lib.c opal_ddt_lib.h
 opal_datatype_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 opal_datatype_test_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+opal_datatype_bigcount_SOURCES = opal_datatype_bigcount.c
+opal_datatype_bigcount_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+opal_datatype_bigcount_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 
 external32_SOURCES = external32.c

--- a/test/datatype/mpi_datatype_bigcount.c
+++ b/test/datatype/mpi_datatype_bigcount.c
@@ -1,0 +1,1275 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * "Big count" datatype tests exercised through the public MPI C API.
+ *
+ * Unlike the other test/datatype programs, this one calls MPI_Init /
+ * MPI_Finalize so that it drives the actual generated C bindings --
+ * including the large-count (_c) entry points and the
+ * MPI_Type_get_contents[_c] wrappers.  It runs as a singleton (one
+ * process, no mpirun), so it is suitable for "make check".
+ *
+ * Coverage:
+ *   A. MPI_Type_contiguous_c() with a count above INT_MAX: MPI_Type_size_c,
+ *      MPI_Type_get_envelope_c and MPI_Type_get_contents_c must round-trip
+ *      the large count through the MPI_Count ("large count") array.
+ *   B. Regression test for the #14055 over-read on the large-count path:
+ *      MPI_Type_get_contents_c() called with output arrays *larger* than
+ *      the type's real argument counts (legal per the standard, since the
+ *      required sizes are discovered via get_envelope) must not walk past
+ *      the real constituent datatypes into uninitialized handles.
+ *   C. The same regression on the classic (non-_c) MPI_Type_get_contents()
+ *      path, which had the identical bug.
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mpi.h>
+
+static int failures = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,       \
+                    #cond);                                               \
+            ++failures;                                                   \
+        }                                                                 \
+    } while (0)
+
+/* Big count is only supported where size_t is 64-bit (matches the helper in
+ * the sibling opal_/ompi_datatype_bigcount.c tests). */
+static bool have_64bit_counts(void)
+{
+    return 8 == sizeof(size_t);
+}
+
+/* A recognizable non-NULL garbage handle used to poison surplus output
+ * slots.  If get_contents walks into these, it dereferences garbage --
+ * which is exactly the #14055 crash. */
+static MPI_Datatype const POISON = (MPI_Datatype) (intptr_t) 0xdeadbeef;
+
+/* (A) Large-count contiguous type via the _c API. */
+static void test_contiguous_c_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+
+    MPI_Count count = (MPI_Count) INT_MAX + 4096;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_contiguous_c(count, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    MPI_Count size = 0;
+    CHECK(MPI_SUCCESS == MPI_Type_size_c(t, &size));
+    CHECK(count == size); /* MPI_BYTE has size 1 */
+
+    MPI_Count lb = 1, extent = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_get_extent_c(t, &lb, &extent));
+    CHECK(0 == lb);
+    CHECK(count == extent);
+
+    MPI_Count ni = -1, na = -1, nlc = -1, nd = -1;
+    int combiner = -1;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_envelope_c(t, &ni, &na, &nlc, &nd, &combiner));
+    CHECK(MPI_COMBINER_CONTIGUOUS == combiner);
+    CHECK(1 == nd);
+    /* The _c constructor stored the count as a large count, so it must be
+     * reported in num_large_counts, not num_integers. */
+    CHECK(1 == nlc);
+    CHECK(0 == ni);
+    CHECK(0 == na);
+
+    int aint_ints[1];
+    MPI_Aint addrs[1];
+    MPI_Count larges[1] = {0};
+    MPI_Datatype types[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, ni, na, nlc, nd, aint_ints, addrs,
+                                     larges, types));
+    CHECK(count == larges[0]);
+    CHECK(MPI_BYTE == types[0]);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+/* (B) #14055 regression on the large-count path: oversized output arrays. */
+static void test_get_contents_c_oversized(void)
+{
+    enum { SLACK = 16 };
+    MPI_Count bl[2] = {1, 1};
+    /* array_of_displacements[] is const MPI_Count[] for
+     * MPI_Type_create_struct_c -- this is correct per the MPI standard:
+     * the large-count variants of MPI_Type_create_hindexed,
+     * MPI_Type_create_hindexed_block, and MPI_Type_create_struct take
+     * MPI_Count (not MPI_Aint) byte displacements (MPI 5.0 sec 19.2). */
+    MPI_Count disp[2] = {0, (MPI_Count) sizeof(int)};
+    MPI_Datatype intypes[2] = {MPI_INT, MPI_DOUBLE};
+    MPI_Datatype st = MPI_DATATYPE_NULL;
+
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_struct_c(2, bl, disp, intypes, &st));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&st));
+
+    MPI_Count ni = -1, na = -1, nlc = -1, nd = -1;
+    int combiner = -1;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_envelope_c(st, &ni, &na, &nlc, &nd, &combiner));
+    CHECK(MPI_COMBINER_STRUCT == combiner);
+    /* _c struct: count + 2 blocklengths + 2 displacements are all large
+     * counts; no integers or addresses; two constituent datatypes. */
+    CHECK(0 == ni);
+    CHECK(0 == na);
+    CHECK(5 == nlc);
+    CHECK(2 == nd);
+    if (ni < 0 || na < 0 || nlc < 0 || nd < 0) {
+        return; /* envelope failed (already recorded); counts are bogus */
+    }
+
+    /* Allocate every output array oversized and poison the datatype tail. */
+    int *ai = calloc((size_t) ni + SLACK, sizeof(int));
+    MPI_Aint *aa = calloc((size_t) na + SLACK, sizeof(MPI_Aint));
+    MPI_Count *alc = calloc((size_t) nlc + SLACK, sizeof(MPI_Count));
+    MPI_Datatype *ad = malloc(((size_t) nd + SLACK) * sizeof(MPI_Datatype));
+    CHECK(NULL != ai && NULL != aa && NULL != alc && NULL != ad);
+    if (NULL == ai || NULL == aa || NULL == alc || NULL == ad) {
+        free(ai); free(aa); free(alc); free(ad);
+        return;
+    }
+    for (size_t i = 0; i < (size_t) nd + SLACK; ++i) {
+        ad[i] = POISON;
+    }
+
+    /* Pass capacities LARGER than the real counts -- the legal usage that
+     * crashed before #14055. */
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(st, ni + SLACK, na + SLACK, nlc + SLACK,
+                                     nd + SLACK, ai, aa, alc, ad));
+
+    /* Every returned value is checked: count, both blocklengths, both
+     * displacements, and both constituent datatypes. */
+    CHECK(2 == alc[0]);                     /* count */
+    CHECK(bl[0] == alc[1]);                 /* blocklengths */
+    CHECK(bl[1] == alc[2]);
+    CHECK(disp[0] == alc[3]);               /* displacements */
+    CHECK(disp[1] == alc[4]);
+    CHECK(MPI_INT == ad[0]);
+    CHECK(MPI_DOUBLE == ad[1]);
+    /* Surplus datatype slots untouched (no over-read -- the #14055 bug). */
+    for (size_t i = (size_t) nd; i < (size_t) nd + SLACK; ++i) {
+        CHECK(POISON == ad[i]);
+    }
+
+    free(ai);
+    free(aa);
+    free(alc);
+    free(ad);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&st));
+}
+
+/* (C) Same #14055 regression on the classic (non-_c) path. */
+static void test_get_contents_oversized(void)
+{
+    enum { SLACK = 16 };
+    int bl[2] = {1, 1};
+    MPI_Aint disp[2] = {0, (MPI_Aint) sizeof(int)};
+    MPI_Datatype intypes[2] = {MPI_INT, MPI_DOUBLE};
+    MPI_Datatype st = MPI_DATATYPE_NULL;
+
+    CHECK(MPI_SUCCESS == MPI_Type_create_struct(2, bl, disp, intypes, &st));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&st));
+
+    int ni = -1, na = -1, nd = -1, combiner = -1;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_envelope(st, &ni, &na, &nd, &combiner));
+    CHECK(MPI_COMBINER_STRUCT == combiner);
+    /* classic struct: count + 2 blocklengths are integers; the 2 byte
+     * displacements are addresses; two constituent datatypes. */
+    CHECK(3 == ni);
+    CHECK(2 == na);
+    CHECK(2 == nd);
+    if (ni < 0 || na < 0 || nd < 0) {
+        return; /* envelope failed (already recorded); counts are bogus */
+    }
+
+    int *ai = calloc((size_t) ni + SLACK, sizeof(int));
+    MPI_Aint *aa = calloc((size_t) na + SLACK, sizeof(MPI_Aint));
+    MPI_Datatype *ad = malloc(((size_t) nd + SLACK) * sizeof(MPI_Datatype));
+    CHECK(NULL != ai && NULL != aa && NULL != ad);
+    if (NULL == ai || NULL == aa || NULL == ad) {
+        free(ai); free(aa); free(ad);
+        return;
+    }
+    for (size_t i = 0; i < (size_t) nd + SLACK; ++i) {
+        ad[i] = POISON;
+    }
+
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents(st, ni + SLACK, na + SLACK, nd + SLACK, ai,
+                                   aa, ad));
+
+    /* Every returned value is checked. */
+    CHECK(2 == ai[0]);          /* count */
+    CHECK(bl[0] == ai[1]);      /* blocklengths */
+    CHECK(bl[1] == ai[2]);
+    CHECK(disp[0] == aa[0]);    /* displacements */
+    CHECK(disp[1] == aa[1]);
+    CHECK(MPI_INT == ad[0]);
+    CHECK(MPI_DOUBLE == ad[1]);
+    for (size_t i = (size_t) nd; i < (size_t) nd + SLACK; ++i) {
+        CHECK(POISON == ad[i]);
+    }
+
+    free(ai);
+    free(aa);
+    free(ad);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&st));
+}
+
+/* ===================================================================
+ * (D) Large-count round-trip through every derived-type constructor.
+ *
+ * PR #13460 added MPI_Count type-punning to *all* the datatype
+ * constructors, but only contiguous was previously tested with a count
+ * above INT_MAX.  For each combiner we build a type with at least one
+ * argument above INT_MAX (keeping the number of blocks/dims tiny so only
+ * O(1) datatype metadata is allocated -- no large buffers), then verify
+ * the MPI 5.0 decode:
+ *
+ *   - MPI_Type_get_envelope_c reports the standard (ni, na, nlc, nd).
+ *   - MPI_Type_get_contents_c returns every above-INT_MAX argument
+ *     undamaged, in the array the standard requires.
+ *   - MPI_Type_size_c reflects the 64-bit size.
+ *
+ * Per MPI 5.0 sec 19.2, the "_c" datatype constructors type *all* count
+ * and byte-displacement arguments as MPI_Count -- there are no MPI_Aint
+ * arguments left in any "_c" datatype constructor.  Therefore byte
+ * displacements/strides decode into array_of_large_counts and
+ * num_addresses is 0 for every combiner below (including RESIZED, whose
+ * lb/extent are MPI_Count in the _c interface).
+ * =================================================================== */
+
+/* INT_MAX as an MPI_Count; "BIG + k" is safely above INT_MAX. */
+#define BIG ((MPI_Count) INT_MAX)
+
+static void check_env_c(const char *label, MPI_Datatype t,
+                        int expect_combiner, MPI_Count eni, MPI_Count ena,
+                        MPI_Count enlc, MPI_Count end)
+{
+    MPI_Count ni = -1, na = -1, nlc = -1, nd = -1;
+    int combiner = -1;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_envelope_c(t, &ni, &na, &nlc, &nd, &combiner));
+    printf("  %-15s combiner=%2d ni=%lld na=%lld nlc=%lld nd=%lld\n", label,
+           combiner, (long long) ni, (long long) na, (long long) nlc,
+           (long long) nd);
+    fflush(stdout);
+    CHECK(expect_combiner == combiner);
+    CHECK(eni == ni);
+    CHECK(ena == na);
+    CHECK(enlc == nlc);
+    CHECK(end == nd);
+}
+
+/* Verify a type's full footprint: size, lower bound, and extent. */
+static void check_size_extent_c(MPI_Datatype t, MPI_Count esize, MPI_Count elb,
+                                MPI_Count eextent)
+{
+    MPI_Count size = -1, lb = 1, extent = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_size_c(t, &size));
+    CHECK(esize == size);
+    CHECK(MPI_SUCCESS == MPI_Type_get_extent_c(t, &lb, &extent));
+    CHECK(elb == lb);
+    CHECK(eextent == extent);
+}
+
+static void test_vector_c_bigcount(void)
+{
+    MPI_Count count = BIG + 5, blen = BIG + 6, stride = BIG + 7;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_vector_c(count, blen, stride, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("vector_c", t, MPI_COMBINER_VECTOR, 0, 0, 3, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[3] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 3, 1, ai, aa, alc, ad));
+    CHECK(count == alc[0]);
+    CHECK(blen == alc[1]);
+    CHECK(stride == alc[2]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* size = count*blen; extent spans the last block: (count-1)*stride+blen
+     * (oldextent 1).  ~4.6e18, fits in MPI_Count. */
+    check_size_extent_c(t, count * blen, 0, (count - 1) * stride + blen);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hvector_c_bigcount(void)
+{
+    MPI_Count count = BIG + 5, blen = BIG + 6, stride = BIG + 7; /* bytes */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_hvector_c(count, blen, stride, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("hvector_c", t, MPI_COMBINER_HVECTOR, 0, 0, 3, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[3] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 3, 1, ai, aa, alc, ad));
+    CHECK(count == alc[0]);
+    CHECK(blen == alc[1]);
+    CHECK(stride == alc[2]); /* byte stride survives as a large count */
+    CHECK(MPI_BYTE == ad[0]);
+
+    check_size_extent_c(t, count * blen, 0, (count - 1) * stride + blen);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_indexed_c_bigcount(void)
+{
+    MPI_Count bl[2] = {BIG + 5, 3};
+    MPI_Count disp[2] = {0, BIG + 6}; /* element units */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_indexed_c(2, bl, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("indexed_c", t, MPI_COMBINER_INDEXED, 0, 0, 5, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[5] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 5, 1, ai, aa, alc, ad));
+    CHECK(2 == alc[0]);        /* count */
+    CHECK(bl[0] == alc[1]);    /* blocklengths */
+    CHECK(bl[1] == alc[2]);
+    CHECK(disp[0] == alc[3]);  /* displacements */
+    CHECK(disp[1] == alc[4]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* size = sum of blocklengths; extent spans from the lowest displacement
+     * to the highest displacement+blocklength (element units, oldextent 1). */
+    MPI_Count ub = disp[0] + bl[0];
+    if (disp[1] + bl[1] > ub) { ub = disp[1] + bl[1]; }
+    check_size_extent_c(t, bl[0] + bl[1], 0, ub);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hindexed_c_bigcount(void)
+{
+    MPI_Count bl[2] = {BIG + 5, 3};
+    MPI_Count disp[2] = {0, BIG + 6}; /* bytes */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_hindexed_c(2, bl, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("hindexed_c", t, MPI_COMBINER_HINDEXED, 0, 0, 5, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[5] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 5, 1, ai, aa, alc, ad));
+    CHECK(2 == alc[0]);
+    CHECK(bl[0] == alc[1]);
+    CHECK(bl[1] == alc[2]);
+    CHECK(disp[0] == alc[3]);
+    CHECK(disp[1] == alc[4]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* Byte displacements, oldextent 1: same footprint formula as indexed. */
+    MPI_Count ub = disp[0] + bl[0];
+    if (disp[1] + bl[1] > ub) { ub = disp[1] + bl[1]; }
+    check_size_extent_c(t, bl[0] + bl[1], 0, ub);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_indexed_block_c_bigcount(void)
+{
+    MPI_Count blen = BIG + 5;
+    MPI_Count disp[2] = {0, BIG + 6}; /* element units */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_indexed_block_c(2, blen, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("indexed_block_c", t, MPI_COMBINER_INDEXED_BLOCK, 0, 0, 4, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[4] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 4, 1, ai, aa, alc, ad));
+    CHECK(2 == alc[0]);        /* count */
+    CHECK(blen == alc[1]);     /* blocklength */
+    CHECK(disp[0] == alc[2]);  /* displacements */
+    CHECK(disp[1] == alc[3]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* size = count*blocklength; extent spans to the farthest block end. */
+    MPI_Count ub = disp[0] + blen;
+    if (disp[1] + blen > ub) { ub = disp[1] + blen; }
+    check_size_extent_c(t, 2 * blen, 0, ub);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hindexed_block_c_bigcount(void)
+{
+    MPI_Count blen = BIG + 5;
+    MPI_Count disp[2] = {0, BIG + 6}; /* bytes */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_hindexed_block_c(2, blen, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("hindexed_block_c", t, MPI_COMBINER_HINDEXED_BLOCK, 0, 0, 4, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[4] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 4, 1, ai, aa, alc, ad));
+    CHECK(2 == alc[0]);
+    CHECK(blen == alc[1]);
+    CHECK(disp[0] == alc[2]);
+    CHECK(disp[1] == alc[3]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* Byte displacements, oldextent 1: same footprint as indexed_block. */
+    MPI_Count ub = disp[0] + blen;
+    if (disp[1] + blen > ub) { ub = disp[1] + blen; }
+    check_size_extent_c(t, 2 * blen, 0, ub);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_struct_c_bigcount(void)
+{
+    MPI_Count bl[2] = {BIG + 5, 3};
+    MPI_Count disp[2] = {0, BIG + 6}; /* bytes */
+    MPI_Datatype types[2] = {MPI_BYTE, MPI_INT};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_struct_c(2, bl, disp, types, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("struct_c", t, MPI_COMBINER_STRUCT, 0, 0, 5, 2);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[5] = {0};
+    MPI_Datatype ad[2] = {MPI_DATATYPE_NULL, MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 5, 2, ai, aa, alc, ad));
+    CHECK(2 == alc[0]);
+    CHECK(bl[0] == alc[1]);
+    CHECK(bl[1] == alc[2]);
+    CHECK(disp[0] == alc[3]);
+    CHECK(disp[1] == alc[4]);
+    CHECK(MPI_BYTE == ad[0]);
+    CHECK(MPI_INT == ad[1]);
+
+    /* size = bl0 bytes + bl1 ints.  extent = upper bound rounded up to the
+     * max member alignment (MPI 5.0 eq. 5.1); here that is alignof(int). */
+    MPI_Count esize = bl[0] * 1 + bl[1] * (MPI_Count) sizeof(int);
+    MPI_Count ub = disp[1] + bl[1] * (MPI_Count) sizeof(int); /* > disp0+bl0 */
+    MPI_Count align = (MPI_Count) _Alignof(int);
+    check_size_extent_c(t, esize, 0, ((ub + align - 1) / align) * align);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_subarray_c_bigcount(void)
+{
+    /* 2-D with size, subsize, AND start all above INT_MAX in the first
+     * dimension (start + subsize <= size keeps it legal), so the punning
+     * of the subsize and start arrays is exercised too -- not just sizes. */
+    MPI_Count sizes[2] = {2 * BIG + 100, 6};
+    MPI_Count subsizes[2] = {BIG + 5, 2};
+    MPI_Count starts[2] = {BIG + 3, 1};
+    /* Fail loudly if a future constant edit makes the subarray illegal. */
+    CHECK(starts[0] + subsizes[0] <= sizes[0]);
+    CHECK(starts[1] + subsizes[1] <= sizes[1]);
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_subarray_c(2, sizes, subsizes, starts,
+                                        MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    /* ndims and order are int -> integers; sizes/subsizes/starts are
+     * MPI_Count -> large counts. */
+    check_env_c("subarray_c", t, MPI_COMBINER_SUBARRAY, 2, 0, 6, 1);
+
+    int ai[2] = {0};
+    MPI_Aint aa[1];
+    MPI_Count alc[6] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 2, 0, 6, 1, ai, aa, alc, ad));
+    CHECK(2 == ai[0]);             /* ndims */
+    CHECK(MPI_ORDER_C == ai[1]);   /* order */
+    CHECK(sizes[0] == alc[0]);
+    CHECK(sizes[1] == alc[1]);
+    CHECK(subsizes[0] == alc[2]);
+    CHECK(subsizes[1] == alc[3]);
+    CHECK(starts[0] == alc[4]);
+    CHECK(starts[1] == alc[5]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* size = product of subsizes (the local block); extent = product of the
+     * full sizes (lb 0).  This is what caught the darray int-truncation bug,
+     * so subarray is checked the same way. */
+    check_size_extent_c(t, subsizes[0] * subsizes[1], 0, sizes[0] * sizes[1]);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_darray_c_bigcount(void)
+{
+    /* Single process, two dimensions, block distribution: rank 0 owns the
+     * entire (huge) global array.  Two gsizes exercise a multi-entry
+     * large-count array. */
+    MPI_Count gsizes[2] = {BIG + 5, BIG + 6};
+    int distribs[2] = {MPI_DISTRIBUTE_BLOCK, MPI_DISTRIBUTE_BLOCK};
+    int dargs[2] = {MPI_DISTRIBUTE_DFLT_DARG, MPI_DISTRIBUTE_DFLT_DARG};
+    int psizes[2] = {1, 1};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_darray_c(1, 0, 2, gsizes, distribs, dargs,
+                                      psizes, MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    /* All ints (size, rank, ndims, distribs[2], dargs[2], psizes[2], order)
+     * give ni = 4 + 3*ndims = 10; the gsizes are the only large counts
+     * (nlc = ndims = 2). */
+    check_env_c("darray_c", t, MPI_COMBINER_DARRAY, 10, 0, 2, 1);
+
+    int ai[10] = {0};
+    MPI_Aint aa[1];
+    MPI_Count alc[2] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 10, 0, 2, 1, ai, aa, alc, ad));
+    CHECK(1 == ai[0]);                          /* size */
+    CHECK(0 == ai[1]);                          /* rank */
+    CHECK(2 == ai[2]);                          /* ndims */
+    CHECK(MPI_DISTRIBUTE_BLOCK == ai[3]);       /* distribs[0] */
+    CHECK(MPI_DISTRIBUTE_BLOCK == ai[4]);       /* distribs[1] */
+    CHECK(MPI_DISTRIBUTE_DFLT_DARG == ai[5]);   /* dargs[0] */
+    CHECK(MPI_DISTRIBUTE_DFLT_DARG == ai[6]);   /* dargs[1] */
+    CHECK(1 == ai[7]);                          /* psizes[0] */
+    CHECK(1 == ai[8]);                          /* psizes[1] */
+    CHECK(MPI_ORDER_C == ai[9]);                /* order */
+    CHECK(gsizes[0] == alc[0]);
+    CHECK(gsizes[1] == alc[1]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* One process owns the whole array, so both the size (local bytes) and
+     * the extent equal the product of the gsizes.  Asserting size here is
+     * what catches the block()/cyclic() int-truncation bug. */
+    check_size_extent_c(t, gsizes[0] * gsizes[1], 0, gsizes[0] * gsizes[1]);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_darray_cyclic_c_bigcount(void)
+{
+    /* CYCLIC distribution drives the cyclic() helper -- a different local-size
+     * computation from block() -- which also widened to 64-bit.  One process
+     * owns the whole (huge) global array. */
+    MPI_Count gsizes[1] = {BIG + 5};
+    int distribs[1] = {MPI_DISTRIBUTE_CYCLIC};
+    int dargs[1] = {MPI_DISTRIBUTE_DFLT_DARG};
+    int psizes[1] = {1};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_darray_c(1, 0, 1, gsizes, distribs, dargs, psizes,
+                                      MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("darray_cyclic_c", t, MPI_COMBINER_DARRAY, 7, 0, 1, 1);
+
+    /* Local size == whole array (one process); gsize survives cyclic(). */
+    check_size_extent_c(t, gsizes[0], 0, gsizes[0]);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_darray_multiproc_c_bigcount(void)
+{
+    /* Two processes, query rank 1: blksize = ceil(gsize/2) and the rank*blksize
+     * start offset both exceed INT_MAX, exercising the 64-bit products in
+     * block() that the single-process darray tests (rank 0, nprocs 1) never
+     * reach -- with int arithmetic those products would overflow. */
+    MPI_Count gsizes[1] = {4 * BIG};
+    int distribs[1] = {MPI_DISTRIBUTE_BLOCK};
+    int dargs[1] = {MPI_DISTRIBUTE_DFLT_DARG};
+    int psizes[1] = {2};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_darray_c(2, 1, 1, gsizes, distribs, dargs, psizes,
+                                      MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("darray_2proc_c", t, MPI_COMBINER_DARRAY, 7, 0, 1, 1);
+
+    /* BLOCK over 2 ranks: blksize = 2*BIG; rank 1 owns the upper 2*BIG
+     * elements; the type extent spans the full global array (4*BIG). */
+    check_size_extent_c(t, 2 * BIG, 0, 4 * BIG);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_darray_blockcyclic_c_bigcount(void)
+{
+    /* CYCLIC with an explicit block size > 1 and a gsize not divisible by
+     * nprocs*blksize forces rem != 0, exercising cyclic()'s trailing-struct
+     * branch (blklens[1] = rem, disps[1] = count*stride) with count*stride
+     * above INT_MAX -- untested by the DFLT_DARG (blksize 1) cyclic case. */
+    MPI_Count gsizes[1] = {BIG + 7}; /* not a multiple of 3 */
+    int distribs[1] = {MPI_DISTRIBUTE_CYCLIC};
+    int dargs[1] = {3};
+    int psizes[1] = {1};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_darray_c(1, 0, 1, gsizes, distribs, dargs, psizes,
+                                      MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    check_env_c("darray_blkcyc_c", t, MPI_COMBINER_DARRAY, 7, 0, 1, 1);
+
+    /* Single process owns everything: size == extent == gsize. */
+    check_size_extent_c(t, gsizes[0], 0, gsizes[0]);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_resized_c_bigcount(void)
+{
+    MPI_Count lb = BIG + 5, extent = BIG + 6;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_resized_c(MPI_BYTE, lb, extent, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    /* MPI 5.0 sec 19.2: MPI_Type_create_resized_c types lb and extent as
+     * MPI_Count (not MPI_Aint), so -- exactly as for every other "_c"
+     * constructor above -- MPI_Type_get_contents_c must return them in
+     * array_of_large_counts with num_addresses == 0. */
+    check_env_c("resized_c", t, MPI_COMBINER_RESIZED, 0, 0, 2, 1);
+
+    int ai[1];
+    MPI_Aint aa[1];
+    MPI_Count alc[2] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, 0, 0, 2, 1, ai, aa, alc, ad));
+    CHECK(lb == alc[0]);
+    CHECK(extent == alc[1]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* Resizing does not change the data size (one MPI_BYTE); the requested
+     * lb and extent are reported back by get_extent_c. */
+    check_size_extent_c(t, 1, lb, extent);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+
+    /* A negative lb above INT_MAX in magnitude must also round-trip through
+     * the large-count array on the public _c path (signed value preserved). */
+    MPI_Count nlb = -(BIG + 5), next = BIG + 6;
+    MPI_Datatype t2 = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_resized_c(MPI_BYTE, nlb, next, &t2));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t2));
+    check_env_c("resized_c(neg)", t2, MPI_COMBINER_RESIZED, 0, 0, 2, 1);
+    MPI_Count alc2[2] = {0};
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t2, 0, 0, 2, 1, ai, aa, alc2, ad));
+    CHECK(nlb == alc2[0]);
+    CHECK(next == alc2[1]);
+    check_size_extent_c(t2, 1, nlb, next);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t2));
+}
+
+/* ===================================================================
+ * (E) Classic (small-count, int) decode coverage.
+ *
+ * The (D) tests drive only the "_c" interface, which stores every count
+ * and byte displacement as a large count (na == 0).  The classic
+ * interface is a *separate* code path (the "#else" branch of each
+ * binding): block lengths and element counts land in array_of_integers,
+ * while byte displacements/strides (MPI_Aint) land in array_of_addresses.
+ * Nothing else in test/datatype exercises get_envelope/get_contents, so
+ * these build each constructor with the classic int API and small values
+ * and assert the full MPI 5.0 sec 5.1.13 classic decode -- combiner,
+ * (ni, na, nd), and the value in every slot.
+ * =================================================================== */
+
+static void check_env_classic(const char *label, MPI_Datatype t,
+                              int expect_combiner, int eni, int ena, int end)
+{
+    int ni = -1, na = -1, nd = -1, combiner = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_get_envelope(t, &ni, &na, &nd, &combiner));
+    printf("  %-15s combiner=%2d ni=%d na=%d nd=%d\n", label, combiner, ni, na,
+           nd);
+    fflush(stdout);
+    CHECK(expect_combiner == combiner);
+    CHECK(eni == ni);
+    CHECK(ena == na);
+    CHECK(end == nd);
+}
+
+/* Classic-API footprint check: size, lower bound, and extent. */
+static void check_size_extent_classic(MPI_Datatype t, int esize, MPI_Aint elb,
+                                      MPI_Aint eextent)
+{
+    int size = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_size(t, &size));
+    CHECK(esize == size);
+    MPI_Aint lb = 1, extent = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_get_extent(t, &lb, &extent));
+    CHECK(elb == lb);
+    CHECK(eextent == extent);
+}
+
+static void test_contiguous_classic(void)
+{
+    int count = 7;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_contiguous(count, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("contiguous", t, MPI_COMBINER_CONTIGUOUS, 1, 0, 1);
+
+    int ai[1] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 1, 0, 1, ai, aa, ad));
+    CHECK(count == ai[0]);
+    CHECK(MPI_BYTE == ad[0]);
+    check_size_extent_classic(t, count, 0, count);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_vector_classic(void)
+{
+    int count = 4, blen = 3, stride = 5;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_vector(count, blen, stride, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("vector", t, MPI_COMBINER_VECTOR, 3, 0, 1);
+
+    int ai[3] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 3, 0, 1, ai, aa, ad));
+    CHECK(count == ai[0]);
+    CHECK(blen == ai[1]);
+    CHECK(stride == ai[2]);
+    CHECK(MPI_BYTE == ad[0]);
+    check_size_extent_classic(t, count * blen, 0, (count - 1) * stride + blen);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hvector_classic(void)
+{
+    int count = 4, blen = 3;
+    MPI_Aint stride = 64; /* bytes -> array_of_addresses */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_hvector(count, blen, stride, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("hvector", t, MPI_COMBINER_HVECTOR, 2, 1, 1);
+
+    int ai[2] = {0};
+    MPI_Aint aa[1] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 2, 1, 1, ai, aa, ad));
+    CHECK(count == ai[0]);
+    CHECK(blen == ai[1]);
+    CHECK(stride == aa[0]);
+    CHECK(MPI_BYTE == ad[0]);
+    check_size_extent_classic(t, count * blen, 0, (count - 1) * stride + blen);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_indexed_classic(void)
+{
+    int bl[2] = {5, 3};
+    int disp[2] = {0, 8}; /* element units */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_indexed(2, bl, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("indexed", t, MPI_COMBINER_INDEXED, 5, 0, 1);
+
+    int ai[5] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 5, 0, 1, ai, aa, ad));
+    CHECK(2 == ai[0]);        /* count */
+    CHECK(bl[0] == ai[1]);
+    CHECK(bl[1] == ai[2]);
+    CHECK(disp[0] == ai[3]);  /* element displacements stay in integers */
+    CHECK(disp[1] == ai[4]);
+    CHECK(MPI_BYTE == ad[0]);
+    {
+        MPI_Aint ub = disp[0] + bl[0];
+        if (disp[1] + bl[1] > ub) { ub = disp[1] + bl[1]; }
+        check_size_extent_classic(t, bl[0] + bl[1], 0, ub);
+    }
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hindexed_classic(void)
+{
+    int bl[2] = {5, 3};
+    MPI_Aint disp[2] = {0, 64}; /* bytes -> array_of_addresses */
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_hindexed(2, bl, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("hindexed", t, MPI_COMBINER_HINDEXED, 3, 2, 1);
+
+    int ai[3] = {0};
+    MPI_Aint aa[2] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 3, 2, 1, ai, aa, ad));
+    CHECK(2 == ai[0]);
+    CHECK(bl[0] == ai[1]);
+    CHECK(bl[1] == ai[2]);
+    CHECK(disp[0] == aa[0]);
+    CHECK(disp[1] == aa[1]);
+    CHECK(MPI_BYTE == ad[0]);
+    {
+        MPI_Aint ub = disp[0] + bl[0];
+        if (disp[1] + bl[1] > ub) { ub = disp[1] + bl[1]; }
+        check_size_extent_classic(t, bl[0] + bl[1], 0, ub);
+    }
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_indexed_block_classic(void)
+{
+    int blen = 5;
+    int disp[2] = {0, 8};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_indexed_block(2, blen, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("indexed_block", t, MPI_COMBINER_INDEXED_BLOCK, 4, 0, 1);
+
+    int ai[4] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 4, 0, 1, ai, aa, ad));
+    CHECK(2 == ai[0]);        /* count */
+    CHECK(blen == ai[1]);     /* blocklength */
+    CHECK(disp[0] == ai[2]);
+    CHECK(disp[1] == ai[3]);
+    CHECK(MPI_BYTE == ad[0]);
+    {
+        MPI_Aint ub = disp[0] + blen;
+        if (disp[1] + blen > ub) { ub = disp[1] + blen; }
+        check_size_extent_classic(t, 2 * blen, 0, ub);
+    }
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_hindexed_block_classic(void)
+{
+    int blen = 5;
+    MPI_Aint disp[2] = {0, 64};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_hindexed_block(2, blen, disp, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("hindexed_block", t, MPI_COMBINER_HINDEXED_BLOCK, 2, 2, 1);
+
+    int ai[2] = {0};
+    MPI_Aint aa[2] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 2, 2, 1, ai, aa, ad));
+    CHECK(2 == ai[0]);
+    CHECK(blen == ai[1]);
+    CHECK(disp[0] == aa[0]);
+    CHECK(disp[1] == aa[1]);
+    CHECK(MPI_BYTE == ad[0]);
+    {
+        MPI_Aint ub = disp[0] + blen;
+        if (disp[1] + blen > ub) { ub = disp[1] + blen; }
+        check_size_extent_classic(t, 2 * blen, 0, ub);
+    }
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_struct_classic(void)
+{
+    int bl[2] = {5, 3};
+    MPI_Aint disp[2] = {0, 64};
+    MPI_Datatype types[2] = {MPI_BYTE, MPI_INT};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_struct(2, bl, disp, types, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("struct", t, MPI_COMBINER_STRUCT, 3, 2, 2);
+
+    int ai[3] = {0};
+    MPI_Aint aa[2] = {0};
+    MPI_Datatype ad[2] = {MPI_DATATYPE_NULL, MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 3, 2, 2, ai, aa, ad));
+    CHECK(2 == ai[0]);
+    CHECK(bl[0] == ai[1]);
+    CHECK(bl[1] == ai[2]);
+    CHECK(disp[0] == aa[0]);
+    CHECK(disp[1] == aa[1]);
+    CHECK(MPI_BYTE == ad[0]);
+    CHECK(MPI_INT == ad[1]);
+    {
+        MPI_Aint ub = disp[1] + bl[1] * (MPI_Aint) sizeof(int); /* > disp0+bl0 */
+        MPI_Aint align = (MPI_Aint) _Alignof(int);
+        check_size_extent_classic(t, bl[0] * 1 + bl[1] * (int) sizeof(int), 0,
+                                  ((ub + align - 1) / align) * align);
+    }
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_subarray_classic(void)
+{
+    int sizes[2] = {6, 4};
+    int subsizes[2] = {2, 2};
+    int starts[2] = {1, 1};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_subarray(2, sizes, subsizes, starts, MPI_ORDER_C,
+                                      MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("subarray", t, MPI_COMBINER_SUBARRAY, 8, 0, 1);
+
+    int ai[8] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 8, 0, 1, ai, aa, ad));
+    CHECK(2 == ai[0]); /* ndims */
+    CHECK(sizes[0] == ai[1]);
+    CHECK(sizes[1] == ai[2]);
+    CHECK(subsizes[0] == ai[3]);
+    CHECK(subsizes[1] == ai[4]);
+    CHECK(starts[0] == ai[5]);
+    CHECK(starts[1] == ai[6]);
+    CHECK(MPI_ORDER_C == ai[7]); /* order */
+    CHECK(MPI_BYTE == ad[0]);
+    check_size_extent_classic(t, subsizes[0] * subsizes[1], 0,
+                              sizes[0] * sizes[1]);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_darray_classic(void)
+{
+    int gsizes[1] = {12};
+    int distribs[1] = {MPI_DISTRIBUTE_BLOCK};
+    int dargs[1] = {MPI_DISTRIBUTE_DFLT_DARG};
+    int psizes[1] = {1};
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_darray(1, 0, 1, gsizes, distribs, dargs, psizes,
+                                    MPI_ORDER_C, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+    check_env_classic("darray", t, MPI_COMBINER_DARRAY, 8, 0, 1);
+
+    int ai[8] = {0};
+    MPI_Aint aa[1];
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 8, 0, 1, ai, aa, ad));
+    CHECK(1 == ai[0]);                        /* size */
+    CHECK(0 == ai[1]);                        /* rank */
+    CHECK(1 == ai[2]);                        /* ndims */
+    CHECK(gsizes[0] == ai[3]);
+    CHECK(MPI_DISTRIBUTE_BLOCK == ai[4]);
+    CHECK(MPI_DISTRIBUTE_DFLT_DARG == ai[5]);
+    CHECK(1 == ai[6]);                        /* psizes */
+    CHECK(MPI_ORDER_C == ai[7]);              /* order */
+    CHECK(MPI_BYTE == ad[0]);
+    check_size_extent_classic(t, gsizes[0], 0, gsizes[0]);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+/* Regression guard for the classic (non-_c) resized path, which shares the
+ * binding fixed alongside the _c path: lb/extent are MPI_Aint and must still
+ * decode into array_of_addresses (na=2, no large counts). */
+static void test_resized_classic(void)
+{
+    MPI_Aint lb = -3, extent = 4096;
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS == MPI_Type_create_resized(MPI_BYTE, lb, extent, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    int ni = -1, na = -1, nd = -1, combiner = -1;
+    CHECK(MPI_SUCCESS == MPI_Type_get_envelope(t, &ni, &na, &nd, &combiner));
+    CHECK(MPI_COMBINER_RESIZED == combiner);
+    CHECK(0 == ni);
+    CHECK(2 == na);
+    CHECK(1 == nd);
+
+    int ai[1];
+    MPI_Aint aa[2] = {0};
+    MPI_Datatype ad[1] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS == MPI_Type_get_contents(t, 0, 2, 1, ai, aa, ad));
+    CHECK(lb == aa[0]);
+    CHECK(extent == aa[1]);
+    CHECK(MPI_BYTE == ad[0]);
+
+    /* Resizing keeps the data size (one MPI_BYTE) but applies lb/extent. */
+    check_size_extent_classic(t, 1, lb, extent);
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+static void test_constructors_classic(void)
+{
+    test_contiguous_classic();
+    test_vector_classic();
+    test_hvector_classic();
+    test_indexed_classic();
+    test_hindexed_classic();
+    test_indexed_block_classic();
+    test_hindexed_block_classic();
+    test_struct_classic();
+    test_subarray_classic();
+    test_darray_classic();
+    test_resized_classic();
+}
+
+static void test_constructors_c_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped big-count constructors)\n");
+        return;
+    }
+    test_vector_c_bigcount();
+    test_hvector_c_bigcount();
+    test_indexed_c_bigcount();
+    test_hindexed_c_bigcount();
+    test_indexed_block_c_bigcount();
+    test_hindexed_block_c_bigcount();
+    test_struct_c_bigcount();
+    test_subarray_c_bigcount();
+    test_darray_c_bigcount();
+    test_darray_cyclic_c_bigcount();
+    test_darray_multiproc_c_bigcount();
+    test_darray_blockcyclic_c_bigcount();
+    test_resized_c_bigcount();
+}
+
+/* (F) get_elements with an element count above INT_MAX.  We seed the status
+ * with the public MPI_Status_set_elements_c (no multi-GB transfer needed)
+ * so the byte->element division is genuinely exercised by the binding. */
+static void test_get_elements_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+
+    MPI_Status status;
+    memset(&status, 0, sizeof(status)); /* defined fields for memchecker builds */
+
+    /* MPI_BYTE: element count == byte count. */
+    MPI_Count nbytes = (MPI_Count) INT_MAX + 100;
+    CHECK(MPI_SUCCESS == MPI_Status_set_elements_c(&status, MPI_BYTE, nbytes));
+
+    MPI_Count ec = -1;
+    CHECK(MPI_SUCCESS == MPI_Get_elements_c(&status, MPI_BYTE, &ec));
+    CHECK(nbytes == ec);
+
+    /* The classic int interface cannot represent > INT_MAX elements, so it
+     * must return MPI_UNDEFINED (MPI 3.0). */
+    int eci = 0;
+    CHECK(MPI_SUCCESS == MPI_Get_elements(&status, MPI_BYTE, &eci));
+    CHECK(MPI_UNDEFINED == eci);
+
+    /* MPI_INT: seed the element count and let the binding divide the byte
+     * count back out -- a real round-trip, with a result above INT_MAX. */
+    MPI_Count nints = (MPI_Count) INT_MAX + 99;
+    CHECK(MPI_SUCCESS == MPI_Status_set_elements_c(&status, MPI_INT, nints));
+    ec = -1;
+    CHECK(MPI_SUCCESS == MPI_Get_elements_c(&status, MPI_INT, &ec));
+    CHECK(nints == ec);
+
+    /* A byte count that is NOT an integral number of MPI_INT elements must
+     * decode to MPI_UNDEFINED (MPI 5.0 sec 5.1.11).  There is no public way
+     * to seed a partial byte count, so set the internal _ucount field
+     * directly for just this case. */
+    status._ucount = (size_t) nints * sizeof(int) + 1;
+    ec = 0;
+    CHECK(MPI_SUCCESS == MPI_Get_elements_c(&status, MPI_INT, &ec));
+    CHECK(MPI_UNDEFINED == ec);
+
+    printf("  get_elements_c: MPI_BYTE/%lld -> %lld, MPI_INT -> %lld; "
+           "classic int & partial -> MPI_UNDEFINED\n",
+           (long long) nbytes, (long long) nbytes, (long long) nints);
+    fflush(stdout);
+}
+
+/* #14055 over-read check, factored so it can run against more than the
+ * struct combiner in test_get_contents_c_oversized: with output arrays
+ * larger than the envelope, get_contents_c must fill only the real
+ * constituent datatypes and leave the surplus slots untouched. */
+static void check_no_overread_c(const char *label, MPI_Datatype t)
+{
+    enum { SLACK = 8 };
+    MPI_Count ni = -1, na = -1, nlc = -1, nd = -1;
+    int combiner = -1;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_envelope_c(t, &ni, &na, &nlc, &nd, &combiner));
+    if (ni < 0 || na < 0 || nlc < 0 || nd < 0) {
+        CHECK(false);
+        return;
+    }
+    int *ai = calloc((size_t) ni + SLACK, sizeof(int));
+    MPI_Aint *aa = calloc((size_t) na + SLACK, sizeof(MPI_Aint));
+    MPI_Count *alc = calloc((size_t) nlc + SLACK, sizeof(MPI_Count));
+    MPI_Datatype *ad = malloc(((size_t) nd + SLACK) * sizeof(MPI_Datatype));
+    CHECK(NULL != ai && NULL != aa && NULL != alc && NULL != ad);
+    if (NULL == ai || NULL == aa || NULL == alc || NULL == ad) {
+        free(ai); free(aa); free(alc); free(ad);
+        return;
+    }
+    for (size_t i = 0; i < (size_t) nd + SLACK; ++i) {
+        ad[i] = POISON;
+    }
+    CHECK(MPI_SUCCESS
+          == MPI_Type_get_contents_c(t, ni + SLACK, na + SLACK, nlc + SLACK,
+                                     nd + SLACK, ai, aa, alc, ad));
+    for (size_t i = 0; i < (size_t) nd; ++i) {
+        CHECK(POISON != ad[i]); /* real constituents filled in */
+    }
+    for (size_t i = (size_t) nd; i < (size_t) nd + SLACK; ++i) {
+        CHECK(POISON == ad[i]); /* surplus slots untouched */
+    }
+    printf("  no-overread: %-16s nd=%lld\n", label, (long long) nd);
+    fflush(stdout);
+    free(ai); free(aa); free(alc); free(ad);
+}
+
+static void test_oversized_more_combiners(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+    /* hindexed_block and resized are the combiners whose large-count decode
+     * this work changed; verify their get_contents_c has no over-read too. */
+    MPI_Count blen = BIG + 5;
+    MPI_Count disp[2] = {0, BIG + 6};
+    MPI_Datatype hib = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_hindexed_block_c(2, blen, disp, MPI_BYTE, &hib));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&hib));
+    check_no_overread_c("hindexed_block_c", hib);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&hib));
+
+    MPI_Datatype rsz = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_create_resized_c(MPI_BYTE, BIG + 5, BIG + 6, &rsz));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&rsz));
+    check_no_overread_c("resized_c", rsz);
+    CHECK(MPI_SUCCESS == MPI_Type_free(&rsz));
+}
+
+/* A datatype built with a large count cannot be decoded through the classic
+ * (non-_c) envelope/contents calls: MPI 5.0 sec 5.1.13 requires MPI_ERR_TYPE
+ * rather than silent truncation.  This is the exact mismatch a user hits when
+ * they build with MPI_Type_*_c and query with the classic API. */
+static void test_classic_rejects_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+    MPI_Datatype t = MPI_DATATYPE_NULL;
+    CHECK(MPI_SUCCESS
+          == MPI_Type_contiguous_c((MPI_Count) INT_MAX + 7, MPI_BYTE, &t));
+    CHECK(MPI_SUCCESS == MPI_Type_commit(&t));
+
+    /* Both classic decode entry points must fail (num_large_counts > 0). */
+    int ni = -1, na = -1, nd = -1, combiner = -1;
+    CHECK(MPI_SUCCESS != MPI_Type_get_envelope(t, &ni, &na, &nd, &combiner));
+
+    int ai[4] = {0};
+    MPI_Aint aa[4] = {0};
+    MPI_Datatype ad[4] = {MPI_DATATYPE_NULL};
+    CHECK(MPI_SUCCESS != MPI_Type_get_contents(t, 4, 4, 4, ai, aa, ad));
+
+    CHECK(MPI_SUCCESS == MPI_Type_free(&t));
+}
+
+int main(int argc, char *argv[])
+{
+    int rc = MPI_Init(&argc, &argv);
+    if (MPI_SUCCESS != rc) {
+        fprintf(stderr, "MPI_Init failed (rc=%d)\n", rc);
+        return 1;
+    }
+    /* Report MPI errors as return codes so a single failing call records a
+     * CHECK failure and the test keeps running, instead of aborting the
+     * whole program on the first problem. */
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    printf("--- MPI_Type_contiguous_c (count > INT_MAX) ---\n");
+    test_contiguous_c_bigcount();
+    printf("--- MPI_Type_get_contents_c oversized arrays (#14055, _c) ---\n");
+    test_get_contents_c_oversized();
+    printf("--- MPI_Type_get_contents oversized arrays (#14055, classic) ---\n");
+    test_get_contents_oversized();
+    printf("--- get_contents_c oversized arrays, more combiners (#14055) ---\n");
+    test_oversized_more_combiners();
+    printf("--- classic get_envelope/get_contents reject a _c big-count type ---\n");
+    test_classic_rejects_bigcount();
+    printf("--- derived-type constructors (classic) with small counts ---\n");
+    test_constructors_classic();
+    printf("--- derived-type constructors (_c) with args > INT_MAX ---\n");
+    test_constructors_c_bigcount();
+    printf("--- MPI_Get_elements[_c] (elements > INT_MAX) ---\n");
+    test_get_elements_bigcount();
+
+    MPI_Finalize();
+
+    if (0 == failures) {
+        printf("SUCCESS: all MPI big-count datatype checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "FAILURE: %d MPI big-count datatype check(s) failed\n",
+            failures);
+    return 1;
+}

--- a/test/datatype/ompi_datatype_bigcount.c
+++ b/test/datatype/ompi_datatype_bigcount.c
@@ -1,0 +1,730 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * OMPI-layer "big count" datatype tests, exercised through the internal
+ * ompi_datatype_* routines.
+ *
+ * This is a singleton test that initializes only the OMPI datatype
+ * engine (opal_init + ompi_datatype_init) -- it does NOT call MPI_Init,
+ * matching every other auto-run test in test/datatype.  The public MPI
+ * C-binding wrappers (MPI_Type_*_c, MPI_Type_get_contents[_c]) are
+ * exercised separately by mpi_datatype_bigcount.c, which does call
+ * MPI_Init.
+ *
+ * Coverage:
+ *   1. ompi_datatype_create_contiguous() with a count above INT_MAX:
+ *      the resulting size/extent must be computed in 64 bits.
+ *   2. ompi_datatype_set_args()/get_args() round-trip with an
+ *      above-INT_MAX count, modeled exactly on the big-count branch of
+ *      the generated type_contiguous binding (counts stored in the
+ *      "large" array; ci=0, cl=1).  Verifies the int-vs-MPI_Count
+ *      type-punning preserves the value.
+ *   3. The get_args() invariant that the #14055 get_contents fix relies
+ *      on: when handed an oversized output array, get_args fills only
+ *      the real number of constituent entries and never touches the
+ *      caller's surplus slots.
+ *   4. ompi_datatype_match_size() (#14057): a (typeclass, size) request
+ *      returns only a basic scalar predefined type, and fails cleanly
+ *      otherwise.
+ *   5. Pack/unpack of the datatype description for above-INT_MAX types:
+ *      ompi_datatype_get_pack_description() followed by
+ *      ompi_datatype_create_from_packed_description() must rebuild an
+ *      equivalent type.  This is the only path that exercises the
+ *      bigcount ("l != NULL") branches of __ompi_datatype_create_from_args
+ *      and the size_t count array in the packed description -- the code
+ *      that one-sided, MPI-IO, and heterogeneous transfers rely on.
+ */
+
+#include "ompi_config.h"
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mpi.h>
+
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/proc/proc.h"
+#include "ompi/util/count_disp_array.h"
+#include "opal/datatype/opal_datatype.h"
+#include "opal/runtime/opal.h"
+
+static int failures = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,       \
+                    #cond);                                               \
+            ++failures;                                                   \
+        }                                                                 \
+    } while (0)
+
+/* Recognizable non-NULL garbage handle used to poison surplus output
+ * slots (named to match POISON in mpi_datatype_bigcount.c). */
+static ompi_datatype_t *const POISON = (ompi_datatype_t *) (intptr_t) 0xdeadbeef;
+
+static bool have_64bit_counts(void)
+{
+    return 8 == sizeof(size_t);
+}
+
+/* (1) Engine size/extent for a contiguous type whose count exceeds
+ * INT_MAX, built through the OMPI wrapper. */
+static void test_create_contiguous_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+
+    size_t count = (size_t) INT_MAX + 4096;
+    ompi_datatype_t *type = NULL;
+    int rc = ompi_datatype_create_contiguous(count, &ompi_mpi_byte.dt, &type);
+    CHECK(OMPI_SUCCESS == rc);
+    CHECK(NULL != type);
+    if (NULL == type) {
+        return;
+    }
+    ompi_datatype_commit(&type);
+
+    size_t size = 0;
+    ompi_datatype_type_size(type, &size);
+    CHECK(count == size); /* MPI_BYTE has size 1 */
+
+    ptrdiff_t extent = 0;
+    ompi_datatype_type_extent(type, &extent);
+    CHECK((ptrdiff_t) count == extent);
+
+    printf("  contiguous(%" PRIuPTR " x MPI_BYTE): size=%" PRIuPTR "\n",
+           (uintptr_t) count, (uintptr_t) size);
+
+    ompi_datatype_destroy(&type);
+}
+
+/* (2) + (3) set_args/get_args type-punning round-trip and the
+ * oversized-output-array invariant.  We store the args exactly as the
+ * big-count type_contiguous binding does. */
+static void test_set_get_args_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        return;
+    }
+
+    size_t count = (size_t) INT_MAX + 12345;
+    ompi_datatype_t *type = NULL;
+    int rc = ompi_datatype_create_contiguous(count, &ompi_mpi_byte.dt, &type);
+    CHECK(OMPI_SUCCESS == rc);
+    if (NULL == type) {
+        return;
+    }
+
+    /* Mirror type_contiguous.c.in's OMPI_BIGCOUNT_SRC branch: a single
+     * MPI_Count count (8 bytes => 64-bit count array) goes into the
+     * "large" slot, so ci=0, cl=1. */
+    MPI_Count cnt = (MPI_Count) count;
+    ompi_count_array_t a_i[1] = {OMPI_COUNT_ARRAY_CREATE(&cnt)};
+    ompi_datatype_t *oldtype = &ompi_mpi_byte.dt;
+    CHECK(ompi_count_array_is_64bit(a_i[0]));
+
+    rc = ompi_datatype_set_args(type, 0, 1, a_i, 0, OMPI_DISP_ARRAY_NULL, 1,
+                                &oldtype, MPI_COMBINER_CONTIGUOUS);
+    CHECK(OMPI_SUCCESS == rc);
+
+    /* which=0: retrieve the real counts and combiner. */
+    size_t ci = 0, cl = 0, ca = 0, cd = 0;
+    int32_t combiner = -1;
+    rc = ompi_datatype_get_args(type, 0, &ci, NULL, &cl, NULL, &ca, NULL, &cd,
+                                NULL, &combiner);
+    CHECK(OMPI_SUCCESS == rc);
+    CHECK(MPI_COMBINER_CONTIGUOUS == combiner);
+    CHECK(0 == ci);
+    CHECK(1 == cl);
+    CHECK(0 == ca);
+    CHECK(1 == cd);
+
+    /* which=1: retrieve the values; the above-INT_MAX count must come
+     * back undamaged through the large (MPI_Count) array. */
+    MPI_Count lout[1] = {0};
+    ompi_datatype_t *dout[1] = {NULL};
+    rc = ompi_datatype_get_args(type, 1, &ci, NULL, &cl, lout, &ca, NULL, &cd,
+                                dout, NULL);
+    CHECK(OMPI_SUCCESS == rc);
+    CHECK((MPI_Count) count == lout[0]);
+    CHECK(&ompi_mpi_byte.dt == dout[0]);
+
+    /* (3) Oversized output array: ask get_args to fill a datatype array
+     * far larger than the single real constituent.  This is the legal
+     * usage (max_datatypes discovered via get_envelope may exceed the
+     * real count) that crashed MPI_Type_get_contents before #14055.  At
+     * this layer the invariant is: only the first cd entries are
+     * written; the surplus poisoned slots are left untouched. */
+    enum { SLACK = 8 };
+    enum { LPOISON = -424242 }; /* sentinel for surplus large-count slots */
+    ompi_datatype_t *big_d[1 + SLACK];
+    MPI_Count lbig[1 + SLACK];
+    for (int i = 0; i < 1 + SLACK; ++i) {
+        big_d[i] = POISON;
+        lbig[i] = LPOISON;
+    }
+    size_t cap_ci = 0, cap_cl = (size_t) 1 + SLACK, cap_ca = 0,
+           cap_cd = (size_t) 1 + SLACK;
+    rc = ompi_datatype_get_args(type, 1, &cap_ci, NULL, &cap_cl, lbig, &cap_ca,
+                                NULL, &cap_cd, big_d, NULL);
+    CHECK(OMPI_SUCCESS == rc);
+    CHECK(&ompi_mpi_byte.dt == big_d[0]);
+    CHECK((MPI_Count) count == lbig[0]);
+    /* Both the datatype and large-count surplus slots must be untouched. */
+    for (int i = 1; i < 1 + SLACK; ++i) {
+        CHECK(POISON == big_d[i]);
+        CHECK((MPI_Count) LPOISON == lbig[i]);
+    }
+
+    ompi_datatype_destroy(&type);
+}
+
+/* (4) match_size (#14057): only basic scalar predefined types may be
+ * returned; size 0 (and any request with no scalar match) must fail. */
+static void check_match(uint16_t datakind, size_t size, bool expect_match)
+{
+    /* On no match, ompi_datatype_match_size() returns the sentinel
+     * &ompi_mpi_datatype_null.dt (which MPI_Type_match_size turns into
+     * MPI_ERR_ARG) -- it does not return NULL. */
+    const ompi_datatype_t *none = &ompi_mpi_datatype_null.dt;
+    const ompi_datatype_t *dt =
+        ompi_datatype_match_size(size, datakind, OMPI_DATATYPE_FLAG_DATA_C);
+    if (!expect_match) {
+        CHECK(none == dt);
+        return;
+    }
+    CHECK(NULL != dt && none != dt);
+    if (NULL == dt || none == dt) {
+        return;
+    }
+    /* Must be a basic scalar type of exactly the requested size and the
+     * requested language/kind -- never a composite (e.g. a paired type)
+     * and never an unavailable size-0 type. */
+    CHECK(OPAL_DATATYPE_FLAG_BASIC
+          == (dt->super.flags & OPAL_DATATYPE_FLAG_BASIC));
+    CHECK(size == dt->super.size);
+    CHECK(OMPI_DATATYPE_FLAG_DATA_C
+          == (dt->super.flags & OMPI_DATATYPE_FLAG_DATA_LANGUAGE));
+    CHECK(datakind == (dt->super.flags & OMPI_DATATYPE_FLAG_DATA_TYPE));
+}
+
+static void test_match_size_basic_only(void)
+{
+    /* C float scalars always exist regardless of Fortran availability. */
+    check_match(OMPI_DATATYPE_FLAG_DATA_FLOAT, sizeof(float), true);
+    check_match(OMPI_DATATYPE_FLAG_DATA_FLOAT, sizeof(double), true);
+    check_match(OMPI_DATATYPE_FLAG_DATA_INT, sizeof(int), true);
+
+    /* A size-0 request must never succeed (it previously could return an
+     * unavailable predefined type). */
+    check_match(OMPI_DATATYPE_FLAG_DATA_FLOAT, 0, false);
+    check_match(OMPI_DATATYPE_FLAG_DATA_INT, 0, false);
+
+    /* A wildly unlikely size has no basic scalar match and must fail
+     * rather than fall through to a composite. */
+    check_match(OMPI_DATATYPE_FLAG_DATA_FLOAT, 7, false);
+}
+
+/* (5) Pack the description of a committed bigcount type and rebuild it
+ * from the packed bytes, then verify the rebuilt type is equivalent.
+ * Rebuilding runs __ompi_datatype_create_from_args, whose bigcount
+ * branches (l != NULL) are otherwise untested. */
+static void pack_unpack_check(const char *label, ompi_datatype_t *type)
+{
+    /* A 0 length is the documented upstream failure return; treat it as the
+     * real failure rather than letting malloc(0) muddy the diagnostic. */
+    size_t plen = ompi_datatype_pack_description_length(type);
+    CHECK(plen > 0);
+    if (0 == plen) {
+        return;
+    }
+    void *buf = malloc(plen);
+    CHECK(NULL != buf);
+    const void *packed = NULL;
+    int rc = ompi_datatype_get_pack_description(type, &packed);
+    CHECK(OMPI_SUCCESS == rc);
+    if (OMPI_SUCCESS != rc || NULL == buf) {
+        free(buf);
+        return;
+    }
+    memcpy(buf, packed, plen);
+
+    /* create_from_packed_description advances the cursor, so keep buf to
+     * free.  ompi_proc_local() works because main() points
+     * ompi_proc_local_proc at a dummy proc (same trick as ddt_pack.c);
+     * remote==local makes the heterogeneous byte-swap path a no-op.
+     *
+     * COVERAGE NOTE: this therefore does NOT exercise the big-endian
+     * byte-swap branch of __ompi_datatype_create_from_packed_description
+     * (the opal_swap_bytes8 loops over the size_t count and ptrdiff_t disp
+     * arrays).  Driving that path would require pre-swapping the packed
+     * buffer to mimic a different-endian sender, i.e. re-implementing the
+     * wire format here; it is better covered by a real heterogeneous run. */
+    void *cursor = buf;
+    ompi_datatype_t *rebuilt =
+        ompi_datatype_create_from_packed_description(&cursor, ompi_proc_local());
+    free(buf);
+    CHECK(NULL != rebuilt);
+    if (NULL == rebuilt) {
+        return;
+    }
+
+    /* Size, extent, and true extent must survive unchanged. */
+    size_t s0 = 0, s1 = 0;
+    ompi_datatype_type_size(type, &s0);
+    ompi_datatype_type_size(rebuilt, &s1);
+    CHECK(s0 == s1);
+
+    ptrdiff_t lb0, ext0, lb1, ext1, tlb0, text0, tlb1, text1;
+    ompi_datatype_get_extent(type, &lb0, &ext0);
+    ompi_datatype_get_extent(rebuilt, &lb1, &ext1);
+    CHECK(lb0 == lb1);
+    CHECK(ext0 == ext1);
+    ompi_datatype_get_true_extent(type, &tlb0, &text0);
+    ompi_datatype_get_true_extent(rebuilt, &tlb1, &text1);
+    CHECK(tlb0 == tlb1);
+    CHECK(text0 == text1);
+
+    /* Envelope must match: same combiner and the same number of each kind
+     * of argument.  In particular cl (large counts) must be preserved --
+     * if a bigcount were truncated into the int array on the way through,
+     * cl would shrink here. */
+    size_t ci0, cl0, ca0, cd0, ci1, cl1, ca1, cd1;
+    int32_t comb0 = -1, comb1 = -2;
+    ompi_datatype_get_args(type, 0, &ci0, NULL, &cl0, NULL, &ca0, NULL, &cd0,
+                           NULL, &comb0);
+    ompi_datatype_get_args(rebuilt, 0, &ci1, NULL, &cl1, NULL, &ca1, NULL, &cd1,
+                           NULL, &comb1);
+    CHECK(comb0 == comb1);
+    CHECK(ci0 == ci1);
+    CHECK(cl0 == cl1);
+    CHECK(ca0 == ca1);
+    CHECK(cd0 == cd1);
+
+    /* Every stored argument value -- ints, large counts, displacements, and
+     * constituent datatypes -- must survive the round-trip, not just the
+     * counts.  Compare the rebuilt type's args against the original's (the
+     * original's values are checked against the constructor inputs by the
+     * MPI-level constructor tests). */
+    if (ci0 == ci1 && cl0 == cl1 && ca0 == ca1 && cd0 == cd1) {
+        int *i0 = malloc((ci0 + 1) * sizeof(int));
+        int *i1 = malloc((ci1 + 1) * sizeof(int));
+        MPI_Count *l0 = malloc((cl0 + 1) * sizeof(MPI_Count));
+        MPI_Count *l1 = malloc((cl1 + 1) * sizeof(MPI_Count));
+        ptrdiff_t *a0 = malloc((ca0 + 1) * sizeof(ptrdiff_t));
+        ptrdiff_t *a1 = malloc((ca1 + 1) * sizeof(ptrdiff_t));
+        ompi_datatype_t **d0 = malloc((cd0 + 1) * sizeof(ompi_datatype_t *));
+        ompi_datatype_t **d1 = malloc((cd1 + 1) * sizeof(ompi_datatype_t *));
+
+        if (NULL == i0 || NULL == i1 || NULL == l0 || NULL == l1
+            || NULL == a0 || NULL == a1 || NULL == d0 || NULL == d1) {
+            CHECK(false); /* allocation failure */
+        } else {
+            size_t qi = ci0, ql = cl0, qa = ca0, qd = cd0;
+            ompi_datatype_get_args(type, 1, &qi, i0, &ql, l0, &qa, a0, &qd, d0,
+                                   NULL);
+            qi = ci1; ql = cl1; qa = ca1; qd = cd1;
+            ompi_datatype_get_args(rebuilt, 1, &qi, i1, &ql, l1, &qa, a1, &qd,
+                                   d1, NULL);
+
+            for (size_t k = 0; k < ci0; ++k) {
+                CHECK(i0[k] == i1[k]);
+            }
+            for (size_t k = 0; k < cl0; ++k) {
+                CHECK(l0[k] == l1[k]);
+            }
+            for (size_t k = 0; k < ca0; ++k) {
+                CHECK(a0[k] == a1[k]);
+            }
+            /* Constituent datatypes must be *equivalent*, but not necessarily
+             * the same handle: reconstruction canonicalizes predefined types
+             * by id (e.g. a packed MPI_INT rebuilds as ompi_mpi_int32_t), so
+             * check predefined-ness and size rather than pointer identity. */
+            for (size_t k = 0; k < cd0; ++k) {
+                size_t z0 = 0, z1 = 0;
+                ompi_datatype_type_size(d0[k], &z0);
+                ompi_datatype_type_size(d1[k], &z1);
+                CHECK(z0 == z1);
+                CHECK(ompi_datatype_is_predefined(d0[k])
+                      == ompi_datatype_is_predefined(d1[k]));
+            }
+        }
+
+        free(i0); free(i1); free(l0); free(l1);
+        free(a0); free(a1); free(d0); free(d1);
+    }
+
+    printf("  %-11s size=%" PRIuPTR " extent=%td combiner=%d cl=%zu  ok\n",
+           label, (uintptr_t) s0, ext0, (int) comb0, cl0);
+
+    if (!ompi_datatype_is_predefined(rebuilt)) {
+        ompi_datatype_destroy(&rebuilt);
+    }
+}
+
+static void test_pack_unpack_bigcount(void)
+{
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+
+    ompi_datatype_t *old = &ompi_mpi_byte.dt;
+
+    /* contiguous: a single above-INT_MAX count (cl=1). */
+    {
+        MPI_Count count = (MPI_Count) INT_MAX + 7;
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS == ompi_datatype_create_contiguous(count, old, &t));
+        ompi_count_array_t a_i[1] = {OMPI_COUNT_ARRAY_CREATE(&count)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 1, a_i, 0, OMPI_DISP_ARRAY_NULL,
+                                        1, &old, MPI_COMBINER_CONTIGUOUS));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("contiguous", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* vector: above-INT_MAX count, blocklength, and (element) stride. */
+    {
+        MPI_Count count = (MPI_Count) INT_MAX + 5;
+        MPI_Count blen = (MPI_Count) INT_MAX + 6;
+        MPI_Count stride = (MPI_Count) INT_MAX + 7;
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_vector(count, blen, stride, old, &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(&blen),
+                                     OMPI_COUNT_ARRAY_CREATE(&stride)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 3, a_i, 0, OMPI_DISP_ARRAY_NULL,
+                                        1, &old, MPI_COMBINER_VECTOR));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("vector", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* indexed: 2 blocks, with an above-INT_MAX blocklength and (element)
+     * displacement. */
+    {
+        MPI_Count count = 2;
+        MPI_Count bl[2] = {(MPI_Count) INT_MAX + 5, 3};
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_indexed(count, OMPI_COUNT_ARRAY_CREATE(bl),
+                                              OMPI_DISP_ARRAY_CREATE(disp), old,
+                                              &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(bl),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 * count + 1, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_INDEXED));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("indexed", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* hindexed: 2 blocks, above-INT_MAX blocklength and (byte)
+     * displacement. */
+    {
+        MPI_Count count = 2;
+        MPI_Count bl[2] = {(MPI_Count) INT_MAX + 5, 3};
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_hindexed(count,
+                                               OMPI_COUNT_ARRAY_CREATE(bl),
+                                               OMPI_DISP_ARRAY_CREATE(disp), old,
+                                               &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(bl),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 * count + 1, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_HINDEXED));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("hindexed", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* struct: 2 heterogeneous blocks, above-INT_MAX blocklength and (byte)
+     * displacement. */
+    {
+        MPI_Count count = 2;
+        MPI_Count bl[2] = {(MPI_Count) INT_MAX + 5, 3};
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *types[2] = {&ompi_mpi_byte.dt, &ompi_mpi_int.dt};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_struct(count, OMPI_COUNT_ARRAY_CREATE(bl),
+                                             OMPI_DISP_ARRAY_CREATE(disp), types,
+                                             &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(bl),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 * count + 1, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, count, types,
+                                        MPI_COMBINER_STRUCT));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("struct", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* struct with a *derived* (non-predefined) constituent: exercises the
+     * recursive pack/reconstruct path (OBJ_RETAIN + nested pack) that a
+     * predefined-only struct does not. */
+    {
+        ompi_datatype_t *inner = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_contiguous(2, &ompi_mpi_int.dt, &inner));
+        /* A derived type used as a struct member must carry its own args (the
+         * binding layer normally does this); set them so the recursive pack
+         * of the constituent has a description to walk. */
+        {
+            int two = 2;
+            ompi_count_array_t inner_a[1] = {OMPI_COUNT_ARRAY_CREATE(&two)};
+            ompi_datatype_t *inner_old = &ompi_mpi_int.dt;
+            CHECK(OMPI_SUCCESS
+                  == ompi_datatype_set_args(inner, 1, 0, inner_a, 0,
+                                            OMPI_DISP_ARRAY_NULL, 1, &inner_old,
+                                            MPI_COMBINER_CONTIGUOUS));
+        }
+        ompi_datatype_commit(&inner);
+
+        MPI_Count count = 2;
+        MPI_Count bl[2] = {(MPI_Count) INT_MAX + 5, 1};
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *types[2] = {&ompi_mpi_byte.dt, inner};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_struct(count, OMPI_COUNT_ARRAY_CREATE(bl),
+                                             OMPI_DISP_ARRAY_CREATE(disp), types,
+                                             &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(bl),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 * count + 1, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, count, types,
+                                        MPI_COMBINER_STRUCT));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("struct+derived", t);
+        ompi_datatype_destroy(&t);
+        ompi_datatype_destroy(&inner);
+    }
+
+    /* hvector: above-INT_MAX count, blocklength, and (byte) stride. */
+    {
+        MPI_Count count = (MPI_Count) INT_MAX + 5;
+        MPI_Count blen = (MPI_Count) INT_MAX + 6;
+        MPI_Count stride = (MPI_Count) INT_MAX + 7; /* bytes */
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_hvector(count, blen, (ptrdiff_t) stride,
+                                              old, &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(&blen),
+                                     OMPI_COUNT_ARRAY_CREATE(&stride)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 3, a_i, 0, OMPI_DISP_ARRAY_NULL,
+                                        1, &old, MPI_COMBINER_HVECTOR));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("hvector", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* indexed_block: above-INT_MAX blocklength and (element) displacement. */
+    {
+        MPI_Count count = 2;
+        MPI_Count blen = (MPI_Count) INT_MAX + 5;
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_indexed_block(count, blen,
+                                                    OMPI_DISP_ARRAY_CREATE(disp),
+                                                    old, &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(&blen),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 + count, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_INDEXED_BLOCK));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("indexed_block", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* hindexed_block: above-INT_MAX blocklength and (byte) displacement. */
+    {
+        MPI_Count count = 2;
+        MPI_Count blen = (MPI_Count) INT_MAX + 5;
+        MPI_Count disp[2] = {0, (MPI_Count) INT_MAX + 6};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_hindexed_block(count, blen,
+                                                     OMPI_DISP_ARRAY_CREATE(disp),
+                                                     old, &t));
+        ompi_count_array_t a_i[3] = {OMPI_COUNT_ARRAY_CREATE(&count),
+                                     OMPI_COUNT_ARRAY_CREATE(&blen),
+                                     OMPI_COUNT_ARRAY_CREATE(disp)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2 + count, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_HINDEXED_BLOCK));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("hindexed_block", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* subarray: above-INT_MAX size, subsize, and start in dimension 0. */
+    {
+        int ndims = 2, order = MPI_ORDER_C;
+        MPI_Count sizes[2] = {2 * (MPI_Count) INT_MAX + 100, 6};
+        MPI_Count subsizes[2] = {(MPI_Count) INT_MAX + 5, 2};
+        MPI_Count starts[2] = {(MPI_Count) INT_MAX + 3, 1};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_subarray(ndims,
+                                               OMPI_COUNT_ARRAY_CREATE(sizes),
+                                               OMPI_COUNT_ARRAY_CREATE(subsizes),
+                                               OMPI_COUNT_ARRAY_CREATE(starts),
+                                               order, old, &t));
+        ompi_count_array_t a_i[5] = {OMPI_COUNT_ARRAY_CREATE(&ndims),
+                                     OMPI_COUNT_ARRAY_CREATE(sizes),
+                                     OMPI_COUNT_ARRAY_CREATE(subsizes),
+                                     OMPI_COUNT_ARRAY_CREATE(starts),
+                                     OMPI_COUNT_ARRAY_CREATE(&order)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 2, 3 * ndims, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_SUBARRAY));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("subarray", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* darray: 2-D, single process, above-INT_MAX gsizes. */
+    {
+        int size = 1, rank = 0, ndims = 2, order = MPI_ORDER_C;
+        MPI_Count gsizes[2] = {(MPI_Count) INT_MAX + 5,
+                               (MPI_Count) INT_MAX + 6};
+        int distribs[2] = {MPI_DISTRIBUTE_BLOCK, MPI_DISTRIBUTE_BLOCK};
+        int dargs[2] = {MPI_DISTRIBUTE_DFLT_DARG, MPI_DISTRIBUTE_DFLT_DARG};
+        int psizes[2] = {1, 1};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_darray(size, rank, ndims,
+                                             OMPI_COUNT_ARRAY_CREATE(gsizes),
+                                             distribs, dargs, psizes, order, old,
+                                             &t));
+        ompi_count_array_t a_i[8] = {OMPI_COUNT_ARRAY_CREATE(&size),
+                                     OMPI_COUNT_ARRAY_CREATE(&rank),
+                                     OMPI_COUNT_ARRAY_CREATE(&ndims),
+                                     OMPI_COUNT_ARRAY_CREATE(gsizes),
+                                     OMPI_COUNT_ARRAY_CREATE(distribs),
+                                     OMPI_COUNT_ARRAY_CREATE(dargs),
+                                     OMPI_COUNT_ARRAY_CREATE(psizes),
+                                     OMPI_COUNT_ARRAY_CREATE(&order)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 3 * ndims + 4, ndims, a_i, 0,
+                                        OMPI_DISP_ARRAY_NULL, 1, &old,
+                                        MPI_COMBINER_DARRAY));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("darray", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* resized: above-INT_MAX extent and a *negative* lb, exercising the
+     * large-count reconstruction branch of create_from_args and the
+     * signed round-trip of lb through the (unsigned) size_t count array. */
+    {
+        MPI_Count lb = -((MPI_Count) INT_MAX + 5);
+        MPI_Count extent = (MPI_Count) INT_MAX + 6;
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_resized(old, (ptrdiff_t) lb,
+                                              (ptrdiff_t) extent, &t));
+        MPI_Count a_l[2] = {lb, extent};
+        ompi_count_array_t a_i[1] = {OMPI_COUNT_ARRAY_CREATE(a_l)};
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 2, a_i, 0, OMPI_DISP_ARRAY_NULL,
+                                        1, &old, MPI_COMBINER_RESIZED));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("resized", t);
+        ompi_datatype_destroy(&t);
+    }
+
+    /* resized (classic form): lb/extent stored as MPI_Aint displacements
+     * (ca=2, cl=0), exercising the NULL == l reconstruction branch of
+     * create_from_args that the large-count resized case above does not. */
+    {
+        ptrdiff_t disp[2] = {-3, 4096};
+        ompi_datatype_t *t = NULL;
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_create_resized(old, disp[0], disp[1], &t));
+        CHECK(OMPI_SUCCESS
+              == ompi_datatype_set_args(t, 0, 0, NULL, 2,
+                                        OMPI_DISP_ARRAY_CREATE(disp), 1, &old,
+                                        MPI_COMBINER_RESIZED));
+        ompi_datatype_commit(&t);
+        pack_unpack_check("resized_aint", t);
+        ompi_datatype_destroy(&t);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    /* Make ompi_proc_local() usable without MPI_Init (same approach as
+     * ddt_pack.c): the dummy proc is only compared against itself in the
+     * pack/unpack path, so its (uninitialized) fields never matter. */
+    /* Zero-init so that, even if a future pack/unpack change reads a remote
+     * proc field other than proc_arch, the test reads defined memory rather
+     * than uninitialized stack. */
+    struct ompi_proc_t dummy_proc;
+    memset(&dummy_proc, 0, sizeof(dummy_proc));
+    ompi_proc_local_proc = &dummy_proc;
+
+    opal_init(&argc, &argv);
+    ompi_datatype_init();
+
+    printf("--- ompi_datatype_create_contiguous (count > INT_MAX) ---\n");
+    test_create_contiguous_bigcount();
+    printf("--- ompi_datatype_set_args/get_args punning + oversized array ---\n");
+    test_set_get_args_bigcount();
+    printf("--- ompi_datatype_match_size (basic scalar only) ---\n");
+    test_match_size_basic_only();
+    printf("--- pack/unpack datatype description (count > INT_MAX) ---\n");
+    test_pack_unpack_bigcount();
+
+    opal_finalize();
+
+    if (0 == failures) {
+        printf("SUCCESS: all OMPI big-count datatype checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "FAILURE: %d OMPI big-count datatype check(s) failed\n",
+            failures);
+    return 1;
+}

--- a/test/datatype/ompi_datatype_bigcount.c
+++ b/test/datatype/ompi_datatype_bigcount.c
@@ -307,10 +307,12 @@ static void pack_unpack_check(const char *label, ompi_datatype_t *type)
      * cl would shrink here. */
     size_t ci0, cl0, ca0, cd0, ci1, cl1, ca1, cd1;
     int32_t comb0 = -1, comb1 = -2;
-    ompi_datatype_get_args(type, 0, &ci0, NULL, &cl0, NULL, &ca0, NULL, &cd0,
-                           NULL, &comb0);
-    ompi_datatype_get_args(rebuilt, 0, &ci1, NULL, &cl1, NULL, &ca1, NULL, &cd1,
-                           NULL, &comb1);
+    CHECK(OMPI_SUCCESS
+          == ompi_datatype_get_args(type, 0, &ci0, NULL, &cl0, NULL, &ca0, NULL,
+                                    &cd0, NULL, &comb0));
+    CHECK(OMPI_SUCCESS
+          == ompi_datatype_get_args(rebuilt, 0, &ci1, NULL, &cl1, NULL, &ca1,
+                                    NULL, &cd1, NULL, &comb1));
     CHECK(comb0 == comb1);
     CHECK(ci0 == ci1);
     CHECK(cl0 == cl1);
@@ -337,11 +339,13 @@ static void pack_unpack_check(const char *label, ompi_datatype_t *type)
             CHECK(false); /* allocation failure */
         } else {
             size_t qi = ci0, ql = cl0, qa = ca0, qd = cd0;
-            ompi_datatype_get_args(type, 1, &qi, i0, &ql, l0, &qa, a0, &qd, d0,
-                                   NULL);
+            CHECK(OMPI_SUCCESS
+                  == ompi_datatype_get_args(type, 1, &qi, i0, &ql, l0, &qa, a0,
+                                            &qd, d0, NULL));
             qi = ci1; ql = cl1; qa = ca1; qd = cd1;
-            ompi_datatype_get_args(rebuilt, 1, &qi, i1, &ql, l1, &qa, a1, &qd,
-                                   d1, NULL);
+            CHECK(OMPI_SUCCESS
+                  == ompi_datatype_get_args(rebuilt, 1, &qi, i1, &ql, l1, &qa,
+                                            a1, &qd, d1, NULL));
 
             for (size_t k = 0; k < ci0; ++k) {
                 CHECK(i0[k] == i1[k]);

--- a/test/datatype/opal_datatype_bigcount.c
+++ b/test/datatype/opal_datatype_bigcount.c
@@ -1,0 +1,219 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * OPAL-layer "big count" datatype tests.
+ *
+ * This is a singleton test (no MPI_Init, OPAL library only) that
+ * exercises the parts of the big-count datatype support that live in
+ * OPAL:
+ *
+ *   1. The count/displacement type-punning helpers in
+ *      opal/util/count_disp_array.h.  An opal_count_array_t aliases
+ *      either an int[] (32 bits per element) or a size_t[] (64 bits
+ *      per element); the disp variant aliases int[] or ptrdiff_t[].
+ *      These tests verify that values larger than INT_MAX survive a
+ *      store/read-back through the 64-bit-backed flavor, and that the
+ *      32-bit-backed flavor is reported correctly.
+ *
+ *   2. The OPAL datatype engine's 64-bit size/extent accounting: a
+ *      contiguous type whose element count exceeds INT_MAX must report
+ *      the correct (64-bit) size and extent rather than a truncated
+ *      32-bit value.
+ *
+ * These paths are not otherwise covered by the test/datatype suite.
+ */
+
+#include "opal_config.h"
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "opal/datatype/opal_datatype.h"
+#include "opal/runtime/opal.h"
+#include "opal/util/count_disp_array.h"
+
+static int failures = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,       \
+                    #cond);                                               \
+            ++failures;                                                   \
+        }                                                                 \
+    } while (0)
+
+/* True only where size_t is wide enough for the 64-bit count path to be
+ * meaningful (and therefore where opal_count_array_is_64bit() can be
+ * true).  On a 32-bit size_t platform big count is not supported, so the
+ * 64-bit-specific assertions are skipped. */
+static bool have_64bit_counts(void)
+{
+    return 8 == sizeof(size_t);
+}
+
+static void test_count_array_punning(void)
+{
+    /* 32-bit-backed: int[] with values up to INT_MAX. */
+    int idata[3] = {0, 7, INT_MAX};
+    opal_count_array_t ia = OPAL_COUNT_ARRAY_CREATE(idata);
+
+    CHECK(!opal_count_array_is_64bit(ia));
+    CHECK(sizeof(int) == opal_count_array_sizeof(ia));
+    CHECK((size_t) 0 == opal_count_array_get(ia, 0));
+    CHECK((size_t) 7 == opal_count_array_get(ia, 1));
+    CHECK((size_t) INT_MAX == opal_count_array_get(ia, 2));
+
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipping 64-bit count assertions)\n");
+        return;
+    }
+
+    /* 64-bit-backed: size_t[] holding values above INT_MAX.  This is the
+     * heart of big count: the value must round-trip undamaged. */
+    size_t big1 = (size_t) INT_MAX + 1;
+    size_t big2 = (size_t) INT_MAX * 4 + 123;
+    size_t sdata[3] = {1, big1, big2};
+    opal_count_array_t sa = OPAL_COUNT_ARRAY_CREATE(sdata);
+
+    CHECK(opal_count_array_is_64bit(sa));
+    CHECK(sizeof(size_t) == opal_count_array_sizeof(sa));
+    CHECK((size_t) 1 == opal_count_array_get(sa, 0));
+    CHECK(big1 == opal_count_array_get(sa, 1));
+    CHECK(big2 == opal_count_array_get(sa, 2));
+
+    /* Write-back of an above-INT_MAX value. */
+    size_t big3 = (size_t) INT_MAX * 7 + 5;
+    opal_count_array_set(sa, 0, big3);
+    CHECK(big3 == opal_count_array_get(sa, 0));
+    /* Untouched neighbors stay intact. */
+    CHECK(big1 == opal_count_array_get(sa, 1));
+    CHECK(big2 == opal_count_array_get(sa, 2));
+}
+
+static void test_disp_array_punning(void)
+{
+    /* 32-bit-backed: int[] displacements. */
+    int idata[2] = {-3, INT_MAX};
+    opal_disp_array_t ia = OPAL_DISP_ARRAY_CREATE(idata);
+
+    CHECK(!opal_disp_array_is_64bit(ia));
+    CHECK(sizeof(int) == opal_disp_array_sizeof(ia));
+    CHECK((ptrdiff_t) -3 == opal_disp_array_get(ia, 0));
+    CHECK((ptrdiff_t) INT_MAX == opal_disp_array_get(ia, 1));
+
+    if (!have_64bit_counts()) {
+        return;
+    }
+
+    /* 64-bit-backed: ptrdiff_t[] displacements above INT_MAX, including a
+     * large negative one. */
+    ptrdiff_t big_pos = (ptrdiff_t) INT_MAX * 5 + 9;
+    ptrdiff_t big_neg = -((ptrdiff_t) INT_MAX * 5 + 9);
+    ptrdiff_t pdata[2] = {big_pos, big_neg};
+    opal_disp_array_t pa = OPAL_DISP_ARRAY_CREATE(pdata);
+
+    CHECK(opal_disp_array_is_64bit(pa));
+    CHECK(sizeof(ptrdiff_t) == opal_disp_array_sizeof(pa));
+    CHECK(big_pos == opal_disp_array_get(pa, 0));
+    CHECK(big_neg == opal_disp_array_get(pa, 1));
+
+    /* Write-back of a large negative displacement; neighbor stays intact. */
+    ptrdiff_t big3 = -((ptrdiff_t) INT_MAX * 7 + 5);
+    opal_disp_array_set(pa, 0, big3);
+    CHECK(big3 == opal_disp_array_get(pa, 0));
+    CHECK(big_neg == opal_disp_array_get(pa, 1));
+}
+
+static void test_engine_large_contiguous(void)
+{
+    /* The whole function builds types whose size/extent exceed INT_MAX, so it
+     * is only meaningful (and only well-defined) where size_t/ptrdiff_t are
+     * 64-bit.  Guard up front -- otherwise the very first contiguous below
+     * overflows ptrdiff_t on a 32-bit platform. */
+    if (!have_64bit_counts()) {
+        printf("  (32-bit size_t: skipped)\n");
+        return;
+    }
+
+    /* A contiguous run of (INT_MAX + 1000) single bytes: an int would
+     * overflow, so size/extent must be computed in 64 bits.  Note this
+     * only allocates O(1) datatype *metadata* -- no large buffer. */
+    size_t count = (size_t) INT_MAX + 1000;
+    opal_datatype_t *pdt = opal_datatype_create(2);
+    CHECK(NULL != pdt);
+    if (NULL == pdt) {
+        return;
+    }
+
+    int rc = opal_datatype_add(pdt, &opal_datatype_uint1, count, 0, 1);
+    CHECK(0 == rc);
+    opal_datatype_commit(pdt);
+
+    size_t size = 0;
+    opal_datatype_type_size(pdt, &size);
+    CHECK(count == size);
+
+    ptrdiff_t extent = 0;
+    opal_datatype_type_extent(pdt, &extent);
+    CHECK((ptrdiff_t) count == extent);
+
+    printf("  contiguous(%" PRIuPTR " x uint1): size=%" PRIuPTR
+           " extent=%td\n",
+           (uintptr_t) count, (uintptr_t) size, extent);
+
+    opal_datatype_destroy(&pdt);
+
+    /* Push past 4 GB to make truncation unmistakable. */
+    size_t bigger = (size_t) INT_MAX * 3; /* ~6.4 GB */
+    opal_datatype_t *pdt2 = opal_datatype_create(2);
+    CHECK(NULL != pdt2);
+    if (NULL == pdt2) {
+        return;
+    }
+    rc = opal_datatype_add(pdt2, &opal_datatype_uint1, bigger, 0, 1);
+    CHECK(0 == rc);
+    opal_datatype_commit(pdt2);
+    size = 0;
+    opal_datatype_type_size(pdt2, &size);
+    CHECK(bigger == size);
+    extent = 0;
+    opal_datatype_type_extent(pdt2, &extent);
+    CHECK((ptrdiff_t) bigger == extent);
+    opal_datatype_destroy(&pdt2);
+}
+
+int main(int argc, char *argv[])
+{
+    opal_init(&argc, &argv);
+
+    printf("--- opal_count_array punning ---\n");
+    test_count_array_punning();
+    printf("--- opal_disp_array punning ---\n");
+    test_disp_array_punning();
+    printf("--- opal datatype engine (size/extent > INT_MAX) ---\n");
+    test_engine_large_contiguous();
+
+    opal_finalize();
+
+    if (0 == failures) {
+        printf("SUCCESS: all OPAL big-count datatype checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "FAILURE: %d OPAL big-count datatype check(s) failed\n",
+            failures);
+    return 1;
+}


### PR DESCRIPTION
In response to the large changed in https://github.com/open-mpi/ompi/pull/13460, create a bunch of tests for formal DDT testing.

Specifically, this PR adds singleton `make check` tests for MPI big-count (> INT_MAX) datatype support at the OPAL, OMPI-internal, and public MPI layers (and also tests < INT_MAX sizes), and fixes three big-count bugs the tests uncovered. Each fix is its own commit; the tests are a fourth commit.

## Bug fixes

1. **`MPI_Type_create_resized_c` argument decoding.** lb/extent are
   `MPI_Count` in the large-count interface (MPI 5.0 sec 19.2), but were
   stored through the address array, so `MPI_Type_get_envelope_c` /
   `MPI_Type_get_contents_c` reported them in `num_addresses` instead of
   `num_large_counts`. The binding now stores them as large counts for the
   `_c` form (na=0, nlc=2) and keeps them as `MPI_Aint` displacements for the
   classic form (na=2).

2. **hindexed_block reconstruction over-allocation.**
   `__ompi_datatype_create_from_args` hardcoded the large-count length to 3
   (the count==1 case). For any other block count this reported the wrong
   envelope and wrote past the large-count array allocated in `set_args`.
   Fixed to `2 + count`.

3. **darray integer truncation.** `block()`/`cyclic()` held the global size
   and derived local/stride values in `int`, truncating gsizes > INT_MAX
   (yielding a type of size 0). Widened to `ptrdiff_t`, with overflow-safe
   ceiling division and 64-bit index/stride products.

## Tests

Three new programs (`opal_`/`ompi_`/`mpi_datatype_bigcount`) wired into
`make check`:

- **OPAL:** count/disp array type-punning and 64-bit engine size/extent.
- **OMPI internal:** set_args/get_args punning, match_size, and pack/unpack
  reconstruction of every big-count combiner (including a derived
  constituent and both resized forms).
- **Public MPI:** every derived constructor through both the classic
  (small-count) and `_c` (> INT_MAX) interfaces, asserting the full MPI 5.0
  sec 5.1.13 decode (combiner, ni/na/nlc/nd, and every returned value) plus
  size/lb/extent; `get_elements` (overflow and partial-element); the #14055
  over-read regression across multiple combiners; multi-process and
  block-cyclic darray; and that the classic decode of a `_c` big-count type
  errors cleanly rather than truncating.

Each constructor's size/extent is asserted (not just the decoded arguments),
which is what surfaced the darray truncation; the darray multi-process and
block-cyclic tests were verified to fail when the widening is reverted.

## Notes for reviewers

- **`mpi_datatype_bigcount` placement.** It is in `MPI_TESTS` (auto-run by
  `make check`) and is the only `test/datatype` program that calls
  `MPI_Init` (as a singleton). If a target `make check` environment cannot
  bring up a singleton runtime, it may belong in `MPI_CHECKS` instead -- at
  the cost of losing `_c`-binding coverage from `make check`. Flagging for a
  conscious decision.
- **Heterogeneous byte-swap reconstruction** (the `opal_swap_bytes8` path) is
  not exercised: the pack/unpack test forces remote==local. Covering it would
  require re-implementing the wire format in the test; it is better covered by
  a real heterogeneous run.
- The packed-description reconstruction trusts the wire-format counts for all
  combiners (pre-existing behavior); not changed here.

These changes affect the datatype construction/decode and serialization paths
used by one-sided, MPI-IO, and heterogeneous transfers, so they warrant a full
mpirun-based CI run in addition to the singleton `make check` coverage.

https://claude.ai/code/session_01Fq42stwkMLTExNFCPHVkYQ
