### PR TITLE
coll/han: fix reorder_buf leak on gather allocation failure

### DIFF
--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -409,7 +409,16 @@ mca_coll_han_gather_intra_simple(const void *sbuf, size_t scount,
                                         &han_module->scratch_buf_size[1],
                                         (size_t)rsize,
                                         mca_coll_han_component.han_use_persist_buffers);
-        if (NULL == tmp_buf) return OMPI_ERR_OUT_OF_RESOURCE;
+        if (NULL == tmp_buf) {
+            /* Release the root's reorder buffer if it was heap-allocated
+             * (persistent scratch buffers are owned by the module and must
+             * not be freed here). */
+            if (!mca_coll_han_component.han_use_persist_buffers) {
+                free(reorder_buf);
+                reorder_buf = NULL;
+            }
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
         tmp_buf_start = tmp_buf - rgap;
     }
 


### PR DESCRIPTION
In mca_coll_han_gather_intra_simple() the root rank may allocate reorder_buf before the intra-node tmp_buf is allocated. If the tmp_buf allocation fails, the function returned OMPI_ERR_OUT_OF_RESOURCE without releasing reorder_buf, leaking it on the root rank when persistent scratch buffers are disabled.

Release reorder_buf on that early-return path, guarded by !han_use_persist_buffers so the module-owned persistent scratch buffer is not freed. free(NULL) is safe, so the guard also covers the map-by-core case where reorder_buf is never allocated.

related to CID 1697456