### PR TITLE
btl/ofi: enable multi-rail - one module per NIC with disjoint per-process NIC slices

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -121,7 +121,7 @@ struct mca_btl_ofi_module_t {
     int num_contexts;
     mca_btl_ofi_context_t *contexts;
 
-    char *linux_device_name;
+    char *domain_name;
 
     /** whether the module has been fully initialized or not */
     bool initialized;

--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -51,7 +51,6 @@
 #include <rdma/fi_rma.h>
 
 BEGIN_C_DECLS
-#define MCA_BTL_OFI_MAX_MODULES  16
 #define MCA_BTL_OFI_NUM_CQE_READ 64
 
 #define MCA_BTL_OFI_DEFAULT_RD_NUM             10
@@ -122,6 +121,9 @@ struct mca_btl_ofi_module_t {
     mca_btl_ofi_context_t *contexts;
 
     char *domain_name;
+    int module_index;
+    void *ep_name;
+    size_t ep_namelen;
 
     /** whether the module has been fully initialized or not */
     bool initialized;
@@ -172,7 +174,8 @@ struct mca_btl_ofi_component_t {
     bool disable_hmem;
 
     /** All BTL OFI modules (1 per tl) */
-    mca_btl_ofi_module_t *modules[MCA_BTL_OFI_MAX_MODULES];
+    mca_btl_ofi_module_t **modules;
+    int modules_allocated;
 };
 typedef struct mca_btl_ofi_component_t mca_btl_ofi_component_t;
 

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -60,6 +60,12 @@ static char *ofi_progress_mode;
 static bool disable_sep;
 static int mca_btl_ofi_init_device(struct fi_info *info);
 
+/* qsort comparator for an array of domain name strings */
+static int domain_name_compare(const void *a, const void *b)
+{
+    return strcmp(*(const char *const *) a, *(const char *const *) b);
+}
+
 /* validate information returned from fi_getinfo().
  * return OPAL_ERROR if we dont have what we need. */
 static int validate_info(struct fi_info *info, uint64_t required_caps, char **include_list,
@@ -244,6 +250,8 @@ static int mca_btl_ofi_component_close(void)
 {
     int ret;
     ret = opal_common_ofi_close();
+    free(mca_btl_ofi_component.modules);
+    mca_btl_ofi_component.modules = NULL;
     /* If we don't sleep, sockets provider freaks out. Ummm this is a scary comment */
     sleep(1);
     return ret;
@@ -285,7 +293,8 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init(int *num_btl_modules,
         return NULL;
     }
 
-    struct fi_info *info, *info_list = NULL, *selected_info = NULL;
+    struct fi_info *info, *info_list = NULL;
+    const char **unique_domains = NULL;
     struct fi_info hints = {0};
     struct fi_ep_attr ep_attr = {0};
     struct fi_rx_attr rx_attr = {0};
@@ -447,38 +456,128 @@ no_hmem:
 
     info = info_list;
 
-    while (info) {
-        rc = validate_info(info, required_caps, include_list, exclude_list);
-        if (OPAL_SUCCESS == rc) {
-            /* Device passed sanity check, let's make a module.
-             *
-             * The initial fi_getinfo() call will return a list of providers
-             * available for this process. once a provider is selected from the
-             * list, we will cycle through the remaining list to identify NICs
-             * serviced by this provider, and try to pick one on the same NUMA
-             * node as this process. If there are no NICs on the same NUMA node,
-             * we pick one in a manner which allows all ranks to make balanced
-             * use of available NICs on the system.
-             *
-             * Most providers give a separate fi_info object for each NIC,
-             * however some may have multiple info objects with different
-             * attributes for the same NIC. The initial provider attributes
-             * are used to ensure that all NICs we return provide the same
-             * capabilities as the initial one.
-             */
-            selected_info = opal_common_ofi_select_provider(info, &opal_process_info);
-            rc = mca_btl_ofi_init_device(selected_info);
-            if (OPAL_SUCCESS == rc) {
-                info = selected_info;
+    /* Count unique NIC domains for the selected provider to determine how many
+     * modules this process should create. This avoids creating resources that
+     * will never be used. We match by both provider name and domain name to
+     * avoid double-counting entries that share a physical NIC but differ in
+     * provider variant (e.g., efa vs efa-direct) or attributes. */
+    int num_nics = 0;
+    const char *first_prov = NULL;
+    if (resource_count > 0) {
+        unique_domains = (const char **) calloc(resource_count, sizeof(const char *));
+    }
+    {
+        struct fi_info *tmp = info_list;
+        while (tmp && NULL != unique_domains) {
+            if (OPAL_SUCCESS == validate_info(tmp, required_caps, include_list, exclude_list)) {
+                const char *p = (NULL != tmp->fabric_attr) ? tmp->fabric_attr->prov_name : NULL;
+                const char *d = (NULL != tmp->domain_attr) ? tmp->domain_attr->name : NULL;
+                if (NULL == first_prov) first_prov = p;
+                if (NULL != first_prov && NULL != p && 0 == strcmp(first_prov, p) && NULL != d) {
+                    /* Only count unique domain names */
+                    bool dup = false;
+                    for (int i = 0; i < num_nics; i++) {
+                        if (0 == strcmp(unique_domains[i], d)) { dup = true; break; }
+                    }
+                    if (!dup) {
+                        unique_domains[num_nics] = d;
+                        num_nics++;
+                    }
+                }
+            }
+            tmp = tmp->next;
+        }
+    }
+    /* Sort the unique domain names so the list order is deterministic and
+     * identical on every process regardless of how the provider ordered
+     * its fi_getinfo() results. */
+    if (1 < num_nics) {
+        qsort(unique_domains, num_nics, sizeof(unique_domains[0]),
+              domain_name_compare);
+    }
+
+    /* Distribute NICs evenly across local processes */
+    int num_local_procs = (int)(opal_process_info.num_local_peers + 1);
+    int modules_per_proc = (num_nics > num_local_procs) ? (num_nics / num_local_procs) : 1;
+
+    /* Each local process takes a disjoint, contiguous slice of the sorted
+     * unique NIC (domain) list so that local processes do not collapse
+     * onto the same NICs. The list order is identical on all processes on
+     * a node, so slices are disjoint whenever there are at least as many
+     * NICs as local processes. */
+    int slice_start = 0;
+    if (0 < num_nics) {
+        slice_start = ((int) opal_process_info.my_local_rank * modules_per_proc) % num_nics;
+    }
+
+    /* Allocate the modules array dynamically based on actual need */
+    mca_btl_ofi_component.modules = (mca_btl_ofi_module_t **)
+        calloc(modules_per_proc, sizeof(mca_btl_ofi_module_t *));
+    if (NULL == mca_btl_ofi_component.modules) {
+        goto out;
+    }
+    mca_btl_ofi_component.modules_allocated = modules_per_proc;
+
+    /* Create one module per NIC (domain) in this process' slice of the
+     * unique-domain list. Pin to a single provider (the first valid one)
+     * so all modules share one address format. */
+    for (int mi = 0; mi < modules_per_proc && 0 < num_nics; mi++) {
+        const char *want = unique_domains[(slice_start + mi) % num_nics];
+        for (info = info_list; NULL != info; info = info->next) {
+            if (OPAL_SUCCESS != validate_info(info, required_caps, include_list, exclude_list)) {
+                continue;
+            }
+            const char *prov = (NULL != info->fabric_attr)
+                               ? info->fabric_attr->prov_name : NULL;
+            const char *d = (NULL != info->domain_attr) ? info->domain_attr->name : NULL;
+            if (NULL != first_prov && NULL != prov && NULL != d
+                && 0 == strcmp(first_prov, prov) && 0 == strcmp(want, d)) {
+                (void) mca_btl_ofi_init_device(info);
                 break;
             }
         }
-        info = info->next;
     }
 
-    if (NULL == info) {
+    if (0 == mca_btl_ofi_component.module_count) {
         BTL_VERBOSE(("No provider is selected"));
         goto out;
+    }
+
+    /* Publish all module endpoint names in a single modex blob so peers can
+     * pair modules by index. Layout: uint32 nmodules, then per module:
+     * uint32 namelen, namelen bytes. */
+    {
+        size_t total = sizeof(uint32_t);
+        for (int mi = 0; mi < mca_btl_ofi_component.module_count; mi++) {
+            total += sizeof(uint32_t) + mca_btl_ofi_component.modules[mi]->ep_namelen;
+        }
+        uint8_t *blob = (uint8_t *) malloc(total);
+        if (NULL == blob) {
+            BTL_ERROR(("failed to allocate modex blob"));
+            goto out;
+        }
+        uint8_t *p = blob;
+        uint32_t nm = (uint32_t) mca_btl_ofi_component.module_count;
+        memcpy(p, &nm, sizeof(uint32_t));
+        p += sizeof(uint32_t);
+        for (int mi = 0; mi < mca_btl_ofi_component.module_count; mi++) {
+            uint32_t nl = (uint32_t) mca_btl_ofi_component.modules[mi]->ep_namelen;
+            memcpy(p, &nl, sizeof(uint32_t));
+            p += sizeof(uint32_t);
+            memcpy(p, mca_btl_ofi_component.modules[mi]->ep_name, nl);
+            p += nl;
+        }
+        OPAL_MODEX_SEND(rc, PMIX_GLOBAL, &mca_btl_ofi_component.super.btl_version, blob, total);
+        free(blob);
+        if (OPAL_SUCCESS != rc) {
+            BTL_ERROR(("modex send failed"));
+            goto out;
+        }
+        /* ep_name copies no longer needed after packing into blob */
+        for (int mi = 0; mi < mca_btl_ofi_component.module_count; mi++) {
+            free(mca_btl_ofi_component.modules[mi]->ep_name);
+            mca_btl_ofi_component.modules[mi]->ep_name = NULL;
+        }
     }
 
     /* pass module array back to caller */
@@ -496,6 +595,7 @@ no_hmem:
     *num_btl_modules = mca_btl_ofi_component.module_count;
 
 out:
+    free(unique_domains);
     if (include_list) {
         opal_argv_free(include_list);
     }
@@ -724,12 +824,12 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         }
     }
 
-    /* post our endpoint name so peer can use it to connect to us */
-    OPAL_MODEX_SEND(rc, PMIX_GLOBAL, &mca_btl_ofi_component.super.btl_version, ep_name, namelen);
-    mca_btl_ofi_component.namelen = namelen;
-    free(ep_name);
+    /* Save endpoint name on the module; modex send happens after all modules are created */
+    module->ep_name = ep_name;
+    module->ep_namelen = namelen;
 
     /* add this module to the list */
+    module->module_index = *module_count;
     mca_btl_ofi_component.modules[(*module_count)++] = module;
 
     return OPAL_SUCCESS;

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -516,7 +516,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     size_t namelen;
     size_t num_contexts_to_create;
 
-    char *domain_name;
+    char *domain_name = NULL;
     void *ep_name = NULL;
 
     struct fi_info *ofi_info;
@@ -564,7 +564,11 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
                      fi_strerror(-rc)));
     }
 
-    domain_name = info->domain_attr->name;
+    domain_name = strdup(info->domain_attr->name);
+    if (NULL == domain_name) {
+        BTL_ERROR(("failed to duplicate domain name"));
+        goto fail;
+    }
     BTL_VERBOSE(
         ("initializing dev:%s provider:%s", domain_name, info->fabric_attr->prov_name));
 
@@ -765,6 +769,7 @@ fail:
     if (NULL != fabric) {
         opal_common_ofi_fabric_release(fabric);
     }
+    free(domain_name);
     free(module);
 
     if (NULL != ep_name) {

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -516,7 +516,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     size_t namelen;
     size_t num_contexts_to_create;
 
-    char *linux_device_name;
+    char *domain_name;
     void *ep_name = NULL;
 
     struct fi_info *ofi_info;
@@ -564,21 +564,21 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
                      fi_strerror(-rc)));
     }
 
-    linux_device_name = info->domain_attr->name;
+    domain_name = info->domain_attr->name;
     BTL_VERBOSE(
-        ("initializing dev:%s provider:%s", linux_device_name, info->fabric_attr->prov_name));
+        ("initializing dev:%s provider:%s", domain_name, info->fabric_attr->prov_name));
 
     /* fabric */
     rc = opal_common_ofi_fi_fabric(ofi_info->fabric_attr, &fabric);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_fabric with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_fabric with err=%s", domain_name, fi_strerror(-rc)));
         goto fail;
     }
 
     /* domain */
     rc = opal_common_ofi_fi_domain(fabric, ofi_info, &domain);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_domain with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_domain with err=%s", domain_name, fi_strerror(-rc)));
         goto fail;
     }
 
