### PR TITLE
v6.0.x: coll/han: fall back in gatherv/scatterv when comm is not mapped by core

### DIFF
--- a/ompi/mca/coll/han/coll_han_gatherv.c
+++ b/ompi/mca/coll/han/coll_han_gatherv.c
@@ -100,6 +100,29 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
                                             root, comm, han_module->previous_gatherv_module);
     }
 
+    /* HAN's hierarchical gatherv assigns each rank to a role (root, root's local
+     * peer, other-node follower, or node leader) using the virtual-rank
+     * decomposition vrank = low_size * up_rank + low_rank.  That decomposition
+     * only matches the physical node layout when the ranks are mapped by core
+     * (consecutive on each node).  On a communicator that is balanced but not
+     * mapped by core -- for example the local_comm produced by
+     * MPI_Intercomm_merge -- two ranks that share one intra-node sub-communicator
+     * (low_comm) can be assigned different up_rank values.  They then take
+     * different gatherv branches: a node leader posts a Low Gather expecting a
+     * contribution from every low_comm member, while a peer classified as a
+     * root's-local-peer skips that Low Gather, so the leader blocks forever.
+     * Only the fixed-role gather/scatter paths reorder via the topo array; the
+     * gatherv branch logic has no such handling, so fall back to the previous
+     * component when the layout is not mapped by core. */
+    if (!han_module->is_mapbycore) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle gatherv with this communicator (not mapped by "
+                             "core). Fall back on another component\n"));
+        HAN_UNINSTALL_COLL_API(comm, han_module, gatherv);
+        return han_module->previous_gatherv(sbuf, scount, sdtype, rbuf, rcounts, displs, rdtype,
+                                            root, comm, han_module->previous_gatherv_module);
+    }
+
     w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
 

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -113,6 +113,27 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
                                              root, comm, han_module->previous_scatterv_module);
     }
 
+    /* HAN's hierarchical scatterv assigns each rank to a role (root, root's
+     * local peer, other-node follower, or node leader) using the virtual-rank
+     * decomposition vrank = low_size * up_rank + low_rank.  That decomposition
+     * only matches the physical node layout when the ranks are mapped by core
+     * (consecutive on each node).  On a communicator that is balanced but not
+     * mapped by core -- for example the local_comm produced by
+     * MPI_Intercomm_merge -- two ranks that share one intra-node sub-communicator
+     * (low_comm) can be assigned different up_rank values and take inconsistent
+     * branches, so a node leader blocks on an intra-node sub-collective that a
+     * peer classified into a different branch never joins.  The scatterv branch
+     * logic has no topo-array reordering to handle this, so fall back to the
+     * previous component when the layout is not mapped by core. */
+    if (!han_module->is_mapbycore) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle scatterv with this communicator (not mapped by "
+                             "core). Fall back on another component\n"));
+        HAN_UNINSTALL_COLL_API(comm, han_module, scatterv);
+        return han_module->previous_scatterv(sbuf, scounts, displs, sdtype, rbuf, rcount, rdtype,
+                                             root, comm, han_module->previous_scatterv_module);
+    }
+
     w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
 


### PR DESCRIPTION
Backport of #14197 to v6.0.x 

HAN's hierarchical gatherv and scatterv assign each rank one of four roles (root, root's local peer, other-node follower, node leader) from the virtual-rank decomposition vrank = low_size * up_rank + low_rank. As the comment in coll_han_subcomms.c warns, that decomposition only matches the physical node layout when ranks are mapped by core (consecutive on each node).

On a communicator that is balanced but not mapped by core -- for example the local_comm that MPI_Intercomm_merge produces, whose rank order interleaves the two merged groups -- the up_comm split (color = low_rank, key = comm rank) can place members of one physical node at different positions in different columns, so ranks sharing one low_comm end up with different up_rank values.  The gatherv branch logic then partitions one low_comm inconsistently: the node leader posts a Low Gather expecting a contribution from every low_comm member, while a peer whose up_rank happens to equal root_up_rank is misclassified as a "root's local peer" and skips that Low Gather.  The leader blocks forever on a message that is never sent.

This is a deterministic missing-message deadlock, reproducible 100% of the time with the intel_tests MPI_Intercomm_merge2 test at np=32 on 4 nodes: MPI_Intercomm_merge -> ompi_comm_determine_first ->coll_inter_allgatherv -> gatherv on the merged local_comm -> HAN.  It was verified by instrumenting the branch decisions and capturing the blocked receive (the node leader waiting on a low_comm peer that returned without sending).  Scatterv has the identical branch structure reading the same cached vranks; instrumentation confirmed it computes a byte-identical role partition on the same communicator, so it carries the same latent deadlock, reachable by a user calling MPI_Scatterv on such a communicator.

Fix: fall back to the previous component when the communicator is not mapped by core, mirroring the existing are_ppn_imbalanced fallback immediately above and the !is_mapbycore fallback that alltoall and alltoallv already use.  is_mapbycore is already computed by mca_coll_han_topo_init on the preceding line, so the guard adds no new state or communication.  Mapped-by-core communicators (the common case) are unaffected and keep HAN's hierarchical path.

The fixed-role gather/scatter handle non-mapped-by-core layouts by reordering through the topo array; extending the same handling to the v collectives so they can keep the hierarchical algorithm instead of falling back is left as a follow-up.

Validated on 4 x c5n.18xlarge (EFA, pml cm + mtl ofi): the merge2/3 hang went from 100% to 0 across 220+ runs, including a 24-test sweep of the intel_tests collective and communicator suites, an optimized (non-debug) build, --map-by node runs (where COMM_WORLD itself is not mapped by core and the fallback fires on every communicator, with all data validation passing), and np=30 uneven-ppn runs exercising the imbalance fallback alongside the new guard.

Fixes open-mpi/ompi#14165

(cherry picked from commit 45e473a24bd6a7f841695051e08dd12b679faca7)