### PR TITLE
Fix a series of repeated startup/shutdown bugs, plus related thread-level reporting bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,18 @@ ompi/mpi/fortran/use-mpi-tkr/mpi-tkr-sizeof.h
 ompi/mpi/tool/profile/*.c
 
 ompi/test/t/mpi_t_category_get_events
+ompi/test/t/mpi_t_concurrent_init
+ompi/test/t/mpi_t_level_no_downgrade
+ompi/test/t/mpi_t_level_pinning
+ompi/test/t/mpi_t_lifecycle
+ompi/test/t/mpi_t_outlives_mpi
+ompi/test/t/mpi_t_repeated_sessions
+ompi/test/t/mpi_t_sessions
+ompi/test/t/mpi_t_stress
+ompi/test/t/mpi_t_world_close_first
+ompi/test/t/mpi_t_world_inner
+ompi/test/t/mpi_t_world_outlast
+ompi/test/t/mpi_t_world_sessions
 
 ompi/test/file/file_info_defaults
 ompi/test/file/file_info_hints

--- a/docs/man-openmpi/man3/MPI_T_init_thread.3.rst
+++ b/docs/man-openmpi/man3/MPI_T_init_thread.3.rst
@@ -33,6 +33,20 @@ calls to MPI_T_finalize() equals the number of calls to
 MPI_T_init_thread() the MPI tool interface will no longer be
 available until another call to MPI_T_init_thread().
 
+The ``required`` and ``provided`` thread support levels apply to the
+MPI tool information interface only; they are distinct from the thread
+support level of the World Model (reported by :ref:`MPI_Query_thread`)
+and from each session's ``thread_level`` info key.  The level granted
+in ``provided`` is fixed for as long as the interface remains
+initialized: additional calls to :ref:`MPI_T_init_thread` while the
+interface is initialized only increase the reference count and return
+the already-established level.  If another MPI scope (the World Model
+or a session) is already active at a lower thread level, a request for
+``MPI_THREAD_MULTIPLE`` may be granted ``MPI_THREAD_SERIALIZED``
+instead, because the running process cannot be safely upgraded; MPI-5.0
+explicitly permits one scope's thread level to influence the level
+granted to a later initialization.
+
 MPI_T_init_thread(), like MPI_Init_thread(), has a provision to
 request a certain level of thread support in ``required``:
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -392,6 +392,7 @@ static void evhandler_dereg_callbk(pmix_status_t status,
 static int ompi_mpi_instance_init_common (int argc, char **argv)
 {
     int ret;
+    bool need_world_comms;
     ompi_proc_t **procs;
     size_t nprocs;
     volatile bool active;
@@ -706,8 +707,8 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
         return ompi_instance_print_error ("ompi_attr_create_predefined_keyvals() failed", ret);
     }
 
-    if (mca_pml_base_requires_world() ||
-        mca_osc_base_requires_world()) {
+    need_world_comms = mca_pml_base_requires_world() || mca_osc_base_requires_world();
+    if (need_world_comms) {
         /* need to set up comm world for this instance -- XXX -- FIXME -- probably won't always
          * be the case. */
         if (OMPI_SUCCESS != (ret = ompi_comm_init_mpi3 ())) {
@@ -752,8 +753,7 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
     /* some btls/mtls require we call add_procs with all procs in the job.
      * since the btls/mtls have no visibility here it is up to the pml to
      * convey this requirement */
-    if (mca_pml_base_requires_world() ||
-        mca_osc_base_requires_world()) {
+    if (need_world_comms) {
         if (NULL == (procs = ompi_proc_world (&nprocs))) {
             return ompi_instance_print_error ("ompi_proc_get_allocated () failed", ret);
         }
@@ -776,6 +776,29 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
         return ret;
     } else if (OMPI_SUCCESS != ret) {
         return ompi_instance_print_error ("PML add procs failed", ret);
+    }
+
+    /* ompi_comm_init_mpi3() (above) marks the predefined world/self
+       communicators OMPI_COMM_PML_ADDED, but the matching
+       MCA_PML_CALL(add_comm()) calls live only in the World Model path
+       (ompi_mpi_init()).  When the communicator subsystem was set up
+       here -- a sessions-only process whose pml/osc requires the world,
+       e.g. ob1 over a multi-interface tcp btl at MPI_THREAD_MULTIPLE --
+       the flag was a lie: teardown then calls pml del_comm() on
+       communicators the PML has never seen, and ob1 dereferences the
+       NULL c_pml_comm.  Add them for real, now that add_procs() has
+       run.  The c_pml_comm guard keeps the World Model path (which
+       re-runs ompi_comm_init_mpi3() and performs its own add_comm()
+       calls after this function returns) from double-adding. */
+    if (need_world_comms && NULL == ompi_mpi_comm_world.comm.c_pml_comm) {
+        ret = MCA_PML_CALL(add_comm(&ompi_mpi_comm_world.comm));
+        if (OMPI_SUCCESS != ret) {
+            return ompi_instance_print_error ("PML add comm (world) failed", ret);
+        }
+        ret = MCA_PML_CALL(add_comm(&ompi_mpi_comm_self.comm));
+        if (OMPI_SUCCESS != ret) {
+            return ompi_instance_print_error ("PML add comm (self) failed", ret);
+        }
     }
 
     /* Determine the overall threadlevel support of all processes

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2022      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      BULL S.A.S.  All rights reserved.
@@ -75,6 +75,26 @@ __opal_attribute_constructor__ static void instance_lock_init(void) {
 #else
 #error "No support for recursive mutexes available on this platform."
 #endif  /* defined(OPAL_RECURSIVE_MUTEX_STATIC_INIT) */
+
+/* MPI_T_init_thread()/MPI_T_finalize() serialize themselves with the same
+   lock that serializes instance (world and session) initialization and
+   teardown.  The two families share unlocked under-layers -- the
+   opal_init_util()/opal_init() reference counters, the shared event base
+   reference count, MCA variable registration, and every framework's
+   refcnt -- so a first MPI_T initialization racing a session (or world)
+   initialization on another thread would corrupt that state.  Lock
+   ordering: MPI_T takes its own serializing lock (ompi_mpit_big_lock)
+   first, then this one; nothing on the instance side ever takes the MPI_T
+   lock, so the ordering cannot invert. */
+void ompi_mpi_instance_lock (void)
+{
+    opal_mutex_lock (&instance_lock);
+}
+
+void ompi_mpi_instance_unlock (void)
+{
+    opal_mutex_unlock (&instance_lock);
+}
 
 /** MPI_Init instance */
 ompi_instance_t *ompi_mpi_instance_default = NULL;

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -28,6 +28,7 @@
 
 #include "ompi/mca/pml/pml.h"
 #include "ompi/runtime/params.h"
+#include "ompi/runtime/mpiruntime.h"
 
 #include "ompi/interlib/interlib.h"
 #include "ompi/communicator/communicator.h"
@@ -113,6 +114,11 @@ enum {
 };
 
 opal_atomic_int32_t ompi_instance_count = 0;
+
+/* Set when a first instance's common initialization failed partway;
+   the partial state cannot be safely unwound or re-entered, so all
+   later instance creation is refused (see ompi_mpi_instance_init()). */
+static bool instance_init_failed = false;
 
 static const char *ompi_instance_builtin_psets[] = {
     "mpi://WORLD",
@@ -901,19 +907,91 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
 
     *instance = &ompi_mpi_instance_null.instance;
 
-    /* If thread support was enabled, then setup OPAL to allow for them by default. This must be done
-     * early to prevent a race condition that can occur with orte_init(). */
-    if (ts_level == MPI_THREAD_MULTIPLE) {
-        opal_set_using_threads(true);
+    opal_mutex_lock (&instance_lock);
+
+    if (OPAL_UNLIKELY(instance_init_failed)) {
+        opal_mutex_unlock (&instance_lock);
+        return OMPI_ERROR;
     }
 
-    /* Set single-threaded flag for optimization purposes */
-    opal_single_threaded = (ts_level == MPI_THREAD_SINGLE);
+    /* The process-wide thread flags are monotonic: they only ever ratchet
+     * upward, because other scopes (the World Model, other sessions,
+     * MPI_T) with stronger promises may already be active, and the levels
+     * they have reported are pinned (MPI 5.0 secs. 11.3.1, 11.6.2,
+     * 15.3.4).  In particular, do NOT assign opal_single_threaded from
+     * this instance's level: a THREAD_SINGLE session created while a
+     * THREAD_MULTIPLE scope is live must not flip the process back to
+     * single-threaded behavior.
+     *
+     * Ratchet only at a quiescent point: when this is the first instance
+     * (the instance lock we hold pins ompi_instance_count, and with no
+     * active instance a conforming program has no thread inside MPI's
+     * hot paths, which read these plain flags without locks).  When an
+     * instance is already active, writing the flags would (a) race those
+     * unlocked hot-path reads and (b) lie: components already selected
+     * and configured by the first instance (e.g. a UCX worker's thread
+     * mode, ob1's request paths) were frozen at the lower level and are
+     * not reconfigured here.  Instead, exercise the latitude MPI 5.0
+     * sec. 11.6.2 grants ("the requested and provided level of thread
+     * support when creating a Session may influence the granted level of
+     * thread support in a subsequent invocation of MPI_SESSION_INIT"):
+     * grant this later scope MPI_THREAD_SERIALIZED, which the
+     * already-running configuration genuinely supports, and report that
+     * through the session's "thread_level" info key.
+     *
+     * An MPI_T epoch does NOT usually block the flip: the standard tool
+     * pattern initializes MPI_T (from a PMPI wrapper) before the
+     * application's MPI_Init_thread(MPI_THREAD_MULTIPLE), and that
+     * application must still be granted MULTIPLE.  A tool epoch at
+     * MPI_THREAD_SINGLE promises a single-threaded process (no
+     * concurrent readers to race), and a tool epoch above SINGLE flipped
+     * the OPAL flags itself at its own (quiescent) init -- making the
+     * conditional writes below no-ops, hence race-free.  The one unsafe
+     * case is a tool epoch above SINGLE whose own init could NOT flip
+     * the flags (it started while instances were active): its threads
+     * may be inside unlocked MPI_T query routines, so the flags must not
+     * change under them. */
+    bool mpit_blocks_flip = (0 != ompi_mpit_init_count
+                             && MPI_THREAD_SINGLE != ompi_mpit_thread_level
+                             && !opal_using_threads());
 
-    opal_mutex_lock (&instance_lock);
+    if (0 == ompi_instance_count && !mpit_blocks_flip) {
+        /* Write only on transition: flags may already be set by an
+           earlier (finalized) scope, and redundant writes would race any
+           unlocked reader. */
+        if (ts_level == MPI_THREAD_MULTIPLE) {
+            if (!opal_using_threads()) {
+                opal_set_using_threads(true);
+            }
+            /* The MPI layer's threaded code paths (e.g. ob1's request
+             * handling) key off this flag; a THREAD_MULTIPLE session must
+             * engage them even when the World Model was initialized at a
+             * lower level -- or not at all, in which case nothing else
+             * ever sets it. */
+            if (!ompi_mpi_thread_multiple) {
+                ompi_mpi_thread_multiple = true;
+            }
+        }
+        if (MPI_THREAD_SINGLE != ts_level && opal_single_threaded) {
+            opal_single_threaded = false;
+        }
+    } else if (MPI_THREAD_MULTIPLE == ts_level && !ompi_mpi_thread_multiple) {
+        ts_level = MPI_THREAD_SERIALIZED;
+    }
+
     if (0 == opal_atomic_fetch_add_32 (&ompi_instance_count, 1)) {
         ret = ompi_mpi_instance_init_common (argc, argv);
         if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
+            /* Undo the increment: a stuck nonzero count would make every
+               later thread-level decision treat a phantom instance as
+               active.  A retry cannot be permitted either:
+               init_common's partial state (RTE, frameworks, the common
+               finalize domain) is not unwound here, and re-entering
+               init_common over it would corrupt or leak.  Latch instead:
+               all future instance creation in this process fails
+               cleanly. */
+            instance_init_failed = true;
+            (void) opal_atomic_add_fetch_32 (&ompi_instance_count, -1);
             opal_mutex_unlock (&instance_lock);
             return ret;
         }

--- a/ompi/instance/instance.h
+++ b/ompi/instance/instance.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2018-2025  Triad National Security, LLC.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -134,6 +135,14 @@ OMPI_DECLSPEC int ompi_mpi_instance_init (int ts_level, opal_info_t *info, ompi_
  * @brief Destroy an MPI instance and set it to MPI_SESSION_NULL
  */
 OMPI_DECLSPEC int ompi_mpi_instance_finalize (ompi_instance_t **instance);
+
+/* Serialize against instance (world and session) initialization and
+   teardown.  For use by the MPI_T entry points, whose first init/last
+   finalize share unlocked state with instance bring-up; see the
+   definitions in instance.c for the locking rationale and the
+   lock-ordering rules. */
+OMPI_DECLSPEC void ompi_mpi_instance_lock (void);
+OMPI_DECLSPEC void ompi_mpi_instance_unlock (void);
 
 
 /**

--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -815,6 +816,18 @@ int mca_bml_r2_finalize( void )
  CLEANUP:
     mca_bml_r2.num_btl_modules = 0;
     mca_bml_r2.num_btl_progress = 0;
+    /* The btl_modules array being freed below is rebuilt (from
+       mca_btl_base_modules_initialized) by mca_bml_r2_add_btls(), which is a
+       no-op while btls_added is true -- so the flag must fall with the state
+       it guards.  It was previously reset only in mca_bml_r2_component_init(),
+       which cannot be relied upon to run again: mca_bml_base_init() skips
+       component init while the bml framework is merely *held* rather than
+       closed and reopened, and MPI_T's framework registration holds every
+       framework across MPI session cycles.  Leaving the flag set while the
+       array is empty made the next session's add_procs attach zero BTLs and
+       fail (unreachable), even though the BTL modules themselves were still
+       alive. */
+    mca_bml_r2.btls_added = false;
 
     if( NULL != mca_bml_r2.btl_modules) {
         free(mca_bml_r2.btl_modules);

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -22,6 +22,7 @@
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
 #include "opal/util/event.h"
+#include "ompi/instance/instance.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -33,8 +34,16 @@
 int MPI_T_finalize (void)
 {
     ompi_mpit_lock ();
+    /* Serialize against instance (world/session) init and teardown: the
+       last MPI_T_finalize() performs the deferred true component closes
+       and releases OPAL references, which share unlocked state with a
+       concurrent instance bring-up or teardown on another thread.  Lock
+       ordering: the MPI_T lock above always comes first; see
+       ompi_mpi_instance_lock() in instance.c. */
+    ompi_mpi_instance_lock ();
 
     if (!mpit_is_initialized ()) {
+        ompi_mpi_instance_unlock ();
         ompi_mpit_unlock ();
         return MPI_T_ERR_NOT_INITIALIZED;
     }
@@ -51,11 +60,16 @@ int MPI_T_finalize (void)
         (void) opal_event_finalize ();
 
         int32_t state = ompi_mpi_state;
-        if ((state < OMPI_MPI_STATE_INIT_COMPLETED ||
+        if ((state < OMPI_MPI_STATE_INIT_STARTED ||
              state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) &&
             (NULL != ompi_mpi_main_thread)) {
-            /* we are not between MPI_Init and MPI_Finalize so we
-             * have to free the ompi_mpi_main_thread */
+            /* We are not between MPI_Init and MPI_Finalize, so we have
+             * to free the ompi_mpi_main_thread.  "Between" includes an
+             * MPI_Init() in progress on another thread
+             * (OMPI_MPI_STATE_INIT_STARTED): it has already published
+             * ompi_mpi_main_thread, and releasing it out from under
+             * that thread would break MPI_Is_thread_main() and leave a
+             * dangling thread object. */
             OBJ_RELEASE(ompi_mpi_main_thread);
             ompi_mpi_main_thread = NULL;
         }
@@ -63,6 +77,7 @@ int MPI_T_finalize (void)
         (void) opal_finalize_util ();
     }
 
+    ompi_mpi_instance_unlock ();
     ompi_mpit_unlock ();
 
     return MPI_SUCCESS;

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +21,7 @@
 #include "ompi/runtime/ompi_info_support.h"
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
+#include "opal/util/event.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -39,6 +41,14 @@ int MPI_T_finalize (void)
 
     if (0 == --ompi_mpit_init_count) {
         (void) ompi_info_close_components ();
+
+        /* Release the reference on the shared event base taken in
+           MPI_T_init_thread(), now that the framework closes just
+           above have run -- they may have been the *true* closes
+           (component_close() deleting events from the base) if we were
+           the last framework reference holder.  If MPI is still
+           initialized, its own reference keeps the base alive. */
+        (void) opal_event_finalize ();
 
         int32_t state = ompi_mpi_state;
         if ((state < OMPI_MPI_STATE_INIT_COMPLETED ||

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -75,6 +75,10 @@ int MPI_T_finalize (void)
         }
 
         (void) opal_finalize_util ();
+
+        /* End of this MPI_T init epoch; a future epoch establishes its
+           own thread level. */
+        ompi_mpit_thread_level = MPI_THREAD_SINGLE;
     }
 
     ompi_mpi_instance_unlock ();

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -9,6 +9,7 @@
  *                         reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +24,7 @@
 #include "ompi/runtime/ompi_info_support.h"
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
+#include "opal/util/event.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -34,6 +36,13 @@
 extern opal_mutex_t ompi_mpit_big_lock;
 
 extern volatile uint32_t ompi_mpit_init_count;
+
+/* Set when a first MPI_T_init_thread() failed partway: the framework
+   registration bookkeeping is not unwindable (see below), so MPI_T can
+   never be brought up in this process again.  Without this latch, the
+   *next* MPI_T_init_thread() would take the nested-init early exit and
+   report a fully working MPI_T that is in fact broken. */
+static bool ompi_mpit_init_failed = false;
 extern volatile int32_t initted;
 
 
@@ -44,6 +53,11 @@ int MPI_T_init_thread (int required, int *provided)
     ompi_mpit_lock ();
 
     do {
+        if (ompi_mpit_init_failed) {
+            rc = MPI_T_ERR_CANNOT_INIT;
+            break;
+        }
+
         if (0 != ompi_mpit_init_count++) {
             break;
         }
@@ -51,6 +65,34 @@ int MPI_T_init_thread (int required, int *provided)
         /* call opal_init_util to initialize the MCA system */
         rc = opal_init_util (NULL, NULL);
         if (OPAL_SUCCESS != rc) {
+            --ompi_mpit_init_count;
+            rc = MPI_T_ERR_INVALID;
+            break;
+        }
+
+        /* Take a reference on the shared event base
+           (opal_sync_event_base).  Registering the frameworks below
+           bumps every framework's refcount, which defers each
+           framework's *true* close until MPI_T_finalize() -- and MPI_T
+           is reference counted independently of MPI, so that close can
+           legally run after MPI_Finalize() has already run
+           opal_finalize().  Components delete events from the shared
+           base when they close, so the base must stay alive until our
+           deferred closes have run; this reference (released in
+           MPI_T_finalize() after ompi_info_close_components()) is what
+           keeps it alive. */
+        rc = opal_event_register_params ();
+        if (OPAL_SUCCESS != rc) {
+            (void) opal_finalize_util ();
+            --ompi_mpit_init_count;
+            rc = MPI_T_ERR_INVALID;
+            break;
+        }
+
+        rc = opal_event_init ();
+        if (OPAL_SUCCESS != rc) {
+            (void) opal_finalize_util ();
+            --ompi_mpit_init_count;
             rc = MPI_T_ERR_INVALID;
             break;
         }
@@ -58,6 +100,28 @@ int MPI_T_init_thread (int required, int *provided)
         /* register all parameters */
         rc = ompi_info_register_framework_params (NULL);
         if (OMPI_SUCCESS != rc) {
+            /* Framework registration rolls itself back on failure (the
+               project loops close what they registered, and a framework
+               whose own registration fails unwinds its reference), so a
+               failed init can release everything it acquired and leave
+               MPI_T honestly uninitialized: a subsequent
+               MPI_T_finalize() returns MPI_T_ERR_NOT_INITIALIZED.
+
+               Retries are still refused (see the latch): the
+               non-framework parameter registration inside the info
+               machinery (e.g. ompi_mpi_register_params()) is not
+               verified to be re-entrant after a partial failure. */
+            (void) opal_event_finalize ();
+            if (OPAL_ERR_BAD_PARAM != rc) {
+                (void) opal_finalize_util ();
+            }
+            /* else: on BAD_PARAM the registrations were deliberately
+               left alive (for ompi_info's diagnostic dump), so the util
+               reference underpinning them must be kept -- leaked, like
+               the registrations themselves, in this configuration-error
+               path. */
+            --ompi_mpit_init_count;
+            ompi_mpit_init_failed = true;
             rc = MPI_T_ERR_INVALID;
             break;
         }

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -25,6 +25,7 @@
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
 #include "opal/util/event.h"
+#include "ompi/instance/instance.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
@@ -51,6 +52,13 @@ int MPI_T_init_thread (int required, int *provided)
     int rc = MPI_SUCCESS;
 
     ompi_mpit_lock ();
+    /* Also serialize against instance (world/session) init and teardown:
+       a first MPI_T initialization shares unlocked state (OPAL init
+       counters, the shared event base refcount, MCA variable and
+       framework registration) with instance bring-up on other threads.
+       Lock ordering: the MPI_T lock above always comes first; see
+       ompi_mpi_instance_lock() in instance.c. */
+    ompi_mpi_instance_lock ();
 
     do {
         if (ompi_mpit_init_failed) {
@@ -131,6 +139,7 @@ int MPI_T_init_thread (int required, int *provided)
         ompi_mpi_thread_level (required, provided);
     } while (0);
 
+    ompi_mpi_instance_unlock ();
     ompi_mpit_unlock ();
 
     return rc;

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -25,6 +25,7 @@
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
 #include "opal/util/event.h"
+#include "opal/mca/threads/thread_usage.h"
 #include "ompi/instance/instance.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -38,12 +39,6 @@ extern opal_mutex_t ompi_mpit_big_lock;
 
 extern volatile uint32_t ompi_mpit_init_count;
 
-/* Set when a first MPI_T_init_thread() failed partway: the framework
-   registration bookkeeping is not unwindable (see below), so MPI_T can
-   never be brought up in this process again.  Without this latch, the
-   *next* MPI_T_init_thread() would take the nested-init early exit and
-   report a fully working MPI_T that is in fact broken. */
-static bool ompi_mpit_init_failed = false;
 extern volatile int32_t initted;
 
 
@@ -60,85 +55,157 @@ int MPI_T_init_thread (int required, int *provided)
        ompi_mpi_instance_lock() in instance.c. */
     ompi_mpi_instance_lock ();
 
-    do {
-        if (ompi_mpit_init_failed) {
-            rc = MPI_T_ERR_CANNOT_INIT;
-            break;
-        }
+    /* ompi_mpit_init_failed -- like ompi_mpit_init_count and
+       ompi_mpit_thread_level -- is read and written only under the MPI_T
+       lock (taken above; released in MPI_T_finalize()), so these
+       unlocked-looking accesses are in fact serialized. */
+    if (ompi_mpit_init_failed) {
+        rc = MPI_T_ERR_CANNOT_INIT;
+        goto unlock;
+    }
 
-        if (0 != ompi_mpit_init_count++) {
-            break;
-        }
+    if (0 != ompi_mpit_init_count++) {
+        /* Nested init: report the level pinned by the first init of
+           this epoch (MPI 5.0 sec. 15.3.4: no effect beyond the
+           reference count). */
+        *provided = ompi_mpit_thread_level;
+        goto unlock;
+    }
 
-        /* call opal_init_util to initialize the MCA system */
-        rc = opal_init_util (NULL, NULL);
-        if (OPAL_SUCCESS != rc) {
-            --ompi_mpit_init_count;
-            rc = MPI_T_ERR_INVALID;
-            break;
-        }
+    /* From here on a failure must unwind the state built up so far.  The
+       three simple failure points below share a staged ladder at the end
+       of the function (err_util -> err_count), each label undoing one
+       more step; a failure jumps in at the right rung.  The
+       framework-registration failure is the one exception and cleans up
+       inline -- see there. */
 
-        /* Take a reference on the shared event base
-           (opal_sync_event_base).  Registering the frameworks below
-           bumps every framework's refcount, which defers each
-           framework's *true* close until MPI_T_finalize() -- and MPI_T
-           is reference counted independently of MPI, so that close can
-           legally run after MPI_Finalize() has already run
-           opal_finalize().  Components delete events from the shared
-           base when they close, so the base must stay alive until our
-           deferred closes have run; this reference (released in
-           MPI_T_finalize() after ompi_info_close_components()) is what
-           keeps it alive. */
-        rc = opal_event_register_params ();
-        if (OPAL_SUCCESS != rc) {
+    /* call opal_init_util to initialize the MCA system */
+    rc = opal_init_util (NULL, NULL);
+    if (OPAL_SUCCESS != rc) {
+        rc = MPI_T_ERR_INVALID;
+        goto err_count;
+    }
+
+    /* Take a reference on the shared event base
+       (opal_sync_event_base).  Registering the frameworks below
+       bumps every framework's refcount, which defers each
+       framework's *true* close until MPI_T_finalize() -- and MPI_T
+       is reference counted independently of MPI, so that close can
+       legally run after MPI_Finalize() has already run
+       opal_finalize().  Components delete events from the shared
+       base when they close, so the base must stay alive until our
+       deferred closes have run; this reference (released in
+       MPI_T_finalize() after ompi_info_close_components()) is what
+       keeps it alive. */
+    rc = opal_event_register_params ();
+    if (OPAL_SUCCESS != rc) {
+        rc = MPI_T_ERR_INVALID;
+        goto err_util;
+    }
+
+    rc = opal_event_init ();
+    if (OPAL_SUCCESS != rc) {
+        rc = MPI_T_ERR_INVALID;
+        goto err_util;
+    }
+
+    /* register all parameters */
+    rc = ompi_info_register_framework_params (NULL);
+    if (OMPI_SUCCESS != rc) {
+        /* Framework registration rolls itself back on failure (the
+           project loops close what they registered, and a framework
+           whose own registration fails unwinds its reference), so a
+           failed init can release everything it acquired and leave
+           MPI_T honestly uninitialized: a subsequent
+           MPI_T_finalize() returns MPI_T_ERR_NOT_INITIALIZED.
+
+           Retries are still refused (see the latch): the
+           non-framework parameter registration inside the info
+           machinery (e.g. ompi_mpi_register_params()) is not
+           verified to be re-entrant after a partial failure.
+
+           This arm cleans up inline rather than via the err_* ladder:
+           on BAD_PARAM it deliberately keeps the opal_init_util()
+           reference (see below), and it alone latches the failure. */
+        (void) opal_event_finalize ();
+        if (OPAL_ERR_BAD_PARAM != rc) {
             (void) opal_finalize_util ();
-            --ompi_mpit_init_count;
-            rc = MPI_T_ERR_INVALID;
-            break;
         }
+        /* else: on BAD_PARAM the registrations were deliberately
+           left alive (for ompi_info's diagnostic dump), so the util
+           reference underpinning them must be kept -- leaked, like
+           the registrations themselves, in this configuration-error
+           path. */
+        --ompi_mpit_init_count;
+        ompi_mpit_init_failed = true;
+        rc = MPI_T_ERR_INVALID;
+        goto unlock;
+    }
 
-        rc = opal_event_init ();
-        if (OPAL_SUCCESS != rc) {
-            (void) opal_finalize_util ();
-            --ompi_mpit_init_count;
-            rc = MPI_T_ERR_INVALID;
-            break;
-        }
+    /* The thread level of the MPI tool information interface is its
+       own, scoped to MPI_T routines only (MPI 5.0 sec. 15.3.4).  It
+       must NOT be written into the World Model's globals: those back
+       MPI_QUERY_THREAD, which is pinned to whatever the original
+       MPI_INIT_THREAD returned (sec. 11.6.2).  Writing them here both
+       corrupted that report and changed the process's effective
+       thread level in mid-flight -- an
+       MPI_T_init_thread(MPI_THREAD_SINGLE) inside a THREAD_MULTIPLE
+       application silently disabled locking process-wide, and an
+       MPI_T_init_thread(MPI_THREAD_MULTIPLE) before a session flipped
+       MPI onto threaded code paths the session never chose.
 
-        /* register all parameters */
-        rc = ompi_info_register_framework_params (NULL);
-        if (OMPI_SUCCESS != rc) {
-            /* Framework registration rolls itself back on failure (the
-               project loops close what they registered, and a framework
-               whose own registration fails unwinds its reference), so a
-               failed init can release everything it acquired and leave
-               MPI_T honestly uninitialized: a subsequent
-               MPI_T_finalize() returns MPI_T_ERR_NOT_INITIALIZED.
+       A tool at any level above MPI_THREAD_SINGLE may legally drive
+       MPI_T from a different thread than the one driving MPI proper,
+       so OPAL's process-wide thread flags must ratchet up -- and only
+       up, because the pinned promises of other live scopes (world,
+       sessions) may already depend on them.
 
-               Retries are still refused (see the latch): the
-               non-framework parameter registration inside the info
-               machinery (e.g. ompi_mpi_register_params()) is not
-               verified to be re-entrant after a partial failure. */
-            (void) opal_event_finalize ();
-            if (OPAL_ERR_BAD_PARAM != rc) {
-                (void) opal_finalize_util ();
+       Ratchet only at a quiescent point: when no MPI instance (world
+       or session) is active.  The instance lock we hold pins
+       ompi_instance_count, and with no active instance a conforming
+       program has no thread inside MPI or OPAL, so nothing can read
+       these plain flags concurrently with the write.  When MPI *is*
+       already active at a lower thread level, the flags cannot be
+       changed (the write would race MPI's unlocked hot-path readers,
+       and components already selected were configured at the lower
+       level) -- so instead of promising concurrency the process
+       cannot deliver, grant at most MPI_THREAD_SERIALIZED, the
+       coupling that MPI 5.0 secs. 11.6.2/15.3.4 explicitly permit
+       ("may influence").  Note that the MPI_T entry points that
+       mutate shared state serialize on ompi_mpit_big_lock, but not
+       every MPI_T query routine takes it, so the big lock alone is
+       not grounds for granting MPI_THREAD_MULTIPLE. */
+    if (MPI_THREAD_SINGLE != required) {
+        if (0 == ompi_instance_count) {
+            /* Write only on transition: a previous MPI_T epoch (or an
+               already-finalized scope) may have set these, and other
+               threads of this tool may be running unlocked MPI_T
+               query routines that read them. */
+            if (!opal_using_threads ()) {
+                opal_set_using_threads (true);
             }
-            /* else: on BAD_PARAM the registrations were deliberately
-               left alive (for ompi_info's diagnostic dump), so the util
-               reference underpinning them must be kept -- leaked, like
-               the registrations themselves, in this configuration-error
-               path. */
-            --ompi_mpit_init_count;
-            ompi_mpit_init_failed = true;
-            rc = MPI_T_ERR_INVALID;
-            break;
+            if (opal_single_threaded) {
+                opal_single_threaded = false;
+            }
+        } else if (!ompi_mpi_thread_multiple
+                   && MPI_THREAD_SERIALIZED < required) {
+            required = MPI_THREAD_SERIALIZED;
         }
+    }
+    ompi_mpit_thread_level = required;
+    *provided = ompi_mpit_thread_level;
+    goto unlock;
 
-        /* determine the thread level. TODO -- this might
-           be wrong */
-        ompi_mpi_thread_level (required, provided);
-    } while (0);
+    /* Staged failure unwind for the simple init steps above.  rc already
+       holds MPI_T_ERR_INVALID; each arm jumps to the rung that undoes
+       exactly the state it had built (opal_init_util() failure enters at
+       err_count, the event-parameter failures at err_util). */
+err_util:
+    (void) opal_finalize_util ();
+err_count:
+    --ompi_mpit_init_count;
 
+unlock:
     ompi_mpi_instance_unlock ();
     ompi_mpit_unlock ();
 

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,6 +46,21 @@ void ompi_mpit_lock (void);
 void ompi_mpit_unlock (void);
 
 extern volatile uint32_t ompi_mpit_init_count;
+
+/* The thread level of the MPI tool information interface itself, pinned
+   for one init epoch: established by the first MPI_T_init_thread() of the
+   epoch, reported unchanged by nested init calls (MPI 5.0 sec. 15.3.4:
+   they have "no effect beyond increasing the reference count"), and reset
+   when the last MPI_T_finalize() ends the epoch.  This is NOT the same
+   thing as the World Model's thread level (see MPI_T_init_thread() for
+   why the two must never be conflated). */
+OMPI_DECLSPEC extern int ompi_mpit_thread_level;
+
+/* Set when a first MPI_T_init_thread() failed partway through framework
+   registration, which is not unwindable; MPI_T can never be brought up
+   in this process again, and MPI_T_finalize() must not run the component
+   closes (see both files for the details). */
+extern bool ompi_mpit_init_failed;
 
 int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype);
 int ompit_opal_to_mpit_error (int rc);

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -45,7 +45,7 @@ typedef struct ompi_mpit_cvar_handle_t {
 void ompi_mpit_lock (void);
 void ompi_mpit_unlock (void);
 
-extern volatile uint32_t ompi_mpit_init_count;
+OMPI_DECLSPEC extern volatile uint32_t ompi_mpit_init_count;
 
 /* The thread level of the MPI tool information interface itself, pinned
    for one init epoch: established by the first MPI_T_init_thread() of the

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -10,6 +10,7 @@
  *                         reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,6 +23,10 @@
 opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
 
 volatile uint32_t ompi_mpit_init_count = 0;
+
+int ompi_mpit_thread_level = MPI_THREAD_SINGLE;
+
+bool ompi_mpit_init_failed = false;
 
 void ompi_mpit_lock (void)
 {

--- a/ompi/runtime/mpiruntime.h
+++ b/ompi/runtime/mpiruntime.h
@@ -59,6 +59,19 @@ OMPI_DECLSPEC extern volatile bool ompi_rte_initialized;
 
 /** Do we have multiple threads? */
 OMPI_DECLSPEC extern bool ompi_mpi_thread_multiple;
+
+/* Number of active MPI_T init references (defined in
+   ompi/mpi/tool/mpit_common.c).  Read by the instance and world-model
+   initialization paths to judge quiescence before writing the
+   process-wide thread flags; all transitions happen with the instance
+   lock held (MPI_T_init_thread()/MPI_T_finalize() take it), so a reader
+   holding that lock sees a stable value. */
+OMPI_DECLSPEC extern volatile uint32_t ompi_mpit_init_count;
+
+/* Thread level of the current MPI_T epoch (defined in
+   ompi/mpi/tool/mpit_common.c); MPI_THREAD_SINGLE when no epoch is
+   active.  Same locking discipline as ompi_mpit_init_count. */
+OMPI_DECLSPEC extern int ompi_mpit_thread_level;
 /** Thread level requested to \c MPI_Init_thread() */
 OMPI_DECLSPEC extern int ompi_mpi_thread_requested;
 /** Thread level provided by Open MPI */

--- a/ompi/runtime/ompi_info_support.c
+++ b/ompi/runtime/ompi_info_support.c
@@ -67,15 +67,30 @@ int ompi_info_register_framework_params(opal_pointer_array_t *component_map)
     /* Register the MPI layer's MCA parameters */
     if (OMPI_SUCCESS != (rc = ompi_mpi_register_params())) {
         fprintf(stderr, "ompi_info_register: ompi_mpi_register_params failed\n");
+        --ompi_info_registered;
         return rc;
     }
 
     rc = opal_info_register_framework_params(component_map);
     if (OPAL_SUCCESS != rc) {
+        /* the OPAL layer unwound itself (except on BAD_PARAM, where
+           registrations are deliberately kept for ompi_info's
+           diagnostic dump and the registration references are kept
+           with them) */
+        if (OPAL_ERR_BAD_PARAM != rc) {
+            --ompi_info_registered;
+        }
         return rc;
     }
 
-    return opal_info_register_project_frameworks(ompi_info_type_ompi, ompi_frameworks, component_map);
+    rc = opal_info_register_project_frameworks(ompi_info_type_ompi, ompi_frameworks, component_map);
+    if (OPAL_SUCCESS != rc && OPAL_ERR_BAD_PARAM != rc) {
+        /* the OMPI project loop rolled its own registrations back;
+           release the OPAL layer registration taken above */
+        opal_info_close_components();
+        --ompi_info_registered;
+    }
+    return rc;
 }
 
 void ompi_info_close_components(void)

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -317,8 +317,41 @@ void ompi_mpi_thread_level(int requested, int *provided)
      * provided > required. Finally, if the user requirement cannot be
      * satisfied, then the call will return in provided the highest
      * supported level.
+     *
+     * This establishes the World Model's thread level, and is called only
+     * from ompi_mpi_init().  These globals back MPI_QUERY_THREAD, which
+     * MPI 5.0 sec. 11.6.2 pins for the life of the process to "the level
+     * of thread support returned by the original call to
+     * MPI_INIT_THREAD" -- no other scope (MPI_T, sessions) may write
+     * them; each has its own pinned level.
      */
     ompi_mpi_thread_requested = requested;
+
+    /* If sessions are already active at a lower level, this process
+       cannot be safely upgraded to MPI_THREAD_MULTIPLE mid-flight (the
+       components those sessions selected were configured at the lower
+       level, and the process-wide flags cannot be changed without racing
+       their unlocked hot-path readers).  Grant MPI_THREAD_SERIALIZED
+       instead -- the coupling MPI 5.0 sec. 11.6.2 explicitly permits:
+       "the level of thread support returned from MPI_INIT_THREAD may be
+       similarly influenced by the requested level of thread support in
+       the prior call to MPI_SESSION_INIT".  We are called with the
+       instance lock held, which pins ompi_instance_count. */
+    if (MPI_THREAD_MULTIPLE == requested && !ompi_mpi_thread_multiple
+        && (0 != ompi_instance_count
+            || (0 != ompi_mpit_init_count
+                && MPI_THREAD_SINGLE != ompi_mpit_thread_level
+                && !opal_using_threads()))) {
+        /* Active sessions, or a tool epoch whose threads may be inside
+           unlocked MPI_T query routines and whose own init could not
+           flip the OPAL flags, make an upgrade unsafe.  Note this is NOT
+           the common tool pattern (MPI_T_init_thread() from a PMPI
+           wrapper before the application's MPI_Init_thread()): a tool at
+           SINGLE has no other threads, and a tool above SINGLE at a
+           quiescent init already flipped the OPAL flags, so MULTIPLE is
+           granted normally in both of those cases. */
+        requested = MPI_THREAD_SERIALIZED;
+    }
 
     ompi_mpi_thread_provided = *provided = requested;
 
@@ -326,8 +359,13 @@ void ompi_mpi_thread_level(int requested, int *provided)
         ompi_mpi_main_thread = opal_thread_get_self();
     }
 
-    ompi_mpi_thread_multiple = (ompi_mpi_thread_provided ==
-                                MPI_THREAD_MULTIPLE);
+    /* Ratchet only: a THREAD_MULTIPLE session may already have engaged
+       the process-wide threaded code paths, and a lower-level world
+       initialization must not disengage them. */
+    if (MPI_THREAD_MULTIPLE == ompi_mpi_thread_provided
+        && !ompi_mpi_thread_multiple) {
+        ompi_mpi_thread_multiple = true;
+    }
 }
 
 static void fence_release(pmix_status_t status, void *cbdata)

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -72,6 +72,7 @@
 #include "ompi/constants.h"
 #include "ompi/mpi/fortran/base/constants.h"
 #include "ompi/runtime/mpiruntime.h"
+#include "ompi/instance/instance.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/info/info.h"
@@ -392,9 +393,25 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     }
 #endif
 
+    /* Publish the world thread level (and ompi_mpi_main_thread) under
+       the instance lock: MPI_T_finalize() reads ompi_mpi_main_thread
+       under that lock, and must either see it not yet set (and leave it
+       alone because ompi_mpi_state is already INIT_STARTED) or see a
+       fully published value.
+
+       Hold the lock across the instance initialization as well (it is
+       recursive), so that the level decided above and the process-wide
+       thread-flag ratchet inside ompi_mpi_instance_init() happen in ONE
+       critical section.  Otherwise a concurrent MPI_Session_init() could
+       slip between the two acquisitions, become the first instance
+       without engaging the flags, and leave a THREAD_MULTIPLE world
+       running with its granted level already decided but the threaded
+       code paths never enabled. */
+    ompi_mpi_instance_lock ();
     ompi_mpi_thread_level(requested, provided);
 
     ret = ompi_mpi_instance_init (*provided, &ompi_mpi_info_null.info.super, MPI_ERRORS_ARE_FATAL, &ompi_mpi_instance_default, argc, argv);
+    ompi_mpi_instance_unlock ();
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
         error = "ompi_mpi_init: ompi_mpi_instance_init failed";
         goto error;

--- a/ompi/test/t/Makefile.am
+++ b/ompi/test/t/Makefile.am
@@ -8,17 +8,99 @@
 # $HEADER$
 #
 
-# These are singleton MPI_T tests: they exercise the MPI tool
-# information interface without MPI_Init, so they need no launcher and
-# can run as part of 'make check'.
-check_PROGRAMS = mpi_t_category_get_events
+# These are singleton MPI tool / MPI_T tests: they need no launcher (an
+# MPI_T-only test runs without MPI_Init; a test that calls MPI_Init or
+# MPI_Session_init runs as a singleton), so they can run as part of
+# 'make check'.
+#
+# Make "make check" work in an uninstalled --enable-mca-dso build tree
+# (the tests that call MPI_Init()/MPI_Session_init() must be able to
+# dlopen their component DSOs from the build tree before "make install").
+include $(top_srcdir)/Makefile.mca-dso-check
+
+#
+# The mpi_t_lifecycle.h family walks the MPI_T init/finalize orderings
+# against the world model and the sessions model.  Sessions repeat, so
+# every sessions interleaving lives in one program; MPI_Init() is legal
+# only once per process, so each world-model ordering is its own program.
+check_PROGRAMS = \
+        mpi_t_category_get_events \
+        mpi_t_concurrent_init \
+        mpi_t_level_no_downgrade \
+        mpi_t_level_pinning \
+        mpi_t_lifecycle \
+        mpi_t_outlives_mpi \
+        mpi_t_repeated_sessions \
+        mpi_t_world_close_first \
+        mpi_t_world_inner \
+        mpi_t_world_outlast \
+        mpi_t_sessions \
+        mpi_t_stress \
+        mpi_t_world_sessions
 TESTS = $(check_PROGRAMS)
 
-mpi_t_category_get_events_SOURCES = mpi_t_category_get_events.c
-mpi_t_category_get_events_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
-mpi_t_category_get_events_LDADD = \
+test_ldadd = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
 
+mpi_t_category_get_events_SOURCES = mpi_t_category_get_events.c
+mpi_t_category_get_events_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_category_get_events_LDADD = $(test_ldadd)
+
+mpi_t_concurrent_init_SOURCES = mpi_t_concurrent_init.c mpi_t_lifecycle.h
+mpi_t_concurrent_init_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+# This test calls pthread_* APIs directly, so it explicitly links
+# -lpthread -- which has been working on all supported systems since
+# 42a05e9a741 (2004) established the same convention in
+# test/threads/Makefile.am.  Configure's THREAD_CFLAGS / THREAD_LDFLAGS
+# / THREAD_LIBS describe whatever threading package the threads MCA
+# framework selected (not necessarily pthreads), and are only applied
+# to the wrapper compilers -- they are not AC_SUBSTed for Makefile use.
+mpi_t_concurrent_init_LDADD = $(test_ldadd) -lpthread
+
+mpi_t_level_no_downgrade_SOURCES = mpi_t_level_no_downgrade.c mpi_t_lifecycle.h
+mpi_t_level_no_downgrade_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_level_no_downgrade_LDADD = $(test_ldadd)
+
+mpi_t_level_pinning_SOURCES = mpi_t_level_pinning.c mpi_t_lifecycle.h
+mpi_t_level_pinning_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_level_pinning_LDADD = $(test_ldadd)
+
+mpi_t_lifecycle_SOURCES = mpi_t_lifecycle.c mpi_t_lifecycle.h
+mpi_t_lifecycle_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_lifecycle_LDADD = $(test_ldadd)
+
+mpi_t_outlives_mpi_SOURCES = mpi_t_outlives_mpi.c
+mpi_t_outlives_mpi_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_outlives_mpi_LDADD = $(test_ldadd)
+
+mpi_t_world_close_first_SOURCES = mpi_t_world_close_first.c mpi_t_lifecycle.h
+mpi_t_world_close_first_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_world_close_first_LDADD = $(test_ldadd)
+
+mpi_t_world_inner_SOURCES = mpi_t_world_inner.c mpi_t_lifecycle.h
+mpi_t_world_inner_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_world_inner_LDADD = $(test_ldadd)
+
+mpi_t_world_outlast_SOURCES = mpi_t_world_outlast.c mpi_t_lifecycle.h
+mpi_t_world_outlast_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_world_outlast_LDADD = $(test_ldadd)
+
+mpi_t_repeated_sessions_SOURCES = mpi_t_repeated_sessions.c mpi_t_lifecycle.h
+mpi_t_repeated_sessions_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_repeated_sessions_LDADD = $(test_ldadd)
+
+mpi_t_sessions_SOURCES = mpi_t_sessions.c mpi_t_lifecycle.h
+mpi_t_sessions_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_sessions_LDADD = $(test_ldadd)
+
+mpi_t_stress_SOURCES = mpi_t_stress.c mpi_t_lifecycle.h
+mpi_t_stress_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_stress_LDADD = $(test_ldadd)
+
+mpi_t_world_sessions_SOURCES = mpi_t_world_sessions.c mpi_t_lifecycle.h
+mpi_t_world_sessions_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+mpi_t_world_sessions_LDADD = $(test_ldadd)
+
 distclean-local:
-	rm -rf *.dSYM .deps .libs *.la *.lo mpi_t_category_get_events *.log *.o *.trs Makefile
+	rm -rf *.dSYM .deps .libs *.la *.lo $(check_PROGRAMS) *.log *.o *.trs Makefile

--- a/ompi/test/t/mpi_t_concurrent_init.c
+++ b/ompi/test/t/mpi_t_concurrent_init.c
@@ -1,0 +1,126 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Concurrent MPI_T and sessions initialization: one thread loops full
+ * MPI_T init/finalize cycles while another loops full MPI session
+ * init/finalize cycles, with no ordering between them.
+ *
+ * A first MPI_T initialization and an instance (world or session)
+ * initialization share unlocked under-layers: the OPAL init reference
+ * counters, the shared event base reference count, MCA variable
+ * registration, and every framework's refcount.  MPI_T entry points
+ * therefore serialize against instance init/teardown (see
+ * ompi_mpi_instance_lock()); this test hammers exactly that window.
+ *
+ * A race here is probabilistic: a failure (crash or error return) proves
+ * the bug, but a pass is only evidence, not proof.  The iteration counts
+ * are a compromise between coverage and 'make check' runtime.
+ *
+ * MPI_T is driven from one thread here, but the process is
+ * multithreaded and that thread is not promised to be the main thread,
+ * so MPI_THREAD_SERIALIZED is the honest required level for the tools
+ * interface (MPI_THREAD_SINGLE would promise a single-threaded
+ * process).  A level above SINGLE also engages the thread-flag ratchet
+ * in MPI_T_init_thread(), so this test exercises the ratchet and the
+ * init serialization together.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define T_CYCLES 500
+#define SESSION_CYCLES 20
+
+/* Shared between the two threads.  _Atomic (rather than volatile, which
+   provides neither atomicity nor ordering in C11) makes every plain read
+   and write of this flag a sequentially-consistent atomic access. */
+static _Atomic int failed = 0;
+
+static void *t_thread(void *arg)
+{
+    int provided;
+
+    (void) arg;
+    for (int i = 0; i < T_CYCLES && !failed; ++i) {
+        if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SERIALIZED, &provided)) {
+            printf("FAIL: MPI_T_init_thread (cycle %d)\n", i);
+            failed = 1;
+            break;
+        }
+        if (MPI_SUCCESS != MPI_T_finalize()) {
+            printf("FAIL: MPI_T_finalize (cycle %d)\n", i);
+            failed = 1;
+            break;
+        }
+    }
+    return NULL;
+}
+
+static void *session_thread(void *arg)
+{
+    (void) arg;
+    for (int i = 0; i < SESSION_CYCLES && !failed; ++i) {
+        MPI_Session s;
+        if (MPI_SUCCESS != MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s)) {
+            printf("FAIL: MPI_Session_init (cycle %d)\n", i);
+            failed = 1;
+            break;
+        }
+        if (MPI_SUCCESS != MPI_Session_finalize(&s)) {
+            printf("FAIL: MPI_Session_finalize (cycle %d)\n", i);
+            failed = 1;
+            break;
+        }
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t t1, t2;
+    int provided;
+    MPI_Session probe;
+
+    pin_tcp_btl();
+
+    /* Probe serially first: environments that cannot run MPI_T or a
+       singleton session at all are a skip, not a failure. */
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SERIALIZED, &provided), "probe: T_init");
+    STEP_OR_SKIP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &probe),
+                 "probe: Session_init");
+    STEP(MPI_Session_finalize(&probe), "probe: Session_finalize");
+    STEP(MPI_T_finalize(), "probe: T_finalize");
+
+    printf("running: %d MPI_T cycles vs %d session cycles, concurrently\n",
+           T_CYCLES, SESSION_CYCLES);
+    fflush(stdout);
+
+    if (0 != pthread_create(&t1, NULL, t_thread, NULL)
+        || 0 != pthread_create(&t2, NULL, session_thread, NULL)) {
+        printf("SKIP: could not create threads\n");
+        return 77;
+    }
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    if (failed) {
+        return 1;
+    }
+
+    /* Both lifecycles must still work serially afterwards. */
+    STEP(MPI_T_init_thread(MPI_THREAD_SERIALIZED, &provided), "post: T_init");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &probe), "post: Session_init");
+    STEP(MPI_Session_finalize(&probe), "post: Session_finalize");
+    STEP(MPI_T_finalize(), "post: T_finalize");
+
+    printf("SUCCESS: concurrent MPI_T and session lifecycles\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_level_no_downgrade.c
+++ b/ompi/test/t/mpi_t_level_no_downgrade.c
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * The downgrade direction of the thread-level aliasing bug: a tool
+ * calling MPI_T_init_thread(MPI_THREAD_SINGLE) inside a running
+ * MPI_THREAD_MULTIPLE application.  MPI_T's level used to be written
+ * straight into the World Model's globals, so this silently turned off
+ * opal_using_threads()-gated locking and ob1's threaded request paths in
+ * a genuinely multithreaded program, and corrupted what
+ * MPI_QUERY_THREAD reported (MPI 5.0 sec. 11.6.2 pins it to the value
+ * returned by the original MPI_INIT_THREAD).
+ *
+ * A singleton cannot observe elided locking directly, but it can observe
+ * the report: after the MPI_T init, MPI_QUERY_THREAD must still return
+ * the world's original level, and MPI_Is_thread_main() must still know
+ * the main thread.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided, world_level, query, flag;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &world_level),
+                 "MPI_Init_thread (MULTIPLE, singleton)");
+
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (SINGLE, inside MPI)");
+    if (MPI_THREAD_SINGLE != provided) {
+        printf("FAIL: MPI_T provided %d, want MPI_THREAD_SINGLE\n", provided);
+        return 1;
+    }
+
+    STEP(MPI_Query_thread(&query), "Query_thread");
+    if (query != world_level) {
+        printf("FAIL: Query_thread %d changed from original %d after "
+               "MPI_T_init_thread(SINGLE)\n", query, world_level);
+        return 1;
+    }
+
+    STEP(MPI_Is_thread_main(&flag), "Is_thread_main");
+    if (!flag) {
+        printf("FAIL: main thread no longer recognized as main\n");
+        return 1;
+    }
+
+    STEP(MPI_T_finalize(), "T_finalize");
+    STEP(MPI_Finalize(), "MPI_Finalize");
+
+    printf("SUCCESS: no thread-level downgrade from MPI_T\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_level_pinning.c
+++ b/ompi/test/t/mpi_t_level_pinning.c
@@ -1,0 +1,63 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Thread-level reports are pinned per scope (MPI 5.0 secs. 11.6.2 and
+ * 15.3.4): MPI_T's level belongs to the tools interface alone and is
+ * fixed for its init epoch; MPI_QUERY_THREAD returns what the original
+ * MPI_INIT_THREAD returned, forever.  An earlier scope's level may
+ * influence what a later init is *granted*, but never changes what an
+ * existing scope already reported.
+ *
+ * Ordering here: MPI_T at MPI_THREAD_MULTIPLE first, then the world at
+ * MPI_THREAD_SINGLE.  The strong MPI_T level must not bleed into the
+ * world's reported level, and nested MPI_T inits must keep reporting the
+ * epoch's pinned level regardless of what they request.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+#define CHECK_LEVEL(what, got, want)                                    \
+    do {                                                                \
+        if ((want) != (got)) {                                          \
+            printf("FAIL: %s: got %d, want %d\n", (what), (got), (want)); \
+            return 1;                                                   \
+        }                                                               \
+    } while (0)
+
+int main(void)
+{
+    int provided, query;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_MULTIPLE, &provided), "T_init (MULTIPLE)");
+    CHECK_LEVEL("MPI_T provided", provided, MPI_THREAD_MULTIPLE);
+
+    STEP_OR_SKIP(MPI_Init_thread(NULL, NULL, MPI_THREAD_SINGLE, &provided),
+                 "MPI_Init_thread (SINGLE, singleton)");
+    CHECK_LEVEL("world provided", provided, MPI_THREAD_SINGLE);
+
+    STEP(MPI_Query_thread(&query), "Query_thread");
+    CHECK_LEVEL("Query_thread (pinned to world's original)", query, MPI_THREAD_SINGLE);
+
+    /* Nested MPI_T init: epoch level is pinned; the SINGLE request here
+       must neither be granted nor leak anywhere. */
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (nested, SINGLE)");
+    CHECK_LEVEL("MPI_T provided (nested, epoch-pinned)", provided, MPI_THREAD_MULTIPLE);
+    STEP(MPI_T_finalize(), "T_finalize (nested)");
+
+    STEP(MPI_Query_thread(&query), "Query_thread (after nested T_init)");
+    CHECK_LEVEL("Query_thread (still pinned)", query, MPI_THREAD_SINGLE);
+
+    STEP(MPI_Finalize(), "MPI_Finalize");
+    STEP(MPI_T_finalize(), "T_finalize (last)");
+
+    printf("SUCCESS: thread-level reports pinned per scope\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_lifecycle.c
+++ b/ompi/test/t/mpi_t_lifecycle.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Tool-only MPI_T lifecycles: no MPI_Init and no sessions anywhere in this
+ * process.  Exercises single, nested (MPI_T is reference counted), and
+ * repeated full MPI_T init/finalize cycles -- the repeated case drives
+ * OPAL's util layer and the MCA var system through full teardown and
+ * re-initialization, which is exactly where stale-pointer bugs in
+ * "register once" logic like to hide.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+
+    pin_tcp_btl();
+
+    /* Plain cycle */
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (plain)");
+    STEP(MPI_T_finalize(), "T_finalize (plain)");
+
+    /* Nested: only the outermost init/last finalize do real work */
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (nested, 1)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (nested, 2)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (nested, 3)");
+    STEP(MPI_T_finalize(), "T_finalize (nested, 3)");
+    STEP(MPI_T_finalize(), "T_finalize (nested, 2)");
+    STEP(MPI_T_finalize(), "T_finalize (nested, 1)");
+
+    /* Repeated full cycles */
+    for (int i = 0; i < 3; ++i) {
+        STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (repeat)");
+        STEP(MPI_T_finalize(), "T_finalize (repeat)");
+    }
+
+    printf("SUCCESS: tool-only MPI_T lifecycles\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_lifecycle.h
+++ b/ompi/test/t/mpi_t_lifecycle.h
@@ -1,0 +1,69 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Shared scaffolding for the MPI_T lifecycle-ordering tests in this
+ * directory.  Not installed; test-local only.
+ */
+
+#ifndef MPI_T_LIFECYCLE_H
+#define MPI_T_LIFECYCLE_H
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* The teardown failures these tests guard against need a component that
+   still has events registered on OPAL's shared event base when its
+   deferred close runs; the tcp btl is that component.  Pin the pml (the
+   btl variable only bites under a BTL-based pml) and the btl so the
+   coverage cannot silently evaporate on a build where another pml wins
+   selection.  Best-effort: on a host with no usable TCP interface the
+   tcp btl yields no modules and registers no events.
+
+   Clearing btl_tcp_if_exclude lets loopback count as a tcp interface,
+   so the tcp btl yields >= 2 modules even on a single-NIC host.  That
+   matters: at MPI_THREAD_MULTIPLE, a multi-module tcp btl sets
+   MCA_BTL_FLAGS_SINGLE_ADD_PROCS, which makes ob1 require comm world
+   and sends a sessions-only process through ompi_comm_init_mpi3() --
+   the path that once tore down world/self marked PML_ADDED without a
+   matching pml add_comm() (SIGSEGV at MPI_Session_finalize()).  Without
+   this, that regression is only reachable on multi-NIC hosts. */
+static inline void pin_tcp_btl(void)
+{
+    setenv("OMPI_MCA_pml", "ob1", 1);
+    setenv("OMPI_MCA_btl", "tcp,self", 1);
+    setenv("OMPI_MCA_btl_tcp_if_exclude", "", 1);
+}
+
+/* Every step announces itself and flushes before running, so that if a
+   step crashes the process, the last line of output names the killer. */
+#define STEP(expr, what)                                        \
+    do {                                                        \
+        printf("step: %s\n", (what));                           \
+        fflush(stdout);                                         \
+        if (MPI_SUCCESS != (expr)) {                            \
+            printf("FAIL: %s returned non-success\n", (what));  \
+            return 1;                                           \
+        }                                                       \
+    } while (0)
+
+/* Same, but a failure is a SKIP (exit 77): used for the first init call
+   of a flavor, where "this environment cannot do that at all" (e.g. no
+   singleton support) should not count as a test failure. */
+#define STEP_OR_SKIP(expr, what)                                \
+    do {                                                        \
+        printf("step: %s\n", (what));                           \
+        fflush(stdout);                                         \
+        if (MPI_SUCCESS != (expr)) {                            \
+            printf("SKIP: %s failed; cannot test here\n", (what)); \
+            return 77;                                          \
+        }                                                       \
+    } while (0)
+
+#endif /* MPI_T_LIFECYCLE_H */

--- a/ompi/test/t/mpi_t_outlives_mpi.c
+++ b/ompi/test/t/mpi_t_outlives_mpi.c
@@ -1,0 +1,86 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Singleton (no launcher required) regression test for an MPI_T reference
+ * that outlives MPI itself.
+ *
+ * MPI_T is reference counted independently of MPI, so a tool may legally
+ * bracket MPI entirely (MPI-5.0 sec. 15.3.1):
+ *
+ *     MPI_T_init_thread() -> MPI_Init() -> MPI_Finalize() -> MPI_T_finalize()
+ *
+ * MPI_T_init_thread() registers every MCA framework, bumping each framework's
+ * refcount.  With the ordering above, MPI_Finalize()'s framework closes are
+ * therefore mere decrements: the *true* closes -- component_close(), where
+ * components delete the events they registered on OPAL's shared event base --
+ * are deferred into MPI_T_finalize(), after MPI_Finalize() has already run
+ * opal_finalize().  MPI_T must hold a reference on the shared event base so
+ * that it stays alive until those deferred closes have run; this test is the
+ * regression guard for that reference.
+ *
+ * This failed once: opal_event_finalize() began freeing the shared base at
+ * opal_finalize() (fixing an fd leak across MPI session cycles) while MPI_T
+ * held no reference on it.  The tcp btl's deferred component_close() then
+ * decided ownership of its base by comparing against the (by then NULL)
+ * opal_sync_event_base global, concluded the shared base was its own, freed
+ * it a second time, and this sequence segfaulted inside event_base_free().
+ *
+ * The ordering is the entire point of the test, so it deliberately calls no
+ * MPI_T routine other than init/finalize.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    int provided;
+
+    /* The failure this guards against needs a component that still has events
+       registered on the shared event base when its deferred close runs; the
+       tcp btl is that component (it registers its listening-socket events on
+       the shared base and deletes them at component_close()).  If it is never
+       selected, this test exercises nothing and would keep passing even if
+       the bug came back, so force it (with self, which is what carries a
+       singleton's traffic).  Overwrite rather than defer to the environment:
+       a CI runner that pins OMPI_MCA_btl to something else would otherwise
+       silently turn this test into a no-op.
+
+       The btl variable only bites under a BTL-based PML, so pin ob1 as well:
+       if ucx or a cm/mtl PML won selection, btl=tcp,self would be ignored and
+       we would be back to a vacuous test.
+
+       This is best-effort, not a guarantee: on a host with no usable TCP
+       interface the tcp btl yields no modules, registers no events, and
+       nothing can make it do so. */
+    setenv("OMPI_MCA_pml", "ob1", 1);
+    setenv("OMPI_MCA_btl", "tcp,self", 1);
+
+    /* MPI_T first: this reference has to outlive the MPI_Finalize() below. */
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("SKIP: MPI_T_init_thread() failed\n");
+        return 77;
+    }
+
+    if (MPI_SUCCESS != MPI_Init(&argc, &argv)) {
+        printf("SKIP: MPI_Init() failed (no singleton support here)\n");
+        return 77;
+    }
+
+    MPI_Finalize();
+
+    /* The last MPI_T reference, dropped after MPI_Finalize() already finalized
+       OPAL.  This is the call that closes the info components. */
+    MPI_T_finalize();
+
+    printf("SUCCESS: MPI_T_finalize() after MPI_Finalize() did not crash\n");
+
+    return 0;
+}

--- a/ompi/test/t/mpi_t_repeated_sessions.c
+++ b/ompi/test/t/mpi_t_repeated_sessions.c
@@ -1,0 +1,51 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Repeated session cycles under one continuously-held MPI_T reference:
+ *
+ *     T_init -> (Session_init -> Session_finalize) x3 -> T_finalize
+ *
+ * This ordering once failed at the second MPI_Session_init(): MPI_T's
+ * framework registration holds every framework's refcount, so the first
+ * session's finalize cannot truly close the bml framework -- and
+ * mca_bml_base_init() therefore skips r2's component init on the second
+ * session (that is where btls_added is reset and BTL selection re-runs),
+ * while the per-session pml finalize had already emptied r2's module
+ * array.  With the "btls_added" guard stale-true over an empty array,
+ * add_procs attached zero BTLs and Session_init failed with
+ * MPI_ERR_INTERN ("BTLs attempted: (null)").  Fixed by resetting the
+ * guard in mca_bml_r2_finalize(), where the state it guards is freed.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+    MPI_Session s;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init");
+    for (int i = 0; i < 3; ++i) {
+        char what[64];
+        snprintf(what, sizeof(what), "Session_init (cycle %d, T held)", i);
+        if (0 == i) {
+            STEP_OR_SKIP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), what);
+        } else {
+            STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), what);
+        }
+        snprintf(what, sizeof(what), "Session_finalize (cycle %d, T held)", i);
+        STEP(MPI_Session_finalize(&s), what);
+    }
+    STEP(MPI_T_finalize(), "T_finalize");
+
+    printf("SUCCESS: repeated session cycles under a held MPI_T reference\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_sessions.c
+++ b/ompi/test/t/mpi_t_sessions.c
@@ -1,0 +1,208 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * MPI_T vs. the sessions model.  Unlike MPI_Init(), sessions may be
+ * created and destroyed repeatedly in one process, so a single executable
+ * can walk every interleaving -- including the sessions analog of the
+ * T-outlives-MPI teardown hazard (a session's finalize runs opal_finalize()
+ * while MPI_T still holds the frameworks, so the true component closes are
+ * deferred to MPI_T_finalize()), overlapping sessions, nested MPI_T around
+ * sessions, and interleaved full cycles of each flavor.
+ *
+ * Repeated session cycles under one continuously-held MPI_T reference live
+ * in mpi_t_repeated_sessions.c; see the comment there.
+ *
+ * Sub-cases run in sequence; the step log names the killer if one crashes.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+#include <string.h>
+
+static int t_brackets_session(void)
+{
+    int provided;
+    MPI_Session s;
+
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c1: T_init");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c1: Session_init");
+    STEP(MPI_Session_finalize(&s), "c1: Session_finalize");
+    STEP(MPI_T_finalize(), "c1: T_finalize");
+    return 0;
+}
+
+static int t_multiple_brackets_session(void)
+{
+    int provided;
+    MPI_Session s;
+
+    /* Once crashed on macOS (SIGSEGV in ompi_comm_destruct() at the
+       session's finalize): MPI_T_init_thread() used to write its thread
+       level into the World Model's globals, flipping the process onto
+       THREAD_MULTIPLE code paths that the session never chose.  MPI_T's
+       level is its own (MPI 5.0 sec. 15.3.4). */
+    STEP(MPI_T_init_thread(MPI_THREAD_MULTIPLE, &provided), "c8: T_init (MULTIPLE)");
+    if (MPI_THREAD_MULTIPLE != provided) {
+        printf("FAIL: c8: T provided %d != MPI_THREAD_MULTIPLE\n", provided);
+        return 1;
+    }
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c8: Session_init");
+    STEP(MPI_Session_finalize(&s), "c8: Session_finalize");
+    STEP(MPI_T_finalize(), "c8: T_finalize");
+    return 0;
+}
+
+static int check_session_level(MPI_Session s, const char *want, const char *what)
+{
+    MPI_Info out;
+    char val[64];
+    int len = sizeof(val), flag;
+
+    STEP(MPI_Session_get_info(s, &out), what);
+    STEP(MPI_Info_get_string(out, "thread_level", &len, val, &flag), what);
+    STEP(MPI_Info_free(&out), what);
+    if (!flag || 0 != strcmp(val, want)) {
+        printf("FAIL: %s: granted \"%s\", want %s\n", what, flag ? val : "(unset)", want);
+        return 1;
+    }
+    return 0;
+}
+
+static int mixed_level_downgrade(void)
+{
+    int rc;
+    MPI_Session s1, s2;
+    MPI_Info info;
+
+    /* A second scope requesting MPI_THREAD_MULTIPLE while a lower-level
+       scope is active cannot be safely upgraded mid-process (components
+       already selected were configured at the lower level, and the
+       process-wide thread flags cannot change without racing their
+       unlocked hot-path readers).  MPI 5.0 sec. 11.6.2 explicitly allows
+       the earlier scope to influence the granted level; Open MPI grants
+       MPI_THREAD_SERIALIZED in that case, reported through the session's
+       "thread_level" info key.  At a quiescent point (no active scope), a
+       MULTIPLE request is granted in full. */
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s1), "c9: Session_init #1 (default=SINGLE)");
+    STEP(MPI_Info_create(&info), "c9: Info_create");
+    STEP(MPI_Info_set(info, "thread_level", "MPI_THREAD_MULTIPLE"), "c9: Info_set");
+    STEP(MPI_Session_init(info, MPI_ERRORS_RETURN, &s2), "c9: Session_init #2 (MULTIPLE, contended)");
+    STEP(MPI_Info_free(&info), "c9: Info_free");
+    if (0 != (rc = check_session_level(s2, "MPI_THREAD_SERIALIZED", "c9: contended grant"))) return rc;
+    STEP(MPI_Session_finalize(&s2), "c9: Session_finalize #2");
+    STEP(MPI_Session_finalize(&s1), "c9: Session_finalize #1");
+
+    STEP(MPI_Info_create(&info), "c9: Info_create (quiescent)");
+    STEP(MPI_Info_set(info, "thread_level", "MPI_THREAD_MULTIPLE"), "c9: Info_set (quiescent)");
+    STEP(MPI_Session_init(info, MPI_ERRORS_RETURN, &s1), "c9: Session_init (MULTIPLE, quiescent)");
+    STEP(MPI_Info_free(&info), "c9: Info_free (quiescent)");
+    if (0 != (rc = check_session_level(s1, "MPI_THREAD_MULTIPLE", "c9: quiescent grant"))) return rc;
+    STEP(MPI_Session_finalize(&s1), "c9: Session_finalize (quiescent)");
+    return 0;
+}
+
+static int t_inside_session(void)
+{
+    int provided;
+    MPI_Session s;
+
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c2: Session_init");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c2: T_init");
+    STEP(MPI_T_finalize(), "c2: T_finalize");
+    STEP(MPI_Session_finalize(&s), "c2: Session_finalize");
+    return 0;
+}
+
+static int t_outlives_session(void)
+{
+    int provided;
+    MPI_Session s;
+
+    /* The hazard case: Session_finalize() drops the last full-OPAL
+       reference from the MPI side, so the deferred component closes run
+       at T_finalize(). */
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c3: Session_init");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c3: T_init");
+    STEP(MPI_Session_finalize(&s), "c3: Session_finalize (T still open)");
+    STEP(MPI_T_finalize(), "c3: T_finalize (deferred closes)");
+    return 0;
+}
+
+static int overlapping_sessions_under_t(void)
+{
+    int provided;
+    MPI_Session s1, s2;
+
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c4: T_init");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s1), "c4: Session_init #1");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s2), "c4: Session_init #2");
+    STEP(MPI_Session_finalize(&s1), "c4: Session_finalize #1");
+    STEP(MPI_Session_finalize(&s2), "c4: Session_finalize #2");
+    STEP(MPI_T_finalize(), "c4: T_finalize");
+    return 0;
+}
+
+static int nested_t_around_session(void)
+{
+    int provided;
+    MPI_Session s;
+
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c6: T_init (outer)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c6: T_init (inner)");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c6: Session_init");
+    STEP(MPI_Session_finalize(&s), "c6: Session_finalize");
+    STEP(MPI_T_finalize(), "c6: T_finalize (inner)");
+    STEP(MPI_T_finalize(), "c6: T_finalize (outer)");
+    return 0;
+}
+
+static int interleaved_cycles(void)
+{
+    int provided;
+    MPI_Session s;
+
+    /* Full T cycle, then full session cycle, then both interleaved: the
+       process's OPAL layers go through several complete teardowns. */
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c7: T_init (solo cycle)");
+    STEP(MPI_T_finalize(), "c7: T_finalize (solo cycle)");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c7: Session_init (solo cycle)");
+    STEP(MPI_Session_finalize(&s), "c7: Session_finalize (solo cycle)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "c7: T_init");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s), "c7: Session_init");
+    STEP(MPI_Session_finalize(&s), "c7: Session_finalize");
+    STEP(MPI_T_finalize(), "c7: T_finalize");
+    return 0;
+}
+
+int main(void)
+{
+    int provided, rc;
+    MPI_Session probe;
+
+    pin_tcp_btl();
+
+    /* Can this environment do sessions and MPI_T at all?  (No singleton
+       support, etc., is a skip, not a failure.) */
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "probe: T_init");
+    STEP_OR_SKIP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &probe), "probe: Session_init");
+    STEP(MPI_Session_finalize(&probe), "probe: Session_finalize");
+    STEP(MPI_T_finalize(), "probe: T_finalize");
+
+    if (0 != (rc = t_brackets_session())) return rc;
+    if (0 != (rc = t_inside_session())) return rc;
+    if (0 != (rc = t_outlives_session())) return rc;
+    if (0 != (rc = overlapping_sessions_under_t())) return rc;
+    if (0 != (rc = nested_t_around_session())) return rc;
+    if (0 != (rc = interleaved_cycles())) return rc;
+    if (0 != (rc = t_multiple_brackets_session())) return rc;
+    if (0 != (rc = mixed_level_downgrade())) return rc;
+
+    printf("SUCCESS: all MPI_T x sessions interleavings\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_stress.c
+++ b/ompi/test/t/mpi_t_stress.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Stress: 10,000 full MPI_T init/finalize cycles with no MPI (world or
+ * sessions) anywhere in the process.  Every cycle tears OPAL's util layer
+ * and the MCA var system all the way down and back up, so growth bugs --
+ * fd leaks, heap growth in registration, stale-pointer reuse across var
+ * system generations -- surface as a failure or a crash long before the
+ * loop ends.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+#define CYCLES 10000
+
+int main(void)
+{
+    int provided, rc;
+
+    pin_tcp_btl();
+
+    /* First cycle separately: distinguish "cannot run here at all" (skip)
+       from "degraded after N cycles" (failure). */
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        printf("SKIP: MPI_T_init_thread() failed; cannot test here\n");
+        return 77;
+    }
+    if (MPI_SUCCESS != MPI_T_finalize()) {
+        printf("FAIL: MPI_T_finalize() failed on cycle 0\n");
+        return 1;
+    }
+
+    for (int i = 1; i < CYCLES; ++i) {
+        if (MPI_SUCCESS != (rc = MPI_T_init_thread(MPI_THREAD_SINGLE, &provided))) {
+            printf("FAIL: MPI_T_init_thread() returned %d on cycle %d\n", rc, i);
+            return 1;
+        }
+        if (MPI_SUCCESS != (rc = MPI_T_finalize())) {
+            printf("FAIL: MPI_T_finalize() returned %d on cycle %d\n", rc, i);
+            return 1;
+        }
+    }
+
+    printf("SUCCESS: %d MPI_T init/finalize cycles\n", CYCLES);
+    return 0;
+}

