### PR TITLE
coll/base: stop release_arrays from aliasing the refcounted vecs

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -151,11 +151,16 @@ release_objs_callback(struct ompi_coll_base_nbc_request_t *request)
         request->data.refcounted.objs.objs[1] = NULL;
     }
     for(int i = 0; i < OMPI_REQ_NB_RELEASE_ARRAYS; i++ ) {
-        if (NULL == request->data.release_arrays[i]) {
+        /* Atomically claim each slot: the post-append drain in
+         * ompi_coll_base_add_release_arrays_cb() can race with this
+         * callback on an asynchronous-progress completion, and the
+         * swap guarantees each array is freed exactly once. */
+        void *array = (void *) opal_atomic_swap_ptr(
+            &request->data.release_arrays[i], (intptr_t) NULL);
+        if (NULL == array) {
             break;
         }
-        free(request->data.release_arrays[i]);
-        request->data.release_arrays[i] = NULL;
+        free(array);
     }
 }
 
@@ -355,14 +360,32 @@ int ompi_coll_base_add_release_arrays_cb(ompi_request_t *req)
 
     assert(NULL != request);
 
-    if (req->req_persistent && (NULL == req->req_free)) {
-        request->cb.req_free = req->req_free;
-        req->req_free = free_objs_callback;
-    } else if(NULL == req->req_complete_cb) {
+    if (req->req_persistent) {
+        if (req->req_free != free_objs_callback &&
+            req->req_free != free_vecs_callback) {
+            /* Chain whatever free hook is installed (including none),
+             * the same way the retain helpers do.  Our own hooks
+             * already drain the release arrays. */
+            request->cb.req_free = req->req_free;
+            req->req_free = free_objs_callback;
+        }
+    } else if (req->req_complete_cb != complete_objs_callback &&
+               req->req_complete_cb != complete_vecs_callback) {
         request->cb.req_complete_cb = req->req_complete_cb;
         request->req_complete_cb_data = req->req_complete_cb_data;
         req->req_complete_cb = complete_objs_callback;
         req->req_complete_cb_data = request;
+    }
+
+    /* The operation may already have completed -- either before this
+     * call (the completion callback ran too early to see the arrays,
+     * or was not installed yet) or concurrently with it.  Drain
+     * inline in that case; the atomic swap in release_objs_callback()
+     * makes the two drains safe against each other.  Persistent
+     * requests are excluded: their arrays must live until the request
+     * is freed, and the req_free hook above handles that. */
+    if (!req->req_persistent && REQUEST_COMPLETE(req)) {
+        release_objs_callback(request);
     }
     return OMPI_SUCCESS;
 }
@@ -374,7 +397,7 @@ static void nbc_req_constructor(ompi_coll_base_nbc_request_t *req)
     req->data.refcounted.objs.objs[0] = NULL;
     req->data.refcounted.objs.objs[1] = NULL;
     for (int i = 0; i < OMPI_REQ_NB_RELEASE_ARRAYS; i++ ) {
-        req->data.release_arrays[i] = NULL;
+        req->data.release_arrays[i] = 0;
     }
 }
 

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -26,6 +26,8 @@
 
 #include "ompi_config.h"
 
+#include "opal/sys/atomic.h"
+
 #include "mpi.h"
 #include "ompi/mca/mca.h"
 #include "ompi/datatype/ompi_datatype.h"
@@ -56,6 +58,15 @@ struct ompi_coll_base_nbc_request_t {
     } cb;
     void *req_complete_cb_data;
     struct {
+        /* The refcounted modes are mutually exclusive (each retain
+         * helper uses exactly one of them), so they share a union.
+         * release_arrays is NOT part of that union: temporary arrays
+         * (e.g. the Fortran bindings' converted count/displacement and
+         * datatype arrays for the *w collectives) are appended to the
+         * same request whose refcounted.vecs entries were populated by
+         * ompi_coll_base_retain_datatypes_w().  When the two aliased,
+         * releasing the vecs NULLed the leading release_arrays slots
+         * and every appended array leaked. */
         union {
             struct {
                 ompi_op_t *op;
@@ -75,7 +86,12 @@ struct ompi_coll_base_nbc_request_t {
                 int rcount;
             } vecs;
         } refcounted;
-        void* release_arrays[OMPI_REQ_NB_RELEASE_ARRAYS];
+        /* Slots are claimed by ompi_coll_base_append_array_to_release()
+         * and drained (with an atomic swap, so a completion callback
+         * racing with the post-append drain in
+         * ompi_coll_base_add_release_arrays_cb() cannot double-free)
+         * by release_objs_callback(). */
+        opal_atomic_intptr_t release_arrays[OMPI_REQ_NB_RELEASE_ARRAYS];
     } data;
 };
 
@@ -115,16 +131,16 @@ ompi_coll_base_append_array_to_release(struct ompi_request_t *req, void *array_p
     assert(request->super.req_type == OMPI_REQUEST_COLL);
 
     for(i = 0; i < OMPI_REQ_NB_RELEASE_ARRAYS; i++ ) {
-        if (NULL == request->data.release_arrays[i]) {
+        if (0 == request->data.release_arrays[i]) {
             break;
         }
     }
 
     if (OMPI_REQ_NB_RELEASE_ARRAYS > i) {
-        request->data.release_arrays[i] = array_ptr;
+        request->data.release_arrays[i] = (intptr_t) array_ptr;
         ++i;
         if (OMPI_REQ_NB_RELEASE_ARRAYS > i) {
-            request->data.release_arrays[i] = NULL;
+            request->data.release_arrays[i] = 0;
         }
     } else {
         ret = OMPI_ERR_OUT_OF_RESOURCE;


### PR DESCRIPTION
`ompi_coll_base_nbc_request_t` kept its refcounted bookkeeping and its `release_arrays[]` in one union. The two are used together: for the *w nonblocking collectives the C binding calls `ompi_coll_base_retain_datatypes_w()`, which stores the caller's type vectors in `refcounted.vecs`, and the Fortran mpif-h/use-mpi-f08 shims then append their converted count/displacement/datatype arrays to the same request with `ompi_coll_base_append_array_to_release()`. Because the storage aliased, the appended arrays landed in the slots after the vecs fields; at completion `release_vecs_callback()` NULLed the vecs pointers (the leading `release_arrays` slots) and the drain loop in `release_objs_callback()` stopped at the first NULL slot — so every appended array leaked, one set per Fortran `MPI_Ialltoallw` / `MPI_Alltoallw_init` (and neighbor variant) call with a resized index type. Any future reordering of the union members would have turned the leak into a double free.

Give `release_arrays[]` its own storage next to the refcounted union. The existing cleanup design already funnels every completion path through `release_objs_callback()`, so separating the storage is enough to make the coexisting mechanisms correct.

While in here, close two smaller holes in the same machinery:

* `ompi_coll_base_add_release_arrays_cb()` only installed its cleanup hook when no completion callback was present at all, so arrays appended to a request carrying a foreign (e.g. libnbc-internal) callback were never freed. Chain foreign callbacks the same way the retain helpers do, and recognize our own hooks (which now always drain the arrays) instead of matching on NULL.

* An asynchronous-progress completion could fire before the cleanup hook was installed, leaking everything appended so far. Drain inline when the (non-persistent) request is already complete, and claim each slot with an atomic swap so the inline drain and a concurrently running completion callback free each array exactly once.

Verified: full build and `make check` on AlmaLinux 10 (aarch64).