### PR TITLE
btl/tcp: fix the multi-module wire-up race (replace the #5917 workaround)

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -89,53 +90,43 @@ int mca_btl_tcp_add_procs(struct mca_btl_base_module_t *btl, size_t nprocs,
 
         struct opal_proc_t *opal_proc = procs[i];
         mca_btl_tcp_proc_t *tcp_proc;
-        mca_btl_base_endpoint_t *tcp_endpoint;
-        bool existing_found = false;
+        mca_btl_base_endpoint_t *tcp_endpoint = NULL;
 
         /* Do not create loopback TCP connections */
         if (my_proc == opal_proc) {
             continue;
         }
 
-        if (NULL == (tcp_proc = mca_btl_tcp_proc_create(opal_proc))) {
+        /* The btl_proc datastructure is shared by all TCP BTL
+         * instances that are trying to reach this destination.
+         * mca_btl_tcp_proc_create() returns the existing proc for this
+         * peer if there is one; otherwise it creates the proc along
+         * with the endpoints for *all* TCP BTL modules before
+         * publishing it.  Either way, the proc's endpoint list is
+         * complete by the time we get here, so all that is left to do
+         * is find the endpoint that belongs to this module. */
+        if (NULL == (tcp_proc = mca_btl_tcp_proc_create(opal_proc, &rc))) {
+            if (OPAL_ERR_OUT_OF_RESOURCE == rc) {
+                /* resource exhaustion is fatal; anything else just
+                   means this peer is unreachable via TCP */
+                return rc;
+            }
             continue;
         }
 
         OPAL_THREAD_LOCK(&tcp_proc->proc_lock);
-
         for (uint32_t j = 0; j < (uint32_t) tcp_proc->proc_endpoint_count; ++j) {
-            tcp_endpoint = tcp_proc->proc_endpoints[j];
-            if (tcp_endpoint->endpoint_btl == tcp_btl) {
-                existing_found = true;
+            if (tcp_proc->proc_endpoints[j]->endpoint_btl == tcp_btl) {
+                tcp_endpoint = tcp_proc->proc_endpoints[j];
                 break;
             }
         }
-
-        if (!existing_found) {
-            /* The btl_proc datastructure is shared by all TCP BTL
-             * instances that are trying to reach this destination.
-             * Cache the peer instance on the btl_proc.
-             */
-            tcp_endpoint = OBJ_NEW(mca_btl_tcp_endpoint_t);
-            if (NULL == tcp_endpoint) {
-                OPAL_THREAD_UNLOCK(&tcp_proc->proc_lock);
-                return OPAL_ERR_OUT_OF_RESOURCE;
-            }
-
-            tcp_endpoint->endpoint_btl = tcp_btl;
-            rc = mca_btl_tcp_proc_insert(tcp_proc, tcp_endpoint);
-            if (rc != OPAL_SUCCESS) {
-                OPAL_THREAD_UNLOCK(&tcp_proc->proc_lock);
-                OBJ_RELEASE(tcp_endpoint);
-                continue;
-            }
-
-            OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
-            opal_list_append(&tcp_btl->tcp_endpoints, (opal_list_item_t *) tcp_endpoint);
-            OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);
-        }
-
         OPAL_THREAD_UNLOCK(&tcp_proc->proc_lock);
+
+        if (NULL == tcp_endpoint) {
+            /* the peer is not reachable via this module's interface */
+            continue;
+        }
 
         if (NULL != reachable) {
             opal_bitmap_set_bit(reachable, i);
@@ -153,13 +144,17 @@ int mca_btl_tcp_del_procs(struct mca_btl_base_module_t *btl, size_t nprocs,
     mca_btl_tcp_module_t *tcp_btl = (mca_btl_tcp_module_t *) btl;
     size_t i;
 
-    OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
     for (i = 0; i < nprocs; i++) {
         mca_btl_tcp_endpoint_t *tcp_endpoint = endpoints[i];
+        OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
         opal_list_remove_item(&tcp_btl->tcp_endpoints, (opal_list_item_t *) tcp_endpoint);
+        OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);
+        /* the endpoint destructor takes the proc lock (and the
+           component lock if it destroys the proc), so it must not run
+           while we hold tcp_endpoints_mutex: proc creation acquires
+           those locks in the opposite order */
         OBJ_RELEASE(tcp_endpoint);
     }
-    OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -20,7 +20,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1385,24 +1385,6 @@ mca_btl_base_module_t **mca_btl_tcp_component_init(int *num_btl_modules,
         for (i = 0; i < mca_btl_tcp_component.tcp_num_btls; i++) {
             mca_btl_tcp_component.tcp_btls[i]->super.btl_flags
                 |= MCA_BTL_FLAGS_BTL_PROGRESS_THREAD_ENABLED;
-        }
-    }
-
-    /* Avoid a race in wire-up when using threads (progress or user)
-       and multiple BTL modules.  The details of the race are in
-       https://github.com/open-mpi/ompi/issues/3035#issuecomment-429500032,
-       but the summary is that the lookup code in
-       component_recv_handler() below assumes that add_procs() is
-       atomic across all active TCP BTL modules, but in multi-threaded
-       code, that isn't guaranteed, because the locking is inside
-       add_procs(), and add_procs() is called once per module.  This
-       isn't a proper fix, but will solve the "dropped connection"
-       problem until we can come up with a more complete fix to how we
-       initialize procs, endpoints, and modules in the TCP BTL. */
-    if (mca_btl_tcp_component.tcp_num_btls > 1
-        && (enable_mpi_threads || 0 < mca_btl_tcp_progress_thread_trigger)) {
-        for (i = 0; i < mca_btl_tcp_component.tcp_num_btls; i++) {
-            mca_btl_tcp_component.tcp_btls[i]->super.btl_flags |= MCA_BTL_FLAGS_SINGLE_ADD_PROCS;
         }
     }
 

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -21,6 +21,7 @@
  *                         reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -357,19 +358,99 @@ cleanup:
 }
 
 /*
+ * Create an endpoint for every TCP BTL module that the interface
+ * matching paired with one of the peer's exported addresses.  Called
+ * from mca_btl_tcp_proc_create() while the btl_proc is still private
+ * to the calling thread (i.e., before it is published in
+ * mca_btl_tcp_component.tcp_procs), so no proc_lock is needed to
+ * modify the endpoint array.
+ */
+static int mca_btl_tcp_proc_create_endpoints(mca_btl_tcp_proc_t *btl_proc, opal_proc_t *proc)
+{
+    for (uint32_t i = 0; i < mca_btl_tcp_component.tcp_num_btls; ++i) {
+        mca_btl_tcp_module_t *tcp_btl = mca_btl_tcp_component.tcp_btls[i];
+        mca_btl_tcp_addr_t *remote_addr;
+        mca_btl_base_endpoint_t *tcp_endpoint;
+        int rc;
+
+        rc = opal_hash_table_get_value_uint32(&btl_proc->btl_index_to_endpoint,
+                                              tcp_btl->btl_index, (void **) &remote_addr);
+        if (OPAL_SUCCESS != rc) {
+            /* The interface matching did not pair this module with any
+               of the peer's addresses: the peer is not reachable
+               through this module. */
+            if (9 < opal_output_get_verbosity(opal_btl_base_framework.framework_output)) {
+                char *proc_hostname = opal_get_proc_hostname(proc);
+                opal_output(0, "btl:tcp: host %s, process %s UNREACHABLE", proc_hostname,
+                            OPAL_NAME_PRINT(proc->proc_name));
+                free(proc_hostname);
+            }
+            continue;
+        }
+
+        tcp_endpoint = OBJ_NEW(mca_btl_tcp_endpoint_t);
+        if (NULL == tcp_endpoint) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        tcp_endpoint->endpoint_btl = tcp_btl;
+        tcp_endpoint->endpoint_addr = remote_addr;
+#ifndef WORDS_BIGENDIAN
+        /* if we are little endian and our peer is not so lucky, then we
+           need to put all information sent to him in big endian (aka
+           Network Byte Order) and expect all information received to
+           be in NBO.  Since big endian machines always send and receive
+           in NBO, we don't care so much about that case. */
+        if (proc->proc_arch & OPAL_ARCH_ISBIGENDIAN) {
+            tcp_endpoint->endpoint_nbo = true;
+        }
+#endif
+        tcp_endpoint->endpoint_proc = btl_proc;
+        btl_proc->proc_endpoints[btl_proc->proc_endpoint_count++] = tcp_endpoint;
+
+        OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
+        opal_list_append(&tcp_btl->tcp_endpoints, (opal_list_item_t *) tcp_endpoint);
+        OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/*
  * Create a TCP process structure. There is a one-to-one correspondence
  * between a opal_proc_t and a mca_btl_tcp_proc_t instance. We cache
  * additional data (specifically the list of mca_btl_tcp_endpoint_t instances,
  * and published addresses) associated w/ a given destination on this
  * datastructure.
+ *
+ * The endpoints for *all* TCP BTL modules are created here, before the
+ * proc is published in mca_btl_tcp_component.tcp_procs.  This ordering
+ * is what makes the wire-up safe against concurrent incoming
+ * connections: mca_btl_tcp_proc_accept() matches an incoming
+ * connection's source address against the proc's endpoint list, so any
+ * thread that can find the proc (via mca_btl_tcp_proc_lookup()) must
+ * also be able to find every endpoint.  If endpoints were instead added
+ * one module at a time (as the BML's per-module add_procs loop used to
+ * do), a connection arriving between two of those calls would find a
+ * partially wired proc and be dropped; see
+ * https://github.com/open-mpi/ompi/issues/3035.
+ *
+ * On failure, returns NULL and sets *errcode to the reason; callers
+ * use it to tell resource exhaustion apart from an unreachable peer
+ * (e.g., one that exported no TCP addresses).  errcode may be NULL if
+ * the caller does not care.
  */
 
-mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc)
+mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc, int *errcode)
 {
     mca_btl_tcp_proc_t *btl_proc;
     int rc, local_proc_is_left;
     mca_btl_tcp_modex_addr_t *remote_addrs = NULL;
     size_t size;
+
+    if (NULL != errcode) {
+        *errcode = OPAL_SUCCESS;
+    }
 
     OPAL_THREAD_LOCK(&mca_btl_tcp_component.tcp_lock);
     rc = opal_proc_table_get_value(&mca_btl_tcp_component.tcp_procs, proc->proc_name,
@@ -441,6 +522,10 @@ mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc)
         goto cleanup;
     }
 
+    /* wire up the endpoints for all modules before the proc becomes
+       visible to the rest of the component */
+    rc = mca_btl_tcp_proc_create_endpoints(btl_proc, proc);
+
 cleanup:
     if (OPAL_SUCCESS == rc) {
         btl_proc->proc_opal = proc; /* link with the proc */
@@ -448,9 +533,29 @@ cleanup:
         opal_proc_table_set_value(&mca_btl_tcp_component.tcp_procs, proc->proc_name, btl_proc);
     } else {
         if (btl_proc) {
+            /* unwind any endpoints that were created before the
+               failure; the proc was never published, so nothing else
+               can hold a reference to them */
+            for (size_t j = 0; j < btl_proc->proc_endpoint_count; ++j) {
+                mca_btl_base_endpoint_t *tcp_endpoint = btl_proc->proc_endpoints[j];
+                mca_btl_tcp_module_t *tcp_btl = tcp_endpoint->endpoint_btl;
+
+                OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
+                opal_list_remove_item(&tcp_btl->tcp_endpoints,
+                                      (opal_list_item_t *) tcp_endpoint);
+                OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);
+                /* keep the endpoint destructor from dereferencing the
+                   half-constructed proc */
+                tcp_endpoint->endpoint_proc = NULL;
+                OBJ_RELEASE(tcp_endpoint);
+            }
+            btl_proc->proc_endpoint_count = 0;
             OBJ_RELEASE(btl_proc); /* release the local proc */
             OBJ_RELEASE(proc);     /* and the ref on the OMPI proc */
             btl_proc = NULL;
+        }
+        if (NULL != errcode) {
+            *errcode = rc;
         }
     }
 
@@ -461,49 +566,6 @@ cleanup:
     OPAL_THREAD_UNLOCK(&mca_btl_tcp_component.tcp_lock);
 
     return btl_proc;
-}
-
-/*
- * Note that this routine must be called with the lock on the process
- * already held.  Insert a btl instance into the proc array and assign
- * it an address.
- */
-int mca_btl_tcp_proc_insert(mca_btl_tcp_proc_t *btl_proc, mca_btl_base_endpoint_t *btl_endpoint)
-{
-    mca_btl_tcp_module_t *tcp_btl = btl_endpoint->endpoint_btl;
-    mca_btl_tcp_addr_t *remote_addr;
-    int rc = OPAL_SUCCESS;
-
-    rc = opal_hash_table_get_value_uint32(&btl_proc->btl_index_to_endpoint, tcp_btl->btl_index,
-                                          (void **) &remote_addr);
-    if (OPAL_SUCCESS != rc) {
-        if (9 < opal_output_get_verbosity(opal_btl_base_framework.framework_output)) {
-            char *proc_hostname = opal_get_proc_hostname(btl_proc->proc_opal);
-            opal_output(0, "btl:tcp: host %s, process %s UNREACHABLE", proc_hostname,
-                        OPAL_NAME_PRINT(btl_proc->proc_opal->proc_name));
-            free(proc_hostname);
-        }
-        goto out;
-    }
-    btl_endpoint->endpoint_addr = remote_addr;
-
-#ifndef WORDS_BIGENDIAN
-    /* if we are little endian and our peer is not so lucky, then we
-       need to put all information sent to him in big endian (aka
-       Network Byte Order) and expect all information received to
-       be in NBO.  Since big endian machines always send and receive
-       in NBO, we don't care so much about that case. */
-    if (btl_proc->proc_opal->proc_arch & OPAL_ARCH_ISBIGENDIAN) {
-        btl_endpoint->endpoint_nbo = true;
-    }
-#endif
-
-    /* insert into endpoint array */
-    btl_endpoint->endpoint_proc = btl_proc;
-    btl_proc->proc_endpoints[btl_proc->proc_endpoint_count++] = btl_endpoint;
-
-out:
-    return rc;
 }
 
 /*
@@ -546,26 +608,19 @@ mca_btl_tcp_proc_t *mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
     opal_proc_table_get_value(&mca_btl_tcp_component.tcp_procs, *name, (void **) &proc);
     OPAL_THREAD_UNLOCK(&mca_btl_tcp_component.tcp_lock);
     if (OPAL_UNLIKELY(NULL == proc)) {
-        mca_btl_base_endpoint_t *endpoint;
         opal_proc_t *opal_proc;
 
         BTL_VERBOSE(("adding tcp proc for peer {%s}", OPAL_NAME_PRINT(*name)));
 
         opal_proc = opal_proc_for_name(*name);
-        if (NULL == opal_proc) {
+        if (NULL == opal_proc || opal_proc_local_get() == opal_proc) {
             return NULL;
         }
 
-        /* try adding this proc to each btl until */
-        for (uint32_t i = 0; i < mca_btl_tcp_component.tcp_num_btls; ++i) {
-            endpoint = NULL;
-            (void) mca_btl_tcp_add_procs(&mca_btl_tcp_component.tcp_btls[i]->super, 1, &opal_proc,
-                                         &endpoint, NULL);
-            if (NULL != endpoint && NULL == proc) {
-                /* construct all the endpoints and get the proc */
-                proc = endpoint->endpoint_proc;
-            }
-        }
+        /* creates the proc, including the endpoints for all modules,
+           or returns the existing proc if another thread beat us to
+           creating it */
+        proc = mca_btl_tcp_proc_create(opal_proc, NULL);
     }
 
     return proc;