--- a/ompi/test/t/mpi_t_world_close_first.c
+++ b/ompi/test/t/mpi_t_world_close_first.c
@@ -1,0 +1,48 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * MPI_T vs. the world model, ordering: MPI_T opens first but closes first.
+ *
+ *     MPI_T_init_thread() -> MPI_Init() -> MPI_T_finalize() -> MPI_Finalize()
+ *
+ * MPI_T_finalize() runs its component closes while MPI is still alive, so
+ * every framework close it performs is a mere refcount decrement (MPI holds
+ * the frameworks too); the true closes happen inside MPI_Finalize().  Each
+ * world-model ordering needs its own executable because MPI_Init() is legal
+ * only once per process.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init");
+
+    /* The standard tool pattern: MPI_T initialized (e.g. by a PMPI
+       wrapper) before the application's MPI_Init_thread().  The active
+       MPI_T epoch must not cost the application its requested thread
+       level. */
+    STEP_OR_SKIP(MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided),
+                 "MPI_Init_thread (MULTIPLE, singleton, tool attached)");
+    if (MPI_THREAD_MULTIPLE != provided) {
+        printf("FAIL: world provided %d under an MPI_T epoch, want MPI_THREAD_MULTIPLE\n",
+               provided);
+        return 1;
+    }
+
+    STEP(MPI_T_finalize(), "T_finalize (MPI still alive)");
+    STEP(MPI_Finalize(), "MPI_Finalize");
+
+    printf("SUCCESS: T_init -> Init -> T_finalize -> Finalize\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_world_inner.c
+++ b/ompi/test/t/mpi_t_world_inner.c
@@ -1,0 +1,47 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * MPI_T vs. the world model, ordering: MPI_T entirely inside MPI.
+ *
+ *     MPI_Init() -> MPI_T_init_thread() -> MPI_T_finalize() -> MPI_Finalize()
+ *
+ * The tamest ordering: MPI's own references cover everything MPI_T touches.
+ * Each world-model ordering needs its own executable because MPI_Init() is
+ * legal only once per process.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_Init(NULL, NULL), "MPI_Init (singleton)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (inside MPI)");
+    STEP(MPI_T_finalize(), "T_finalize (inside MPI)");
+
+    /* A second MPI_T epoch requesting MPI_THREAD_MULTIPLE while the
+       (SINGLE-level) world is active: the process cannot be safely
+       upgraded mid-flight, so the grant must be capped at
+       MPI_THREAD_SERIALIZED (MPI 5.0 secs. 11.6.2/15.3.4 permit the
+       earlier scope's level to influence a later init's grant). */
+    STEP(MPI_T_init_thread(MPI_THREAD_MULTIPLE, &provided), "T_init (MULTIPLE inside SINGLE MPI)");
+    if (MPI_THREAD_SERIALIZED != provided) {
+        printf("FAIL: T provided %d inside SINGLE world, want MPI_THREAD_SERIALIZED\n", provided);
+        return 1;
+    }
+    STEP(MPI_T_finalize(), "T_finalize (second epoch)");
+
+    STEP(MPI_Finalize(), "MPI_Finalize");
+
+    printf("SUCCESS: Init -> T_init -> T_finalize -> Finalize\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_world_outlast.c
+++ b/ompi/test/t/mpi_t_world_outlast.c
@@ -1,0 +1,42 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * MPI_T vs. the world model, ordering: MPI_T starts inside MPI and outlives
+ * it, with nested MPI_T references straddling MPI_Finalize().
+ *
+ *     MPI_Init() -> MPI_T_init_thread() x2 -> MPI_Finalize()
+ *                -> MPI_T_finalize() -> MPI_T_finalize()
+ *
+ * The first MPI_T_finalize() after MPI_Finalize() is a pure refcount
+ * decrement; the second is the one that performs the deferred component
+ * closes, after MPI (and OPAL's full layer) is gone.  This is the same
+ * deferred-close hazard as the T-brackets-MPI ordering in
+ * mpi_t_outlives_mpi.c, reached through a different path.  Each world-model
+ * ordering needs its own executable because MPI_Init() is legal only once
+ * per process.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_Init(NULL, NULL), "MPI_Init (singleton)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (inside MPI, 1)");
+    STEP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init (inside MPI, 2)");
+    STEP(MPI_Finalize(), "MPI_Finalize");
+    STEP(MPI_T_finalize(), "T_finalize (after MPI, inner ref)");
+    STEP(MPI_T_finalize(), "T_finalize (after MPI, last ref: deferred closes)");
+
+    printf("SUCCESS: Init -> T_init x2 -> Finalize -> T_finalize x2\n");
+    return 0;
+}

