### PR TITLE
Fix file descriptor leaks and teardown ordering in MPI instance finalize

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -425,6 +425,14 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
         return ompi_instance_print_error ("ompi_mpi_init: ompi_rte_init failed", ret);
     }
 
+    /* ompi_rte_init() called opal_init(), which set the current finalize
+     * domain to its own.  Restore ours, or every cleanup we register from here
+     * on lands in OPAL's domain and runs from inside opal_finalize() -- after
+     * we have already torn the RTE down, and before we close the frameworks
+     * whose components those cleanups touch.
+     */
+    opal_finalize_set_domain (&ompi_instance_common_domain);
+
     /* open the ompi hook framework */
     for (int i = 0 ; ompi_framework_dependencies[i] ; ++i) {
         ret = mca_base_framework_open (ompi_framework_dependencies[i], 0);
@@ -1011,13 +1019,13 @@ static int ompi_mpi_instance_finalize_common (void)
         ompi_ulfm_pmix_err_handler = 0;
     }
 
-    /* Leave the RTE */
-    if (OMPI_SUCCESS != (ret = ompi_rte_finalize())) {
-        return ret;
-    }
-
-    ompi_rte_initialized = false;
-
+    /* Close our frameworks before leaving the RTE.  ompi_rte_finalize() calls
+     * opal_finalize(), and the BML opens the *OPAL* BTL framework on our
+     * behalf -- so leaving these open across ompi_rte_finalize() means
+     * finalizing OPAL while an OPAL framework is still open, and its
+     * components (e.g., the TCP BTL) still have events registered on
+     * opal_sync_event_base.
+     */
     for (int i = 0 ; ompi_lazy_frameworks[i] ; ++i) {
         if (0 < ompi_lazy_frameworks[i]->framework_refcnt) {
             /* May have been "opened" multiple times. We want it closed now! */
@@ -1041,6 +1049,13 @@ static int ompi_mpi_instance_finalize_common (void)
             return ret;
         }
     }
