### PR TITLE
docs: correctness pass over MCA, large-cluster, and platform pages

### DIFF
--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -673,23 +673,31 @@ MCA Parameter Changes Between Open MPI 4.x and newer releases
 When Open MPI :ref:`switched from using ORTE to PRRTE as its run-time
 environment, <label-running-role-of-pmix-and-prte>` some MCA
 parameters were renamed to be more consistent and/or allow more
-flexible behavior.  The deprecated Open MPI MCA parameters listed
-below are currently replaced by a corresponding new PRRTE parameter,
-but may be removed in future releases.
+flexible behavior.  The Open MPI (ORTE-era) MCA parameters in the left column below no
+longer exist; use the corresponding replacement shown in the right
+column.
 
-.. note:: In all cases listed below, the deprecated MCA parameter is
-          an Open MPI MCA parameter, meaning that its corresponding
-          environment variable was prefixed with ``OMPI_MCA_`` (e.g.,
-          ``OMPI_MCA_orte_xml_output``).  However, the corresponding
-          new MCA parameter is a PRRTE MCA parameter, meaning that its
-          corresponding environment variable is prefixed with
-          ``PRTE_MCA_`` (e.g., ``PRTE_MCA_output``).
+.. note:: The old MCA parameters in the left column were Open MPI
+          parameters, meaning that their corresponding environment
+          variables were prefixed with ``OMPI_MCA_`` (e.g.,
+          ``OMPI_MCA_orte_xml_output``).  Most of their replacements are
+          PRRTE parameters, meaning that their corresponding environment
+          variables are prefixed with ``PRTE_MCA_`` (e.g.,
+          ``PRTE_MCA_output``).  The one exception is
+          ``ompi_stream_buffering``, which remains an Open MPI parameter
+          (``OMPI_MCA_ompi_stream_buffering``).
 
           .. important:: Yes, that's a single ``R`` in the
                          ``PRTE_MCA_`` environment variable prefix.
                          `See this explanation
-                         <https://docs.prrte.org/>`_ for the when one
-                         R or two R's are used in the PRRTE name.
+                         <https://docs.prrte.org/>`_ for when one R or
+                         two R's are used in the PRRTE name.
+
+.. note:: ``mapby`` and ``bindto`` are the current names for these two
+          parameters.  The older ``rmaps_default_mapping_policy`` and
+          ``hwloc_default_binding_policy`` names still work as deprecated
+          synonyms, but new configurations should use ``mapby`` and
+          ``bindto``.
 
 
 .. list-table::
@@ -794,7 +802,7 @@ but may be removed in future releases.
       - ``rmaps_base_no_schedule_local``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``[<mapping>]:nolocal``
 
@@ -803,7 +811,7 @@ but may be removed in future releases.
       - ``rmaps_base_oversubscribe``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``[<mapping>]:oversubscribe``
 
@@ -812,7 +820,7 @@ but may be removed in future releases.
       - ``rmaps_base_no_oversubscribe``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``[<mapping>]:nooversubscribe``
 
@@ -820,7 +828,7 @@ but may be removed in future releases.
       - ``hwloc_base_use_hwthreads_as_cpus``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``[<mapping>]:hwtcpus``
 
@@ -829,23 +837,23 @@ but may be removed in future releases.
       - ``hwloc_base_cpu_set``
 
         Value: ``<value>``
-      - ``rmaps_default_mapping_policy``
+      - ``hwloc_default_cpu_list``
 
-        Value: ``pe-list=<value>``
+        Value: ``<value>``
 
     * - List of processor IDs to bind processes to
       - ``hwloc_base_cpu_list``
 
         Value: ``<value>``
-      - ``rmaps_default_mapping_policy``
+      - ``hwloc_default_cpu_list``
 
-        Value: ``pe-list=<value>``
+        Value: ``<value>``
 
     * - Bind processes to cores
       - ``hwloc_base_bind_to_core``
 
         Values: boolean
-      - ``hwloc_default_binding_policy``
+      - ``bindto``
 
         Value: ``core``
 
@@ -853,7 +861,7 @@ but may be removed in future releases.
       - ``hwloc_base_bind_to_socket``
 
         Values: boolean
-      - ``hwloc_default_binding_policy``
+      - ``bindto``
 
         Value: ``package``
 
@@ -861,7 +869,7 @@ but may be removed in future releases.
       - ``rmaps_base_bynode``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``node``
 
@@ -869,7 +877,7 @@ but may be removed in future releases.
       - ``rmaps_base_bycore``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``core``
 
@@ -877,7 +885,7 @@ but may be removed in future releases.
       - ``rmaps_base_byslot``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``slot``
 