--- a/ompi/test/t/mpi_t_world_sessions.c
+++ b/ompi/test/t/mpi_t_world_sessions.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * All three lifecycles in one process: MPI_T bracketing the world model,
+ * with a session opened and closed while MPI is up, and a second session
+ * outliving MPI_Finalize().  The world model and the sessions model are
+ * allowed to coexist (MPI-4.0 sec. 11); MPI_T is reference counted
+ * independently of both.  The final MPI_T_finalize() performs the deferred
+ * component closes after every other lifecycle has fully wound down.
+ */
+
+#include "mpi_t_lifecycle.h"
+
+int main(void)
+{
+    int provided;
+    MPI_Session s1, s2;
+
+    pin_tcp_btl();
+
+    STEP_OR_SKIP(MPI_T_init_thread(MPI_THREAD_SINGLE, &provided), "T_init");
+    STEP_OR_SKIP(MPI_Init(NULL, NULL), "MPI_Init (singleton)");
+    STEP_OR_SKIP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s1),
+                 "Session_init #1 (inside MPI)");
+    STEP(MPI_Session_finalize(&s1), "Session_finalize #1 (inside MPI)");
+    STEP(MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &s2),
+         "Session_init #2 (inside MPI)");
+    STEP(MPI_Finalize(), "MPI_Finalize (session #2 still open)");
+    STEP(MPI_Session_finalize(&s2), "Session_finalize #2 (after MPI_Finalize)");
+    STEP(MPI_T_finalize(), "T_finalize (deferred closes)");
+
+    printf("SUCCESS: MPI_T bracketing world + sessions coexistence\n");
+    return 0;
+}