@@ -591,7 +591,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     av_attr.type = FI_AV_MAP;
     rc = fi_av_open(domain, &av_attr, &av, NULL);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_av_open with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_av_open with err=%s", domain_name, fi_strerror(-rc)));
         goto fail;
     }
 
@@ -616,7 +616,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         rc = fi_scalable_ep(domain, ofi_info, &ep, NULL);
         if (0 != rc) {
             BTL_VERBOSE(
-                ("%s failed fi_scalable_ep with err=%s", linux_device_name, fi_strerror(-rc)));
+                ("%s failed fi_scalable_ep with err=%s", domain_name, fi_strerror(-rc)));
             goto fail;
         }
 
@@ -639,7 +639,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
 
         rc = fi_endpoint(domain, ofi_info, &ep, NULL);
         if (0 != rc) {
-            BTL_VERBOSE(("%s failed fi_endpoint with err=%s", linux_device_name, fi_strerror(-rc)));
+            BTL_VERBOSE(("%s failed fi_endpoint with err=%s", domain_name, fi_strerror(-rc)));
             goto fail;
         }
 
@@ -658,7 +658,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     /* enable the endpoint for using */
     rc = fi_enable(ep);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_enable with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_enable with err=%s", domain_name, fi_strerror(-rc)));
         goto fail;
     }
 