@@ -885,7 +893,7 @@ but may be removed in future releases.
       - ``rmaps_base_cpus_per_rank``
 
         Value: ``<X>``
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``[<mapping>]:pe=<X>``
 
@@ -893,7 +901,7 @@ but may be removed in future releases.
       - ``rmaps_ppr_n_pernode``
 
         Value: ``<X>``
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``ppr:<X>:node``
 
@@ -901,7 +909,7 @@ but may be removed in future releases.
       - ``rmaps_ppr_pernode``
 
         Values: boolean
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``ppr:1:node``
 
@@ -909,7 +917,7 @@ but may be removed in future releases.
       - ``rmaps_ppr_n_persocket``
 
         Value: integer ``<X>``
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``ppr:<X>:package``
 
@@ -918,7 +926,7 @@ but may be removed in future releases.
       - ``rmaps_ppr_pattern``
 
         Value: ``<value>``
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``ppr:<value>``
 
@@ -926,7 +934,7 @@ but may be removed in future releases.
       - ``orte_rankfile``
 
         Value: ``<filename>``
-      - ``rmaps_default_mapping_policy``
+      - ``mapby``
 
         Value: ``rankfile:file=<filename>``
 
@@ -948,7 +956,7 @@ Simple values, where only the name of the MCA parameter changed
    export OMPI_MCA_orte_ess_base_stream_buffering=2
 
    # New environment variable: (integer value)
-   export PRTE_MCA_ompi_stream_buffering=2
+   export OMPI_MCA_ompi_stream_buffering=2
 
 .. code-block:: ini
 
@@ -1043,7 +1051,7 @@ Converting mapping parameters
 
 Mapping parameters were previously prefixed with ``rmaps_base_`` or ``hwloc_base_``
 (and also the ``orte_rankfile`` parameter).  These have been updated
-to the ``rmaps_default_mapping_policy`` and ``hwloc_default_binding_policy``
+to the ``mapby`` and ``bindto``
 parameters to be more consistent and indicate that they are the *default*
 mapping for processes.  Some of the old parameters are now values for a
 new parameter and some are now suffixes, as shown in the examples below.
@@ -1057,7 +1065,7 @@ parameter values:
    export OMPI_MCA_rmaps_base_bycore=1
 
    # New environment variable: (parameter value)
-   export PRTE_MCA_rmaps_default_mapping_policy=core
+   export PRTE_MCA_mapby=core
 
 .. code-block:: ini
 
@@ -1065,7 +1073,7 @@ parameter values:
    export OMPI_MCA_hwloc_base_bind_to_socket=1
 
    # New environment variable: (parameter value)
-   export PRTE_MCA_hwloc_default_binding_policy=package
+   export PRTE_MCA_bindto=package
 
 
 The examples below show conversions from old parameters that have integer or
@@ -1077,7 +1085,7 @@ string values to new parameter values with those same values:
    export OMPI_MCA_hwloc_base_cpu_set=1,3,8
 
    # New environment variable: (parameter value)
-   export PRTE_MCA_rmaps_default_mapping_policy=pe-list=1,3,8
+   export PRTE_MCA_hwloc_default_cpu_list=1,3,8
 
 .. code-block:: ini
 
@@ -1085,7 +1093,7 @@ string values to new parameter values with those same values:
    export OMPI_MCA_rmaps_ppr_n_persocket=4
 
    # New environment variable: (parameter value)
-   export PRTE_MCA_rmaps_default_mapping_policy=ppr:4:package
+   export PRTE_MCA_mapby=ppr:4:package
 
 .. code-block:: ini
 
@@ -1093,7 +1101,7 @@ string values to new parameter values with those same values:
    export OMPI_MCA_orte_rankfile=rankfile.txt
 
    # New environment variable: (parameter value)
-   export PRTE_MCA_rmaps_default_mapping_policy=rankfile:file=rankfile.txt
+   export PRTE_MCA_mapby=rankfile:file=rankfile.txt
 
 The examples below show conversions from old parameters that map to suffixes
 for new parameter values:
@@ -1104,7 +1112,7 @@ for new parameter values:
    export OMPI_MCA_hwloc_base_use_hwthreads_as_cpus=1
 
    # New environment variable: (standalone suffix)
-   export PRTE_MCA_rmaps_default_mapping_policy=:hwtcpus
+   export PRTE_MCA_mapby=:hwtcpus
 
 .. code-block:: ini
 
@@ -1112,7 +1120,7 @@ for new parameter values:
    export OMPI_MCA_rmaps_base_oversubscribe=1
 
    # New environment variable: (standalone suffix)
