### PR TITLE
Make "make check" pass in an uninstalled --enable-mca-dso tree

### DIFF
--- a/test/Makefile.mca-dso-check
+++ b/test/Makefile.mca-dso-check
@@ -1,0 +1,93 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Shared Automake fragment for "make check" unit tests that initialize
+# OPAL (via opal_init() / opal_init_util()) or MPI (via MPI_Init(),
+# which additionally pulls in OMPI-level frameworks such as pml).
+#
+# When Open MPI is configured with --enable-mca-dso, MCA components are
+# built as standalone DSOs that are dlopen'ed at run time.  In an
+# installed tree they live in $libdir/openmpi; but "make check" runs
+# before "make install", so at test time they are scattered through the
+# build tree under libtool ".libs" directories.  Two things are needed
+# to make such tests work in an uninstalled --enable-mca-dso tree:
+#
+# 1. Point the Open MPI and PMIx MCA component search paths at the
+#    build-tree ".libs" directories that hold the freshly-built
+#    component DSOs, so opal_init() / MPI_Init() can find them.  A
+#    single Open MPI MCA search path (opal_mca_base_component_path)
+#    serves all of the Open MPI layers, so it lists the ".libs" dirs
+#    under opal/mca, ompi/mca, and oshmem/mca -- not just opal/mca.  The
+#    corresponding PMIx parameter uses PMIx's own "PMIX_MCA_" prefix and
+#    is named mca_base_component_path (no "opal_").  These are computed
+#    at test-run time (shell backquotes), not at Makefile-parse time,
+#    because the DSOs do not exist until the "all" prerequisite of "make
+#    check" has completed.
+#
+#    The PMIx search path is only set when Open MPI was built against its
+#    internal (bundled) PMIx (OPAL_USING_INTERNAL_PMIX); with an external
+#    PMIx there are no PMIx component DSOs to find under 3rd-party, and a
+#    stale internal-PMIx build left over in the tree must not be pointed
+#    at by a run that actually links the external PMIx library.
+#
+# 2. Make each component DSO's own load-time dependencies resolvable.
+#    Some components link against an "mca_common" shared library shared
+#    by a family of sibling components (e.g. io/ompio, fcoll/*, fbtl/*,
+#    and sharedfp/* all depend on libmca_common_ompio).  Those common
+#    libraries live under <project>/mca/common/<name>/.libs, which is
+#    NOT on the runtime library search path baked into the libtool test
+#    wrapper scripts: the wrapper only lists <project>/.libs (home of
+#    libopen-pal / libmpi / liboshmem).  On macOS this cannot be worked
+#    around via DYLD_LIBRARY_PATH in AM_TESTS_ENVIRONMENT, because
+#    System Integrity Protection strips DYLD_* when the /bin/sh wrapper
+#    is exec'ed.  So, before the tests run, symlink each project's
+#    mca_common shared libraries into that project's own .libs
+#    directory, which the wrapper already searches.
+#
+# Both mechanisms are harmless for a static (non-DSO) build: the symlink
+# step finds nothing to link, and although the component-search-path
+# variables may still be exported (libtool creates ".libs" dirs for
+# static convenience libraries too), they point at directories with no
+# loadable components, so nothing is dlopen'ed.  They are likewise
+# harmless for tests that never open a framework.  The symlinks live in
+# build-tree ".libs" directories and are removed automatically by
+# libtool's "clean-libtool" rule (rm -rf .libs).
+#
+# Note: the env var prefix really is "OMPI_MCA_" even for OPAL-level
+# parameters (OPAL_MCA_PREFIX == "OMPI_MCA_"); the full parameter name
+# is opal_mca_base_component_path.
+#
+# NOTE: this fragment defines an "all-local" rule.  Automake forbids two
+# definitions of the same *-local target in one Makefile.am, so a
+# Makefile.am that includes this fragment must NOT define its own
+# "all-local"; instead, add prerequisites to the mca-common-dso-symlinks
+# target below.
+
+AM_TESTS_ENVIRONMENT = \
+	ompi_mca_path="`find $(abs_top_builddir)/opal/mca $(abs_top_builddir)/ompi/mca $(abs_top_builddir)/oshmem/mca -type d -name .libs 2>/dev/null | sort | tr '\n' ':'`"; \
+	if test -n "$$ompi_mca_path"; then OMPI_MCA_opal_mca_base_component_path="$$ompi_mca_path"; export OMPI_MCA_opal_mca_base_component_path; fi; \
+	if test "@OPAL_USING_INTERNAL_PMIX@" = "1"; then \
+	  pmix_mca_path="`find $(abs_top_builddir)/3rd-party/openpmix/src/mca -type d -name .libs 2>/dev/null | sort | tr '\n' ':'`"; \
+	  if test -n "$$pmix_mca_path"; then PMIX_MCA_mca_base_component_path="$$pmix_mca_path"; export PMIX_MCA_mca_base_component_path; fi; \
+	fi;
+
+# See item 2 above.  Symlink each project's mca_common DSOs into that
+# project's own .libs directory (which the libtool wrappers already put
+# on the runtime library search path) so dlopen'ed components can
+# resolve their load-time dependencies.  Created "if missing" so
+# concurrent invocations (parallel "make check") never leave a symlink
+# transiently absent.
+all-local: mca-common-dso-symlinks
+.PHONY: mca-common-dso-symlinks
+mca-common-dso-symlinks:
+	$(AM_V_at)for proj in opal ompi oshmem; do \
+	  libs="$(abs_top_builddir)/$$proj/.libs"; test -d "$$libs" || continue; \
+	  find "$(abs_top_builddir)/$$proj/mca/common" \( -name 'lib*mca_common_*.dylib' -o -name 'lib*mca_common_*.so' -o -name 'lib*mca_common_*.so.*' \) 2>/dev/null | \
+	  while read lib; do base=`basename "$$lib"`; test -e "$$libs/$$base" || ln -s "$$lib" "$$libs/$$base" 2>/dev/null || true; done; \
+	done

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -14,6 +14,9 @@
 # $HEADER$
 #
 
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/test/Makefile.mca-dso-check
+
 if PROJECT_OMPI
     MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data partial ompi_datatype_bigcount mpi_datatype_bigcount
     MPI_CHECKS = to_self reduce_local

