### PR TITLE
docs: resolve stale TODO markers in launching / help pages 

### DIFF
--- a/docs/getting-help.rst
+++ b/docs/getting-help.rst
@@ -249,8 +249,6 @@ of the following additional information:
 #. If you are experiencing networking problems, include detailed
    information about your network.
 
-   .. error:: TODO Update link to IB FAQ entry.
-
    #. For RoCE- or InfiniBand-based networks, include the information
       :ref:`in this FAQ entry <faq-ib-troubleshoot-label>`.
 

--- a/docs/launching-apps/gridengine.rst
+++ b/docs/launching-apps/gridengine.rst
@@ -1,13 +1,13 @@
 Launching with Grid Engine
 ==========================
 
-Open MPI supports the family of run-time schedulers including the Sun
-Grid Engine (SGE), Oracle Grid Engine (OGE), Grid Engine (GE), Son of
-Grid Engine, and others.
+Open MPI supports the Grid Engine family of run-time schedulers.  This
+family traces back to Sun Grid Engine (SGE) and includes its many
+descendants |mdash| among them Oracle Grid Engine, Son of Grid Engine,
+Univa Grid Engine (now Altair Grid Engine), and Open Cluster Scheduler.
 
-This documentation will collectively refer to all of them as "Grid
-Engine", unless a referring to a specific flavor of the Grid Engine
-family.
+This documentation collectively refers to all of them as "Grid Engine",
+unless referring to a specific member of the family.
 
 Verify Grid Engine support
 --------------------------
@@ -52,11 +52,11 @@ that were allocated by Grid Engine:
 
    # Get the environment variables for Grid Engine
 
-   # (Assuming Grid Engine is installed at /opt/sge and $Grid
-   # Engine_CELL is 'default' in your environment)
+   # (Assuming Grid Engine is installed at /opt/sge and $SGE_CELL
+   # is 'default' in your environment)
    shell$ . /opt/sge/default/common/settings.sh
 
-   # Allocate an Grid Engine interactive job with 4 slots from a
+   # Allocate a Grid Engine interactive job with 4 slots from a
    # parallel environment (PE) named 'ompi' and run a 4-process Open
    # MPI job
    shell$ qrsh -pe ompi 4 -b y mpirun -n 4 mpi-hello-world
@@ -130,18 +130,11 @@ that is used to send parallel tasks to the remote Grid Engine
 execution hosts. It will show whether the connections to the remote
 hosts are established successfully or not.
 
-.. error:: TODO is this site still live?  Doesn't look like it..  Jeff
-   emailed Dave Love on 31 Dec 2021 to ask if this is still the
-   correct URL.
-
-   Update March 2022: it doesn't look like this web site is good any
-   more.  Perhaps use https://github.com/grisu48/gridengine instead...?
-
-Various Grid Engine documentation with pointers to more is available
-at `the Son of GridEngine site <http://arc.liv.ac.uk/sge/>`_, and
-configuration instructions can be found at `the Son of GridEngine
-configuration how-to site
-<http://arc.liv.ac.uk/SGE/howto/sge-configs.html>`_.
+For more information about Grid Engine, see the actively-maintained
+open-source `Open Cluster Scheduler
+<https://github.com/hpc-gridware/clusterscheduler>`_ project |mdash|
+the current successor to Sun Grid Engine, Univa Grid Engine, and Son of
+Grid Engine |mdash| and its documentation.
 
 Grid Engine tight integration support of the ``qsub -notify`` flag
 ------------------------------------------------------------------

--- a/docs/launching-apps/gridengine.rst
+++ b/docs/launching-apps/gridengine.rst
@@ -177,9 +177,7 @@ like this batch script can be used:
    #$ -pe ompi 16
    #$ -j y
    #$ -l h_rt=00:20:00
-   mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
-
-.. error:: Ralph: Does ``orte_forward_job_control`` still exist?
+   mpirun -n 16 mpi-hello-world
 
 However, one has to make one of two changes to this script for things
 to work properly.  By default, a SIGUSR1 signal will kill a shell
@@ -196,7 +194,7 @@ to handle it:
    #$ -pe ompi 16
    #$ -j y
    #$ -l h_rt=00:20:00
-   exec mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
+   exec mpirun -n 16 mpi-hello-world
 
 Alternatively, one can catch the signals in the script instead of doing
 an exec on the mpirun:
@@ -225,7 +223,7 @@ an exec on the mpirun:
    trap sigusr1handler SIGUSR1
    trap sigusr2handler SIGUSR2
 
-   mpirun -n 16 -mca orte_forward_job_control 1 mpi-hello-world
+   mpirun -n 16 mpi-hello-world
 
 Grid Engine job suspend / resume support
 ----------------------------------------
@@ -236,16 +234,14 @@ To suspend the job, you send a SIGTSTP (not SIGSTOP) signal to
 a SIGCONT signal to :ref:`mpirun(1) <man1-mpirun>` which will be caught and forwarded to
 the ``mpi-hello-world``.
 
