### PR TITLE
[v4.1.x] Reserve dist graph tags outside the libnbc tag range

### DIFF
--- a/ompi/mca/coll/base/coll_tags.h
+++ b/ompi/mca/coll/base/coll_tags.h
@@ -41,7 +41,12 @@
 #define MCA_COLL_BASE_TAG_SCAN -24
 #define MCA_COLL_BASE_TAG_SCATTER -25
 #define MCA_COLL_BASE_TAG_SCATTERV -26
-#define MCA_COLL_BASE_TAG_NONBLOCKING_BASE -27
+/* Distributed graph construction uses PML messages before the new
+ * communicator is fully created. Keep these tags out of the nonblocking
+ * collective tag range. */
+#define MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN -27
+#define MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT -28
+#define MCA_COLL_BASE_TAG_NONBLOCKING_BASE -29
 #define MCA_COLL_BASE_TAG_NONBLOCKING_END ((-1 * INT_MAX/2) + 1)
 #define MCA_COLL_BASE_TAG_NEIGHBOR_BASE  (MCA_COLL_BASE_TAG_NONBLOCKING_END - 1)
 #define MCA_COLL_BASE_TAG_NEIGHBOR_END   (MCA_COLL_BASE_TAG_NEIGHBOR_BASE - 1024)

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -16,6 +16,7 @@
 #include "ompi_config.h"
 
 #include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/base/coll_tags.h"
 #include "ompi/info/info.h"
 #include "ompi/mca/topo/base/base.h"
 #include "ompi/datatype/ompi_datatype.h"
@@ -24,8 +25,6 @@
 
 #define IN_INDEX   0
 #define OUT_INDEX  1
-#define MCA_TOPO_BASE_TAG_DIST_EDGE_IN    -50
-#define MCA_TOPO_BASE_TAG_DIST_EDGE_OUT   -51
 
 typedef struct _dist_graph_elem {
     int in;
@@ -169,7 +168,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
                 position *= 2;
             }
             err = MCA_PML_CALL(isend( &rin[position], count, (ompi_datatype_t*)&ompi_mpi_int,
-                                      i, MCA_TOPO_BASE_TAG_DIST_EDGE_IN, MCA_PML_BASE_SEND_STANDARD,
+                                      i, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN, MCA_PML_BASE_SEND_STANDARD,
                                       comm, &reqs[pending_reqs]));
             pending_reqs++;
         }
@@ -180,7 +179,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
                 position *= 2;
             }
             err = MCA_PML_CALL(isend(&rout[position], count, (ompi_datatype_t*)&ompi_mpi_int,
-                                     i, MCA_TOPO_BASE_TAG_DIST_EDGE_OUT, MCA_PML_BASE_SEND_STANDARD,
+                                     i, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT, MCA_PML_BASE_SEND_STANDARD,
                                      comm, &reqs[pending_reqs]));
             pending_reqs++;
         }
@@ -207,7 +206,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
     for( left_over = count, current_pos = i = 0; left_over > 0; i++ ) {
 
         MCA_PML_CALL(recv( &temp[count - left_over], left_over, (ompi_datatype_t*)&ompi_mpi_int,  /* keep receiving in the same buffer */
-                           MPI_ANY_SOURCE, MCA_TOPO_BASE_TAG_DIST_EDGE_IN,
+                           MPI_ANY_SOURCE, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_IN,
                            comm, &status ));
         how_much = status._ucount / int_size;
         if (MPI_UNWEIGHTED != weights) {
@@ -243,7 +242,7 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
     for( left_over = count, current_pos = i = 0; left_over > 0; i++ ) {
 
         MCA_PML_CALL(recv( &temp[count - left_over], left_over, (ompi_datatype_t*)&ompi_mpi_int,  /* keep receiving in the same buffer */
-                           MPI_ANY_SOURCE, MCA_TOPO_BASE_TAG_DIST_EDGE_OUT,
+                           MPI_ANY_SOURCE, MCA_COLL_BASE_TAG_TOPO_DIST_EDGE_OUT,
                            comm, &status ));
         how_much = status._ucount / int_size;
 


### PR DESCRIPTION
Backport of #13931 (fixes #13918) to v4.1.x. The fix is on main, v6.0.x (#13932), and v5.0.x (#13933), but was never backported to
v4.1.x.

(cherry picked from commit 9b71f5593128cac7730e9aea377b797dae5093ee)

The cherry-pick required a small conflict resolution in `coll_tags.h`: v4.1.x predates the FT/UCC static tag block, so the reserved
dist-graph tags become `-27`/`-28` and `MCA_COLL_BASE_TAG_NONBLOCKING_BASE` moves from `-27` to `-29`. The
effect is identical to the original commit: the dist-graph edge-exchange tags are static, outside the nonblocking-collective tag
range.

`MPI_Dist_graph_create` exchanges edge metadata with PML sends/receives on the parent communicator using hard-coded tags `-50`/`-51`. On v4.1.x the libnbc dynamic tag allocator starts at `-27` and counts down, so in repeated communicator creation `c_nbc_tag` walks into `-50`/`-51` and dist-graph edge traffic collides with the nonblocking allreduce inside `ompi_comm_nextcid`. CID allocation then never converges and all ranks spin in `ompi_comm_nextcid` forever.

This is caught by the IBM `distgraph_test_4` test, which hangs on v4.1.x with multiple nodes and passes with this fix.