### PR TITLE
coll/han: fix up_comm sort key so vrank is valid for any balanced layout

### DIFF
--- a/ompi/mca/coll/han/coll_han_gatherv.c
+++ b/ompi/mca/coll/han/coll_han_gatherv.c
@@ -100,29 +100,6 @@ int mca_coll_han_gatherv_intra(const void *sbuf, size_t scount, struct ompi_data
                                             root, comm, han_module->previous_gatherv_module);
     }
 
-    /* HAN's hierarchical gatherv assigns each rank to a role (root, root's local
-     * peer, other-node follower, or node leader) using the virtual-rank
-     * decomposition vrank = low_size * up_rank + low_rank.  That decomposition
-     * only matches the physical node layout when the ranks are mapped by core
-     * (consecutive on each node).  On a communicator that is balanced but not
-     * mapped by core -- for example the local_comm produced by
-     * MPI_Intercomm_merge -- two ranks that share one intra-node sub-communicator
-     * (low_comm) can be assigned different up_rank values.  They then take
-     * different gatherv branches: a node leader posts a Low Gather expecting a
-     * contribution from every low_comm member, while a peer classified as a
-     * root's-local-peer skips that Low Gather, so the leader blocks forever.
-     * Only the fixed-role gather/scatter paths reorder via the topo array; the
-     * gatherv branch logic has no such handling, so fall back to the previous
-     * component when the layout is not mapped by core. */
-    if (!han_module->is_mapbycore) {
-        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
-                             "han cannot handle gatherv with this communicator (not mapped by "
-                             "core). Fall back on another component\n"));
-        HAN_UNINSTALL_COLL_API(comm, han_module, gatherv);
-        return han_module->previous_gatherv(sbuf, scount, sdtype, rbuf, rcounts, displs, rdtype,
-                                            root, comm, han_module->previous_gatherv_module);
-    }
-
     w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
 

--- a/ompi/mca/coll/han/coll_han_scatterv.c
+++ b/ompi/mca/coll/han/coll_han_scatterv.c
@@ -113,27 +113,6 @@ int mca_coll_han_scatterv_intra(const void *sbuf, ompi_count_array_t scounts, om
                                              root, comm, han_module->previous_scatterv_module);
     }
 