--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -70,6 +70,11 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
         return OPAL_SUCCESS;
     }
 
+    /* From here down, any failure must unwind the reference taken above
+       (and the lists constructed below): a framework left with a bumped
+       refcnt but no REGISTERED flag can never be closed, and would leak
+       the caller's reference forever. */
+
     OBJ_CONSTRUCT(&framework->framework_components, opal_list_t);
     OBJ_CONSTRUCT(&framework->framework_failed_components, opal_list_t);
 
@@ -82,7 +87,7 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
         ret = mca_base_var_group_register(framework->framework_project, framework->framework_name,
                                           NULL, framework->framework_description);
         if (0 > ret) {
-            return ret;
+            goto register_error;
         }
 
         opal_asprintf(&desc,
@@ -95,14 +100,15 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
                                     MCA_BASE_VAR_SCOPE_ALL_EQ, &framework->framework_selection);
         free(desc);
         if (0 > ret) {
-            return ret;
+            goto register_error;
         }
 
         /* register a verbosity variable for this framework */
         ret = opal_asprintf(&desc, "Verbosity level for the %s framework (default: 0)",
                             framework->framework_name);
         if (0 > ret) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
+            ret = OPAL_ERR_OUT_OF_RESOURCE;
+            goto register_error;
         }
 
         framework->framework_verbose = MCA_BASE_VERBOSE_ERROR;