-   export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
+   export PRTE_MCA_mapby=:oversubscribe
 
 The examples below show conversions from old parameters that map to suffixes
 combined with parameters that have values:
@@ -1125,8 +1133,29 @@ combined with parameters that have values:
    # Old environment variable: (boolean value)
    export OMPI_MCA_rmaps_base_oversubscribe=1
 
-   # New environment variable: (suffix on value)
-   export PRTE_MCA_rmaps_default_mapping_policy=pe-list=1,3,8:oversubscribe
+   # New environment variables: (separate parameters)
+   export PRTE_MCA_hwloc_default_cpu_list=1,3,8
+   export PRTE_MCA_mapby=:oversubscribe
+
+.. note:: ``hwloc_default_cpu_list`` restricts the set of CPUs that
+          PRRTE may use; it does not bind each process to all of the
+          listed CPUs.  With the default mapping and binding policies,
+          the example above therefore places one process on CPU 1, one
+          on CPU 3, and one on CPU 8, each bound to just that one CPU.
+
+          To bind each process to *all* of the listed CPUs, use the
+          ``pe-list`` mapping directive instead:
+
+          .. code-block:: sh
+
+             shell$ mpirun --map-by pe-list=1,3,8:oversubscribe ...
+
+          Adding the ``ordered`` qualifier (``--map-by
+          pe-list=1,3,8:ordered:oversubscribe``) yields the
+          one-process-per-listed-CPU placement described above.  Note
+          that ``pe-list`` is only accepted on the command line; PRRTE
+          rejects it as a default mapping policy (i.e., as the value
+          of the ``mapby`` MCA parameter).
 
 .. code-block:: ini
 
@@ -1137,7 +1166,7 @@ combined with parameters that have values:
    export OMPI_MCA_hwloc_base_use_hwthreads_as_cpus=1
 
    # New environment variable: (suffix on value)
-   export PRTE_MCA_rmaps_default_mapping_policy=ppr:4:package:hwtcpus
+   export PRTE_MCA_mapby=ppr:4:package:hwtcpus
 
 Multiple suffixes may be appended to a mapping value:
 
@@ -1151,4 +1180,4 @@ Multiple suffixes may be appended to a mapping value:
    export OMPI_MCA_rmaps_base_oversubscribe=1
 
    # New environment variable: (suffix on value)
-   export PRTE_MCA_rmaps_default_mapping_policy=ppr:4:package:hwtcpus:oversubscribe
+   export PRTE_MCA_mapby=ppr:4:package:hwtcpus:oversubscribe

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -264,8 +264,6 @@ shells):
 Tuning MCA parameter files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. error:: TODO This entire section needs to be checked for correctness.
-
 Simple text files can be used to set MCA parameter values for a
 specific application.
 
@@ -301,8 +299,9 @@ can be added to the command line as follows:
    shell$ mpirun -np 2 --tune foo.conf,bar.conf a.out
 
 The contents of tuned files consist of one or more lines, each of
-which contain zero or more `-x` and `--mca` options.  Comments are not
-allowed.  For example, the following tuned file:
+which contain zero or more ``-x`` and ``--mca`` options.  Empty lines
+and lines beginning with the ``#`` character are ignored.  For example,
+the following tuned file:
 
 .. code-block::
 
@@ -322,13 +321,11 @@ is equivalent to:
 
 Although the typical use case for tuned parameter files is to be
 specified on the command line, they can also be set as MCA parameters
-in the environment.  The MCA parameter ``mca_base_envvar_file_prefix``
+in the environment.  The MCA parameter ``mca_base_envar_file_prefix``
 contains a comma-delimited list of tuned parameter files exactly as
-they would be passed to the ``--tune`` command line option.  The MCA
-parameter ``mca_base_envvar_file_path`` specifies the path to search
-for tuned files with relative paths.
-
-.. error:: TODO Check that these MCA var names ^^ are correct.
+they would be passed to the ``--tune`` command line option.  Tuned
+files named with relative paths are resolved against the directories
+listed in the ``mca_base_param_file_path`` MCA parameter.
 
 Configuration files
 ^^^^^^^^^^^^^^^^^^^
@@ -361,9 +358,9 @@ By default, two files are searched (in order):
 #. ``$prefix/etc/openmpi-mca-params.conf``: The system-supplied set
    of values has a lower precedence.
 
-More specifically, the MCA parameter ``mca_param_files`` specifies a
-colon-delimited path of files to search for MCA parameters.  Files to
-the left have lower precedence; files to the right are higher
+More specifically, the MCA parameter ``mca_base_param_files`` specifies
+a comma-delimited list of files to search for MCA parameters.  Files to
+the left have *higher* precedence; files to the right have lower
 precedence.
 
 .. note:: Keep in mind that, just like components, these parameter