@@ -669,7 +669,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     module->domain = domain;
     module->av = av;
     module->ofi_endpoint = ep;
-    module->linux_device_name = linux_device_name;
+    module->domain_name = domain_name;
     module->outstanding_rdma = 0;
     module->use_virt_addr = false;
     module->use_fi_mr_bind = false;
@@ -704,7 +704,7 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
                                      &ep_name,
                                      &namelen);
     if (OPAL_SUCCESS != rc) {
-        BTL_VERBOSE(("%s failed opal_common_ofi_fi_getname  with err=%d", linux_device_name, rc));
+        BTL_VERBOSE(("%s failed opal_common_ofi_fi_getname  with err=%d", domain_name, rc));
         goto fail;
     }
 

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -595,6 +595,20 @@ no_hmem:
     *num_btl_modules = mca_btl_ofi_component.module_count;
 
 out:
+    if (NULL == base_modules) {
+        /* Initialization failed after some modules may already have been
+         * created: finalize them so we do not leak libfabric resources. */
+        for (int mi = 0; mi < mca_btl_ofi_component.module_count; mi++) {
+            if (NULL != mca_btl_ofi_component.modules[mi]) {
+                (void) mca_btl_ofi_finalize(
+                    (mca_btl_base_module_t *) mca_btl_ofi_component.modules[mi]);
+            }
+        }
+        mca_btl_ofi_component.module_count = 0;
+        free(mca_btl_ofi_component.modules);
+        mca_btl_ofi_component.modules = NULL;
+        mca_btl_ofi_component.modules_allocated = 0;
+    }
     free(unique_domains);
     if (include_list) {
         opal_argv_free(include_list);

--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -67,7 +67,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_normal(struct fi_info *info,
 {
     int rc;
     uint32_t cq_flags = FI_TRANSMIT | FI_SEND | FI_RECV;
-    char *linux_device_name = info->domain_attr->name;
+    char *domain_name = info->domain_attr->name;
 
     struct fi_cq_attr cq_attr = {0};
 
@@ -82,8 +82,8 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_normal(struct fi_info *info,
     /* Don't really need to check, just avoiding compiler warning because
      * BTL_VERBOSE is a no op in performance build and the compiler will
      * complain about unused variable. */
-    if (NULL == linux_device_name) {
-        BTL_VERBOSE(("linux device name is NULL. This shouldn't happen."));
+    if (NULL == domain_name) {
+        BTL_VERBOSE(("domain name is NULL. This shouldn't happen."));
         goto single_fail;
     }
 
@@ -91,20 +91,20 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_normal(struct fi_info *info,
     cq_attr.wait_obj = FI_WAIT_NONE;
     rc = fi_cq_open(domain, &cq_attr, &context->cq, NULL);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_cq_open with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_cq_open with err=%s", domain_name, fi_strerror(-rc)));
         goto single_fail;
     }
 
     rc = fi_ep_bind(ep, (fid_t) av, 0);
     if (0 != rc) {
-        BTL_VERBOSE(("%s failed fi_ep_bind with err=%s", linux_device_name, fi_strerror(-rc)));
+        BTL_VERBOSE(("%s failed fi_ep_bind with err=%s", domain_name, fi_strerror(-rc)));
         goto single_fail;
     }
 
     rc = fi_ep_bind(ep, (fid_t) context->cq, cq_flags);
     if (0 != rc) {
         BTL_VERBOSE(
-            ("%s failed fi_scalable_ep_bind with err=%s", linux_device_name, fi_strerror(-rc)));
+            ("%s failed fi_scalable_ep_bind with err=%s", domain_name, fi_strerror(-rc)));
         goto single_fail;
     }
 
@@ -141,7 +141,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
 
     int rc;
     size_t i;
-    char *linux_device_name = info->domain_attr->name;
+    char *domain_name = info->domain_attr->name;
 
     struct fi_cq_attr cq_attr = {0};
     struct fi_tx_attr tx_attr = {0};
@@ -159,8 +159,8 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
     /* Don't really need to check, just avoiding compiler warning because
      * BTL_VERBOSE is a no op in performance build and the compiler will
      * complain about unused variable. */
-    if (NULL == linux_device_name) {
-        BTL_VERBOSE(("linux device name is NULL. This shouldn't happen."));
+    if (NULL == domain_name) {
+        BTL_VERBOSE(("domain name is NULL. This shouldn't happen."));
         goto scalable_fail;
     }
 
@@ -168,7 +168,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
     rc = fi_scalable_ep_bind(sep, (fid_t) av, 0);
     if (0 != rc) {
         BTL_VERBOSE(
-            ("%s failed fi_scalable_ep_bind with err=%s", linux_device_name, fi_strerror(-rc)));
+            ("%s failed fi_scalable_ep_bind with err=%s", domain_name, fi_strerror(-rc)));
         goto scalable_fail;
     }
 
@@ -176,7 +176,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
         rc = fi_tx_context(sep, i, &tx_attr, &contexts[i].tx_ctx, NULL);
         if (0 != rc) {
             BTL_VERBOSE(
-                ("%s failed fi_tx_context with err=%s", linux_device_name, fi_strerror(-rc)));
+                ("%s failed fi_tx_context with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 
@@ -186,7 +186,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
         rc = fi_rx_context(sep, i, &rx_attr, &contexts[i].rx_ctx, NULL);
         if (0 != rc) {
             BTL_VERBOSE(
-                ("%s failed fi_rx_context with err=%s", linux_device_name, fi_strerror(-rc)));
+                ("%s failed fi_rx_context with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 
@@ -195,14 +195,14 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
         cq_attr.wait_obj = FI_WAIT_NONE;
         rc = fi_cq_open(domain, &cq_attr, &contexts[i].cq, NULL);
         if (0 != rc) {
-            BTL_VERBOSE(("%s failed fi_cq_open with err=%s", linux_device_name, fi_strerror(-rc)));
+            BTL_VERBOSE(("%s failed fi_cq_open with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 
         /* bind cq to transmit context */
         rc = fi_ep_bind(contexts[i].tx_ctx, (fid_t) contexts[i].cq, FI_TRANSMIT);
         if (0 != rc) {
-            BTL_VERBOSE(("%s failed fi_ep_bind with err=%s", linux_device_name, fi_strerror(-rc)));
+            BTL_VERBOSE(("%s failed fi_ep_bind with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 
@@ -211,7 +211,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
             rc = fi_ep_bind(contexts[i].rx_ctx, (fid_t) contexts[i].cq, FI_RECV);
             if (0 != rc) {
                 BTL_VERBOSE(
-                    ("%s failed fi_ep_bind with err=%s", linux_device_name, fi_strerror(-rc)));
+                    ("%s failed fi_ep_bind with err=%s", domain_name, fi_strerror(-rc)));
                 goto scalable_fail;
             }
         }
@@ -219,13 +219,13 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
         /* enable the context. */
         rc = fi_enable(contexts[i].tx_ctx);
         if (0 != rc) {
-            BTL_VERBOSE(("%s failed fi_enable with err=%s", linux_device_name, fi_strerror(-rc)));
+            BTL_VERBOSE(("%s failed fi_enable with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 
         rc = fi_enable(contexts[i].rx_ctx);
         if (0 != rc) {
-            BTL_VERBOSE(("%s failed fi_enable with err=%s", linux_device_name, fi_strerror(-rc)));
+            BTL_VERBOSE(("%s failed fi_enable with err=%s", domain_name, fi_strerror(-rc)));
             goto scalable_fail;
         }
 

--- a/opal/mca/btl/ofi/btl_ofi_context.c
+++ b/opal/mca/btl/ofi/btl_ofi_context.c
@@ -16,7 +16,7 @@
 #include "btl_ofi_rdma.h"
 
 #if OPAL_HAVE_THREAD_LOCAL
-static opal_thread_local mca_btl_ofi_context_t *my_context = NULL;
+static opal_thread_local int64_t my_ctx_idx = -1;
 #endif /* OPAL_HAVE_THREAD_LOCAL */
 
 static int init_context_freelists(mca_btl_ofi_context_t *context)
@@ -117,7 +117,6 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_normal(struct fi_info *info,
     context->rx_ctx = ep;
     context->context_id = 0;
     context->btl = btl;
-    my_context = NULL;
 
     return context;
 
@@ -287,20 +286,17 @@ void mca_btl_ofi_context_finalize(mca_btl_ofi_context_t *context, bool scalable_
 mca_btl_ofi_context_t *get_ofi_context(mca_btl_ofi_module_t *btl)
 {
 #if OPAL_HAVE_THREAD_LOCAL
-    /* With TLS, we cache the context we use. */
-    static volatile int64_t cur_num = 0;
+    /* With TLS, we cache a per-thread context slot index and always index
+     * into the requested module's own contexts array. Caching the context
+     * pointer itself would pin every module's traffic to whichever module
+     * was used first. */
+    static opal_atomic_int64_t cur_num = 0;
 
-    if (OPAL_UNLIKELY(my_context == NULL)) {
-        OPAL_THREAD_LOCK(&btl->module_lock);
-
-        my_context = &btl->contexts[cur_num];
-        cur_num = (cur_num + 1) % btl->num_contexts;
-
-        OPAL_THREAD_UNLOCK(&btl->module_lock);
+    if (OPAL_UNLIKELY(my_ctx_idx < 0)) {
+        my_ctx_idx = opal_atomic_fetch_add_64(&cur_num, 1);
     }
 
-    assert(my_context);
-    return my_context;
+    return &btl->contexts[my_ctx_idx % btl->num_contexts];
 #else
     return get_ofi_context_rr(btl);
 #endif

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -171,7 +171,7 @@ void mca_btl_ofi_rcache_init(mca_btl_ofi_module_t *module)
                                 fi_strerror(-ret));
         }
 
-        (void) opal_asprintf(&tmp, "ofi.%s", module->linux_device_name);
+        (void) opal_asprintf(&tmp, "ofi.%s", module->domain_name);
 
         rcache_resources.cache_name = tmp;
         rcache_resources.reg_data = (void *) module;

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -46,7 +46,7 @@ static int mca_btl_ofi_add_procs(mca_btl_base_module_t *btl, size_t nprocs,
                                  opal_bitmap_t *reachable)
 {
     int rc;
-    int count;
+    int count = 0;
     char *ep_name = NULL;
     size_t namelen = mca_btl_ofi_component.namelen;
 
@@ -89,20 +89,43 @@ static int mca_btl_ofi_add_procs(mca_btl_base_module_t *btl, size_t nprocs,
             MCA_BTL_OFI_ABORT();
         }
 
-        /* get peer fi_addr */
-        count = fi_av_insert(ofi_btl->av,          /* Address vector to insert */
-                             ep_name,              /* peer name */
-                             1,                    /* amount to insert */
-                             &peers[i]->peer_addr, /* return peer address here */
-                             0,                    /* flags */
-                             NULL);                /* context */
+        /* The modex blob is packed as: uint32 nmodules, then per module:
+         * uint32 namelen, namelen bytes. Insert only this module's paired peer
+         * (by module_index) into the AV. */
+        {
+            uint8_t *p = (uint8_t *) ep_name;
+            uint32_t nm = 0;
+            memcpy(&nm, p, sizeof(uint32_t));
+            p += sizeof(uint32_t);
+
+            if (0 == nm) {
+                free(ep_name);
+                BTL_VERBOSE(("peer published 0 modules"));
+                MCA_BTL_OFI_ABORT();
+            }
+
+            int target = ofi_btl->module_index % (int) nm;
+            fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+
+            for (int k = 0; k <= target && k < (int) nm; k++) {
+                uint32_t nl = 0;
+                memcpy(&nl, p, sizeof(uint32_t));
+                p += sizeof(uint32_t);
+                if (k == target) {
+                    count = fi_av_insert(ofi_btl->av, p, 1, &peer_addr, 0, NULL);
+                }
+                p += nl;
+            }
+            peers[i]->peer_addr = peer_addr;
+        }
+        free(ep_name);
 
         /* if succeed, add this proc and mark reachable */
-        if (count == 1) { /* we inserted 1 address. */
+        if (peers[i]->peer_addr != FI_ADDR_NOTAVAIL && count == 1) {
             opal_list_append(&ofi_btl->endpoints, &peers[i]->super);
             opal_bitmap_set_bit(reachable, i);
         } else {
-            BTL_VERBOSE(("fi_av_insert failed with rc = %d", count));
+            BTL_VERBOSE(("fi_av_insert failed for module %d", ofi_btl->module_index));
             MCA_BTL_OFI_ABORT();
         }
     }
@@ -419,6 +442,7 @@ int mca_btl_ofi_finalize(mca_btl_base_module_t *btl)
     OBJ_DESTRUCT(&ofi_btl->module_lock);
 
     free(ofi_btl->domain_name);
+    free(ofi_btl->ep_name);
     free(btl);
 
     return OPAL_SUCCESS;

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -418,6 +418,7 @@ int mca_btl_ofi_finalize(mca_btl_base_module_t *btl)
     OBJ_DESTRUCT(&ofi_btl->id_to_endpoint);
     OBJ_DESTRUCT(&ofi_btl->module_lock);
 
+    free(ofi_btl->domain_name);
     free(btl);
 
     return OPAL_SUCCESS;


### PR DESCRIPTION
Description

  The btl/ofi component created exactly one module (one NIC) per process regardless of how many NICs the system exposes, so the ob1 PML could not stripe a rank's traffic across NICs. On multi-NIC instances (e.g. AWS p5en: 16 NICs at ~25 GB/s each) a rank was limited to a single NIC of bandwidth.

  This series creates one module per NIC domain, with each local process taking a disjoint slice of the NIC list so processes stripe over disjoint NIC sets.

  Commits:

  1. rename linux_device_name to domain_name - mechanical rename; the field holds the OFI domain name, which is not Linux-specific.
  2. copy the domain name into the module - the field pointed into a transient fi_info; strdup it and free it on the fail and finalize paths.
  3. do not cache the selected context pointer per thread - the TLS cache pinned every module's operations to whichever module was used first; cache a per-thread slot index instead and always index into the requested module's own contexts array.
  4. create one module per NIC in the process' slice of the NIC list - modules_per_proc = max(1, num_nics / num_local_procs), computed automatically. The NIC count is the number of unique domain names for the selected provider, deduplicated so provider variants that expose the same physical NIC (e.g. efa and efa-direct) are not double-counted, and sorted so the list order is deterministic and identical on every process regardless of provider enumeration order. Each local process opens the slice starting at my_local_rank * modules_per_proc, so local processes use disjoint NIC sets. Endpoint names of all modules are published in one packed modex blob; each module inserts its index-paired peer module into its address vector. The fixed-size MCA_BTL_OFI_MAX_MODULES array is replaced by a dynamically sized one.
  5. finalize created modules when component init fails - failure paths after module creation no longer leak libfabric resources (fabrics, domains, endpoints, contexts).

  Validation ( 2-node p5en cluster)

  Active-NIC counts are from per-NIC hardware tx_bytes counters snapshotted around each run.

  Two-sided (ob1, --mca btl ofi,self --mca btl_ofi_mode 2), aggregate bandwidth:

  │          Config          │    before    │      after       │ active NICs │
  │ osu_bw, 1 rank/node      │ 24.0 GB/s    │ 162.6 GB/s       │ 1 -> 16      │
  │ osu_mbw_mr, 4 ranks/node │ —            │ 202.5 GB/s       │ 16          │
  │ osu_mbw_mr, 8 ranks/node │ 24 GB/s/rank │ 165.6–212.5 GB/s │ 16          │