### PR TITLE
osc/ucx: Allow shared windows with local transports

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -37,6 +37,7 @@ typedef struct ompi_osc_ucx_component {
     opal_free_list_t accumulate_requests; /* request free list for the r* communication variants */
     bool env_initialized; /* UCX environment is initialized or not */
     bool priority_is_set; /* Is ucp_ctx created and component priority has been set */
+    opal_common_ucx_support_level_t support_level;
     int comm_world_size;
     ucp_ep_h *endpoints;
     int num_modules;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -81,6 +81,7 @@ ompi_osc_ucx_component_t mca_osc_ucx_component = {
     .wpool                  = NULL,
     .env_initialized        = false,
     .priority_is_set        = false,
+    .support_level          = OPAL_COMMON_UCX_SUPPORT_NONE,
     .num_modules            = 0,
     .acc_single_intrinsic   = false,
     .comm_world_size        = 0,
@@ -293,16 +294,20 @@ static int component_init(bool enable_progress_threads, bool enable_mpi_threads)
     mca_osc_ucx_component.enable_mpi_threads = enable_mpi_threads;
     mca_osc_ucx_component.wpool = opal_common_ucx_wpool_allocate();
     mca_osc_ucx_component.priority_is_set = false;
+    mca_osc_ucx_component.support_level = OPAL_COMMON_UCX_SUPPORT_NONE;
 
     return OMPI_SUCCESS;
 }
 
-static int component_set_priority(void) {
+static int component_set_priority(int flavor) {
     int param, ret;
-    opal_common_ucx_support_level_t support_level = OPAL_COMMON_UCX_SUPPORT_NONE;
     mca_base_var_source_t param_source = MCA_BASE_VAR_SOURCE_DEFAULT;
 
     if (mca_osc_ucx_component.priority_is_set == true) {
+        if (OPAL_COMMON_UCX_SUPPORT_NONE == mca_osc_ucx_component.support_level
+            && MPI_WIN_FLAVOR_SHARED != flavor) {
+            return OMPI_ERR_NOT_AVAILABLE;
+        }
         return OMPI_SUCCESS;
     }
 
@@ -317,8 +322,10 @@ static int component_set_priority(void) {
         }
     }
 
-    support_level = opal_common_ucx_support_level(mca_osc_ucx_component.wpool->ucp_ctx);
-    if (OPAL_COMMON_UCX_SUPPORT_NONE == support_level) {
+    mca_osc_ucx_component.support_level =
+        opal_common_ucx_support_level(mca_osc_ucx_component.wpool->ucp_ctx);
+    if (OPAL_COMMON_UCX_SUPPORT_NONE == mca_osc_ucx_component.support_level
+        && MPI_WIN_FLAVOR_SHARED != flavor) {
         ucp_cleanup(mca_osc_ucx_component.wpool->ucp_ctx);
         mca_osc_ucx_component.wpool->ucp_ctx = NULL;
         return OMPI_ERR_NOT_AVAILABLE;
@@ -334,7 +341,8 @@ static int component_set_priority(void) {
      * Lower priority if we have supported transports, but not supported devices.
      */
     if(MCA_BASE_VAR_SOURCE_DEFAULT == param_source) {
-        mca_osc_ucx_component.priority = (support_level == OPAL_COMMON_UCX_SUPPORT_DEVICE) ?
+        mca_osc_ucx_component.priority =
+            (mca_osc_ucx_component.support_level == OPAL_COMMON_UCX_SUPPORT_DEVICE) ?
                     mca_osc_ucx_component.priority : 9;
     }
     OSC_UCX_VERBOSE(2, "returning priority %d", mca_osc_ucx_component.priority);
@@ -372,13 +380,10 @@ static int component_finalize(void) {
 
 static int component_query(struct ompi_win_t *win, void **base, size_t size, ptrdiff_t disp_unit,
                            struct ompi_communicator_t *comm, struct opal_info_t *info, int flavor) {
-    int ret;
-    if (mca_osc_ucx_component.priority_is_set == false) {
-        ret = component_set_priority();
-        if (OMPI_SUCCESS != ret) {
-            OSC_UCX_ERROR("OSC UCX component priority set inside component query failed \n ");
-            return ret;
-        }
+    int ret = component_set_priority(flavor);
+    if (OMPI_SUCCESS != ret) {
+        OSC_UCX_ERROR("OSC UCX component priority set inside component query failed \n ");
+        return ret;
     }
     return mca_osc_ucx_component.priority;
 }
@@ -577,12 +582,10 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, pt
          * we don't want to initialize in the component_init()
          */
 
-        if (mca_osc_ucx_component.priority_is_set == false) {
-            ret = component_set_priority();
-            if (OMPI_SUCCESS != ret) {
-                OSC_UCX_ERROR("OSC UCX component priority set inside component select failed \n ");
-                return ret;
-            }
+        ret = component_set_priority(flavor);
+        if (OMPI_SUCCESS != ret) {
+            OSC_UCX_ERROR("OSC UCX component priority set inside component select failed \n ");
+            return ret;
         }
 
         OBJ_CONSTRUCT(&mca_osc_ucx_component.requests, opal_free_list_t);


### PR DESCRIPTION
The common UCX support-level check intentionally ignores local-only transport selections when deciding whether UCX should be selected for network communication. That check also prevented an explicitly selected OSC/UCX component from creating MPI shared windows with self and shared-memory transports, even though those transports provide everything the shared-window flavor requires.

Pass the window flavor into the priority setup and permit a support level of NONE only for MPI_WIN_FLAVOR_SHARED. Cache the detected support level alongside the priority so later window queries enforce the same flavor-specific decision without repeatedly inspecting the UCX context. This retains the existing rejection for unsupported non-shared windows and leaves the shared-memory OSC component preferred by default.

Fixes #11391