+
+    /* Leave the RTE */
+    if (OMPI_SUCCESS != (ret = ompi_rte_finalize())) {
+        return ret;
+    }
+
+    ompi_rte_initialized = false;
 
     ompi_proc_finalize();
 

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -164,6 +164,14 @@ static int posix_runtime_query(mca_base_module_t **module, int *priority, const 
                          "starting run-time test...\n"));
     /* shmem_posix_shm_open successfully shm_opened - we can use posix sm! */
     if (-1 != (fd = opal_shmem_posix_shm_open(tmp_buff, OPAL_SHMEM_POSIX_FILE_LEN_MAX - 1))) {
+        /* the run-time test only needed to know that the shm_open(2)
+         * succeeded.  close the descriptor it handed back -- shm_unlink(3)
+         * below removes the name, but the descriptor would otherwise stay
+         * open for the life of the process, and this query runs on every
+         * opal_init().
+         */
+        (void) close(fd);
+
         /* free up allocated resources before we return */
         if (0 != shm_unlink(tmp_buff)) {
             int err = errno;

--- a/opal/util/event.c
+++ b/opal/util/event.c
@@ -152,6 +152,16 @@ int opal_event_init(void)
 
 int opal_event_finalize(void)
 {
+    if (NULL != opal_sync_event_base) {
+        opal_event_base_free(opal_sync_event_base);
+        opal_sync_event_base = NULL;
+    }
+
+    if (NULL != opal_event_config) {
+        event_config_free(opal_event_config);
+        opal_event_config = NULL;
+    }
+
     return OPAL_SUCCESS;
 }
 


### PR DESCRIPTION
Three teardown bugs in the common `ompi_mpi_instance_*` / OPAL finalize path. They are not sessions-specific -- `MPI_Init()` goes through the same `ompi_mpi_instance_init()` -- but a world-model program finalizes exactly once and exits, so the leak is invisible. Sessions are the only MPI-legal way to cycle init/finalize repeatedly in one process, which turns a harmless one-shot leak into unbounded file-descriptor growth.

Reproducer (a modified `examples/hello_sessions_c.c`):

```c
MPI_Info info;
MPI_Info_create(&info);
for (int i = 0; i < 10000; i++) {
    MPI_Session s;
    MPI_Session_init(info, MPI_ERRORS_RETURN, &s);
    MPI_Session_finalize(&s);
}
```

Before: open descriptors grow by 5 every cycle (~50,000 by iteration 10,000); with `ulimit -n 1024`, `MPI_Session_init()` starts failing at iteration 203. After: the fd count is **flat** for the whole run.

**NOTE:** You also need a PMIx fix that is currently on openpmix `master` to be able to reliably session init+finalize 10K times.  The possibility of bringing that fix to the openpmix `v6.1.x` branch (tracked in submodules on OMPI's `main` and `v6.0.x` branches) is being discussed here: https://github.com/open-mpi/ompi/issues/14125#issuecomment-4949187377

## The three commits

**`ompi/instance: fix finalize domain and close frameworks before the RTE`**

Two bugs that must be fixed together.

*The finalize domain.* `ompi_mpi_instance_init_common()` sets the current finalize domain to `ompi_instance_common_domain`, then calls `ompi_rte_init()` -> `opal_init()`, which sets the current domain to its own `opal_init_domain` and never restores ours. The current domain is a single global, so every cleanup OMPI registers after that point silently lands in **OPAL's** domain. Today that is `ompi_mpi_instance_cleanup_pml()`, which therefore runs from inside `opal_finalize()` instead of from the `ompi_instance_common_domain` cleanup where it belongs.

*The framework close order.* `ompi_rte_finalize()` calls `opal_finalize()`, and the BML opens the **OPAL** BTL framework on OMPI's behalf (`bml_base_frame.c`). Closing the OMPI frameworks *after* `ompi_rte_finalize()` therefore means finalizing OPAL while an OPAL framework is still open -- and its components (the TCP BTL, for one) still have events registered on `opal_sync_event_base`.

These land in one commit because either alone is broken. Reordering the closes without fixing the domain runs PML `del_procs()` -- still stranded in OPAL's domain, hence inside `opal_finalize()` -- *after* the BTLs have closed, tearing the same shared-memory endpoints down twice: a use-after-free in `fini_sm_endpoint()`, which AddressSanitizer catches under `mpirun -n 2`.

**`opal/event: free the sync event base in opal_event_finalize()`** (4 fds/cycle)

`opal_event_init()` creates `opal_sync_event_base` and its `event_config`; `opal_event_finalize()` was an empty function that returned `OPAL_SUCCESS` and freed neither. Each leaked libevent base costs 4 descriptors: libevent's internal notification pipe plus its signal-handling socketpair. Only safe with the commit above, since components hold events on the base until their `component_close()`.

**`shmem/posix: close the descriptor opened by the run-time query`** (1 fd/cycle)

`posix_runtime_query()` probes for POSIX shared memory with `shm_open(2)`, then cleans up with `shm_unlink(3)` -- which removes the name but not the descriptor. The query runs on every `opal_init()`. (Visible in `lsof` as a growing pile of `PSXSHM` entries named `/open_mpi.0000`.)

## Testing

Linux (AlmaLinux 10) and macOS:

- fd count flat across 200+ session cycles (was +5/cycle); the 10,000-cycle loop completes even at `ulimit -n 1024`, where it previously died at iteration 203.
- **AddressSanitizer**, `mpirun -n 2 ring_c`: 0 errors, exit 0.
- `make check`: 84 pass, 0 fail, 0 error.
- `mpirun -n 4 hello_c`, `mpirun -n 2 ring_c`, and `test/datatype/mpi_datatype_bigcount` all pass.
- No new compiler warnings.

## Review notes

The teardown re-ordering deserves scrutiny. It changes global finalize order, and restoring the finalize domain changes *when* any OMPI cleanup registered after `ompi_rte_init()` runs -- today only `cleanup_pml`, which now runs at the instance cleanup while the RTE is still up (strictly safer than inside `opal_finalize()`). Testing has been on Linux and macOS with ASan and `make check`; it has not been exercised against real networks, multi-node jobs, accelerator components, or the ULFM paths. If any framework's `close()` depends on the RTE still being up, that is where it would show.


## Affected branches

These bugs are **not** new to `main`. All four defects -- the empty `opal_event_finalize()`, the unclosed `shmem/posix` probe descriptor, the framework close order across `ompi_rte_finalize()`, and `opal_init()` never restoring the finalize domain it takes over -- are present verbatim on **`main`**, **`v6.0.x`**, and **`v5.0.x`**.

All three commits cherry-pick **cleanly onto both `v6.0.x` and `v5.0.x`** (verified with `git cherry-pick`; no conflicts), so no manual back-port is needed.

One thing for whoever does the back-port: keep the commit grouping. The `ompi/instance` commit has to stay a single commit, and it has to precede the `opal/event` commit. Splitting the finalize-domain fix from the framework-close reordering leaves an intermediate state that double-tears-down the shared-memory endpoints (a use-after-free in `fini_sm_endpoint()`), which would break `git bisect`.
