### PR TITLE
Update Intel Omni-Path branding to Cornelis Networks

### DIFF
--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -20,6 +20,7 @@
 #  Copyright (c) 2021     Triad National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+# Copyright (c) 2025      Cornelis Networks, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,10 +38,10 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
 
     AC_ARG_WITH([psm2],
                 [AS_HELP_STRING([--with-psm2(=DIR)],
-                    [Build PSM2 (Intel PSM2) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+                    [Build PSM2 (Cornelis PSM2) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     AC_ARG_WITH([psm2-libdir],
                 [AS_HELP_STRING([--with-psm2-libdir=DIR],
-                    [Search for PSM (Intel PSM2) libraries in DIR])])
+                    [Search for PSM (Cornelis PSM2) libraries in DIR])])
 
     AC_ARG_ENABLE([psm2-version-check],
                   [AS_HELP_STRING([--disable-psm2-version-check],
@@ -81,7 +82,7 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
 
     CPPFLAGS="${opal_psm2_CPPFLAGS_save}"
 
-    OPAL_SUMMARY_ADD([Transports], [Intel Omnipath (PSM2)], [], [${$1_SUMMARY}])
+    OPAL_SUMMARY_ADD([Transports], [Cornelis Omnipath (PSM2)], [], [${$1_SUMMARY}])
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],
           [$2],

--- a/docs/installing-open-mpi/configure-cli-options/networking.rst
+++ b/docs/installing-open-mpi/configure-cli-options/networking.rst
@@ -32,7 +32,7 @@ can be used with ``configure``:
   compiler/linker search paths.
 
   Libfabric is the support library for OpenFabrics Interfaces-based
-  network adapters, such as Cisco usNIC, Intel True Scale PSM, etc.
+  network adapters, such as Cisco usNIC, etc.
 
 * ``--with-libfabric-libdir=DIR``:
   Look in directory for the libfabric libraries.  By default, Open MPI
@@ -57,20 +57,6 @@ can be used with ``configure``:
 * ``--with-portals4-max-md-size=SIZE`` and
   ``--with-portals4-max-va-size=SIZE``:
   Set configuration values for Portals 4
-
-* ``--with-psm=<directory>``:
-  Specify the directory where the QLogic InfiniPath / Intel True Scale
-  PSM library and header files are located.  This option is generally
-  only necessary if the PSM headers and libraries are not in default
-  compiler/linker search paths.
-
-  PSM is the support library for QLogic InfiniPath and Intel True Scale
-  network adapters.
-
-* ``--with-psm-libdir=DIR``:
-  Look in directory for the PSM libraries.  By default, Open MPI will
-  look in ``DIR/lib`` and ``DIR/lib64``, which covers most cases.  This
-  option is only needed for special configurations.
 
 * ``--with-psm2=DIR``:
   Specify the directory where the Intel Omni-Path PSM2 library and

--- a/docs/installing-open-mpi/configure-cli-options/networking.rst
+++ b/docs/installing-open-mpi/configure-cli-options/networking.rst
@@ -59,12 +59,12 @@ can be used with ``configure``:
   Set configuration values for Portals 4
 
 * ``--with-psm2=DIR``:
-  Specify the directory where the Intel Omni-Path PSM2 library and
+  Specify the directory where the Cornelis Networks Omni-Path PSM2 library and
   header files are located.  This option is generally only necessary
   if the PSM2 headers and libraries are not in default compiler/linker
   search paths.
 
-  PSM is the support library for Intel Omni-Path network adapters.
+  PSM2 is the support library for Cornelis Networks Omni-Path network adapters.
 
 * ``--with-psm2-libdir=DIR``:
   Look in directory for the PSM2 libraries.  By default, Open MPI will

--- a/docs/release-notes/networks.rst
+++ b/docs/release-notes/networks.rst
@@ -23,7 +23,7 @@ There are multiple MPI network models available in this release:
   utilizing MTL ("Matching Transport Layer") plugins:
 
   * OpenFabrics Interfaces ("libfabric" tag matching)
-  * Intel Omni-Path PSM2 (version 11.2.173 or later)
+  * Cornelis Networks Omni-Path PSM2 (version 11.2.173 or later)
   * Portals 4
 
 * ``ucx`` uses the `Unified Communication X (UCX) communication

--- a/docs/release-notes/networks.rst
+++ b/docs/release-notes/networks.rst
@@ -24,7 +24,6 @@ There are multiple MPI network models available in this release:
 
   * OpenFabrics Interfaces ("libfabric" tag matching)
   * Intel Omni-Path PSM2 (version 11.2.173 or later)
-  * Intel True Scale PSM (QLogic InfiniPath)
   * Portals 4
 
 * ``ucx`` uses the `Unified Communication X (UCX) communication

--- a/ompi/mca/mtl/ofi/README.md
+++ b/ompi/mca/mtl/ofi/README.md
@@ -187,7 +187,7 @@ approach also favours only creating as many contexts as needed.
        Number of threads = Number of communicators = Number of contexts
 
      For example, when using PSM2 provider, the number of contexts is
-     dictated by the Intel Omni-Path HFI1 driver module.
+     dictated by the Cornelis Networks Omni-Path HFI1 driver module.
 
    * OPAL layer allows for multiple threads to enter progress
      simultaneously. To enable this feature, user needs to set MCA


### PR DESCRIPTION
Intel's Omni-Path business was acquired by Cornelis Networks. This PR updates references in the Open MPI documentation and configure scripts to reflect the current product branding.
Changes:
- Remove documentation for --with-psm / --with-psm-libdir configure options. The PSM MTL was removed from Open MPI in commit 0348d14ff3 ("PSM MTL is obsolete and should be removed"), so these entries are stale.
- Update --with-psm2 / --with-psm2-libdir help strings and the configure summary to reference Cornelis rather than Intel.
- Update references to "Intel Omni-Path PSM2" in the networking configure options doc and release notes to "Cornelis Networks Omni-Path PSM2".

This picks up work originally started in #12938.