### PR TITLE
OSHMEM/MCA/SSHMEM/BASE: Change default base address from UINTPTR_MAX to NULL

### DIFF
--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
@@ -31,7 +31,7 @@
  * globals
  */
 
-void *mca_sshmem_base_start_address = (void *)UINTPTR_MAX;
+void *mca_sshmem_base_start_address = NULL;
 
 char * mca_sshmem_base_backing_file_dir = NULL;
 


### PR DESCRIPTION
## What

Change the default value of `mca_sshmem_base_start_address` from
`UINTPTR_MAX` to `NULL`.

Both values request automatic base address selection, but `NULL` enables
collective address validation and the existing fixed-address fallback.
Explicitly configured addresses, including `UINTPTR_MAX`, retain their
existing behavior.

## Why

During automatic selection, rank 0 reserves an address and broadcasts it
to the other processes. Because the address is passed to `mmap()` as a
hint, another process may receive a different address.

With `UINTPTR_MAX` as the default, collective validation is disabled, so
such a mismatch causes initialization to fail. Using `NULL` enables all
processes to compare their mappings and collectively use the existing
fallback when the proposed address is not available everywhere.

Fixes #13698