### PR TITLE
MPI Extensions doc updates

### DIFF
--- a/docs/features/extension-affinity.rst
+++ b/docs/features/extension-affinity.rst
@@ -1,0 +1,49 @@
+.. _ompi-features-extension-affinity-label:
+
+Affinity extension
+==================
+
+Overview
+--------
+
+The ``affinity`` extension provides a single Open MPI-specific
+function, :ref:`OMPI_Affinity_str(3) <ompi_affinity_str>`.  Given a
+format selector, it fills in three human-readable strings describing:
+
+* where Open MPI bound the calling process at launch time (or that it
+  was not bound);
+* where the process is *currently* bound (or that it is unbound); and
+* which processors exist on the local host.
+
+The strings can be requested either as resource descriptions (for
+example, ``socket 0, core 0``) or as an ASCII-art layout of the
+machine (for example, ``[. B][. .]``).  This is an Open
+MPI-specific convenience API for applications that want to introspect
+their own binding; it is not part of the MPI standard.
+
+When it is built
+----------------
+
+The ``affinity`` extension has no build-time prerequisites, so it is
+built by default on every platform.  Like all extensions, it can be
+excluded by configuring with ``--disable-mpi-ext``, or by naming an
+explicit list that omits it (for example,
+``--enable-mpi-ext=cuda,rocm``).  See :ref:`the extensions overview
+<ompi-features-extensions-label>` for the full set of
+``--enable-mpi-ext`` / ``--disable-mpi-ext`` options.
+
+Availability at run time
+------------------------
+
+Because the extension has no external dependencies, it is available at
+run time whenever it was compiled in.  Applications should still guard
+their use of it with the preprocessor macro
+``OMPI_HAVE_MPI_EXT_AFFINITY``, which ``<mpi-ext.h>`` defines to ``1``
+when the extension is present.  This keeps application code portable
+across Open MPI builds that omitted the extension and across other MPI
+implementations.
+
+Functions
+---------
+
+* :ref:`OMPI_Affinity_str(3) <ompi_affinity_str>`

--- a/docs/features/extension-example.rst
+++ b/docs/features/extension-example.rst
@@ -1,0 +1,50 @@
+.. _ompi-features-extension-example-label:
+
+Example extension
+=================
+
+Overview
+--------
+
+The ``example`` extension is **non-functional**: it exists solely as a
+worked template for developers who want to create a new Open MPI
+extension.  It defines a demonstration API named ``OMPI_Progress()`` in
+all four MPI binding types (C, the Fortran ``mpif.h`` bindings, the
+Fortran ``mpi`` module, and the Fortran ``mpi_f08`` module), showing
+how each piece is wired into the publicly-available ``mpi-ext.h`` header
+and the ``mpi_ext`` / ``mpi_f08_ext`` Fortran modules.
+
+It is not intended for use by applications.  Anyone writing a real
+extension should read the heavily-commented source and the
+``README.md`` in the source tree
+(``ompi/mpiext/example/README.md``), which walk through the required
+directory layout, file naming, and ``configure.m4`` conventions.
+
+When it is built
+----------------
+
+Unlike the other extensions, ``example`` is not built as part of a
+normal build.  Because it is a developer template, it is only compiled
+when it is explicitly requested at configure time:
+
+.. code-block:: sh
+
+   shell$ ./configure --enable-mpi-ext=example <other configure params>
+
+See :ref:`the extensions overview <ompi-features-extensions-label>` for
+the full ``--enable-mpi-ext`` syntax.
+
+Availability at run time
+------------------------
+
+When the extension is compiled in, ``<mpi-ext.h>`` defines the
+preprocessor macro ``OMPI_HAVE_MPI_EXT_EXAMPLE`` to ``1``.  Since the
+extension is a demonstration only, applications have no reason to depend
+on it; it is documented here for completeness because it appears in the
+list of available extensions.
+
+Functions
+---------
+
+This extension provides only a demonstration ``OMPI_Progress()`` entry
+point and has no manual pages.

--- a/docs/features/extension-shortfloat.rst
+++ b/docs/features/extension-shortfloat.rst
@@ -1,0 +1,57 @@
+.. _ompi-features-extension-shortfloat-label:
+
+Short float extension
+=====================
+
+Overview
+--------
+
+The ``shortfloat`` extension provides MPI datatypes corresponding to
+short / half-precision floating point language types.  Depending on
+which types the compiler supports, it defines some or all of:
+
+* ``MPIX_C_FLOAT16`` |mdash| for the C type ``_Float16`` (ISO/IEC TS
+  18661-3:2015).  This name and meaning match MPICH.
+* ``MPIX_SHORT_FLOAT`` |mdash| for the C/C++ type ``short float``.
+* ``MPIX_C_SHORT_FLOAT_COMPLEX`` |mdash| for the C type ``short float
+  _Complex``.
+* ``MPIX_CXX_SHORT_FLOAT_COMPLEX`` |mdash| for the C++ type
+  ``std::complex<short float>``.
+
+These datatypes were proposed for (but not accepted into) the MPI
+standard, so they carry the ``MPIX_`` prefix.  See the extension's
+``README.md`` in the source tree
+(``ompi/mpiext/shortfloat/README.md``) and `MPI Forum issue 65
+<https://github.com/mpi-forum/mpi-issues/issues/65>`_ for background.
+
+Because this extension only adds datatype handles (constants), it does
+not provide any functions, and therefore has no manual pages.
+
+When it is built
+----------------
+
+The ``shortfloat`` extension is built by default, but *only* when the
+compiler provides a suitable short / half-precision floating point
+type.  Specifically, Open MPI's ``configure`` builds it when either:
+
+* the compiler natively supports a ``short float`` type; or
+* Open MPI can provide an equivalent 16-bit type (``opal_short_float_t``,
+  typically mapped to ``_Float16``).
+
+If neither is available, the extension is silently omitted |mdash| there
+is no dedicated configure option to force it on, since it depends
+entirely on compiler support.  As with all extensions, it can be
+excluded explicitly with ``--disable-mpi-ext`` or by omitting it from
+an explicit ``--enable-mpi-ext=LIST``.  See :ref:`the extensions
+overview <ompi-features-extensions-label>` for details.
+
+Availability at run time
+------------------------
+
+When the extension is compiled in, ``<mpi-ext.h>`` defines the
+preprocessor macro ``OMPI_HAVE_MPI_EXT_SHORTFLOAT`` to ``1``.
+Applications should test this macro before using any of the ``MPIX_``
+datatypes above, both because the extension may have been omitted (if
+the compiler lacked a short float type) and to remain portable to other
+MPI implementations.  Note that the individual datatype handles that are
+defined depend on which language types were available at build time.

--- a/docs/features/extensions.rst
+++ b/docs/features/extensions.rst
@@ -20,37 +20,74 @@ to MPI applications.
 Available extensions
 --------------------
 
-The following extensions are included in this version of Open MPI:
+The following extensions are included in this version of Open MPI.
+Follow the link on each name for a full description of what it
+provides, when it is built, when it is available at run time, and the
+functions it offers:
 
