### PR TITLE
common/ucx: Flush the target endpoint for RMA requests

### DIFF
--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -935,7 +935,7 @@ OPAL_DECLSPEC int opal_common_ucx_wpmem_flush_ep_nb(opal_common_ucx_wpmem_t *mem
 
     opal_mutex_lock(&winfo->mutex);
     opal_common_ucx_request_t *req;
-    req = ucp_worker_flush_nb(winfo->worker, 0, opal_common_ucx_req_completion);
+    req = ucp_ep_flush_nb(ep, 0, opal_common_ucx_req_completion);
     if (UCS_PTR_IS_PTR(req)) {
         req->ext_req = user_req_ptr;
         req->ext_cb = user_req_cb;


### PR DESCRIPTION
opal_common_ucx_wpmem_flush_ep_nb obtains the endpoint for a specific target, but starts a worker flush. Each unfinished worker flush retains the endpoint while linking it into the worker flush request. UCX stores the endpoint reference count in eight bits, so the 255th outstanding MPI_Rput aborts when that counter is exhausted.

Use ucp_ep_flush_nb on the endpoint already returned by the target lookup. Endpoint scope is sufficient to complete the preceding operation to that target and avoids retaining unrelated worker endpoints for every MPI request.

Fixes #14192