### PR TITLE
OSHMEM/MCA/SSHMEM/BASE: Change default base address to NULL - v5.0.x

### DIFF
--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
@@ -31,7 +31,7 @@
  * globals
  */
 
-void *mca_sshmem_base_start_address = (void *)UINTPTR_MAX;
+void *mca_sshmem_base_start_address = NULL;
 
 char * mca_sshmem_base_backing_file_dir = NULL;
 


### PR DESCRIPTION
(cherry picked from commit e4bff3523dcd50b16e3a2b9e8cfb873ba3d77673)