### PR TITLE
bindings: remove dead ABIHeaderBuilder and 'c header' subcommand

### DIFF
--- a/ompi/mpi/bindings/bindings.py
+++ b/ompi/mpi/bindings/bindings.py
@@ -56,11 +56,6 @@ def main():
     # C set up code
     parser_c = subparsers.add_parser('c', help='subcommand for generating C code')
     subparsers_c = parser_c.add_subparsers()
-    parser_header = subparsers_c.add_parser('header', help='generate header file from template files')
-    parser_header.add_argument('file', nargs='+', help='list of template source files')
-    parser_header.add_argument('--external', action='store_true', help='generate external mpi.h header file')
-    parser_header.add_argument('--srcdir', help='source directory')
-    parser_header.set_defaults(handler=lambda args, out: c.generate_header(args, out))
     parser_gen = subparsers_c.add_parser('source', help='generate source file from template file')
     # parser = argparse.ArgumentParser(description='C ABI binding generation code')
     parser_gen.add_argument('type', choices=('ompi', 'standard'),

--- a/ompi/mpi/bindings/ompi_bindings/c.py
+++ b/ompi/mpi/bindings/ompi_bindings/c.py
@@ -12,8 +12,7 @@
 """MPI C Binding Code.
 
 This file is used for generating C bindings, as well as bigcount interfaces,
-from individual *.c.in template files. This also currently includes unused ABI
-code, in preparation for the standard ABI.
+from individual *.c.in template files.
 
 TEMPLATE SOURCE FILE ASSUMPTIONS:
 * Only one function per file
@@ -25,262 +24,13 @@ TEMPLATE SOURCE FILE ASSUMPTIONS:
   place of MPI_Count or int for each count parameter. Bigcount functions will
   be generated automatically for any function that includes a COUNT type.
 """
-from abc import ABC, abstractmethod
 import argparse
 import re
 import sys
 import os
 from ompi_bindings import consts, util
-from ompi_bindings.consts import ConvertFuncs, ConvertOMPIToStandard
 from ompi_bindings.c_type import Type
 from ompi_bindings.parser import SourceTemplate
-
-
-class ABIHeaderBuilder:
-    """ABI header builder code."""
-
-    def __init__(self, prototypes, out, external=False):
-        self.out = out
-        self.external = external
-
-        if external:
-            mangle_name = lambda name: name
-        else:
-            mangle_name = util.abi_internal_name
-
-        # Build up the list of standard ABI signatures
-        signatures = []
-        for prototype in prototypes:
-            base_name = util.mpi_fn_name_from_base_fn_name(prototype.name)
-            signatures.append(prototype.signature(base_name, abi_type='standard',
-                                                  mangle_name=mangle_name))
-            # Profiling prototype
-            signatures.append(prototype.signature(f'P{base_name}', abi_type='standard',
-                                                  mangle_name=mangle_name))
-            if util.prototype_has_bigcount(prototype):
-                signatures.append(prototype.signature(f'{base_name}_c', abi_type='standard',
-                                                      enable_count=True,
-                                                      mangle_name=mangle_name))
-                # Profiling prototype
-                signatures.append(prototype.signature(f'P{base_name}_c', abi_type='standard',
-                                                      enable_count=True,
-                                                      mangle_name=mangle_name))
-        self.signatures = signatures
-
-    def mangle_name(self, extname):
-        """Mangle names, depending on whether building external or internal header."""
-        if self.external:
-            return extname
-        return util.abi_internal_name(extname)
-
-    def dump(self, *pargs, **kwargs):
-        self.out.dump(*pargs, **kwargs)
-
-    def dump_lines(self, lines):
-        lines = util.indent_lines(lines, 4 * ' ', start=1)
-        for line in lines:
-            self.dump(line)
-
-    def generate_error_convert_fn(self):
-        self.dump(f'{consts.INLINE_ATTRS} int {ConvertFuncs.ERROR_CLASS}(int error_class)')
-        self.dump('{')
-        lines = []
-        lines.append('switch (error_class) {')
-        for error in consts.ERROR_CLASSES:
-            lines.append(f'case {self.mangle_name(error)}:')
-            lines.append(f'return {error};')
-        lines.append('default:')
-        lines.append('return error_class;')
-        lines.append('}')
-        self.dump_lines(lines)
-        self.dump('}')
-
-    def generic_convert(self, fn_name, param_name, type_, value_names):
-        intern_type = self.mangle_name(type_)
-        self.dump(f'{consts.INLINE_ATTRS} {type_} {fn_name}({intern_type} {param_name})')
-        self.dump('{')
-        lines = []
-        for i, value_name in enumerate(value_names):
-            intern_name = self.mangle_name(value_name)
-            if i == 0:
-                lines.append('if (%s == %s) {' % (intern_name, param_name))
-            else:
-                lines.append('} else if (%s == %s) {' % (intern_name, param_name))
-            lines.append(f'return {value_name};')
-        lines.append('}')
-        lines.append(f'return ({type_}) {param_name};')
-        self.dump_lines(lines)
-        self.dump('}')
-
-    def generic_convert_reverse(self, fn_name, param_name, type_, value_names):
-        intern_type = self.mangle_name(type_)
-        self.dump(f'{consts.INLINE_ATTRS} {intern_type} {fn_name}({type_} {param_name})')
-        self.dump('{')
-        lines = []
-        for i, value_name in enumerate(value_names):
-            intern_name = self.mangle_name(value_name)
-            if i == 0:
-                lines.append('if (%s == %s) {' % (value_name, param_name))
-            else:
-                lines.append('} else if (%s == %s) {' % (value_name, param_name))
-            lines.append(f'return {intern_name};')
-        lines.append('}')
-        lines.append(f'return ({intern_type}) {param_name};')
-        self.dump_lines(lines)
-        self.dump('}')
-
-    def generate_comm_convert_fn(self):
-        self.generic_convert(ConvertFuncs.COMM, 'comm', 'MPI_Comm', consts.RESERVED_COMMUNICATORS)
-
-    def generate_comm_convert_fn_intern_to_abi(self):
-        self.generic_convert_reverse(ConvertOMPIToStandard.COMM, 'comm', 'MPI_Comm', consts.RESERVED_COMMUNICATORS)
-
-    def generate_info_convert_fn(self):
-        self.generic_convert(ConvertFuncs.INFO, 'info', 'MPI_Info', consts.RESERVED_INFOS)
-
-    def generate_file_convert_fn_intern_to_abi(self):
-        self.generic_convert_reverse(ConvertFuncs.FILE, 'file', 'MPI_File', consts.RESERVED_FILES)
-
-    def generate_datatype_convert_fn(self):
-        self.generic_convert(ConvertFuncs.DATATYPE, 'datatype', 'MPI_Datatype', consts.PREDEFINED_DATATYPES)
-
-    def generate_op_convert_fn(self):
-        self.generic_convert(ConvertFuncs.OP, 'op', 'MPI_Op', consts.COLLECTIVE_OPERATIONS)
-
-    def generate_win_convert_fn(self):
-        self.generic_convert(ConvertFuncs.WIN, 'win', 'MPI_Win', consts.RESERVED_WINDOWS)
-
-    def generate_pointer_convert_fn(self, type_, fn_name, constants):
-        abi_type = self.mangle_name(type_)
-        self.dump(f'{consts.INLINE_ATTRS} void {fn_name}({abi_type} *ptr)')
-        self.dump('{')
-        lines = []
-        for i, ompi_name in enumerate(constants):
-            abi_name = self.mangle_name(ompi_name)
-            if i == 0:
-                lines.append('if (%s == (%s) *ptr) {' % (ompi_name, type_))
-            else:
-                lines.append('} else if (%s == (%s) *ptr) {' % (ompi_name, type_))
-            lines.append(f'*ptr = {abi_name};')
-        lines.append('}')
-        self.dump_lines(lines)
-        self.dump('}')
-
-    def generate_request_convert_fn(self):
-        self.generate_pointer_convert_fn('MPI_Request', ConvertFuncs.REQUEST, consts.RESERVED_REQUESTS)
-
-    def generate_file_convert_fn(self):
-        self.generate_pointer_convert_fn('MPI_File', ConvertFuncs.FILE, consts.RESERVED_FILES)
-
-    def generate_status_convert_fn(self):
-        type_ = 'MPI_Status'
-        abi_type = self.mangle_name(type_)
-        self.dump(f'{consts.INLINE_ATTRS} void {ConvertFuncs.STATUS}({abi_type} *out, {type_} *inp)')
-        self.dump('{')
-        self.dump('    out->MPI_SOURCE = inp->MPI_SOURCE;')
-        self.dump('    out->MPI_TAG = inp->MPI_TAG;')
-        self.dump(f'    out->MPI_ERROR = {ConvertFuncs.ERROR_CLASS}(inp->MPI_ERROR);')
-        # Ignoring the private fields for now
-        self.dump('}')
-
-    def define(self, type_, name, value):
-        self.dump(f'#define {name} OMPI_CAST_CONSTANT({type_}, {value})')
-
-    def define_all(self, type_, constants):
-        for i, const in enumerate(constants):
-            self.define(self.mangle_name(type_), self.mangle_name(const), i + 1)
-        self.dump()
-
-    def dump_header(self):
-        header_guard = '_ABI_INTERNAL_'
-        self.dump(f'#ifndef {header_guard}')
-        self.dump(f'#define {header_guard}')
-
-        self.dump('#include "stddef.h"')
-        self.dump('#include "stdint.h"')
-
-        self.dump("""
-#if defined(c_plusplus) || defined(__cplusplus)
-extern "C" {
-#endif
-""")
-
-        self.dump("""
-#if defined(c_plusplus) || defined(__cplusplus)
-#define OMPI_CAST_CONSTANT(type, value) (static_cast<type> (static_cast<void *> (value)))
-#else
-#define OMPI_CAST_CONSTANT(type, value) ((type) ((void *) value))
-#endif
-""")
-
-        for i, err in enumerate(consts.ERROR_CLASSES):
-            self.dump(f'#define {self.mangle_name(err)} {i + 1}')
-        self.dump()
-
-        self.define_all('MPI_Datatype', consts.PREDEFINED_DATATYPES)
-        self.define_all('MPI_Op', COLLECTIVE_OPERATIONS)
-        self.define_all('MPI_Comm', consts.RESERVED_COMMUNICATORS)
-        self.define_all('MPI_Request', consts.RESERVED_REQUESTS)
-        self.define_all('MPI_Win', consts.RESERVED_WINDOWS)
-        self.define_all('MPI_Info', consts.RESERVED_INFOS)
-        self.define_all('MPI_File', consts.RESERVED_FILES)
-
-        for name, value in consts.VARIOUS_CONSTANTS.items():
-            self.dump(f'#define {self.mangle_name(name)} {value}')
-        self.dump()
-
-        status_type = self.mangle_name('MPI_Status')
-        for i, name in enumerate(consts.IGNORED_STATUS_HANDLES):
-            self.define(f'{status_type} *', self.mangle_name(name), i + 1)
-        self.dump()
-
-        for i, name in enumerate(consts.COMMUNICATOR_SPLIT_TYPES):
-            self.dump(f'#define {self.mangle_name(name)} {i}')
-        self.dump()
-
-        for mpi_type, c_type in consts.C_OPAQUE_TYPES.items():
-            self.dump(f'typedef {c_type} {self.mangle_name(mpi_type)};')
-        self.dump()
-
-        for handle in consts.C_HANDLES:
-            prefix, suffix = handle.split('_')
-            name = f'{prefix}_ABI_{suffix}'
-            self.dump(f'typedef struct {self.mangle_name(name)} *{self.mangle_name(handle)};')
-        self.dump()
-        self.dump("""
-struct MPI_Status_ABI {
-    int MPI_SOURCE;
-    int MPI_TAG;
-    int MPI_ERROR;
-    int mpi_abi_private[5];
-};""")
-        self.dump(f'typedef struct MPI_Status_ABI {self.mangle_name("MPI_Status")};')
-        self.dump()
-        # Function signatures
-        for sig in self.signatures:
-            self.dump(f'{sig};')
-        self.dump('int MPI_Abi_details(int *buflen, char *details, MPI_Info *info);')
-        self.dump('int MPI_Abi_supported(int *flag);')
-        self.dump('int MPI_Abi_version(int *abi_major, int *abi_minor);')
-        if not self.external:
-            # Now generate the conversion code
-            self.generate_error_convert_fn()
-            self.generate_comm_convert_fn()
-            self.generate_comm_convert_fn_intern_to_abi()
-            self.generate_info_convert_fn()
-            self.generate_file_convert_fn()
-            self.generate_datatype_convert_fn()
-            self.generate_op_convert_fn()
-            self.generate_win_convert_fn()
-            self.generate_request_convert_fn()
-            self.generate_status_convert_fn()
-
-        self.dump("""
-#if defined(c_plusplus) || defined(__cplusplus)
-}
-#endif
-""")
-        self.dump(f'#endif /* {header_guard} */')
 
 
 def print_profiling_header(fn_name, out):
@@ -365,15 +115,6 @@ def standard_abi(base_name, template, out):
         base_name_c = f'{base_name}_c'
         generate_function(template.prototype, base_name_c, internal_name,
                           enable_count=True)
-
-
-def generate_header(args, out):
-    """Generate an ABI header and conversion code."""
-    out.dump(f'/* {consts.GENERATED_MESSAGE} */')
-    prototypes = [SourceTemplate.load(file_, args.srcdir, type_constructor=Type.construct).prototype
-                  for file_ in args.file]
-    builder = ABIHeaderBuilder(prototypes, out, external=args.external)
-    builder.dump_header()
 
 
 def generate_source(args, out):


### PR DESCRIPTION
No Makefile rule has ever invoked `bindings.py ... c header`: the build generates binding sources only through the `c source` subcommand. The `ABIHeaderBuilder` class behind it was parked in c.py in preparation for MPI standard ABI support, but it was never wired into the build and has drifted badly from reality: it assigns handle and error constants positionally (e.g., `MPI_SUCCESS` would be 1), hardcodes `MPI_MAX_LIBRARY_VERSION_STRING` to 256, and emits typedefs that collide with mpi.h when both are visible.

The actual MPI standard ABI work (#13280) generates the ABI header by a different mechanism entirely, so this preparation code will never be used. Remove the class, its `generate_header()` entry point, the `c header` argparse subcommand, and the imports that only it used.

Verified that `c source` generation still works after the removal.