--- a/opal/mca/btl/tcp/btl_tcp_proc.h
+++ b/opal/mca/btl/tcp/btl_tcp_proc.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved
  * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,9 +65,8 @@ struct mca_btl_tcp_proc_t {
 typedef struct mca_btl_tcp_proc_t mca_btl_tcp_proc_t;
 OBJ_CLASS_DECLARATION(mca_btl_tcp_proc_t);
 
-mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc);
+mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc, int *errcode);
 mca_btl_tcp_proc_t *mca_btl_tcp_proc_lookup(const opal_process_name_t *name);
-int mca_btl_tcp_proc_insert(mca_btl_tcp_proc_t *, mca_btl_base_endpoint_t *);
 int mca_btl_tcp_proc_remove(mca_btl_tcp_proc_t *, mca_btl_base_endpoint_t *);
 void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t *, struct sockaddr *, int);
 bool mca_btl_tcp_proc_tosocks(mca_btl_tcp_addr_t *, struct sockaddr_storage *);


### PR DESCRIPTION
While reviewing BTL framework code/comments recently, I came across the `MCA_BTL_FLAGS_SINGLE_ADD_PROCS` workaround that #5917 added to the TCP BTL back in 2018. That PR's description explicitly says it is a workaround, not a fix, and sketches what the real fix should be. This PR is purely a target of opportunity: it implements that real fix and removes the workaround.

