### PR TITLE
ci: update PR-check actions to v1.0.2

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.1
+        uses: open-mpi/pr-git-commit-checker@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
   label:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Labeler
-        uses: open-mpi/pr-labeler@v1.0.1
+        uses: open-mpi/pr-labeler@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -45,6 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Milestoner
-        uses: open-mpi/pr-milestoner@v1.0.1
+        uses: open-mpi/pr-milestoner@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Update the open-mpi/pr-git-commit-checker, open-mpi/pr-labeler, and open-mpi/pr-milestoner actions from v1.0.1 to v1.0.2. The v1.0.2 releases (open-mpi/pr-git-commit-checker#3, open-mpi/pr-labeler#2, open-mpi/pr-milestoner#3) switch those actions to PyGithub's non-deprecated `Auth.Token()` authentication API, eliminating the `DeprecationWarning` that current PyGithub versions emit on every workflow run. No behavior change.