-#. ``shortfloat``: Provides MPI datatypes ``MPIX_C_FLOAT16``,
-   ``MPIX_SHORT_FLOAT``, ``MPIX_SHORT_FLOAT``, and
-   ``MPIX_CXX_SHORT_FLOAT_COMPLEX`` if corresponding language types are
-   available. See ``ompi/mpiext/shortfloat/README.txt`` for details.
-#. ``affinity``: Provides the ``OMPI_Affinity_str()`` API, which returns
-   a string indicating the resources which a process is bound. For
-   more details, see its man page.
-#. ``cuda``: When the library is compiled with CUDA-aware support, it
-   provides two things.  First, a macro
-   ``MPIX_CUDA_AWARE_SUPPORT``. Secondly, the function
-   ``MPIX_Query_cuda_support()`` that can be used to query for support.
-#. ``example``: A non-functional extension; its only purpose is to
-   provide an example for how to create other extensions.
-#. ``ftmpi``: An implementation of the User Level Fault Mitigation
-   (ULFM) proposal.  :ref:`See its documentation section <ulfm-label>`
-   for more details.
+* :doc:`affinity </features/extension-affinity>`: Provides the
+  ``OMPI_Affinity_str()`` API, which returns human-readable strings
+  describing how the calling process is bound to processor resources.
+
+* :doc:`cuda </tuning-apps/accelerators/cuda>`: Provides the
+  ``MPIX_CUDA_AWARE_SUPPORT`` compile-time macro and the
+  ``MPIX_Query_cuda_support()`` run-time function for detecting whether
+  the library has NVIDIA CUDA-aware support.
+
+* :doc:`rocm </tuning-apps/accelerators/rocm>`: Provides the
+  ``MPIX_ROCM_AWARE_SUPPORT`` compile-time macro and the
+  ``MPIX_Query_rocm_support()`` run-time function for detecting whether
+  the library has AMD ROCm-aware support.
+
+* :doc:`ftmpi </features/ulfm>`: An implementation of the MPI Forum's
+  User-Level Failure Mitigation (ULFM) proposal, providing the
+  ``MPIX_Comm_*`` functions and ``MPIX_ERR_*`` error codes for writing
+  fault-tolerant MPI applications.
+
+* :doc:`shortfloat </features/extension-shortfloat>`: Provides MPI
+  datatypes corresponding to short / half-precision floating point C
+  and C++ language types, when such types are available.
+
+* :doc:`example </features/extension-example>`: A non-functional
+  extension whose only purpose is to demonstrate how to create a new
+  Open MPI extension.
+
+.. toctree::
+   :hidden:
+
+   extension-affinity
+   extension-shortfloat
+   extension-example
 
 Compiling the extensions
 ------------------------
 
-Open MPI extensions are all enabled by default; they can be disabled
-via the ``--disable-mpi-ext`` command line switch.
+Most Open MPI extensions are enabled by default; the exceptions are
+extensions that require functionality not present in your build
+environment (for example, ``shortfloat`` is only built when the
+compiler provides a suitable short / half-precision floating point
+type) and the developer-only ``example`` extension (which is only
+built when explicitly requested).
 
-Since extensions are meant to be used by advanced users only, this
-file does not document which extensions are available or what they do.
-Look in the ``ompi/mpiext`` directory in a distribution Open MPI
-tarball to see the extensions; each subdirectory of that directory
-contains an extension.  Each has a ``README`` file that describes what
-it does.
+The set of extensions to build is selected at configure time:
+
+* ``--enable-mpi-ext`` (the default) builds all available extensions.
+* ``--enable-mpi-ext=LIST`` builds only the comma-separated extensions
+  named in ``LIST`` |mdash| for example,
+  ``--enable-mpi-ext=cuda,rocm``.
+* ``--disable-mpi-ext`` builds none of the extensions.
+
+Each extension's own page (linked above) documents any additional
+build-time prerequisites and the configure options needed to satisfy
+them.
+
+You can confirm which extensions were compiled into a given Open MPI
+installation with ``ompi_info``:
+
+.. code-block:: sh
+
+   shell$ ompi_info | grep "MPI extensions"
+          MPI extensions: affinity, cuda, ftmpi, rocm
 
 Using the extensions
 --------------------
@@ -75,7 +112,7 @@ prototypes, constant declarations, etc.  For example:
        char exists[OMPI_AFFINITY_STRING_MAX];
 
        OMPI_Affinity_str(OMPI_AFFINITY_LAYOUT_FMT, ompi_bound,
-                         current_bindings, exists);
+                         current_binding, exists);
    #endif
 
        MPI_Finalize();
@@ -84,6 +121,15 @@ prototypes, constant declarations, etc.  For example:
 
 Notice that the Open MPI-specific code is surrounded by the ``#if``
 statement to ensure that it is only ever compiled by Open MPI.
+
+Including ``<mpi-ext.h>`` defines the preprocessor macro
+``OMPI_HAVE_MPI_EXT`` to ``1``.  In addition, for each extension that
+is present, it defines a macro named ``OMPI_HAVE_MPI_EXT_<NAME>`` (with
+``<NAME>`` being the uppercased extension name, e.g.,
+``OMPI_HAVE_MPI_EXT_AFFINITY``) to ``1``.  Applications can test these
+macros to portably guard their use of a given extension |mdash| both
+against Open MPI builds that omitted the extension and against other
+MPI implementations that do not provide ``<mpi-ext.h>`` at all.
 
 The Open MPI wrapper compilers (``mpicc`` and friends) should
 automatically insert all relevant compiler and linker flags necessary

--- a/docs/tuning-apps/accelerators/cuda.rst
+++ b/docs/tuning-apps/accelerators/cuda.rst
@@ -1,265 +1,353 @@
 CUDA
 ====
 
-.. error:: TODO This section needs to be converted from FAQ Q&A style
-           to regular documentation style.
-
-How do I build Open MPI with CUDA-aware support?
-------------------------------------------------
-
 CUDA-aware support means that the MPI library can send and receive GPU
-buffers directly.  CUDA support is being continuously updated so
-different levels of support exist in different versions.  We recommend
-you use the latest version of Open MPI for best support.
+buffers directly, without the application first staging them into host
+memory.  Open MPI automatically detects that a buffer passed to an MPI
+routine is a CUDA device pointer and handles it appropriately; this
+detection relies on CUDA's Unified Virtual Addressing (UVA), which lets
+the library determine whether a given pointer refers to device or host
+memory.
 
-Open MPI offers two flavors of CUDA support:
+CUDA support is updated continuously, and different levels of support
+exist in different versions, so we recommend using the latest release
+of Open MPI for the best support.  Open MPI offers two flavors of CUDA
+support, described below; you may build with either or both.
 
-#. Via `UCX <https://openucx.org/>`_.
+Building Open MPI with CUDA-aware support
+-----------------------------------------
 
