### PR TITLE
[v5.0.x] ci: update PR-check actions to v1.0.2

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.1
+        uses: open-mpi/pr-git-commit-checker@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
           cherry-pick-required: true
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Labeler
-        uses: open-mpi/pr-labeler@v1.0.1
+        uses: open-mpi/pr-labeler@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -46,6 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Milestoner
-        uses: open-mpi/pr-milestoner@v1.0.1
+        uses: open-mpi/pr-milestoner@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Backport of #14185 to `v5.0.x`.

Note: this backport PR was created manually because the backport GitHub Action does not have permission to modify GitHub Actions workflow files.

---

Update the open-mpi/pr-git-commit-checker, open-mpi/pr-labeler, and open-mpi/pr-milestoner actions from v1.0.1 to v1.0.2. The v1.0.2 releases (open-mpi/pr-git-commit-checker#3, open-mpi/pr-labeler#2, open-mpi/pr-milestoner#3) switch those actions to PyGithub's non-deprecated `Auth.Token()` authentication API, eliminating the `DeprecationWarning` that current PyGithub versions emit on every workflow run. No behavior change.
