### PR TITLE
GH: test PR builds with two configure option sets

### DIFF
--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -89,7 +89,7 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build everything: (${{ matrix.config_name }})
+    - name: Build everything (${{ matrix.os }}, ${{ matrix.config_name }})
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.

--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -89,7 +89,7 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build Open MPI forcing Sphinx docs and Fortran bindings (${{ matrix.config_name }})
+    - name: Build everything: ${{ matrix.os }}, ${{ matrix.config_name }})
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.

--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -89,7 +89,7 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build everything: ${{ matrix.os }}, ${{ matrix.config_name }})
+    - name: Build everything: ${{ matrix.os }}, ${{ matrix.config_name }}
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.

--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -24,7 +24,33 @@ jobs:
       # Run both platforms to completion even if one fails.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            config_name: default
+            configure_options: >-
+              --enable-sphinx
+              --enable-mpi-fortran
+              --disable-silent-rules
+          - os: ubuntu-latest
+            config_name: mca-dso
+            configure_options: >-
+              --enable-sphinx
+              --enable-mpi-fortran
+              --disable-silent-rules
+              --enable-mca-dso
+          - os: macos-latest
+            config_name: default
+            configure_options: >-
+              --enable-sphinx
+              --enable-mpi-fortran
+              --disable-silent-rules
+          - os: macos-latest
+            config_name: mca-dso
+            configure_options: >-
+              --enable-sphinx
+              --enable-mpi-fortran
+              --disable-silent-rules
+              --enable-mca-dso
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -63,16 +89,13 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build Open MPI (forcing Sphinx docs and Fortran bindings)
+    - name: Build Open MPI forcing Sphinx docs and Fortran bindings (${{ matrix.config_name }})
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.
         export AUTOMAKE_JOBS=$NCPU
         ./autogen.pl
-        ./configure --prefix=${PWD}/install \
-            --enable-sphinx \
-            --enable-mpi-fortran \
-            --disable-silent-rules
+        ./configure --prefix=${PWD}/install ${{ matrix.configure_options }}
         make -j $NCPU
 
     - name: Run unit tests

--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -89,7 +89,7 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build everything: ${{ matrix.os }}, ${{ matrix.config_name }}
+    - name: Build everything: (${{ matrix.config_name }})
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.

--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -89,7 +89,7 @@ jobs:
       run: |
         find . -name .opal_ignore -exec rm -f {} \; -print
 
-    - name: Build everything (${{ matrix.os }}, ${{ matrix.config_name }})
+    - name: Build Open MPI (forcing Sphinx docs and Fortran bindings)
       run: |
         NCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         # Parallelize automake's Makefile.in generation during autogen.pl.


### PR DESCRIPTION
Expand the ompi-pr-builds GitHub Actions matrix so that each pull request build runs on both Linux and macOS with two configure configurations.

The workflow now tests the existing Sphinx/Fortran/silent-rules configuration and a second configuration that additionally enables --enable-mca-dso.  This yields four total build jobs and gives PR coverage for both operating systems with and without MCA DSO enabled.