-   This is the preferred mechanism.  Since UCX will be providing the
-   CUDA support, it is important to ensure that UCX itself is built
-   with CUDA support.
-
-   To see if your ucx was built with CUDA support run the following
-   command:
-
-   .. code-block:: sh
-
-      # Check if ucx was built with CUDA support
-      shell$ ucx_info -v
-
-      # configured with: --build=powerpc64le-redhat-linux-gnu --host=powerpc64le-redhat-linux-gnu --program-prefix= --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 --libexecdir=/usr/libexec --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man --infodir=/usr/share/info --disable-optimizations --disable-logging --disable-debug --disable-assertions --enable-mt --disable-params-check --enable-cma --without-cuda --without-gdrcopy --with-verbs --with-cm --with-knem --with-rdmacm --without-rocm --without-xpmem --without-java
-
-   If you need to build ucx yourself to include CUDA support, please
-   see the UCX documentation for `building ucx with Open MPI: <https://openucx.readthedocs.io/en/master/running.html#openmpi-with-ucx>`_
-
-   It should look something like:
-
-   .. code-block:: sh
-
-      # Configure UCX this way
-      shell$ ./configure --prefix=/path/to/ucx-cuda-install --with-cuda=/usr/local/cuda --with-gdrcopy=/usr
-
-      # Configure Open MPI this way
-      shell$ ./configure --with-cuda=/usr/local/cuda --with-ucx=/path/to/ucx-cuda-install <other configure params>
-
-#. Via internal Open MPI CUDA support
-
-Regardless of which flavor of CUDA support (or both) you plan to use,
-Open MPI should be configured using the ``--with-cuda=<path-to-cuda>``
-configure option to build CUDA support into Open MPI. The configure
-script will automatically search the path given for ``libcuda.so``. If it cannot
-be found, please also pass ``--with-cuda-libdir``. For example:
-``--with-cuda=<path-to-cuda> --with-cuda-libdir=/usr/local/cuda/lib64/stubs``.
-
-Open MPI supports building with CUDA libraries and running on systems
-without CUDA libraries or hardware.
-
-For releases v5.0.2 and newer no special steps are required to get this behavior.
-
-In order to realize this behavior for the v5.0.0 and v5.0.1 releases,
-when configuring Open MPI, you have to specify the CUDA dependent components to be built as DSOs using the
-``--enable-mca-dso=<comma-delimited-list-of-cuda-components.``
-configure option.
-
-This affects the ``smcuda`` shared memory and ``uct`` BTLs, as well
-as the ``rgpusm`` and ``gpusm`` rcache components.
-
-An example configure command would look like the following:
-
-   .. code-block:: sh
-
-      # Configure Open MPI this way
-      shell$ ./configure --with-cuda=/usr/local/cuda \
-             --enable-mca-dso=btl-smcuda,rcache-rgpusm,rcache-gpusm,accelerator-cuda <other configure params>
-
-/////////////////////////////////////////////////////////////////////////
-
-How do I verify that Open MPI has been built with CUDA support?
----------------------------------------------------------------
-
-Verify that Open MPI has been built with cuda using ``ompi_info``
-with one of the following commands.
+Regardless of which flavor of CUDA support you plan to use, configure
+Open MPI with the ``--with-cuda=<path-to-cuda>`` option to build in
+CUDA support.  The configure script searches the given path for
+``libcuda.so``; if it cannot be found, also pass
+``--with-cuda-libdir``, for example:
 
 .. code-block:: sh
 
-   # Use ompi_info to verify cuda support in Open MPI
+   shell$ ./configure --with-cuda=/usr/local/cuda \
+          --with-cuda-libdir=/usr/local/cuda/lib64/stubs <other configure params>
+
+Support via UCX
+^^^^^^^^^^^^^^^
+
+Using `UCX <https://openucx.org/>`_ is the preferred mechanism.  Since
+UCX provides the CUDA support in this configuration, it is important
+that UCX itself is built with CUDA support.  To check whether your UCX
+was built with CUDA support, run:
+
+.. code-block:: sh
+
+   shell$ ucx_info -v
+
+and look for ``--with-cuda`` in the reported configure line.  If you
+need to build UCX yourself to include CUDA support, see the UCX
+documentation for `building UCX with Open MPI
+<https://openucx.readthedocs.io/en/master/running.html#openmpi-with-ucx>`_.
+A typical build looks like:
+
+.. code-block:: sh
+
+   # Configure UCX with CUDA support
+   shell$ ./configure --prefix=/path/to/ucx-cuda-install \
+          --with-cuda=/usr/local/cuda --with-gdrcopy=/usr
+
+   # Configure Open MPI to use that UCX
+   shell$ ./configure --with-cuda=/usr/local/cuda \
+          --with-ucx=/path/to/ucx-cuda-install <other configure params>
+
+Internal Open MPI CUDA support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open MPI also provides its own internal CUDA support, used by the
+CUDA-ized components such as the ``smcuda`` shared-memory BTL.  This is
+enabled by the same ``--with-cuda`` option.
+
+Running on hosts without CUDA
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open MPI supports building with CUDA libraries and then running on
+systems that have neither CUDA libraries nor CUDA hardware.  For
+releases v5.0.2 and newer, no special steps are required.
+
+For the v5.0.0 and v5.0.1 releases only, you must build the
+CUDA-dependent components as DSOs to get this behavior, using the
+``--enable-mca-dso`` option.  This affects the ``smcuda`` shared-memory
+and ``uct`` BTLs, as well as the ``rgpusm`` and ``gpusm`` rcache
+components:
+
+.. code-block:: sh
+
+   shell$ ./configure --with-cuda=/usr/local/cuda \
+          --enable-mca-dso=btl-smcuda,rcache-rgpusm,rcache-gpusm,accelerator-cuda \
+          <other configure params>
+
+Building with the NVIDIA compilers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With CUDA 6.5 and later, CUDA-aware Open MPI builds with the NVIDIA
+compilers without anything special.  With CUDA 7.0 and 7.5, some
+additional compiler flags are required:
+
+.. code-block:: sh
+
+   # For NVIDIA compilers version 15.9 and later
+   shell$ ./configure --with-wrapper-cflags=-ta:tesla
+
+   # For earlier NVIDIA compiler versions
+   shell$ ./configure CFLAGS=-D__LP64__ \
+          --with-wrapper-cflags="-D__LP64__ -ta:tesla"
+
+Verifying that CUDA support was built
+-------------------------------------
+
+Use :ref:`ompi_info(1) <man1-ompi_info>` to confirm that a given Open
+MPI installation was built with CUDA support:
+
+.. code-block:: sh
+
+   # List the MPI extensions that were built
    shell$ ompi_info | grep "MPI extensions"
-          MPI extensions: affinity, cuda, pcollreq
+          MPI extensions: affinity, cuda, ftmpi, rocm
+
+   # Query the CUDA support MCA parameter directly
    shell$ ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
           mca:mpi:base:param:mpi_built_with_cuda_support:value:true
 
-/////////////////////////////////////////////////////////////////////////
+Detecting CUDA-aware support at compile and run time
+----------------------------------------------------
 
-How do I run Open MPI with applications that pass CUDA buffers to MPI?
-----------------------------------------------------------------------
+The ``cuda`` MPI extension provides both a compile-time and a run-time
+check, and you can use whichever is more convenient.  Both require
+including the Open MPI-specific header ``<mpi-ext.h>``:
 
-Open MPI will detect and enable CUDA enabled components at runtime with
-no additional mpirun parameters.
+* The compile-time check is the ``MPIX_CUDA_AWARE_SUPPORT`` macro.
+* The run-time check is the :ref:`MPIX_Query_cuda_support(3)
+  <mpix_query_cuda_support>` function.
 
-/////////////////////////////////////////////////////////////////////////
+The extension is built by default, whether or not Open MPI itself was
+built with CUDA-aware support; when support is absent, the run-time
+check simply returns ``0``.  The following program illustrates both
+checks:
 
-How do I build Open MPI with CUDA-aware support using PGI?
-----------------------------------------------------------
+.. code-block:: c
 
