### PR TITLE
exscan: reject intercommunicators as per MPI standard

### DIFF
--- a/ompi/mpi/c/exscan.c.in
+++ b/ompi/mpi/c/exscan.c.in
@@ -62,8 +62,15 @@ PROTOTYPE ERROR_CLASS exscan(BUFFER sendbuf, BUFFER_OUT recvbuf, COUNT count,
                                           FUNC_NAME);
         }
 
-        /* Unrooted operation -- same checks for intracommunicators
-           and intercommunicators */
+        /* No intercommunicators allowed! (MPI does not define
+           MPI_EXSCAN on intercommunicators) */
+
+        else if (OMPI_COMM_IS_INTER(comm)) {
+          err = MPI_ERR_COMM;
+        }
+
+        /* Unrooted operation; checks for all ranks */
+
         else if (MPI_OP_NULL == op) {
             err = MPI_ERR_OP;
         } else if (!ompi_op_is_valid(op, datatype, &msg, FUNC_NAME)) {


### PR DESCRIPTION
The MPI standard does not define MPI_EXSCAN on intercommunicators, but Open MPI was not properly validating this. This change adds an explicit check to return MPI_ERR_COMM when an intercommunicator is passed to MPI_EXSCAN.

Fixes #14006