### PR TITLE
[v6.0.x] sync change log with main

### DIFF
--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -77,3 +77,40 @@ Open MPI version v6.0.0
   now validate their ``cat_index`` argument and return
   ``MPI_T_ERR_INVALID_INDEX`` for an out-of-range index, consistent
   with the other ``MPI_T_category_get_*`` query functions.
+
+- Partitioned communication fixes:
+
+  - ``MPI_Parrived`` now returns ``flag = true`` for a null request
+    (``MPI_REQUEST_NULL``) and for an inactive request, as required by
+    MPI-5.0 section 4.2.2.  It previously raised ``MPI_ERR_REQUEST`` for
+    a null request and returned ``flag = false`` for a partitioned
+    receive request that had never been started.
+
+  - ``MPI_Psend_init`` and ``MPI_Precv_init`` now accept
+    ``MPI_PROC_NULL`` as the peer rank, per MPI-5.0 section 3.10.  Such
+    a request completes as soon as it is started, ``MPI_Pready`` on it
+    has no effect, and ``MPI_Parrived`` reports every partition as
+    arrived.  Previously, ``MPI_PROC_NULL`` was passed down as if it
+    were a real peer rank, reading outside the communicator's process
+    array.
+
+  - Freeing a partitioned communication request that was never started
+    no longer leaves its internal setup receive posted.  Such a stale
+    receive could consume the setup message of the next partitioned
+    operation using the same communicator, peer, and tag, which then
+    never completed.
+
+- Renamed the ``--enable-weak-symbols`` configure option to
+  ``--enable-weak-aliases``, which more accurately reflects the linker
+  feature (weak symbol *aliases*) that Open MPI actually tests for and
+  uses.  ``--enable-weak-symbols`` is retained as a deprecated synonym.
+
+- The documentation now publishes machine-readable, LLM-friendly
+  artifacts for the public MPI APIs alongside the human-facing HTML and
+  man pages: a JSONL API catalog, aggregate and per-interface Markdown
+  corpora, per-symbol Markdown pages, curated examples, an interface
+  guide, an ``ompi_info`` runtime-introspection guide (how to query an
+  installed Open MPI for its version, configuration, components, and
+  run-time MCA parameters), and a manifest, all indexed from
+  ``llms.txt``. See the "LLM-friendly documentation artifacts" page in
+  the developer documentation.


### PR DESCRIPTION
there were several PRs with changelog entries
that were cherry-picked back to 6.0.x but without a changelog.

Add them here.

bot:notacherrypick