## The race (recap of #5917 / issue #3035)

The full analysis is in https://github.com/open-mpi/ompi/issues/3035#issuecomment-429500032. Summary: with multiple TCP BTL modules (one per usable interface), the BML calls `add_procs()` once per module, and each call added only that module's endpoint to the shared `mca_btl_tcp_proc_t`. Meanwhile `mca_btl_tcp_proc_accept()` assumes that any proc it can find via `mca_btl_tcp_proc_lookup()` has its *complete* endpoint list, because it matches the incoming connection's source address against that list. With threads in the picture (user threads or the TCP progress thread), an incoming connection can arrive between two of the per-module `add_procs()` calls, find a partially-wired proc, fail the address match, and get dropped ("dropped inbound connection"). #5917 avoided the race by setting `MCA_BTL_FLAGS_SINGLE_ADD_PROCS` (threads + >1 module), which forces the PML into `MCA_PML_BASE_FLAG_REQUIRE_WORLD` — every proc in the job is wired up inside `MPI_INIT` — at the cost of lazy connection setup and startup scalability.

## The fix

#5917's description says: *"The long term fix is to do all endpoint setup in the first call to add_procs for a given remote proc, removing the race."* That is what this PR does, and it turns out to be quite natural in today's code: since the bipartite interface-matching rework (2019), `mca_btl_tcp_proc_create()` already computes the module-to-remote-address pairing for **all** local modules (the `btl_index_to_endpoint` table) at proc-creation time. So this PR moves endpoint creation there too: `mca_btl_tcp_proc_create()` now creates the endpoints for every matched module *before* publishing the proc in the component's proc table, all under `tcp_lock`. Publication becomes the commit point: any thread that can find the proc — the BML's `add_procs()` loop or the connection-accept path — sees a complete, immutable endpoint list. The race window is structurally gone, not just narrowed.

