### PR TITLE
Add missing functions to Fortran use_mpi interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -637,5 +637,6 @@ ompi/mpi/fortran/use-mpi-f08/base/*_generated.c
 ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces-generated.h
 ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces-generated.h
 ompi/mpi/fortran/use-mpi-ignore-tkr/*_generated.F90
+ompi/mpi/fortran/use-mpi-ignore-tkr/base/*_generated.c
 
 .vscode/

--- a/config/ompi_config_files.m4
+++ b/config/ompi_config_files.m4
@@ -43,6 +43,7 @@ AC_DEFUN([OMPI_CONFIG_FILES],[
         ompi/mpi/fortran/use-mpi/Makefile
         ompi/mpi/fortran/use-mpi/mpi-types.F90
         ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile
+        ompi/mpi/fortran/use-mpi-ignore-tkr/base/Makefile
         ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h
         ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-file-interfaces.h
         ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-removed-interfaces.h

--- a/ompi/Makefile.am
+++ b/ompi/Makefile.am
@@ -84,6 +84,7 @@ SUBDIRS = \
         mpi/fortran/mpif-h \
         mpi/fortran/use-mpi \
         $(OMPI_MPIEXT_USEMPI_DIR) \
+        mpi/fortran/use-mpi-ignore-tkr/base \
         mpi/fortran/use-mpi-ignore-tkr \
         mpi/fortran/mpiext-use-mpi \
         mpi/fortran/use-mpi-f08/base \
@@ -116,6 +117,7 @@ DIST_SUBDIRS = \
         mpi/fortran/mpif-h \
         mpi/fortran/use-mpi \
         mpi/fortran/use-mpi-ignore-tkr \
+        mpi/fortran/use-mpi-ignore-tkr/base \
         mpi/fortran/mpiext-use-mpi \
         mpi/fortran/use-mpi-f08 \
         mpi/fortran/use-mpi-f08/base \

--- a/ompi/mpi/bindings/ompi_bindings/fortran.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran.py
@@ -25,14 +25,14 @@ from ompi_bindings.fortran_type import FortranType
 from ompi_bindings.parser import SourceTemplate
 
 
-# Cache of {function_name_lower: [standard f08 dummy-argument names]} loaded
+# Cache of { f08/f90 : {function_name_lower: [standard dummy-argument names]} } loaded
 # from pympistandard.  None means "not yet attempted"; an empty dict means
 # "attempted but unavailable" (the generator then falls back to the names
 # hard-coded in the *.in PROTOTYPE lines).
-_STANDARD_F08_NAMES = None
+_STANDARD_PARAMETER_NAMES = None
 
 
-def standard_f08_names(pympistd_dir):
+def standard_parameter_names(pympistd_dir, use_f90):
     """Load the standard MPI F08 dummy-argument names from pympistandard.
 
     The Open MPI templates use generic internal names (e.g. 'x', 'x1') for
@@ -43,10 +43,11 @@ def standard_f08_names(pympistd_dir):
     (excluding ierror), which the Fortran generator substitutes for the
     template names -- without touching the C back-end.
     """
-    global _STANDARD_F08_NAMES
-    if _STANDARD_F08_NAMES is not None:
-        return _STANDARD_F08_NAMES
-    names = {}
+    global _STANDARD_PARAMETER_NAMES
+    lang = "f90" if use_f90 else "f08"
+    if _STANDARD_PARAMETER_NAMES is not None:
+        return _STANDARD_PARAMETER_NAMES[lang]
+    names = { "f90": {}, "f08": {} }
     if pympistd_dir:
         src = os.path.join(pympistd_dir, 'src')
         if os.path.isdir(src):
@@ -54,20 +55,21 @@ def standard_f08_names(pympistd_dir):
             import pympistandard as std
             std.use_api_version(1)
             for key, proc in std.PROCEDURES.items():
-                f08 = getattr(proc.express, 'f08', None)
-                if f08 is None:
-                    continue
-                names[key.lower()] = [p.name.lower() for p in f08.parameters
-                                      if p.name.lower() != consts.FORTRAN_ERROR_NAME]
-    _STANDARD_F08_NAMES = names
-    return names
+                for kind in ['f08', 'f90']:
+                    kind_attr = getattr(proc.express, kind, None)
+                    if kind_attr is None:
+                        continue
+                    names[kind][key.lower()] = [p.name.lower() for p in kind_attr.parameters
+                                          if p.name.lower() != consts.FORTRAN_ERROR_NAME]
+    _STANDARD_PARAMETER_NAMES = names
+    return names[lang]
 
 
 class FortranBinding:
     """Class for generating the binding for a single function."""
 
     def __init__(self, prototype, out, template=None, bigcount=False, needs_ts=False,
-                 gen_f90=False, f08_names=None):
+                 gen_f90=False, param_names=None):
         # Generate bigcount interface version
         self.bigcount = bigcount
         self.fn_name = template.prototype.name
@@ -86,9 +88,9 @@ class FortranBinding:
         # standard agree on the number of non-ierror arguments); otherwise the
         # template names are kept so a misaligned prototype never silently
         # emits a wrong name.  The C back-end (print_c_source) constructs its
-        # own FortranBinding without f08_names, so it is unaffected.
-        if f08_names is not None and len(f08_names) == len(self.parameters):
-            for param, std_name in zip(self.parameters, f08_names):
+        # own FortranBinding without param_names, so it is unaffected.
+        if param_names is not None and len(param_names) == len(self.parameters):
+            for param, std_name in zip(self.parameters, param_names):
                 param.name = std_name
 
     def dump(self, *pargs, **kwargs):
@@ -102,7 +104,8 @@ class FortranBinding:
     @property
     def c_func_name(self):
         """Produce the final C func name from base_name."""
-        return f'ompi_{self.fn_name}_wrapper_f08{self._fn_name_suffix()}'
+        module = 'f90' if self.gen_f90 else 'f08'
+        return f'ompi_{self.fn_name}_wrapper_{module}{self._fn_name_suffix()}'
 
     @property
     def inner_call(self):
@@ -242,7 +245,10 @@ class FortranBinding:
             self.dump(line)
 
         # Convert error type
-        self.dump(f'    if (present({consts.FORTRAN_ERROR_NAME})) {consts.FORTRAN_ERROR_NAME} = {consts.C_ERROR_TMP_NAME}')
+        if self.gen_f90:
+            self.dump(f'    {consts.FORTRAN_ERROR_NAME} = {consts.C_ERROR_TMP_NAME}')
+        else:
+            self.dump(f'    if (present({consts.FORTRAN_ERROR_NAME})) {consts.FORTRAN_ERROR_NAME} = {consts.C_ERROR_TMP_NAME}')
 
         for param in self.parameters:
             self.dump_lines(param.post())
@@ -292,14 +298,13 @@ def print_profiling_rename_macros(templates, out, args):
     for template in templates:
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        name = util.fortran_name(template.prototype.name, gen_f90=gen_f90, needs_ts=needs_ts)
-        out.dump(f'#define {name} P{name}')
+        names = {util.fortran_name(template.prototype.name, gen_f90=gen_f90, needs_ts=needs_ts)}
         # Check for bigcount version
         if util.prototype_has_bigcount(template.prototype):
-            bigcount_name = util.fortran_name(template.prototype.name, bigcount=True, needs_ts=needs_ts)
-            out.dump(f'#define {bigcount_name} P{bigcount_name}')
-        if gen_f90 == False:
-            name = util.fortran_f08_generic_interface_name(template.prototype.name)
+            names.add(util.fortran_name(template.prototype.name, gen_f90=gen_f90, bigcount=True, needs_ts=needs_ts))
+        interface_name = util.fortran_generic_interface_name(template.prototype.name)
+        names.add(interface_name)
+        for name in sorted(names):
             out.dump(f'#define {name} P{name}')
     out.dump('#endif /* OMPI_BUILD_MPI_PROFILING */')
 
