### PR TITLE
ftmpi: bind MPIX_Comm_ishrink_f08 to the ishrink C shim

### DIFF
--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_ishrink_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_ishrink_f08.F90
@@ -15,7 +15,7 @@ subroutine MPIX_Comm_ishrink_f08(comm, newcomm, request, ierror)
   implicit none
   interface
      subroutine ompix_comm_ishrink_f(comm, newcomm, request, ierror) &
-          BIND(C, name="ompix_comm_shrink_f")
+          BIND(C, name="ompix_comm_ishrink_f")
        implicit none
        INTEGER, INTENT(IN) :: comm
        INTEGER, INTENT(OUT) :: newcomm

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_ishrink_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_ishrink_f08.F90
@@ -15,7 +15,7 @@ subroutine PMPIX_Comm_ishrink_f08(comm, newcomm, request, ierror)
   implicit none
   interface
      subroutine ompix_comm_ishrink_f(comm, newcomm, request, ierror) &
-          BIND(C, name="ompix_comm_shrink_f")
+          BIND(C, name="ompix_comm_ishrink_f")
        implicit none
        INTEGER, INTENT(IN) :: comm
        INTEGER, INTENT(OUT) :: newcomm


### PR DESCRIPTION
The mpi_f08 bindings for MPIX_Comm_ishrink declared a 4-argument interface (comm, newcomm, request, ierror) but bound it via BIND(C) to `ompix_comm_shrink_f`, which is the 3-argument *blocking* shrink shim. The correct 4-argument shim, `ompix_comm_ishrink_f`, already exists in `ompi/mpiext/ftmpi/mpif-h/comm_ishrink_f.c` but was never referenced.

As a result, calling MPIX_Comm_ishrink from mpi_f08 silently performed a blocking shrink: the C shim wrote its ierr output into the caller's `request%MPI_VAL`, no request was ever created for a later MPI_Wait, and the caller's ierror was left uninitialized.

This was a copy/paste error from `comm_shrink_f08.F90`, present in both the MPIX_ binding and its PMPIX_ profile copy.