### PR TITLE
Fix issue #14003: MPI_Parrived with null or inactive requests

### DIFF
--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -567,6 +567,13 @@ mca_part_persist_parrived(size_t min_part,
     int _flag = false;
     mca_part_persist_request_t *req = (mca_part_persist_request_t *)request;
 
+    // An inactive (never-started) precv request has no flags array yet.
+    // MPI-5.0 sec 4.2.2 (p.119): an inactive request is trivially arrived.
+    if(NULL == req->flags && OMPI_REQUEST_INACTIVE == request->req_state) {
+        *flag = 1;
+        return err;
+    }
+
     if(0 != req->flags) {
         _flag = 1;
         if(req->req_parts == req->real_parts) {

--- a/ompi/mpi/c/parrived.c.in
+++ b/ompi/mpi/c/parrived.c.in
@@ -45,7 +45,20 @@ PROTOTYPE ERROR_CLASS parrived(REQUEST request, INT partition, INT_OUT flag)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        // MPI-5.0 sec 4.2.2 (p.119): MPI_Parrived on a null or inactive
+        // request returns flag = true.  Handle these before the
+        // request-type check so MPI_REQUEST_NULL (req_type ==
+        // OMPI_REQUEST_NULL) and a never-started inactive partitioned
+        // receive request are not rejected with MPI_ERR_REQUEST.
+        if (NULL == request || MPI_REQUEST_NULL == request) {
+            *flag = 1;
+            return MPI_SUCCESS;
+        }
+        if (OMPI_REQUEST_INACTIVE == request->req_state) {
+            *flag = 1;
+            return MPI_SUCCESS;
+        }
+        if (OMPI_REQUEST_PART != request->req_type) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);


### PR DESCRIPTION
MPI-5.0 sec 4.2.2 (p.119) states that MPI_Parrived on a null or inactive request returns flag = true. This commit implements that behavior correctly.

Changes:
- In parrived.c.in: Check for NULL and MPI_REQUEST_NULL before the request type check, so these cases return flag = true instead of generating MPI_ERR_REQUEST
- In part_persist.h: Handle inactive (never-started) precv requests that have no flags array yet, returning flag = 1 as required by the MPI standard

This ensures compliance with the MPI-5.0 specification for partitioned communication operations.