--- a/test/mpi/file/Makefile.am
+++ b/test/mpi/file/Makefile.am
@@ -13,6 +13,10 @@
 # launcher and can run as part of 'make check'.  They exercise the OMPIO
 # MPI_Info hint reporting required by MPI-5.0 sec. 15.2.8 (Open MPI issue
 # #13367).
+
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/test/Makefile.mca-dso-check
+
 if PROJECT_OMPI
     check_PROGRAMS = \
         file_info_defaults \

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -23,6 +23,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/support
 
 AM_LDFLAGS = -lpthread
 
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/test/Makefile.mca-dso-check
+
 check_PROGRAMS = \
 	opal_thread \
 	opal_condition \


### PR DESCRIPTION
### What

Make `make check` succeed in an uninstalled `--enable-mca-dso` build tree.

### Why

With `--enable-mca-dso`, MCA components are built as standalone DSOs that
are `dlopen`'ed at run time from the install tree (`$libdir/openmpi`).
But `make check` runs before `make install`, so at test time those DSOs
exist only in the build tree under libtool `.libs` directories.  Tests
that call `opal_init()` / `MPI_Init()` therefore fail — for example,
`opal_init()` aborts in `opal_shmem_base_select()` because no shmem
component can be loaded.

In an uninstalled DSO build this currently breaks:

- `test/threads/opal_condition`
- `test/datatype/mpi_datatype_bigcount`
- all of `test/mpi/file/*`

### How

A shared Automake fragment, `test/Makefile.mca-dso-check`, `include`d by
the affected test directories, fixes this in two ways:

1. Point the Open MPI and PMIx MCA component search paths at the
   build-tree `.libs` directories holding the freshly-built component
   DSOs (computed at test-run time), so `opal_init()` / `MPI_Init()` can
   find them.  The exports are guarded so an empty result never clobbers
   a default search path (e.g. an external PMIx).

2. Symlink each project's `mca_common` shared libraries into that
   project's own `.libs` directory.  Some component DSOs carry a
   load-time dependency on an `mca_common` library shared by a family of
   sibling components (e.g. `io/ompio`, `fcoll/*`, `fbtl/*`, and
   `sharedfp/*` all depend on `libmca_common_ompio`).  Those common
   libraries live under `<project>/mca/common/<name>/.libs`, which is not
   on the runtime library search path baked into the libtool test
   wrapper scripts — the wrapper only lists `<project>/.libs`.  On macOS
   this cannot be worked around via `DYLD_LIBRARY_PATH` in
   `AM_TESTS_ENVIRONMENT`, because System Integrity Protection strips
   `DYLD_*` when the `/bin/sh` wrapper is exec'ed; symlinking into
   `<project>/.libs`, which the wrapper already searches, works on both
   macOS and Linux.

Both mechanisms are harmless for a static (non-DSO) build, and the
symlinks live in build-tree `.libs` directories that are removed
automatically by libtool's existing `clean-libtool` rule.

### Testing

Verified on macOS:

- `make check` in an uninstalled `--enable-mca-dso` tree — all test
  directories pass.
- `make distcheck` with `--enable-mca-dso` — succeeds (clean-room VPATH
  build → `make check` → install → distclean leftover-file check all
  pass, confirming the symlinks are cleaned up and do not break
  `distcheck`).
- `make check` in a static (non-DSO) build — all test directories pass;
  the fragment is a no-op there (no symlinks created, component-path
  exports harmless).
