### PR TITLE
docs: tell agents to gitignore new build products

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,16 @@ and [`docs/contributing.rst`](docs/contributing.rst):
   style — match the surrounding code.
 - **Stay compiler-warning-free.** Open MPI strives to build with zero
   compiler warnings. Do not introduce code that adds new warnings.
+- **Ignore new build products; never commit them.** If your change makes
+  the build emit something new — a test binary, a generated source or
+  header, a wrapper data file — add it to the top-level
+  [`.gitignore`](.gitignore), in the block for its directory, matching
+  the surrounding path style (repo-root-relative, no leading slash).
+  Open MPI keeps essentially all ignores in that one file; per-directory
+  `.gitignore` files are a rare exception, so don't create one. After a
+  clean build, `git status` must be clean — an untracked generated file
+  means you missed an entry, and committing the artifact itself is never
+  the fix.
 
 ## Generated code: edit the source, not the output
 


### PR DESCRIPTION
AI coding agents that add a new test binary, generated source, or wrapper data file frequently leave the resulting build product as an untracked file — or, worse, commit the artifact itself. This adds a golden rule in `AGENTS.md` directing them to the top-level `.gitignore` instead.

Adapted from openpmix/openpmix#3942. That PR's wording points contributors at a "per-directory `.gitignore` convention," which is **not** how Open MPI works: we keep essentially all ignore patterns in the single repo-root `.gitignore`, grouped into blocks by directory (`ompi/mca/mtl/ofi/.gitignore` is the lone exception). The rule here says so explicitly, because an agent that has internalized the per-directory convention from other projects will otherwise create a new `.gitignore` next to the file it just added.

Also states the check as something an agent can actually run: after a clean build, `git status` must be clean.

Docs-only change; no build impact.