### PR TITLE
osc/rdma: Preserve remote base for local window peers

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -787,6 +787,8 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
 
     /* optimize communication with peers that we can do direct load and store operations on */
     if (ompi_osc_rdma_peer_local_base (peer)) {
+        ompi_osc_rdma_peer_basic_t *ex_peer = (ompi_osc_rdma_peer_basic_t *) peer;
+        target_address = ex_peer->local_base + target_address - ex_peer->base;
         return ompi_osc_rdma_copy_local (origin_addr, origin_count, origin_datatype, (void *) (intptr_t) target_address,
                                          target_count, target_datatype, request);
     }
@@ -827,6 +829,8 @@ static inline int ompi_osc_rdma_get_w_req (ompi_osc_rdma_sync_t *sync, void *ori
 
     /* optimize self/local communication */
     if (ompi_osc_rdma_peer_local_base (peer)) {
+        ompi_osc_rdma_peer_basic_t *ex_peer = (ompi_osc_rdma_peer_basic_t *) peer;
+        source_address = ex_peer->local_base + source_address - ex_peer->base;
         return ompi_osc_rdma_copy_local ((void *) (intptr_t) source_address, source_count, source_datatype,
                                          origin_addr, origin_count, origin_datatype, request);
     }

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -547,7 +547,7 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
     if (MPI_WIN_FLAVOR_DYNAMIC != module->flavor) {
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) my_peer;
 
-        ex_peer->super.base = (intptr_t) *base;
+        ex_peer->super.local_base = ex_peer->super.base = (intptr_t) *base;
 
         if (!module->same_size) {
             ex_peer->size = size;
@@ -858,9 +858,10 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
             if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor || peer_rank == my_rank) {
                 /* base is local and cpu atomics are available */
                 if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
-                    ex_peer->super.base = (uintptr_t) module->segment_base + offset;
+                    ex_peer->super.local_base = (uintptr_t) module->segment_base + offset;
+                    ex_peer->super.base = use_cpu_atomics ? ex_peer->super.local_base : state_region->base + offset;
                 } else {
-                    ex_peer->super.base = (uintptr_t) *base;
+                    ex_peer->super.local_base = ex_peer->super.base = (uintptr_t) *base;
                 }
 
                 peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
@@ -1667,7 +1668,7 @@ int ompi_osc_rdma_shared_query(
             }
             ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
             if (ompi_osc_rdma_peer_local_base(peer)) {
-                if (module->same_size && ex_peer->super.base) {
+                if (module->same_size && ex_peer->super.local_base) {
                     break;
                 } else if (ex_peer->size > 0) {
                     break;
@@ -1688,13 +1689,13 @@ int ompi_osc_rdma_shared_query(
         *size = module->size;
         *disp_unit = module->disp_unit;
         ompi_osc_rdma_peer_basic_t *ex_peer = (ompi_osc_rdma_peer_basic_t *) peer;
-        *((void**) baseptr) = (void *) (intptr_t)ex_peer->base;
+        *((void**) baseptr) = (void *) (intptr_t)ex_peer->local_base;
         rc = OMPI_SUCCESS;
     } else {
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
-        if (ex_peer->super.base != 0) {
+        if (ex_peer->super.local_base != 0) {
             /* we know the base of the peer */
-            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.base;
+            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.local_base;
             *size = ex_peer->size;
             *disp_unit = ex_peer->disp_unit;
             rc = OMPI_SUCCESS;


### PR DESCRIPTION
MPI_Win_allocate maps a node-local shared segment into every process. When CPU and NIC atomics cannot be mixed, local accumulates are sent through the node leader's BTL endpoint and must use the leader's registered virtual address. The shared peer initialization instead stored each origin process's local mapping in the remote base field, causing OFI to access an invalid address in the leader and corrupt process memory.

Store the process-local mapping in the existing local_base field while preserving the leader's address in base. Translate local Put and Get copies to local_base, and return local_base from MPI_Win_shared_query.

Fixes #14203