@@ -322,14 +327,14 @@ def print_c_source_header(out):
     out.dump('#include "ompi/datatype/ompi_datatype.h"')
     out.dump('#include "ompi/attribute/attribute.h"')
     out.dump('#include "ompi/mca/coll/base/coll_base_util.h"')
-    out.dump('#include "ts.h"')
-    out.dump('#include "bigcount.h"')
+    out.dump('#include "ompi/mpi/fortran/use-mpi-f08/base/ts.h"')
+    out.dump('#include "ompi/mpi/fortran/use-mpi-f08/base/bigcount.h"')
 
 
-def print_binding(prototype, lang, out, bigcount=False, template=None, needs_ts=False, gen_f90=False, f08_names=None):
+def print_binding(prototype, lang, out, bigcount=False, template=None, needs_ts=False, gen_f90=False, param_names=None):
     """Print the binding with or without bigcount."""
     binding = FortranBinding(prototype, out=out, bigcount=bigcount, template=template, needs_ts=needs_ts,
-                             gen_f90=gen_f90, f08_names=f08_names)
+                             gen_f90=gen_f90, param_names=param_names)
     if lang == 'fortran':
         binding.print_f_source()
     else:
@@ -353,10 +358,10 @@ def generate_code(args, out):
     else:
         gen_f90 = True
 