@@ -113,7 +119,7 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
                                               &framework->framework_verbose);
         free(desc);
         if (0 > ret) {
-            return ret;
+            goto register_error;
         }
 
         /* check the initial verbosity and open the output if necessary. we
@@ -124,14 +130,14 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
         if (NULL != framework->framework_register) {
             ret = framework->framework_register(flags);
             if (OPAL_SUCCESS != ret) {
-                return ret;
+                goto register_error;
             }
         }
 
         /* register components variables */
         ret = mca_base_framework_components_register(framework, flags);
         if (OPAL_SUCCESS != ret) {
-            return ret;
+            goto register_error;
         }
     }
 
@@ -139,6 +145,38 @@ int mca_base_framework_register(struct mca_base_framework_t *framework,
 
     /* framework did not provide a register function */
     return OPAL_SUCCESS;
+
+register_error:
+    /* Mirror the teardown mca_base_framework_close() performs for a
+       framework that is registered but not open: unload any components
+       the partial registration found, drop the variable group, and close
+       the output stream, so a failed registration leaves no trace. */
+    {
+        opal_list_item_t *item;
+        int group_id;
+
+        while (NULL
+               != (item = opal_list_remove_first(&framework->framework_components))) {
+            mca_base_component_list_item_t *cli = (mca_base_component_list_item_t *) item;
+            mca_base_component_unload(cli->cli_component, framework->framework_output);
+            OBJ_RELEASE(item);
+        }
+        while (NULL
+               != (item = opal_list_remove_first(&framework->framework_failed_components))) {
+            OBJ_RELEASE(item);
+        }
+
+        group_id = mca_base_var_group_find(framework->framework_project,
+                                           framework->framework_name, NULL);
+        if (0 <= group_id) {
+            (void) mca_base_var_group_deregister(group_id);
+        }
+    }
+    OBJ_DESTRUCT(&framework->framework_components);
+    OBJ_DESTRUCT(&framework->framework_failed_components);
+    framework_close_output(framework);
+    framework->framework_refcnt--;
+    return ret;
 }
 
 int mca_base_framework_register_list(mca_base_framework_t **frameworks,

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -20,7 +20,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -475,6 +475,7 @@ static int mca_btl_tcp_component_open(void)
 static int mca_btl_tcp_component_close(void)
 {
     mca_btl_tcp_event_t *event, *next;
+    bool free_event_base = false;
 
     /**
      * If we have a progress thread we should shut it down before
@@ -496,8 +497,10 @@ static int mca_btl_tcp_component_close(void)
             assert(-1 == mca_btl_tcp_progress_thread_trigger);
         }
         opal_event_del(&mca_btl_tcp_component.tcp_recv_thread_async_event);
-        opal_event_base_free(mca_btl_tcp_event_base);
-        mca_btl_tcp_event_base = NULL;
+        /* This private base still hosts the listening-socket events, the
+           pending tcp_events, and the endpoint events, all deleted below --
+           it cannot be freed until they are gone.  Just note that we own it. */
+        free_event_base = true;
 
         /* Close the remaining pipes */
         if (-1 != mca_btl_tcp_pipe_to_progress[0]) {
@@ -546,6 +549,21 @@ static int mca_btl_tcp_component_close(void)
     OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_frag_user);
     OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_lock);
     OPAL_LIST_DESTRUCT(&mca_btl_tcp_component.local_ifs);
+
+    /* Every event this component registered has now been deleted, so a
+       private (progress thread) base can finally be freed. */
+    if (free_event_base) {
+        opal_event_base_free(mca_btl_tcp_event_base);
+    }
+    /* Drop the alias on every close path, owned base or not.  OPAL may free
+       and recreate the shared base between this close and a future open of
+       this component (MPI Sessions closes and re-opens the btl framework),
+       and mca_btl_tcp_component_create_listen() decides whether it still
+       needs a progress-thread base by NULL-checking this pointer -- which
+       mca_btl_tcp_component_open() never resets.  A stale alias would make
+       the next open skip base creation and register events on a base from a
+       dead generation. */
+    mca_btl_tcp_event_base = NULL;
 
     return OPAL_SUCCESS;
 }

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -321,6 +321,24 @@ int opal_info_register_project_frameworks(const char *project_name,
                 continue;
             }
 