-With CUDA 6.5, you can build all versions of CUDA-aware Open MPI
-without doing anything special.  However, with CUDA 7.0 and CUDA 7.5,
-you need to pass in some specific compiler flags for things to work
-correctly.  Add the following to your configure line.
+   /*
+    * Program that shows the use of the CUDA-aware macro and run-time check.
+    */
+   #include <stdio.h>
+   #include "mpi.h"
+
+   #if !defined(OPEN_MPI) || !OPEN_MPI
+   #error This source code uses an Open MPI-specific extension
+   #endif
+
+   /* Needed for MPIX_Query_cuda_support(), below */
+   #include "mpi-ext.h"
+
+   int main(int argc, char *argv[])
+   {
+       MPI_Init(&argc, &argv);
+
+       printf("Compile time check:\n");
+   #if defined(MPIX_CUDA_AWARE_SUPPORT) && MPIX_CUDA_AWARE_SUPPORT
+       printf("This MPI library has CUDA-aware support.\n");
+   #elif defined(MPIX_CUDA_AWARE_SUPPORT) && !MPIX_CUDA_AWARE_SUPPORT
+       printf("This MPI library does not have CUDA-aware support.\n");
+   #else
+       printf("This MPI library cannot determine if there is CUDA-aware support.\n");
+   #endif /* MPIX_CUDA_AWARE_SUPPORT */
+
+       printf("Run time check:\n");
+   #if defined(MPIX_CUDA_AWARE_SUPPORT)
+       if (1 == MPIX_Query_cuda_support()) {
+           printf("This MPI library has CUDA-aware support.\n");
+       } else {
+           printf("This MPI library does not have CUDA-aware support.\n");
+       }
+   #else /* !defined(MPIX_CUDA_AWARE_SUPPORT) */
+       printf("This MPI library cannot determine if there is CUDA-aware support.\n");
+   #endif /* MPIX_CUDA_AWARE_SUPPORT */
+
+       MPI_Finalize();
+       return 0;
+   }
+
+Running applications that pass CUDA buffers
+-------------------------------------------
+
+Open MPI detects and enables its CUDA-capable components at run time
+with no additional ``mpirun`` parameters; an application may simply pass
+CUDA device buffers to MPI routines.  CUDA-aware support is available
+in the following transports:
+
+* The UCX (``ucx``) PML.
+* The PSM2 (``psm2``) MTL with the CM (``cm``) PML.
+* The OFI (``ofi``) MTL with the CM (``cm``) PML.
+* The CUDA-ized shared-memory (``smcuda``) and TCP (``tcp``) BTLs with
+  the OB1 (``ob1``) PML.
+
+Both contiguous and non-contiguous derived datatypes are supported.
+Non-contiguous datatypes currently carry high overhead, however,
+because copying the pieces of the buffer into an intermediate buffer
+requires many separate device-to-device copies.
+
+.. _faq-cuda-mpi-apis-cuda-label:
+
+CUDA-aware MPI APIs
+-------------------
+
+The following MPI operations accept CUDA device buffers:
+
+* ``MPI_Allgather``, ``MPI_Allgatherv``
+* ``MPI_Allreduce``
+* ``MPI_Alltoall``, ``MPI_Alltoallv``, ``MPI_Alltoallw``
+* ``MPI_Bcast``
+* ``MPI_Bsend``, ``MPI_Bsend_init``
+* ``MPI_Exscan``
+* ``MPI_Gather``, ``MPI_Gatherv``
+* ``MPI_Get``, ``MPI_Put``
+* ``MPI_Ibsend``
+* ``MPI_Irecv``, ``MPI_Isend``, ``MPI_Irsend``, ``MPI_Issend``
+* ``MPI_Recv``, ``MPI_Recv_init``
+* ``MPI_Reduce``, ``MPI_Reduce_scatter``, ``MPI_Reduce_scatter_block``
+* ``MPI_Rsend``, ``MPI_Rsend_init``
+* ``MPI_Scan``
+* ``MPI_Scatter``, ``MPI_Scatterv``
+* ``MPI_Send``, ``MPI_Send_init``
+* ``MPI_Sendrecv``
+* ``MPI_Ssend``, ``MPI_Ssend_init``
+* ``MPI_Win_create``
+
+The following operations do *not* currently accept CUDA device buffers:
+
+* ``MPI_Accumulate``, ``MPI_Get_Accumulate``
+* ``MPI_Compare_and_swap``, ``MPI_Fetch_and_op``
+* The non-blocking collectives ``MPI_Iallgather``, ``MPI_Iallgatherv``,
+  ``MPI_Iallreduce``, ``MPI_Ialltoall``, ``MPI_Ialltoallv``,
+  ``MPI_Ialltoallw``, ``MPI_Ibcast``, and ``MPI_Iexscan``
+* ``MPI_Rget``, ``MPI_Rput``
+
+.. note:: These lists reflect known support and may vary between Open
+   MPI versions and transports.  The set of CUDA-aware operations when
+   using the UCX PML is essentially the same as above, with the
+   additional restriction that UCX's one-sided component does not
+   support CUDA buffers: all one-sided operations (for example,
+   ``MPI_Put``, ``MPI_Get``, ``MPI_Accumulate``), all window creation
+   calls (for example, ``MPI_Win_create``), and all non-blocking
+   reduction collectives are not CUDA-aware when using UCX.
+
+Transport-specific notes
+------------------------
+
+CUDA-aware UCX
+^^^^^^^^^^^^^^
+
+When both UCX and Open MPI are built with CUDA support, selecting the
+UCX PML is sufficient to use it.  For example, to run ``osu_latency``
+from the `OSU benchmarks <https://mvapich.cse.ohio-state.edu/benchmarks>`_
+with CUDA buffers:
 
 .. code-block:: sh
 
-   # For PGI 15.9 and later (Also called NVCC):
-   shell$ ./configure --with-wrapper-cflags=-ta:tesla
+   shell$ mpirun -n 2 --mca pml ucx \
+       -x UCX_TLS=rc,sm,cuda_copy,gdr_copy,cuda_ipc ./osu_latency D D
 
-   # For earlier versions of PGI:
-   shell$ ./configure CFLAGS=-D__LP64__ --with-wrapper-cflags="-D__LP64__ -ta:tesla"
+OFI / libfabric
+^^^^^^^^^^^^^^^
 
-/////////////////////////////////////////////////////////////////////////
+When running over Libfabric, the OFI MTL checks whether any provider
+can handle GPU (or other accelerator) memory through the
+``hmem``-related flags.  If a CUDA-capable provider is available, the
+OFI MTL sends GPU buffers directly through Libfabric's API after
+registering the memory; otherwise, the buffers are automatically copied
+to host memory before being transferred.
 
-What kind of CUDA support exists in Open MPI?
----------------------------------------------
+PSM2 / Omni-Path
+^^^^^^^^^^^^^^^^^^
 
-CUDA-aware support is defined as Open MPI automatically detecting that
-the argument pointer being passed to an MPI routine is a CUDA device
-memory pointer.
+CUDA-aware support is present in the PSM2 MTL.  When running CUDA-aware
+Open MPI on Cornelis Networks Omni-Path, the PSM2 MTL automatically sets
+the ``PSM2_CUDA`` environment variable so that PSM2 handles GPU
+buffers.  If you want to use host buffers with a CUDA-aware Open MPI, it
+is recommended to set ``PSM2_CUDA`` to ``0`` in the environment.  PSM2
+also supports NVIDIA GPUDirect; to enable it, set ``PSM2_GPUDIRECT`` to
+``1``.  These variables must be set before ``MPI_Init()`` is called, for
+example:
 
