### PR TITLE
[v5.0.x] pml/cm,ob1: pack data from application buffer in successive MPI_Start calls

### DIFF
--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -376,7 +376,7 @@ do {                                                                    \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
             opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
-                                             sendreq->req_send.req_base.req_datatype,   \
+                                             &sendreq->req_send.req_base.req_datatype->super,   \
                                              max_data,                  \
                                              sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -375,6 +375,10 @@ do {                                                                    \
             iov.iov_base = (IOVBASE_TYPE*)sendreq->req_buff;            \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
+            opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
+                                             sendreq->req_send.req_base.req_datatype,   \
+                                             max_data,                  \
+                                             sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \
                                  &iov,                                  \
                                  &iov_count,                            \

--- a/ompi/mca/pml/ob1/pml_ob1_start.c
+++ b/ompi/mca/pml/ob1/pml_ob1_start.c
@@ -84,13 +84,16 @@ int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
                     sendreq = (mca_pml_ob1_send_request_t *) request;
                     requests[i] = request;
                 } else if (sendreq->req_send.req_bytes_packed != 0) {
-                    size_t offset = 0;
                     /**
                      * Reset the convertor in case we're dealing with the original
-                     * request, which when completed do not reset the convertor.
+                     * request, which when completed do not reset the convertor but
+                     * leaves it pointing to the buffered send location, with the
+                     * packed datatype and count.
                      */
-                    opal_convertor_set_position (&sendreq->req_send.req_base.req_convertor,
-                                                 &offset);
+                    opal_convertor_prepare_for_send(&sendreq->req_send.req_base.req_convertor,
+                                                    &sendreq->req_send.req_base.req_datatype->super,
+                                                    sendreq->req_send.req_base.req_count,
+                                                    sendreq->req_send.req_base.req_addr);
                 }
 
                 /* reset the completion flag */


### PR DESCRIPTION
Backport of #12797 to v5.0.x. The fix is on `main` and v6.0.x but was never backported to v5.0.x.

(cherry picked from commit 3226c6c8f69d37a719c27d53840db93bbb0ff4d1)
(cherry picked from commit 429c7b7e61b6d3ef2d1022f5066a169fcb27a3d0)

`MPI_Bsend_init` + `MPI_Start` resends the first payload on every restart instead of the current application buffer contents:

- pml/cm packs the application buffer into the bsend bounce buffer in `MPI_Bsend_init` but not in `MPI_Start`, so successive starts resend stale data.
- pml/ob1 has the analogous issue in `mca_pml_ob1_start`, resetting the convertor position instead of re-preparing it from the application buffer.

This is caught by the intel_tests `MPI_Bsend_init_overtake` test, which fails on v5.0.x and passes on main and v6.0.x.