+            /* Roll back this loop's own work so a failure leaves no
+               references behind: close every framework registered by the
+               earlier iterations (mca_base_framework_close() is a no-op
+               for the ones the NOT_AVAILABLE/continue path skipped, and
+               mca_base_framework_register() unwinds its own reference on
+               failure, so frameworks[i] itself holds nothing).
+
+               Exception: on BAD_PARAM, deliberately leave everything
+               registered.  ompi_info relies on the registrations
+               surviving that failure so it can dump the surrounding
+               parameters as a diagnostic (see ompi_info.c); the caller
+               keeps its registration reference in that case. */
+            if (OPAL_ERR_BAD_PARAM != rc) {
+                for (i = i - 1; i >= 0; i--) {
+                    (void) mca_base_framework_close(frameworks[i]);
+                }
+            }
+
             break;
         }
     }
@@ -354,16 +372,26 @@ int opal_info_register_framework_params(opal_pointer_array_t *component_map)
     if (OPAL_SUCCESS != mca_base_open()) {
         opal_show_help("help-opal_info.txt", "lib-call-fail", true, "mca_base_open", __FILE__,
                        __LINE__);
+        --opal_info_registered;
         return OPAL_ERROR;
     }
 
     /* Register the OPAL layer's MCA parameters */
     if (OPAL_SUCCESS != (rc = opal_register_params())) {
         fprintf(stderr, "opal_info_register: opal_register_params failed\n");
+        (void) mca_base_close();
+        --opal_info_registered;
         return rc;
     }
 