@@ -379,8 +376,6 @@ precedence.
           customization, which is especially relevant in heterogeneous
           environments.
 
-.. error:: TODO This table needs to be checked for correctness.
-
 .. warning:: Setting Open MPI MCA parameters via configuration files
              entails editing (by default) the ``mca-params.conf`` or
              ``openmpi-mca-params.conf`` files.  When setting PMIx-
@@ -392,11 +387,22 @@ precedence.
              |          | ``$prefix/etc/openmpi-mca-params.conf``  |
              +----------+------------------------------------------+
              | PMIx     | ``$HOME/.pmix/mca-params.conf`` or       |
-             |          | ``$prefix/etc/openpmix-mca-params.conf`` |
+             |          | ``$prefix/etc/pmix-mca-params.conf``     |
              +----------+------------------------------------------+
-             | PRRTE    | ``$HOME/.prrte/mca-params.conf`` or      |
+             | PRRTE    | ``$HOME/.prte/mca-params.conf`` or       |
              |          | ``$prefix/etc/prte-mca-params.conf``     |
              +----------+------------------------------------------+
+
+.. note:: By default, PRRTE and PMIx read only their own configuration
+          files (the PMIx and PRRTE rows above), not Open MPI's
+          ``openmpi-mca-params.conf``.  If you set the ``OMPIHOME``
+          environment variable, however, the runtime will additionally
+          read ``$OMPIHOME/etc/openmpi-mca-params.conf`` and apply any
+          PRRTE- and PMIx-related MCA parameters it finds there.  This
+          is a convenient way to keep the PRRTE and PMIx settings for a
+          given Open MPI installation alongside the Open MPI settings in
+          a single file.  Values already set in the environment take
+          precedence and are not overwritten.
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -463,7 +469,7 @@ instead of being printed to stdout.  For example:
 .. code-block:: sh
 
    shell$ mpirun --mca mpi_show_mca_params enviro \
-       --mca mpi_show_mca_param_file /tmp/foo.txt hello_c
+       --mca mpi_show_mca_params_file /tmp/foo.txt hello_c
    Hello, World, I am 0 of 1
    shell$ cat /tmp/foo.txt
    #

--- a/docs/release-notes/platform.rst
+++ b/docs/release-notes/platform.rst
@@ -3,53 +3,133 @@
 Platform Notes
 ==============
 
-.. error:: **TODO We should have a canonical list of:**
-
-   *  *required* 3rd-party package versions supported (PRRTE, hwloc,
-      libevent)
-   * back-end run-time systems supported (behind PRRTE)
-   * OS's and compilers supported
-   * network interconnects supported.
-
 Open MPI uses both `OpenPMIx <https://openpmix.github.io/>`_ and
-`PRRTE <https://github.com/openpmix/prrte>`_ for its run-time system support,
-and therefore supports whatever run-time systems they support.
+`PRRTE <https://github.com/openpmix/prrte>`_ for its run-time system
+support, and therefore supports whatever run-time systems they support.
 
 .. note:: See the :ref:`PMIx and PRRTE section
           <label-running-role-of-pmix-and-prte>` of the Open MPI
           documentation for more details about those projects and
           their relationship to Open MPI.
 