-See :ref:`this FAQ entry <faq-cuda-mpi-apis-cuda-label>`
-for more details on which APIs are CUDA-aware.
+.. code-block:: sh
 
+   shell$ mpirun -x PSM2_CUDA=1 -x PSM2_GPUDIRECT=1 --mca mtl psm2 ./mpi_hello
 
-.. error:: CUDA 4.0 is SUPER OLD!  End users dont care about the
-   differences between cuda-aware, cuda-ipc, gpu-direct, and gpu-direct-rdma
+GPUDirect support on Omni-Path requires a PSM2 library and ``hfi1``
+driver with CUDA support; the minimum required PSM2 version is `PSM2
+10.2.175 <https://github.com/01org/opa-psm2/releases/tag/PSM2_10.2-175>`_.
 
-Open MPI depends on various features of CUDA 4.0, so one needs to have
-at least the CUDA 4.0 driver and toolkit.  The new features of
-interest are the Unified Virtual Addressing (UVA) so that all pointers
-within a program have unique addresses.  In addition, there is a new
-API that allows one to determine if a pointer is a CUDA device pointer
-or host memory pointer.  This API is used by the library to decide
-what needs to be done with each buffer.  In addition, CUDA 4.1 also
-provides the ability to register host memory with the CUDA driver,
-which can improve performance.  CUDA 4.1 also added CUDA IPC support
-for fast communication between GPUs on the same node.
+When binding processes to GPUs on Omni-Path, each process should select
+a specific GPU (within the same NUMA node as the CPU the process runs
+on) before calling ``MPI_Init()`` using ``cudaChooseDevice()``,
+``cudaSetDevice()``, and similar; use the ``mpirun`` binding options
+(such as ``--bind-to core``) to keep processes from migrating between
+NUMA nodes.  See :ref:`Selecting a GPU close to the process
+<faq-cuda-mpi-cuda-numa-issues-label>`.
 
-Note that derived datatypes |mdash| both contiguous and non-contiguous
-|mdash| are supported.  However, the non-contiguous datatypes
-currently have high overhead because of the many calls to the CUDA
-function ``cuMemcpy()`` to copy all the pieces of the buffer into the
-intermediate buffer.
+.. note:: The Cornelis Networks Omni-Path / PSM2 details above may be
+   dated.  For current guidance, consult the PSM2 and Omni-Path
+   documentation from `Cornelis Networks
+   <https://customercenter.cornelisnetworks.com/>`_.
 
-CUDA-aware support is available in:
+Selecting a CUDA device
+-----------------------
 
-* The UCX (``ucx``) PML
-* The PSM2 (``psm2``) MTL with the CM (``cm``) PML.
-* The OFI (``ofi``) MTL with the CM (``cm``) PML.
-* Both CUDA-ized shared memory (``smcuda``) and TCP (``tcp``) BTLs
-  with the OB1 (``ob1``) PML.
+Open MPI requires some CUDA resources for internal use.  When possible,
+these are allocated lazily, the first time they are needed |mdash| for
+example, CUDA IPC memory handles are created when a transfer first
+requires them.  ``MPI_Init()`` and most communicator operations do not
+create any CUDA resources (this is guaranteed at least for
+``MPI_Comm_rank`` and ``MPI_Comm_size`` on ``MPI_COMM_WORLD``).
 
-/////////////////////////////////////////////////////////////////////////
+This is not always the case, however.  When using PSM2 or the
+``smcuda`` BTL (with the OB1 PML), it is not feasible to delay the
+allocation, so those CUDA resources are allocated during
+``MPI_Init()``.
 
-PSM2 support for CUDA
----------------------
+In all cases, the CUDA device must be selected *before* the first MPI
+call that requires a CUDA resource.  When CUDA resources are initialized
+lazily, you may use the communicator operations above to determine rank
+information and select a GPU accordingly:
 
-CUDA-aware support is present in PSM2 MTL.  When running CUDA-aware
-Open MPI on Cornelis Networks Omni-Path, the PSM2 MTL will automatically set
-``PSM2_CUDA`` environment variable which enables PSM2 to handle GPU
-buffers.  If the user wants to use host buffers with a CUDA-aware Open
-MPI, it is recommended to set ``PSM2_CUDA`` to ``0`` in the execution
-environment. PSM2 also has support for the NVIDIA GPUDirect support
-feature. To enable this, users will need to set ``PSM2_GPUDIRECT``
-to ``1`` in the execution environment.
+.. code-block:: c
 
-Note: The PSM2 library and ``hfi1`` driver with CUDA support are requirements
-to use GPUDirect support on Cornelis Networks Omni-Path. The minimum
-PSM2 build version required is `PSM2 10.2.175
-<https://github.com/01org/opa-psm2/releases/tag/PSM2_10.2-175>`_.
+   int local_rank = -1;
+   {
+       MPI_Comm local_comm;
+       MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank,
+                           MPI_INFO_NULL, &local_comm);
+       MPI_Comm_rank(local_comm, &local_rank);
+       MPI_Comm_free(&local_comm);
+   }
+   int num_devices = 0;
+   cudaGetDeviceCount(&num_devices);
+   cudaSetDevice(local_rank % num_devices);
 
-For more information refer to the `Cornelis Networks Customer Center
-<https://customercenter.cornelisnetworks.com/>`_.
+Open MPI's internal CUDA resources are released during
+``MPI_Finalize()``, so it is an application error to call
+``cudaDeviceReset()`` before ``MPI_Finalize()``.
 
-/////////////////////////////////////////////////////////////////////////
-
-OFI support for CUDA
----------------------
-
-CUDA-aware support is present in OFI MTL.  When running CUDA-aware
-Open MPI over Libfabric, the OFI MTL will check if there are any
-providers capable of handling GPU (or other accelerator) memory
-through the ``hmem``-related flags. If a CUDA-capable provider is
-available, the OFI MTL will directly send GPU buffers through
-Libfabric's API after registering the memory. If there are no
-CUDA-capable providers available, the buffers will automatically
-be copied to host buffers before being transferred through
-Libfabric's API.
-
-/////////////////////////////////////////////////////////////////////////
-
-Can I get additional CUDA debug-level information at run-time?
---------------------------------------------------------------
-
-Yes, by enabling some verbosity flags.
-
-* The ``opal_cuda_verbose`` parameter has only one level of verbosity:
-
-  .. code-block::
-
-     shell$ mpirun --mca opal_cuda_verbose 10 ...
-
-
-* The ``mpi_common_cuda_verbose`` parameter provides additional
-  information about CUDA-aware related activities.  This can be set to
-  a variety of different values.  There is really no need to use these
-  unless you have strange problems:
-
-  .. code-block:: sh
-
-     # A bunch of CUDA debug information
-     shell$ mpirun --mca mpi_common_cuda_verbose 10 ...
-     # Even more CUDA debug information
-     shell$ mpirun --mca mpi_common_cuda_verbose 20 ...
-     # Yet more CUDA debug information
-     shell$ mpirun --mca mpi_common_cuda_verbose 100 ...
-
-* The ``smcuda`` BTL has three MCA parameters related to the use of
-  CUDA IPC.  By default, CUDA IPC is used where possible.  But the
-  user can now turn it off if they prefer.
-
-  .. code-block:: sh
-
-     shell$ mpirun --mca btl_smcuda_use_cuda_ipc 0 ...
-
-  In addition, it is assumed that CUDA IPC is possible when running on
-  the same GPU, and this is typically true.  However, there is the
-  ability to turn it off.
-
-  .. code-block:: sh
-
-     shell$ mpirun --mca btl_smcuda_use_cuda_ipc_same_gpu 0 ...
-
-  Last, to get some insight into whether CUDA IPC is being used, you
-  can turn on some verbosity that shows whether CUDA IPC gets enabled
-  between two GPUs.
-
-  .. code-block:: sh
-
-     shell$ mpirun --mca btl_smcuda_cuda_ipc_verbose 100 ...
-
-/////////////////////////////////////////////////////////////////////////
+For a general treatment of selecting an accelerator device before
+``MPI_Init()`` (using the ``OMPI_COMM_WORLD_LOCAL_RANK`` environment
+variable), see :doc:`initialize`.
 
 .. _faq-cuda-mpi-cuda-numa-issues-label:
 
