### PR TITLE
Fix MPI_Parrived for null/inactive requests, and partitioned communication with MPI_PROC_NULL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,8 @@ ompi/test/file/file_info_hints
 ompi/test/file/file_info_memkind
 ompi/test/file/file_info_set_view
 
+ompi/test/part/parrived_null_inactive
+
 ompi/test/datatype/checksum
 ompi/test/datatype/ddt_pack
 ompi/test/datatype/ddt_raw

--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ ompi/test/file/file_info_memkind
 ompi/test/file/file_info_set_view
 
 ompi/test/part/parrived_null_inactive
+ompi/test/part/partitioned_proc_null
 
 ompi/test/datatype/checksum
 ompi/test/datatype/ddt_pack

--- a/config/ompi_config_files.m4
+++ b/config/ompi_config_files.m4
@@ -30,6 +30,7 @@ AC_DEFUN([OMPI_CONFIG_FILES],[
         ompi/test/Makefile
         ompi/test/t/Makefile
         ompi/test/file/Makefile
+        ompi/test/part/Makefile
         ompi/test/datatype/Makefile
         ompi/test/general/Makefile
         ompi/test/monitoring/Makefile

--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -26,7 +26,8 @@ DESCRIPTION
 -----------
 
 ``request`` may be a null request (``MPI_REQUEST_NULL``) or an inactive
-request, in which case ``flag`` is set to true.
+request, in which case ``flag`` is set to true.  A request created with
+``MPI_PROC_NULL`` is likewise always reported as arrived.
 
 Calling :ref:`MPI_Parrived` on a request that does not correspond to a
 partitioned receive operation is erroneous.

--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -22,6 +22,15 @@ OUTPUT PARAMETERS
 * ``flag``: True if partition is completed.
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``request`` may be a null request (``MPI_REQUEST_NULL``) or an inactive
+request, in which case ``flag`` is set to true.
+
+Calling :ref:`MPI_Parrived` on a request that does not correspond to a
+partitioned receive operation is erroneous.
+
 ERRORS
 ------
 

--- a/docs/man-openmpi/man3/MPI_Precv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Precv_init.3.rst
@@ -27,6 +27,16 @@ OUTPUT PARAMETERS
 * ``request``: Communication request (handle).
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``source`` may be ``MPI_PROC_NULL``, in which case the communication has
+no effect: the resulting request completes as soon as it is started, the
+receive buffer is not modified, and the status returned by a completing
+procedure has ``source = MPI_PROC_NULL``, ``tag = MPI_ANY_TAG``, and a
+count of zero.  :ref:`MPI_Parrived` reports every partition of such a
+request as arrived.
+
 ERRORS
 ------
 

--- a/docs/man-openmpi/man3/MPI_Psend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Psend_init.3.rst
@@ -27,6 +27,14 @@ OUTPUT PARAMETERS
 * ``request``: Communication request (handle).
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``dest`` may be ``MPI_PROC_NULL``, in which case the communication has no
+effect: the resulting request completes as soon as it is started, and
+:ref:`MPI_Pready` (and its variants) on that request succeeds without
+transferring anything.
+
 ERRORS
 ------
 

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -10,6 +10,12 @@ Open MPI version v6.1.0
 
 - Partitioned communication fixes:
 
+  - ``MPI_Parrived`` now returns ``flag = true`` for a null request
+    (``MPI_REQUEST_NULL``) and for an inactive request, as required by
+    MPI-5.0 section 4.2.2.  It previously raised ``MPI_ERR_REQUEST`` for
+    a null request and returned ``flag = false`` for a partitioned
+    receive request that had never been started.
+
   - Freeing a partitioned communication request that was never started
     no longer leaves its internal setup receive posted.  Such a stale
     receive could consume the setup message of the next partitioned

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,14 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- Partitioned communication fixes:
+
+  - Freeing a partitioned communication request that was never started
+    no longer leaves its internal setup receive posted.  Such a stale
+    receive could consume the setup message of the next partitioned
+    operation using the same communicator, peer, and tag, which then
+    never completed.
+
 - Renamed the ``--enable-weak-symbols`` configure option to
   ``--enable-weak-aliases``, which more accurately reflects the linker
   feature (weak symbol *aliases*) that Open MPI actually tests for and

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -16,6 +16,14 @@ Open MPI version v6.1.0
     a null request and returned ``flag = false`` for a partitioned
     receive request that had never been started.
 
+  - ``MPI_Psend_init`` and ``MPI_Precv_init`` now accept
+    ``MPI_PROC_NULL`` as the peer rank, per MPI-5.0 section 3.10.  Such
+    a request completes as soon as it is started, ``MPI_Pready`` on it
+    has no effect, and ``MPI_Parrived`` reports every partition as
+    arrived.  Previously, ``MPI_PROC_NULL`` was passed down as if it
+    were a real peer rank, reading outside the communicator's process
+    array.
+
   - Freeing a partitioned communication request that was never started
     no longer leaves its internal setup receive posted.  Such a stale
     receive could consume the setup message of the next partitioned

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -96,10 +96,14 @@ mca_part_persist_free_req(struct mca_part_persist_request_t* req)
     opal_list_remove_item(ompi_part_persist.progress_list, (opal_list_item_t*)req->progress_elem);
     OBJ_RELEASE(req->progress_elem);
 
-    for(i = 0; i < req->real_parts; i++) {
-        ompi_request_free(&(req->persist_reqs[i]));
+    /* The per-partition requests are only created once the setup handshake
+     * has completed, so an uninitialized request has none. */
+    if(NULL != req->persist_reqs) {
+        for(i = 0; i < req->real_parts; i++) {
+            ompi_request_free(&(req->persist_reqs[i]));
+        }
+        free(req->persist_reqs);
     }
-    free(req->persist_reqs);
     free(req->flags);
 
     if( MCA_PART_PERSIST_REQUEST_PRECV == req->req_type ) {
@@ -221,6 +225,18 @@ mca_part_persist_progress(void)
     OPAL_LIST_FOREACH(current, ompi_part_persist.progress_list, mca_part_persist_list_t) {
         mca_part_persist_request_t *req = (mca_part_persist_request_t *) current->item;
 
+        /* A request that MPI_Request_free has been called on is reclaimed
+         * once it is inactive.  This is checked before anything else, and
+         * for uninitialized requests as well as initialized ones: a request
+         * that was never started never completes its lazy setup handshake,
+         * so it would otherwise be left on the progress list forever.  Its
+         * handshake was already cancelled by mca_part_persist_free, so it
+         * must not be run through the setup path below. */
+        if(true == req->req_free_called && true == req->req_part_complete && REQUEST_COMPLETED == req->req_ompi.req_complete &&  OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
+            to_delete = req;
+            continue;
+        }
+
         /* Check to see if request is initilaized */
         if(false == req->initialized) {
             int done = 0; 
@@ -316,11 +332,7 @@ mca_part_persist_progress(void)
                 {
                     req->first_send = false;
                     mca_part_persist_complete(req);
-                } 
-            }
-
-            if(true == req->req_free_called && true == req->req_part_complete && REQUEST_COMPLETED == req->req_ompi.req_complete &&  OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
-                to_delete = req;
+                }
             }
         }
 
@@ -370,11 +382,15 @@ mca_part_persist_precv_init(void *buf,
 
     mca_part_persist_request_t *req = (mca_part_persist_request_t *) recvreq;
 
-    /* Set lazy initializion flags */
+    /* Set lazy initializion flags.  real_parts and persist_reqs are not
+     * known until the setup handshake completes; keep them empty so that
+     * freeing a request that was never started is safe. */
     req->initialized = false;
-    req->first_send  = true; 
+    req->first_send  = true;
     req->flag_post_setup_recv = false;
     req->flags = NULL;
+    req->persist_reqs = NULL;
+    req->real_parts = 0;
     /* Non-blocking receive on setup info */
     err	= MCA_PML_CALL(irecv(&req->setup_info[1], sizeof(struct ompi_mca_persist_setup_t), MPI_BYTE, src, tag, comm, &req->setup_req[1])); 
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
@@ -434,10 +450,14 @@ mca_part_persist_psend_init(const void* buf,
                                     datatype, buf, parts, count, flags);
     mca_part_persist_request_t *req = (mca_part_persist_request_t *) sendreq;
 
-    /* Set lazy initialization variables */
+    /* Set lazy initialization variables.  The per-partition sends are not
+     * created until the setup handshake completes; keep the array empty so
+     * that freeing a request that was never started is safe. */
     req->initialized = false;
-    req->first_send  = true; 
-    
+    req->first_send  = true;
+    req->persist_reqs = NULL;
+
+
 
     /* Determine total bytes to send. */
     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
@@ -609,6 +629,28 @@ mca_part_persist_free(ompi_request_t** request)
 
     if(true == req->req_free_called) return OMPI_ERROR;
     req->req_free_called = true;
+
+    /* If this request never completed its lazy setup handshake, its setup
+     * requests are still outstanding against req->setup_info[], which will
+     * be recycled when the request is reclaimed.  The setup receive is
+     * posted on the user's communicator with the user's peer and tag, so if
+     * it is left posted it will also match -- and consume -- the setup
+     * message of the next partitioned operation that uses that same
+     * communicator, peer, and tag; that operation would then never be set up
+     * and would never complete.  Cancel the handshake here rather than when
+     * the request is reclaimed in the progress engine: the next partitioned
+     * operation can be initialized before the progress engine runs again. */
+    if(false == req->initialized &&
+       OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
+        if(false == req->flag_post_setup_recv) {
+            ompi_request_cancel(req->setup_req[1]);
+            ompi_request_wait(&(req->setup_req[1]), MPI_STATUS_IGNORE);
+        }
+        if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
+            ompi_request_cancel(req->setup_req[0]);
+            ompi_request_wait(&(req->setup_req[0]), MPI_STATUS_IGNORE);
+        }
+    }
 
     *request = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;

--- a/ompi/mpi/c/parrived.c.in
+++ b/ompi/mpi/c/parrived.c.in
@@ -56,7 +56,8 @@ PROTOTYPE ERROR_CLASS parrived(REQUEST request, INT partition, INT_OUT flag)
             rc = MPI_ERR_ARG;
         } else if (NULL == request ||
                    (MPI_REQUEST_NULL != request &&
-                    OMPI_REQUEST_PART != request->req_type)) {
+                    OMPI_REQUEST_PART != request->req_type &&
+                    OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
@@ -69,6 +70,18 @@ PROTOTYPE ERROR_CLASS parrived(REQUEST request, INT partition, INT_OUT flag)
             *flag = 1;
             return MPI_SUCCESS;
         }
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): a receive from MPI_PROC_NULL "succeeds and
+    // returns as soon as possible", so every partition of a partitioned
+    // receive from MPI_PROC_NULL (a persistent no-op request; see
+    // MPI_Precv_init) has trivially arrived.  This is checked
+    // unconditionally: such a request is not a partitioned request, so it
+    // must never be handed to the part framework, and -- once started -- it
+    // is active, so the inactive short circuit above does not cover it.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        *flag = 1;
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_parrived(partition, partition, flag, request);

--- a/ompi/mpi/c/parrived.c.in
+++ b/ompi/mpi/c/parrived.c.in
@@ -45,23 +45,30 @@ PROTOTYPE ERROR_CLASS parrived(REQUEST request, INT partition, INT_OUT flag)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        // MPI-5.0 sec 4.2.2 (p.119): MPI_Parrived on a null or inactive
-        // request returns flag = true.  Handle these before the
-        // request-type check so MPI_REQUEST_NULL (req_type ==
-        // OMPI_REQUEST_NULL) and a never-started inactive partitioned
-        // receive request are not rejected with MPI_ERR_REQUEST.
-        if (NULL == request || MPI_REQUEST_NULL == request) {
-            *flag = 1;
-            return MPI_SUCCESS;
-        }
-        if (OMPI_REQUEST_INACTIVE == request->req_state) {
-            *flag = 1;
-            return MPI_SUCCESS;
-        }
-        if (OMPI_REQUEST_PART != request->req_type) {
+        // MPI-5.0 sec 4.2.2 (p.119) explicitly permits a null request
+        // here, so MPI_REQUEST_NULL must survive the request type check:
+        // its req_type is OMPI_REQUEST_NULL, not OMPI_REQUEST_PART.  Any
+        // other type of request is erroneous ("Calling MPI_PARRIVED on a
+        // request that does not correspond to a partitioned receive
+        // operation is erroneous"), including an inactive one, so this
+        // check must precede the inactive check below.
+        if (NULL == flag) {
+            rc = MPI_ERR_ARG;
+        } else if (NULL == request ||
+                   (MPI_REQUEST_NULL != request &&
+                    OMPI_REQUEST_PART != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+
+        // MPI-5.0 sec 4.2.2 (p.119): "MPI_PARRIVED may be called with a
+        // null or inactive request argument.  In either case, the
+        // operation returns with flag = true."
+        if (MPI_REQUEST_NULL == request ||
+            OMPI_REQUEST_INACTIVE == request->req_state) {
+            *flag = 1;
+            return MPI_SUCCESS;
+        }
     }
 
     rc = mca_part.part_parrived(partition, partition, flag, request);

--- a/ompi/mpi/c/pready.c.in
+++ b/ompi/mpi/c/pready.c.in
@@ -45,10 +45,21 @@ PROTOTYPE ERROR_CLASS pready(INT partition, REQUEST request)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_pready(partition, partition, request);

--- a/ompi/mpi/c/pready_list.c.in
+++ b/ompi/mpi/c/pready_list.c.in
@@ -45,10 +45,21 @@ PROTOTYPE ERROR_CLASS pready_list(INT length, INT_ARRAY partitions, REQUEST requ
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     for(int i = 0; i < length && OMPI_SUCCESS == rc; i++) {

--- a/ompi/mpi/c/pready_range.c.in
+++ b/ompi/mpi/c/pready_range.c.in
@@ -45,10 +45,21 @@ PROTOTYPE ERROR_CLASS pready_range(INT partition_low, INT partition_high, REQUES
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_pready(partition_low, partition_high, request);

--- a/ompi/mpi/c/precv_init.c.in
+++ b/ompi/mpi/c/precv_init.c.in
@@ -34,6 +34,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mca/part/part.h"
 #include "ompi/datatype/ompi_datatype.h"
+#include "ompi/request/request.h"
 #include "ompi/runtime/ompi_spc.h"
 
 PROTOTYPE ERROR_CLASS precv_init(BUFFER_OUT buf, INT partitions, PARTITIONED_COUNT count,
@@ -52,6 +53,16 @@ PROTOTYPE ERROR_CLASS precv_init(BUFFER_OUT buf, INT partitions, PARTITIONED_COU
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): MPI_PROC_NULL may be used wherever a source
+    // or destination rank is required, and "a communication with
+    // MPI_PROC_NULL has no effect."  Hand back the same persistent no-op
+    // request that MPI_Recv_init does, rather than passing MPI_PROC_NULL
+    // down to the PML as if it were a real peer rank.
+    if (MPI_PROC_NULL == source) {
+        rc = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
 
     rc = mca_part.part_precv_init(buf, partitions, count, datatype, source, tag, comm, info, request);

--- a/ompi/mpi/c/psend_init.c.in
+++ b/ompi/mpi/c/psend_init.c.in
@@ -34,6 +34,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mca/part/part.h"
 #include "ompi/datatype/ompi_datatype.h"
+#include "ompi/request/request.h"
 #include "ompi/runtime/ompi_spc.h"
 
 PROTOTYPE ERROR_CLASS psend_init(BUFFER buf, INT partitions, PARTITIONED_COUNT count,
@@ -52,6 +53,16 @@ PROTOTYPE ERROR_CLASS psend_init(BUFFER buf, INT partitions, PARTITIONED_COUNT c
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): MPI_PROC_NULL may be used wherever a source
+    // or destination rank is required, and "a communication with
+    // MPI_PROC_NULL has no effect."  Hand back the same persistent no-op
+    // request that MPI_Send_init does, rather than passing MPI_PROC_NULL
+    // down to the PML as if it were a real peer rank.
+    if (MPI_PROC_NULL == dest) {
+        rc = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
 
     rc = mca_part.part_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);

--- a/ompi/test/Makefile.am
+++ b/ompi/test/Makefile.am
@@ -17,7 +17,7 @@
 # that they exercise.
 #
 
-# t, file, datatype, and general are run by "make check".  spc and
+# t, file, part, datatype, and general are run by "make check".  spc and
 # monitoring are multi-process tests: they are built, but not run by
 # "make check".
-SUBDIRS = t file datatype general monitoring spc
+SUBDIRS = t file part datatype general monitoring spc

--- a/ompi/test/part/Makefile.am
+++ b/ompi/test/part/Makefile.am
@@ -8,16 +8,19 @@
 # $HEADER$
 #
 
-# This is a single-process partitioned communication test.  It calls
-# MPI_Init and performs all of its communication on MPI_COMM_SELF, so it
-# needs no launcher and can run as part of 'make check'.  It exercises the
-# MPI_Parrived null / inactive request behavior required by MPI-5.0
-# sec. 4.2.2 (Open MPI issue #14003).
+# These are single-process partitioned communication tests.  Each calls
+# MPI_Init and performs all of its communication on MPI_COMM_SELF or with
+# MPI_PROC_NULL, so they need no launcher and can run as part of 'make
+# check'.  They exercise the MPI_Parrived null / inactive request behavior
+# required by MPI-5.0 sec. 4.2.2 (Open MPI issue #14003), and partitioned
+# communication with MPI_PROC_NULL (MPI-5.0 sec. 3.10).
 
 # Make "make check" work in an uninstalled --enable-mca-dso build tree
 include $(top_srcdir)/Makefile.mca-dso-check
 
-check_PROGRAMS = parrived_null_inactive
+check_PROGRAMS = \
+        parrived_null_inactive \
+        partitioned_proc_null
 TESTS = $(check_PROGRAMS)
 
 common_ldflags = $(OMPI_PKG_CONFIG_LDFLAGS)
@@ -29,6 +32,10 @@ parrived_null_inactive_SOURCES = parrived_null_inactive.c
 parrived_null_inactive_LDFLAGS = $(common_ldflags)
 parrived_null_inactive_LDADD = $(common_ldadd)
 
+partitioned_proc_null_SOURCES = partitioned_proc_null.c
+partitioned_proc_null_LDFLAGS = $(common_ldflags)
+partitioned_proc_null_LDADD = $(common_ldadd)
+
 distclean-local:
 	rm -rf *.dSYM .deps .libs *.la *.lo *.log *.o *.trs \
-		parrived_null_inactive Makefile
+		parrived_null_inactive partitioned_proc_null Makefile

--- a/ompi/test/part/Makefile.am
+++ b/ompi/test/part/Makefile.am
@@ -1,0 +1,34 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is a single-process partitioned communication test.  It calls
+# MPI_Init and performs all of its communication on MPI_COMM_SELF, so it
+# needs no launcher and can run as part of 'make check'.  It exercises the
+# MPI_Parrived null / inactive request behavior required by MPI-5.0
+# sec. 4.2.2 (Open MPI issue #14003).
+
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+include $(top_srcdir)/Makefile.mca-dso-check
+
+check_PROGRAMS = parrived_null_inactive
+TESTS = $(check_PROGRAMS)
+
+common_ldflags = $(OMPI_PKG_CONFIG_LDFLAGS)
+common_ldadd = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+parrived_null_inactive_SOURCES = parrived_null_inactive.c
+parrived_null_inactive_LDFLAGS = $(common_ldflags)
+parrived_null_inactive_LDADD = $(common_ldadd)
+
+distclean-local:
+	rm -rf *.dSYM .deps .libs *.la *.lo *.log *.o *.trs \
+		parrived_null_inactive Makefile

--- a/ompi/test/part/parrived_null_inactive.c
+++ b/ompi/test/part/parrived_null_inactive.c
@@ -1,0 +1,235 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) regression test for Open MPI
+ * issue #14003: MPI_Parrived must return flag = true when called with a
+ * null or an inactive request.
+ *
+ * MPI-5.0 section 4.2.2 (p.119) states:
+ *
+ *   "MPI_PARRIVED may be called with a null or inactive request
+ *    argument.  In either case, the operation returns with flag = true.
+ *    Calling MPI_PARRIVED on a request that does not correspond to a
+ *    partitioned receive operation is erroneous."
+ *
+ * Four cases are covered: a null request, an inactive request that has
+ * never been started, an active request being probed per partition, and
+ * an inactive request that has completed and been reset.
+ *
+ * The partitioned send/receive pair is set up on MPI_COMM_SELF, so this
+ * is a valid single-process test and needs no launcher.
+ *
+ * Note: Open MPI only guarantees the null-request case when MPI
+ * parameter checking is enabled (the check lives in the C binding, which
+ * is compiled/branched out when checking is off, so as not to burden the
+ * probing fast path).  The null case is therefore skipped when the
+ * mpi_param_check MCA variable reads as false.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "mpi.h"
+
+/* Bound the polling loops so that a regression fails the test rather
+   than hanging "make check" forever. */
+#define MAX_POLL 10000000
+
+#define PARTITIONS 4
+#define COUNT 3
+
+static int failures = 0;
+
+static void check(int condition, const char *msg)
+{
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        ++failures;
+    }
+}
+
+/* Verify that MPI_Parrived succeeded and returned the expected flag. */
+static void check_parrived(int rc, int flag, int expected, const char *msg)
+{
+    if (MPI_SUCCESS != rc) {
+        char estr[MPI_MAX_ERROR_STRING];
+        int elen;
+        MPI_Error_string(rc, estr, &elen);
+        fprintf(stderr, "FAIL: %s: MPI_Parrived returned '%s' (expected "
+                "MPI_SUCCESS)\n", msg, estr);
+        ++failures;
+    } else if (!!flag != !!expected) {
+        fprintf(stderr, "FAIL: %s: MPI_Parrived returned flag=%s (expected "
+                "%s)\n", msg, flag ? "true" : "false",
+                expected ? "true" : "false");
+        ++failures;
+    }
+}
+
+/* Read the mpi_param_check MCA variable through MPI_T.  Assume checking
+   is enabled if it cannot be read (that is the default). */
+static int param_check_enabled(void)
+{
+    int provided, num_cvar, i, enabled = 1;
+
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        return enabled;
+    }
+    if (MPI_SUCCESS != MPI_T_cvar_get_num(&num_cvar)) {
+        MPI_T_finalize();
+        return enabled;
+    }
+
+    for (i = 0; i < num_cvar; ++i) {
+        char name[128];
+        int name_len = (int) sizeof(name);
+        int desc_len = 0;
+        int verbosity, bind, scope, count;
+        MPI_Datatype datatype;
+        MPI_T_enum enumtype;
+        MPI_T_cvar_handle handle;
+        int value;
+
+        if (MPI_SUCCESS != MPI_T_cvar_get_info(i, name, &name_len, &verbosity,
+                                               &datatype, &enumtype, NULL,
+                                               &desc_len, &bind, &scope)) {
+            continue;
+        }
+        if (0 != strcmp(name, "mpi_param_check") || MPI_INT != datatype) {
+            continue;
+        }
+        if (MPI_SUCCESS == MPI_T_cvar_handle_alloc(i, NULL, &handle, &count)) {
+            if (1 == count && MPI_SUCCESS == MPI_T_cvar_read(handle, &value)) {
+                enabled = value;
+            }
+            MPI_T_cvar_handle_free(&handle);
+        }
+        break;
+    }
+
+    MPI_T_finalize();
+
+    return enabled;
+}
+
+int main(int argc, char *argv[])
+{
+    double sendbuf[PARTITIONS * COUNT];
+    double recvbuf[PARTITIONS * COUNT];
+    MPI_Request sreq = MPI_REQUEST_NULL;
+    MPI_Request rreq = MPI_REQUEST_NULL;
+    int i, j, flag, rc;
+
+    MPI_Init(&argc, &argv);
+
+    /* Report errors instead of aborting, so that a non-conformant
+       MPI_ERR_REQUEST is counted as a test failure. */
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+    MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_RETURN);
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        sendbuf[i] = (double) i;
+        recvbuf[i] = -1.0;
+    }
+
+    /* Case 1: a null request is trivially arrived.  MPI_Parrived may be
+       called more than once for a partition, so call it twice. */
+    if (param_check_enabled()) {
+        for (i = 0; i < 2; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(MPI_REQUEST_NULL, 0, &flag);
+            check_parrived(rc, flag, 1, "null request");
+        }
+    } else {
+        printf("SKIP: null request (MPI parameter checking is disabled)\n");
+    }
+
+    /* Case 2: an inactive (initialized but never started) partitioned
+       receive request is trivially arrived. */
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &rreq);
+    check(MPI_SUCCESS == rc, "MPI_Precv_init failed");
+    if (MPI_SUCCESS == rc) {
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_parrived(rc, flag, 1, "never-started inactive request");
+        }
+        MPI_Request_free(&rreq);
+    }
+
+    /* Cases 3 and 4: an active partitioned receive must report per-
+       partition arrival, and the same request must again report arrived
+       once it has completed and returned to the inactive state.
+
+       Send to and receive from MPI_COMM_SELF: matching is by the order in
+       which the initialization calls are made (MPI-5.0 section 4.2.3). */
+    rc = MPI_Psend_init(sendbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &sreq);
+    check(MPI_SUCCESS == rc, "MPI_Psend_init failed");
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &rreq);
+    check(MPI_SUCCESS == rc, "MPI_Precv_init failed");
+
+    if (0 == failures) {
+        MPI_Start(&sreq);
+        MPI_Start(&rreq);
+
+        /* Case 3a: no partition has been marked ready yet, so no
+           partition can have arrived. */
+        flag = 1;
+        rc = MPI_Parrived(rreq, 0, &flag);
+        check_parrived(rc, flag, 0, "active request, no MPI_Pready yet");
+
+        /* Case 3b: mark the send partitions ready one at a time; each
+           must eventually arrive on the receive side (MPI-5.0 section
+           4.2.2: "Repeated calls to MPI_PARRIVED ... will eventually
+           return flag = true"). */
+        for (i = 0; i < PARTITIONS; ++i) {
+            rc = MPI_Pready(i, sreq);
+            check(MPI_SUCCESS == rc, "MPI_Pready failed");
+
+            flag = 0;
+            for (j = 0; j < MAX_POLL && !flag; ++j) {
+                rc = MPI_Parrived(rreq, i, &flag);
+                if (MPI_SUCCESS != rc) {
+                    break;
+                }
+            }
+            check_parrived(rc, flag, 1, "active request, partition ready");
+        }
+
+        MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+        MPI_Wait(&rreq, MPI_STATUS_IGNORE);
+
+        for (i = 0; i < PARTITIONS * COUNT; ++i) {
+            check(recvbuf[i] == (double) i, "received wrong data");
+        }
+
+        /* Case 4: the operation completed, so the request is inactive
+           again -- but, unlike case 2, it has been started before.  It
+           must still report arrived. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_parrived(rc, flag, 1, "completed, reset inactive request");
+        }
+    }
+
+    MPI_Request_free(&sreq);
+    MPI_Request_free(&rreq);
+
+    if (0 == failures) {
+        printf("PASS: parrived_null_inactive\n");
+    }
+
+    MPI_Finalize();
+
+    return failures ? 1 : 0;
+}

--- a/ompi/test/part/partitioned_proc_null.c
+++ b/ompi/test/part/partitioned_proc_null.c
@@ -1,0 +1,168 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) regression test for partitioned
+ * communication with MPI_PROC_NULL.
+ *
+ * MPI-5.0 section 3.10 (p.110) states:
+ *
+ *   "The special value MPI_PROC_NULL can be used instead of a rank
+ *    wherever a source or a destination argument is required in a call.
+ *    A communication with MPI_PROC_NULL has no effect.  A send to
+ *    MPI_PROC_NULL succeeds and returns as soon as possible.  A receive
+ *    from MPI_PROC_NULL succeeds and returns as soon as possible with no
+ *    modifications to the receive buffer.  When a receive with source =
+ *    MPI_PROC_NULL is executed then the status object returns source =
+ *    MPI_PROC_NULL, tag = MPI_ANY_TAG and count = 0."
+ *
+ * MPI_Psend_init and MPI_Precv_init take dest and source arguments, so
+ * MPI_PROC_NULL is valid for both.  Open MPI used to pass MPI_PROC_NULL
+ * straight through to the PML as if it were a real peer rank, which read
+ * past the start of the communicator's process array.
+ */
+
+#include <stdio.h>
+
+#include "mpi.h"
+
+#define PARTITIONS 4
+#define COUNT 3
+
+static int failures = 0;
+
+static void check(int condition, const char *msg)
+{
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        ++failures;
+    }
+}
+
+static void check_rc(int rc, const char *msg)
+{
+    if (MPI_SUCCESS != rc) {
+        char estr[MPI_MAX_ERROR_STRING];
+        int elen;
+        MPI_Error_string(rc, estr, &elen);
+        fprintf(stderr, "FAIL: %s returned '%s' (expected MPI_SUCCESS)\n",
+                msg, estr);
+        ++failures;
+    }
+}
+
+/* An MPI_PROC_NULL receive must leave the buffer untouched. */
+static void check_untouched(const double *buf, const char *msg)
+{
+    int i;
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        if (buf[i] != -1.0) {
+            fprintf(stderr, "FAIL: %s: receive buffer was modified\n", msg);
+            ++failures;
+            return;
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    double sendbuf[PARTITIONS * COUNT];
+    double recvbuf[PARTITIONS * COUNT];
+    MPI_Request sreq = MPI_REQUEST_NULL;
+    MPI_Request rreq = MPI_REQUEST_NULL;
+    MPI_Status status;
+    int i, flag, rc, count;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        sendbuf[i] = (double) i;
+        recvbuf[i] = -1.0;
+    }
+
+    /* Both of these must succeed rather than reaching the PML with
+       MPI_PROC_NULL as a peer rank. */
+    rc = MPI_Psend_init(sendbuf, PARTITIONS, COUNT, MPI_DOUBLE, MPI_PROC_NULL,
+                        1, MPI_COMM_WORLD, MPI_INFO_NULL, &sreq);
+    check_rc(rc, "MPI_Psend_init(MPI_PROC_NULL)");
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, MPI_PROC_NULL,
+                        1, MPI_COMM_WORLD, MPI_INFO_NULL, &rreq);
+    check_rc(rc, "MPI_Precv_init(MPI_PROC_NULL)");
+
+    if (0 == failures) {
+        /* An inactive request is trivially arrived (MPI-5.0 sec 4.2.2). */
+        flag = 0;
+        rc = MPI_Parrived(rreq, 0, &flag);
+        check_rc(rc, "MPI_Parrived (inactive, MPI_PROC_NULL)");
+        check(flag, "inactive MPI_PROC_NULL request: expected flag = true");
+
+        rc = MPI_Start(&sreq);
+        check_rc(rc, "MPI_Start (MPI_PROC_NULL send)");
+        rc = MPI_Start(&rreq);
+        check_rc(rc, "MPI_Start (MPI_PROC_NULL receive)");
+
+        /* Marking partitions ready has no effect, but must succeed. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            rc = MPI_Pready(i, sreq);
+            check_rc(rc, "MPI_Pready (MPI_PROC_NULL)");
+        }
+        rc = MPI_Pready_range(0, PARTITIONS - 1, sreq);
+        check_rc(rc, "MPI_Pready_range (MPI_PROC_NULL)");
+        {
+            int list[PARTITIONS];
+            for (i = 0; i < PARTITIONS; ++i) {
+                list[i] = i;
+            }
+            rc = MPI_Pready_list(PARTITIONS, list, sreq);
+            check_rc(rc, "MPI_Pready_list (MPI_PROC_NULL)");
+        }
+
+        /* A receive from MPI_PROC_NULL "succeeds ... as soon as possible":
+           every partition is arrived, without any peer ever sending. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_rc(rc, "MPI_Parrived (active, MPI_PROC_NULL)");
+            check(flag, "active MPI_PROC_NULL request: expected flag = true");
+        }
+
+        /* Completion must not block: there is no peer. */
+        rc = MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+        check_rc(rc, "MPI_Wait (MPI_PROC_NULL send)");
+
+        status.MPI_SOURCE = 0;
+        status.MPI_TAG = 0;
+        rc = MPI_Wait(&rreq, &status);
+        check_rc(rc, "MPI_Wait (MPI_PROC_NULL receive)");
+
+        /* MPI-5.0 sec 3.10: source = MPI_PROC_NULL, tag = MPI_ANY_TAG,
+           count = 0, and the receive buffer is not modified. */
+        check(MPI_PROC_NULL == status.MPI_SOURCE,
+              "expected status.MPI_SOURCE = MPI_PROC_NULL");
+        check(MPI_ANY_TAG == status.MPI_TAG,
+              "expected status.MPI_TAG = MPI_ANY_TAG");
+        rc = MPI_Get_count(&status, MPI_DOUBLE, &count);
+        check_rc(rc, "MPI_Get_count");
+        check(0 == count, "expected status count = 0");
+        check_untouched(recvbuf, "MPI_PROC_NULL receive");
+    }
+
+    MPI_Request_free(&sreq);
+    MPI_Request_free(&rreq);
+
+    if (0 == failures) {
+        printf("PASS: partitioned_proc_null\n");
+    }
+
+    MPI_Finalize();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Three related partitioned communication fixes, each a separate commit.

**NOTE:** https://github.com/open-mpi/ompi/pull/14156 should be sequenced to land on `v6.0.x` before a back-port of this PR lands on `v6.0.x`.

### 1. `part/persist`: cancel the setup handshake when freeing a request

Partitioned requests negotiate their setup lazily: `MPI_Precv_init`/`MPI_Psend_init` post a receive for the peer's setup information, on the *user's* communicator, with the *user's* peer and tag, into a buffer that lives inside the request object. Nothing ever took that receive back down.

Freeing a request that was never started therefore left its setup receive posted against memory that had been returned to the request free list — and, because that receive is posted on the user's communicator/peer/tag, it would go on to match and consume the setup message of the **next** partitioned operation using the same communicator, peer, and tag. That operation then never initialized: `MPI_Parrived` never reported any partition as arrived, and `MPI_Wait` deadlocked.

A conforming program reaches this by initializing a partitioned receive, never starting it, freeing it, and then reusing the tag.

### 2. Fix `MPI_Parrived` for null and inactive requests (#14003)

MPI-5.0 §4.2.2 (p.119): "MPI_PARRIVED may be called with a null or inactive request argument. In either case, the operation returns with flag = true."

This builds on @hppritcha's #14103 (commit 2cb429610a). Relative to that commit, this one moves the request-type check *ahead* of the inactive check, so that an inactive request which is not a partitioned request — an un-started `MPI_Send_init` request, say — is still reported as `MPI_ERR_REQUEST` rather than silently "arrived" (§4.2.2: "Calling MPI_PARRIVED on a request that does not correspond to a partitioned receive operation is erroneous"). A literal C `NULL` handle likewise remains an error rather than "arrived", and a `NULL` `flag` argument is now `MPI_ERR_ARG`, as `MPI_Request_get_status` already does.

The null/inactive short circuit is deliberately kept inside `MPI_PARAM_CHECK` to keep the branch off the probing fast path.

### 3. Support `MPI_PROC_NULL` in partitioned communication

MPI-5.0 §3.10 (p.110): "MPI_PROC_NULL can be used instead of a rank wherever a source or a destination argument is required in a call. A communication with MPI_PROC_NULL has no effect."

`MPI_Psend_init`/`MPI_Precv_init` take dest/source arguments, but neither binding recognized `MPI_PROC_NULL`: they passed it down to the part framework, which handed it to the PML as if it were a real peer rank. The PML has no `MPI_PROC_NULL` handling of its own — it never needs any, because the point-to-point bindings filter it out first — so it looked the peer up at index `-2` of the communicator's process array and dereferenced whatever it found. Whether that read is fatal depends on what happens to sit before the array; it is undefined behavior either way.

This is handled in the bindings, exactly as `MPI_Send_init`/`MPI_Recv_init` already do: return the persistent no-op request from `ompi_request_persistent_noop_create()`, whose status is already the empty status the standard requires (`source = MPI_PROC_NULL`, `tag = MPI_ANY_TAG`, count 0), and which `MPI_Start`/`MPI_Test`/`MPI_Wait`/`MPI_Request_free` already understand. `MPI_Pready`, `MPI_Pready_range`, `MPI_Pready_list`, and `MPI_Parrived` then accept such a request.

### Tests

Two new single-process tests under `test/mpi/part/`, wired into `make check` (no launcher needed — they use `MPI_COMM_SELF` and `MPI_PROC_NULL`):

* `parrived_null_inactive` — null, never-started inactive, active per-partition probing, and completed-then-reset inactive.
* `partitioned_proc_null` — `MPI_PROC_NULL` init/start/pready/parrived/wait, including the required status and untouched receive buffer.

Verified on macOS and Linux (AlmaLinux 10): clean builds with no new warnings, both tests pass, and a real 2-rank partitioned transfer with per-partition probing still delivers correct data.