-Each version of Open MPI supports a specific set of versions of
-OpenPMIx and PRRTE.  Those versions therefore determine which run-time systems
-that a release of Open MPI supports.
+Required support libraries
+--------------------------
+
+Open MPI |ompi_ver| depends on the following support libraries.  Each
+may be supplied by a system installation (if it is recent enough) or
+used from the copy embedded in the Open MPI distribution:
+
+* `OpenPMIx <https://openpmix.github.io/>`_: version
+  |pmix_min_version| or later when building without PRRTE (when
+  building with PRRTE, PRRTE's own OpenPMIx minimum applies).  Open
+  MPI |ompi_ver| embeds OpenPMIx |pmix_embedded_version|.
+* `PRRTE <https://github.com/openpmix/prrte>`_: version
+  |prte_min_version| or later.  Open MPI |ompi_ver| embeds PRRTE
+  |prte_embedded_version|.  PRRTE is what provides ``mpirun``; it is
+  not needed if MPI jobs are always launched directly by a
+  PMIx-enabled resource manager.
+* `hwloc <https://www.open-mpi.org/projects/hwloc/>`_: version
+  |hwloc_min_version| or later, and older than v3.0.0 (Open MPI does
+  not yet support the hwloc v3.x series).  Open MPI |ompi_ver| embeds
+  hwloc |hwloc_embedded_version|.
+* `Libevent <https://libevent.org/>`_: version |event_min_version| or
+  later.  Open MPI |ompi_ver| embeds Libevent
+  |event_embedded_version|.
+
+See the :ref:`Required support libraries section
+<label-install-required-support-libraries>` for the full details,
+including how ``configure`` chooses between an embedded and an
+external copy of each library.
+
+The versions of OpenPMIx and PRRTE that a given Open MPI release
+supports determine which back-end run-time systems that release
+supports.
+
+Building Open MPI additionally requires Perl 5 and Python
+|python_min_version| or later.  These are needed only to *build* Open
+MPI itself |mdash| not to build or run MPI applications.
+
+Operating systems and compilers
+-------------------------------
+
+Open MPI |ompi_ver| requires a C11 (or newer) C compiler.
 
 * Systems that have been tested are:
 
-  * Linux (various flavors/distros), 64 bit (x86, ppc, aarch64),
-    with gcc/gfortran (>=7.x+), clang (>=10.x), Intel,
-    and Portland (be sure to also see :ref:`the Compiler Notes
-    section <compiler-notes-section-label>`)
-  * macOS (14.x, 15.x), 64 bit (x86_64) with XCode compilers
+  * Linux (various flavors/distros), 64 bit (x86, ppc, aarch64), with
+    gcc/gfortran (>= 7.x), clang (>= 10.x), Intel, and NVIDIA (be sure
+    to also see :ref:`the Compiler Notes section
+    <compiler-notes-section-label>`)
+  * macOS (26.x), 64 bit (arm64/Apple silicon), with Xcode compilers.
+    This is the macOS platform exercised by Open MPI's GitHub Actions
+    CI, which builds, runs ``make check``, and runs the example
+    programs on the ``macos-latest`` runner image.
 
 * Other systems have been lightly (but not fully) tested:
 
+  * macOS on 64 bit x86_64 (Intel) hardware with Xcode compilers.
+    Open MPI is expected to work here, but it is not covered by CI.
   * Cygwin 64 bit with gcc
   * ARMv6, ARMv7, ARMv9
   * Other 64 bit platforms.
-  * OpenBSD.  Requires configure options ``--enable-mca-no-build=patcher``
-    and ``--disable-dlopen`` with this release.
+  * OpenBSD.  Requires configure options
+    ``--enable-mca-no-build=patcher`` and ``--disable-dlopen`` with
+    this release.
   * Problems have been reported when building Open MPI on FreeBSD 11.1
-    using the clang-4.0 system compiler. A workaround is to build
+    using the clang-4.0 system compiler.  A workaround is to build
     Open MPI using the GNU compiler.
 
 .. note:: 32-bit environments are no longer supported.
 
-* The run-time systems that are currently supported are:
+Run-time systems
+----------------
 
-  * ssh / rsh
-  * PBS Pro, Torque
-  * Platform LSF (tested with v9.1.1 and later)
-  * Slurm
-  * HPE/Cray PALS
-  * Oracle Grid Engine (OGE) 6.1, 6.2 and open source Grid Engine
+Because Open MPI delegates launch to PRRTE, the supported back-end
+run-time systems are those that PRRTE supports.  The currently
+supported run-time systems are:
+
+* **ssh / rsh:** used in non-scheduled environments, and also to launch
+  within an allocation from a resource manager that does not provide
+  its own launch mechanism.  See :doc:`Launching with SSH
+  </launching-apps/ssh>`.
+* **Slurm:** Open MPI obtains the node list and slot counts from
+  Slurm, and uses Slurm's native mechanisms to start processes.
+  Slurm's ``srun`` "direct launch" mode is also supported.  See
+  :doc:`Launching with Slurm </launching-apps/slurm>`.
+* **PBS Pro / Torque / OpenPBS:** the allocation is obtained from the
+  resource manager, and processes are started via the TM interface.
+  See :doc:`Launching with PBS / Torque </launching-apps/tm>`.
+* **Platform LSF** (tested with v9.1.1 and later): the allocation is
+  obtained from LSF, and processes are started via LSF's native
+  mechanisms.  Problems have been reported with the most recent LSF
+  releases; see :doc:`Launching with LSF </launching-apps/lsf>` for
+  the details and a workaround.
+* **HPE PALS:** processes are started via the Parallel Application
+  Launch Service on HPE systems; PALS' ``aprun`` "direct launch" mode
+  is also supported.  See :doc:`Launching with HPE PALS
+  </launching-apps/pals>`.
+* **Grid Engine:** the allocation is obtained from Grid Engine, and
+  processes are started via ``qrsh`` so that Grid Engine can monitor
+  and control them.  This covers the whole Grid Engine family (Oracle
+  Grid Engine, Son of Grid Engine, Altair/Univa Grid Engine, Open
+  Cluster Scheduler, and friends); it must be explicitly enabled with
+  ``configure --with-sge``.  See :doc:`Launching with Grid Engine
+  </launching-apps/gridengine>`.
+* **Flux:** the allocation is obtained from Flux, but Flux provides no
+  native launch mechanism to PRRTE; processes within the allocation
+  are started via ``ssh``.
+
+Network interconnects
+---------------------
+
+The primary network transports that Open MPI supports are:
+
+* Shared memory, for on-node communication
+* TCP / IP
+* InfiniBand and RoCE, via `UCX <https://openucx.org/>`_
+* Networks supported by `Libfabric (OFI) <https://libfabric.org/>`_,
+  including AWS EFA, Cornelis Networks Omni-Path, and HPE Slingshot
+* Cisco usNIC
+
+See the networking pages under :doc:`/tuning-apps/index` for
+configuration and tuning details.

--- a/docs/tuning-apps/large-clusters/reduce-startup-time.rst
+++ b/docs/tuning-apps/large-clusters/reduce-startup-time.rst
@@ -1,8 +1,6 @@
 Reducing startup time for jobs
 ==============================
 
-.. error:: TODO This whole section needs to be checked.
-
 There are several ways to reduce the startup time on large
 clusters. Some of them are described on this page. We continue to work
 on making startup even faster, especially on the large clusters coming

--- a/docs/tuning-apps/large-clusters/reduce-wireup-time.rst
+++ b/docs/tuning-apps/large-clusters/reduce-wireup-time.rst
@@ -2,32 +2,67 @@ Reducing wireup time
 ====================
 
 Open MPI's run-time uses an *out-of-band* (OOB) communication
-subsystem to pass messages during the launch, initialization, and
-termination stages for the job. These messages allow ``mpirun`` to tell
-its daemons what processes to launch, and allow the daemons in turn to
-forward stdio to ``mpirun``, update ``mpirun`` on process status, etc.
+subsystem to pass control messages during the launch, initialization,
+and termination stages of a job. These messages allow ``mpirun`` to
+tell its daemons which processes to launch, and allow the daemons in
+turn to forward stdio to ``mpirun``, update ``mpirun`` on process
+status, and so on.
 
-The OOB uses TCP sockets for its communication, with each daemon
-opening a socket back to ``mpirun`` upon startup. In a large cluster,
-this can mean thousands of connections being formed on the node where
-``mpirun`` resides, and requires that ``mpirun`` actually process all
-these connection requests. ``mpirun`` defaults to processing
-connection requests sequentially |mdash| so on large clusters, a
-backlog can be created that can cause remote daemons to timeout
-waiting for a response.
+.. note:: Since Open MPI 5.0, the run-time environment |mdash|
+   including the OOB subsystem and the ``mpirun`` launcher |mdash| is
+   provided by :ref:`PRRTE <label-running-role-of-pmix-and-prte>`, not
+   by Open MPI itself.
 
-Fortunately, Open MPI provides an alternative mechanism for processing
-connection requests that helps alleviate this problem. Setting the MCA
-parameter ``oob_tcp_listen_mode`` to ``listen_thread`` causes
-``mpirun`` to startup a separate thread dedicated to responding to
-connection requests. Thus, remote daemons receive a quick response to
-their connection request, allowing ``mpirun`` to deal with the message
-as soon as possible.
+The OOB uses TCP sockets, but the daemons do *not* all connect back to
+``mpirun``. Instead, PRRTE arranges them in a *radix tree*: each daemon
+connects only to its parent in that tree, and traffic bound for
+``mpirun`` is relayed up the tree hop by hop. The fan-out of the tree
+is set by the ``rml_base_radix`` PRTE MCA parameter, which defaults to
+64 |mdash| so no matter how large the job is, only the first 64 daemons
+connect directly to ``mpirun``, and each daemon below them accepts at
+most 64 connections from its own children.
 
-.. error:: TODO This seems very out of date.  We should have content
-           about PMIx instant on.
+Similarly, when the ``ssh`` launcher is used, the daemons are also
+*launched* through a tree: each daemon ``ssh``\ s the next level of
+daemons into existence, rather than ``mpirun`` launching every daemon
+itself. (This can be disabled by setting the ``plm_ssh_no_tree_spawn``
+PRTE MCA parameter to 1, but there is rarely a reason to do so on a
+large cluster.)
 
-This parameter can be included in the default MCA parameter file,
-placed in the user's environment, or added to the ``mpirun`` command
-line.  See :ref:`this FAQ entry <label-running-setting-mca-param-values>`
-for more details on how to set MCA parameters.
+Together, these keep the connection and launch load on the node where
+``mpirun`` resides bounded rather than growing with the job size.
+``mpirun`` additionally services the connections it does receive on a
+dedicated listener thread, so remote daemons get a prompt response.
+This behavior is built in and requires no tuning.
+
+PMIx "Instant On"
+-----------------
+
+A larger contributor to startup cost at scale is the exchange of
+per-process communication endpoint information (the "modex") that MPI
+processes historically performed during ``MPI_Init`` in order to wire
+up their point-to-point connections. As the job size grows, this global
+exchange grows with it.
+
+Open MPI, PRRTE, and PMIx support the PMIx *Instant On* capability,
+which moves this work out of ``MPI_Init``. Rather than having the
+processes exchange endpoint information among themselves at run time,
+the launcher (PRRTE) and the fabric/network software collect the
+necessary network addressing information as part of the launch and
+pre-position it in each process's PMIx data store before the process
+starts. Each process can then look up any peer's endpoint information
+locally, so no global wireup exchange is required |mdash| the processes
+start already "wired up."
+
+Instant On is provided cooperatively by PMIx, PRRTE, and the
+network/fabric components. Whether |mdash| and how much of |mdash| it
+is available therefore depends on the interconnect and its software
+stack, rather than on a single user-settable MCA parameter. See the
+:ref:`PMIx and PRRTE section <label-running-role-of-pmix-and-prte>` for
+more information about these projects.
+
+For applications with sparse communication patterns, you can also
+reduce or eliminate the up-front modex with the
+``pmix_base_async_modex`` MCA parameter, which defers endpoint lookups
+until first message. See :doc:`reduce-startup-time` for details on that
+and other launch-time options.

--- a/docs/tuning-apps/large-clusters/static-cluster-config.rst
+++ b/docs/tuning-apps/large-clusters/static-cluster-config.rst
@@ -1,43 +1,57 @@
 Static cluster configurations
 =============================
 
-.. error:: This entire section needs to be checked.
-
 Clusters rarely change from day-to-day, and large clusters rarely
 change at all.  If you know your cluster's configuration, there are
 several steps you can take to both reduce Open MPI's memory footprint
 and reduce the launch time of large-scale applications.  These steps
 use a combination of build-time configuration options to eliminate
-components |mdash| thus eliminating their libraries and avoiding
-unnecessary component open/close operations |mdash| as well as
-run-time MCA parameters to specify what modules to use by default for
-most users.
+components |mdash| making Open MPI's libraries smaller and avoiding the
+work of registering and querying components that will never be used
+|mdash| as well as run-time MCA parameters to select the components to
+use by default for most users.
 
-One way to save memory is to avoid building components that will
-actually never be selected by the system. Unless MCA parameters
-specify which components to open, built components are always opened
-and tested as to whether or not they should be selected for use. If
-you know that a component can build on your system, but due to your
-cluster's configuration will never actually be selected, then it is
-best to simply configure OMPI to not build that component by using the
-``--enable-mca-no-build`` configure option.
+.. note:: Since Open MPI v5.0, components are, by default, compiled
+   directly into Open MPI's core libraries (for example,
+   ``libopen-pal`` and ``libmpi``) rather than being built as separate
+   dynamically-loaded plugins (DSOs).  Even when a component is compiled
+   in this way, it is still registered and queried at run time so that
+   each framework can decide which of its components to use.  The
+   techniques on this page |mdash| not building components you do not
+   need, and choosing framework defaults up front |mdash| therefore
+   still reduce both memory footprint and startup work.  See
+   :ref:`Components ("plugins"): static or DSO?
+   <label-install-packagers-dso-or-not>` for more about the static and
+   DSO build models and how to select between them.
 