-NUMA Node Issues
-----------------
+Selecting a GPU close to the process
+------------------------------------
 
-When running on a node that has multiple GPUs, you may want to select
-the GPU that is closest to the NUMA node on which your process is
-running.  One way to do this is to make use of the ``hwloc`` library.
-The following is a C code snippet that can be used in your application
-to select a GPU that is close.  It will determine on which CPU it is
-running and then look for the closest GPU.  There could be multiple
-GPUs that are the same distance away.  This is dependent on having
-``hwloc`` somewhere on your system.
+On a node with multiple GPUs, you may want each process to use the GPU
+closest to the NUMA node on which it is running.  One way to do this is
+with the ``hwloc`` library.  The following C snippet determines the CPU
+the process is running on and then looks for the closest GPU; note that
+several GPUs may be equidistant.
 
 .. code-block:: c
 
@@ -268,7 +356,6 @@ GPUs that are the same distance away.  This is dependent on having
     * that the MPI program is running on.  Note that this works even without
     * any libpciaccess or libpci support as it keys off the NVIDIA vendor ID.
     * There may be other ways to implement this but this is one way.
-    * January 10, 2014
     */
    #include <assert.h>
    #include <stdio.h>
@@ -375,329 +462,90 @@ GPUs that are the same distance away.  This is dependent on having
        return 0;
    }
 
-/////////////////////////////////////////////////////////////////////////
+Run-time tuning and debugging
+-----------------------------
 
-How do I develop CUDA-aware Open MPI applications?
---------------------------------------------------
+CUDA IPC in the shared-memory BTL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Developing CUDA-aware applications is a complex topic, and beyond the
-scope of this document. CUDA-aware applications often have to take
-machine-specific considerations into account, including the number of
-GPUs installed on each node and how the GPUs are connected to the CPUs
-and to each other. Often, when using a particular transport layer
-(such as OPA/PSM2) there will be run-time decisions to make about
-which CPU cores will be used with which GPUs.
+By default, the ``smcuda`` BTL uses CUDA IPC where possible to move GPU
+data quickly between GPUs on the same node and PCI root complex.  A few
+MCA parameters control this behavior.  You can disable CUDA IPC
+entirely:
 
-A good place to start is the `NVIDIA CUDA Toolkit Documentation
-<https://docs.nvidia.com/cuda/>`_ including the `Programming Guide
-<https://docs.nvidia.com/cuda/cuda-c-programming-guide/>`_ and the
-`Best Practices Guide
-<https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/>`_.  For
-examples of how to write CUDA-aware MPI applications, the `NVIDIA
-developers blog
-<https://github.com/NVIDIA-developer-blog/code-samples/tree/master/posts/cuda-aware-mpi-example>`_
-offers examples and the `OSU Micro-Benchmarks
-<https://mvapich.cse.ohio-state.edu/benchmarks/>`_ offer an excellent
-example of how to write CUDA-aware MPI applications.
+.. code-block:: sh
 
-/////////////////////////////////////////////////////////////////////////
+   shell$ mpirun --mca btl_smcuda_use_cuda_ipc 0 ...
 
-.. _faq-cuda-mpi-apis-cuda-label:
+CUDA IPC is assumed to be possible when two ranks run on the same GPU;
+this too can be disabled:
 
-Which MPI APIs work with CUDA-aware?
-------------------------------------
+.. code-block:: sh
 
-* MPI_Allgather
-* MPI_Allgatherv
-* MPI_Allreduce
-* MPI_Alltoall
-* MPI_Alltoallv
-* MPI_Alltoallw
-* MPI_Bcast
-* MPI_Bsend
-* MPI_Bsend_init
-* MPI_Exscan
-* MPI_Ibsend
-* MPI_Irecv
-* MPI_Isend
-* MPI_Irsend
-* MPI_Issend
-* MPI_Gather
-* MPI_Gatherv
-* MPI_Get
-* MPI_Put
-* MPI_Rsend
-* MPI_Rsend_init
-* MPI_Recv
-* MPI_Recv_init
-* MPI_Reduce
-* MPI_Reduce_scatter
-* MPI_Reduce_scatter_block
-* MPI_Scan
-* MPI_Scatter
-* MPI_Scatterv
-* MPI_Send
-* MPI_Send_init
-* MPI_Sendrecv
-* MPI_Ssend
-* MPI_Ssend_init
-* MPI_Win_create
+   shell$ mpirun --mca btl_smcuda_use_cuda_ipc_same_gpu 0 ...
 
-.. FIXME: We need to verify the above list.
+To see whether CUDA IPC is being enabled between two GPUs, turn on some
+verbosity:
 
-/////////////////////////////////////////////////////////////////////////
+.. code-block:: sh
 
-Which MPI APIs do NOT work with CUDA-aware?
--------------------------------------------
+   shell$ mpirun --mca btl_smcuda_cuda_ipc_verbose 100 ...
 
-* MPI_Accumulate
-* MPI_Compare_and_swap
-* MPI_Fetch_and_op
-* MPI_Get_Accumulate
-* MPI_Iallgather
-* MPI_Iallgatherv
-* MPI_Iallreduce
-* MPI_Ialltoall
-* MPI_Ialltoallv
-* MPI_Ialltoallw
-* MPI_Ibcast
-* MPI_Iexscan
-* MPI_Rget
-* MPI_Rput
+The ``smcuda`` BTL holds on to CUDA IPC registrations even after a
+transfer completes, because the registration calls are expensive.  To
+limit how much memory is registered, use the
+``mpool_rgpusm_rcache_size_limit`` MCA parameter (in bytes); when the
+cache reaches this size, the least-recently-used entries are evicted to
+make room:
 
