### PR TITLE
pmix/base: remove the unused evbase field

### DIFF
--- a/opal/mca/pmix/base/base.h
+++ b/opal/mca/pmix/base/base.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +37,6 @@ OPAL_DECLSPEC extern bool opal_pmix_base_allow_delayed_server;
 OPAL_DECLSPEC int opal_pmix_base_exchange(pmix_info_t *info, pmix_pdata_t *pdat, int timeout);
 
 typedef struct {
-    opal_event_base_t *evbase;
     int timeout;
     int initialized;
     opal_pmix_lock_t lock;

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2022      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,7 @@
 bool opal_pmix_collect_all_data = true;
 int opal_pmix_verbose_output = -1;
 bool opal_pmix_base_async_modex = false;
-opal_pmix_base_t opal_pmix_base = {.evbase = NULL,
-                                   .timeout = 0,
+opal_pmix_base_t opal_pmix_base = {.timeout = 0,
                                    .initialized = 0,
                                    .lock = {.mutex = OPAL_MUTEX_STATIC_INIT,
                                             .cond = OPAL_PMIX_CONDITION_STATIC_INIT,
@@ -103,8 +103,6 @@ static int opal_pmix_base_frame_open(mca_base_open_flag_t flags)
 
     /* Open up all available components */
     rc = mca_base_framework_components_open(&opal_pmix_base_framework, flags);
-    /* default to the OPAL event base */
-    opal_pmix_base.evbase = opal_sync_event_base;
     /* pass across the verbosity */
     opal_pmix_verbose_output = opal_pmix_base_framework.framework_output;
     /* Set the distributed name service via PMIx */


### PR DESCRIPTION
`opal_pmix_base.evbase` was write-only: initialized to NULL, set to `opal_sync_event_base` in the framework's open function, and never read or freed by anything in the tree. Remove the field and the assignment.

Dead as it is, it is exactly the shape of pointer that produced the teardown bugs being fixed in #14164: a long-lived copy of OPAL's shared event base parked in a component's global state. `opal_event_finalize()` frees that base, so any such copy is dangling for the remainder of teardown, and any code that later grows a use of it inherits a use-after-free. Removing the trap is cheaper than auditing it forever.

Split out of #14164 (where earlier revisions of this change were reviewed) since it is independent of the event-base lifetime fix there. Compile-validated on macOS (clang, Apple Silicon) and AlmaLinux 10 (gcc 14, arm64) as part of that PR's full `make check` runs.