-For example, if you know that your system will only utilize the
-``ob1`` component of the PML framework, then you can ``no_build`` all
-the others. This not only reduces memory in the libraries, but also
-reduces memory footprint that is consumed by Open MPI opening all the
-built components to see which of them can be selected to run.
+One way to save memory is to avoid building components that will never
+be selected on your system.  Every component that is built into Open
+MPI is registered and tested at run time to decide whether it should be
+selected, unless MCA parameters restrict which components are
+considered.  If you know that a component can build on your system but,
+due to your cluster's configuration, will never actually be selected,
+then it is best to configure Open MPI to not build that component by
+using the ``--enable-mca-no-build`` configure option.
 
-In some cases, however, a user may optionally choose to use a
-component other than the default.  For example, you may want to build
-all of the PRRTE ``routed`` framework components, even though the vast
-majority of users will simply use the default ``debruijn``
+For example, if you know that your system will only use the ``ob1``
+component of the PML framework, then you can ``no_build`` all the
+others.  This both makes the resulting libraries smaller and avoids the
+startup cost of registering and querying components that would never be
+used.
+
+In some cases, however, you may want to keep a framework's other
+components built |mdash| so that users retain the option to select them
+|mdash| even though most users will use a single default.  For example,
+you may want to keep all of the ``pml`` framework's components built (so
+that users can still select ``ucx`` or ``cm`` when appropriate), even
+though the vast majority of users will use the default ``ob1``
 component.  This means you have to allow the system to build the other
 components, even though they may rarely be used.
 
 You can still save launch time and memory, though, by setting the