-    /* HAN's hierarchical scatterv assigns each rank to a role (root, root's
-     * local peer, other-node follower, or node leader) using the virtual-rank
-     * decomposition vrank = low_size * up_rank + low_rank.  That decomposition
-     * only matches the physical node layout when the ranks are mapped by core
-     * (consecutive on each node).  On a communicator that is balanced but not
-     * mapped by core -- for example the local_comm produced by
-     * MPI_Intercomm_merge -- two ranks that share one intra-node sub-communicator
-     * (low_comm) can be assigned different up_rank values and take inconsistent
-     * branches, so a node leader blocks on an intra-node sub-collective that a
-     * peer classified into a different branch never joins.  The scatterv branch
-     * logic has no topo-array reordering to handle this, so fall back to the
-     * previous component when the layout is not mapped by core. */
-    if (!han_module->is_mapbycore) {
-        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
-                             "han cannot handle scatterv with this communicator (not mapped by "
-                             "core). Fall back on another component\n"));
-        HAN_UNINSTALL_COLL_API(comm, han_module, scatterv);
-        return han_module->previous_scatterv(sbuf, scounts, displs, sdtype, rbuf, rcount, rdtype,
-                                             root, comm, han_module->previous_scatterv_module);
-    }
-
     w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
 

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -55,7 +55,7 @@
 int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
                                  mca_coll_han_module_t *han_module)
 {
-    int low_rank, low_size, up_rank, w_rank, w_size;
+    int low_rank, low_size, up_rank, w_rank, w_size, node_leader_w_rank;
     ompi_communicator_t **low_comm = &(han_module->sub_comm[INTRA_NODE]);
     ompi_communicator_t **up_comm = &(han_module->sub_comm[INTER_NODE]);
     mca_coll_han_collectives_fallback_t fallbacks;
@@ -151,11 +151,56 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     low_rank = ompi_comm_rank(*low_comm);
 
     /*
-     * This sub-communicator contains one process per node: processes with the
-     * same intra-node rank id share such a sub-communicator
+     * This sub-communicator contains one process per node: all ranks that share
+     * a given intra-node rank id (low_rank) form one such sub-communicator.
+     *
+     * Sort key = global rank of this node's leader (the rank with low_rank 0),
+     * NOT each rank's own w_rank.
+     *
+     * Why: the split produces one inter-node "column" for each low_rank value
+     * 0 .. low_size-1.  Ranks on the same physical node but with different
+     * low_rank values end up in different columns.  When the sort key is w_rank,
+     * each column is ordered independently by global rank, so a rank's position
+     * (up_rank) in its column can differ from its node-mates in other columns.
+     * The vrank formula  vrank = low_size * up_rank + low_rank  then assigns
+     * inconsistent node identifiers to ranks on the same node, breaking the
+     * role-assignment logic in gatherv, scatterv, and alltoall*.
+     *
+     * Using the node leader's global rank as the key guarantees that every rank
+     * on node K uses the same key regardless of which column it sits in, so all
+     * ranks on node K receive the same up_rank value.  The formula then
+     * correctly encodes each rank's 2-D position in the node × intra-node grid
+     * for ANY balanced rank layout, not just map-by-core.
+     *
+     * Example: 4 ranks, 2 nodes, mapped by node (NOT map-by-core)
+     *   Node 0: global ranks {0, 2}    low_rank: 0→0, 2→1
+     *   Node 1: global ranks {1, 3}    low_rank: 1→0, 3→1
+     *
+     *   Old key = w_rank:
+     *     col (low_rank=0): {0,1} sorted by w_rank → up_rank 0→0, 1→1
+     *     col (low_rank=1): {2,3} sorted by w_rank → up_rank 2→0, 3→1
+     *     up_rank is still consistent here, but for a layout like
+     *     MPI_Intercomm_merge where the same node's global ranks are
+     *     not monotone, a node's members get *different* up_rank values
+     *     across columns, e.g. up_rank=0 in col 0 but up_rank=1 in col 1.
+     *
+     *   New key = node_leader_w_rank (min global rank on the node):
+     *     Node 0 leader = rank 0;  Node 1 leader = rank 1.
+     *     col (low_rank=0): {0,1} sorted by key 0,1 → up_rank 0→0, 1→1
+     *     col (low_rank=1): {2,3} sorted by key 0,1 → up_rank 2→0, 3→1
+     *     Every rank on node 0 has up_rank=0; every rank on node 1
+     *     has up_rank=1, regardless of which column it sits in.
+     *
+     * The node leader's global rank is obtained via a pure local group
+     * translation (no communication).
      */
+    {
+        int local_zero = 0;
+        ompi_group_translate_ranks((*low_comm)->c_local_group, 1, &local_zero,
+                                   comm->c_local_group, &node_leader_w_rank);
+    }
     opal_info_set(&comm_info, "ompi_comm_coll_han_topo_level", "INTER_NODE");
-    rc = ompi_comm_split_with_info(comm, low_rank, w_rank, &comm_info, up_comm, false);
+    rc = ompi_comm_split_with_info(comm, low_rank, node_leader_w_rank, &comm_info, up_comm, false);
     if( OMPI_SUCCESS != rc ) {
         /* cannot create subcommunicators. Return the error upstream */
         goto return_with_error;
@@ -165,11 +210,13 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
 
     /*
      * Set my virtual rank number.
-     * my rank # = <intra-node comm size> * <inter-node rank number>
-     *             + <intra-node rank number>
-     * WARNING: this formula works only if the ranks are perfectly spread over
-     *          the nodes
-     * TODO: find a better way of doing
+     * vrank = low_size * up_rank + low_rank
+     *
+     * This encodes the 2-D position of a rank in the node × intra-node grid:
+     * up_rank  = which node (row), low_rank = position within the node (column).
+     * Because the up_comm split above uses node_leader_w_rank as the key, all
+     * ranks on the same node share the same up_rank across every column, so
+     * the formula is valid for any balanced rank layout.
      */
     vrank = low_size * up_rank + low_rank;
     vranks = (int *)malloc(sizeof(int) * w_size);
@@ -235,7 +282,7 @@ return_with_error:
 int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
                              mca_coll_han_module_t *han_module)
 {
-    int low_rank, low_size, up_rank, w_rank, w_size;
+    int low_rank, low_size, up_rank, w_rank, w_size, node_leader_w_rank;
     mca_coll_han_collectives_fallback_t fallbacks;
     ompi_communicator_t **low_comms = NULL, **up_comms = NULL;
     int vrank, *vranks;
@@ -354,12 +401,35 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     }
     assert(OMPI_COMM_IS_DISJOINT_SET(low_comms[2]) && !OMPI_COMM_IS_DISJOINT(low_comms[2]));
     /*
-     * Upgrade libnbc module priority to set up up_comms[0] with libnbc module
-     * This sub-communicator contains one process per node: processes with the
-     * same intra-node rank id share such a sub-communicator
+     * Determine the global rank of this node's leader (the rank with low_rank 0
+     * in low_comms[0]).  This is computed locally with no communication.
+     *
+     * All up_comm splits below use node_leader_w_rank as the sort key instead
+     * of each rank's own w_rank.  See mca_coll_han_comm_create_new for the
+     * full explanation; in short, this guarantees that every rank on the same
+     * physical node receives the same up_rank across all up_comm columns
+     * (one column per low_rank value), making the vrank formula valid for any
+     * balanced rank layout.
+     *
+     * Example: 4 ranks, 2 nodes, global ranks {0,2} on node 0 / {1,3} on node 1
+     *   node 0 leader = rank 0, node 1 leader = rank 1
+     *   Both col (low_rank=0) and col (low_rank=1) sort by {0,1} not {w_rank},
+     *   so rank 0 and rank 2 both get up_rank=0, rank 1 and rank 3 both get
+     *   up_rank=1 — consistent across columns.
+     */
+    {
+        int local_zero = 0;
+        ompi_group_translate_ranks(low_comms[0]->c_local_group, 1, &local_zero,
+                                   comm->c_local_group, &node_leader_w_rank);
+    }
+
+    /*
+     * Upgrade libnbc module priority to set up up_comms[0] with libnbc module.
+     * One process per node: processes with the same intra-node rank id share
+     * this sub-communicator.
      */
     opal_info_set(&comm_info, "ompi_comm_coll_preference", "libnbc,^han");
-    rc = ompi_comm_split_with_info(comm, low_rank, w_rank, &comm_info, &(up_comms[0]), false);
+    rc = ompi_comm_split_with_info(comm, low_rank, node_leader_w_rank, &comm_info, &(up_comms[0]), false);
     if (OMPI_SUCCESS != rc) {
         goto final_agree;
     }
@@ -367,11 +437,11 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     assert(OMPI_COMM_IS_DISJOINT_SET(up_comms[0]) && OMPI_COMM_IS_DISJOINT(up_comms[0]));
 
     /*
-     * Upgrade adapt module priority to set up up_comms[0] with adapt module
-     * This sub-communicator contains one process per node.
+     * Upgrade adapt module priority to set up up_comms[1] with adapt module.
+     * One process per node.
      */
     opal_info_set(&comm_info, "ompi_comm_coll_preference", "adapt,^han");
-    rc = ompi_comm_split_with_info(comm, low_rank, w_rank, &comm_info, &(up_comms[1]), false);
+    rc = ompi_comm_split_with_info(comm, low_rank, node_leader_w_rank, &comm_info, &(up_comms[1]), false);
     if (OMPI_SUCCESS != rc) {
         goto final_agree;
     }
@@ -379,11 +449,15 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
 
     /*
      * Set my virtual rank number.
-     * my rank # = <intra-node comm size> * <inter-node rank number>
-     *             + <intra-node rank number>
-     * WARNING: this formula works only if the ranks are perfectly spread over
-     *          the nodes
-     * TODO: find a better way of doing
+     * vrank = low_size * up_rank + low_rank
+     *
+     * Encodes the 2-D position of this rank in the node × intra-node grid:
+     *   up_rank  = which node (row)
+     *   low_rank = position within the node (column)
+     *
+     * Because the up_comm splits above use node_leader_w_rank as the key,
+     * all ranks on the same node share the same up_rank value across every
+     * column, so this formula is valid for any balanced rank layout.
      */
     vrank = low_size * up_rank + low_rank;
     vranks = (int *)malloc(sizeof(int) * w_size);


### PR DESCRIPTION
The inter-node sub-communicators (up_comms) are constructed by splitting the global communicator with color=low_rank.  This produces one "column" per intra-node rank index; ranks on the same physical node but with different low_rank values therefore land in different columns.  Each column was previously sorted by the rank's own global rank (key=w_rank). Because the global-rank ordering is not guaranteed to be monotone with respect to node index across columns, a rank's position in its column (up_rank) could differ from its node-mates in other columns.

The vrank formula  vrank = low_size * up_rank + low_rank  then encoded inconsistent node identifiers for ranks that share a node, breaking the cross-rank comparison  root_up_rank == up_rank  used in gatherv and scatterv to classify each rank as "root's local peer", "other-node follower", or "node leader".  A rank on a different node could be misclassified as a root's-local-peer, skip the obligatory Low Gather step, and permanently block the node leader waiting for that contribution.  This is the underlying cause of the deadlock reported in issue #14165 and worked around by PR #14197 ("coll/han: fall back in gatherv/scatterv when comm is not mapped by core", commit 45e473a).

Fix: use the global rank of the node leader (low_rank=0) as the sort key for every up_comm split instead of the rank's own global rank.  All ranks on the same physical node share the same key regardless of which column they sit in, so they all receive the same up_rank value.  The vrank formula then correctly encodes each rank's 2-D position in the node × intra-node grid for ANY balanced rank layout, not just map-by-core.

The node leader's global rank is obtained via ompi_group_translate_ranks on the already-created low_comm, which is a pure local metadata operation requiring no communication.

This commit supersedes PR #14197: the !is_mapbycore fallback guards added to mca_coll_han_gatherv_intra and mca_coll_han_scatterv_intra are no longer needed for correctness and are removed here.  Both collectives now take their hierarchical path on any balanced communicator, including those produced by MPI_Intercomm_merge, rather than falling back to the previous component whenever the layout is not map-by-core.

Note: alltoall and alltoallv retain their !is_mapbycore fallback because those algorithms independently assume map-by-core when computing remote partner global ranks as  up_partner * low_size + low_rank, which is a separate issue requiring algorithmic changes.

Fixes #14165