-.. FIXME: We need to verify the above list.
-
-/////////////////////////////////////////////////////////////////////////
-
-How do I use CUDA-aware UCX for Open MPI?
------------------------------------------
-
-Example of running ``osu_latency`` from the `OSU benchmarks
-<https://mvapich.cse.ohio-state.edu/benchmarks>`_ with CUDA buffers
-using Open MPI and UCX CUDA support:
-
-.. code-block::
-
-   shell$ mpirun -n 2 --mca pml ucx \
-       -x UCX_TLS=rc,sm,cuda_copy,gdr_copy,cuda_ipc ./osu_latency D D
-
-/////////////////////////////////////////////////////////////////////////
-
-Which MPI APIs work with CUDA-aware UCX?
-----------------------------------------
-
-* MPI_Send
-* MPI_Bsend
-* MPI_Ssend
-* MPI_Rsend
-* MPI_Isend
-* MPI_Ibsend
-* MPI_Issend
-* MPI_Irsend
-* MPI_Send_init
-* MPI_Bsend_init
-* MPI_Ssend_init
-* MPI_Rsend_init
-* MPI_Recv
-* MPI_Irecv
-* MPI_Recv_init
-* MPI_Sendrecv
-* MPI_Bcast
-* MPI_Gather
-* MPI_Gatherv
-* MPI_Allgather
-* MPI_Reduce
-* MPI_Reduce_scatter
-* MPI_Reduce_scatter_block
-* MPI_Allreduce
-* MPI_Scan
-* MPI_Exscan
-* MPI_Allgatherv
-* MPI_Alltoall
-* MPI_Alltoallv
-* MPI_Alltoallw
-* MPI_Scatter
-* MPI_Scatterv
-* MPI_Iallgather
-* MPI_Iallgatherv
-* MPI_Ialltoall
-* MPI_Iialltoallv
-* MPI_Ialltoallw
-* MPI_Ibcast
-* MPI_Iexscan
-
-.. FIXME: We need to verify the above list.  These _SHOULD_ be the same
-   as above.
-
-/////////////////////////////////////////////////////////////////////////
-
-Which MPI APIs do NOT work with CUDA-aware UCX?
------------------------------------------------
-
-* All one-sided operations such as MPI_Put, MPI_Get, MPI_Accumulate,
-  MPI_Rget, MPI_Rput, MPI_Get_Accumulate, MPI_Fetch_and_op,
-  MPI_Compare_and_swap, etc
-* All window creation calls such as MPI_Win_create
-* All non-blocking reduction collectives like MPI_Ireduce,
-  MPI_Iallreduce, etc
-
-.. FIXME: Checking with nVidia.  This may be more of an issue of OSC_UCX
-   not supporting CUDA, though perhaps it's just performance.
-
-/////////////////////////////////////////////////////////////////////////
-
-Can I tell at compile time or runtime whether I have CUDA-aware support?
-------------------------------------------------------------------------
-
-There is both a compile time check and a run-time check available.
-You can use whichever is the most convenient for your program.  To
-access them, you need to include ``mpi-ext.h``. Note that
-``mpi-ext.h`` is specific to Open MPI. The following program shows an
-example of using the CUDA-aware macro and run-time check.
-
-.. code-block:: c
-
-   /*
-    * Program that shows the use of CUDA-aware macro and runtime check.
-    */
-   #include <stdio.h>
-   #include "mpi.h"
-
-   #if !defined(OPEN_MPI) || !OPEN_MPI
-   #error This source code uses an Open MPI-specific extension
-   #endif
-
-   /* Needed for MPIX_Query_cuda_support(), below */
-   #include "mpi-ext.h"
-
-   int main(int argc, char *argv[])
-   {
-       MPI_Init(&argc, &argv);
-
-       printf("Compile time check:\n");
-   #if defined(MPIX_CUDA_AWARE_SUPPORT) && MPIX_CUDA_AWARE_SUPPORT
-       printf("This MPI library has CUDA-aware support.\n", MPIX_CUDA_AWARE_SUPPORT);
-   #elif defined(MPIX_CUDA_AWARE_SUPPORT) && !MPIX_CUDA_AWARE_SUPPORT
-       printf("This MPI library does not have CUDA-aware support.\n");
-   #else
-       printf("This MPI library cannot determine if there is CUDA-aware support.\n");
-   #endif /* MPIX_CUDA_AWARE_SUPPORT */
-
-       printf("Run time check:\n");
-   #if defined(MPIX_CUDA_AWARE_SUPPORT)
-       if (1 == MPIX_Query_cuda_support()) {
-           printf("This MPI library has CUDA-aware support.\n");
-       } else {
-           printf("This MPI library does not have CUDA-aware support.\n");
-       }
-   #else /* !defined(MPIX_CUDA_AWARE_SUPPORT) */
-       printf("This MPI library cannot determine if there is CUDA-aware support.\n");
-   #endif /* MPIX_CUDA_AWARE_SUPPORT */
-
-       MPI_Finalize();
-
-       return 0;
-   }
-
-/////////////////////////////////////////////////////////////////////////
-
-How do I limit how much CUDA IPC memory is held in the registration cache?
---------------------------------------------------------------------------
-
-As mentioned earlier, the Open MPI library will make use of CUDA IPC support where
-possible to move the GPU data quickly between GPUs that are on the same node and
-same PCI root complex. The library holds on to registrations even after the data
-transfer is complete as it is expensive to make some of the CUDA IPC registration
-calls. If you want to limit how much memory is registered, you can use the
-``mpool_rgpusm_rcache_size_limit`` MCA parameter. For example, this sets the limit
-to 1000000 bytes:
-
-.. code-block::
+.. code-block:: sh
 
    shell$ mpirun --mca mpool_rgpusm_rcache_size_limit 1000000 ...
 
-When the cache reaches this size, it will kick out the least recently used until
-it can fit the new registration in.
+Alternatively, the cache can empty itself entirely when the limit is
+reached:
 
-There also is the ability to have the cache empty itself out when the
-limit is reached:
-
-.. code-block::
+.. code-block:: sh
 
    shell$ mpirun --mca mpool_rgpusm_rcache_empty_cache 1 ...
 
-/////////////////////////////////////////////////////////////////////////
+Verbose output
+^^^^^^^^^^^^^^
 
-What are some guidelines for using CUDA and Open MPI with Omni-Path?
---------------------------------------------------------------------
+Additional CUDA debugging output is available at run time.  The
+``opal_cuda_verbose`` parameter has a single verbosity level:
 
-When developing CUDA-aware Open MPI applications for OPA-based fabrics, the
-PSM2 transport is preferred and a CUDA-aware version of PSM2 is provided with
-all versions of the Cornelis Networks Omni-Path OPXS software suite.
+.. code-block:: sh
 
-.. error:: TODO Are Intel/OPA references still correct?
+   shell$ mpirun --mca opal_cuda_verbose 10 ...
 
-The PSM2 library provides a number of settings that will govern how it
-will interact with CUDA, including ``PSM2_CUDA`` and ``PSM2_GPUDIRECT``,
-which should be set in the environment before ``MPI_Init()`` is called. For
-example:
+The ``mpi_common_cuda_verbose`` parameter provides more detailed
+information about CUDA-aware activities and accepts a range of values.
+There is normally no need to use these unless you are diagnosing a
+problem:
 
-.. code-block::
+.. code-block:: sh
 
-   shell$ mpirun -x PSM2_CUDA=1 -x PSM2_GPUDIRECT=1 --mca mtl psm2 mpi_hello
+   shell$ mpirun --mca mpi_common_cuda_verbose 10 ...    # some detail
+   shell$ mpirun --mca mpi_common_cuda_verbose 20 ...    # more detail
+   shell$ mpirun --mca mpi_common_cuda_verbose 100 ...   # most detail
 
