### PR TITLE
pmix: move back over to master branch

### DIFF
--- a/.github/workflows/ompi_mpi4py.yaml
+++ b/.github/workflows/ompi_mpi4py.yaml
@@ -83,6 +83,15 @@ jobs:
         mca_params="$HOME/.prte/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+        #
+        # Recent versions of OpenPMIx started emitting warnings about use of deprecated
+        # MCA parameters its emission to stderr causes the demo/test-run stuff below to fail.
+        # Suppress generation of these warnings.  A simpler CI test should be used to
+        # to check for these messages.
+        #
+        mca_params="$HOME/.pmix/mca-params.conf"
+        mkdir -p "$(dirname "$mca_params")"
+        echo mca_base_suppress_deprecated_warning = true >> "$mca_params"
 
     - name: Show MPI
       run:  ompi_info


### PR DESCRIPTION
at sha 60c0dc3a to pick up multiple session/finalize related fixes that will not be ported back to the 6.1.x branch.

https://github.com/openpmix/openpmix/commit/60c0dc3ae0e964003d79777c90fd6f116e2cd1d7

We may at a later date switch back to using the 6.2.x (not available yet) branch of openpmix.