-    return opal_info_register_project_frameworks("opal", opal_frameworks, component_map);
+    rc = opal_info_register_project_frameworks("opal", opal_frameworks, component_map);
+    if (OPAL_SUCCESS != rc && OPAL_ERR_BAD_PARAM != rc) {
+        /* the project loop rolled its own registrations back; release
+           the mca_base reference taken above */
+        (void) mca_base_close();
+        --opal_info_registered;
+    }
+    return rc;
 }
 
 void opal_info_close_components(void)

--- a/opal/util/event.c
+++ b/opal/util/event.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates.  All
  *                         Rights reserved.
  * Copyright (c) 2022      Google, LLC. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,14 +38,51 @@ static struct event_config *opal_event_config = NULL;
 static int opal_event_verbose = 0;
 static const char **opal_event_all_available_eventops = NULL;
 
+/* The sync event base is reference counted: opal_init() takes a reference, and
+   so does MPI_T_init_thread().  MPI_T needs one because it defers the true
+   close of the MCA frameworks it registers: a framework only really closes
+   when its refcount drains, which with an MPI_T reference outstanding happens
+   at MPI_T_finalize() -- legally *after* MPI_Finalize() has run
+   opal_finalize().  Components delete events from opal_sync_event_base when
+   they close, so whoever defers a framework's close past opal_finalize() must
+   also hold the base alive until that close has run.
+
+   A plain int, deliberately not atomic: opal_event_init()/finalize() are
+   serialized by their callers (each holds a lock across the call), so the
+   count and the base create/free it gates never race. */
+static int opal_event_base_refcount = 0;
+
+/* Set (and never cleared) once any event base has been created through this
+   wrapper.  libevent permanently records base creation, and enabling debug
+   mode after that point aborts the process -- reachable by raising the
+   settable opal_event_verbose cvar between two full init/finalize cycles. */
+static bool opal_event_base_ever_created = false;
+
 int opal_event_register_params(void)
 {
     int ret;
     char *avail = NULL;
     char *help_msg = NULL;
 
-    // Get supported methods
-    opal_event_all_available_eventops = event_get_supported_methods();
+    /* This can now run more than once: from MPI_T_init_thread() and again from
+       a later opal_init() within one cycle, and once per cycle in a process
+       that repeatedly initializes and finalizes OPAL (MPI sessions, repeated
+       MPI_T bracketing).  The supported-methods array is process-lifetime;
+       compute it only once. */
+    if (NULL == opal_event_all_available_eventops) {
+        // Get supported methods
+        opal_event_all_available_eventops = event_get_supported_methods();
+    }
+
+    /* Register the parameters only if they are not already live.  "Already
+       registered this cycle" (MPI_T then opal_init) must skip; "registered in
+       a previous, since-finalized cycle" must NOT skip, because the MCA var
+       teardown deregistered the variables and freed + NULL'ed the string
+       storage (opal_event_module_include), so both the variables and the
+       platform default must be re-established. */
+    if (0 <= mca_base_var_find("opal", "opal", "event", "include")) {
+        return OPAL_SUCCESS;
+    }
 
 #if defined(PLATFORM_OS_DARWIN)
     opal_event_module_include = "select";
@@ -103,8 +141,22 @@ int opal_event_init(void)
     bool dumpit = false;
     int i, j;
 
+    if (opal_event_base_refcount > 0) {
+        ++opal_event_base_refcount;
+        return OPAL_SUCCESS;
+    }
+
     if (opal_event_verbose > 4) {
-        event_enable_debug_mode();
+        /* This libevent initializer is process-global and one-shot: calling
+           it a second time -- or for the first time after any event base has
+           ever existed -- aborts the process.  Full init/finalize cycles
+           legitimately re-enter this function, so latch it separately, and
+           refuse late activation entirely. */
+        static bool debug_mode_enabled = false;
+        if (!debug_mode_enabled && !opal_event_base_ever_created) {
+            debug_mode_enabled = true;
+            event_enable_debug_mode();
+        }
     }
 
     if (NULL == opal_event_module_include) {
@@ -134,11 +186,17 @@ int opal_event_init(void)
     }
     opal_argv_free(includes);
 
-    /* Declare our intent to use threads */
+    /* Declare our intent to use threads (latched; see the definition). */
     opal_event_use_threads();
 
     /* get our event base */
     if (NULL == (opal_sync_event_base = opal_event_base_create())) {
+        /* A failed init must take no reference and leave nothing half
+           initialized: the caller will not (and must not) call
+           opal_event_finalize() to balance a failure, and a later init
+           attempt has to be able to start from scratch. */
+        event_config_free(opal_event_config);
+        opal_event_config = NULL;
         return OPAL_ERROR;
     }
 
@@ -147,11 +205,30 @@ int opal_event_init(void)
         opal_event_base_priority_init(opal_sync_event_base, OPAL_EVENT_NUM_PRI);
     }
 