Consequences:

* `mca_btl_tcp_add_procs()` reduces to looking up the calling module's endpoint (and now propagates `OPAL_ERR_OUT_OF_RESOURCE` from proc creation instead of silently treating allocation failure as "unreachable").
* `mca_btl_tcp_proc_insert()` is gone; its logic moved into endpoint creation inside `proc_create()`.
* `mca_btl_tcp_proc_lookup()` no longer replays `add_procs()` against every module to wire up an unknown incoming peer.
* The #5917 workaround block in `mca_btl_tcp_component_init()` is removed, restoring lazy add_procs for multi-NIC/threaded jobs. (`MCA_BTL_FLAGS_SINGLE_ADD_PROCS` itself stays: portals4 and usnic still use it.)
* `mca_btl_tcp_del_procs()` now releases endpoints *outside* `tcp_endpoints_mutex`: the endpoint destructor chain takes the proc lock (and possibly the component lock), which proc creation now acquires before `tcp_endpoints_mutex`, so releasing inside the mutex could deadlock against a concurrent proc creation.

## Testing

* Builds warning-free in the TCP BTL on macOS (clang) and AlmaLinux 10 (gcc 14.3), `--enable-mpi-threads` default config, internal hwloc/pmix/prrte/libevent.
* Smoke: `hello_c` / `ring_c` over `--mca btl tcp,self` on both platforms.
* Race-targeted stress on both platforms: a test doing what the original reproducer (IBM `collective/allgather_init`) did — `MPI_THREAD_MULTIPLE`, 4 ranks x 4 threads each doing immediate simultaneous bidirectional sendrecv with every peer so both sides race to connect during lazy wire-up — over 4 TCP modules (2 interfaces x `btl_tcp_links=2`), with and without `btl_tcp_progress_thread=1`. 60+ fresh-wire-up runs across both platforms: zero dropped connections, zero hangs.

Caveat: the original failure was observed on a real multi-node, multi-NIC cluster under MTT load, which I cannot replicate locally — single-host multi-interface stress is the closest approximation. Extra eyes (and any multi-NIC cluster testing) much appreciated.

@bwbarrett — you wrote #5917 and the race analysis, so you're the best judge of whether this matches the fix you had in mind. @hppritcha @bosilca — review appreciated as well.
