### PR TITLE
coll/han: fix subcomm creation failure cleanup

### DIFF
--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -238,7 +238,7 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     int low_rank, low_size, up_rank, w_rank, w_size;
     mca_coll_han_collectives_fallback_t fallbacks;
     ompi_communicator_t **low_comms = NULL, **up_comms = NULL;
-    int vrank, *vranks;
+    int vrank, *vranks = NULL;
     int rc;
     opal_info_t comm_info;
 
@@ -444,6 +444,15 @@ final_agree:
 
     if (!agree_flag) {
         han_module->enabled = false;  /* entire module set to pass-through from now on */
+        if (han_module->cached_low_comms == low_comms) {
+            han_module->cached_low_comms = NULL;
+        }
+        if (han_module->cached_up_comms == up_comms) {
+            han_module->cached_up_comms = NULL;
+        }
+        if (han_module->cached_vranks == vranks) {
+            han_module->cached_vranks = NULL;
+        }
         if (low_comms != NULL) {
             for(int i = 0; i < COLL_HAN_LOW_MODULES; i++) {
                 if (NULL != low_comms[i]) {
@@ -452,6 +461,7 @@ final_agree:
                 }
             }
             free(low_comms);
+            low_comms = NULL;
         }
         if (up_comms != NULL) {
             for(int i = 0; i < COLL_HAN_UP_MODULES; i++) {
@@ -461,6 +471,11 @@ final_agree:
                 }
             }
             free(up_comms);
+            up_comms = NULL;
+        }
+        if (NULL != vranks) {
+            free(vranks);
+            vranks = NULL;
         }
         return rc;  /* sub-communicator creation failed on at least one process */
     }


### PR DESCRIPTION
Tighten error handling in mca_coll_han_comm_create() so failure teardown releases all locally-created resources and does not leave stale cached pointers behind.

Initialize vranks to NULL, free it in the !agree_flag cleanup path, and clear cached_low_comms, cached_up_comms, and cached_vranks when they still alias the local allocations being torn down. This avoids a potential vranks leak and prevents later use of freed cached state after collective sub-communicator creation fails.

related to CIDS 1697461 and 1697458