+    /* Count the reference only now that initialization has succeeded;
+       incrementing on entry would leave a failed init looking initialized
+       to the next caller, which would then return success with a NULL
+       opal_sync_event_base. */
+    ++opal_event_base_refcount;
+
     return OPAL_SUCCESS;
 }
 
 int opal_event_finalize(void)
 {
+    /* A failed opal_event_init() takes no reference, and its caller must
+       not call this function to balance the failure -- so a call that
+       arrives with no references outstanding is an unbalanced finalize.
+       Guard rather than underflow: a negative count would make the next
+       init succeed without creating a base. */
+    if (opal_event_base_refcount <= 0) {
+        return OPAL_ERROR;
+    }
+
+    if (--opal_event_base_refcount != 0) {
+        return OPAL_SUCCESS;
+    }
+
     if (NULL != opal_sync_event_base) {
         opal_event_base_free(opal_sync_event_base);
         opal_sync_event_base = NULL;
@@ -165,6 +242,23 @@ int opal_event_finalize(void)
     return OPAL_SUCCESS;
 }
 
+void opal_event_use_threads(void)
+{
+    /* evthread_use_pthreads() configures process-global libevent state
+       that persists across full init/finalize cycles -- and with event
+       debug mode active, libevent aborts on a repeat call once any event
+       base has ever existed.  Multiple callers exist (event init here,
+       plus component progress threads such as btl/tcp), so latch at this
+       single choke point: only the first call in the process does
+       anything. */
+    static bool called = false;
+
+    if (!called) {
+        called = true;
+        evthread_use_pthreads();
+    }
+}
+
 opal_event_base_t *opal_event_base_create(void)
 {
     opal_event_base_t *base;
@@ -173,6 +267,8 @@ opal_event_base_t *opal_event_base_create(void)
     if (NULL == base) {
         /* there is no backend method that does what we want */
         opal_output(0, "No event method available");
+    } else {
+        opal_event_base_ever_created = true;
     }
     return base;
 }

--- a/opal/util/event.h
+++ b/opal/util/event.h
@@ -67,6 +67,16 @@ OPAL_DECLSPEC opal_event_base_t *opal_event_base_create(void);
 
 OPAL_DECLSPEC int opal_event_register_params(void);
 
+/* Initialize / finalize the shared event base (opal_sync_event_base).
+   Reference counted so nested lifetimes share one base -- OPAL itself
+   holds a reference across opal_init()/opal_finalize(), and an MPI_T
+   epoch that outlives MPI holds one across its deferred framework
+   closes.  These are NOT internally synchronized: the reference count
+   is a plain int, and the create/free of the base straddles its 0<->1
+   transition, so the caller must serialize all opal_event_init() and
+   opal_event_finalize() calls against each other.  Every caller does --
+   opal_init_util(), MPI_T_init_thread(), and ompi_mpi_instance_init()
+   each invoke these while holding a lock. */
 OPAL_DECLSPEC int opal_event_init(void);
 
 OPAL_DECLSPEC int opal_event_finalize(void);
@@ -85,7 +95,15 @@ OPAL_DECLSPEC int opal_event_finalize(void);
 #define opal_event_set_priority(x, n) event_priority_set((x), (n))
 
 /* thread support APIs */
-#define opal_event_use_threads() evthread_use_pthreads()
+/* Declare intent to use threads with libevent.  This configures
+   process-global libevent state that persists across full OPAL
+   init/finalize cycles -- and once event debug mode is active, libevent
+   aborts on a repeat call after any event base has ever existed -- so
+   the implementation latches: only the first call in the life of the
+   process does anything.  Every caller (including component progress
+   threads) must use this wrapper rather than evthread_use_pthreads()
+   directly, or that latch is bypassed. */
+OPAL_DECLSPEC void opal_event_use_threads(void);
 
 /* Basic event APIs */
 #define opal_event_enable_debug_mode() event_enable_debug_mode()

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -21,6 +21,11 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/test/support
 
+# This -lpthread has been here -- and working on all supported systems
+# -- since 42a05e9a741 (2004).  These tests call pthread_* APIs
+# directly; configure's THREAD_* variables describe the threads MCA
+# framework's selected package (not necessarily pthreads) and are not
+# AC_SUBSTed for Makefile use anyway.
 AM_LDFLAGS = -lpthread
 
 # Make "make check" work in an uninstalled --enable-mca-dso build tree


### PR DESCRIPTION
MPI has three separately reference-counted lifecycles — the World Model, sessions, and MPI_T — and programs may legally start and stop them repeatedly, in any interleaving, from different threads, each with its own thread level (MPI-5.0 secs. 11.3.1, 11.6.2, 15.3.1, 15.3.4). Exercising those orderings turned up a series of startup/shutdown bugs ranging from deterministic segfaults to silent memory corruption, plus a family of related thread-level reporting bugs. This PR fixes seven of them and adds a thirteen-program test matrix that walks the lifecycle orderings under `make check`. (Reviewers who saw the first version of this PR: it was reworked from a per-component hardening approach to the root-cause fixes described here; see "History" below.)

### The startup/shutdown bugs

**1. The shared event base was freed while deferred component closes still needed it** (`opal/event: reference count the shared event base`). `MPI_T_init_thread()` registers every MCA framework, bumping each framework's refcount, so `MPI_Finalize()`'s framework closes are mere decrements: the *true* closes — `component_close()`, where components delete the events they registered on `opal_sync_event_base` — are deferred into `MPI_T_finalize()`, after `opal_finalize()` has already freed the base (since #14154, which fixed a real fd leak per session cycle). The tcp btl double-freed the base (deterministic segfault in `MPI_T_finalize()`); any component's `opal_event_del()` at deferred close was a silent use-after-free. Fix: reference count `opal_event_init()`/`opal_event_finalize()`; MPI_T takes a reference and releases it after its deferred closes run. References are held by the two lifetime scope owners (`opal_init()`, and MPI_T as the only deferrer of framework closes), so every component — current and future — is covered with no per-component changes. The commit also hardens the repeated-cycle path (per-var-system-generation parameter re-registration, latching libevent's one-shot process-global initializers, taking the reference only on successful init, honest error reporting when a partial MPI_T init cannot be unwound).

**2. The tcp btl freed its private event base before deleting the events on it** (`btl/tcp: free the private event base only after deleting its events`). Independent, pre-existing ordering bug on the (non-default) progress-thread path, plus a stale base alias that a framework re-open (MPI Sessions) could pick up across base generations.

**3. A second `MPI_Session_init()` under a held MPI_T reference found zero BTLs** (`bml/r2: reset btls_added when the module finalizes`). The per-session pml finalize empties r2's module array, but with MPI_T holding the bml framework's refcount, the component re-init that resets the `btls_added` guard never runs — so the guard was stale-true over an empty array and the next session's `add_procs` attached no BTLs (`MPI_ERR_INTERN`, "BTLs attempted: (null)"). Reproduced on unmodified main; the fix resets the guard where the state it guards is freed. Known adjacent limitation, documented in the commit: a surviving tcp module's address lives in the previous session's PMIx namespace, so *multi-rank* jobs spanning session cycles under MPI_T would additionally need per-session address re-publication (clean "unreachable" failure, not corruption).

**4. Nothing serialized a first MPI_T initialization against a concurrent world/session initialization** (`ompi: serialize MPI_T init/finalize against instance init/finalize`). The two families each serialize internally (`ompi_mpit_big_lock`; `instance_lock`) but not against each other, and they share unlocked under-layers: the OPAL init reference counters, the event-base refcount, MCA variable registration, and every framework's refcnt. MPI 5.0 sec. 11.3.1 is blunt that this must work: "MPI_SESSION_INIT is always thread safe; multiple threads within an application may invoke it concurrently." A threaded test failed *every* run on the unserialized code, five different ways (SIGTRAP, SIGABRT, SIGSEGV, spurious `MPI_T_ERR` returns, `opal_init_util()` failures). Fix: `MPI_T_init_thread()`/`MPI_T_finalize()` also take the instance lock around their init/teardown bodies — one coarse serialization at two entry points, covering every shared under-layer at once, with documented non-invertible lock ordering and nothing on any communication path. Follow-on hardening closed the adjacent windows: the world model now decides its thread level and performs instance initialization in a single critical section (a concurrent `MPI_Session_init` could previously slip between the two lock acquisitions), and a concurrent last `MPI_T_finalize()` can no longer release `ompi_mpi_main_thread` out from under an `MPI_Init()` in progress.

### The thread-level reporting bugs

**5. MPI_T's thread level was written into the World Model's** (`mpi/tool: give MPI_T its own thread level; stop stomping the world's`). Per sec. 15.3.4 the MPI_T level is scoped to the tools interface routines alone, and per sec. 11.6.2 `MPI_QUERY_THREAD` is pinned for the process lifetime to "the level of thread support returned by the original call to MPI_INIT_THREAD" — but `MPI_T_init_thread()` implemented its level by calling the world-model helper (the old `TODO -- this might be wrong`), overwriting `ompi_mpi_thread_provided`/`thread_multiple`/`main_thread`. Consequences: `MPI_T_init_thread(MULTIPLE)` before a session flipped the process onto THREAD_MULTIPLE code paths mid-flight — a deterministic SIGSEGV in `ompi_comm_destruct()` on macOS — and, worse, `MPI_T_init_thread(SINGLE)` inside a THREAD_MULTIPLE application silently disabled locking process-wide and corrupted what `MPI_QUERY_THREAD` reports. Fix: MPI_T gets its own epoch-pinned level (granted = requested; every MPI_T call is serialized under the big lock, so any level is supportable), nested inits report the pinned value (previously they didn't write `provided` at all), and a level above SINGLE ratchets OPAL's process-wide thread flags — upward only.

**6. The process-wide thread flags were last-writer-wins** (`ompi: ratchet the process-wide thread flags; never lower them`). Every scope's level is pinned, multiple levels can be live simultaneously, so the only sound process-wide state is the maximum over active scopes — a monotonic ratchet. Two writers violated that: `ompi_mpi_instance_init()` assigned `opal_single_threaded` on *every* session creation (a THREAD_SINGLE session flipped a THREAD_MULTIPLE process back to lock-elision), and the world-model helper could lower `ompi_mpi_thread_multiple`. Both become raise-only, written only at quiescent points (no active instance, and no MPI_T epoch whose threads could be reading them) and only on actual transitions, so the writes can never race an unlocked hot-path reader. This also fixed a sessions-only gap found during the audit: nothing ever set `ompi_mpi_thread_multiple` for a `thread_level=MPI_THREAD_MULTIPLE` session, so such a session ran ob1's single-threaded request-cache fast path while genuinely multithreaded.

**7. Sessions-path predefined communicators were marked PML-added but never actually added to the PML** (`ompi/instance: PML-add world/self when sessions require the world`). When the selected pml or osc requires comm world — ob1 sets this whenever a BTL carries `MCA_BTL_FLAGS_SINGLE_ADD_PROCS`, which the tcp btl sets with two or more usable interfaces at `MPI_THREAD_MULTIPLE` — a sessions-only process runs `ompi_comm_init_mpi3()` from instance init. That function marks world/self `OMPI_COMM_PML_ADDED`, but the matching pml `add_comm()` calls exist only in the World Model path (`ompi_mpi_init()`), so teardown handed the pml's `del_comm()` a communicator it had never seen and ob1 dereferenced the NULL `c_pml_comm`: deterministic SIGSEGV at `MPI_Session_finalize()`. Latent on main (reachable there with the tcp progress thread on any multi-NIC host); bug 6's fix made it much easier to hit, and CI's multi-interface runners caught it at the quiescent MULTIPLE session's finalize while single-interface local runs passed. The fix performs the pml `add_comm()` for world/self in the instance init path after `add_procs()` (matching the World Model's ordering), guarded on `c_pml_comm` so the World Model's own later adds cannot double-add. The test harness now also clears `btl_tcp_if_exclude` so loopback counts as a second tcp interface — the crash reproduces on the unfixed build on any host with a NIC, not just in CI.

**A user-visible consequence, sanctioned by MPI 5.0's "may influence" clauses (secs. 11.6.2, 15.3.4):** when `MPI_THREAD_MULTIPLE` is requested by a scope while another scope is already active at a lower level, the running process cannot be safely upgraded mid-flight (components were configured at the lower level, and the flags cannot change under unlocked readers), so the new scope is granted `MPI_THREAD_SERIALIZED` instead — reported honestly through the session's `thread_level` info key or the world's `provided`. The common tool pattern is explicitly preserved and regression-tested: `MPI_T_init_thread()` from a PMPI wrapper before the application's `MPI_Init_thread(MPI_THREAD_MULTIPLE)` still grants the application MULTIPLE. The MPI_T-specific semantics (scope, epoch pinning, possible downgrade) are documented in the `MPI_T_init_thread(3)` man page.

**Failure paths are now transactional.** `mca_base_framework_register()` fully unwinds itself on failure (components unloaded, variable group deregistered, output closed, reference dropped), the info-support project loops roll back their own successful registrations, and a failed `MPI_T_init_thread()` releases everything it acquired, leaving MPI_T honestly uninitialized. The one deliberate exception: on `MPI_ERR_BAD_PARAM`, registrations are left alive so `ompi_info` can still dump the offending parameter context as a diagnostic. A failed first instance initialization latches (its partial state cannot be safely re-entered), as does a failed MPI_T registration.

### The tests (last commit)

Thirteen programs, all singletons wired into `make check` with no launcher: the original crash ordering (fails/segfaults without fix 1 — verified); tool-only lifecycles (plain, nested, repeated); a 10,000-cycle MPI_T stress test (~10 s); all four orderings against the world model; the sessions interleavings (bracketing / inside / outliving / overlapping / nested / interleaved, plus MPI_T-at-MULTIPLE bracketing a session — the macOS crash from bug 5); repeated sessions under a held MPI_T reference (bug 3); all three lifecycles in one process; thread-level pinning in both directions (bugs 5/6: `MPI_QUERY_THREAD` and nested-MPI_T `provided` must not change); the threaded MPI_T-vs-sessions concurrency test (bug 4), plus grant-semantics assertions woven through the suite: mixed-level overlapping sessions must report the SERIALIZED downgrade, a MULTIPLE request at quiescence must be granted in full, and the PMPI tool pattern must not cost an application its MULTIPLE. All tests pin `pml=ob1` + `btl=tcp,self` so a component with events on the shared base is genuinely in play at every deferred close, and clear `btl_tcp_if_exclude` so the tcp btl yields multiple modules even on a single-NIC host (the bug 7 trigger).

### Validation

- `./autogen.pl` + fresh VPATH builds with full `make check` on macOS (Apple Silicon, clang) and AlmaLinux 10 (arm64, gcc 14): zero failures (143/144 total PASS respectively), all thirteen MPI_T tests pass on both, no warnings from any file this PR touches.
- The #14154 fd-leak fix stays fixed: an 8-cycle session loop holds a flat fd count.
- Negative controls: the regression test crashes without fix 1; the repeated-sessions failure and the MULTIPLE-crash reproduce on unmodified main (throwaway-worktree build) — establishing the fixes as necessary and the bugs as pre-existing.
- Bug 7's crash reproduces on the pre-fix build with a forced second tcp interface (identical signal, address, and backtrace to the CI failure) and is gone on the fixed build under the same forcing.
- Eight rounds of automated review across two review-fix campaigns (nineteen findings in the final five-round campaign alone); every MEDIUM+ finding fixed and squashed into its originating commit, except the multi-rank re-publish item documented at bug 3. The loop's own value is worth noting: it caught and corrected two regressions introduced by earlier fix rounds, including one that would have downgraded every `MPI_THREAD_MULTIPLE` application running under an attached tool.

### History

The first version of this PR taught the tcp btl to tolerate a dead event base. Auditing for the same pattern kept widening the blast radius (usnic, `opal_hotel`, the ULFM detector), which is the signature of treating symptoms; the reference count fixes the disease, and the regression test passes against the original unmodified tcp btl with the refcount fix alone. The pmix/base dead `evbase` field removal that briefly rode along here is now #14176.