-    # Standard F08 dummy-argument names are only applied to the F08 Fortran
+    # Standard dummy-argument names are only applied to the Fortran
     # interfaces, never to the C back-end (whose body refers to the template's
-    # internal names) and not to the older mpi (f90) module.
-    std_names = standard_f08_names(args.pympistd_dir) if (args.lang == 'fortran' and not gen_f90) else {}
+    # internal names)
+    std_names = standard_parameter_names(args.pympistd_dir, use_f90=gen_f90) if (args.lang == 'fortran') else {}
 
     if args.lang == 'fortran':
         print_f_source_header(out)
@@ -367,16 +372,21 @@ def generate_code(args, out):
         print_c_source_header(out)
 
     for template in templates:
-        out.dump()
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        f08_names = std_names.get('mpi_' + template.prototype.name.lower())
+
+        # use-mpi needs generated procedure only for the suffixed ts functions
+        # Rest are covered by mpif already
+        if gen_f90 and not needs_ts:
+            continue
+        out.dump()
+        param_names = std_names.get('mpi_' + template.prototype.name.lower())
         print_binding(template.prototype, args.lang, out, template=template, needs_ts=needs_ts,
-                      gen_f90=gen_f90, f08_names=f08_names)
+                      gen_f90=gen_f90, param_names=param_names)
         if util.prototype_has_bigcount(template.prototype) and gen_f90 == False:
             out.dump()
             print_binding(template.prototype, args.lang, bigcount=True, out=out, template=template,
-                          needs_ts=needs_ts, f08_names=f08_names)
+                          needs_ts=needs_ts, param_names=param_names)
 
 
 def generate_interface(args, out):
@@ -391,23 +401,22 @@ def generate_interface(args, out):
     else:
         gen_f90 = True
 
-    # The interface specifications are part of the user-visible mpi_f08
-    # module, so they use the standard MPI dummy-argument names too.  The
-    # older mpi (f90) module is out of scope.
-    std_names = standard_f08_names(args.pympistd_dir) if not gen_f90 else {}
+    # The interface specifications are part of the user-visible use mpi(_f08)
+    # modules, so they use the standard MPI dummy-argument names too.
+    std_names = standard_parameter_names(args.pympistd_dir, use_f90=gen_f90)
 
     for template in templates:
         ext_name = util.ext_api_func_name(template.prototype.name)
         out.dump(f'interface {ext_name}')
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        f08_names = std_names.get('mpi_' + template.prototype.name.lower())
+        param_names = std_names.get('mpi_' + template.prototype.name.lower())
         binding = FortranBinding(template.prototype, template=template, needs_ts=needs_ts,
-                                 gen_f90=gen_f90, out=out, f08_names=f08_names)
+                                 gen_f90=gen_f90, out=out, param_names=param_names)
         binding.print_interface()
         if util.prototype_has_bigcount(template.prototype) and gen_f90 == False:
             out.dump()
             binding_c = FortranBinding(template.prototype, out=out, template=template,
-                                       needs_ts=needs_ts, bigcount=True, f08_names=f08_names)
+                                       needs_ts=needs_ts, bigcount=True, param_names=param_names)
             binding_c.print_interface()
         out.dump(f'end interface {ext_name}')

--- a/ompi/mpi/bindings/ompi_bindings/fortran.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran.py
@@ -292,14 +292,13 @@ def print_profiling_rename_macros(templates, out, args):
     for template in templates:
         has_buffers = util.prototype_has_buffers(template.prototype)
         needs_ts = has_buffers and args.generate_ts_suffix
