### PR TITLE
io/ompio: remove spurious coll_barrier from MPI_File_sync

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -434,13 +434,6 @@ int mca_io_ompio_file_sync (ompi_file_t *fh)
     if ( data->ompio_fh.f_amode & MPI_MODE_RDONLY ) {
         OPAL_THREAD_UNLOCK(&fh->f_lock);
         return MPI_ERR_ACCESS;
-    }        
-    // Make sure all processes reach this point before syncing the file.
-    ret = data->ompio_fh.f_comm->c_coll->coll_barrier (data->ompio_fh.f_comm,
-                                                       data->ompio_fh.f_comm->c_coll->coll_barrier_module);
-    if ( MPI_SUCCESS != ret ) {
-        OPAL_THREAD_UNLOCK(&fh->f_lock);
-        return ret;
     }
     ret = data->ompio_fh.f_fs->fs_file_sync (&data->ompio_fh);
     OPAL_THREAD_UNLOCK(&fh->f_lock);


### PR DESCRIPTION
MPI_File_sync is NOT a collective operation per MPI-3.1 §13.4.

Commit 849d0452a0 ("io/ompio: execute barrier before sync", 2018) added a coll_barrier(f_comm) inside mca_io_ompio_file_sync to fix a testmpio failure.  The barrier was intended to ensure all ranks finish their writes before any rank's fsync returns.  While convenient for that test, it imposes collective semantics on a function the MPI standard defines as non-collective, breaking any application that calls MPI_File_sync from fewer than all the ranks in the file's communicator group.

Observed failure: IMB-IO 2021.10 hangs indefinitely after completing P_Write_Indv NON-AGGREGATE when OMPIO is the active io module. In NON-AGGREGATE mode IMB-IO calls MPI_File_sync(fh) from the active writer rank only.  ROMIO's implementation (the default io module before OMPI 5.0.x) delegates directly to ADIO_Flush -> fsync with no barrier, so IMB-IO has worked for years.  With OMPIO as the default the barrier inside file_sync deadlocks:

  Rank 0: MPI_File_sync -> coll_barrier(f_comm = dup(COMM_WORLD))  [stuck]
  Rank 1: MPI_Barrier(MPI_COMM_WORLD)                              [stuck]

f_comm is a dup of the file-open communicator (distinct MPI context ID), so the two barriers never rendezvous and the job hangs indefinitely.

The correct fix is to remove the internal barrier.  Applications that need coherence across ranks must add an explicit MPI_Barrier before MPI_File_sync, as MPI-3.1 §13.4.7 requires of the application, not the implementation.  The testmpio test fixed by 849d0452a0 should be updated to add that explicit barrier.

This makes OMPIO's MPI_File_sync consistent with ROMIO.