### PR TITLE
config: require the Fortran default INTEGER to be at least as large as a C int

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -255,6 +255,19 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     # MPI_Status struct contains 4 C ints and a size_t.
     OMPI_FORTRAN_STATUS_SIZE=0
 
+    # The C-to-Fortran MPI_Status conversion (and other code that passes
+    # MPI values through Fortran default INTEGERs) copies C ints into
+    # INTEGER slots one-for-one.  If the Fortran default INTEGER is
+    # narrower than a C int, the public MPI_Status fields (and other
+    # values) would be silently truncated.  Refuse to build in that case
+    # rather than produce a broken Fortran MPI.  Skip the check when we
+    # are not building any Fortran bindings (e.g., --disable-mpi-fortran,
+    # or no usable Fortran compiler), in which case
+    # OMPI_SIZEOF_FORTRAN_INTEGER is 0.
+    AS_IF([test "$OMPI_SIZEOF_FORTRAN_INTEGER" -gt 0 && \
+           test "$OMPI_SIZEOF_FORTRAN_INTEGER" -lt "$ac_cv_sizeof_int"],
+          [AC_MSG_ERROR([the Fortran default INTEGER ($OMPI_SIZEOF_FORTRAN_INTEGER bytes) is smaller than a C int ($ac_cv_sizeof_int bytes).  Open MPI requires the Fortran default INTEGER to be at least as large as a C int; otherwise values such as the public MPI_Status fields would be truncated when converted between C and Fortran.  Reconfigure with a larger Fortran default INTEGER, or build with --disable-mpi-fortran.])])
+
     # Calculate how many C int's can fit in sizeof(MPI_Status).  Yes,
     # I do mean C ints -- not Fortran INTEGERS.  The reason is because
     # an mpif.h MPI_Status is an array of INTEGERS.  But these

--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -136,8 +136,9 @@
  *          -> *ret will equal 7.
  *
  * 5. Fortran MPI-1 reads the attribute value.  The C int value is
- *    cast to a fortran INTEGER (i.e., MPI_Fint) -- potentially being
- *    truncated if sizeof(int) > sizeof(INTEGER).
+ *    cast to a fortran INTEGER (i.e., MPI_Fint).  configure requires
+ *    sizeof(INTEGER) >= sizeof(int) (see OMPI_SETUP_MPI_FORTRAN), so
+ *    this conversion is always exact.
  *
  * Example: INTEGER ret
  *          CALL MPI_ATTR_GET(..., ret, ierr)


### PR DESCRIPTION
While reviewing the MPI Standard ABI work in #13280 (specifically @bosilca's questions about the C/Fortran `MPI_Status` conversion), we noticed a long-standing, pre-existing gap that is independent of the ABI work and applies to `main` on its own.

### Problem

Open MPI converts a C `MPI_Status` to/from its Fortran (`mpif.h`) form by copying the C `int` words of the struct **one-for-one** into the array of Fortran default `INTEGER`s, and `MPI_STATUS_SIZE` is computed in units of C `int`. The same one-int-per-INTEGER pattern appears elsewhere (e.g. attribute values).

This is fine when `sizeof(INTEGER) >= sizeof(int)`:
- equal sizes → the copy is exact;
- larger INTEGER (e.g. `-i8`) → each `int` is widened into a wider slot.

But when the Fortran default `INTEGER` is **narrower** than a C `int`, the public `MPI_Status` fields (`MPI_SOURCE`/`MPI_TAG`/`MPI_ERROR`) are silently truncated and the Fortran status array is too small to hold the C struct. In practice such a build is unusable far beyond `MPI_Status` — MPI handles, ranks, tags, and counts are all passed through Fortran `INTEGER`s and could not hold their values either.

### Fix

Add a `configure`-time check that stops with a clear error when `sizeof(INTEGER) < sizeof(int)`, rather than building a subtly-broken Fortran MPI. This also updates the `ompi/attribute/attribute.c` comment that documented the now-impossible case.

- No effect on the usual `sizeof(INTEGER) == sizeof(int)` case.
- C-only builds (`--disable-mpi-fortran`) never reach the check.

### Testing (macOS)

- A normal Fortran build (`INTEGER` = 4, `int` = 4) still configures cleanly.
- Temporarily forcing the condition to trigger produces the expected hard error:
  > configure: error: the Fortran default INTEGER (4 bytes) is smaller than a C int (4 bytes). Open MPI requires the Fortran default INTEGER to be at least as large as a C int; ... Reconfigure with a larger Fortran default INTEGER, or build with `--disable-mpi-fortran`.