-        name = util.fortran_name(template.prototype.name, gen_f90=gen_f90, needs_ts=needs_ts)
-        out.dump(f'#define {name} P{name}')
+        names = {util.fortran_name(template.prototype.name, gen_f90=gen_f90, needs_ts=needs_ts)}
         # Check for bigcount version
         if util.prototype_has_bigcount(template.prototype):
-            bigcount_name = util.fortran_name(template.prototype.name, bigcount=True, needs_ts=needs_ts)
-            out.dump(f'#define {bigcount_name} P{bigcount_name}')
-        if gen_f90 == False:
-            name = util.fortran_f08_generic_interface_name(template.prototype.name)
+            names.add(util.fortran_name(template.prototype.name, gen_f90=gen_f90, bigcount=True, needs_ts=needs_ts))
+        interface_name = util.fortran_generic_interface_name(template.prototype.name)
+        names.add(interface_name)
+        for name in sorted(names):
             out.dump(f'#define {name} P{name}')
     out.dump('#endif /* OMPI_BUILD_MPI_PROFILING */')
 

--- a/ompi/mpi/bindings/ompi_bindings/fortran_type.py
+++ b/ompi/mpi/bindings/ompi_bindings/fortran_type.py
@@ -485,7 +485,10 @@ class CommType(FortranType):
         return f'INTEGER, INTENT(IN) :: {self.name}'
 
     def argument(self):
-        return f'{self.name}%MPI_VAL'
+        if not self.gen_f90:
+            return f'{self.name}%MPI_VAL'
+        else:
+            return f'{self.name}'
 
     def use(self):
         if self.gen_f90 == False:
@@ -531,7 +534,10 @@ class GroupType(FortranType):
         return f'INTEGER, INTENT(IN) :: {self.name}'
             
     def argument(self):
-        return f'{self.name}%MPI_VAL'
+        if not self.gen_f90:
+            return f'{self.name}%MPI_VAL'
+        else:
+            return f'{self.name}'
 
     def use(self):
         if self.gen_f90 == False:
@@ -576,8 +582,11 @@ class SessionType(FortranType):
         return f'INTEGER, INTENT(IN) :: {self.name}'
     
     def argument(self):
-        return f'{self.name}%MPI_VAL'
-        
+        if not self.gen_f90:
+            return f'{self.name}%MPI_VAL'
+        else:
+            return f'{self.name}'
+
     def use(self):
         if self.gen_f90 == False:
             return [('mpi_f08_types', 'MPI_Session')]

--- a/ompi/mpi/bindings/ompi_bindings/util.py
+++ b/ompi/mpi/bindings/ompi_bindings/util.py
@@ -79,7 +79,7 @@ def fortran_name(fn_name, bigcount=False, needs_ts=False, gen_f90=False):
         name = f'MPI_{fn_name.capitalize()}{ts}'
     return name
 
-def fortran_f08_generic_interface_name(fn_name):
+def fortran_generic_interface_name(fn_name):
     """Produce the generic interface name from the base_name."""
     return f'MPI_{fn_name.capitalize()}'
 

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -77,6 +77,28 @@ nodist_lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES += \
         mpi-ignore-tkr-sizeof.f90
 endif
 
+api_f90_generated_libs =
+if OMPI_FORTRAN_HAVE_TS
+noinst_LTLIBRARIES = \
+        libusempi_ignore_tkr_api.la \
+        libusempi_ignore_tkr_api_profile.la
+
+libusempi_ignore_tkr_api_la_SOURCES = api_f90_generated.F90
+libusempi_ignore_tkr_api_la_FCFLAGS = \
+        $(AM_FCFLAGS) \
+        -DOMPI_BUILD_MPI_PROFILING=0
+
+libusempi_ignore_tkr_api_profile_la_SOURCES = api_f90_generated.F90
+libusempi_ignore_tkr_api_profile_la_FCFLAGS = \
+        $(AM_FCFLAGS) \
+        -DOMPI_BUILD_MPI_PROFILING=1
+
+api_f90_generated_libs += \
+        libusempi_ignore_tkr_api.la \
+        libusempi_ignore_tkr_api_profile.la \
+        base/libusempi_ignore_tkr_ccode.la
+endif
+
 libusempi_internal_modules =
 if OMPI_FORTRAN_HAVE_TYPE_MPI_STATUS
 libusempi_internal_modules += $(top_builddir)/ompi/mpi/fortran/use-mpi/libusempi_internal_modules.la
