### PR TITLE
coll/acoll: Fixes for shared mem and smsc paths

### DIFF
--- a/ompi/mca/coll/acoll/coll_acoll.h
+++ b/ompi/mca/coll/acoll/coll_acoll.h
@@ -49,6 +49,7 @@ extern int mca_coll_acoll_bcast_nonsg;
 extern int mca_coll_acoll_bcast_socket;
 extern int mca_coll_acoll_allgather_lin;
 extern int mca_coll_acoll_allgather_ring_1;
+extern int mca_coll_acoll_is_heterogeneous_case;
 
 /* API functions */
 int mca_coll_acoll_init_query(bool enable_progress_threads, bool enable_mpi_threads);

--- a/ompi/mca/coll/acoll/coll_acoll_allgather.c
+++ b/ompi/mca/coll/acoll/coll_acoll_allgather.c
@@ -493,6 +493,14 @@ int mca_coll_acoll_allgather(const void *sbuf, size_t scount, struct ompi_dataty
                                                    module);
     }
 
+    /* Fallback to linear for small message sizes to avoid the barrier overhead */
+    size_t dsize;
+    ompi_datatype_type_size(rdtype, &dsize);
+    if (dsize * rcount < 512) {
+        return ompi_coll_base_allgather_intra_basic_linear(sbuf, scount, sdtype, rbuf, rcount, rdtype, comm, module);
+    }
+
+
     size = ompi_comm_size(comm);
     if (!subc->initialized && size > 2) {
         err = mca_coll_acoll_comm_split_init(comm, acoll_module, subc, 0);

--- a/ompi/mca/coll/acoll/coll_acoll_allreduce.c
+++ b/ompi/mca/coll/acoll/coll_acoll_allreduce.c
@@ -23,6 +23,14 @@
 #include "coll_acoll.h"
 #include "coll_acoll_utils.h"
 
+/* SMSC message size thresholds for allreduce */
+#define ACOLL_ALLREDUCE_SHM_MIN_MSG_THRESH      32
+#define ACOLL_ALLREDUCE_SHM_SMALL_MSG_THRESH    512
+#define ACOLL_ALLREDUCE_SMSC_MULTINODE_THRESH   8192
+#define ACOLL_ALLREDUCE_SMSC_LOW_THRESH         65536
+#define ACOLL_ALLREDUCE_SMSC_MID_THRESH         4194304
+#define ACOLL_ALLREDUCE_SMSC_HIGH_THRESH        16777216
+
 
 void mca_coll_acoll_sync(coll_acoll_data_t *data, int offset, int *group, int gp_size, int rank, int up);
 int mca_coll_acoll_allreduce_small_msgs_h(const void *sbuf, void *rbuf, size_t count,
@@ -97,16 +105,18 @@ static inline int mca_coll_acoll_reduce_smsc_h(const void *sbuf, void *rbuf, siz
     void *rbuf_vaddr[1] = {tmp_rbuf};
     int err = MPI_SUCCESS;
 
-    err = comm->c_coll->coll_allgather(sbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_sbuf,
+    err = ompi_coll_base_allgather_intra_recursivedoubling(sbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_sbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
     if (MPI_SUCCESS != err) {
         return err;
     }
 
-    err = comm->c_coll->coll_allgather(rbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_rbuf,
+    err = ompi_coll_base_allgather_intra_recursivedoubling(rbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_rbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
     if (MPI_SUCCESS != err) {
         return err;
     }
@@ -228,15 +238,17 @@ static inline int mca_coll_acoll_allreduce_smsc_f(const void *sbuf, void *rbuf, 
     int err = MPI_SUCCESS;
     int rank = ompi_comm_rank(comm);
 
-    err = comm->c_coll->coll_allgather(sbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_sbuf,
+    err = ompi_coll_base_allgather_intra_recursivedoubling(sbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_sbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
     if (MPI_SUCCESS != err) {
         return err;
     }
-    err = comm->c_coll->coll_allgather(rbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_rbuf,
+    err = ompi_coll_base_allgather_intra_recursivedoubling(rbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_rbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
 
     if (MPI_SUCCESS != err) {
         return err;
@@ -507,6 +519,24 @@ int mca_coll_acoll_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
 
     num_nodes = subc->num_nodes;
 
+    /* Call recursive doubling allreduce on is_opt for cases where
+     * shm/smsc based implementations are used.
+     */
+    if (mca_coll_acoll_is_heterogeneous_case
+        && ((num_nodes > 1 && total_dsize > ACOLL_ALLREDUCE_SMSC_MULTINODE_THRESH)
+            || (1 == num_nodes && ((total_dsize >= ACOLL_ALLREDUCE_SHM_MIN_MSG_THRESH
+                                    && total_dsize < ACOLL_ALLREDUCE_SHM_SMALL_MSG_THRESH)
+                                   || total_dsize >= ACOLL_ALLREDUCE_SMSC_LOW_THRESH)))) {
+        int is_opt_local = (int) is_opt;
+        int is_opt_final;
+        err = ompi_coll_base_allreduce_intra_recursivedoubling(&is_opt_local, &is_opt_final, 1,
+                                                               MPI_INT, MPI_BAND,
+                                                               subc->local_comm, module);
+        if (MPI_SUCCESS == err) {
+            is_opt = (bool) is_opt_final;
+        }
+    }
+
     alg = coll_allreduce_decision_fixed(size, total_dsize);
 
     /* Try with socket/node based split */
@@ -550,13 +580,13 @@ int mca_coll_acoll_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                     tmp_sbuf = tmp_rbuf;
                 }
 
-                if((total_dsize > 8192) &&
+                if((total_dsize > ACOLL_ALLREDUCE_SMSC_MULTINODE_THRESH) &&
                     ((0 != subc->smsc_use_sr_buf) || (subc->smsc_buf_size > 2 * total_dsize)) &&
                     (1 != subc->without_smsc) && is_opt) {
                     err = mca_coll_acoll_reduce_smsc_h(sbuf, tmp_rbuf, count, dtype, op,
                                                        soc_comm, module, soc_subc);
                 } else {
-                    acoll_module->red_algo = total_dsize <= 8192 ? 0 : 1;
+                    acoll_module->red_algo = total_dsize <= ACOLL_ALLREDUCE_SMSC_MULTINODE_THRESH ? 0 : 1;
                     err = mca_coll_acoll_reduce_intra(sbuf, tmp_rbuf, count, dtype, op,
                                                       soc_root, soc_comm, module);
                     acoll_module->red_algo = -1;
@@ -605,16 +635,16 @@ int mca_coll_acoll_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
     }
 
     if (1 == num_nodes) {
-        if (total_dsize < 32) {
+        if (total_dsize < ACOLL_ALLREDUCE_SHM_MIN_MSG_THRESH) {
             return ompi_coll_base_allreduce_intra_recursivedoubling(sbuf, rbuf, count, dtype, op,
                                                                     comm, module);
-        } else if ((total_dsize < 512) && is_opt) {
+        } else if ((total_dsize < ACOLL_ALLREDUCE_SHM_SMALL_MSG_THRESH) && is_opt) {
             return mca_coll_acoll_allreduce_small_msgs_h(sbuf, rbuf, count, dtype, op, comm, module,
                                                          subc, 1);
         } else if (total_dsize <= 2048) {
             return ompi_coll_base_allreduce_intra_recursivedoubling(sbuf, rbuf, count, dtype, op,
                                                                     comm, module);
-        } else if (total_dsize < 65536) {
+        } else if (total_dsize < ACOLL_ALLREDUCE_SMSC_LOW_THRESH) {
             if (1 == alg) {
                 return ompi_coll_base_allreduce_intra_recursivedoubling(sbuf, rbuf, count, dtype,
                                                                         op, comm, module);
@@ -625,7 +655,7 @@ int mca_coll_acoll_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                 return ompi_coll_base_allreduce_intra_ring_segmented(sbuf, rbuf, count, dtype, op,
                                                                      comm, module, 0);
             }
-        } else if (total_dsize < 4194304) {
+        } else if (total_dsize < ACOLL_ALLREDUCE_SMSC_MID_THRESH) {
             if (((0 != subc->smsc_use_sr_buf) || (subc->smsc_buf_size > 2 * total_dsize))
                 && (1 != subc->without_smsc) && is_opt) {
                 return mca_coll_acoll_allreduce_smsc_f(sbuf, rbuf, count, dtype, op, comm, module, subc);
@@ -633,7 +663,7 @@ int mca_coll_acoll_allreduce_intra(const void *sbuf, void *rbuf, size_t count,
                 return ompi_coll_base_allreduce_intra_redscat_allgather(sbuf, rbuf, count, dtype,
                                                                         op, comm, module);
             }
-        } else if (total_dsize <= 16777216) {
+        } else if (total_dsize <= ACOLL_ALLREDUCE_SMSC_HIGH_THRESH) {
             if (((0 != subc->smsc_use_sr_buf) || (subc->smsc_buf_size > 2 * total_dsize))
                 && (1 != subc->without_smsc) && is_opt) {
                 mca_coll_acoll_reduce_smsc_h(sbuf, rbuf, count, dtype, op, comm, module, subc);

--- a/ompi/mca/coll/acoll/coll_acoll_bcast.c
+++ b/ompi/mca/coll/acoll/coll_acoll_bcast.c
@@ -722,6 +722,7 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
                               &use_numa, &use_socket, &use_shm, &lin_0,
                               &lin_1, &lin_2, num_nodes, acoll_module, subc);
     no_sg = (sg_cnt == node_size) ? 1 : 0;
+    int use_shm_bcast = use_shm ? 1 : 0;
 
     /* Disable shm based bcast if: */
     /* - datatype is not a predefined type */
@@ -732,6 +733,19 @@ int mca_coll_acoll_bcast(void *buff, size_t count, struct ompi_datatype_t *datat
         if (!ompi_datatype_is_predefined(datatype)
             || (0 < opal_accelerator.check_addr(buff, &dev_id, &flags))) {
             use_shm = 0;
+        }
+    }
+
+    /* Ensure all ranks agree on use_shm to handle heterogeneous cases
+     * (e.g., mixed GPU/non-GPU buffers across ranks).
+     */
+    if (mca_coll_acoll_is_heterogeneous_case && use_shm_bcast) {
+        int use_shm_final;
+        err = ompi_coll_base_allreduce_intra_recursivedoubling(&use_shm, &use_shm_final, 1,
+                                                               MPI_INT, MPI_BAND,
+                                                               subc->local_comm, module);
+        if (MPI_SUCCESS == err) {
+            use_shm = use_shm_final;
         }
     }
 

--- a/ompi/mca/coll/acoll/coll_acoll_component.c
+++ b/ompi/mca/coll/acoll/coll_acoll_component.c
@@ -47,6 +47,7 @@ uint64_t mca_coll_acoll_reserve_memory_size_for_algo = 128 * 32768; // 4 MB
 uint64_t mca_coll_acoll_smsc_buffer_size = 128 * 32768;
 int mca_coll_acoll_alltoall_split_factor = 0;
 size_t mca_coll_acoll_alltoall_psplit_msg_thres = 0;
+int mca_coll_acoll_is_heterogeneous_case = 0;
 
 /* By default utilize smsc based algorithms applicable when built with smsc. */
 int mca_coll_acoll_without_smsc = 0;
@@ -230,6 +231,12 @@ static int acoll_register(void)
         "should not be used.",
         MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
         &mca_coll_acoll_alltoall_psplit_msg_thres);
+    (void) mca_base_component_var_register(
+        &mca_coll_acoll_component.collm_version, "is_heterogeneous_case",
+        "Enable recursive doubling allreduce for heterogeneous rank detection "
+        "(1=enabled, 0=disabled).",
+        MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+        &mca_coll_acoll_is_heterogeneous_case);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/coll/acoll/coll_acoll_reduce.c
+++ b/ompi/mca/coll/acoll/coll_acoll_reduce.c
@@ -21,6 +21,9 @@
 #include "coll_acoll.h"
 #include "coll_acoll_utils.h"
 
+/* SMSC message size threshold for reduce */
+#define ACOLL_REDUCE_SMSC_THRESH  262144
+
 static inline int coll_reduce_decision_fixed(int comm_size, size_t msg_size)
 {
     /* Set default to topology aware algorithm */
@@ -256,15 +259,17 @@ static inline int mca_coll_acoll_reduce_smsc(const void *sbuf, void *rbuf, size_
 
     int ret;
 
-    ret = comm->c_coll->coll_allgather(sbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_sbuf,
+    ret = ompi_coll_base_allgather_intra_recursivedoubling(sbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_sbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
     if (MPI_SUCCESS != ret) {
         return ret;
     }
-    ret = comm->c_coll->coll_allgather(rbuf_vaddr, sizeof(void *), MPI_BYTE, data->allshm_rbuf,
+    ret = ompi_coll_base_allgather_intra_recursivedoubling(rbuf_vaddr, sizeof(void *),
+                                       MPI_BYTE, data->allshm_rbuf,
                                        sizeof(void *), MPI_BYTE, comm,
-                                       comm->c_coll->coll_allgather_module);
+                                       module);
 
     if (MPI_SUCCESS != ret) {
         return ret;
@@ -407,8 +412,23 @@ int mca_coll_acoll_reduce_intra(const void *sbuf, void *rbuf, size_t count,
     }
 
     num_nodes = subc->num_nodes;
+
+    /* Call recursive doubling allreduce on is_opt for cases where
+     * shm/smsc based implementations are used.
+     */
+    if (mca_coll_acoll_is_heterogeneous_case
+        && 1 == num_nodes && total_dsize >= ACOLL_REDUCE_SMSC_THRESH) {
+        int is_opt_local = (int) is_opt;
+        int is_opt_final;
+        ret = ompi_coll_base_allreduce_intra_recursivedoubling(&is_opt_local, &is_opt_final, 1,
+                                                              MPI_INT, MPI_BAND, comm, module);
+        if (MPI_SUCCESS == ret) {
+            is_opt = (bool) is_opt_final;
+        }
+    }
+
     if (1 == num_nodes) {
-        int is_dsize_lt_thresh = total_dsize < 262144 ? 1 : 0;
+        int is_dsize_lt_thresh = total_dsize < ACOLL_REDUCE_SMSC_THRESH ? 1 : 0;
         if (-1 != acoll_module->red_algo) {
             is_dsize_lt_thresh = 1;
             alg = acoll_module->red_algo;


### PR DESCRIPTION
This PR handles the heterogeneous case of gpu buffers (some ranks having device buffers while others having cpu buffers) properly for the shared memory and smsc based implementations. This check is turned off by default to prevent unnecessary allreduce computation for homogeneous cases. The mca parameter coll_acoll_is_heterogeneous_case can set to enable the check when needed.
Also adds a fallback path in allgather for small messages to avoid performance overhead due to barrier.