### PR TITLE
mpif.h: Add missing sources for MPI_Buffer_(i)flush to build

### DIFF
--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -166,6 +166,8 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         bsend_init_f.c \
         buffer_attach_f.c \
         buffer_detach_f.c \
+        buffer_flush_f.c \
+        buffer_iflush_f.c \
         cancel_f.c \
         cart_coords_f.c \
         cart_create_f.c \

--- a/ompi/mpi/fortran/mpif-h/buffer_iflush_f.c
+++ b/ompi/mpi/fortran/mpif-h/buffer_iflush_f.c
@@ -31,8 +31,8 @@
 #pragma weak pmpi_buffer_iflush_ = ompi_buffer_iflush_f
 #pragma weak pmpi_buffer_iflush__ = ompi_buffer_iflush_f
 
-#pragma weak PMPI_buffer_iflush_f = ompi_buffer_iflush_f
-#pragma weak PMPI_buffer_iflush_f08 = ompi_buffer_iflush_f
+#pragma weak PMPI_Buffer_iflush_f = ompi_buffer_iflush_f
+#pragma weak PMPI_Buffer_iflush_f08 = ompi_buffer_iflush_f
 #else
 OMPI_GENERATE_F77_BINDINGS (PMPI_BUFFER_IFLUSH,
                             pmpi_buffer_iflush,
@@ -50,8 +50,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_BUFFER_IFLUSH,
 #pragma weak mpi_buffer_iflush_ = ompi_buffer_iflush_f
 #pragma weak mpi_buffer_iflush__ = ompi_buffer_iflush_f
 
-#pragma weak MPI_buffer_iflush_f = ompi_buffer_iflush_f
-#pragma weak MPI_buffer_iflush_f08 = ompi_buffer_iflush_f
+#pragma weak MPI_Buffer_iflush_f = ompi_buffer_iflush_f
+#pragma weak MPI_Buffer_iflush_f08 = ompi_buffer_iflush_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_BUFFER_IFLUSH,
@@ -72,7 +72,7 @@ void ompi_buffer_iflush_f(MPI_Fint *request, MPI_Fint *ierr)
     int ierr_c;
     MPI_Request c_req;
 
-    ierr_c = PMPI_buffer_iflush(&c_req);
+    ierr_c = PMPI_Buffer_iflush(&c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 
     if (MPI_SUCCESS == ierr_c) *request = PMPI_Request_c2f(c_req);

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -78,6 +78,8 @@ linked_files = \
         pbsend_init_f.c \
         pbuffer_attach_f.c \
         pbuffer_detach_f.c \
+        pbuffer_flush_f.c \
+        pbuffer_iflush_f.c \
         pcancel_f.c \
         pcart_coords_f.c \
         pcart_create_f.c \

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -120,6 +120,7 @@ PN2(void, MPI_Bsend_init, mpi_bsend_init, MPI_BSEND_INIT, (char *buf, MPI_Fint *
 PN2(void, MPI_Buffer_attach, mpi_buffer_attach, MPI_BUFFER_ATTACH, (char *buffer, MPI_Fint *size, MPI_Fint *ierr));
 PN2(void, MPI_Buffer_detach, mpi_buffer_detach, MPI_BUFFER_DETACH, (char *buffer, MPI_Fint *size, MPI_Fint *ierr));
 PN2(void, MPI_Buffer_flush, mpi_buffer_flush, MPI_BUFFER_FLUSH, (MPI_Fint *ierr));
+PN2(void, MPI_Buffer_iflush, mpi_buffer_iflush, MPI_BUFFER_IFLUSH, (MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Cancel, mpi_cancel, MPI_CANCEL, (MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Cart_coords, mpi_cart_coords, MPI_CART_COORDS, (MPI_Fint *comm, MPI_Fint *rank, MPI_Fint *maxdims, MPI_Fint *coords, MPI_Fint *ierr));
 PN2(void, MPI_Cart_create, mpi_cart_create, MPI_CART_CREATE, (MPI_Fint *old_comm, MPI_Fint *ndims, MPI_Fint *dims, ompi_fortran_logical_t *periods, ompi_fortran_logical_t *reorder, MPI_Fint *comm_cart, MPI_Fint *ierr));


### PR DESCRIPTION
This set of files is never compiled, leading to linker errors if used.
Can be seen from the casing typos which means the files weren't previously able to be compiled anyway.