-By default, this feature is not enabled.  This means that both the
-SIGTSTP and SIGCONT signals will simply be consumed by the :ref:`mpirun(1) <man1-mpirun>`
-process.  To have them forwarded, you have to run the job with ``--mca
-orte_forward_job_control 1``.  Here is an example on Solaris:
-
-.. error:: TODO Ralph: does ``orte_forward_job_control`` still exist?
+By default, ``mpirun`` forwards the SIGTSTP and SIGCONT signals to the
+application processes (delivering SIGTSTP as SIGSTOP so the processes
+suspend), so no special option is required to enable this behavior.
+Here is an example on Solaris:
 
 .. code-block:: sh
 
-   shell$ mpirun -mca orte_forward_job_control 1 -n 2 mpi-hello-world
+   shell$ mpirun -n 2 mpi-hello-world
 
 In another window, we suspend and continue the job:
 

--- a/docs/launching-apps/prerequisites.rst
+++ b/docs/launching-apps/prerequisites.rst
@@ -249,8 +249,3 @@ uses ``--prefix``:
 .. code-block::
 
    shell$ /opt/openmpi-VERSION/bin/mpirun -n 4 a.out
-
-.. error:: TODO Josh H points out that we might also want to mention
-           ``OMPIHOME`` for PRRTE's ``.ini`` file here.  Leaving this
-           as a future to-do item, since PRRTE's ``.ini`` file support
-           does not exist yet.

--- a/docs/launching-apps/troubleshooting.rst
+++ b/docs/launching-apps/troubleshooting.rst
@@ -61,9 +61,11 @@ why this can happen.
     linker is smart enough to not load ``libmpi`` twice |mdash| but it
     does keeps ``libmpi`` in a public scope.
   * Use the ``--disable-dlopen`` or ``--disable-mca-dso`` options to
-    Open MPI's ``configure`` script (see this TODO NONEXISTENT FAQ entry
-    for more details on these
-    options).  These options slurp all of Open MPI's plugins up in to
+    Open MPI's ``configure`` script (see the
+    :ref:`--disable-dlopen <building-ompi-cli-options-disable-dlopen-label>`
+    and :ref:`--enable-mca-dso / --enable-mca-static
+    <building-ompi-cli-options-mca-dso-label>` option descriptions for
+    more details).  These options slurp all of Open MPI's plugins up in to
     ``libmpi`` |mdash| meaning that the plugins physically reside in
     ``libmpi`` and will not be dynamically opened at run time.
   * Build Open MPI as a static library by configuring Open MPI with


### PR DESCRIPTION
This resolves the remaining "Theme C" `.. error:: TODO` markers in the
launching-apps and getting-help documentation. Each was verified against
the current code base (including the embedded PRRTE/OpenPMIx on both
`main` and `v6.0.x`).

**Opened as a draft** for review.

## Grid Engine (`docs/launching-apps/gridengine.rst`)

- **`orte_forward_job_control` removed.** That ORTE-era MCA parameter no
  longer exists. Its behavior is now the default: PRRTE forwards SIGTSTP
  and SIGCONT to the application processes by default, and the daemon
  converts SIGTSTP to SIGSTOP to suspend / tracks SIGCONT to resume
  (`prted/prted_comm.c`). Dropped the flag from the examples and reworded
  the "not enabled by default" text.
- **Dead Son of Grid Engine links replaced.** The `arc.liv.ac.uk` site
  is defunct (refuses connections). Repointed readers at the
  actively-maintained open-source [Open Cluster
  Scheduler](https://github.com/hpc-gridware/clusterscheduler) and
  refreshed the intro to name the modern forks (Oracle GE, Son of GE,
  Univa GE / now Altair GE, Open Cluster Scheduler). Grid Engine remains
  supported: PRRTE still ships `ras/gridengine` on both main and v6.0.x.
- Fixed two `SGE`->`Grid Engine` find/replace artifacts (`$SGE_CELL`,
  "a Grid Engine").

## Other stale TODOs

- **`getting-help.rst`**: removed the "update link to IB FAQ entry" TODO
  (the cross-reference below it already points at the current IB/RoCE
  troubleshooting section, `faq-ib-troubleshoot-label`).
- **`troubleshooting.rst`**: replaced the "NONEXISTENT FAQ entry"
  placeholder with real `:ref:`s to the `--disable-dlopen` and
  `--enable-mca-dso` / `--enable-mca-static` configure-option
  descriptions.
- **`prerequisites.rst`**: removed the internal "future to-do" note
  about OMPIHOME / PRRTE's `.ini` file (it rendered as a user-facing
  error box). The anticipated `.ini` support never materialized in that
  form; PRRTE's OMPIHOME support instead reads
  `$OMPIHOME/etc/openmpi-mca-params.conf` (now documented in the MCA
  page via the Theme B PR).

Documentation-only; verified with a warning-free Sphinx build (including
under the Sphinx 8.x that Read the Docs uses).