-In addition, each process of the application should select a specific
-GPU card to use before calling ``MPI_Init()``, by using
-``cudaChooseDevice()``, ``cudaSetDevice()`` and similar. The chosen
-GPU should be within the same NUMA node as the CPU the MPI process is
-running on. You will also want to use the ``mpirun``
-``--bind-to-core`` or ``--bind-to-socket`` option to ensure that MPI
-processes do not move between NUMA nodes. See the section on
-:ref:`NUMA Node Issues <faq-cuda-mpi-cuda-numa-issues-label>`, for
-more information.
+Developing CUDA-aware applications
+----------------------------------
 
-For more information see the *Cornelis Networks Performance Scaled Messaging 2
-(PSM2) Programmer's Guide* and the *Cornelis Networks Omni-Path Performance
-Tuning Guide*, which can be found in the `Cornelis Networks Customer Center
-<https://customercenter.cornelisnetworks.com/>`_.
+Developing CUDA-aware applications is a broad topic, beyond the scope of
+this document.  Such applications often must account for
+machine-specific details, including the number of GPUs per node and how
+the GPUs are connected to the CPUs and to each other.  With some
+transports there are additional run-time decisions to make about which
+CPU cores are used with which GPUs.
 
-.. error:: TODO Are Intel/OPA references still correct?
-
-/////////////////////////////////////////////////////////////////////////
-
-When do I need to select a CUDA device?
----------------------------------------
-
-Open MPI requires CUDA resources allocated for internal use. When possible,
-these resources are allocated lazily when they are first needed, e.g. CUDA
-IPC mem handles are created when a communication routine first requires them
-during a transfer.  MPI_Init and most communicator related operations do not
-create any CUDA resources (guaranteed at least for MPI_Comm_rank,
-MPI_Comm_size on ``MPI_COMM_WORLD``).
-
-However, this is not always the case. In certain instances, such as when
-using PSM2 or the ``smcuda`` BTL (with the OB1 PML), it is not feasible to
-delay the CUDA resources allocation. Consequently, these resources will need
-to be allocated during ``MPI_Init()``.
-
-Regardless of the situation, the CUDA device must be selected before the first
-MPI call that requires a CUDA resource. When CUDA resources can be initialized
-lazily, it is possible to use the aforementioned communicator-related operations
-to query rank information and utilize that to select a GPU.
-
-
-.. code-block:: c
-
-    int local_rank = -1;
-    {
-        MPI_Comm local_comm;
-        MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, &local_comm);
-        MPI_Comm_rank(local_comm, &local_rank);
-        MPI_Comm_free(&local_comm);
-    }
-    int num_devices = 0;
-    cudaGetDeviceCount(&num_devices);
-    cudaSetDevice(local_rank % num_devices);
-
-MPI internal CUDA resources are released during MPI_Finalize. Thus it is an
-application error to call cudaDeviceReset before MPI_Finalize is called.
+A good place to start is the `NVIDIA CUDA Toolkit Documentation
+<https://docs.nvidia.com/cuda/>`_, including the `Programming Guide
+<https://docs.nvidia.com/cuda/cuda-c-programming-guide/>`_ and the `Best
+Practices Guide
+<https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/>`_.  For
+examples of CUDA-aware MPI applications, the `NVIDIA developer blog
+<https://github.com/NVIDIA-developer-blog/code-samples/tree/master/posts/cuda-aware-mpi-example>`_
+and the `OSU Micro-Benchmarks
+<https://mvapich.cse.ohio-state.edu/benchmarks/>`_ are good references.

--- a/ompi/mpiext/AGENTS.md
+++ b/ompi/mpiext/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md — Open MPI extensions (`ompi/mpiext/`)
+
+Scoped guidance for AI coding agents (and humans) working on the MPI
+*extensions* tree. This complements the top-level
+[`AGENTS.md`](../../CLAUDE.md) / `CLAUDE.md`; when the two disagree, the
+top-level file and the docs under [`docs/`](../../docs/) win.
+
+An MPI extension is a self-contained set of non-standard, Open
+MPI-specific APIs and/or constants exposed to user applications via the
+separate `mpi-ext.h` header (and the Fortran `mpif-ext.h` /
+`use mpi_ext` / `use mpi_f08_ext` equivalents). Each subdirectory here
+is one extension; its name is its directory name. See
+[`example/README.md`](example/README.md) for the canonical walk-through
+of an extension's required layout, and [`README.md`](README.md) for the
+symbol-naming rules (`OMPI_` vs. `MPIX_` vs. `MPI_`).
+
+## Current extensions and where each is documented
+
+The canonical, user-facing *index* of all extensions is
+[`docs/features/extensions.rst`](../../docs/features/extensions.rst)
+(rendered under "Open MPI-specific features → Open MPI extensions").
+**Every buildable extension must be listed there.**
+
+## Documentation-sync checklist
+
+When you **add, remove, or change the public API/constants of an
+extension** in this tree, update the docs in the same PR:
+
+1. **`docs/features/extensions.rst`** — the "Available extensions" list.
+   Add/remove/adjust the bullet so it matches what actually builds. This
+   is the single most-often-missed step.
+2. **Man pages** — every public `MPIX_*` / `OMPI_*` symbol should have a
+   page under [`docs/man-openmpi/man3/`](../../docs/man-openmpi/man3/),
+   listed in that directory's `index.rst`. New API → new man page.
+3. **Accelerator extensions** (`cuda`, `rocm`) — keep the relevant
+   `docs/tuning-apps/accelerators/*.rst` page in sync.
+4. **`ftmpi`** — user-facing behavior is documented in
+   [`docs/features/ulfm.rst`](../../docs/features/ulfm.rst), not just the
+   man pages.
+5. **Changelog** — add a release-notes entry under
+   [`docs/release-notes/changelog/`](../../docs/release-notes/changelog/)
+   (`vMAJOR.MINOR.x.rst`) for any user-visible change.
+6. **LLM-friendly docs** — if you touch public MPI-extension
+   documentation, check whether the curated sources under
+   [`docs/llms-src/`](../../docs/llms-src/) (e.g. the interface guide)
+   need a matching update; see
+   [`docs/developers/llm-friendly-docs.rst`](../../docs/developers/llm-friendly-docs.rst).
+
+## How an extension is selected to be built
+
+Each extension has a mandatory `configure.m4` whose macro decides,
+during Open MPI's `configure`, whether the extension builds. Extensions
+are enabled by default and can be disabled globally with
+`--disable-mpi-ext` (or selectively via its argument list). Individual
+extensions typically also gate themselves on a prerequisite — e.g.
+`cuda`/`rocm` on the corresponding accelerator support being configured,
+`shortfloat` on the compiler actually providing `_Float16` / `short
+float`. When you document an extension, describe *when* it is present,
+not just what it does — that build-selection story is currently
+under-documented.

--- a/ompi/mpiext/CLAUDE.md
+++ b/ompi/mpiext/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
* Add AGENTS.md/CLAUDE.md instructions on keeping MPI Extensions documentation updated
* Update to match current MPI Extensions
  * Add RST pages for MPI Extensions that did not have them
* Revamped CUDA RST page
   *  The page was still in FAQ-style with a "TODO" at the top to re-write it into prose.
   * Used an LLM to re-write the FAQ-style text into prose.

See individual commit messages for details.