@@ -87,8 +109,11 @@ endif
 # directly (pulling it in indirectly via libmpi.la does not work on
 # all platforms).
 lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LIBADD = \
+        $(api_f90_generated_libs) \
         $(libusempi_internal_modules) \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_NAME@.la
+EXTRA_lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_DEPENDENCIES = $(api_f90_generated_libs)
 lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LDFLAGS = \
         -version-info $(libmpi_usempi_ignore_tkr_so_version) \
         $(OMPI_FORTRAN_EXTRA_SHARED_LIBRARY_FLAGS)
@@ -141,15 +166,29 @@ if OMPI_FORTRAN_HAVE_TS
 gen_ts = --generate-ts-suffix
 endif
 
-mpi-ignore-tkr-interfaces-generated.h: $(template_files)
+mpi-ignore-tkr-interfaces-generated.h: $(template_files) $(OMPI_BINDINGS_GENERATOR)
 	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
 	    --builddir $(abs_top_builddir) \
 	    --srcdir $(abs_top_srcdir) \
 	    --output $(abs_builddir)/$@ \
 	    fortran \
 	    $(gen_ts) \
+        --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
 	    --fort-std f90 \
 	    interface \
+	    --prototype-files $(template_files)
+
+api_f90_generated.F90: $(template_files) $(OMPI_BINDINGS_GENERATOR)
+	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
+	    --builddir $(abs_top_builddir) \
+	    --srcdir $(abs_top_srcdir) \
+	    --output $(abs_builddir)/$@ \
+	    fortran \
+	    $(gen_ts) \
+        --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
+	    --fort-std f90 \
+	    code \
+	    --lang fortran \
 	    --prototype-files $(template_files)
 
 #
@@ -159,9 +198,13 @@ mpi-ignore-tkr-interfaces-generated.h: $(template_files)
 CLEANFILES += mpi-ignore-tkr-sizeof.h mpi-ignore-tkr-sizeof.f90
 MOSTLYCLEANFILES = *.mod
 CLEANFILES += *.i90
-MAINTAINERCLEANFILES = mpi-ignore-tkr-interfaces-generated.h
+MAINTAINERCLEANFILES = \
+        mpi-ignore-tkr-interfaces-generated.h \
+        api_f90_generated.F90
 if OPAL_DEVEL_BUILD
-CLEANFILES += mpi-ignore-tkr-interfaces-generated.h
+CLEANFILES += \
+        mpi-ignore-tkr-interfaces-generated.h \
+        api_f90_generated.F90
 endif
 
 # Install the generated .mod files.  Unfortunately, each F90 compiler

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -141,7 +141,7 @@ if OMPI_FORTRAN_HAVE_TS
 gen_ts = --generate-ts-suffix
 endif
 
