### PR TITLE
Add missing .gitignore entry for mpi_t_category_get_events test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,6 +311,8 @@ opal/tools/wrappers/opal.pc
 opal/util/show_help_content.c
 opal/util/keyval/keyval_lex.c
 
+test/mpi/t/mpi_t_category_get_events
+
 test/monitoring/aggregate_profile.pl
 test/monitoring/profile2mat.pl
 


### PR DESCRIPTION
The mpi_t_category_get_events test program was added but its compiled binary was never added to .gitignore, so it showed up as an untracked file after building the test suite.

The test was introduced in 925609dbbc ("MPI_T: validate cat_index in category event queries").