-``routed=debruijn`` MCA parameter in the default MCA parameter file.
-This causes OMPI to not open the other components during startup, but
-allows users to override this on their command line or in their
-environment so no functionality is lost |mdash| you just save some
+``pml = ob1`` MCA parameter in the default MCA parameter file.  This
+tells Open MPI to consider only the ``ob1`` component at startup, rather
+than registering and querying every ``pml`` component, but still allows
+users to override the setting on their command line or in their
+environment |mdash| so no functionality is lost, and you save some
 memory and time.


### PR DESCRIPTION
This addresses the "Theme B" `.. error:: TODO` markers that asked for
several documentation sections to be checked against the code base.
Each claim below was verified against the actual source (OMPI/OPAL,
plus the embedded PRRTE and OpenPMIx).

**Opened as a draft** for review.

## `docs/mca.rst` (two commits)

Corrected the "Setting MCA parameter values" section (three TODOs):

- Tuned parameter files *do* allow comments (`#` lines and empty lines
  are ignored); the page said they were not allowed.
- `mca_base_envvar_file_prefix` → `mca_base_envar_file_prefix` (one "v").
- `mca_base_envvar_file_path` does not exist; relative tuned files
  resolve against `mca_base_param_file_path`.
- `mca_param_files` → `mca_base_param_files`; it is comma-delimited (not
  colon), and leftmost files have *higher* precedence (was stated
  backwards, contradicting the adjacent list).