-mpi-ignore-tkr-interfaces-generated.h: $(template_files)
+mpi-ignore-tkr-interfaces-generated.h: $(template_files) $(OMPI_BINDINGS_GENERATOR)
 	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
 	    --builddir $(abs_top_builddir) \
 	    --srcdir $(abs_top_srcdir) \

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/base/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/base/Makefile.am
@@ -1,0 +1,56 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Technical University of Darmstadt.  All rights
+#                         reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+include $(top_srcdir)/Makefile.ompi-rules
+
+# This Makefile is only relevant if we're building the ignore-tkr "use
+# mpi" MPI bindings.
+if OMPI_BUILD_FORTRAN_USEMPI_IGNORE_TKR_BINDINGS
+
+# This directory only exists so that we can separate C compilation from
+# Fortran compilation, for the same reason as
+# ompi/mpi/fortran/use-mpi-f08/base: the parent directory zeroes out
+# CPPFLAGS / AM_CPPFLAGS (see https://github.com/open-mpi/ompi/issues/7253).
+#
+# The one .c file here backs the mpi module's TS29113 choice-buffer
+# procedures.
+# This directory + Makefile.am is separate to have non-zeroed CPPFLAGS/AM_CPPFLAGS
+if OMPI_FORTRAN_HAVE_TS
+
+noinst_LTLIBRARIES = libusempi_ignore_tkr_ccode.la
+
+libusempi_ignore_tkr_ccode_la_SOURCES = api_f90_generated.c
+
+endif
+
+include ../Makefile.prototype_files
+template_files =${prototype_files:%=$(abs_top_srcdir)/ompi/mpi/fortran/use-mpi-f08/%}
+
+api_f90_generated.c: $(template_files) $(OMPI_BINDINGS_GENERATOR)
+	$(OMPI_V_GEN) $(PYTHON) $(top_srcdir)/ompi/mpi/bindings/bindings.py \
+	    --builddir $(abs_top_builddir) \
+	    --srcdir $(abs_top_srcdir) \
+	    --output $(abs_builddir)/$@ \
+	    fortran \
+	    --generate-ts-suffix \
+        --pympistd-dir $(abs_top_srcdir)/3rd-party/pympistandard \
+	    --fort-std f90 \
+	    code \
+	    --lang c \
+	    --prototype-files $(template_files)
+
+MAINTAINERCLEANFILES = api_f90_generated.c
+if OPAL_DEVEL_BUILD
+CLEANFILES += api_f90_generated.c
+endif
+
+endif

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
@@ -48,16 +48,29 @@ module mpi
 #if OMPI_FORTRAN_HAVE_TYPE_MPI_STATUS
   include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-status.h"
 #endif
-# include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h"
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-file-interfaces.h"
-# include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-file-interfaces.h"
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces-generated.h"
+
 #if !defined(OMPI_ENABLE_MPI1_COMPAT)
 
 #error "Remove MPI-1 compat code"
 
 #elif OMPI_ENABLE_MPI1_COMPAT
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-removed-interfaces.h"
+#endif
+
+! PMPI interfaces start here.
+! Do not add non-PMPI includes below this point!
+! The PMPI #defines leak and can infect the new interfaces.
+
+# include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h"
+# include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-file-interfaces.h"
+
+# define OMPI_BUILD_MPI_PROFILING 1
+# include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces-generated.h"
+# undef OMPI_BUILD_MPI_PROFILING
+
+#if OMPI_ENABLE_MPI1_COMPAT
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-removed-interfaces.h"
 #endif
 

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
@@ -52,6 +52,9 @@ module mpi
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-file-interfaces.h"
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-file-interfaces.h"
 # include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces-generated.h"
+
+# define OMPI_BUILD_MPI_PROFILING 1
+# include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces-generated.h"
 #if !defined(OMPI_ENABLE_MPI1_COMPAT)
 
 #error "Remove MPI-1 compat code"

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/pmpi-ignore-tkr-interfaces.h
@@ -264,7 +264,6 @@
 #define MPI_Status_f2f08 PMPI_Status_f2f08
 #define MPI_Status_f082f PMPI_Status_f082f
 #define MPI_Status_set_cancelled PMPI_Status_set_cancelled
-#define MPI_Status_set_elements PMPI_Status_set_elements
 #define MPI_Status_set_elements_x PMPI_Status_set_elements_x
 #define MPI_Test PMPI_Test
 #define MPI_Test_cancelled PMPI_Test_cancelled


### PR DESCRIPTION
There's currently two closely related bugs.

The PMPI define for `MPI_Status_set_elements` is defined in `pmpi-ignore-tkr-interfaces.h` but the actual interface is in `mpi-ignore-tkr-interfaces-generated.h`.
Then, in `mpi-ignore-tkr.F90` both are included in that order. This leads to the preprocessor overwriting `MPI_Status_set_elements` with the PMPI version, and the normal one is omitted entirely.
This is fixed by the first commit which just removes the superfluous define.

Then, for the functions in `mpi-ignore-tkr-interfaces-generated.h`, no PMPI interface versions are being generated at the moment, since the define in that header is unused.
In the second commit, I include that header again in `mpi-ignore-tkr.F90` with the define to ensure the PMPI interfaces are in the final output.

I'm a bit unsure about the second commit, would be grateful for a deeper look.
