### PR TITLE
test: fix strict-aliasing violation in attr_interlang truncation check

### DIFF
--- a/ompi/test/general/attr_interlang.c
+++ b/ompi/test/general/attr_interlang.c
@@ -635,20 +635,26 @@ static void c_check_mpi1_backend(MPI_Fint *key, MPI_Fint *value)
             exit(1);
         }
     } else {
-        void *bogus = (void*) 1;
-        MPI_Fint *p = (MPI_Fint*) &bogus;
+        /* Type-pun through a union: reading a void* through a cast
+           MPI_Fint* violates strict-aliasing rules, so optimizing
+           compilers are free to miscompile it. */
+        union {
+            void *ptr;
+            MPI_Fint f[sizeof(void*) / sizeof(MPI_Fint)];
+        } probe;
         int pos;
 
-        for (pos = 0; pos < (sizeof(void*) / sizeof(MPI_Fint));
+        probe.ptr = (void*) 1;
+        for (pos = 0; pos < (int) (sizeof(void*) / sizeof(MPI_Fint));
              ++pos) {
-            if (p[pos] == 1) {
+            if (probe.f[pos] == 1) {
                 break;
             }
         }
-        p = (MPI_Fint *) &v;
-        if (p[pos] != *value) {
+        probe.ptr = (void*) v;
+        if (probe.f[pos] != *value) {
             printf("Checking MPI-2 C attribute value backend (truncate), got value=%x; expected %x\n",
-                   (int)(uintptr_t) xlate.c_ptr, p[pos]);
+                   (int)(uintptr_t) xlate.c_ptr, (int) probe.f[pos]);
             exit(1);
         }
     }


### PR DESCRIPTION
c_check_mpi1_backend() detects which MPI_Fint-sized word of a void* holds the low-order bits by writing (void*) 1 to a pointer variable and reading it back through a cast MPI_Fint*. Reading a void* object through an MPI_Fint lvalue violates the C aliasing rules, and gcc 14 at -O2 optimizes the read away: the probe loop runs off the end, and the comparison then reads stack garbage instead of the truncated pointer value. On AlmaLinux 10 (gcc/gfortran 14.3, aarch64) this makes attr_interlang_mpifh, attr_interlang_usempi, and attr_interlang_usempif08 fail their "C writes, Fortran MPI-1 reads" case with a bogus "expected" value; the value actually returned by MPI_ATTR_GET is correct.

This PR does the type punning through a union instead, which gcc documents as supported and which the optimizer must honor.

Verified: the three tests pass with gcc 14.3 -O2 on Linux/aarch64 and continue to pass with clang on macOS. They also pass unmodified at -O0 and with -fno-strict-aliasing, which is how the miscompilation was isolated.