- Config-file table: PMIx system file is `pmix-mca-params.conf` (not
  `openpmix-...`); PRRTE per-user dir is `$HOME/.prte` (single R).
- Documented the `OMPIHOME` environment variable (makes the runtime
  read `$OMPIHOME/etc/openmpi-mca-params.conf` for PRRTE/PMIx params).
- Typo: `mpi_show_mca_params_file` (was `..._param_file`).

Audited the ORTE→PRRTE deprecated-parameter mapping table:

- `hwloc_base_cpu_set` / `hwloc_base_cpu_list` map to
  `hwloc_default_cpu_list`, not `mapby=pe-list=` (PRRTE rejects
  `pe-list=` on the default-parameter path).
- `ompi_stream_buffering` is an Open MPI parameter
  (`OMPI_MCA_ompi_stream_buffering`), not a PRRTE one.
- The old `orte_*` names are fully removed (not deprecated aliases), so
  the "may be removed in future releases" framing was stale.
- Renamed the mapping/binding parameters throughout the table and
  examples from `rmaps_default_mapping_policy` /
  `hwloc_default_binding_policy` to their current names `mapby` /
  `bindto` (the old names remain as deprecated synonyms). The rest of
  the table verified correct.

## `docs/tuning-apps/large-clusters/*` (one commit)

- **reduce-startup-time**: verified accurate (`pmix_base_async_modex`,
  `async_mpi_init/finalize`, `usnic` all still exist); TODO removed.
- **reduce-wireup**: `oob_tcp_listen_mode=listen_thread` no longer
  exists (the listener thread is now always-on in PRRTE). Rewrote the
  page and added a description of PMIx "Instant On".
- **static-cluster-config**: the PRRTE `routed`/`debruijn` example is
  dead (routing is now a fixed radix tree); replaced it with a current
  `pml`/`ob1` example, and reframed the page for the non-DSO default.

## `docs/release-notes/platform.rst` (one commit)

Filled in the canonical list the TODO asked for: required support-library
minimum versions (OpenPMIx >= 4.2.0, PRRTE >= 3.0.0, hwloc >= 2.1.0 and
< 3.0.0, Libevent >= 2.0.21) plus the embedded hwloc 2.7.1 / Libevent
2.1.12 and Perl 5 / Python 3.6+ build requirements; the C11 compiler
requirement; the supported run-time systems (added Flux); and a network
interconnect summary.

All changes are documentation-only and were verified with a warning-free
Sphinx build (including under the Sphinx 8.x that Read the Docs uses).
