### PR TITLE
v5.0.x: contrib/platform/mellanox: drop deprecated mpirun-prefix-by-default

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -1,6 +1,10 @@
 enable_mca_no_build=coll-ml,btl-uct
 enable_debug_symbols=yes
-enable_mpirun_prefix_by_default=yes
+# orterun/mpirun-prefix-by-default is deprecated and intentionally not replaced
+# by enable_prte_prefix_by_default here: platform variables are sourced into the
+# top-level configure and do not reach the PRRTE sub-configure, while leaving
+# the variable unset makes ompi_setup_prrte.m4 pass
+# --enable-prte-prefix-by-default to PRRTE on its own.
 with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes


### PR DESCRIPTION
v5.0.x cherry-pick of #14127 (currently open against main), adapted to this branch: here the platform file sets the `mpirun` spelling of the option (`enable_mpirun_prefix_by_default`), which hits the same deprecation path.

The mellanox platform file still sets the deprecated option, so every build with `--with-platform=contrib/platform/mellanox/optimized` gets the "ORTE has been replaced by PRRTE" deprecation warning from configure.

The line is dropped rather than renamed because platform variables are sourced, not forwarded to the PRRTE sub-configure: with the variable unset, configure already passes `--enable-prte-prefix-by-default` to PRRTE on its own, while a renamed variable would suppress that and silently turn prefix-by-default off. Full analysis and testing in Mellanox/ompi#43.